### PR TITLE
feat(bot-mode): keep same-gateway rooms running without Desktop

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
+++ b/apps/desktop/src/plugins/hermes-bots/hosted-room-client.js
@@ -1,0 +1,977 @@
+const MIN_ROOM_MEMBERS = 2
+const MAX_ROOM_MEMBERS = 6
+const MAX_REPLAY_PAGE_SIZE = 500
+const MAX_REPLAY_PAGES = 100
+const MAX_ATTACHMENT_COUNT = 8
+const MAX_ATTACHMENT_NAME_CHARS = 255
+const MAX_ATTACHMENT_NAME_BYTES = 512
+const MAX_ATTACHMENT_FILE_BYTES = 15_000_000
+const MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
+const MAX_ATTACHMENT_MIME_CHARS = 127
+const MAX_ATTACHMENT_REFS = 6
+const MAX_MEMBER_ID_CHARS = 128
+const MAX_STAGED_REF_CHARS = 256
+
+export const HOSTED_ROOM_CLIENT_LIMITATIONS = Object.freeze({
+  attachments: false,
+  automaticFailover: false,
+  crossGatewayMembers: false,
+  stagedAttachmentManifest: true
+})
+
+const ATTACHMENT_FIELDS = new Set(['kind', 'name', 'size', 'mime', 'refs'])
+const ATTACHMENT_KINDS = new Set(['image', 'pdf', 'file'])
+const ATTACHMENT_PAYLOAD_ALIASES = new Set(['attachment', 'attachment_manifest', 'files', 'images'])
+const COMMAND_KINDS = new Set(['create', 'send', 'stop', 'disband'])
+const DISALLOWED_STAGED_REF_SCHEMES = new Set(['blob', 'data', 'file', 'http', 'https', 'path'])
+const FORBIDDEN_TRANSPORT_FIELD_TOKENS = new Set(['base64', 'byte', 'bytes', 'data', 'path', 'paths'])
+const MEMBER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+const MIME_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i
+const STAGED_REF_RE = /^[a-z][a-z0-9+.-]*:[A-Za-z0-9][A-Za-z0-9._:-]*$/i
+const STATUS_EVENT_KINDS = new Set([
+  'authority.lost',
+  'member.unavailable',
+  'room.activity',
+  'turn.cancelled',
+  'turn.deferred',
+  'turn.failed',
+  'turn.reassigned',
+  'turn.settled',
+  'turn.started'
+])
+const KNOWN_EVENT_KINDS = new Set([
+  'authority.claimed',
+  'authority.lost',
+  'member.unavailable',
+  'message.member',
+  'message.user',
+  'room.activity',
+  'room.created',
+  'room.disbanded',
+  'room.members_changed',
+  'room.renamed',
+  'turn.cancelled',
+  'turn.deferred',
+  'turn.failed',
+  'turn.reassigned',
+  'turn.settled',
+  'turn.started'
+])
+
+function text(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  const number = Number(value)
+
+  return Number.isSafeInteger(number) && number >= 0 ? number : fallback
+}
+
+function positiveInteger(value, fallback = null) {
+  const number = Number(value)
+
+  return Number.isSafeInteger(number) && number > 0 ? number : fallback
+}
+
+function errorCode(error) {
+  return error?.code ?? error?.error?.code ?? null
+}
+
+function errorMessage(error) {
+  return String(error?.message || error?.error?.message || error || '')
+}
+
+function isMissingCapabilityMethod(error) {
+  return (
+    errorCode(error) === -32601 ||
+    /method not found|-32601|unknown method|no such method|no handler for|unsupported rpc/i.test(errorMessage(error))
+  )
+}
+
+function capabilityResult(probe) {
+  if (!probe || typeof probe !== 'object') {
+    return null
+  }
+
+  if (probe.ok === true && probe.result && typeof probe.result === 'object') {
+    return probe.result
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(probe, 'ok') && !Object.prototype.hasOwnProperty.call(probe, 'error')) {
+    return probe
+  }
+
+  return null
+}
+
+/** Classify a groups.capabilities probe without turning connectivity failures
+ * into a compatibility verdict. */
+export function classifyHostedRoomCapability(probe, { connectionId = null } = {}) {
+  const localConnectionId = text(connectionId)
+  const error = probe instanceof Error ? probe : probe?.ok === false ? probe.error || probe : probe?.error
+
+  if (error) {
+    return {
+      kind: isMissingCapabilityMethod(error) ? 'unsupported' : 'transient-failure',
+      reason: isMissingCapabilityMethod(error) ? 'old-gateway' : 'probe-failed',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: null,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const capabilities = capabilityResult(probe)
+
+  if (!capabilities) {
+    return {
+      kind: 'transient-failure',
+      reason: 'invalid-response',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: null,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  if (capabilities.driver !== true) {
+    return {
+      kind: 'unsupported',
+      reason: capabilities.driver === false ? 'driver-disabled' : 'incomplete-contract',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: capabilities.persistent_process === true,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const authorityId = text(capabilities.authority_gateway_id)
+
+  if (!authorityId) {
+    return {
+      kind: 'unsupported',
+      reason: 'incomplete-contract',
+      connectionId: localConnectionId,
+      authorityId: null,
+      persistentProcess: capabilities.persistent_process === true,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  return {
+    kind: 'driver-capable',
+    reason: null,
+    connectionId: localConnectionId,
+    authorityId,
+    persistentProcess: capabilities.persistent_process === true,
+    maxLogLimit: positiveInteger(capabilities.max_log_limit, 100),
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  }
+}
+
+/** A running driver hosted inside an app-managed child process cannot outlive
+ * Desktop. Accept either a raw capability response or its classified form. */
+export function isHostedRoomContinuityEligible(capability) {
+  if (!capability || typeof capability !== 'object') {
+    return false
+  }
+
+  if (Object.prototype.hasOwnProperty.call(capability, 'kind')) {
+    return capability.kind === 'driver-capable' && capability.persistentProcess === true
+  }
+
+  return capability.driver === true && capability.persistent_process === true
+}
+
+function memberConnectionId(member, activeConnectionId) {
+  if (!member || member.sourceMissing) {
+    return null
+  }
+
+  const explicit = text(member.route?.connectionId) || text(member.connectionId)
+
+  if (explicit) {
+    return explicit
+  }
+
+  if (member.sourceScoped || member.remoteSource) {
+    return null
+  }
+
+  return text(activeConnectionId)
+}
+
+/** Resolve a same-gateway home candidate. This deliberately does not select a
+ * different gateway or attach a stable authority identity. */
+export function resolveSingleGatewayRoute(members, { activeConnectionId = null } = {}) {
+  const roster = Array.isArray(members) ? members : []
+
+  if (roster.length < MIN_ROOM_MEMBERS || roster.length > MAX_ROOM_MEMBERS) {
+    return {
+      kind: 'unsupported',
+      reason: 'member-count',
+      connectionId: null,
+      memberConnectionIds: [],
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const memberConnectionIds = roster.map(member => memberConnectionId(member, activeConnectionId))
+
+  if (memberConnectionIds.some(connectionId => !connectionId)) {
+    return {
+      kind: 'unsupported',
+      reason: 'unresolved-member-route',
+      connectionId: null,
+      memberConnectionIds,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  const connectionIds = [...new Set(memberConnectionIds)]
+
+  if (connectionIds.length !== 1) {
+    return {
+      kind: 'unsupported',
+      reason: 'cross-gateway',
+      connectionId: null,
+      memberConnectionIds,
+      limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+    }
+  }
+
+  return {
+    kind: 'single-gateway',
+    reason: null,
+    connectionId: connectionIds[0],
+    memberConnectionIds,
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  }
+}
+
+function cloneList(value) {
+  return Array.isArray(value) ? value.map(item => (item && typeof item === 'object' ? { ...item } : item)) : []
+}
+
+/** Serializable replay state. Stable gateway authority and local routing are
+ * intentionally separate fields. */
+export function createHostedRoomReplayState({
+  roomId,
+  name = '',
+  members = [],
+  authorityId = null,
+  authorityEpoch = null,
+  connectionId = null,
+  cursor = 0,
+  latestSeq = null,
+  messages = [],
+  activity = [],
+  timeline = [],
+  pendingEvents = [],
+  lastStatusEvent = null,
+  deleted = false,
+  conflicts = []
+} = {}) {
+  const normalizedCursor = nonNegativeInteger(cursor)
+
+  return {
+    roomId: text(roomId),
+    name: typeof name === 'string' ? name : '',
+    members: cloneList(members),
+    authorityId: text(authorityId),
+    authorityEpoch: positiveInteger(authorityEpoch),
+    connectionId: text(connectionId),
+    cursor: normalizedCursor,
+    latestSeq: Math.max(normalizedCursor, nonNegativeInteger(latestSeq, normalizedCursor)),
+    messages: cloneList(messages),
+    activity: cloneList(activity),
+    timeline: cloneList(timeline),
+    pendingEvents: cloneList(pendingEvents),
+    lastStatusEvent: lastStatusEvent && typeof lastStatusEvent === 'object' ? { ...lastStatusEvent } : null,
+    deleted: Boolean(deleted),
+    conflicts: cloneList(conflicts)
+  }
+}
+
+function normalizeEvent(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+
+  const seq = positiveInteger(raw.seq)
+  const eventId = text(raw.event_id) || text(raw.eventId)
+  const kind = text(raw.kind)
+
+  if (!seq || !eventId || !kind) {
+    return null
+  }
+
+  return {
+    roomId: text(raw.room_id) || text(raw.roomId),
+    seq,
+    eventId,
+    kind,
+    actor: raw.actor && typeof raw.actor === 'object' ? { ...raw.actor } : {},
+    payload: raw.payload && typeof raw.payload === 'object' && !Array.isArray(raw.payload) ? { ...raw.payload } : {},
+    createdAt: Number.isFinite(Number(raw.created_at ?? raw.createdAt)) ? Number(raw.created_at ?? raw.createdAt) : 0
+  }
+}
+
+function memberLabel(roomEvent) {
+  const payload = roomEvent?.payload || {}
+  const actor = roomEvent?.actor || {}
+
+  return (
+    text(payload.member_display_name) ||
+    text(payload.member_name) ||
+    text(payload.display_name) ||
+    text(actor.display_name) ||
+    text(actor.profile) ||
+    'A bot'
+  )
+}
+
+function messageFromEvent(roomEvent) {
+  const isUser = roomEvent.kind === 'message.user'
+  const payload = roomEvent.payload || {}
+  const actor = roomEvent.actor || {}
+  const attachments = safeAttachmentMetadata(payload.attachments)
+
+  return {
+    seq: roomEvent.seq,
+    eventId: roomEvent.eventId,
+    from: {
+      kind: isUser ? 'user' : 'member',
+      name: isUser ? 'You' : memberLabel(roomEvent),
+      ...(text(actor.connection_id) ? { source: text(actor.connection_id) } : {})
+    },
+    text: typeof payload.text === 'string' ? payload.text : '',
+    thread: text(payload.thread_id) || text(payload.thread) || 'legacy',
+    at: roomEvent.createdAt,
+    ...(attachments.length ? { attachments } : {})
+  }
+}
+
+function activityFromEvent(roomEvent) {
+  return {
+    seq: roomEvent.seq,
+    eventId: roomEvent.eventId,
+    kind: roomEvent.kind,
+    member: memberLabel(roomEvent),
+    reasonCode: text(roomEvent.payload?.reason_code),
+    at: roomEvent.createdAt
+  }
+}
+
+function applyReplayEvent(state, roomEvent) {
+  const next = state
+
+  if (KNOWN_EVENT_KINDS.has(roomEvent.kind)) {
+    next.timeline.push({ seq: roomEvent.seq, eventId: roomEvent.eventId, kind: roomEvent.kind })
+  }
+
+  if (roomEvent.kind === 'message.user' || roomEvent.kind === 'message.member') {
+    next.messages.push(messageFromEvent(roomEvent))
+  } else if (roomEvent.kind === 'room.created') {
+    next.name = text(roomEvent.payload.name) || next.name
+    if (Array.isArray(roomEvent.payload.members)) {
+      next.members = cloneList(roomEvent.payload.members)
+    }
+  } else if (roomEvent.kind === 'room.renamed') {
+    next.name = text(roomEvent.payload.name) || next.name
+  } else if (roomEvent.kind === 'room.members_changed' && Array.isArray(roomEvent.payload.members)) {
+    next.members = cloneList(roomEvent.payload.members)
+  } else if (roomEvent.kind === 'room.disbanded') {
+    next.deleted = true
+  } else if (roomEvent.kind === 'authority.claimed') {
+    const claimedAuthorityId = text(roomEvent.payload.authority_gateway_id)
+
+    if (claimedAuthorityId) {
+      if (next.authorityId && next.authorityId !== claimedAuthorityId) {
+        next.connectionId = null
+      }
+      next.authorityId = claimedAuthorityId
+    }
+    next.authorityEpoch = positiveInteger(roomEvent.payload.authority_epoch, next.authorityEpoch)
+  } else if (roomEvent.kind === 'authority.lost') {
+    next.connectionId = null
+  }
+
+  if (STATUS_EVENT_KINDS.has(roomEvent.kind)) {
+    next.activity.push(activityFromEvent(roomEvent))
+    next.lastStatusEvent = roomEvent
+  }
+
+  return next
+}
+
+function mergePendingEvents(state, incomingEvents) {
+  const bySeq = new Map()
+  const byId = new Map()
+  const conflicts = [...state.conflicts]
+
+  for (const candidate of [...state.pendingEvents, ...(Array.isArray(incomingEvents) ? incomingEvents : [])]) {
+    const roomEvent = normalizeEvent(candidate)
+
+    if (!roomEvent || roomEvent.seq <= state.cursor) {
+      continue
+    }
+    if (state.roomId && roomEvent.roomId && state.roomId !== roomEvent.roomId) {
+      continue
+    }
+
+    const sequenceTwin = bySeq.get(roomEvent.seq)
+    const idTwin = byId.get(roomEvent.eventId)
+
+    if (sequenceTwin || idTwin) {
+      const prior = sequenceTwin || idTwin
+
+      if (prior.seq !== roomEvent.seq || prior.eventId !== roomEvent.eventId) {
+        conflicts.push({ seq: roomEvent.seq, eventId: roomEvent.eventId })
+      }
+      continue
+    }
+
+    bySeq.set(roomEvent.seq, roomEvent)
+    byId.set(roomEvent.eventId, roomEvent)
+  }
+
+  return {
+    conflicts,
+    events: [...bySeq.values()].sort((left, right) => left.seq - right.seq || left.eventId.localeCompare(right.eventId))
+  }
+}
+
+/** Apply only contiguous gateway events. Reordered pages are buffered; unknown
+ * kinds advance the cursor but cannot erase known room state. */
+export function reduceHostedRoomEvents(state, incomingEvents) {
+  const next = createHostedRoomReplayState(state)
+  const merged = mergePendingEvents(next, incomingEvents)
+  const pending = [...merged.events]
+
+  next.conflicts = merged.conflicts
+  next.latestSeq = Math.max(next.latestSeq, ...pending.map(roomEvent => roomEvent.seq), next.cursor)
+
+  while (pending.length && pending[0].seq === next.cursor + 1) {
+    const roomEvent = pending.shift()
+
+    applyReplayEvent(next, roomEvent)
+    next.cursor = roomEvent.seq
+  }
+
+  next.pendingEvents = pending
+
+  return next
+}
+
+function friendlyStatus(kind, textValue, { member = null, canRetry = false, canStop = false } = {}) {
+  return { kind, text: textValue, member, canRetry, canStop }
+}
+
+function failedTurnStatus(roomEvent) {
+  const member = memberLabel(roomEvent)
+  const reasonCode = text(roomEvent.payload?.reason_code)
+
+  if (reasonCode === 'provider_auth_or_access') {
+    return friendlyStatus('needs-attention', `${member} needs you to sign in again.`, { member })
+  }
+  if (reasonCode === 'provider_quota_limit') {
+    return friendlyStatus('needs-attention', `${member} is out of quota or balance.`, { member })
+  }
+  if (reasonCode === 'missing_config') {
+    return friendlyStatus('needs-attention', `${member} needs a model provider.`, { member })
+  }
+  if (reasonCode === 'agent_blocked') {
+    return friendlyStatus('needs-attention', `${member} needs your help.`, { member })
+  }
+
+  return friendlyStatus('failed', `${member} couldn't respond.`, { member, canRetry: true })
+}
+
+function roomActivityStatus(roomEvent) {
+  const activity = text(roomEvent.payload?.status)?.toLowerCase()
+  const member = memberLabel(roomEvent)
+
+  if (activity === 'working') {
+    return friendlyStatus('working', `${member} is working.`, { member, canStop: true })
+  }
+  if (activity === 'needs_user' || activity === 'waiting_for_user') {
+    return friendlyStatus('needs-you', 'Waiting for your answer.')
+  }
+  if (activity === 'waiting') {
+    return friendlyStatus('waiting', 'The room is waiting.')
+  }
+  if (activity === 'paused') {
+    return friendlyStatus('paused', 'Paused.')
+  }
+  if (activity === 'offline') {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+
+  return friendlyStatus('ready', 'Ready.')
+}
+
+/** Convert durable typed events into short, user-facing status copy. Raw
+ * coordinator and provider errors are never reflected. */
+export function deriveFriendlyHostedRoomStatus(state) {
+  if (state?.deleted) {
+    return friendlyStatus('deleted', 'This group was deleted.')
+  }
+  if (state?.authorityId && !state?.connectionId) {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+
+  const roomEvent = normalizeEvent(state?.lastStatusEvent)
+
+  if (!roomEvent) {
+    return friendlyStatus('ready', 'Ready.')
+  }
+
+  const member = memberLabel(roomEvent)
+
+  if (roomEvent.kind === 'turn.started' || roomEvent.kind === 'turn.reassigned') {
+    return friendlyStatus('working', `${member} is working.`, { member, canStop: true })
+  }
+  if (roomEvent.kind === 'member.unavailable') {
+    return friendlyStatus('member-unavailable', `${member} is unavailable.`, { member, canRetry: true })
+  }
+  if (roomEvent.kind === 'turn.failed') {
+    return failedTurnStatus(roomEvent)
+  }
+  if (roomEvent.kind === 'turn.cancelled') {
+    return friendlyStatus('stopped', 'Stopped.')
+  }
+  if (roomEvent.kind === 'turn.settled') {
+    return friendlyStatus('ready', 'Ready.')
+  }
+  if (roomEvent.kind === 'turn.deferred') {
+    return friendlyStatus('waiting', `${member} is waiting to continue.`, { member, canRetry: true })
+  }
+  if (roomEvent.kind === 'authority.lost') {
+    return friendlyStatus('offline', 'This room is offline.', { canRetry: true })
+  }
+  if (roomEvent.kind === 'room.activity') {
+    return roomActivityStatus(roomEvent)
+  }
+
+  return friendlyStatus('ready', 'Ready.')
+}
+
+/** Fetch monotonic groups.log pages from the persisted replay cursor. The
+ * helper stops on gaps, no-progress responses, transient errors, or a hard
+ * page bound instead of spinning. */
+export async function replayHostedRoomPages({ state, fetchPage, pageSize = 100, maxPages = 20 } = {}) {
+  if (typeof fetchPage !== 'function') {
+    throw new TypeError('fetchPage must be a function')
+  }
+
+  const limit = Math.min(MAX_REPLAY_PAGE_SIZE, Math.max(1, positiveInteger(pageSize, 100)))
+  const pageBound = Math.min(MAX_REPLAY_PAGES, Math.max(1, positiveInteger(maxPages, 20)))
+  let next = createHostedRoomReplayState(state)
+  let pages = 0
+  let fetchedEvents = 0
+
+  while (pages < pageBound) {
+    const beforeCursor = next.cursor
+    let page
+
+    try {
+      page = await fetchPage({ sinceSeq: beforeCursor, limit })
+    } catch (error) {
+      return { state: next, complete: false, reason: 'transient-failure', pages, fetchedEvents, error }
+    }
+
+    if (!page || typeof page !== 'object') {
+      return { state: next, complete: false, reason: 'invalid-response', pages, fetchedEvents }
+    }
+
+    const events = Array.isArray(page.events) ? page.events : []
+    const latestSeq = nonNegativeInteger(page.latest_seq ?? page.latestSeq, next.latestSeq)
+
+    if (events.length > limit) {
+      return { state: next, complete: false, reason: 'oversized-page', pages, fetchedEvents }
+    }
+
+    pages += 1
+    fetchedEvents += events.length
+    next = reduceHostedRoomEvents(next, events)
+    next.latestSeq = Math.max(next.latestSeq, latestSeq)
+
+    const hasMore = page.has_more === true || next.cursor < latestSeq
+
+    if (!hasMore) {
+      if (next.pendingEvents.length) {
+        return { state: next, complete: false, reason: 'gap', pages, fetchedEvents }
+      }
+      return { state: next, complete: true, reason: null, pages, fetchedEvents }
+    }
+
+    if (next.cursor <= beforeCursor) {
+      return { state: next, complete: false, reason: 'stalled', pages, fetchedEvents }
+    }
+  }
+
+  return { state: next, complete: false, reason: 'limit', pages, fetchedEvents }
+}
+
+function cloneJson(value, label) {
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch (error) {
+    throw new TypeError(`${label} must be JSON-serializable`, { cause: error })
+  }
+}
+
+function utf8Size(value) {
+  return new TextEncoder().encode(value).length
+}
+
+function fieldTokens(field) {
+  return String(field)
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+function forbiddenTransportField(field) {
+  return fieldTokens(field).find(token => FORBIDDEN_TRANSPORT_FIELD_TOKENS.has(token)) || null
+}
+
+function assertNoRawTransportFields(value, location = 'payload') {
+  if (!value || typeof value !== 'object') {
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoRawTransportFields(entry, `${location}[${index}]`))
+    return
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    const forbidden = forbiddenTransportField(key)
+
+    if (forbidden) {
+      throw new TypeError(`${location}.${key} contains a forbidden ${forbidden} field`)
+    }
+    if (key !== 'refs') {
+      assertNoRawTransportFields(nested, `${location}.${key}`)
+    }
+  }
+}
+
+function normalizeAttachmentName(value) {
+  const name = text(value)
+
+  if (
+    !name ||
+    name.length > MAX_ATTACHMENT_NAME_CHARS ||
+    utf8Size(name) > MAX_ATTACHMENT_NAME_BYTES ||
+    name.includes('\0') ||
+    name.includes('/') ||
+    name.includes('\\')
+  ) {
+    throw new TypeError('attachment name must be a bounded base filename')
+  }
+
+  return name
+}
+
+function normalizeAttachmentMime(value, kind) {
+  const mime = text(value)?.toLowerCase()
+
+  if (!mime || mime.length > MAX_ATTACHMENT_MIME_CHARS || !MIME_RE.test(mime)) {
+    throw new TypeError('attachment mime must be a bounded MIME type')
+  }
+  if (kind === 'image' && !mime.startsWith('image/')) {
+    throw new TypeError('image attachments require an image MIME type')
+  }
+  if (kind === 'pdf' && mime !== 'application/pdf') {
+    throw new TypeError('pdf attachments require application/pdf')
+  }
+
+  return mime
+}
+
+function normalizeAttachmentRefs(value, { required }) {
+  if (value === undefined && !required) {
+    return null
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('attachment member refs must be an object')
+  }
+
+  const entries = Object.entries(value)
+
+  if (!entries.length || entries.length > MAX_ATTACHMENT_REFS) {
+    throw new TypeError(`attachment member refs must contain 1-${MAX_ATTACHMENT_REFS} entries`)
+  }
+
+  const refs = {}
+
+  for (const [rawMemberId, rawRef] of entries) {
+    const memberId = text(rawMemberId)
+    const ref = text(rawRef)
+    const refScheme = ref?.split(':', 1)[0]?.toLowerCase()
+
+    if (!memberId || memberId.length > MAX_MEMBER_ID_CHARS || !MEMBER_ID_RE.test(memberId)) {
+      throw new TypeError('attachment member refs require valid member_id keys')
+    }
+    if (
+      !ref ||
+      ref.length > MAX_STAGED_REF_CHARS ||
+      !STAGED_REF_RE.test(ref) ||
+      DISALLOWED_STAGED_REF_SCHEMES.has(refScheme)
+    ) {
+      throw new TypeError('attachment member refs require opaque staged reference ids')
+    }
+
+    refs[memberId] = ref
+  }
+
+  return refs
+}
+
+function normalizeAttachmentEntry(raw, { requireRefs }) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new TypeError('each attachment must be an object')
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (!ATTACHMENT_FIELDS.has(key)) {
+      const forbidden = forbiddenTransportField(key)
+
+      throw new TypeError(
+        forbidden
+          ? `attachment ${key} contains a forbidden ${forbidden} field`
+          : `attachment contains unsupported field: ${key}`
+      )
+    }
+  }
+
+  const kind = text(raw.kind)?.toLowerCase()
+
+  if (!kind || !ATTACHMENT_KINDS.has(kind)) {
+    throw new TypeError('attachment kind must be image, pdf, or file')
+  }
+  if (
+    typeof raw.size !== 'number' ||
+    !Number.isSafeInteger(raw.size) ||
+    raw.size < 0 ||
+    raw.size > MAX_ATTACHMENT_FILE_BYTES
+  ) {
+    throw new TypeError(`attachment size must be between 0 and ${MAX_ATTACHMENT_FILE_BYTES} bytes`)
+  }
+
+  const normalized = {
+    kind,
+    name: normalizeAttachmentName(raw.name),
+    size: raw.size,
+    mime: normalizeAttachmentMime(raw.mime, kind)
+  }
+  const refs = normalizeAttachmentRefs(raw.refs, { required: requireRefs })
+
+  return refs ? { ...normalized, refs } : normalized
+}
+
+function normalizeAttachmentManifest(value, { requireRefs }) {
+  if (!Array.isArray(value)) {
+    throw new TypeError('attachments must be a manifest array')
+  }
+  if (value.length > MAX_ATTACHMENT_COUNT) {
+    throw new TypeError(`attachment manifest supports at most ${MAX_ATTACHMENT_COUNT} entries`)
+  }
+
+  const manifest = value.map(entry => normalizeAttachmentEntry(entry, { requireRefs }))
+
+  if (utf8Size(JSON.stringify(manifest)) > MAX_ATTACHMENT_MANIFEST_BYTES) {
+    throw new TypeError('attachment manifest metadata is too large')
+  }
+
+  return manifest
+}
+
+function safeAttachmentMetadata(value) {
+  if (!Array.isArray(value) || value.length > MAX_ATTACHMENT_COUNT) {
+    return []
+  }
+
+  const metadata = []
+
+  for (const entry of value) {
+    try {
+      const normalized = normalizeAttachmentEntry(entry, { requireRefs: false })
+
+      metadata.push({ kind: normalized.kind, name: normalized.name, size: normalized.size, mime: normalized.mime })
+    } catch {
+      // A malformed internal manifest must not expose refs or block replay.
+    }
+  }
+
+  return metadata
+}
+
+function normalizeCommand(raw) {
+  if (!raw || typeof raw !== 'object') {
+    throw new TypeError('command must be an object')
+  }
+
+  const commandId = text(raw.commandId) || text(raw.id)
+  const kind = text(raw.kind)
+  const roomId = text(raw.roomId) || text(raw.room_id)
+  const authorityId = text(raw.authorityId) || text(raw.authority_gateway_id)
+  const connectionId = text(raw.connectionId) || text(raw.connection_id)
+
+  if (!commandId || !kind || !roomId || !authorityId || !connectionId) {
+    throw new TypeError('command requires commandId, kind, roomId, authorityId, and connectionId')
+  }
+  if (!COMMAND_KINDS.has(kind)) {
+    throw new TypeError(`unsupported hosted room command: ${kind}`)
+  }
+
+  const rawPayload = raw.payload && typeof raw.payload === 'object' ? raw.payload : {}
+
+  if (kind === 'send') {
+    assertNoRawTransportFields(rawPayload)
+    for (const alias of ATTACHMENT_PAYLOAD_ALIASES) {
+      if (Object.prototype.hasOwnProperty.call(rawPayload, alias)) {
+        throw new TypeError(`send attachments must use the attachments manifest, not ${alias}`)
+      }
+    }
+  }
+
+  const payload = cloneJson(rawPayload, 'command payload')
+
+  if (kind === 'send' && Object.prototype.hasOwnProperty.call(payload, 'attachments')) {
+    payload.attachments = normalizeAttachmentManifest(payload.attachments, { requireRefs: true })
+  }
+
+  return {
+    commandId,
+    kind,
+    roomId,
+    authorityId,
+    connectionId,
+    payload,
+    status: raw.status === 'failed' ? 'failed' : raw.status === 'in-flight' ? 'in-flight' : 'pending',
+    attempts: nonNegativeInteger(raw.attempts),
+    failureCode: text(raw.failureCode)
+  }
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
+function commandSignature(command) {
+  return stableJson({
+    commandId: command.commandId,
+    kind: command.kind,
+    roomId: command.roomId,
+    authorityId: command.authorityId,
+    connectionId: command.connectionId,
+    payload: command.payload
+  })
+}
+
+/** Rehydrate a persisted outbox. An in-flight command has an unknown outcome
+ * after relaunch, so it returns to pending with the same idempotency key. */
+export function createHostedRoomOutbox(persisted = null) {
+  const commands = []
+
+  for (const raw of Array.isArray(persisted?.commands) ? persisted.commands : []) {
+    const command = normalizeCommand(raw)
+    const existing = commands.find(candidate => candidate.commandId === command.commandId)
+
+    command.status = command.status === 'in-flight' ? 'pending' : command.status
+
+    if (!existing) {
+      commands.push(command)
+    } else if (commandSignature(existing) !== commandSignature(command)) {
+      throw new TypeError(`commandId ${command.commandId} has conflicting persisted content`)
+    }
+  }
+
+  return { version: 1, commands }
+}
+
+function updateCommand(state, commandId, mutate) {
+  const index = state.commands.findIndex(command => command.commandId === commandId)
+
+  if (index < 0) {
+    return state
+  }
+
+  const commands = [...state.commands]
+  commands[index] = mutate({ ...commands[index] })
+
+  return { ...state, commands }
+}
+
+/** Pure state transitions for persisted create/send/stop/disband commands. */
+export function reduceHostedRoomOutbox(state, action) {
+  const current = state && Array.isArray(state.commands) ? state : createHostedRoomOutbox()
+
+  if (!action || typeof action !== 'object') {
+    throw new TypeError('outbox action must be an object')
+  }
+
+  if (action.type === 'enqueue') {
+    const command = normalizeCommand(action.command)
+    const existing = current.commands.find(candidate => candidate.commandId === command.commandId)
+
+    command.status = 'pending'
+
+    if (existing) {
+      if (commandSignature(existing) !== commandSignature(command)) {
+        throw new TypeError(`commandId ${command.commandId} is already bound to different content`)
+      }
+      return current
+    }
+
+    return { ...current, commands: [...current.commands, command] }
+  }
+
+  const commandId = text(action.commandId)
+
+  if (!commandId) {
+    throw new TypeError('outbox action requires commandId')
+  }
+
+  if (action.type === 'dispatch') {
+    return updateCommand(current, commandId, command => ({
+      ...command,
+      status: 'in-flight',
+      attempts: command.attempts + 1,
+      failureCode: null
+    }))
+  }
+  if (action.type === 'retry' || action.type === 'transient-failure') {
+    return updateCommand(current, commandId, command => ({ ...command, status: 'pending' }))
+  }
+  if (action.type === 'terminal-failure') {
+    return updateCommand(current, commandId, command => ({
+      ...command,
+      status: 'failed',
+      failureCode: text(action.failureCode) || 'command-failed'
+    }))
+  }
+  if (action.type === 'acknowledge') {
+    if (!current.commands.some(command => command.commandId === commandId)) {
+      return current
+    }
+    return { ...current, commands: current.commands.filter(command => command.commandId !== commandId) }
+  }
+
+  throw new TypeError(`unsupported outbox action: ${action.type}`)
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -599,6 +599,69 @@ function groupChatRoomKey(name, room) {
     : `name:${String(name)}`
 }
 
+/** Gateway id/label for a backend-hosted room. The field is additive in the
+ *  v3 projection; older clients ignore it, while hosted-aware clients must
+ *  never start a second local round driver for the same room. */
+function groupChatHostedGateway(room) {
+  return typeof room?.hosted === 'string' ? room.hosted.trim().slice(0, 128) : ''
+}
+
+/** Monotonic fencing epoch for the hosted room authority. Draft rooms that
+ *  predate the field are epoch 1; local rooms have no hosted epoch. */
+function groupChatHostedEpoch(room) {
+  const epoch = Number(room?.hostedEpoch || 0)
+  if (Number.isSafeInteger(epoch) && epoch >= 1) {
+    return epoch
+  }
+  return groupChatHostedGateway(room) ? 1 : 0
+}
+
+/** Apply an authority coordinate read directly from ``groups.state``.
+ *  Display projections are client-writable caches and must never call this
+ *  helper. Only a higher server-issued epoch may replace an existing owner. */
+function applyHostedRoomAuthority(room, serverRoom) {
+  const authorityGateway = groupChatHostedGateway({ hosted: serverRoom?.authority_gateway_id })
+  const authorityEpoch = Number(serverRoom?.authority_epoch || 0)
+  const roomId = typeof room?.roomId === 'string' ? room.roomId : ''
+  const serverRoomId = typeof serverRoom?.room_id === 'string' ? serverRoom.room_id : ''
+
+  if (
+    !authorityGateway ||
+    !Number.isSafeInteger(authorityEpoch) ||
+    authorityEpoch < 1 ||
+    (roomId && serverRoomId && roomId !== serverRoomId)
+  ) {
+    return room
+  }
+
+  const currentGateway = groupChatHostedGateway(room)
+  const currentEpoch = groupChatHostedEpoch(room)
+  const claim = serverRoom?.authority_claim
+  const claimPayload = claim?.payload
+  const transferProven = Boolean(
+    claim?.kind === 'authority.claimed' &&
+      claim?.actor?.kind === 'system' &&
+      claim?.actor?.id === 'authority-control' &&
+      Number(claim?.authority_epoch || 0) === authorityEpoch &&
+      claimPayload?.previous_gateway_id === currentGateway &&
+      claimPayload?.authority_gateway_id === authorityGateway &&
+      Number(claimPayload?.authority_epoch || 0) === authorityEpoch
+  )
+  if (
+    currentEpoch > authorityEpoch ||
+    (currentGateway && currentGateway !== authorityGateway && !transferProven) ||
+    (currentEpoch === authorityEpoch && currentGateway && currentGateway !== authorityGateway)
+  ) {
+    return room
+  }
+
+  return {
+    ...room,
+    hosted: authorityGateway,
+    hostedEpoch: authorityEpoch
+  }
+}
+
 /** Lift any historical projection shape (v1 wall-clock, v2 name-keyed) to
  *  the v3 room-key shape so one merge path serves mixed-version fleets. */
 function normalizeGroupChatSyncSnapshot(snapshot) {
@@ -660,6 +723,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
   for (const [name, room] of ranked) {
     const log = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
       ...(entry?.id ? { id: String(entry.id).slice(0, 160) } : {}),
+      ...(groupChatSyncSequence(entry) !== null ? { seq: groupChatSyncSequence(entry) } : {}),
       from: {
         kind: entry?.from?.kind === 'member' ? 'member' : 'user',
         name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
@@ -672,6 +736,11 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
     const compact = {
       name: String(name).slice(0, 64),
       ...(typeof room?.roomId === 'string' && room.roomId ? { roomId: String(room.roomId).slice(0, 128) } : {}),
+      // Presence is the compatibility contract: current clients always emit
+      // a value or null. Older clients omit the unknown field, which must not
+      // be interpreted as moving a hosted room back to local execution.
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
@@ -704,6 +773,12 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
 }
 
 function groupChatSyncEntryKey(entry) {
+  const seq = groupChatSyncSequence(entry)
+
+  if (seq !== null) {
+    return `seq:${seq}`
+  }
+
   if (entry?.id) {
     return `id:${String(entry.id)}`
   }
@@ -722,6 +797,85 @@ function groupChatSyncEntryKey(entry) {
     String(entry?.thread || 'legacy').replace(/^legacy-\d+$/, 'legacy'),
     String(entry?.text || '')
   ])
+}
+
+function groupChatSyncSequence(entry) {
+  const seq = Number(entry?.seq)
+
+  return Number.isSafeInteger(seq) && seq > 0 ? seq : null
+}
+
+/** Hosted gateway logs carry a monotonic per-room sequence. Prefer it when
+ *  both entries have one; legacy/local entries keep their existing time/key
+ *  order until migration assigns them a sequence. */
+function compareGroupChatSyncEntries(left, right) {
+  const leftSeq = groupChatSyncSequence(left)
+  const rightSeq = groupChatSyncSequence(right)
+
+  if (leftSeq !== null && rightSeq !== null) {
+    return leftSeq - rightSeq || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+  }
+
+  const byTime = Number(left?.at || 0) - Number(right?.at || 0)
+
+  return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+}
+
+/** Union gateway replay with a legacy/local mirror without duplicating the
+ *  same event across its two identities. A hosted replay may add ``seq`` to
+ *  an entry the local room already knows by ``id``; repeated replay may also
+ *  carry different transport ids for the same authoritative sequence. Keep
+ *  both indexes while preferring the gateway sequence for ordering. */
+function mergeGroupChatSyncEntries(...logs) {
+  const entries = []
+  const byId = new Map()
+  const bySeq = new Map()
+
+  const remember = (entry, index) => {
+    const id = entry?.id ? String(entry.id) : ''
+    const seq = groupChatSyncSequence(entry)
+
+    if (id) {
+      byId.set(id, index)
+    }
+
+    if (seq !== null) {
+      bySeq.set(seq, index)
+    }
+  }
+
+  for (const entry of logs.flat()) {
+    const id = entry?.id ? String(entry.id) : ''
+    const seq = groupChatSyncSequence(entry)
+    let index = id ? byId.get(id) : undefined
+
+    if (index === undefined && seq !== null) {
+      index = bySeq.get(seq)
+    }
+
+    if (index === undefined) {
+      index = entries.length
+      entries.push(entry)
+      remember(entry, index)
+      continue
+    }
+
+    const prior = entries[index]
+    const authoritativeSeq = groupChatSyncSequence(prior) ?? seq
+    const merged = {
+      ...prior,
+      ...entry,
+      ...(prior?.images && !entry?.images ? { images: prior.images } : {}),
+      ...(prior?.id && !entry?.id ? { id: prior.id } : {}),
+      ...(authoritativeSeq !== null ? { seq: authoritativeSeq } : {})
+    }
+    entries[index] = merged
+    remember(prior, index)
+    remember(entry, index)
+    remember(merged, index)
+  }
+
+  return entries.sort(compareGroupChatSyncEntries)
 }
 
 function groupChatSyncMemberKey(member) {
@@ -804,24 +958,48 @@ function mergeGroupChatSyncSnapshots(
     const localRevision = changed.has(key)
       ? Math.max(0, Number(writeRevision || 0))
       : Math.max(0, Number(localRoom?.revision || 0))
-    const entries = new Map()
-    for (const entry of [...(remoteRoom?.log || []), ...(localRoom?.log || [])]) {
-      entries.set(groupChatSyncEntryKey(entry), entry)
-    }
+    const entries = mergeGroupChatSyncEntries(remoteRoom?.log || [], localRoom?.log || [])
 
     // Identity fields (display name, membership, picture) follow the higher
     // revision; a tie unions members and prefers the local writer's fields.
     let identity
     let members
     let image
+    let hosted
+    let hostedEpoch = 0
+    let hostedPresent = false
+    const remoteHostedPresent = Object.prototype.hasOwnProperty.call(remoteRoom || {}, 'hosted')
+    const localHostedPresent = Object.prototype.hasOwnProperty.call(localRoom || {}, 'hosted')
+    const remoteHostedEpoch = groupChatHostedEpoch(remoteRoom)
+    const localHostedEpoch = groupChatHostedEpoch(localRoom)
     if (localRevision > remoteRevision) {
       identity = localRoom
       members = [...(localRoom?.members || [])]
       image = localRoom?.image
+      if (localHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(localRoom)
+        hostedEpoch = groupChatHostedEpoch(localRoom)
+      } else if (remoteHostedPresent) {
+        // A newer legacy writer omitted a field it cannot understand. Keep
+        // the last explicit hosted/local statement from the other side.
+        hostedPresent = true
+        hosted = groupChatHostedGateway(remoteRoom)
+        hostedEpoch = groupChatHostedEpoch(remoteRoom)
+      }
     } else if (remoteRevision > localRevision) {
       identity = remoteRoom
       members = [...(remoteRoom?.members || [])]
       image = remoteRoom?.image
+      if (remoteHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(remoteRoom)
+        hostedEpoch = groupChatHostedEpoch(remoteRoom)
+      } else if (localHostedPresent) {
+        hostedPresent = true
+        hosted = groupChatHostedGateway(localRoom)
+        hostedEpoch = groupChatHostedEpoch(localRoom)
+      }
     } else {
       identity = localRoom || remoteRoom
       const byId = new Map()
@@ -830,18 +1008,34 @@ function mergeGroupChatSyncSnapshots(
       }
       members = [...byId.values()]
       image = Object.prototype.hasOwnProperty.call(localRoom || {}, 'image') ? localRoom.image : remoteRoom?.image
+      hostedPresent = localHostedPresent || remoteHostedPresent
+      hosted = localHostedPresent ? groupChatHostedGateway(localRoom) : groupChatHostedGateway(remoteRoom)
+      hostedEpoch = localHostedPresent ? groupChatHostedEpoch(localRoom) : groupChatHostedEpoch(remoteRoom)
+    }
+    // Both snapshots are client-writable display projections, not authority
+    // receipts. Keep an existing non-empty owner as a conservative execution
+    // fence; a larger client-authored epoch cannot replace or clear it.
+    const remoteHosted = groupChatHostedGateway(remoteRoom)
+    const localHosted = groupChatHostedGateway(localRoom)
+    if (remoteHosted) {
+      hostedPresent = true
+      hosted = remoteHosted
+      hostedEpoch = remoteHostedEpoch
+    } else if (localHosted) {
+      hostedPresent = true
+      hosted = localHosted
+      hostedEpoch = localHostedEpoch
     }
     rooms[key] = {
       ...(identity?.name ? { name: identity.name } : {}),
       ...(identity?.roomId || (key.startsWith('id:') ? key.slice(3) : '')
         ? { roomId: identity?.roomId || key.slice(3) }
         : {}),
-      log: [...entries.values()].sort((left, right) => {
-        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
-        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
-      }),
+      log: entries,
       members,
       revision: Math.max(remoteRevision, localRevision),
+      ...(hostedPresent ? { hosted: hosted || null } : {}),
+      ...(hostedPresent ? { hostedEpoch: hostedEpoch || null } : {}),
       ...(typeof image === 'string' && image ? { image } : {})
     }
   }
@@ -963,6 +1157,14 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       }
     }
     const isPreserved = preserved.has(displayName) || (localName && preserved.has(localName))
+    const projectedAuthorityEpoch = groupChatHostedEpoch(projected)
+    const existingAuthorityEpoch = groupChatHostedEpoch(existing)
+    const projectedHosted = groupChatHostedGateway(projected)
+    const existingHosted = groupChatHostedGateway(existing)
+    // ``ui_meta`` is only a cache. It may initialize a fail-safe hosted fence,
+    // but it cannot replace or clear one already held by this runtime.
+    const cachedHosted = existingHosted || projectedHosted
+    const cachedHostedEpoch = existingHosted ? existingAuthorityEpoch : projectedAuthorityEpoch
     if (!isPreserved) {
       if (remoteRevision > localRevision) {
         members.clear()
@@ -972,12 +1174,7 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       }
     }
 
-    const log = assignLegacyThreads(
-      [...entries.values()].sort((left, right) => {
-        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
-        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
-      })
-    )
+    const log = assignLegacyThreads([...entries.values()].sort(compareGroupChatSyncEntries))
     const bounded = trimGroupChatLog(log, existing.watermarks || {})
 
     // A remote rename with a higher revision moves the local record to the
@@ -1001,6 +1198,8 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
         : remoteRevision >= localRevision && Object.prototype.hasOwnProperty.call(projected, 'image')
           ? projected.image || null
           : existing.image || null,
+      hosted: cachedHosted || null,
+      hostedEpoch: cachedHostedEpoch || null,
       syncRevision: isPreserved ? localRevision : Math.max(remoteRevision, localRevision),
       epoch: Number(existing.epoch || 0),
       running: Boolean(existing.running)
@@ -1051,7 +1250,9 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       log: room.log,
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
+      sessionOwners: room.sessionOwners || {},
       stranded: room.stranded || {},
+      holds: room.holds || {},
       members: Array.isArray(room.members) ? room.members : [],
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
@@ -1059,12 +1260,51 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       // name-keyed identity — same field updateGroupChat's inline map
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
 
   return durable
+}
+
+/** Rehydrate the durable room cache without weakening execution authority.
+ *  Runtime-only loop state always resets, but a hosted marker is a safety
+ *  fence: dropping it while its gateway is offline would let the renderer
+ *  start the legacy local driver after a relaunch. */
+function hydratePersistedGroupChatRooms(value) {
+  const rooms = {}
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return rooms
+  }
+
+  for (const [name, room] of Object.entries(value)) {
+    if (!room || !Array.isArray(room.log)) {
+      continue
+    }
+
+    rooms[name] = {
+      log: assignLegacyThreads(room.log),
+      watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
+      sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
+      sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
+      stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
+      holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
+      members: Array.isArray(room.members) ? room.members : [],
+      roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      hosted: groupChatHostedGateway(room) || null,
+      hostedEpoch: groupChatHostedEpoch(room) || null,
+      image: typeof room.image === 'string' && room.image ? room.image : null,
+      syncRevision: Math.max(0, Number(room.syncRevision || 0)),
+      epoch: 0,
+      running: false
+    }
+  }
+
+  return rooms
 }
 
 function persistGroupChatRooms(all = $groupChats.get()) {
@@ -7018,6 +7258,8 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         members: Array.isArray(room.members) ? room.members : [],
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+        hosted: groupChatHostedGateway(room) || null,
+        hostedEpoch: groupChatHostedEpoch(room) || null,
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
@@ -7106,6 +7348,8 @@ async function disbandGroupChat(group, members) {
           sessionOwners: room.sessionOwners || {},
           members: Array.isArray(room.members) ? room.members : [],
           roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+          hosted: groupChatHostedGateway(room) || null,
+          hostedEpoch: groupChatHostedEpoch(room) || null,
           image: room.image || null,
           syncRevision: Math.max(0, Number(room.syncRevision || 0))
         }
@@ -7271,6 +7515,13 @@ function normalizeGroupChatText(text) {
 }
 
 function appendGroupChatEntry(group, from, text, thread, images) {
+  // Once a gateway owns the room, its monotonic log is authoritative. Late
+  // renderer harvest/clarify callbacks from the pre-hosted epoch must not
+  // mutate the read mirror after ownership moves.
+  if (groupChatHostedGateway($groupChats.get()[group])) {
+    return null
+  }
+
   const entry = {
     id: groupChatEntryId(),
     at: Date.now(),
@@ -8553,8 +8804,17 @@ async function harvestStrandedUntilSettled(group, members, thread) {
 function sendToGroupChat(group, members, text, thread, images) {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
+  const hosted = groupChatHostedGateway($groupChats.get()[group])
 
   if ((!trimmed && !attached.length) || !members.length) {
+    return null
+  }
+
+  if (hosted) {
+    host.notify?.({
+      kind: 'info',
+      message: `“${group}” runs on ${hosted}. Sending to hosted rooms isn't available in this build yet.`
+    })
     return null
   }
 
@@ -15735,31 +15995,7 @@ export default {
       Promise.resolve(ctx.storage?.get?.('group-chats'))
         .then(async value => {
           if (value && typeof value === 'object' && !Array.isArray(value)) {
-            const rooms = {}
-
-            for (const [name, room] of Object.entries(value)) {
-              if (room && Array.isArray(room.log)) {
-                rooms[name] = {
-                  // Pre-thread entries get synthetic thread ids on hydrate so
-                  // every UI/engine path can assume entry.thread exists.
-                  log: assignLegacyThreads(room.log),
-                  watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
-                  sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
-                  sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
-                  stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
-                  // #93129: rehydrate sticky stop holds with the same shape
-                  // guard as the other maps — a held bot stays held across
-                  // window restarts until explicitly released.
-                  holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
-                  members: Array.isArray(room.members) ? room.members : [],
-                  roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
-                  image: typeof room.image === 'string' && room.image ? room.image : null,
-                  syncRevision: Math.max(0, Number(room.syncRevision || 0)),
-                  epoch: 0,
-                  running: false
-                }
-              }
-            }
+            const rooms = hydratePersistedGroupChatRooms(value)
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -42,6 +42,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   EmptyState,
+  ErrorState,
   GlyphSpinner,
   haptic,
   host,
@@ -563,6 +564,15 @@ const groupChatSyncInFlightConnections = new Set()
 const groupChatSyncRetryTimers = new Map()
 const groupChatSyncRetryCounts = new Map()
 let groupChatSyncDisposed = false
+
+const HOSTED_ROOM_OUTBOX_KEY = 'hosted-room-outbox-v1'
+const HOSTED_ROOM_SYNC_INTERVAL_MS = 5000
+const $hostedRoomCapabilities = atom({})
+const $hostedRoomOutbox = atom({ version: 1, commands: [] })
+let hostedRoomSyncTimer = null
+let hostedRoomSyncRunning = false
+let hostedRoomSyncDisposed = false
+const hostedAuthorityRoutes = new Map()
 
 /** Conservative byte count for the gateway's ensure_ascii JSON encoding.
  *  Python also inserts separator spaces, so reserve one extra byte per JS
@@ -1262,6 +1272,11 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
+      hostedConnectionId:
+        typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+          ? room.hostedConnectionId
+          : null,
+      hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
@@ -1297,6 +1312,11 @@ function hydratePersistedGroupChatRooms(value) {
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       hosted: groupChatHostedGateway(room) || null,
       hostedEpoch: groupChatHostedEpoch(room) || null,
+      hostedConnectionId:
+        typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+          ? room.hostedConnectionId
+          : null,
+      hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
       image: typeof room.image === 'string' && room.image ? room.image : null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0)),
       epoch: 0,
@@ -1459,6 +1479,323 @@ async function groupChatSyncRequest(job, method, params) {
     throw new Error('Group chat gateway changed before sync')
   }
   return host.request(method, params)
+}
+
+async function hostedDefaultRoutes() {
+  if (typeof host.profileRoutes !== 'function') {
+    return []
+  }
+  const routes = await host.profileRoutes()
+  const byConnection = new Map()
+
+  for (const route of Array.isArray(routes) ? routes : []) {
+    const profile = String(route?.targetProfile || route?.profile || '')
+    const connectionId = String(route?.connectionId || '')
+
+    if (!connectionId || profile !== 'default' || byConnection.has(connectionId)) {
+      continue
+    }
+    byConnection.set(connectionId, route)
+  }
+
+  return [...byConnection.values()]
+}
+
+async function requestHostedConnection(route, method, params = {}) {
+  if (!route?.connectionId || typeof host.requestProfile !== 'function') {
+    throw new Error('Hermes gateway is unavailable')
+  }
+  return host.requestProfile(route, method, params)
+}
+
+function hostedMemberDescriptors(room, connectionId, connectionLabel) {
+  return (Array.isArray(room?.members) ? room.members : []).map(member => ({
+    name: String(member?.profile || member?.member_id || 'default'),
+    handle: String(member?.handle || member?.profile || 'hermes'),
+    title: String(member?.display_name || ''),
+    connectionId,
+    connectionLabel,
+    remoteSource: true,
+    sourceScoped: true,
+    targetProfile: String(member?.profile || 'default')
+  }))
+}
+
+async function refreshHostedRooms() {
+  if (hostedRoomSyncDisposed || hostedRoomSyncRunning) {
+    return
+  }
+  hostedRoomSyncRunning = true
+
+  try {
+    const client = await import('./hosted-room-client.js')
+    const routes = await hostedDefaultRoutes()
+    const sources = new Map(
+      ($lastSources.get() || []).map(source => [String(source?.connectionId || ''), source])
+    )
+    const capabilities = { ...$hostedRoomCapabilities.get() }
+
+    for (const route of routes) {
+      const connectionId = String(route.connectionId)
+      let capability
+
+      try {
+        const result = await requestHostedConnection(route, 'groups.capabilities', {})
+        capability = client.classifyHostedRoomCapability(result, { connectionId })
+      } catch (error) {
+        capability = client.classifyHostedRoomCapability({ ok: false, error }, { connectionId })
+      }
+
+      capabilities[connectionId] = capability
+      if (
+        capability.kind !== 'driver-capable' ||
+        capability.persistentProcess !== true ||
+        !capability.authorityId
+      ) {
+        continue
+      }
+
+      hostedAuthorityRoutes.set(capability.authorityId, route)
+      let listed
+      try {
+        listed = await requestHostedConnection(route, 'groups.list', {})
+      } catch {
+        continue
+      }
+
+      for (const listedRoom of Array.isArray(listed?.rooms) ? listed.rooms : []) {
+        const roomId = String(listedRoom?.room_id || '')
+        const roomName = String(listedRoom?.name || '').trim()
+
+        if (!roomId || !roomName) continue
+        let serverState
+        try {
+          serverState = await requestHostedConnection(route, 'groups.state', { room_id: roomId })
+        } catch {
+          continue
+        }
+        const roomState = serverState?.room || listedRoom
+        const existingEntry = Object.entries($groupChats.get()).find(
+          ([, room]) => String(room?.roomId || '') === roomId
+        )
+        const existingName = existingEntry?.[0] || roomName
+        const existing = existingEntry?.[1] || {}
+        const replay = await client.replayHostedRoomPages({
+          state: client.createHostedRoomReplayState({
+            roomId,
+            name: roomName,
+            members: roomState.members,
+            authorityId: roomState.authority_gateway_id,
+            authorityEpoch: roomState.authority_epoch,
+            connectionId,
+            cursor: Number(existing.hostedSeq || 0),
+            messages: existing.log || []
+          }),
+          fetchPage: ({ sinceSeq, limit }) =>
+            requestHostedConnection(route, 'groups.log', {
+              room_id: roomId,
+              since_seq: sinceSeq,
+              limit
+            })
+        })
+        const source = sources.get(connectionId)
+        const label = source?.label || source?.connectionLabel || connectionId
+        const replayState = replay.state
+
+        updateGroupChat(existingName, room => {
+          const authoritative = applyHostedRoomAuthority(room, roomState)
+
+          return {
+            ...authoritative,
+            roomId,
+            members: hostedMemberDescriptors(roomState, connectionId, label),
+            log: mergeGroupChatSyncEntries(room.log || [], replayState.messages || []),
+            hostedConnectionId: connectionId,
+            hostedSeq: replayState.cursor,
+            hostedStatus: client.deriveFriendlyHostedRoomStatus(replayState),
+            running: replayState.lastStatusEvent?.kind === 'turn.started'
+          }
+        }, { sync: false })
+      }
+    }
+
+    $hostedRoomCapabilities.set(capabilities)
+  } finally {
+    hostedRoomSyncRunning = false
+  }
+}
+
+function scheduleHostedRoomSync(delay = HOSTED_ROOM_SYNC_INTERVAL_MS) {
+  if (hostedRoomSyncDisposed || typeof window === 'undefined') return
+  if (hostedRoomSyncTimer) window.clearTimeout(hostedRoomSyncTimer)
+  hostedRoomSyncTimer = window.setTimeout(async () => {
+    hostedRoomSyncTimer = null
+    await refreshHostedRooms().catch(() => undefined)
+    scheduleHostedRoomSync()
+  }, delay)
+}
+
+function stopHostedRoomSync() {
+  hostedRoomSyncDisposed = true
+  if (hostedRoomSyncTimer && typeof window !== 'undefined') {
+    window.clearTimeout(hostedRoomSyncTimer)
+  }
+  hostedRoomSyncTimer = null
+}
+
+async function hostedRouteForRoom(room) {
+  const cachedId = String(room?.hostedConnectionId || '')
+  if (cachedId) {
+    const route = (await hostedDefaultRoutes()).find(candidate => String(candidate?.connectionId || '') === cachedId)
+    if (route) return route
+  }
+  return hostedAuthorityRoutes.get(groupChatHostedGateway(room)) || null
+}
+
+async function persistHostedRoomOutbox() {
+  try {
+    await pluginCtx?.storage?.set?.(HOSTED_ROOM_OUTBOX_KEY, $hostedRoomOutbox.get())
+  } catch {
+    /* a later mutation retries persistence */
+  }
+}
+
+let hostedOutboxDispatching = false
+
+async function dispatchHostedRoomOutbox() {
+  if (hostedOutboxDispatching || hostedRoomSyncDisposed) return
+  hostedOutboxDispatching = true
+
+  try {
+    const client = await import('./hosted-room-client.js')
+    let state = $hostedRoomOutbox.get()
+
+    for (const command of state.commands.filter(entry => entry.status === 'pending')) {
+      const routes = await hostedDefaultRoutes()
+      const route = routes.find(candidate => String(candidate?.connectionId || '') === command.connectionId)
+
+      if (!route) continue
+      state = client.reduceHostedRoomOutbox(state, { type: 'dispatch', commandId: command.commandId })
+      $hostedRoomOutbox.set(state)
+      await persistHostedRoomOutbox()
+
+      const method = {
+        create: 'groups.create',
+        send: 'groups.send',
+        stop: 'groups.stop',
+        disband: 'groups.disband'
+      }[command.kind]
+      const params =
+        command.kind === 'send'
+          ? { room_id: command.roomId, event_id: command.commandId, payload: command.payload }
+          : command.kind === 'stop'
+            ? { room_id: command.roomId, cancel_id: command.commandId }
+            : command.kind === 'disband'
+              ? { room_id: command.roomId, cancel_id: command.commandId }
+              : command.payload
+
+      try {
+        await requestHostedConnection(route, method, params)
+        state = client.reduceHostedRoomOutbox(state, { type: 'acknowledge', commandId: command.commandId })
+        $hostedRoomOutbox.set(state)
+        await persistHostedRoomOutbox()
+        scheduleHostedRoomSync(0)
+      } catch {
+        state = client.reduceHostedRoomOutbox(state, { type: 'transient-failure', commandId: command.commandId })
+        $hostedRoomOutbox.set(state)
+        await persistHostedRoomOutbox()
+      }
+    }
+  } finally {
+    hostedOutboxDispatching = false
+  }
+}
+
+async function enqueueHostedRoomCommand(command) {
+  const client = await import('./hosted-room-client.js')
+  const next = client.reduceHostedRoomOutbox($hostedRoomOutbox.get(), {
+    type: 'enqueue',
+    command
+  })
+  $hostedRoomOutbox.set(next)
+  await persistHostedRoomOutbox()
+  await dispatchHostedRoomOutbox()
+}
+
+function hostedAttachmentRef(eventId, index, memberId) {
+  const seed = `${eventId}-${index}-${memberId}`.replace(/[^A-Za-z0-9._:-]/g, '-').slice(0, 220)
+  return `staged:${seed || `attachment-${index}`}`
+}
+
+function attachmentMime(attachment) {
+  if (attachment?.mime) return String(attachment.mime)
+  const match = /^data:([^;,]+)/i.exec(String(attachment?.data || ''))
+  return match?.[1] || (attachment?.kind === 'pdf' ? 'application/pdf' : attachment?.kind === 'image' ? 'image/png' : 'application/octet-stream')
+}
+
+async function stageHostedAttachments(group, members, eventId, attachments) {
+  const picked = (Array.isArray(attachments) ? attachments : []).slice(0, 8)
+  if (!picked.length) return []
+  const manifests = picked.map(attachment => ({
+    kind: attachment.kind,
+    name: attachment.name || 'attachment',
+    size: Math.max(0, Number(attachment.size || 0)),
+    mime: attachmentMime(attachment),
+    refs: {}
+  }))
+
+  for (const member of members) {
+    const { runtime } = await ensureGroupChatSession(group, member)
+    if (!runtime) throw new Error(`${displayName(member, botRosterMeta(member, $botMeta.get()))} is unavailable.`)
+    const memberId = member.name === 'default' ? 'default' : member.name
+
+    for (let index = 0; index < picked.length; index++) {
+      const attachment = picked[index]
+      if (attachment.kind === 'pdf') {
+        await requestForBot(member, 'pdf.attach', {
+          session_id: runtime,
+          content_base64: attachment.data,
+          filename: attachment.name || 'attachment.pdf'
+        })
+      } else if (attachment.kind === 'file') {
+        await requestForBot(member, 'file.attach', {
+          session_id: runtime,
+          data_url: attachment.data,
+          name: attachment.name || 'attachment'
+        })
+      } else {
+        await requestForBot(member, 'image.attach_bytes', {
+          session_id: runtime,
+          content_base64: attachment.data,
+          filename: attachment.name || 'attachment.png'
+        })
+      }
+      manifests[index].refs[memberId] = hostedAttachmentRef(eventId, index, memberId)
+    }
+  }
+
+  return manifests
+}
+
+async function sendHostedGroupChat(group, members, sent, thread, attachments) {
+  const room = $groupChats.get()[group]
+  const route = await hostedRouteForRoom(room)
+  if (!route) {
+    throw new Error('This group is offline. Try again when its gateway reconnects.')
+  }
+  const manifests = await stageHostedAttachments(group, members, sent.id, attachments)
+  await enqueueHostedRoomCommand({
+    commandId: sent.id,
+    kind: 'send',
+    roomId: room.roomId,
+    authorityId: groupChatHostedGateway(room),
+    connectionId: String(route.connectionId),
+    payload: {
+      text: sent.text || '',
+      thread_id: thread,
+      ...(manifests.length ? { attachments: manifests } : {})
+    }
+  })
 }
 
 async function groupChatRemoteSnapshot(job) {
@@ -4292,7 +4629,11 @@ async function filesToGroupAttachments(files) {
     picked.push({
       name: file.name || (kind === 'image' ? 'pasted image' : 'attachment'),
       data: kind === 'image' ? await normalizeGroupAttachment(data) : data,
-      kind
+      kind,
+      size: Number(file.size || 0),
+      mime:
+        file.type ||
+        (kind === 'image' ? 'image/png' : kind === 'pdf' ? 'application/pdf' : 'application/octet-stream')
     })
   }
 
@@ -7260,6 +7601,11 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         hosted: groupChatHostedGateway(room) || null,
         hostedEpoch: groupChatHostedEpoch(room) || null,
+        hostedConnectionId:
+          typeof room.hostedConnectionId === 'string' && room.hostedConnectionId
+            ? room.hostedConnectionId
+            : null,
+        hostedSeq: Math.max(0, Number(room.hostedSeq || 0)),
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
@@ -12794,6 +13140,12 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
   const [checked, setChecked] = useState({})
   const [name, setName] = useState('')
   const [image, setImage] = useState(null)
+  const [keepRunning, setKeepRunning] = useState(false)
+  const [hostCapability, setHostCapability] = useState(null)
+  const [hostRoute, setHostRoute] = useState(null)
+  const [hostProbePending, setHostProbePending] = useState(false)
+  const [createPending, setCreatePending] = useState(false)
+  const [createError, setCreateError] = useState('')
 
   // Reset per open so a cancelled draft doesn't leak into the next one.
   useEffect(() => {
@@ -12802,6 +13154,12 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
       setChecked({})
       setName('')
       setImage(null)
+      setKeepRunning(false)
+      setHostCapability(null)
+      setHostRoute(null)
+      setHostProbePending(false)
+      setCreatePending(false)
+      setCreateError('')
     }
   }, [open])
 
@@ -12816,7 +13174,66 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     : 'Group name'
   const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
 
-  const create = () => {
+  const selectedRouteKey = selected.map(botRosterKey).sort().join('|')
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!open || selected.length < 2) {
+      setHostCapability(null)
+      setHostRoute(null)
+      setKeepRunning(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setHostProbePending(true)
+    void import('./hosted-room-client.js')
+      .then(async client => {
+        if (cancelled) return
+        const route = client.resolveSingleGatewayRoute(selected, {
+          activeConnectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+        })
+        setHostRoute(route)
+        if (route.kind !== 'single-gateway') {
+          setHostCapability(null)
+          setKeepRunning(false)
+          return
+        }
+        const result = await requestForBot(selected[0], 'groups.capabilities', {})
+        if (cancelled) return
+        const capability = client.classifyHostedRoomCapability(result, {
+          connectionId: route.connectionId
+        })
+        setHostCapability(capability)
+        if (capability.kind !== 'driver-capable' || capability.persistentProcess !== true) {
+          setKeepRunning(false)
+        }
+      })
+      .catch(error => {
+        if (cancelled) return
+        setHostCapability({ kind: 'transient-failure', reason: 'probe-failed', error })
+        setHostRoute(null)
+        setKeepRunning(false)
+      })
+      .finally(() => {
+        if (!cancelled) setHostProbePending(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // The key is stable across harmless roster object refreshes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, selectedRouteKey])
+
+  const hostedEligible =
+    hostRoute?.kind === 'single-gateway' &&
+    hostCapability?.kind === 'driver-capable' &&
+    hostCapability?.persistentProcess === true
+
+  const create = async () => {
     const base = (name.trim() || placeholder).slice(0, 64)
 
     if (selected.length < 2 || !base) {
@@ -12842,29 +13259,67 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     const groupName = uniqueGroupChatName(base, taken)
     const roomId = mintGroupRoomId()
 
-    for (const bot of selected) {
-      void saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, allMeta), groupName, true))
-    }
-
     // Persist every machine identity, including today's active source. That
     // member becomes remote after a source switch and cannot rely on the new
     // gateway's name-keyed bot metadata to remain seated in this room.
     const roomMembers = durableGroupChatMembers(selected)
 
-    updateGroupChat(groupName, room => {
-      room.members = roomMembers
-      room.roomId = roomId
+    setCreatePending(true)
+    setCreateError('')
+    let hostedRoom = null
 
-      if (image) {
-        room.image = image
+    try {
+      if (keepRunning) {
+        if (!hostedEligible) {
+          throw new Error('This gateway cannot keep group work running yet.')
+        }
+        const created = await requestForBot(selected[0], 'groups.create', {
+          room_id: roomId,
+          name: groupName,
+          members: selected.map(bot => ({
+            member_id: bot.name === 'default' ? 'default' : bot.name,
+            profile: bot.name,
+            handle: botMentionTag(bot),
+            ...(displayName(bot, botRosterMeta(bot, allMeta))
+              ? { display_name: displayName(bot, botRosterMeta(bot, allMeta)) }
+              : {})
+          }))
+        })
+        hostedRoom = created?.room
+        if (!hostedRoom?.authority_gateway_id) {
+          throw new Error('The gateway did not create the group.')
+        }
       }
 
-      return room
-    })
+      for (const bot of selected) {
+        await saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, allMeta), groupName, true))
+      }
 
-    host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
-    onClose()
-    onCreated?.(groupName)
+      updateGroupChat(groupName, room => {
+        room.members = roomMembers
+        room.roomId = roomId
+
+        if (hostedRoom) {
+          room.hosted = hostedRoom.authority_gateway_id
+          room.hostedEpoch = hostedRoom.authority_epoch || 1
+          room.hostedConnectionId = hostRoute.connectionId
+        }
+
+        if (image) {
+          room.image = image
+        }
+
+        return room
+      })
+
+      host.notify({ kind: 'info', message: `“${groupName}” created with ${selected.length} bots` })
+      onClose()
+      onCreated?.(groupName)
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : 'Could not create the group.')
+    } finally {
+      setCreatePending(false)
+    }
   }
 
   return jsx(Dialog, {
@@ -12987,14 +13442,48 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
             })
           ]
         }),
+        hostedEligible || hostProbePending
+          ? jsxs('div', {
+              className: 'flex items-start justify-between gap-4 py-1',
+              children: [
+                jsxs('div', {
+                  className: 'min-w-0',
+                  children: [
+                    jsx('div', {
+                      className: 'text-xs font-medium text-foreground',
+                      children: 'Keep working when this app is closed'
+                    }),
+                    jsx('div', {
+                      className: 'mt-0.5 text-[0.6875rem] leading-relaxed text-(--ui-text-tertiary)',
+                      children: hostProbePending
+                        ? 'Checking this gateway…'
+                        : `Runs on ${selected[0]?.connectionLabel || 'this Hermes gateway'}.`
+                    })
+                  ]
+                }),
+                jsx(Switch, {
+                  'aria-label': 'Keep group work running when this app is closed',
+                  checked: keepRunning,
+                  disabled: hostProbePending || !hostedEligible,
+                  onCheckedChange: setKeepRunning,
+                  size: 'xs'
+                })
+              ]
+            })
+          : null,
+        createError
+          ? jsx(ErrorState, { title: 'Could not create the group', description: createError })
+          : null,
         jsxs(DialogFooter, {
           children: [
             jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
             jsx(Button, {
-              disabled: !canCreate,
+              disabled: !canCreate || createPending,
               title: selected.length < 2 ? 'Pick at least 2 bots' : undefined,
-              onClick: create,
-              children: `Create Group${selected.length ? ` (${selected.length})` : ''}`
+              onClick: () => void create(),
+              children: createPending
+                ? 'Creating…'
+                : `Create Group${selected.length ? ` (${selected.length})` : ''}`
             })
           ]
         })
@@ -15481,7 +15970,7 @@ function BotsPane() {
                         children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
                       }),
                       jsxs(DropdownMenuItem, {
-                        disabled: activeSourceRoster.length < 2,
+                        disabled: roster.length < 2,
                         onSelect: () => setGroupCreateOpen(true),
                         children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
                       })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -22,6 +22,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   }
   const calls = []
   const clarifyResponds = []
+  const notifications = []
   const approvalResponds = []
   const requests = []
   const sessions = new Map()
@@ -192,7 +193,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
         return {}
       },
       state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } },
-      notify: () => undefined,
+      notify: notification => notifications.push(notification),
       notifyError: () => undefined
     }
   }
@@ -204,7 +205,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, appendGroupChatEntry, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatHostedGateway, applyHostedRoomAuthority, groupChatSyncSequence, compareGroupChatSyncEntries, mergeGroupChatSyncEntries, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, hydratePersistedGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -212,7 +213,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, notifications, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -319,6 +320,7 @@ test('failed member turn is a pass, not a room error', async () => {
 
   const log = roomLog(gc, 'Flaky')
   assert.equal(log.length, 1) // just the user message; no error entries
+  assert.equal(gc.calls.length, MEMBERS.length, 'remaining members still receive their turns')
 })
 
 test('delta injection: a second user send only feeds members the NEW messages', async () => {
@@ -648,6 +650,458 @@ test('group gateway mirror preserves threads and budgets escaped Unicode', () =>
 
   assert.ok(gc.groupChatGatewayJsonSize(snapshot) <= 48000)
   assert.equal(snapshot.rooms['name:Unicode'].log.at(-1).thread, 'thread-15')
+  assert.equal(snapshot.rooms['name:Unicode'].hosted, null, 'current clients state local execution explicitly')
+})
+
+test('hosted-room marker survives projection, cold hydrate, and plugin persistence', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: '  gateway-a  ',
+      syncRevision: 4,
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [{ name: 'research' }]
+    }
+  })
+
+  assert.equal(snapshot.rooms['id:room-hosted'].hosted, 'gateway-a')
+  assert.equal(snapshot.rooms['id:room-hosted'].hostedEpoch, 1)
+
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(snapshot, {})
+  assert.equal(hydrated.Hosted.hosted, 'gateway-a')
+  assert.equal(hydrated.Hosted.hostedEpoch, 1)
+
+  const durable = gc.durableGroupChatRooms(hydrated)
+  assert.equal(durable.Hosted.hosted, 'gateway-a')
+  assert.equal(durable.Hosted.hostedEpoch, 1)
+
+  const reloaded = gc.hydratePersistedGroupChatRooms(durable)
+  assert.equal(reloaded.Hosted.hosted, 'gateway-a')
+  assert.equal(reloaded.Hosted.hostedEpoch, 1)
+  assert.equal(reloaded.Hosted.epoch, 0)
+  assert.equal(reloaded.Hosted.running, false)
+})
+
+test('persisted hosted fence blocks the local driver after relaunch', () => {
+  const gc = load(() => 'must not run')
+  const reloaded = gc.hydratePersistedGroupChatRooms({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: 'gateway-a',
+      hostedEpoch: 3,
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'before restart', at: 1 }],
+      members: [{ name: 'research' }]
+    }
+  })
+
+  gc.$groupChats.set(reloaded)
+  const thread = gc.sendToGroupChat('Hosted', [{ name: 'research' }], 'after restart')
+
+  assert.equal(thread, null)
+  assert.equal(gc.calls.length, 0)
+  assert.match(gc.notifications.at(-1).message, /gateway-a/)
+})
+
+test('remote-merge persistence preserves session ownership and sticky holds', () => {
+  const gc = load(() => '(pass)')
+  const durable = gc.durableGroupChatRooms({
+    Team: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'pause', at: 1 }],
+      watermarks: {},
+      sessions: { research: 'session-1' },
+      sessionOwners: { research: 'gateway-a' },
+      holds: { research: { at: 1, byMessageId: 'm1' } },
+      members: [{ name: 'research' }]
+    }
+  })
+  const reloaded = gc.hydratePersistedGroupChatRooms(durable)
+
+  assert.equal(reloaded.Team.sessionOwners.research, 'gateway-a')
+  assert.equal(reloaded.Team.holds.research.byMessageId, 'm1')
+})
+
+test('a newer legacy revision cannot clear a hosted-room marker by omission', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          hostedEpoch: 1,
+          revision: 3,
+          log: [{ id: 'old', from: { kind: 'user', name: 'You' }, text: 'old', at: 1 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          revision: 4,
+          log: [{ id: 'new', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a fabricated higher client epoch cannot move a hosted room back to local', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 3,
+          log: [{ id: 'old', from: { kind: 'user', name: 'You' }, text: 'old', at: 1 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: null,
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'new', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a fabricated higher client epoch cannot replace a cached hosted owner', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          hostedEpoch: 1,
+          revision: 4,
+          log: [{ id: 'new-owner', from: { kind: 'user', name: 'You' }, text: 'new', at: 2 }]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 99,
+          revision: 99,
+          log: [{ id: 'stale-owner', from: { kind: 'user', name: 'You' }, text: 'stale', at: 3 }]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].hosted, 'gateway-a')
+  assert.equal(merged.rooms['id:room-1'].hostedEpoch, 1)
+})
+
+test('a client-authored local projection cannot clear a cached hosted owner', () => {
+  const gc = load(() => '(pass)')
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'stale', from: { kind: 'user', name: 'You' }, text: 'stale', at: 1 }]
+        }
+      }
+    },
+    {
+      Team: {
+        roomId: 'room-1',
+        hosted: null,
+        hostedEpoch: 3,
+        syncRevision: 5,
+        log: [{ id: 'local', from: { kind: 'user', name: 'You' }, text: 'local', at: 2 }]
+      }
+    },
+    { preserveRooms: ['Team'] }
+  )
+
+  assert.equal(hydrated.Team.hosted, 'gateway-b')
+  assert.equal(hydrated.Team.hostedEpoch, 2)
+})
+
+test('ordinary hydration cannot replace an existing owner from client projection', () => {
+  const gc = load(() => '(pass)')
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Team',
+          roomId: 'room-1',
+          hosted: 'gateway-b',
+          hostedEpoch: 2,
+          revision: 4,
+          log: [{ id: 'new-owner', from: { kind: 'user', name: 'You' }, text: 'new', at: 1 }]
+        }
+      }
+    },
+    {
+      Team: {
+        roomId: 'room-1',
+        hosted: 'gateway-a',
+        hostedEpoch: 1,
+        syncRevision: 99,
+        log: [{ id: 'stale-owner', from: { kind: 'user', name: 'You' }, text: 'stale', at: 2 }]
+      }
+    }
+  )
+
+  assert.equal(hydrated.Team.hosted, 'gateway-a')
+  assert.equal(hydrated.Team.hostedEpoch, 1)
+})
+
+test('a higher server epoch without transfer lineage cannot replace the cached owner', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'gateway-a',
+    hostedEpoch: 1,
+    log: []
+  }
+
+  const updated = gc.applyHostedRoomAuthority(room, {
+    room_id: 'room-1',
+    authority_gateway_id: 'gateway-b',
+    authority_epoch: 2
+  })
+
+  assert.equal(updated.hosted, 'gateway-a')
+  assert.equal(updated.hostedEpoch, 1)
+})
+
+test('a server-issued transfer receipt replaces the cached owner', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'gateway-a',
+    hostedEpoch: 1,
+    log: []
+  }
+
+  const updated = gc.applyHostedRoomAuthority(room, {
+    room_id: 'room-1',
+    authority_gateway_id: 'gateway-b',
+    authority_epoch: 2,
+    authority_claim: {
+      kind: 'authority.claimed',
+      actor: { kind: 'system', id: 'authority-control' },
+      authority_epoch: 2,
+      payload: {
+        previous_gateway_id: 'gateway-a',
+        authority_gateway_id: 'gateway-b',
+        authority_epoch: 2
+      }
+    }
+  })
+
+  assert.equal(updated.hosted, 'gateway-b')
+  assert.equal(updated.hostedEpoch, 2)
+})
+
+test('a receipted legacy adoption converges on the install authority once', () => {
+  const gc = load(() => '(pass)')
+  const room = {
+    roomId: 'room-1',
+    hosted: 'legacy',
+    hostedEpoch: 1,
+    log: []
+  }
+  const serverRoom = {
+    room_id: 'room-1',
+    authority_gateway_id: 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    authority_epoch: 2,
+    authority_claim: {
+      kind: 'authority.claimed',
+      actor: { kind: 'system', id: 'authority-control' },
+      authority_epoch: 2,
+      payload: {
+        previous_gateway_id: 'legacy',
+        authority_gateway_id: 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        authority_epoch: 2
+      }
+    }
+  }
+
+  const adopted = gc.applyHostedRoomAuthority(room, serverRoom)
+  const repeated = gc.applyHostedRoomAuthority(adopted, serverRoom)
+
+  assert.equal(adopted.hosted, 'install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+  assert.equal(adopted.hostedEpoch, 2)
+  assert.deepEqual(repeated, adopted)
+})
+
+test('a hosted-room marker prevents a second local round driver', () => {
+  const gc = load(() => 'must not run')
+  gc.$groupChats.set({
+    Hosted: {
+      roomId: 'room-hosted',
+      hosted: 'gateway-a',
+      log: [],
+      watermarks: {},
+      sessions: {},
+      members: [{ name: 'research' }]
+    }
+  })
+
+  const sent = gc.sendToGroupChat('Hosted', [{ name: 'research', title: '' }], 'do the work')
+
+  assert.equal(sent, null)
+  assert.equal(gc.calls.length, 0, 'no member turn starts locally')
+  assert.equal(gc.$groupChats.get().Hosted.log.length, 0, 'the local mirror stays read-only')
+  assert.equal(gc.notifications.length, 1)
+  assert.equal(gc.notifications[0].kind, 'info')
+  assert.match(gc.notifications[0].message, /gateway-a/)
+  assert.match(gc.notifications[0].message, /isn't available in this build yet/)
+})
+
+test('late renderer callbacks cannot mutate a hosted room mirror', () => {
+  const gc = load(() => '(pass)')
+  gc.$groupChats.set({
+    Hosted: {
+      hosted: 'gateway-a',
+      log: [{ id: 'm1', seq: 1, from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }]
+    }
+  })
+
+  const appended = gc.appendGroupChatEntry(
+    'Hosted',
+    { kind: 'member', name: 'research' },
+    'late reply',
+    'legacy'
+  )
+
+  assert.equal(appended, null)
+  assert.equal(gc.$groupChats.get().Hosted.log.length, 1)
+})
+
+test('hosted projection preserves only valid monotonic sequence ids', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Hosted: {
+      hosted: 'gateway-a',
+      log: [
+        { seq: 1, from: { kind: 'user', name: 'You' }, text: 'one', at: 30 },
+        { seq: '2', from: { kind: 'member', name: 'research' }, text: 'two', at: 20 },
+        { seq: 0, from: { kind: 'member', name: 'research' }, text: 'legacy', at: 10 }
+      ]
+    }
+  })
+
+  assert.equal(snapshot.rooms['name:Hosted'].log[0].seq, 1)
+  assert.equal(snapshot.rooms['name:Hosted'].log[1].seq, 2)
+  assert.equal(Object.prototype.hasOwnProperty.call(snapshot.rooms['name:Hosted'].log[2], 'seq'), false)
+})
+
+test('since-seq replay deduplicates repeated events and orders clock-skewed deltas by sequence', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 2, id: 'remote-2', from: { kind: 'member', name: 'research' }, text: 'two', at: 1 }
+          ]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 1, id: 'local-1', from: { kind: 'user', name: 'You' }, text: 'one', at: 999 },
+            { seq: 2, id: 'local-copy-2', from: { kind: 'member', name: 'research' }, text: 'two', at: 998 }
+          ]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].log.length, 2)
+  assert.equal(JSON.stringify(merged.rooms['id:room-1'].log.map(entry => entry.seq)), JSON.stringify([1, 2]))
+})
+
+test('hosted replay adds sequence to a same-id legacy entry without duplicating it', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { seq: 4, id: 'stable-id', from: { kind: 'user', name: 'You' }, text: 'hello', at: 20 }
+          ]
+        }
+      }
+    },
+    {
+      version: 3,
+      rooms: {
+        'id:room-1': {
+          name: 'Hosted',
+          roomId: 'room-1',
+          hosted: 'gateway-a',
+          revision: 5,
+          log: [
+            { id: 'stable-id', from: { kind: 'user', name: 'You' }, text: 'hello', at: 10 }
+          ]
+        }
+      }
+    }
+  )
+
+  assert.equal(merged.rooms['id:room-1'].log.length, 1)
+  assert.equal(merged.rooms['id:room-1'].log[0].id, 'stable-id')
+  assert.equal(merged.rooms['id:room-1'].log[0].seq, 4)
 })
 
 test('empty runtime rooms are omitted from the gateway mirror', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hosted-room-client.test.mjs
@@ -1,0 +1,509 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  HOSTED_ROOM_CLIENT_LIMITATIONS,
+  classifyHostedRoomCapability,
+  createHostedRoomOutbox,
+  createHostedRoomReplayState,
+  deriveFriendlyHostedRoomStatus,
+  isHostedRoomContinuityEligible,
+  reduceHostedRoomEvents,
+  reduceHostedRoomOutbox,
+  replayHostedRoomPages,
+  resolveSingleGatewayRoute
+} from '../hosted-room-client.js'
+
+function attachmentManifest() {
+  return [
+    {
+      kind: 'image',
+      name: 'diagram.png',
+      size: 2048,
+      mime: 'image/png',
+      refs: {
+        research: 'stage:research:image-1',
+        builder: 'stage:builder:image-1'
+      }
+    },
+    {
+      kind: 'pdf',
+      name: 'brief.pdf',
+      size: 4096,
+      mime: 'application/pdf',
+      refs: {
+        research: 'stage:research:pdf-1',
+        builder: 'stage:builder:pdf-1'
+      }
+    },
+    {
+      kind: 'file',
+      name: 'notes.txt',
+      size: 128,
+      mime: 'text/plain',
+      refs: {
+        research: 'stage:research:file-1',
+        builder: 'stage:builder:file-1'
+      }
+    }
+  ]
+}
+
+function event(seq, eventId, kind, payload = {}, actor = { kind: 'gateway', id: 'install:home' }) {
+  return {
+    room_id: 'room-1',
+    seq,
+    event_id: eventId,
+    kind,
+    actor,
+    payload,
+    created_at: seq
+  }
+}
+
+test('capability classification distinguishes old, disabled, transient, and driver-capable gateways', () => {
+  const missing = Object.assign(new Error('JSON-RPC -32601: method not found'), { code: -32601 })
+
+  assert.deepEqual(classifyHostedRoomCapability({ ok: false, error: missing }, { connectionId: 'local-a' }), {
+    kind: 'unsupported',
+    reason: 'old-gateway',
+    connectionId: 'local-a',
+    authorityId: null,
+    persistentProcess: null,
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  })
+
+  assert.equal(
+    classifyHostedRoomCapability({ ok: true, result: { driver: false } }, { connectionId: 'local-a' }).reason,
+    'driver-disabled'
+  )
+  assert.equal(
+    classifyHostedRoomCapability({ ok: false, error: new Error('socket closed during reconnect') }).kind,
+    'transient-failure'
+  )
+  assert.equal(classifyHostedRoomCapability(new Error('socket closed during reconnect')).kind, 'transient-failure')
+
+  const capable = classifyHostedRoomCapability(
+    {
+      ok: true,
+      result: {
+        driver: true,
+        persistent_process: true,
+        authority_gateway_id: 'install:stable-home',
+        max_log_limit: 250,
+        features: ['typed_events', 'attachments', 'automatic_failover']
+      }
+    },
+    { connectionId: 'machine-local-7' }
+  )
+
+  assert.equal(capable.kind, 'driver-capable')
+  assert.equal(capable.authorityId, 'install:stable-home')
+  assert.equal(capable.connectionId, 'machine-local-7')
+  assert.equal(capable.persistentProcess, true)
+  assert.equal(capable.maxLogLimit, 250)
+  assert.deepEqual(capable.limits, {
+    attachments: false,
+    automaticFailover: false,
+    crossGatewayMembers: false,
+    stagedAttachmentManifest: true
+  })
+
+  const appManaged = classifyHostedRoomCapability({
+    driver: true,
+    persistent_process: false,
+    authority_gateway_id: 'install:desktop-child'
+  })
+  assert.equal(appManaged.kind, 'driver-capable')
+  assert.equal(appManaged.persistentProcess, false)
+  assert.equal(isHostedRoomContinuityEligible(capable), true)
+  assert.equal(isHostedRoomContinuityEligible(appManaged), false)
+  assert.equal(isHostedRoomContinuityEligible({ driver: true, persistent_process: true }), true)
+  assert.equal(isHostedRoomContinuityEligible({ driver: false, persistent_process: true }), false)
+})
+
+test('single-gateway route resolution accepts 2-6 co-located bots and rejects mixed or incomplete routes', () => {
+  const same = resolveSingleGatewayRoute(
+    [
+      { name: 'research', connectionId: 'connection-a', sourceScoped: true },
+      { name: 'builder', route: { connectionId: 'connection-a' }, remoteSource: true }
+    ],
+    { activeConnectionId: 'active-local' }
+  )
+
+  assert.deepEqual(same, {
+    kind: 'single-gateway',
+    reason: null,
+    connectionId: 'connection-a',
+    memberConnectionIds: ['connection-a', 'connection-a'],
+    limits: HOSTED_ROOM_CLIENT_LIMITATIONS
+  })
+
+  const local = resolveSingleGatewayRoute([{ name: 'one' }, { name: 'two' }], {
+    activeConnectionId: 'active-local'
+  })
+  assert.equal(local.connectionId, 'active-local')
+
+  const mixed = resolveSingleGatewayRoute([
+    { name: 'one', connectionId: 'connection-a', sourceScoped: true },
+    { name: 'two', connectionId: 'connection-b', sourceScoped: true }
+  ])
+  assert.equal(mixed.kind, 'unsupported')
+  assert.equal(mixed.reason, 'cross-gateway')
+
+  assert.equal(
+    resolveSingleGatewayRoute([{ name: 'alone' }], { activeConnectionId: 'active-local' }).reason,
+    'member-count'
+  )
+  assert.equal(
+    resolveSingleGatewayRoute(
+      [
+        { name: 'one', connectionId: 'connection-a', sourceScoped: true },
+        { name: 'lost', sourceScoped: true }
+      ],
+      { activeConnectionId: 'active-local' }
+    ).reason,
+    'unresolved-member-route'
+  )
+})
+
+test('authoritative replay orders and deduplicates by sequence and event id while ignoring unknown events safely', () => {
+  const initial = createHostedRoomReplayState({
+    roomId: 'room-1',
+    name: 'Release room',
+    members: [{ profile: 'research' }],
+    authorityId: 'install:stable-home',
+    connectionId: 'machine-local-7'
+  })
+  const user = event(
+    1,
+    'event-user-1',
+    'message.user',
+    { text: 'Start the review', thread_id: 'thread-1' },
+    { kind: 'user', id: 'desktop' }
+  )
+  const unknown = event(2, 'event-future-1', 'future.room.signal', { destructive: true })
+  const member = event(
+    3,
+    'event-member-1',
+    'message.member',
+    { text: 'Review complete', thread_id: 'thread-1' },
+    { kind: 'member', id: 'research', display_name: 'Research', profile: 'research' }
+  )
+
+  const replayed = reduceHostedRoomEvents(initial, [member, unknown, user, { ...user }])
+
+  assert.equal(replayed.cursor, 3)
+  assert.equal(replayed.name, 'Release room')
+  assert.deepEqual(replayed.members, [{ profile: 'research' }])
+  assert.deepEqual(
+    replayed.messages.map(message => [message.seq, message.eventId, message.text]),
+    [
+      [1, 'event-user-1', 'Start the review'],
+      [3, 'event-member-1', 'Review complete']
+    ]
+  )
+  assert.deepEqual(replayed.pendingEvents, [])
+
+  const repeated = reduceHostedRoomEvents(replayed, [member, unknown, user])
+  assert.equal(repeated.cursor, 3)
+  assert.equal(repeated.messages.length, 2)
+})
+
+test('replay buffers sequence gaps and a tombstone preserves history while closing the room', () => {
+  const initial = createHostedRoomReplayState({ roomId: 'room-1', name: 'Core' })
+  const later = event(
+    2,
+    'event-member-1',
+    'message.member',
+    { text: 'Done' },
+    { kind: 'member', id: 'builder', display_name: 'Builder' }
+  )
+
+  const buffered = reduceHostedRoomEvents(initial, [later])
+  assert.equal(buffered.cursor, 0)
+  assert.equal(buffered.pendingEvents.length, 1)
+
+  const caughtUp = reduceHostedRoomEvents(buffered, [
+    event(1, 'event-user-1', 'message.user', { text: 'Build it' }, { kind: 'user', id: 'desktop' })
+  ])
+  const deleted = reduceHostedRoomEvents(caughtUp, [event(3, 'system:room-disbanded', 'room.disbanded')])
+
+  assert.equal(deleted.cursor, 3)
+  assert.equal(deleted.deleted, true)
+  assert.deepEqual(
+    deleted.messages.map(message => message.text),
+    ['Build it', 'Done']
+  )
+  assert.deepEqual(deriveFriendlyHostedRoomStatus(deleted), {
+    kind: 'deleted',
+    text: 'This group was deleted.',
+    member: null,
+    canRetry: false,
+    canStop: false
+  })
+})
+
+test('replay preserves safe attachment metadata without exposing staged member refs', () => {
+  const replayed = reduceHostedRoomEvents(createHostedRoomReplayState({ roomId: 'room-1' }), [
+    event(
+      1,
+      'event-user-with-attachments',
+      'message.user',
+      { text: 'Review these', thread_id: 'thread-1', attachments: attachmentManifest() },
+      { kind: 'user', id: 'desktop' }
+    )
+  ])
+
+  assert.deepEqual(replayed.messages[0].attachments, [
+    { kind: 'image', name: 'diagram.png', size: 2048, mime: 'image/png' },
+    { kind: 'pdf', name: 'brief.pdf', size: 4096, mime: 'application/pdf' },
+    { kind: 'file', name: 'notes.txt', size: 128, mime: 'text/plain' }
+  ])
+  assert.doesNotMatch(JSON.stringify(replayed.messages[0]), /stage:|refs/)
+})
+
+test('friendly status output uses typed reason codes without exposing coordination jargon', () => {
+  const cases = [
+    [
+      event(1, 'turn-started-1', 'turn.started', { member_display_name: 'Research', task_id: 'task-secret' }),
+      'Research is working.',
+      'working'
+    ],
+    [
+      event(1, 'member-unavailable-1', 'member.unavailable', { member_display_name: 'Builder', lease: 'lease-secret' }),
+      'Builder is unavailable.',
+      'member-unavailable'
+    ],
+    [
+      event(1, 'turn-failed-1', 'turn.failed', {
+        member_display_name: 'Research',
+        reason_code: 'provider_auth_or_access',
+        error: 'stale lease at epoch 9 for task 12'
+      }),
+      'Research needs you to sign in again.',
+      'needs-attention'
+    ],
+    [event(1, 'turn-cancelled-1', 'turn.cancelled', { task_id: 'task-secret' }), 'Stopped.', 'stopped'],
+    [event(1, 'authority-lost-1', 'authority.lost', { authority_epoch: 9 }), 'This room is offline.', 'offline']
+  ]
+
+  for (const [roomEvent, text, kind] of cases) {
+    const state = reduceHostedRoomEvents(createHostedRoomReplayState({ roomId: 'room-1' }), [roomEvent])
+    const status = deriveFriendlyHostedRoomStatus(state)
+
+    assert.equal(status.text, text)
+    assert.equal(status.kind, kind)
+    assert.doesNotMatch(JSON.stringify(status), /lease|epoch|task/i)
+  }
+})
+
+test('bounded paged replay resumes from the persisted cursor and catches up through reordered pages', async () => {
+  const calls = []
+  const pages = [
+    {
+      events: [
+        event(4, 'event-member-2', 'message.member', { text: 'Four' }, { kind: 'member', id: 'builder' }),
+        event(3, 'event-user-2', 'message.user', { text: 'Three' }, { kind: 'user', id: 'desktop' })
+      ],
+      cursor: 4,
+      latest_seq: 5,
+      has_more: true
+    },
+    {
+      events: [event(5, 'turn-settled-1', 'turn.settled')],
+      cursor: 5,
+      latest_seq: 5,
+      has_more: false
+    }
+  ]
+
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1', cursor: 2 }),
+    pageSize: 2,
+    maxPages: 4,
+    fetchPage: async params => {
+      calls.push(params)
+      return pages.shift()
+    }
+  })
+
+  assert.equal(result.complete, true)
+  assert.equal(result.reason, null)
+  assert.equal(result.pages, 2)
+  assert.equal(result.state.cursor, 5)
+  assert.deepEqual(calls, [
+    { sinceSeq: 2, limit: 2 },
+    { sinceSeq: 4, limit: 2 }
+  ])
+  assert.deepEqual(
+    result.state.messages.map(message => message.text),
+    ['Three', 'Four']
+  )
+})
+
+test('paged replay stops at its configured bound instead of spinning', async () => {
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1' }),
+    pageSize: 1,
+    maxPages: 1,
+    fetchPage: async () => ({
+      events: [event(1, 'event-user-1', 'message.user', { text: 'One' }, { kind: 'user', id: 'desktop' })],
+      cursor: 1,
+      latest_seq: 2,
+      has_more: true
+    })
+  })
+
+  assert.equal(result.complete, false)
+  assert.equal(result.reason, 'limit')
+  assert.equal(result.state.cursor, 1)
+})
+
+test('paged replay refuses a gateway response larger than the requested bound', async () => {
+  const result = await replayHostedRoomPages({
+    state: createHostedRoomReplayState({ roomId: 'room-1' }),
+    pageSize: 1,
+    fetchPage: async () => ({
+      events: [
+        event(1, 'event-user-1', 'message.user', { text: 'One' }, { kind: 'user', id: 'desktop' }),
+        event(2, 'event-user-2', 'message.user', { text: 'Two' }, { kind: 'user', id: 'desktop' })
+      ],
+      cursor: 2,
+      latest_seq: 2,
+      has_more: false
+    })
+  })
+
+  assert.equal(result.complete, false)
+  assert.equal(result.reason, 'oversized-page')
+  assert.equal(result.state.cursor, 0)
+})
+
+test('persisted command outbox accepts each supported command and enqueue is idempotent', () => {
+  let outbox = createHostedRoomOutbox()
+
+  for (const kind of ['create', 'send', 'stop', 'disband']) {
+    outbox = reduceHostedRoomOutbox(outbox, {
+      type: 'enqueue',
+      command: {
+        commandId: `${kind}-1`,
+        kind,
+        roomId: 'room-1',
+        authorityId: 'install:stable-home',
+        connectionId: 'machine-local-7',
+        payload: kind === 'send' ? { text: 'Hello', thread_id: 'thread-1', attachments: attachmentManifest() } : {}
+      }
+    })
+  }
+
+  const unchanged = reduceHostedRoomOutbox(outbox, { type: 'enqueue', command: outbox.commands[0] })
+  assert.equal(unchanged, outbox)
+  assert.deepEqual(
+    outbox.commands.map(command => command.kind),
+    ['create', 'send', 'stop', 'disband']
+  )
+  assert.equal(outbox.commands[0].authorityId, 'install:stable-home')
+  assert.equal(outbox.commands[0].connectionId, 'machine-local-7')
+  assert.deepEqual(outbox.commands[1].payload.attachments, attachmentManifest())
+})
+
+test('send attachment manifests reject raw transport data, local paths, malformed refs, and oversized metadata', () => {
+  const enqueue = attachments =>
+    reduceHostedRoomOutbox(createHostedRoomOutbox(), {
+      type: 'enqueue',
+      command: {
+        commandId: 'send-with-files',
+        kind: 'send',
+        roomId: 'room-1',
+        authorityId: 'install:stable-home',
+        connectionId: 'machine-local-7',
+        payload: { text: 'See files', attachments }
+      }
+    })
+
+  assert.throws(() => enqueue(Array.from({ length: 9 }, () => attachmentManifest()[0])), /at most 8/i)
+
+  const oversizedName = attachmentManifest()
+  oversizedName[0].name = `${'x'.repeat(256)}.png`
+  assert.throws(() => enqueue(oversizedName), /attachment name/i)
+
+  const rawData = attachmentManifest()
+  rawData[0].data = 'data:image/png;base64,AAAA'
+  assert.throws(() => enqueue(rawData), /data/i)
+
+  const rawBase64 = attachmentManifest()
+  rawBase64[0].content_base64 = 'AAAA'
+  assert.throws(() => enqueue(rawBase64), /base64/i)
+
+  const localPath = attachmentManifest()
+  localPath[0].path = '/Users/david/Desktop/diagram.png'
+  assert.throws(() => enqueue(localPath), /path/i)
+
+  const pathRef = attachmentManifest()
+  pathRef[0].refs.research = '/tmp/diagram.png'
+  assert.throws(() => enqueue(pathRef), /staged reference/i)
+
+  const fileRef = attachmentManifest()
+  fileRef[0].refs.research = 'file:diagram.png'
+  assert.throws(() => enqueue(fileRef), /staged reference/i)
+
+  assert.throws(
+    () =>
+      reduceHostedRoomOutbox(createHostedRoomOutbox(), {
+        type: 'enqueue',
+        command: {
+          commandId: 'send-with-image-alias',
+          kind: 'send',
+          roomId: 'room-1',
+          authorityId: 'install:stable-home',
+          connectionId: 'machine-local-7',
+          payload: { text: 'See image', images: attachmentManifest() }
+        }
+      }),
+    /attachments manifest/i
+  )
+
+  assert.throws(
+    () =>
+      enqueue([
+        {
+          kind: 'pdf',
+          name: 'report.pdf',
+          size: 10,
+          mime: 'application/pdf',
+          refs: {}
+        }
+      ]),
+    /member refs/i
+  )
+})
+
+test('response-lost commands retry with the same idempotency key after persisted rehydration', () => {
+  const command = {
+    commandId: 'send-stable-1',
+    kind: 'send',
+    roomId: 'room-1',
+    authorityId: 'install:stable-home',
+    connectionId: 'machine-local-7',
+    payload: { text: 'Ship it', thread_id: 'thread-1', attachments: attachmentManifest() }
+  }
+  let outbox = reduceHostedRoomOutbox(createHostedRoomOutbox(), { type: 'enqueue', command })
+  outbox = reduceHostedRoomOutbox(outbox, { type: 'dispatch', commandId: command.commandId })
+
+  const rehydrated = createHostedRoomOutbox(JSON.parse(JSON.stringify(outbox)))
+  assert.equal(rehydrated.commands[0].status, 'pending')
+  assert.equal(rehydrated.commands[0].attempts, 1)
+  assert.equal(rehydrated.commands[0].commandId, command.commandId)
+  assert.deepEqual(rehydrated.commands[0].payload.attachments, attachmentManifest())
+
+  const deduped = reduceHostedRoomOutbox(rehydrated, { type: 'enqueue', command })
+  assert.equal(deduped, rehydrated)
+
+  const retried = reduceHostedRoomOutbox(rehydrated, { type: 'dispatch', commandId: command.commandId })
+  assert.equal(retried.commands[0].attempts, 2)
+  assert.equal(retried.commands[0].commandId, command.commandId)
+
+  const acknowledged = reduceHostedRoomOutbox(retried, { type: 'acknowledge', commandId: command.commandId })
+  assert.deepEqual(acknowledged.commands, [])
+})

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -1,0 +1,1352 @@
+"""Deterministic policy for same-gateway hosted-room Discussions.
+
+This module translates a frozen local member roster and the complete typed room
+log into one next driver task.  It performs no I/O, starts no workers, and knows
+nothing about transports or model runtimes.  Callers persist the returned task
+with :mod:`gateway.hosted_room_driver` and append publication plans with
+:mod:`gateway.hosted_rooms`.
+
+The unpublished driver payload intentionally remains unchanged.  Discussion
+coordinates live in deterministic ``TaskIdentity`` values and typed terminal
+events; a restart can therefore reconstruct a task without widening the driver
+schema.  Callers must reconcile terminal driver rows into publication plans
+before asking for the next task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+MAX_DISCUSSION_MEMBERS = 6
+MIN_DISCUSSION_MEMBERS = 2
+MAX_DISCUSSION_ROUNDS = 3
+MAX_DISCUSSION_MESSAGES = 10
+MAX_DISCUSSION_DELTA_LINES = 24
+MAX_USER_TEXT_BYTES = 64 * 1024
+MAX_ATTACHMENTS = 8
+MAX_ATTACHMENT_NAME_CHARS = 255
+MAX_ATTACHMENT_MIME_CHARS = 127
+MAX_ATTACHMENT_REF_CHARS = 256
+MAX_ATTACHMENT_SIZE_BYTES = 100 * 1024 * 1024
+MAX_ATTACHMENT_MANIFEST_BYTES = 32 * 1024
+
+DecisionStatus = Literal["idle", "task", "settled", "bounded"]
+TerminalKind = Literal["settled", "failed", "cancelled"]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9._:-]*)", re.IGNORECASE)
+_MIME_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$"
+)
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]*$")
+_TURN_ID_RE = re.compile(
+    r"^d(?P<source>[1-9][0-9]*)\.r(?P<round>[0-2])\."
+    r"p(?P<position>[0-5])\.s(?P<seen>[1-9][0-9]*)\."
+    r"m(?P<member>[0-9a-f]{24})$"
+)
+
+_MEMBER_FIELDS = frozenset({"member_id", "profile", "handle", "display_name"})
+_REMOTE_MEMBER_FIELDS = frozenset({
+    "connectionId",
+    "connectionKind",
+    "connectionLabel",
+    "connection_id",
+    "connection_kind",
+    "connection_label",
+    "remoteSource",
+    "route",
+    "sourceMissing",
+    "sourceReachable",
+    "sourceScoped",
+    "targetProfile",
+    "target_profile",
+})
+_USER_PAYLOAD_FIELDS = frozenset({"text", "thread_id"})
+_USER_PAYLOAD_OPTIONAL_FIELDS = frozenset({"attachments"})
+_ATTACHMENT_FIELDS = frozenset({"kind", "name", "size", "mime", "refs"})
+_ATTACHMENT_KINDS = frozenset({"image", "pdf", "file"})
+_MEMBER_MESSAGE_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "task_id",
+    "text",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_COMMON_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "seen_through_seq",
+    "task_id",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_EXTRA_FIELDS = {
+    "turn.settled": frozenset({"message_event_id", "passed"}),
+    "turn.failed": frozenset({"error"}),
+    "turn.cancelled": frozenset({"reason"}),
+}
+_TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_EXTRA_FIELDS)
+
+
+class DiscussionPolicyError(ValueError):
+    """Base class for invalid policy input or unreconstructable state."""
+
+
+class DiscussionValidationError(DiscussionPolicyError):
+    """Raised when a room, roster, payload, or typed event is malformed."""
+
+
+class DiscussionReconstructionError(DiscussionPolicyError):
+    """Raised when a persisted task cannot be reproduced from durable state."""
+
+
+@dataclass(frozen=True)
+class DiscussionMember:
+    """One immutable member local to the room's authority gateway."""
+
+    member_id: str
+    profile: str
+    handle: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True)
+class DiscussionRoom:
+    """Validated policy projection of one active hosted room."""
+
+    room_id: str
+    name: str
+    members: tuple[DiscussionMember, ...]
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class DiscussionTaskPlan:
+    """One deterministic member turn compatible with the driver schema."""
+
+    identity: driver.TaskIdentity
+    payload: Mapping[str, Any]
+    discussion_event_id: str
+    member: DiscussionMember
+    member_index: int
+    round_index: int
+    seen_through_seq: int
+
+
+@dataclass(frozen=True)
+class DiscussionDecision:
+    """Current result of replaying one room's Discussion policy."""
+
+    status: DecisionStatus
+    reason: str
+    discussion_event_id: str | None = None
+    source_event_seq: int | None = None
+    thread_id: str | None = None
+    task: DiscussionTaskPlan | None = None
+
+
+@dataclass(frozen=True)
+class EventPlan:
+    """One idempotent append for :func:`gateway.hosted_rooms.append_event`."""
+
+    event_id: str
+    kind: str
+    actor: Mapping[str, str]
+    payload: Mapping[str, Any]
+    authority_gateway_id: str
+    authority_epoch: int
+
+    def append_kwargs(self, room_id: str) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``append_event``."""
+
+        return {
+            "room_id": room_id,
+            "event_id": self.event_id,
+            "kind": self.kind,
+            "actor": dict(self.actor),
+            "payload": dict(self.payload),
+            "authority_gateway_id": self.authority_gateway_id,
+            "authority_epoch": self.authority_epoch,
+        }
+
+
+@dataclass(frozen=True)
+class PublicationPlan:
+    """Ordered visible and terminal effects for one driver task."""
+
+    task_id: str
+    terminal_kind: str
+    events: tuple[EventPlan, ...]
+
+
+@dataclass(frozen=True)
+class _ValidatedEvent:
+    raw: Mapping[str, Any]
+    seq: int
+    event_id: str
+    kind: str
+    actor: Mapping[str, Any]
+    payload: Mapping[str, Any]
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"{label} must be a string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > driver.MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(normalized)
+    ):
+        raise DiscussionValidationError(f"invalid {label}")
+    return normalized
+
+
+def _positive_int(value: Any, *, label: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DiscussionValidationError(f"{label} must be a positive integer")
+    if maximum is not None and value > maximum:
+        raise DiscussionValidationError(f"{label} must be at most {maximum}")
+    return value
+
+
+def _zero_based_int(value: Any, *, label: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise DiscussionValidationError(
+            f"{label} must be an integer between 0 and {maximum}"
+        )
+    return value
+
+
+def _exact_fields(
+    value: Any,
+    *,
+    label: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError(f"{label} must be an object")
+    keys = frozenset(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise DiscussionValidationError(
+            f"{label} is missing fields: {', '.join(sorted(missing))}"
+        )
+    if unknown:
+        raise DiscussionValidationError(
+            f"{label} has unknown fields: {', '.join(sorted(unknown))}"
+        )
+    return value
+
+
+def _attachment_name(value: Any, *, index: int) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"attachment {index} name must be a string")
+    name = value.strip()
+    if (
+        not name
+        or len(name) > MAX_ATTACHMENT_NAME_CHARS
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+        or "\n" in name
+        or "\r" in name
+    ):
+        raise DiscussionValidationError(
+            f"attachment {index} name must be a bounded basename"
+        )
+    return name
+
+
+def _attachment_mime(value: Any, *, index: int, kind: str) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"attachment {index} mime must be a string")
+    mime = value.strip().lower()
+    if (
+        not mime
+        or len(mime) > MAX_ATTACHMENT_MIME_CHARS
+        or _MIME_RE.fullmatch(mime) is None
+    ):
+        raise DiscussionValidationError(f"attachment {index} has invalid mime metadata")
+    if kind == "image" and not mime.startswith("image/"):
+        raise DiscussionValidationError(
+            f"attachment {index} image kind requires image mime"
+        )
+    if kind == "pdf" and mime != "application/pdf":
+        raise DiscussionValidationError(
+            f"attachment {index} pdf kind requires application/pdf"
+        )
+    return mime
+
+
+def _safe_attachment_ref(value: Any, *, index: int, member_id: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise DiscussionValidationError(
+            f"attachment {index} ref for '{member_id}' must be a string or null"
+        )
+    ref = value.strip()
+    lowered = ref.casefold()
+    if (
+        not ref
+        or len(ref) > MAX_ATTACHMENT_REF_CHARS
+        or _SAFE_REF_RE.fullmatch(ref) is None
+        or lowered.startswith(("data:", "base64:", "file:", "path:"))
+        or ref.startswith((".", "~"))
+    ):
+        raise DiscussionValidationError(
+            f"attachment {index} ref for '{member_id}' is not a safe opaque ref"
+        )
+    return ref
+
+
+def _validate_attachments(
+    value: Any,
+    *,
+    member_ids: Iterable[str] | None,
+) -> list[dict[str, Any]]:
+    if member_ids is None:
+        raise DiscussionValidationError(
+            "attachment validation requires the frozen room member ids"
+        )
+    if not isinstance(value, list):
+        raise DiscussionValidationError("attachments must be a list")
+    if len(value) > MAX_ATTACHMENTS:
+        raise DiscussionValidationError(
+            f"attachments must contain at most {MAX_ATTACHMENTS} entries"
+        )
+    expected_member_ids = tuple(
+        _identifier(member_id, label="attachment member_id") for member_id in member_ids
+    )
+    expected_keys = frozenset(expected_member_ids)
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(value):
+        attachment = _exact_fields(
+            raw,
+            label=f"attachment {index}",
+            required=_ATTACHMENT_FIELDS,
+        )
+        kind = attachment["kind"]
+        if not isinstance(kind, str) or kind not in _ATTACHMENT_KINDS:
+            raise DiscussionValidationError(
+                f"attachment {index} kind must be image, pdf, or file"
+            )
+        name = _attachment_name(attachment["name"], index=index)
+        size = attachment["size"]
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or not 0 <= size <= MAX_ATTACHMENT_SIZE_BYTES
+        ):
+            raise DiscussionValidationError(
+                f"attachment {index} size must be between 0 and "
+                f"{MAX_ATTACHMENT_SIZE_BYTES} bytes"
+            )
+        mime = _attachment_mime(attachment["mime"], index=index, kind=kind)
+        refs = attachment["refs"]
+        if not isinstance(refs, Mapping):
+            raise DiscussionValidationError(
+                f"attachment {index} refs must be an object"
+            )
+        ref_keys = frozenset(refs)
+        missing = expected_keys - ref_keys
+        unknown = ref_keys - expected_keys
+        if missing:
+            raise DiscussionValidationError(
+                f"attachment {index} refs are missing member ids: "
+                f"{', '.join(sorted(missing))}"
+            )
+        if unknown:
+            raise DiscussionValidationError(
+                f"attachment {index} refs contain unknown member ids: "
+                f"{', '.join(sorted(str(key) for key in unknown))}"
+            )
+        normalized.append({
+            "kind": kind,
+            "name": name,
+            "size": size,
+            "mime": mime,
+            "refs": {
+                member_id: _safe_attachment_ref(
+                    refs[member_id],
+                    index=index,
+                    member_id=member_id,
+                )
+                for member_id in expected_member_ids
+            },
+        })
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if len(encoded.encode("utf-8")) > MAX_ATTACHMENT_MANIFEST_BYTES:
+        raise DiscussionValidationError("attachment manifest is too large")
+    return normalized
+
+
+def validate_user_payload(
+    value: Any,
+    *,
+    member_ids: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Validate and normalize the exact ``message.user`` Discussion payload."""
+
+    payload = _exact_fields(
+        value,
+        label="user payload",
+        required=_USER_PAYLOAD_FIELDS,
+        optional=_USER_PAYLOAD_OPTIONAL_FIELDS,
+    )
+    text = payload["text"]
+    if not isinstance(text, str):
+        raise DiscussionValidationError("user payload text must be a string")
+    text = text.strip()
+    if not text:
+        raise DiscussionValidationError("user payload text must not be empty")
+    if len(text.encode("utf-8")) > MAX_USER_TEXT_BYTES:
+        raise DiscussionValidationError("user payload text is too large")
+    thread_id = _identifier(payload["thread_id"], label="thread_id")
+    normalized: dict[str, Any] = {"text": text, "thread_id": thread_id}
+    if "attachments" in payload:
+        normalized["attachments"] = _validate_attachments(
+            payload["attachments"],
+            member_ids=member_ids,
+        )
+    return normalized
+
+
+def validate_roster(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> tuple[DiscussionMember, ...]:
+    """Validate a frozen 2-6 member roster of profiles on this gateway."""
+
+    if not isinstance(value, list):
+        raise DiscussionValidationError("members must be a list")
+    if not MIN_DISCUSSION_MEMBERS <= len(value) <= MAX_DISCUSSION_MEMBERS:
+        raise DiscussionValidationError(
+            f"members must contain between {MIN_DISCUSSION_MEMBERS} and "
+            f"{MAX_DISCUSSION_MEMBERS} entries"
+        )
+
+    known_profiles = {
+        _identifier(profile, label="local profile") for profile in local_profiles
+    }
+    members: list[DiscussionMember] = []
+    profiles: set[str] = set()
+    handles: set[str] = set()
+    member_ids: set[str] = set()
+
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise DiscussionValidationError(f"member {index} must be an object")
+        remote_fields = frozenset(raw) & _REMOTE_MEMBER_FIELDS
+        if remote_fields:
+            raise DiscussionValidationError(
+                f"member {index} contains cross-gateway fields: "
+                f"{', '.join(sorted(remote_fields))}"
+            )
+        member = _exact_fields(
+            raw,
+            label=f"member {index}",
+            required=frozenset({"member_id", "profile", "handle"}),
+            optional=frozenset({"display_name"}),
+        )
+        member_id = _identifier(member["member_id"], label=f"member {index} id")
+        profile = _identifier(member["profile"], label=f"member {index} profile")
+        handle = _identifier(member["handle"], label=f"member {index} handle")
+        if profile not in known_profiles:
+            raise DiscussionValidationError(
+                f"member {index} profile '{profile}' is not local to this gateway"
+            )
+        display_name = member.get("display_name", "")
+        if not isinstance(display_name, str):
+            raise DiscussionValidationError(
+                f"member {index} display_name must be a string"
+            )
+        display_name = display_name.strip()
+        if len(display_name) > hosted_rooms.MAX_ACTOR_LABEL_CHARS:
+            raise DiscussionValidationError(f"member {index} display_name is too long")
+
+        profile_key = profile.casefold()
+        handle_key = handle.casefold()
+        member_key = member_id.casefold()
+        if profile_key in profiles:
+            raise DiscussionValidationError("member profiles must be unique")
+        if handle_key in handles or handle_key in {"all", "everyone"}:
+            raise DiscussionValidationError(
+                "member handles must be unique and cannot reserve @all or @everyone"
+            )
+        if member_key in member_ids:
+            raise DiscussionValidationError("member ids must be unique")
+        profiles.add(profile_key)
+        handles.add(handle_key)
+        member_ids.add(member_key)
+        members.append(
+            DiscussionMember(
+                member_id=member_id,
+                profile=profile,
+                handle=handle,
+                display_name=display_name,
+            )
+        )
+    return tuple(members)
+
+
+def validate_room(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionRoom:
+    """Project a hosted-room row into the strict same-gateway policy shape."""
+
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError("room must be an object")
+    if value.get("disbanded_at") is not None:
+        raise DiscussionValidationError("room is disbanded")
+    room_id = _identifier(value.get("room_id"), label="room_id")
+    name = value.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise DiscussionValidationError("room name must be a non-empty string")
+    name = name.strip()
+    if len(name) > hosted_rooms.MAX_ROOM_NAME_CHARS:
+        raise DiscussionValidationError("room name is too long")
+    gateway_id = _identifier(
+        value.get("authority_gateway_id"),
+        label="authority_gateway_id",
+    )
+    authority_epoch = _positive_int(
+        value.get("authority_epoch"),
+        label="authority_epoch",
+    )
+    members = validate_roster(value.get("members"), local_profiles=local_profiles)
+    return DiscussionRoom(
+        room_id=room_id,
+        name=name,
+        members=members,
+        gateway_id=gateway_id,
+        authority_epoch=authority_epoch,
+    )
+
+
+def is_pass_text(value: Any) -> bool:
+    """Return whether a settled member result is Discussion silence."""
+
+    text = str(value or "").strip()
+    return (
+        not text
+        or re.fullmatch(r"\(?\s*pass\s*\)?\.?", text, re.IGNORECASE) is not None
+    )
+
+
+def resolve_mentions(
+    texts: Iterable[str],
+    members: Sequence[DiscussionMember],
+) -> tuple[DiscussionMember, ...]:
+    """Resolve member handles deterministically; no known mention means all."""
+
+    by_handle = {member.handle.casefold(): member for member in members}
+    mentioned: set[str] = set()
+    everyone = False
+    for text in texts:
+        for match in _MENTION_RE.finditer(str(text or "")):
+            handle = match.group(1).casefold()
+            if handle in {"all", "everyone"}:
+                everyone = True
+            elif handle in by_handle:
+                mentioned.add(handle)
+    if everyone or not mentioned:
+        return tuple(members)
+    return tuple(member for member in members if member.handle.casefold() in mentioned)
+
+
+def _validate_event(
+    raw: Any,
+    *,
+    room: DiscussionRoom,
+    previous_seq: int,
+) -> _ValidatedEvent:
+    if not isinstance(raw, Mapping):
+        raise DiscussionValidationError("room event must be an object")
+    if raw.get("room_id") != room.room_id:
+        raise DiscussionValidationError("room event belongs to a different room")
+    seq = _positive_int(raw.get("seq"), label="event seq")
+    if seq <= previous_seq:
+        raise DiscussionValidationError("room events must be in strict sequence order")
+    event_id = _identifier(raw.get("event_id"), label="event_id")
+    kind = raw.get("kind")
+    if not isinstance(kind, str):
+        raise DiscussionValidationError("event kind must be a string")
+    actor = raw.get("actor")
+    if not isinstance(actor, Mapping):
+        raise DiscussionValidationError("event actor must be an object")
+    payload = raw.get("payload")
+    if not isinstance(payload, Mapping):
+        raise DiscussionValidationError("event payload must be an object")
+
+    if kind == "message.user":
+        payload = validate_user_payload(
+            payload,
+            member_ids=(member.member_id for member in room.members),
+        )
+        if actor.get("kind") != "user":
+            raise DiscussionValidationError("message.user requires a user actor")
+    elif kind == "message.member":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "message.member authority epoch does not match the room"
+            )
+        _validate_member_message(payload, actor=actor, room=room)
+    elif kind in _TERMINAL_EVENT_KINDS:
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                f"{kind} authority epoch does not match the room"
+            )
+        _validate_terminal_event(kind, payload, actor=actor, room=room)
+
+    return _ValidatedEvent(
+        raw=raw,
+        seq=seq,
+        event_id=event_id,
+        kind=kind,
+        actor=actor,
+        payload=payload,
+    )
+
+
+def _member_by_id(room: DiscussionRoom, member_id: Any) -> DiscussionMember:
+    normalized = _identifier(member_id, label="member_id")
+    for member in room.members:
+        if member.member_id == normalized:
+            return member
+    raise DiscussionValidationError(f"unknown Discussion member '{normalized}'")
+
+
+def _validate_turn_coordinates(
+    payload: Mapping[str, Any], room: DiscussionRoom
+) -> None:
+    _member_by_id(room, payload.get("member_id"))
+    member_index = _zero_based_int(
+        payload.get("member_index"),
+        label="member_index",
+        maximum=MAX_DISCUSSION_MEMBERS - 1,
+    )
+    round_index = _zero_based_int(
+        payload.get("round_index"),
+        label="round_index",
+        maximum=MAX_DISCUSSION_ROUNDS - 1,
+    )
+    thread_id = _identifier(payload.get("thread_id"), label="thread_id")
+    task_id = _identifier(payload.get("task_id"), label="task_id")
+    turn_id = _identifier(payload.get("turn_id"), label="turn_id")
+    discussion_event_id = _identifier(
+        payload.get("discussion_event_id"),
+        label="discussion_event_id",
+    )
+    del member_index, round_index, thread_id, task_id, turn_id, discussion_event_id
+
+
+def _validate_member_message(
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    _exact_fields(
+        payload,
+        label="message.member payload",
+        required=_MEMBER_MESSAGE_FIELDS,
+    )
+    _validate_turn_coordinates(payload, room)
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip() or is_pass_text(text):
+        raise DiscussionValidationError("message.member text must be a non-pass string")
+    member = _member_by_id(room, payload.get("member_id"))
+    if (
+        actor.get("kind") != "member"
+        or actor.get("id") != member.member_id
+        or actor.get("profile") != member.profile
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError("message.member actor does not match roster")
+
+
+def _validate_terminal_event(
+    kind: str,
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    required = _TERMINAL_COMMON_FIELDS | _TERMINAL_EXTRA_FIELDS[kind]
+    _exact_fields(payload, label=f"{kind} payload", required=required)
+    _validate_turn_coordinates(payload, room)
+    _positive_int(payload.get("seen_through_seq"), label="seen_through_seq")
+    if (
+        actor.get("kind") != "gateway"
+        or actor.get("id") != room.gateway_id
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError(f"{kind} requires a gateway actor")
+    if kind == "turn.settled":
+        if not isinstance(payload.get("passed"), bool):
+            raise DiscussionValidationError("turn.settled passed must be a boolean")
+        message_event_id = payload.get("message_event_id")
+        if payload["passed"]:
+            if message_event_id is not None:
+                raise DiscussionValidationError(
+                    "a passed turn cannot reference a member message"
+                )
+        else:
+            _identifier(message_event_id, label="message_event_id")
+    else:
+        field = "error" if kind == "turn.failed" else "reason"
+        if not isinstance(payload.get(field), str) or not payload[field].strip():
+            raise DiscussionValidationError(f"{kind} {field} must be non-empty")
+
+
+def _validated_events(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    room: DiscussionRoom,
+) -> tuple[_ValidatedEvent, ...]:
+    validated: list[_ValidatedEvent] = []
+    previous_seq = 0
+    event_ids: set[str] = set()
+    for raw in events:
+        event = _validate_event(raw, room=room, previous_seq=previous_seq)
+        if event.event_id in event_ids:
+            raise DiscussionValidationError("room event ids must be unique")
+        validated.append(event)
+        previous_seq = event.seq
+        event_ids.add(event.event_id)
+    return tuple(validated)
+
+
+def _discussion_user_events(
+    events: Sequence[_ValidatedEvent],
+) -> tuple[_ValidatedEvent, ...]:
+    return tuple(event for event in events if event.kind == "message.user")
+
+
+def _message_events(
+    events: Sequence[_ValidatedEvent],
+    *,
+    thread_id: str | None = None,
+    maximum_seq: int | None = None,
+) -> tuple[_ValidatedEvent, ...]:
+    result = []
+    for event in events:
+        if event.kind not in {"message.user", "message.member"}:
+            continue
+        if thread_id is not None and event.payload.get("thread_id") != thread_id:
+            continue
+        if maximum_seq is not None and event.seq > maximum_seq:
+            continue
+        result.append(event)
+    return tuple(result)
+
+
+def derive_member_watermarks(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+) -> dict[tuple[str, str], int]:
+    """Derive ``(thread_id, member_id)`` watermarks from terminal events."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    return _derive_member_watermarks(validated)
+
+
+def _derive_member_watermarks(
+    events: Sequence[_ValidatedEvent],
+) -> dict[tuple[str, str], int]:
+    messages_by_id = {
+        event.event_id: event for event in events if event.kind == "message.member"
+    }
+    terminal_by_task: dict[str, _ValidatedEvent] = {}
+    watermarks: dict[tuple[str, str], int] = {}
+    for event in events:
+        if event.kind not in _TERMINAL_EVENT_KINDS:
+            continue
+        task_id = str(event.payload["task_id"])
+        if task_id in terminal_by_task:
+            raise DiscussionValidationError(
+                f"task '{task_id}' has more than one terminal room event"
+            )
+        terminal_by_task[task_id] = event
+        key = (str(event.payload["thread_id"]), str(event.payload["member_id"]))
+        watermark = int(event.payload["seen_through_seq"])
+        if event.kind == "turn.settled" and not event.payload["passed"]:
+            message_id = str(event.payload["message_event_id"])
+            message = messages_by_id.get(message_id)
+            if (
+                message is None
+                or message.payload.get("task_id") != task_id
+                or message.payload.get("member_id") != event.payload.get("member_id")
+                or message.payload.get("thread_id") != event.payload.get("thread_id")
+            ):
+                raise DiscussionValidationError(
+                    "turn.settled references no matching member message"
+                )
+            watermark = max(watermark, message.seq)
+        watermarks[key] = max(watermarks.get(key, 0), watermark)
+    return watermarks
+
+
+def _member_digest(member: DiscussionMember) -> str:
+    seed = f"{member.member_id}\0{member.profile}\0{member.handle}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+
+
+def _rotate(
+    members: Sequence[DiscussionMember], round_index: int
+) -> tuple[DiscussionMember, ...]:
+    if len(members) < 2:
+        return tuple(members)
+    shift = round_index % len(members)
+    return tuple((*members[shift:], *members[:shift]))
+
+
+def _format_message(event: _ValidatedEvent, room: DiscussionRoom) -> str:
+    text = str(event.payload["text"])
+    if event.kind == "message.user":
+        return f"User (user): {text}"
+    member = _member_by_id(room, event.payload["member_id"])
+    return f"@{member.handle}: {text}"
+
+
+def _attachment_prompt_lines(
+    messages: Sequence[_ValidatedEvent],
+    member: DiscussionMember,
+) -> list[str]:
+    entries: list[str] = []
+    queued_media = False
+    for event in messages:
+        if event.kind != "message.user":
+            continue
+        for attachment in event.payload.get("attachments", []):
+            ref = attachment["refs"][member.member_id]
+            name = json.dumps(attachment["name"], ensure_ascii=True)
+            metadata = f"{attachment['mime']}, {attachment['size']} bytes"
+            if attachment["kind"] == "file":
+                if ref is not None:
+                    entries.append(f"- Staged file {name} ({metadata}): {ref}")
+                continue
+            queued_media = True
+            label = "image" if attachment["kind"] == "image" else "PDF"
+            ref_note = f" Staged ref: {ref}." if ref is not None else ""
+            entries.append(
+                f"- Queued {label} {name} ({metadata}) for this turn.{ref_note}"
+            )
+    if not entries:
+        return []
+    lines = ["", "Attachments available to you for this turn:", *entries]
+    if queued_media:
+        lines.append(
+            "Queued image/PDF attachments are staged separately for this turn; "
+            "inspect the supplied media rather than treating its filename as content."
+        )
+    return lines
+
+
+def _build_prompt(
+    *,
+    room: DiscussionRoom,
+    member: DiscussionMember,
+    messages: Sequence[_ValidatedEvent],
+    watermark: int,
+    seen_through_seq: int,
+) -> str:
+    delta = [event for event in messages if watermark < event.seq <= seen_through_seq][
+        -MAX_DISCUSSION_DELTA_LINES:
+    ]
+    peers = ", ".join(
+        f"@{candidate.handle}"
+        for candidate in room.members
+        if candidate.member_id != member.member_id
+    )
+    lines = [
+        f'[Discussion: "{room.name}"] You are @{member.handle}, one participant '
+        f"with {peers or 'no other members'} and the user.",
+        "",
+        "New messages in this thread since your last turn (oldest first):",
+        *[f"  {_format_message(event, room)}" for event in delta],
+        *_attachment_prompt_lines(delta, member),
+        "",
+        "Rules for this Discussion:",
+        "- Reply with one conversational message only when you have something new worth adding.",
+        '- If you have nothing new to add, reply with exactly "(pass)".',
+        "- Mention a teammate by handle to pull them into the next round; do not repeat points already made.",
+        "- Never reveal content from private conversations. Your reply is published verbatim.",
+    ]
+    prompt = "\n".join(lines)
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionValidationError("Discussion prompt exceeds the driver limit")
+    return prompt
+
+
+def _turn_id(
+    *,
+    source_event_seq: int,
+    round_index: int,
+    member_index: int,
+    seen_through_seq: int,
+    member: DiscussionMember,
+) -> str:
+    return (
+        f"d{source_event_seq}.r{round_index}.p{member_index}."
+        f"s{seen_through_seq}.m{_member_digest(member)}"
+    )
+
+
+def _task_id(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> str:
+    seed = json.dumps(
+        {
+            "discussion_event_id": discussion_event.event_id,
+            "member_id": member.member_id,
+            "member_index": member_index,
+            "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+            "room_id": room.room_id,
+            "round_index": round_index,
+            "seen_through_seq": seen_through_seq,
+            "source_event_seq": discussion_event.seq,
+            "thread_id": discussion_event.payload["thread_id"],
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"dtask:{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:48]}"
+
+
+def _make_task_plan(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> DiscussionTaskPlan:
+    turn_id = _turn_id(
+        source_event_seq=discussion_event.seq,
+        round_index=round_index,
+        member_index=member_index,
+        seen_through_seq=seen_through_seq,
+        member=member,
+    )
+    task_id = _task_id(
+        room=room,
+        discussion_event=discussion_event,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    identity = driver.TaskIdentity(
+        room_id=room.room_id,
+        task_id=task_id,
+        thread_id=str(discussion_event.payload["thread_id"]),
+        turn_id=turn_id,
+    )
+    payload = {
+        "target_profile": member.profile,
+        "prompt": prompt,
+        "source_event_seq": discussion_event.seq,
+    }
+    return DiscussionTaskPlan(
+        identity=identity,
+        payload=payload,
+        discussion_event_id=discussion_event.event_id,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+    )
+
+
+def plan_next_task(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionDecision:
+    """Replay the complete room log and return at most one next member task."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    user_events = _discussion_user_events(validated)
+    if not user_events:
+        return DiscussionDecision(status="idle", reason="no_user_event")
+
+    discussion = user_events[-1]
+    thread_id = str(discussion.payload["thread_id"])
+    committed_member_message_ids = {
+        str(event.payload["message_event_id"])
+        for event in validated
+        if event.kind == "turn.settled"
+        and event.payload.get("message_event_id") is not None
+    }
+    # Publication writes the visible member message before the terminal event.
+    # A crash in that gap leaves the message in the log, but it is not committed
+    # policy input yet: ignoring it reproduces the original task coordinates so
+    # the caller can inspect the terminal driver row and finish publication.
+    thread_messages = tuple(
+        event
+        for event in _message_events(validated, thread_id=thread_id)
+        if event.kind == "message.user"
+        or event.event_id in committed_member_message_ids
+    )
+    discussion_messages = tuple(
+        event for event in thread_messages if event.seq >= discussion.seq
+    )
+    member_messages = tuple(
+        event
+        for event in thread_messages
+        if event.kind == "message.member"
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    )
+    if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
+        return DiscussionDecision(
+            status="bounded",
+            reason="max_messages",
+            discussion_event_id=discussion.event_id,
+            source_event_seq=discussion.seq,
+            thread_id=thread_id,
+        )
+
+    terminals = {
+        (int(event.payload["round_index"]), str(event.payload["member_id"])): event
+        for event in validated
+        if event.kind in _TERMINAL_EVENT_KINDS
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    }
+    watermarks = _derive_member_watermarks(validated)
+    seen_through_seq = max(event.seq for event in thread_messages)
+
+    for round_index in range(MAX_DISCUSSION_ROUNDS):
+        # Mentions emitted during a round recruit members for the next round,
+        # never retroactively into the one already in progress.
+        mention_texts = [
+            str(event.payload["text"])
+            for event in discussion_messages
+            if event.kind == "message.user"
+            or int(event.payload["round_index"]) < round_index
+        ]
+        responders = resolve_mentions(mention_texts, room.members)
+        ordered = _rotate(responders, round_index)
+        for member_index, member in enumerate(ordered):
+            if (round_index, member.member_id) in terminals:
+                continue
+            watermark = watermarks.get((thread_id, member.member_id), 0)
+            delta = [
+                event
+                for event in thread_messages
+                if watermark < event.seq <= seen_through_seq
+            ]
+            if not delta:
+                continue
+            prompt = _build_prompt(
+                room=room,
+                member=member,
+                messages=thread_messages,
+                watermark=watermark,
+                seen_through_seq=seen_through_seq,
+            )
+            task = _make_task_plan(
+                room=room,
+                discussion_event=discussion,
+                member=member,
+                member_index=member_index,
+                round_index=round_index,
+                seen_through_seq=seen_through_seq,
+                prompt=prompt,
+            )
+            return DiscussionDecision(
+                status="task",
+                reason="member_turn",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+                task=task,
+            )
+
+        spoke = any(
+            int(event.payload["round_index"]) == round_index
+            for event in member_messages
+        )
+        if not spoke:
+            return DiscussionDecision(
+                status="settled",
+                reason="silent_round",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+        if round_index == MAX_DISCUSSION_ROUNDS - 1:
+            return DiscussionDecision(
+                status="bounded",
+                reason="max_rounds",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+
+    raise AssertionError("bounded Discussion loop exhausted unexpectedly")
+
+
+def reconstruct_task_plan(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: Mapping[str, Any],
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionTaskPlan:
+    """Reconstruct and verify one persisted driver task after a restart."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    identity = task.get("identity")
+    payload = task.get("payload")
+    if not isinstance(identity, driver.TaskIdentity) or not isinstance(
+        payload, Mapping
+    ):
+        raise DiscussionReconstructionError(
+            "driver task has no valid identity or payload"
+        )
+    if frozenset(payload) != frozenset({
+        "target_profile",
+        "prompt",
+        "source_event_seq",
+    }):
+        raise DiscussionReconstructionError("driver task payload shape changed")
+    match = _TURN_ID_RE.fullmatch(identity.turn_id)
+    if match is None:
+        raise DiscussionReconstructionError("turn_id is not a Discussion coordinate")
+    source_event_seq = int(match.group("source"))
+    round_index = int(match.group("round"))
+    member_index = int(match.group("position"))
+    seen_through_seq = int(match.group("seen"))
+    if payload.get("source_event_seq") != source_event_seq:
+        raise DiscussionReconstructionError("task source event does not match turn_id")
+    discussion = next(
+        (
+            event
+            for event in validated
+            if event.seq == source_event_seq and event.kind == "message.user"
+        ),
+        None,
+    )
+    if discussion is None:
+        raise DiscussionReconstructionError("task source user event is missing")
+    if (
+        identity.room_id != room.room_id
+        or identity.thread_id != discussion.payload["thread_id"]
+    ):
+        raise DiscussionReconstructionError(
+            "task identity does not match its room thread"
+        )
+    profile = payload.get("target_profile")
+    member = next(
+        (candidate for candidate in room.members if candidate.profile == profile), None
+    )
+    if member is None or _member_digest(member) != match.group("member"):
+        raise DiscussionReconstructionError("task target member does not match turn_id")
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise DiscussionReconstructionError("task prompt is missing")
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionReconstructionError("task prompt exceeds the driver limit")
+    reconstructed = _make_task_plan(
+        room=room,
+        discussion_event=discussion,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    if reconstructed.identity != identity or dict(reconstructed.payload) != dict(
+        payload
+    ):
+        raise DiscussionReconstructionError(
+            "driver task failed deterministic reconstruction"
+        )
+    return reconstructed
+
+
+def _terminal_text(result: Any, *, field: str, fallback: str) -> str:
+    if isinstance(result, Mapping):
+        value = result.get(field)
+        if value is None and field == "error":
+            value = result.get("text")
+    else:
+        value = result
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def plan_publication(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: DiscussionTaskPlan,
+    *,
+    status: TerminalKind,
+    result: Any = None,
+    local_profiles: Iterable[str],
+) -> PublicationPlan:
+    """Plan idempotent room effects for one terminal driver task.
+
+    A newer user event in the same thread supersedes a late result.  The task
+    remains terminal in driver state, but only a deterministic cancellation is
+    published, preventing stale prose and its watermark from hiding the newer
+    user message.
+    """
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    if task.identity.room_id != room.room_id:
+        raise DiscussionValidationError("task belongs to a different room")
+    if task.member not in room.members:
+        raise DiscussionValidationError("task member is not in the frozen roster")
+    if status not in {"settled", "failed", "cancelled"}:
+        raise DiscussionValidationError("invalid terminal publication status")
+
+    newer_same_thread = any(
+        event.kind == "message.user"
+        and event.seq > task.seen_through_seq
+        and event.payload.get("thread_id") == task.identity.thread_id
+        for event in validated
+    )
+    effective_status: TerminalKind = "cancelled" if newer_same_thread else status
+    digest = task.identity.task_id.removeprefix("dtask:")
+    message_event_id = f"dmessage:{digest}"
+    terminal_event_id = f"dterminal:{digest}"
+    common = {
+        "discussion_event_id": task.discussion_event_id,
+        "member_id": task.member.member_id,
+        "member_index": task.member_index,
+        "round_index": task.round_index,
+        "seen_through_seq": task.seen_through_seq,
+        "task_id": task.identity.task_id,
+        "thread_id": task.identity.thread_id,
+        "turn_id": task.identity.turn_id,
+    }
+    effects: list[EventPlan] = []
+
+    if effective_status == "settled":
+        text = _terminal_text(result, field="text", fallback="")
+        passed = is_pass_text(text)
+        if not passed:
+            member_actor = {
+                "kind": "member",
+                "id": task.member.member_id,
+                "profile": task.member.profile,
+            }
+            if task.member.display_name:
+                member_actor["display_name"] = task.member.display_name
+            effects.append(
+                EventPlan(
+                    event_id=message_event_id,
+                    kind="message.member",
+                    actor=member_actor,
+                    payload={
+                        "discussion_event_id": task.discussion_event_id,
+                        "member_id": task.member.member_id,
+                        "member_index": task.member_index,
+                        "round_index": task.round_index,
+                        "task_id": task.identity.task_id,
+                        "text": text,
+                        "thread_id": task.identity.thread_id,
+                        "turn_id": task.identity.turn_id,
+                    },
+                    authority_gateway_id=room.gateway_id,
+                    authority_epoch=room.authority_epoch,
+                )
+            )
+        terminal_payload = {
+            **common,
+            "message_event_id": None if passed else message_event_id,
+            "passed": passed,
+        }
+        terminal_kind = "turn.settled"
+    elif effective_status == "failed":
+        terminal_payload = {
+            **common,
+            "error": _terminal_text(
+                result,
+                field="error",
+                fallback="member turn failed",
+            ),
+        }
+        terminal_kind = "turn.failed"
+    else:
+        terminal_payload = {
+            **common,
+            "reason": (
+                "superseded_by_newer_user_event"
+                if newer_same_thread
+                else _terminal_text(
+                    result,
+                    field="reason",
+                    fallback="member turn cancelled",
+                )
+            ),
+        }
+        terminal_kind = "turn.cancelled"
+
+    effects.append(
+        EventPlan(
+            event_id=terminal_event_id,
+            kind=terminal_kind,
+            actor={"kind": "gateway", "id": room.gateway_id},
+            payload=terminal_payload,
+            authority_gateway_id=room.gateway_id,
+            authority_epoch=room.authority_epoch,
+        )
+    )
+    return PublicationPlan(
+        task_id=task.identity.task_id,
+        terminal_kind=terminal_kind,
+        events=tuple(effects),
+    )

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -100,6 +100,13 @@ _TERMINAL_EXTRA_FIELDS = {
     "turn.cancelled": frozenset({"reason"}),
 }
 _TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_EXTRA_FIELDS)
+_ROOM_ACTIVITY_FIELDS = frozenset({
+    "status",
+    "reason_code",
+    "thread_id",
+    "discussion_event_id",
+})
+_ROOM_STOP_FIELDS = frozenset({"cancel_id"})
 
 
 class DiscussionPolicyError(ValueError):
@@ -629,6 +636,38 @@ def _validate_event(
                 f"{kind} authority epoch does not match the room"
             )
         _validate_terminal_event(kind, payload, actor=actor, room=room)
+    elif kind == "room.activity":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.activity authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.activity payload",
+            required=_ROOM_ACTIVITY_FIELDS,
+        )
+        if payload.get("status") not in {"settled", "bounded"}:
+            raise DiscussionValidationError("invalid room.activity status")
+        _identifier(payload.get("reason_code"), label="reason_code")
+        _identifier(payload.get("thread_id"), label="thread_id")
+        _identifier(payload.get("discussion_event_id"), label="discussion_event_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError("room.activity requires the room gateway")
+    elif kind == "room.stop_requested":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.stop_requested authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.stop_requested payload",
+            required=_ROOM_STOP_FIELDS,
+        )
+        _identifier(payload.get("cancel_id"), label="cancel_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError(
+                "room.stop_requested requires the room gateway"
+            )
 
     return _ValidatedEvent(
         raw=raw,
@@ -1016,10 +1055,33 @@ def plan_next_task(
     room = validate_room(room_value, local_profiles=local_profiles)
     validated = _validated_events(events, room=room)
     user_events = _discussion_user_events(validated)
-    if not user_events:
-        return DiscussionDecision(status="idle", reason="no_user_event")
+    stopped_through_seq = max(
+        (
+            event.seq
+            for event in validated
+            if event.kind == "room.stop_requested"
+        ),
+        default=0,
+    )
+    completed_discussion_ids = {
+        str(event.payload["discussion_event_id"])
+        for event in validated
+        if event.kind == "room.activity"
+        and event.payload.get("status") in {"settled", "bounded"}
+    }
+    latest_by_thread: dict[str, _ValidatedEvent] = {}
+    for event in user_events:
+        latest_by_thread[str(event.payload["thread_id"])] = event
+    pending_user_events = tuple(
+        event
+        for event in sorted(latest_by_thread.values(), key=lambda item: item.seq)
+        if event.seq > stopped_through_seq
+        and event.event_id not in completed_discussion_ids
+    )
+    if not pending_user_events:
+        return DiscussionDecision(status="idle", reason="no_pending_user_event")
 
-    discussion = user_events[-1]
+    discussion = pending_user_events[0]
     thread_id = str(discussion.payload["thread_id"])
     committed_member_message_ids = {
         str(event.payload["message_event_id"])

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -575,8 +575,10 @@ def is_pass_text(value: Any) -> bool:
 def resolve_mentions(
     texts: Iterable[str],
     members: Sequence[DiscussionMember],
+    *,
+    default_all: bool = True,
 ) -> tuple[DiscussionMember, ...]:
-    """Resolve member handles deterministically; no known mention means all."""
+    """Resolve member handles deterministically against the frozen roster."""
 
     by_handle = {member.handle.casefold(): member for member in members}
     mentioned: set[str] = set()
@@ -588,9 +590,38 @@ def resolve_mentions(
                 everyone = True
             elif handle in by_handle:
                 mentioned.add(handle)
-    if everyone or not mentioned:
+    if everyone or (default_all and not mentioned):
         return tuple(members)
     return tuple(member for member in members if member.handle.casefold() in mentioned)
+
+
+def _unaddressed_member_mentions(
+    messages: Sequence[_ValidatedEvent],
+    room: DiscussionRoom,
+) -> tuple[DiscussionMember, ...]:
+    """Return peers explicitly cited by a Bot and not heard from afterward."""
+
+    cited_at: dict[str, int] = {}
+    last_post_at: dict[str, int] = {}
+    for event in messages:
+        if event.kind != "message.member":
+            continue
+        speaker_id = str(event.payload["member_id"])
+        last_post_at[speaker_id] = event.seq
+        cited = resolve_mentions(
+            (str(event.payload["text"]),),
+            room.members,
+            default_all=False,
+        )
+        for member in cited:
+            if member.member_id != speaker_id:
+                cited_at[member.member_id] = event.seq
+    return tuple(
+        member
+        for member in room.members
+        if member.member_id in cited_at
+        and last_post_at.get(member.member_id, 0) <= cited_at[member.member_id]
+    )
 
 
 def _validate_event(
@@ -1127,15 +1158,16 @@ def plan_next_task(
     seen_through_seq = max(event.seq for event in thread_messages)
 
     for round_index in range(MAX_DISCUSSION_ROUNDS):
-        # Mentions emitted during a round recruit members for the next round,
-        # never retroactively into the one already in progress.
-        mention_texts = [
-            str(event.payload["text"])
-            for event in discussion_messages
-            if event.kind == "message.user"
-            or int(event.payload["round_index"]) < round_index
-        ]
-        responders = resolve_mentions(mention_texts, room.members)
+        # The user's message selects the first round, with no mention meaning
+        # everyone. Later rounds are opt-in: only a peer explicitly cited by a
+        # Bot and not heard from afterward gets another turn. Every member's
+        # watermark remains intact, so a peer cited later still receives the
+        # complete bounded transcript delta without consuming turns meanwhile.
+        responders = (
+            resolve_mentions((str(discussion.payload["text"]),), room.members)
+            if round_index == 0
+            else _unaddressed_member_mentions(discussion_messages, room)
+        )
         ordered = _rotate(responders, round_index)
         for member_index, member in enumerate(ordered):
             if (round_index, member.member_id) in terminals:

--- a/gateway/hosted_room_driver.py
+++ b/gateway/hosted_room_driver.py
@@ -1,0 +1,1465 @@
+"""Durable execution state for a same-gateway hosted room driver.
+
+This module owns only the driver lease and task state machine. It does not
+invoke models, touch sessions, or depend on the hosted-room event log. Callers
+provide both the database path and clock so recovery and fencing behavior can
+be tested without process-global state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal
+
+
+Clock = Callable[[], float]
+TaskStatus = Literal[
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "stopping",
+]
+TerminalStatus = Literal["settled", "failed"]
+
+MAX_IDENTIFIER_CHARS = 128
+MAX_PROMPT_BYTES = 128 * 1024
+MAX_RESULT_JSON_BYTES = 256 * 1024
+TASK_STATUSES = frozenset({
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "stopping",
+})
+TERMINAL_STATUSES = frozenset({"settled", "failed", "cancelled"})
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_TASK_PAYLOAD_FIELDS = frozenset({"target_profile", "prompt", "source_event_seq"})
+_LEASE_COLUMNS = frozenset({
+    "room_id",
+    "gateway_id",
+    "authority_epoch",
+    "process_generation",
+    "lease_generation",
+    "expires_at",
+    "acquired_at",
+    "updated_at",
+    "released_at",
+})
+_TASK_COLUMNS = frozenset({
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+})
+_TASK_COLUMN_ORDER = (
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+)
+
+
+class DriverStateError(ValueError):
+    """Base class for invalid or conflicting driver-state operations."""
+
+
+class DriverValidationError(DriverStateError):
+    """Raised when an identifier, clock, TTL, or payload is invalid."""
+
+
+class RoomUnavailableError(DriverStateError):
+    """Raised when the hosted room does not exist or was disbanded."""
+
+
+class LeaseHeldError(DriverStateError):
+    """Raised when another unexpired driver generation owns the room."""
+
+
+class StaleLeaseError(DriverStateError):
+    """Raised when a lease generation can no longer mutate room state."""
+
+
+class TaskConflictError(DriverStateError):
+    """Raised when an idempotency key is reused for different task state."""
+
+
+class StaleTaskError(DriverStateError):
+    """Raised when an obsolete task attempt or cancellation tries to commit."""
+
+
+class InvalidTaskTransitionError(DriverStateError):
+    """Raised when a requested task transition is not allowed."""
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DriverValidationError(f"{label} must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(value)
+    ):
+        raise DriverValidationError(f"invalid {label}")
+    return value
+
+
+def _timestamp(clock: Clock) -> float:
+    if not callable(clock):
+        raise DriverValidationError("clock must be callable")
+    try:
+        value = float(clock())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError("clock must return a finite number") from exc
+    if not math.isfinite(value):
+        raise DriverValidationError("clock must return a finite number")
+    return value
+
+
+def _ttl(value: Any) -> float:
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError(
+            "ttl_seconds must be a finite positive number"
+        ) from exc
+    if not math.isfinite(ttl) or ttl <= 0:
+        raise DriverValidationError("ttl_seconds must be a finite positive number")
+    return ttl
+
+
+def _expiry(now: float, ttl: float) -> float:
+    expires_at = now + ttl
+    if not math.isfinite(expires_at):
+        raise DriverValidationError("lease expiry must be finite")
+    return expires_at
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise DriverValidationError("result must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > MAX_RESULT_JSON_BYTES:
+        raise DriverValidationError("result is too large")
+    return encoded
+
+
+def _authority_epoch(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DriverValidationError("authority_epoch must be a positive integer")
+    return value
+
+
+def _task_payload(value: Any) -> tuple[dict[str, Any], str, str]:
+    if not isinstance(value, dict):
+        raise DriverValidationError("payload must be an object")
+    unknown = set(value) - _TASK_PAYLOAD_FIELDS
+    missing = _TASK_PAYLOAD_FIELDS - set(value)
+    if unknown:
+        raise DriverValidationError(
+            f"unknown payload fields: {', '.join(sorted(unknown))}"
+        )
+    if missing:
+        raise DriverValidationError(
+            f"missing payload fields: {', '.join(sorted(missing))}"
+        )
+
+    target_profile = _identifier(value["target_profile"], label="target_profile")
+    prompt = value["prompt"]
+    if not isinstance(prompt, str):
+        raise DriverValidationError("prompt must be a string")
+    if not prompt.strip():
+        raise DriverValidationError("prompt must not be empty")
+    if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
+        raise DriverValidationError("prompt is too large")
+    source_event_seq = value["source_event_seq"]
+    if (
+        isinstance(source_event_seq, bool)
+        or not isinstance(source_event_seq, int)
+        or source_event_seq < 1
+    ):
+        raise DriverValidationError("source_event_seq must be a positive integer")
+
+    normalized = {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return normalized, encoded, digest
+
+
+@dataclass(frozen=True)
+class TaskIdentity:
+    """Stable identity for one admitted room turn."""
+
+    room_id: str
+    task_id: str
+    thread_id: str
+    turn_id: str
+
+    def __post_init__(self) -> None:
+        for field in ("room_id", "task_id", "thread_id", "turn_id"):
+            object.__setattr__(
+                self,
+                field,
+                _identifier(getattr(self, field), label=field),
+            )
+
+
+@dataclass(frozen=True)
+class DriverLease:
+    """A fenced lease held by one gateway process incarnation."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+    process_generation: str
+    lease_generation: int
+    expires_at: float
+    reclaimed: bool = False
+
+
+@dataclass(frozen=True)
+class TaskAttempt:
+    """The exact running generation authorized to settle one task."""
+
+    identity: TaskIdentity
+    lease: DriverLease
+    execution_generation: int
+    cancel_generation: int
+
+
+def _create_task_table(
+    conn: sqlite3.Connection, table: str = "hosted_room_driver_tasks"
+) -> None:
+    if table not in {"hosted_room_driver_tasks", "hosted_room_driver_tasks_next"}:
+        raise DriverStateError("invalid hosted-room task table name")
+    conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS {table} (
+            room_id TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            source_event_seq INTEGER NOT NULL CHECK (source_event_seq >= 1),
+            payload_json TEXT NOT NULL,
+            payload_digest TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN (
+                    'queued', 'running', 'settled', 'failed',
+                    'cancelled', 'indeterminate', 'stopping'
+                )
+            ),
+            execution_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (execution_generation >= 0),
+            cancel_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (cancel_generation >= 0),
+            run_gateway_id TEXT,
+            run_process_generation TEXT,
+            run_lease_generation INTEGER,
+            cancel_id TEXT,
+            settlement_id TEXT,
+            settlement_status TEXT,
+            result_json TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            started_at REAL,
+            terminal_at REAL,
+            indeterminate_at REAL,
+            PRIMARY KEY (room_id, task_id),
+            UNIQUE (room_id, thread_id, turn_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_driver_leases (
+            room_id TEXT PRIMARY KEY,
+            gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 1),
+            process_generation TEXT NOT NULL,
+            lease_generation INTEGER NOT NULL CHECK (lease_generation >= 1),
+            expires_at REAL NOT NULL,
+            acquired_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            released_at REAL,
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    _create_task_table(conn)
+    _validate_schema(conn)
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _validate_schema(conn: sqlite3.Connection) -> None:
+    lease_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_leases)")
+    )
+    task_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_tasks)")
+    )
+    if lease_columns != _LEASE_COLUMNS or task_columns != _TASK_COLUMNS:
+        raise DriverStateError(
+            "unsupported unpublished hosted-room driver schema; "
+            "recreate the driver tables before starting the driver"
+        )
+
+    for table in ("hosted_room_driver_leases", "hosted_room_driver_tasks"):
+        foreign_keys = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        if not any(
+            row[2] == "hosted_rooms" and row[3] == "room_id" and row[4] == "room_id"
+            for row in foreign_keys
+        ):
+            raise DriverStateError(f"{table} is missing its hosted_rooms foreign key")
+
+
+def _schema_objects_exist(conn: sqlite3.Connection) -> bool:
+    rows = conn.execute(
+        """SELECT name FROM sqlite_master
+           WHERE type='table' AND name IN (
+               'hosted_room_driver_leases', 'hosted_room_driver_tasks'
+           )"""
+    ).fetchall()
+    tables = {row[0] for row in rows}
+    if tables != {"hosted_room_driver_leases", "hosted_room_driver_tasks"}:
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_driver_tasks_status'"""
+    ).fetchone()
+    return index is not None
+
+
+def _task_schema_supports_stopping(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        """SELECT sql FROM sqlite_master
+           WHERE type='table' AND name='hosted_room_driver_tasks'"""
+    ).fetchone()
+    return bool(row and "'stopping'" in str(row[0] or "").lower())
+
+
+def _migrate_task_status_constraint(conn: sqlite3.Connection) -> None:
+    """Expand the unpublished task-state CHECK without losing durable work."""
+    conn.execute("DROP INDEX IF EXISTS idx_hosted_room_driver_tasks_status")
+    _create_task_table(conn, "hosted_room_driver_tasks_next")
+    columns = ", ".join(_TASK_COLUMN_ORDER)
+    conn.execute(
+        f"""INSERT INTO hosted_room_driver_tasks_next ({columns})
+             SELECT {columns} FROM hosted_room_driver_tasks"""
+    )
+    conn.execute("DROP TABLE hosted_room_driver_tasks")
+    conn.execute(
+        "ALTER TABLE hosted_room_driver_tasks_next RENAME TO hosted_room_driver_tasks"
+    )
+    conn.execute(
+        """CREATE INDEX idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (hosted_room_driver)")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_objects_exist(conn):
+            if not _task_schema_supports_stopping(conn):
+                conn.execute("BEGIN IMMEDIATE")
+                _migrate_task_status_constraint(conn)
+                conn.commit()
+            _validate_schema(conn)
+            return conn
+        # Schema creation is one database-wide transaction. The driver schema
+        # has never shipped, so an incompatible draft schema fails closed
+        # instead of attempting a partial in-place migration.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(db_path: Path | str) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _lease_from_row(
+    row: sqlite3.Row | dict[str, Any], *, reclaimed: bool = False
+) -> DriverLease:
+    return DriverLease(
+        room_id=row["room_id"],
+        gateway_id=row["gateway_id"],
+        authority_epoch=int(row["authority_epoch"]),
+        process_generation=row["process_generation"],
+        lease_generation=int(row["lease_generation"]),
+        expires_at=float(row["expires_at"]),
+        reclaimed=reclaimed,
+    )
+
+
+def _task_identity_from_row(row: sqlite3.Row) -> TaskIdentity:
+    return TaskIdentity(
+        room_id=row["room_id"],
+        task_id=row["task_id"],
+        thread_id=row["thread_id"],
+        turn_id=row["turn_id"],
+    )
+
+
+def _task_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    try:
+        raw_payload = json.loads(row["payload_json"])
+        payload, encoded_payload, payload_digest = _task_payload(raw_payload)
+    except (TypeError, json.JSONDecodeError, DriverValidationError) as exc:
+        raise TaskConflictError("stored task payload is invalid") from exc
+    if (
+        encoded_payload != row["payload_json"]
+        or payload_digest != row["payload_digest"]
+        or payload["source_event_seq"] != int(row["source_event_seq"])
+    ):
+        raise TaskConflictError("stored task payload failed its integrity check")
+    result = json.loads(row["result_json"]) if row["result_json"] is not None else None
+    return {
+        "identity": _task_identity_from_row(row),
+        "payload": payload,
+        "payload_digest": row["payload_digest"],
+        "status": row["status"],
+        "execution_generation": int(row["execution_generation"]),
+        "cancel_generation": int(row["cancel_generation"]),
+        "run_gateway_id": row["run_gateway_id"],
+        "run_process_generation": row["run_process_generation"],
+        "run_lease_generation": (
+            int(row["run_lease_generation"])
+            if row["run_lease_generation"] is not None
+            else None
+        ),
+        "cancel_id": row["cancel_id"],
+        "settlement_id": row["settlement_id"],
+        "settlement_status": row["settlement_status"],
+        "result": result,
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "started_at": (
+            float(row["started_at"]) if row["started_at"] is not None else None
+        ),
+        "terminal_at": (
+            float(row["terminal_at"]) if row["terminal_at"] is not None else None
+        ),
+        "indeterminate_at": (
+            float(row["indeterminate_at"])
+            if row["indeterminate_at"] is not None
+            else None
+        ),
+        "idempotent": idempotent,
+    }
+
+
+def _load_task(conn: sqlite3.Connection, identity: TaskIdentity) -> sqlite3.Row:
+    row = conn.execute(
+        """SELECT * FROM hosted_room_driver_tasks
+           WHERE room_id=? AND task_id=?""",
+        (identity.room_id, identity.task_id),
+    ).fetchone()
+    if row is None:
+        raise TaskConflictError("task does not exist")
+    if _task_identity_from_row(row) != identity:
+        raise TaskConflictError("task_id is already bound to a different turn")
+    return row
+
+
+def _load_active_room(conn: sqlite3.Connection, room_id: str) -> sqlite3.Row:
+    try:
+        row = conn.execute(
+            """SELECT room_id, authority_gateway_id, authority_epoch, disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            raise RoomUnavailableError("hosted room does not exist") from exc
+        raise
+    if row is None:
+        raise RoomUnavailableError("hosted room does not exist")
+    if row["disbanded_at"] is not None:
+        raise RoomUnavailableError("hosted room is disbanded")
+    return row
+
+
+def _require_room_authority(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    gateway_id: str,
+    authority_epoch: int,
+) -> sqlite3.Row:
+    room = _load_active_room(conn, room_id)
+    if (
+        room["authority_gateway_id"] != gateway_id
+        or int(room["authority_epoch"]) != authority_epoch
+    ):
+        raise StaleLeaseError("hosted room authority changed")
+    return room
+
+
+def _require_active_lease(
+    conn: sqlite3.Connection,
+    lease: DriverLease,
+    *,
+    now: float,
+) -> sqlite3.Row:
+    _require_room_authority(
+        conn,
+        room_id=lease.room_id,
+        gateway_id=lease.gateway_id,
+        authority_epoch=lease.authority_epoch,
+    )
+    row = conn.execute(
+        "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+        (lease.room_id,),
+    ).fetchone()
+    if (
+        row is None
+        or row["gateway_id"] != lease.gateway_id
+        or int(row["authority_epoch"]) != lease.authority_epoch
+        or row["process_generation"] != lease.process_generation
+        or int(row["lease_generation"]) != lease.lease_generation
+        or row["released_at"] is not None
+        or float(row["expires_at"]) <= now
+    ):
+        raise StaleLeaseError("driver lease is stale or expired")
+    return row
+
+
+def acquire_lease(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    gateway_id: Any,
+    authority_epoch: Any,
+    process_generation: Any,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Acquire an empty or expired room lease with a monotonic generation."""
+    room_id = _identifier(room_id, label="room_id")
+    gateway_id = _identifier(gateway_id, label="gateway_id")
+    authority_epoch = _authority_epoch(authority_epoch)
+    process_generation = _identifier(
+        process_generation,
+        label="process_generation",
+    )
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    expires_at = _expiry(now, ttl_seconds)
+
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=room_id,
+            gateway_id=gateway_id,
+            authority_epoch=authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                """INSERT INTO hosted_room_driver_leases (
+                       room_id, gateway_id, authority_epoch, process_generation,
+                       lease_generation, expires_at, acquired_at,
+                       updated_at, released_at
+                   ) VALUES (?, ?, ?, ?, 1, ?, ?, ?, NULL)""",
+                (
+                    room_id,
+                    gateway_id,
+                    authority_epoch,
+                    process_generation,
+                    expires_at,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            return _lease_from_row(row)
+
+        if (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+            and row["process_generation"] == process_generation
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            renewed_expiry = max(float(row["expires_at"]), expires_at)
+            conn.execute(
+                """UPDATE hosted_room_driver_leases
+                   SET expires_at=?, updated_at=?
+                   WHERE room_id=? AND lease_generation=?""",
+                (renewed_expiry, now, room_id, int(row["lease_generation"])),
+            )
+            current = dict(row)
+            current["expires_at"] = renewed_expiry
+            return _lease_from_row(current)
+
+        same_authority = (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+        )
+        if (
+            same_authority
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            raise LeaseHeldError("room driver lease is held by another generation")
+
+        previous_generation = int(row["lease_generation"])
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET gateway_id=?, authority_epoch=?, process_generation=?,
+                   lease_generation=lease_generation + 1,
+                   expires_at=?, acquired_at=?, updated_at=?, released_at=NULL
+               WHERE room_id=? AND lease_generation=?
+                 AND (
+                     gateway_id != ? OR authority_epoch != ?
+                     OR released_at IS NOT NULL OR expires_at <= ?
+                 )""",
+            (
+                gateway_id,
+                authority_epoch,
+                process_generation,
+                expires_at,
+                now,
+                now,
+                room_id,
+                previous_generation,
+                gateway_id,
+                authority_epoch,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise LeaseHeldError("room driver lease changed during acquisition")
+        current = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        return _lease_from_row(current, reclaimed=True)
+
+
+def renew_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Renew the exact active lease generation or fail closed."""
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    requested_expiry = _expiry(now, ttl_seconds)
+    with _transaction(db_path) as conn:
+        current = _require_active_lease(conn, lease, now=now)
+        expires_at = max(float(current["expires_at"]), requested_expiry)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?
+               WHERE room_id=? AND gateway_id=? AND process_generation=?
+                 AND lease_generation=? AND released_at IS NULL AND expires_at > ?""",
+            (
+                expires_at,
+                now,
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleLeaseError("driver lease changed during renewal")
+        return DriverLease(
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+            process_generation=lease.process_generation,
+            lease_generation=lease.lease_generation,
+            expires_at=expires_at,
+        )
+
+
+def release_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Release the exact active lease generation idempotently."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (lease.room_id,),
+        ).fetchone()
+        if (
+            row is None
+            or row["gateway_id"] != lease.gateway_id
+            or int(row["authority_epoch"]) != lease.authority_epoch
+            or row["process_generation"] != lease.process_generation
+            or int(row["lease_generation"]) != lease.lease_generation
+        ):
+            raise StaleLeaseError("driver lease is stale")
+        if row["released_at"] is not None:
+            return {"lease": _lease_from_row(row), "idempotent": True}
+        if float(row["expires_at"]) <= now:
+            raise StaleLeaseError("driver lease expired before release")
+        running = conn.execute(
+            """SELECT 1 FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running' LIMIT 1""",
+            (lease.room_id,),
+        ).fetchone()
+        if running is not None:
+            raise InvalidTaskTransitionError(
+                "cannot release a room lease while tasks are running"
+            )
+        conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?, released_at=?
+               WHERE room_id=? AND lease_generation=?""",
+            (now, now, now, lease.room_id, lease.lease_generation),
+        )
+        current = dict(row)
+        current["expires_at"] = now
+        current["updated_at"] = now
+        current["released_at"] = now
+        return {"lease": _lease_from_row(current), "idempotent": False}
+
+
+def admit_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    payload: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a queued task, or return the identical admission."""
+    normalized_payload, payload_json, payload_digest = _task_payload(payload)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _load_active_room(conn, identity.room_id)
+        existing = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        ).fetchone()
+        if existing is not None:
+            if _task_identity_from_row(existing) != identity:
+                raise TaskConflictError("task_id is already bound to a different turn")
+            if (
+                existing["payload_digest"] != payload_digest
+                or existing["payload_json"] != payload_json
+            ):
+                raise TaskConflictError(
+                    "task_id is already bound to a different payload"
+                )
+            return _task_from_row(existing, idempotent=True)
+
+        turn = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND thread_id=? AND turn_id=?""",
+            (identity.room_id, identity.thread_id, identity.turn_id),
+        ).fetchone()
+        if turn is not None:
+            raise TaskConflictError("thread_id and turn_id are already bound to a task")
+
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks (
+                   room_id, task_id, thread_id, turn_id,
+                   source_event_seq, payload_json, payload_digest, status,
+                   execution_generation, cancel_generation,
+                   created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 0, 0, ?, ?)""",
+            (
+                identity.room_id,
+                identity.task_id,
+                identity.thread_id,
+                identity.turn_id,
+                normalized_payload["source_event_seq"],
+                payload_json,
+                payload_digest,
+                now,
+                now,
+            ),
+        )
+        row = _load_task(conn, identity)
+        return _task_from_row(row)
+
+
+def start_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> TaskAttempt:
+    """Move one queued task to running under the current driver lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        if row["status"] != "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot start task in state '{row['status']}'"
+            )
+        unresolved = conn.execute(
+            """SELECT task_id, status FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status IN ('running', 'indeterminate', 'stopping')
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if unresolved is not None:
+            raise InvalidTaskTransitionError(
+                "room recovery must resolve the prior task before starting new work"
+            )
+        next_queued = conn.execute(
+            """SELECT task_id FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if next_queued is None or next_queued["task_id"] != identity.task_id:
+            raise InvalidTaskTransitionError(
+                "task is not next in the hosted room event order"
+            )
+        execution_generation = int(row["execution_generation"]) + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='running', execution_generation=?,
+                   run_gateway_id=?, run_process_generation=?,
+                   run_lease_generation=?, started_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='queued'
+                 AND cancel_generation=?""",
+            (
+                execution_generation,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during start")
+        return TaskAttempt(
+            identity=identity,
+            lease=lease,
+            execution_generation=execution_generation,
+            cancel_generation=expected_cancel_generation,
+        )
+
+
+def settle_task(
+    db_path: Path | str,
+    attempt: TaskAttempt,
+    *,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit one terminal result if every lease and task fence still matches."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, attempt.identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+
+        _require_active_lease(conn, attempt.lease, now=now)
+        expected = (
+            row["status"] == "running"
+            and int(row["execution_generation"]) == attempt.execution_generation
+            and int(row["cancel_generation"]) == attempt.cancel_generation
+            and row["run_gateway_id"] == attempt.lease.gateway_id
+            and row["run_process_generation"] == attempt.lease.process_generation
+            and int(row["run_lease_generation"]) == attempt.lease.lease_generation
+        )
+        if not expected:
+            raise StaleTaskError("task attempt is stale or cancelled")
+
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='running'
+                 AND execution_generation=? AND cancel_generation=?
+                 AND run_gateway_id=? AND run_process_generation=?
+                 AND run_lease_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                attempt.identity.room_id,
+                attempt.identity.task_id,
+                attempt.execution_generation,
+                attempt.cancel_generation,
+                attempt.lease.gateway_id,
+                attempt.lease.process_generation,
+                attempt.lease.lease_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during settlement")
+        return _task_from_row(_load_task(conn, attempt.identity))
+
+
+def settle_stopping_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a completion that won the race with an unacknowledged Stop."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    if expected_execution_generation < 1 or expected_cancel_generation < 1:
+        raise DriverValidationError("stopping settlement generations are invalid")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        _require_active_lease(conn, lease, now=now)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task completion lost the stop race")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def resolve_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a verified historical receipt under the current room lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during reconciliation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def requeue_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Explicitly retry uncertain work after an operator accepts at-least-once risk."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='queued', run_gateway_id=NULL,
+                   run_process_generation=NULL, run_lease_generation=NULL,
+                   started_at=NULL, indeterminate_at=NULL, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during requeue")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def cancel_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Cancel a queued task before any external work was admitted."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES:
+            raise InvalidTaskTransitionError(
+                f"cannot cancel task in state '{row['status']}'"
+            )
+        if row["status"] != "queued":
+            raise InvalidTaskTransitionError(
+                "running work requires acknowledged two-phase cancellation"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+
+        next_generation = expected_cancel_generation + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', cancel_generation=?, cancel_id=?,
+                   terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status='queued'
+                 AND cancel_generation=?""",
+            (
+                next_generation,
+                cancel_id,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during cancellation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def begin_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a stop intent without claiming the remote run has stopped."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "stopping" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES or row["status"] == "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot request remote stop in state '{row['status']}'"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='stopping', cancel_generation=?, cancel_id=?,
+                   updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status IN ('running', 'indeterminate')
+                 AND cancel_generation=?""",
+            (
+                expected_cancel_generation + 1,
+                cancel_id,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop request")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def complete_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit cancellation only after the transport acknowledges exact Stop."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if (
+            row["status"] != "stopping"
+            or row["cancel_id"] != cancel_id
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("task stop acknowledgement is stale")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND cancel_id=? AND cancel_generation=?""",
+            (
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                cancel_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop acknowledgement")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def recover_room(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, list[TaskIdentity]]:
+    """Fence abandoned running attempts without requeueing uncertain work."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        stale_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running'
+                 AND NOT (
+                     run_gateway_id=? AND run_process_generation=?
+                     AND run_lease_generation=?
+                 )
+               ORDER BY source_event_seq, created_at, task_id""",
+            (
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+            ),
+        ).fetchall()
+        if stale_rows:
+            conn.execute(
+                """UPDATE hosted_room_driver_tasks
+                   SET status='indeterminate', indeterminate_at=?, updated_at=?
+                   WHERE room_id=? AND status='running'
+                     AND NOT (
+                         run_gateway_id=? AND run_process_generation=?
+                         AND run_lease_generation=?
+                     )""",
+                (
+                    now,
+                    now,
+                    lease.room_id,
+                    lease.gateway_id,
+                    lease.process_generation,
+                    lease.lease_generation,
+                ),
+            )
+        queued_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        indeterminate_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='indeterminate'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        return {
+            "queued": [_task_identity_from_row(row) for row in queued_rows],
+            "indeterminate": [
+                _task_identity_from_row(row) for row in indeterminate_rows
+            ],
+        }
+
+
+def get_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+) -> dict[str, Any]:
+    """Read one task without mutating its state."""
+    conn = _connect(db_path)
+    try:
+        return _task_from_row(_load_task(conn, identity))
+    finally:
+        conn.close()
+
+
+def list_tasks(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    status: TaskStatus | None = None,
+) -> list[dict[str, Any]]:
+    """Return room tasks in deterministic admission order."""
+    room_id = _identifier(room_id, label="room_id")
+    if status is not None and status not in TASK_STATUSES:
+        raise DriverValidationError("invalid task status")
+    conn = _connect(db_path)
+    try:
+        if status is None:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=? AND status=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id, status),
+            ).fetchall()
+        return [_task_from_row(row) for row in rows]
+    finally:
+        conn.close()

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -12,6 +12,7 @@ can isolate state. Production handlers use the gateway's root ``state.db``.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sqlite3
@@ -64,6 +65,7 @@ _EVENT_KINDS_BY_ACTOR = {
     "gateway": frozenset({
         "member.unavailable",
         "room.activity",
+        "room.stop_requested",
         "turn.deferred",
         "turn.reassigned",
         "turn.cancelled",
@@ -736,6 +738,33 @@ def room_state(
     if claim_row is not None:
         state["authority_claim"] = _event_from_row(claim_row)
     return state
+
+
+def request_room_stop(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    cancel_id: Any,
+) -> dict[str, Any]:
+    """Append an idempotent fence that supersedes earlier user turns."""
+
+    cancel_id = _validate_identifier(
+        cancel_id,
+        label="cancel_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    room = room_state(db_path, room_id=room_id)
+    digest = hashlib.sha256(cancel_id.encode()).hexdigest()[:32]
+    return append_event(
+        db_path,
+        room_id=room["room_id"],
+        event_id=f"room-stop:{digest}",
+        kind="room.stop_requested",
+        actor={"kind": "gateway", "id": room["authority_gateway_id"]},
+        payload={"cancel_id": cancel_id},
+        authority_gateway_id=room["authority_gateway_id"],
+        authority_epoch=room["authority_epoch"],
+    )
 
 
 def claim_authority(

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -1,0 +1,1035 @@
+"""Durable state for gateway-hosted Bot Mode rooms.
+
+This module owns only hosted-room identity and its append-only event log. It
+does not deliver events, lease relay work, or run agent turns; those concerns
+belong to the relay and the future hosted-room driver. Keeping that boundary
+explicit lets the room log compose with a durable relay without creating a
+second transport queue.
+
+The caller supplies the database path so tests and alternate gateway layouts
+can isolate state. Production handlers use the gateway's root ``state.db``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+PROTOCOL_VERSION = 2
+MAX_ROOM_ID_CHARS = 128
+MAX_EVENT_ID_CHARS = 128
+MAX_ROOM_NAME_CHARS = 200
+MAX_EVENT_KIND_CHARS = 64
+MAX_ACTOR_ID_CHARS = 128
+MAX_ACTOR_LABEL_CHARS = 200
+MAX_MEMBERS = 128
+MAX_MEMBERS_JSON_BYTES = 128 * 1024
+MAX_EVENT_JSON_BYTES = 256 * 1024
+MAX_LOG_LIMIT = 500
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_EVENT_KIND_RE = re.compile(r"^[a-z][a-z0-9_.-]*$")
+_ROOM_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "name",
+    "members_json",
+    "authority_gateway_id",
+    "authority_epoch",
+    "next_seq",
+    "revision",
+    "created_at",
+    "updated_at",
+    "disbanded_at",
+})
+_EVENT_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "seq",
+    "event_id",
+    "kind",
+    "actor_json",
+    "authority_epoch",
+    "payload_json",
+    "created_at",
+})
+
+_EVENT_KINDS_BY_ACTOR = {
+    "user": frozenset({"message.user"}),
+    "member": frozenset({"message.member"}),
+    "gateway": frozenset({
+        "member.unavailable",
+        "room.activity",
+        "turn.deferred",
+        "turn.reassigned",
+        "turn.cancelled",
+        "turn.failed",
+        "turn.settled",
+        "turn.started",
+    }),
+    "system": frozenset({
+        "authority.claimed",
+        "authority.lost",
+        "room.created",
+        "room.disbanded",
+        "room.members_changed",
+        "room.renamed",
+    }),
+}
+_ACTOR_FIELDS = frozenset({"kind", "id", "display_name", "profile", "connection_id"})
+
+
+class HostedRoomError(ValueError):
+    """Base class for invalid or conflicting hosted-room operations."""
+
+
+class RoomNotFoundError(HostedRoomError):
+    """Raised when a room does not exist or has been disbanded."""
+
+
+class RoomConflictError(HostedRoomError):
+    """Raised when an idempotency key is reused for different room state."""
+
+
+class EventConflictError(HostedRoomError):
+    """Raised when an event id is reused with different immutable content."""
+
+
+class AuthorityConflictError(HostedRoomError):
+    """Raised when a stale room authority attempts to mutate hosted state."""
+
+
+class AuthoritySupersededError(AuthorityConflictError):
+    """Raised when a successful authority claim was later superseded."""
+
+
+def default_db_path() -> Path:
+    """Return the gateway-wide state database for the active install."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    return root / "state.db"
+
+
+def local_authority_gateway_id() -> str:
+    """Return the stable server-owned identity for hosted-room authority."""
+    from hermes_cli.install_identity import get_install_id
+
+    install_id = get_install_id()
+    if not install_id:
+        raise HostedRoomError("stable gateway install identity is unavailable")
+    return _validate_identifier(
+        f"install:{install_id}",
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+
+
+def _canonical_json(value: Any, *, label: str, max_bytes: int) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise HostedRoomError(f"{label} must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise HostedRoomError(f"{label} is too large")
+    return encoded
+
+
+def _validate_identifier(value: Any, *, label: str, max_chars: int) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError(f"{label} must be a string")
+    value = value.strip()
+    if not value or len(value) > max_chars or not _IDENTIFIER_RE.fullmatch(value):
+        raise HostedRoomError(f"invalid {label}")
+    return value
+
+
+def _validate_room_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("name must be a string")
+    value = value.strip()
+    if not value or len(value) > MAX_ROOM_NAME_CHARS:
+        raise HostedRoomError("invalid room name")
+    return value
+
+
+def _validate_members(value: Any) -> tuple[list[dict[str, Any]], str]:
+    if not isinstance(value, list):
+        raise HostedRoomError("members must be a list")
+    if len(value) > MAX_MEMBERS:
+        raise HostedRoomError("too many room members")
+    members: list[dict[str, Any]] = []
+    for member in value:
+        if not isinstance(member, dict):
+            raise HostedRoomError("each room member must be an object")
+        members.append(dict(member))
+    encoded = _canonical_json(
+        members,
+        label="members",
+        max_bytes=MAX_MEMBERS_JSON_BYTES,
+    )
+    return members, encoded
+
+
+def _validate_event_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("kind must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_EVENT_KIND_CHARS
+        or not _EVENT_KIND_RE.fullmatch(value)
+    ):
+        raise HostedRoomError("invalid event kind")
+    return value
+
+
+def _optional_actor_field(actor: dict[str, Any], field: str, max_chars: int) -> str:
+    value = actor.get(field)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise HostedRoomError(f"actor.{field} must be a string")
+    value = value.strip()
+    if len(value) > max_chars:
+        raise HostedRoomError(f"actor.{field} is too long")
+    return value
+
+
+def _validate_actor(value: Any, *, kind: str) -> tuple[dict[str, str], str]:
+    if not isinstance(value, dict):
+        raise HostedRoomError("actor must be an object")
+    unknown = set(value) - _ACTOR_FIELDS
+    if unknown:
+        raise HostedRoomError(f"unknown actor fields: {', '.join(sorted(unknown))}")
+
+    actor_kind = value.get("kind")
+    if not isinstance(actor_kind, str) or actor_kind not in _EVENT_KINDS_BY_ACTOR:
+        raise HostedRoomError("invalid actor.kind")
+    if kind not in _EVENT_KINDS_BY_ACTOR[actor_kind]:
+        raise HostedRoomError(f"actor kind '{actor_kind}' cannot append '{kind}'")
+
+    actor_id = _validate_identifier(
+        value.get("id"),
+        label="actor.id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    actor = {"kind": actor_kind, "id": actor_id}
+    for field, max_chars in (
+        ("display_name", MAX_ACTOR_LABEL_CHARS),
+        ("profile", MAX_ACTOR_ID_CHARS),
+        ("connection_id", MAX_ACTOR_ID_CHARS),
+    ):
+        field_value = _optional_actor_field(value, field, max_chars)
+        if field_value:
+            actor[field] = field_value
+    encoded = _canonical_json(
+        actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    return actor, encoded
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_rooms (
+            room_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            members_json TEXT NOT NULL,
+            authority_gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL DEFAULT 1 CHECK (authority_epoch >= 1),
+            next_seq INTEGER NOT NULL DEFAULT 1 CHECK (next_seq >= 1),
+            revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            disbanded_at REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_events (
+            room_id TEXT NOT NULL,
+            seq INTEGER NOT NULL CHECK (seq >= 1),
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            actor_json TEXT NOT NULL,
+            authority_epoch INTEGER CHECK (authority_epoch IS NULL OR authority_epoch >= 1),
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (room_id, seq),
+            UNIQUE (room_id, event_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    room_columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    if "authority_gateway_id" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+    if "authority_epoch" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_epoch INTEGER NOT NULL DEFAULT 1"
+        )
+
+    event_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    }
+    if "actor_json" not in event_columns:
+        # Draft builds before the actor contract carried no identity. Preserve
+        # their inert replay rows explicitly as legacy system events rather
+        # than guessing a user or Bot author.
+        legacy_actor = _canonical_json(
+            {"kind": "system", "id": "legacy"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        escaped_actor = legacy_actor.replace("'", "''")
+        conn.execute(
+            "ALTER TABLE hosted_room_events "
+            f"ADD COLUMN actor_json TEXT NOT NULL DEFAULT '{escaped_actor}'"
+        )
+    if "authority_epoch" not in event_columns:
+        conn.execute(
+            "ALTER TABLE hosted_room_events ADD COLUMN authority_epoch INTEGER"
+        )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_events_cursor
+           ON hosted_room_events(room_id, seq)"""
+    )
+    if not _schema_is_current(conn):
+        raise HostedRoomError("hosted room schema migration did not complete")
+
+
+def _schema_is_current(conn: sqlite3.Connection) -> bool:
+    room_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")
+    )
+    event_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    )
+    if not _ROOM_SCHEMA_COLUMNS.issubset(room_columns):
+        return False
+    if not _EVENT_SCHEMA_COLUMNS.issubset(event_columns):
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_events_cursor'"""
+    ).fetchone()
+    return index is not None
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (hosted_rooms)")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_is_current(conn):
+            return conn
+        # Multiple profile gateways share this root database. Serialize every
+        # draft-schema transition in SQLite itself so a crash rolls back the
+        # whole DDL/data migration and another process can safely retry it.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(
+    db_path: Path | str, *, immediate: bool = False
+) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        if immediate:
+            conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _room_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    room = {
+        "room_id": row["room_id"],
+        "name": row["name"],
+        "members": json.loads(row["members_json"]),
+        "authority_gateway_id": row["authority_gateway_id"],
+        "authority_epoch": int(row["authority_epoch"]),
+        "revision": int(row["revision"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "idempotent": idempotent,
+    }
+    if "disbanded_at" in row.keys() and row["disbanded_at"] is not None:
+        room["disbanded_at"] = float(row["disbanded_at"])
+    if "next_seq" in row.keys():
+        room["latest_seq"] = int(row["next_seq"]) - 1
+    return room
+
+
+def _event_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    return {
+        "room_id": row["room_id"],
+        "seq": int(row["seq"]),
+        "event_id": row["event_id"],
+        "kind": row["kind"],
+        "actor": json.loads(row["actor_json"]),
+        "authority_epoch": (
+            int(row["authority_epoch"]) if row["authority_epoch"] is not None else None
+        ),
+        "payload": json.loads(row["payload_json"]),
+        "created_at": float(row["created_at"]),
+        "idempotent": idempotent,
+    }
+
+
+def create_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    name: Any,
+    members: Any,
+    authority_gateway_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Create a room, or return the identical existing room idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    name = _validate_room_name(name)
+    normalized_members, members_json = _validate_members(members)
+    authority_gateway_id = _validate_identifier(
+        authority_gateway_id,
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if existing is not None:
+            if existing["disbanded_at"] is not None:
+                raise RoomConflictError("room_id belongs to a disbanded room")
+            if existing["name"] != name or existing["members_json"] != members_json:
+                raise RoomConflictError("room_id already exists with different state")
+            if (
+                existing["authority_gateway_id"] == "legacy"
+                and authority_gateway_id != "legacy"
+            ):
+                target_epoch = int(existing["authority_epoch"]) + 1
+                seq = int(existing["next_seq"])
+                claim_actor_json = _canonical_json(
+                    {"kind": "system", "id": "authority-control"},
+                    label="actor",
+                    max_bytes=4 * 1024,
+                )
+                claim_payload_json = _canonical_json(
+                    {
+                        "previous_gateway_id": "legacy",
+                        "authority_gateway_id": authority_gateway_id,
+                        "authority_epoch": target_epoch,
+                    },
+                    label="payload",
+                    max_bytes=MAX_EVENT_JSON_BYTES,
+                )
+                conn.execute(
+                    """INSERT INTO hosted_room_events
+                       (room_id, seq, event_id, kind, actor_json,
+                        authority_epoch, payload_json, created_at)
+                       VALUES (?, ?, 'system:authority-adopted',
+                               'authority.claimed', ?, ?, ?, ?)""",
+                    (
+                        room_id,
+                        seq,
+                        claim_actor_json,
+                        target_epoch,
+                        claim_payload_json,
+                        now,
+                    ),
+                )
+                adopted = conn.execute(
+                    """UPDATE hosted_rooms
+                          SET authority_gateway_id=?, authority_epoch=?,
+                              next_seq=next_seq+1, revision=revision+1,
+                              updated_at=?
+                        WHERE room_id=? AND authority_gateway_id='legacy'
+                          AND authority_epoch=? AND next_seq=?
+                          AND disbanded_at IS NULL""",
+                    (
+                        authority_gateway_id,
+                        target_epoch,
+                        now,
+                        room_id,
+                        int(existing["authority_epoch"]),
+                        seq,
+                    ),
+                )
+                if adopted.rowcount != 1:
+                    raise AuthorityConflictError("legacy room adoption lost its fence")
+                existing = conn.execute(
+                    """SELECT room_id, name, members_json, authority_gateway_id,
+                              authority_epoch, next_seq, revision, created_at,
+                              updated_at, disbanded_at
+                         FROM hosted_rooms WHERE room_id=?""",
+                    (room_id,),
+                ).fetchone()
+                if existing is None:  # pragma: no cover - row updated above
+                    raise RuntimeError("adopted room could not be reloaded")
+                result = _room_from_row(existing, idempotent=True)
+                result["adopted"] = True
+                claim_event = conn.execute(
+                    """SELECT room_id, seq, event_id, kind, actor_json,
+                              authority_epoch, payload_json, created_at
+                         FROM hosted_room_events
+                        WHERE room_id=? AND event_id='system:authority-adopted'""",
+                    (room_id,),
+                ).fetchone()
+                if claim_event is None:  # pragma: no cover - inserted above
+                    raise RuntimeError("legacy adoption event could not be reloaded")
+                result["claim_event"] = _event_from_row(claim_event)
+                return result
+            if existing["authority_gateway_id"] != authority_gateway_id:
+                raise RoomConflictError(
+                    "room_id already belongs to a different authority"
+                )
+            return _room_from_row(existing, idempotent=True)
+
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               (room_id, name, members_json, authority_gateway_id,
+                authority_epoch, next_seq, revision,
+                created_at, updated_at, disbanded_at)
+               VALUES (?, ?, ?, ?, 1, 1, 1, ?, ?, NULL)""",
+            (room_id, name, members_json, authority_gateway_id, now, now),
+        )
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, revision, created_at, updated_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("created room could not be reloaded")
+    result = _room_from_row(row)
+    result["members"] = normalized_members
+    return result
+
+
+def list_rooms(
+    db_path: Path | str,
+    *,
+    include_disbanded: bool = False,
+) -> list[dict[str, Any]]:
+    """Return hosted rooms ordered by most recent change."""
+    with _transaction(db_path) as conn:
+        rows = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+               FROM hosted_rooms
+               WHERE disbanded_at IS NULL OR ?
+               ORDER BY updated_at DESC, room_id ASC""",
+            (int(include_disbanded),),
+        ).fetchall()
+    return [_room_from_row(row) for row in rows]
+
+
+def append_event(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    event_id: Any,
+    kind: Any,
+    actor: Any,
+    payload: Any,
+    authority_gateway_id: Any = None,
+    authority_epoch: Any = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Append one immutable event and allocate its per-room sequence atomically.
+
+    Repeating the same ``event_id`` and immutable content returns the original
+    event. Reusing the id for different content fails closed.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    kind = _validate_event_kind(kind)
+    normalized_actor, actor_json = _validate_actor(actor, kind=kind)
+    authority_scoped = normalized_actor["kind"] in {"member", "gateway", "system"}
+    normalized_authority_gateway_id: str | None = None
+    normalized_authority_epoch: int | None = None
+    if authority_scoped:
+        normalized_authority_gateway_id = _validate_identifier(
+            authority_gateway_id,
+            label="authority_gateway_id",
+            max_chars=MAX_ACTOR_ID_CHARS,
+        )
+        if (
+            normalized_actor["kind"] == "gateway"
+            and normalized_actor["id"] != normalized_authority_gateway_id
+        ):
+            raise HostedRoomError("gateway actor.id must match authority_gateway_id")
+        if (
+            isinstance(authority_epoch, bool)
+            or not isinstance(authority_epoch, int)
+            or authority_epoch < 1
+        ):
+            raise HostedRoomError("authority_epoch must be a positive integer")
+        normalized_authority_epoch = authority_epoch
+    elif authority_gateway_id is not None or authority_epoch is not None:
+        raise HostedRoomError(
+            "authority fields are only valid for member, gateway, or system events"
+        )
+    if not isinstance(payload, dict):
+        raise HostedRoomError("payload must be an object")
+    payload_json = _canonical_json(
+        payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing is not None:
+            if (
+                existing["kind"] != kind
+                or existing["actor_json"] != actor_json
+                or existing["authority_epoch"] != normalized_authority_epoch
+                or existing["payload_json"] != payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            return _event_from_row(existing, idempotent=True)
+
+        room = conn.execute(
+            """SELECT next_seq, authority_gateway_id, authority_epoch
+                  FROM hosted_rooms
+               WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        if authority_scoped and (
+            room["authority_gateway_id"] != normalized_authority_gateway_id
+            or int(room["authority_epoch"]) != normalized_authority_epoch
+        ):
+            raise AuthorityConflictError("stale hosted room authority")
+        seq = int(room["next_seq"])
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                event_id,
+                kind,
+                actor_json,
+                normalized_authority_epoch,
+                payload_json,
+                now,
+            ),
+        )
+        advanced = conn.execute(
+            """UPDATE hosted_rooms
+               SET next_seq=?, updated_at=?
+               WHERE room_id=? AND next_seq=?""",
+            (seq + 1, now, room_id, seq),
+        )
+        if advanced.rowcount != 1:
+            raise RuntimeError("hosted room sequence advance lost its write fence")
+        row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND seq=?""",
+            (room_id, seq),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("appended event could not be reloaded")
+    result = _event_from_row(row)
+    result["actor"] = normalized_actor
+    return result
+
+
+def room_state(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Return durable replay and authority state for one room."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    with _transaction(db_path) as conn:
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+                 FROM hosted_rooms
+                WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if row is None:
+            raise RoomNotFoundError("hosted room not found")
+        claim_row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND kind='authority.claimed'
+                  AND authority_epoch=?
+                ORDER BY seq DESC LIMIT 1""",
+            (room_id, int(row["authority_epoch"])),
+        ).fetchone()
+    state = _room_from_row(row)
+    state["latest_seq"] = int(row["next_seq"]) - 1
+    if claim_row is not None:
+        state["authority_claim"] = _event_from_row(claim_row)
+    return state
+
+
+def claim_authority(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    expected_gateway_id: Any,
+    expected_epoch: Any,
+    new_gateway_id: Any,
+    event_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Fence a verified authority transfer with a compare-and-swap epoch.
+
+    This storage primitive does not decide *when* takeover is safe. A future
+    replicated driver must call it only after its lease/quorum policy has
+    established that the previous owner can no longer commit.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    expected_gateway_id = _validate_identifier(
+        expected_gateway_id,
+        label="expected_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    new_gateway_id = _validate_identifier(
+        new_gateway_id,
+        label="new_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    if (
+        isinstance(expected_epoch, bool)
+        or not isinstance(expected_epoch, int)
+        or expected_epoch < 1
+    ):
+        raise HostedRoomError("expected_epoch must be a positive integer")
+    now = time.time() if now is None else float(now)
+    target_epoch = expected_epoch + 1
+    claim_actor = {"kind": "system", "id": "authority-control"}
+    claim_actor_json = _canonical_json(
+        claim_actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    claim_payload = {
+        "previous_gateway_id": expected_gateway_id,
+        "authority_gateway_id": new_gateway_id,
+        "authority_epoch": target_epoch,
+    }
+    claim_payload_json = _canonical_json(
+        claim_payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+
+    with _transaction(db_path, immediate=True) as conn:
+        row = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, next_seq
+                 FROM hosted_rooms
+                WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            raise RoomNotFoundError("hosted room not found")
+        current_gateway = str(row["authority_gateway_id"])
+        current_epoch = int(row["authority_epoch"])
+        existing_event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing_event is not None:
+            if (
+                existing_event["kind"] != "authority.claimed"
+                or existing_event["actor_json"] != claim_actor_json
+                or existing_event["authority_epoch"] != target_epoch
+                or existing_event["payload_json"] != claim_payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            if current_gateway != new_gateway_id or current_epoch != target_epoch:
+                raise AuthoritySupersededError(
+                    "authority claim succeeded but was later superseded"
+                )
+            idempotent = True
+        elif current_gateway != expected_gateway_id or current_epoch != expected_epoch:
+            raise AuthorityConflictError("hosted room authority changed")
+        else:
+            seq = int(row["next_seq"])
+            conn.execute(
+                """INSERT INTO hosted_room_events
+                   (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                    payload_json, created_at)
+                   VALUES (?, ?, ?, 'authority.claimed', ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    seq,
+                    event_id,
+                    claim_actor_json,
+                    target_epoch,
+                    claim_payload_json,
+                    now,
+                ),
+            )
+            updated = conn.execute(
+                """UPDATE hosted_rooms
+                      SET authority_gateway_id=?, authority_epoch=authority_epoch+1,
+                          next_seq=next_seq+1, revision=revision+1, updated_at=?
+                    WHERE room_id=? AND disbanded_at IS NULL
+                      AND authority_gateway_id=? AND authority_epoch=?""",
+                (
+                    new_gateway_id,
+                    now,
+                    room_id,
+                    expected_gateway_id,
+                    expected_epoch,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise AuthorityConflictError("hosted room authority changed")
+            idempotent = False
+            existing_event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+                (room_id, event_id),
+            ).fetchone()
+        state_row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if state_row is None:  # pragma: no cover - room exists in this transaction
+            raise RuntimeError("claimed room could not be reloaded")
+    state = _room_from_row(state_row, idempotent=idempotent)
+    state["latest_seq"] = int(state_row["next_seq"]) - 1
+    if existing_event is None:  # pragma: no cover - both claim paths set it
+        raise RuntimeError("authority claim event could not be reloaded")
+    state["claim_event"] = _event_from_row(
+        existing_event,
+        idempotent=idempotent,
+    )
+    return state
+
+
+def disband_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Tombstone a room id permanently and idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        room = conn.execute(
+            """SELECT authority_epoch, next_seq, disbanded_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        if room["disbanded_at"] is not None:
+            event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events
+                    WHERE room_id=? AND event_id='system:room-disbanded'""",
+                (room_id,),
+            ).fetchone()
+            return {
+                "room_id": room_id,
+                "disbanded_at": float(room["disbanded_at"]),
+                "idempotent": True,
+                **(
+                    {"event": _event_from_row(event, idempotent=True)}
+                    if event is not None
+                    else {}
+                ),
+            }
+        seq = int(room["next_seq"])
+        actor_json = _canonical_json(
+            {"kind": "system", "id": "room-control"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        payload_json = _canonical_json(
+            {"room_id": room_id},
+            label="payload",
+            max_bytes=MAX_EVENT_JSON_BYTES,
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, 'system:room-disbanded', 'room.disbanded', ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                actor_json,
+                int(room["authority_epoch"]),
+                payload_json,
+                now,
+            ),
+        )
+        updated = conn.execute(
+            """UPDATE hosted_rooms
+               SET disbanded_at=?, updated_at=?, revision=revision+1,
+                   next_seq=next_seq+1
+               WHERE room_id=? AND disbanded_at IS NULL""",
+            (now, now, room_id),
+        )
+        if updated.rowcount != 1:
+            raise RoomConflictError("hosted room disband lost its fence")
+        event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND event_id='system:room-disbanded'""",
+            (room_id,),
+        ).fetchone()
+        if event is None:  # pragma: no cover - inserted in this transaction
+            raise RuntimeError("room disband event could not be reloaded")
+    return {
+        "room_id": room_id,
+        "disbanded_at": now,
+        "idempotent": False,
+        "event": _event_from_row(event),
+    }
+
+
+def read_events(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    since_seq: Any = 0,
+    limit: Any = 100,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Read a monotonic room-log delta after ``since_seq``."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    if isinstance(since_seq, bool) or not isinstance(since_seq, int) or since_seq < 0:
+        raise HostedRoomError("since_seq must be a non-negative integer")
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_LOG_LIMIT
+    ):
+        raise HostedRoomError(f"limit must be between 1 and {MAX_LOG_LIMIT}")
+
+    with _transaction(db_path) as conn:
+        room = conn.execute(
+            """SELECT next_seq FROM hosted_rooms
+               WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if room is None:
+            raise RoomNotFoundError("hosted room not found")
+        latest_seq = int(room["next_seq"]) - 1
+        if since_seq > latest_seq:
+            raise HostedRoomError("since_seq is ahead of the hosted room log")
+        rows = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events
+               WHERE room_id=? AND seq>?
+               ORDER BY seq ASC LIMIT ?""",
+            (room_id, since_seq, limit),
+        ).fetchall()
+    events = [_event_from_row(row) for row in rows]
+    cursor = events[-1]["seq"] if events else since_seq
+    return {
+        "events": events,
+        "cursor": cursor,
+        "latest_seq": latest_seq,
+        "has_more": cursor < latest_seq,
+    }

--- a/hermes_cli/install_identity.py
+++ b/hermes_cli/install_identity.py
@@ -1,0 +1,149 @@
+"""Stable opaque identity shared by every profile in one Hermes install."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import re
+import tempfile
+import threading
+from typing import Optional
+import uuid
+
+from hermes_constants import get_default_hermes_root
+
+_INSTALL_ID_FILENAME = "install_id"
+_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_INSTALL_ID_CACHE: dict[str, Optional[str]] = {"root": None, "value": None}
+_INSTALL_ID_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _install_id_file_lock(root: Path):
+    """Serialize identity publication across processes on POSIX and Windows."""
+    lock_path = root / ".install_id.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    windows = os.name == "nt"
+    try:
+        if windows:
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if windows:
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort durability for the directory entry after replace."""
+    if os.name == "nt":
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def read_or_create_install_id(root: Path | None = None) -> Optional[str]:
+    """Read or atomically mint the opaque id for the physical install.
+
+    ``None`` means the id could neither be read nor persisted. Returning an
+    ephemeral id would violate the authority and connection-registry contract.
+    """
+    root = get_default_hermes_root() if root is None else root
+    path = root / _INSTALL_ID_FILENAME
+    try:
+        existing = path.read_text(encoding="utf-8").strip().lower()
+        if _INSTALL_ID_RE.fullmatch(existing):
+            return existing
+    except FileNotFoundError:
+        pass
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    try:
+        with _install_id_file_lock(root):
+            try:
+                existing = path.read_text(encoding="utf-8").strip().lower()
+                if _INSTALL_ID_RE.fullmatch(existing):
+                    return existing
+            except FileNotFoundError:
+                pass
+            except (OSError, UnicodeDecodeError):
+                return None
+
+            minted = uuid.uuid4().hex
+            fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(minted + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, path)
+                _fsync_directory(root)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
+
+            committed = path.read_text(encoding="utf-8").strip().lower()
+            return committed if _INSTALL_ID_RE.fullmatch(committed) else None
+    except OSError:
+        return None
+
+
+def get_install_id(
+    *,
+    cache: dict[str, Optional[str]] | None = None,
+) -> Optional[str]:
+    """Return the process-cached stable id for the active Hermes root."""
+    root = get_default_hermes_root()
+    root_key = str(root)
+    target_cache = _INSTALL_ID_CACHE if cache is None else cache
+    cached = target_cache.get("value")
+    if cached and target_cache.get("root") in (None, root_key):
+        return cached
+
+    with _INSTALL_ID_LOCK:
+        cached = target_cache.get("value")
+        if cached and target_cache.get("root") in (None, root_key):
+            return cached
+        value = read_or_create_install_id(root)
+        if value:
+            target_cache["root"] = root_key
+            target_cache["value"] = value
+        return value
+
+
+__all__ = ["get_install_id", "read_or_create_install_id"]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -428,6 +428,14 @@ async def _lifespan(app: "FastAPI"):
 
     record_boot_fingerprint()
 
+    # Hosted Bot rooms belong to the backend process, not to any connected
+    # Desktop socket. Start their coordinator before accepting clients so a
+    # restart can reconcile durable work even when no viewer reconnects.
+    from tui_gateway import methods_groups as _hosted_groups
+    import tui_gateway.server  # noqa: F401
+
+    _hosted_groups.start_hosted_room_service()
+
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.
@@ -470,6 +478,7 @@ async def _lifespan(app: "FastAPI"):
     try:
         yield
     finally:
+        _hosted_groups.stop_hosted_room_service(timeout=5.0)
         if cron_stop is not None:
             cron_stop.set()
         pty_reaper_task.cancel()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,6 +47,7 @@ import urllib.parse
 import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli.install_identity import get_install_id as _shared_get_install_id
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -3520,66 +3521,12 @@ _TOPOLOGY_CACHE_TTL = 10.0
 # fact it reveals is "these addresses are the same box", which is the feature.
 # It must never change across restarts/updates, so reads are cached for the
 # process lifetime and the file is written once, atomically.
-_INSTALL_ID_FILENAME = "install_id"
-_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
-_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"value": None}
-_INSTALL_ID_LOCK = threading.Lock()
-
-
-def _read_or_create_install_id() -> Optional[str]:
-    """Read (or mint + persist) the install id under the root Hermes home.
-
-    Returns ``None`` only when the id can neither be read nor persisted (e.g.
-    a read-only filesystem) — an unpersisted id would violate the stability
-    contract, so callers omit the field rather than emit a churning value.
-    """
-    import uuid
-
-    from hermes_constants import get_default_hermes_root
-
-    root = get_default_hermes_root()
-    path = root / _INSTALL_ID_FILENAME
-    try:
-        existing = path.read_text(encoding="utf-8").strip().lower()
-        if _INSTALL_ID_RE.match(existing):
-            return existing
-    except FileNotFoundError:
-        pass
-    except (OSError, UnicodeDecodeError):
-        return None
-
-    minted = uuid.uuid4().hex
-    try:
-        root.mkdir(parents=True, exist_ok=True)
-        # Atomic replace so a crash mid-write can't leave a truncated id that
-        # would be regenerated (i.e. changed) on the next boot.
-        fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(minted + "\n")
-            os.replace(tmp_name, path)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            raise
-    except OSError:
-        return None
-    return minted
+_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"root": None, "value": None}
 
 
 def get_install_id() -> Optional[str]:
-    """Process-lifetime-cached stable install id (see _read_or_create_install_id)."""
-    cached = _INSTALL_ID_CACHE["value"]
-    if cached:
-        return cached
-    with _INSTALL_ID_LOCK:
-        cached = _INSTALL_ID_CACHE["value"]
-        if cached:
-            return cached
-        value = _read_or_create_install_id()
-        if value:
-            _INSTALL_ID_CACHE["value"] = value
-        return value
+    """Process-lifetime-cached stable install id."""
+    return _shared_get_install_id(cache=_INSTALL_ID_CACHE)
 
 
 # Serializes read-modify-write cycles over config.yaml for handlers that run

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -148,6 +148,30 @@ def _append_publication(
     ]
 
 
+def _append_activity(
+    db: Path,
+    *,
+    event_id: str,
+    discussion_event_id: str,
+    thread_id: str,
+) -> dict:
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="room.activity",
+        actor={"kind": "gateway", "id": GATEWAY_ID},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": thread_id,
+            "discussion_event_id": discussion_event_id,
+        },
+        authority_gateway_id=GATEWAY_ID,
+        authority_epoch=1,
+    )
+
+
 def _next_task(room: dict, db: Path) -> discussion.DiscussionTaskPlan:
     decision = discussion.plan_next_task(
         room,
@@ -176,6 +200,44 @@ def _settle_next(
     )
     _append_publication(db, publication)
     return task
+
+
+def test_distinct_threads_are_planned_fifo_without_skipping(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    _append_user(db, event_id="user-2", text="Second", thread_id="thread-2")
+
+    first = _next_task(room, db)
+    assert first.discussion_event_id == "user-1"
+    _append_activity(
+        db,
+        event_id="activity-1",
+        discussion_event_id="user-1",
+        thread_id="thread-1",
+    )
+    second = _next_task(room, db)
+    assert second.discussion_event_id == "user-2"
+
+
+def test_room_stop_fences_old_work_but_allows_a_later_message(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    stop = hosted_rooms.request_room_stop(
+        db,
+        room_id=ROOM_ID,
+        cancel_id="user-stop-1",
+    )
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "idle"
+    assert stop["kind"] == "room.stop_requested"
+
+    _append_user(db, event_id="user-2", text="Continue", thread_id="thread-2")
+    resumed = _next_task(room, db)
+    assert resumed.discussion_event_id == "user-2"
 
 
 def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -1,0 +1,920 @@
+"""Behavior tests for deterministic same-gateway Discussion policy."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+ROOM_ID = "room-1"
+GATEWAY_ID = "gateway-a"
+LOCAL_PROFILES = ("research", "build", "review", "ops", "qa", "docs")
+MEMBERS = [
+    {
+        "member_id": f"member-{profile}",
+        "profile": profile,
+        "handle": profile,
+        "display_name": profile.title(),
+    }
+    for profile in LOCAL_PROFILES[:3]
+]
+MEMBER_IDS = tuple(member["member_id"] for member in MEMBERS)
+
+
+def _refs(
+    overrides: dict[str, str | None] | None = None,
+) -> dict[str, str | None]:
+    refs: dict[str, str | None] = {member_id: None for member_id in MEMBER_IDS}
+    if overrides:
+        refs.update(overrides)
+    return refs
+
+
+def _attachment(
+    kind: str,
+    name: str,
+    mime: str,
+    *,
+    size: int = 128,
+    refs: dict[str, str | None] | None = None,
+) -> dict:
+    return {
+        "kind": kind,
+        "name": name,
+        "size": size,
+        "mime": mime,
+        "refs": refs if refs is not None else _refs(),
+    }
+
+
+def _attachment_manifest() -> list[dict]:
+    return [
+        _attachment(
+            "image",
+            "diagram.png",
+            "image/png",
+            size=2048,
+            refs=_refs({
+                "member-research": "stage:image:research",
+                "member-build": "stage:image:build",
+            }),
+        ),
+        _attachment(
+            "pdf",
+            "release.pdf",
+            "application/pdf",
+            size=4096,
+            refs=_refs({
+                "member-research": "stage:pdf:research",
+                "member-build": "stage:pdf:build",
+            }),
+        ),
+        _attachment(
+            "file",
+            "notes.txt",
+            "text/plain",
+            size=512,
+            refs=_refs({
+                "member-research": "stage:file:research",
+                "member-build": "stage:file:build",
+                "member-review": "stage:file:review",
+            }),
+        ),
+    ]
+
+
+@pytest.fixture
+def room_db(tmp_path: Path) -> tuple[Path, dict]:
+    db = tmp_path / "state.db"
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Release",
+        members=MEMBERS,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    return db, room
+
+
+def _events(db: Path) -> list[dict]:
+    return hosted_rooms.read_events(
+        db,
+        room_id=ROOM_ID,
+        since_seq=0,
+        limit=hosted_rooms.MAX_LOG_LIMIT,
+    )["events"]
+
+
+def _append_user(
+    db: Path,
+    *,
+    event_id: str,
+    text: str,
+    thread_id: str = "thread-1",
+    attachments: list[dict] | None = None,
+) -> dict:
+    payload: dict[str, object] = {"text": text, "thread_id": thread_id}
+    if attachments is not None:
+        payload["attachments"] = attachments
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="message.user",
+        actor={"kind": "user", "id": "local-user"},
+        payload=payload,
+        now=time.time(),
+    )
+
+
+def _append_publication(
+    db: Path,
+    plan: discussion.PublicationPlan,
+) -> list[dict]:
+    return [
+        hosted_rooms.append_event(
+            db,
+            **event.append_kwargs(ROOM_ID),
+            now=time.time(),
+        )
+        for event in plan.events
+    ]
+
+
+def _next_task(room: dict, db: Path) -> discussion.DiscussionTaskPlan:
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "task", decision
+    assert decision.task is not None
+    return decision.task
+
+
+def _settle_next(
+    room: dict,
+    db: Path,
+    *,
+    text: str,
+) -> discussion.DiscussionTaskPlan:
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": text},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+    return task
+
+
+def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    user = _append_user(db, event_id="user-1", text="Check the release.")
+
+    first = _next_task(room, db)
+    repeated = _next_task(room, db)
+    assert first == repeated
+    assert first.identity.thread_id == "thread-1"
+    assert first.payload == {
+        "target_profile": "research",
+        "prompt": first.payload["prompt"],
+        "source_event_seq": user["seq"],
+    }
+    assert set(first.payload) == {"target_profile", "prompt", "source_event_seq"}
+
+    admitted = driver.admit_task(
+        db,
+        first.identity,
+        payload=first.payload,
+        clock=time.time,
+    )
+    stored = driver.get_task(db, first.identity)
+    reconstructed = discussion.reconstruct_task_plan(
+        room,
+        _events(db),
+        stored,
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert admitted["status"] == "queued"
+    assert reconstructed == first
+
+    reopened_events = _events(db)
+    assert (
+        discussion.reconstruct_task_plan(
+            room,
+            reopened_events,
+            driver.get_task(db, first.identity),
+            local_profiles=LOCAL_PROFILES,
+        )
+        == first
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_profile"),
+    [
+        ("@build please inspect this", "build"),
+        ("@all inspect this", "research"),
+        ("@everyone inspect this", "research"),
+        ("inspect this", "research"),
+        ("@unknown inspect this", "research"),
+    ],
+)
+def test_mentions_select_handles_or_everyone(
+    room_db: tuple[Path, dict],
+    text: str,
+    expected_profile: str,
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text=text)
+
+    assert _next_task(room, db).member.profile == expected_profile
+
+
+def test_member_mention_joins_the_next_round_not_the_current_round(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research lead this")
+
+    first = _settle_next(room, db, text="@build can add the implementation detail.")
+    second = _next_task(room, db)
+
+    assert first.member.profile == "research"
+    assert first.round_index == 0
+    assert second.member.profile == "build"
+    assert second.round_index == 1
+
+
+@pytest.mark.parametrize("value", ["", "pass", "pass.", "(pass)", " ( PASS ). "])
+def test_pass_detection(value: str):
+    assert discussion.is_pass_text(value)
+
+
+def test_real_text_is_not_a_pass():
+    assert not discussion.is_pass_text("I found the issue.")
+
+
+def test_full_pass_round_settles_without_member_messages(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for _member in MEMBERS:
+        _settle_next(room, db, text="(pass)")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+    assert [event["kind"] for event in _events(db)].count("message.member") == 0
+
+
+def test_failed_members_advance_the_round_as_silence(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for expected in ("research", "build", "review"):
+        task = _next_task(room, db)
+        assert task.member.profile == expected
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="failed",
+            result={"error": f"{expected} unavailable"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        assert publication.terminal_kind == "turn.failed"
+        assert len(publication.events) == 1
+        _append_publication(db, publication)
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+
+
+def test_publication_is_idempotent_and_changed_result_conflicts(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    first = _append_publication(db, publication)
+    repeated = _append_publication(db, publication)
+    assert [event["seq"] for event in first] == [event["seq"] for event in repeated]
+    assert all(event["idempotent"] for event in repeated)
+
+    changed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Different."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    with pytest.raises(hosted_rooms.EventConflictError):
+        _append_publication(db, changed)
+
+
+def test_partial_publication_replays_same_effects_before_policy_advances(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    message_effect = publication.events[0]
+    hosted_rooms.append_event(
+        db,
+        **message_effect.append_kwargs(ROOM_ID),
+        now=time.time(),
+    )
+    assert _next_task(room, db).identity == task.identity
+
+    replayed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, replayed)
+    assert _next_task(room, db).member.profile == "build"
+
+
+def test_watermark_excludes_a_members_old_input_and_own_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Old request.")
+    first = _settle_next(room, db, text="Old answer.")
+    watermark = discussion.derive_member_watermarks(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )[("thread-1", first.member.member_id)]
+    assert watermark == max(
+        event["seq"]
+        for event in _events(db)
+        if event["kind"] == "message.member"
+        and event["payload"]["task_id"] == first.identity.task_id
+    )
+
+    latest = _append_user(db, event_id="user-2", text="New request.")
+    next_task = _next_task(room, db)
+    assert next_task.member.profile == "research"
+    assert next_task.payload["source_event_seq"] == latest["seq"]
+    assert "New request." in next_task.payload["prompt"]
+    assert "Old request." not in next_task.payload["prompt"]
+    assert "Old answer." not in next_task.payload["prompt"]
+
+
+def test_newer_same_thread_user_event_cancels_a_late_result(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.")
+    stale = _next_task(room, db)
+    latest = _append_user(db, event_id="user-2", text="Second request.")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        stale,
+        status="settled",
+        result={"text": "Late stale answer."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert publication.terminal_kind == "turn.cancelled"
+    assert [event.kind for event in publication.events] == ["turn.cancelled"]
+    assert publication.events[0].payload["reason"] == "superseded_by_newer_user_event"
+    _append_publication(db, publication)
+
+    current = _next_task(room, db)
+    assert current.payload["source_event_seq"] == latest["seq"]
+    assert "Second request." in current.payload["prompt"]
+
+
+def test_cross_thread_newer_user_does_not_discard_completed_old_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.", thread_id="thread-1")
+    old = _next_task(room, db)
+    _append_user(db, event_id="user-2", text="Other topic.", thread_id="thread-2")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        old,
+        status="settled",
+        result={"text": "Completed first topic."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert [event.kind for event in publication.events] == [
+        "message.member",
+        "turn.settled",
+    ]
+
+
+def test_three_round_bound(room_db: tuple[Path, dict]):
+    db, room = room_db
+    room["members"] = MEMBERS[:2]
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(6):
+        _settle_next(room, db, text=f"Reply {index}.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_rounds"
+
+
+def test_ten_message_bound(tmp_path: Path):
+    db = tmp_path / "state.db"
+    members = [
+        {
+            "member_id": f"member-{profile}",
+            "profile": profile,
+            "handle": profile,
+        }
+        for profile in LOCAL_PROFILES
+    ]
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Large",
+        members=members,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(discussion.MAX_DISCUSSION_MESSAGES):
+        _settle_next(room, db, text=f"Reply {index}.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_messages"
+
+
+def test_prompt_delta_is_bounded_to_24_message_lines(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    for index in range(30):
+        _append_user(
+            db,
+            event_id=f"user-{index}",
+            text=f"Message {index}.",
+        )
+
+    task = _next_task(room, db)
+    assert task.payload["prompt"].count("User (user):") == 24
+    assert "Message 5." not in task.payload["prompt"]
+    assert "Message 6." in task.payload["prompt"]
+    assert "Message 29." in task.payload["prompt"]
+
+
+def test_valid_image_pdf_and_file_manifest_is_normalized():
+    payload = discussion.validate_user_payload(
+        {
+            "text": "Review the attached material.",
+            "thread_id": "thread-1",
+            "attachments": _attachment_manifest(),
+        },
+        member_ids=MEMBER_IDS,
+    )
+
+    assert [attachment["kind"] for attachment in payload["attachments"]] == [
+        "image",
+        "pdf",
+        "file",
+    ]
+    assert payload["attachments"][0] == {
+        "kind": "image",
+        "name": "diagram.png",
+        "size": 2048,
+        "mime": "image/png",
+        "refs": _refs({
+            "member-research": "stage:image:research",
+            "member-build": "stage:image:build",
+        }),
+    }
+
+
+def test_prompts_include_only_the_current_members_refs_and_queued_media_note(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+
+    research = _next_task(room, db)
+    research_prompt = research.payload["prompt"]
+    assert research.member.member_id == "member-research"
+    assert "User (user): Review the upload." in research_prompt
+    assert "User (user): Review the upload. diagram.png" not in research_prompt
+    assert "stage:image:research" in research_prompt
+    assert "stage:pdf:research" in research_prompt
+    assert "stage:file:research" in research_prompt
+    assert "stage:image:build" not in research_prompt
+    assert "Queued image/PDF attachments are staged separately" in research_prompt
+    assert 'Queued image "diagram.png"' in research_prompt
+    assert 'Queued PDF "release.pdf"' in research_prompt
+    assert 'Staged file "notes.txt"' in research_prompt
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        research,
+        status="settled",
+        result={"text": "(pass)"},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+    build = _next_task(room, db)
+    build_prompt = build.payload["prompt"]
+    assert build.member.member_id == "member-build"
+    assert "stage:image:build" in build_prompt
+    assert "stage:pdf:build" in build_prompt
+    assert "stage:file:build" in build_prompt
+    assert "stage:image:research" not in build_prompt
+    assert build.identity.task_id != research.identity.task_id
+
+
+def test_attachment_manifest_changes_the_deterministic_task_id(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+    with_attachments = _next_task(room, db)
+    without_events = [
+        {
+            **event,
+            "payload": {
+                "text": event["payload"]["text"],
+                "thread_id": event["payload"]["thread_id"],
+            },
+        }
+        if event["kind"] == "message.user"
+        else event
+        for event in _events(db)
+    ]
+    without_attachments = discussion.plan_next_task(
+        room,
+        without_events,
+        local_profiles=LOCAL_PROFILES,
+    ).task
+
+    assert without_attachments is not None
+    assert with_attachments.identity.turn_id == without_attachments.identity.turn_id
+    assert with_attachments.identity.task_id != without_attachments.identity.task_id
+    assert with_attachments.payload["prompt"] != without_attachments.payload["prompt"]
+
+
+def test_attachment_task_reconstructs_after_driver_reopen(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-attachments",
+        text="Review the upload.",
+        attachments=_attachment_manifest(),
+    )
+    task = _next_task(room, db)
+    driver.admit_task(db, task.identity, payload=task.payload, clock=time.time)
+
+    reconstructed = discussion.reconstruct_task_plan(
+        room,
+        _events(db),
+        driver.get_task(db, task.identity),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert reconstructed == task
+    assert "stage:image:research" in reconstructed.payload["prompt"]
+
+
+def test_attachment_refs_require_every_member_and_reject_unknown_members():
+    missing = _refs()
+    missing.pop("member-review")
+    unknown = _refs()
+    unknown["member-remote"] = "stage:file:remote"
+
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="missing member ids"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=missing)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="unknown member ids"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=unknown)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize("field", ["data", "data_url", "base64", "path"])
+def test_attachment_manifest_rejects_raw_data_and_path_fields(field: str):
+    attachment = _attachment("file", "notes.txt", "text/plain")
+    attachment[field] = "/tmp/raw" if field == "path" else "AAAA"
+
+    with pytest.raises(discussion.DiscussionValidationError, match="unknown fields"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_manifest_requires_every_exact_metadata_field():
+    attachment = _attachment("file", "notes.txt", "text/plain")
+    attachment.pop("mime")
+
+    with pytest.raises(discussion.DiscussionValidationError, match="missing fields"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize(
+    "unsafe_ref",
+    [
+        "data:image/png;base64,AAAA",
+        "base64:AAAA",
+        "file:secret",
+        "path:secret",
+        "/tmp/secret",
+        "../secret",
+        "folder/secret",
+        "C:\\secret",
+    ],
+)
+def test_attachment_manifest_rejects_unsafe_refs(unsafe_ref: str):
+    refs = _refs({"member-research": unsafe_ref})
+
+    with pytest.raises(discussion.DiscussionValidationError, match="safe opaque ref"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [
+                    _attachment("file", "notes.txt", "text/plain", refs=refs)
+                ],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+@pytest.mark.parametrize(
+    ("attachment", "match"),
+    [
+        (
+            _attachment("file", "x" * 256, "text/plain"),
+            "bounded basename",
+        ),
+        (
+            _attachment("file", "../secret", "text/plain"),
+            "bounded basename",
+        ),
+        (
+            _attachment(
+                "file",
+                "notes.txt",
+                "text/plain",
+                size=discussion.MAX_ATTACHMENT_SIZE_BYTES + 1,
+            ),
+            "size must be between",
+        ),
+        (
+            _attachment("image", "image.bin", "application/octet-stream"),
+            "image kind requires image mime",
+        ),
+        (
+            _attachment("pdf", "release.pdf", "application/octet-stream"),
+            "pdf kind requires application/pdf",
+        ),
+        (
+            _attachment(
+                "file",
+                "notes.txt",
+                "text/plain",
+                refs=_refs({"member-research": "r" * 257}),
+            ),
+            "safe opaque ref",
+        ),
+    ],
+)
+def test_attachment_metadata_is_bounded(attachment: dict, match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": [attachment],
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_count_is_bounded():
+    attachments = [
+        _attachment("file", f"notes-{index}.txt", "text/plain")
+        for index in range(discussion.MAX_ATTACHMENTS + 1)
+    ]
+
+    with pytest.raises(discussion.DiscussionValidationError, match="at most 8"):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": attachments,
+            },
+            member_ids=MEMBER_IDS,
+        )
+
+
+def test_attachment_manifest_total_metadata_is_bounded():
+    maximum_ref = "r" * discussion.MAX_ATTACHMENT_REF_CHARS
+    member_ids = tuple(f"member-{profile}" for profile in LOCAL_PROFILES)
+    refs: dict[str, str | None] = {member_id: maximum_ref for member_id in member_ids}
+    attachments = [
+        _attachment(
+            "file",
+            "\U0001f9ea" * discussion.MAX_ATTACHMENT_NAME_CHARS,
+            "application/octet-stream",
+            refs=refs,
+        )
+        for _index in range(discussion.MAX_ATTACHMENTS)
+    ]
+
+    with pytest.raises(
+        discussion.DiscussionValidationError, match="manifest is too large"
+    ):
+        discussion.validate_user_payload(
+            {
+                "text": "Review.",
+                "thread_id": "thread-1",
+                "attachments": attachments,
+            },
+            member_ids=member_ids,
+        )
+
+
+@pytest.mark.parametrize(
+    ("members", "match"),
+    [
+        (MEMBERS[:1], "between 2 and 6"),
+        (MEMBERS + MEMBERS + MEMBERS[:1], "between 2 and 6"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "profile": "research"}],
+            "profiles must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "handle": "RESEARCH"}], "handles must be unique"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "member_id": "MEMBER-RESEARCH"}],
+            "ids must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "route": {"mode": "ssh"}}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "connectionId": "remote"}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "profile": "missing"}], "not local"),
+    ],
+)
+def test_malformed_or_remote_roster_is_rejected(members: list[dict], match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_roster(members, local_profiles=LOCAL_PROFILES)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"text": "hello"},
+        {"text": "hello", "thread_id": "thread-1", "images": []},
+        {"text": "", "thread_id": "thread-1"},
+        {"text": "hello", "thread_id": "../escape"},
+        {"text": ["hello"], "thread_id": "thread-1"},
+    ],
+)
+def test_user_payload_is_exact_and_text_only(payload: dict):
+    with pytest.raises(discussion.DiscussionValidationError):
+        discussion.validate_user_payload(payload)
+
+
+def test_malformed_log_and_task_reconstruction_fail_closed(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    _append_user(db, event_id="user-2", text="Report again.")
+    task = _next_task(room, db)
+    events = _events(db)
+
+    with pytest.raises(discussion.DiscussionValidationError, match="sequence order"):
+        discussion.plan_next_task(
+            room,
+            list(reversed(events)),
+            local_profiles=LOCAL_PROFILES,
+        )
+
+    malformed = {
+        "identity": driver.TaskIdentity(
+            room_id=task.identity.room_id,
+            task_id="dtask:wrong",
+            thread_id=task.identity.thread_id,
+            turn_id=task.identity.turn_id,
+        ),
+        "payload": dict(task.payload),
+    }
+    with pytest.raises(
+        discussion.DiscussionReconstructionError,
+        match="deterministic reconstruction",
+    ):
+        discussion.reconstruct_task_plan(
+            room,
+            events,
+            malformed,
+            local_profiles=LOCAL_PROFILES,
+        )

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -319,6 +319,25 @@ def test_member_mention_joins_the_next_round_not_the_current_round(
     assert first.round_index == 0
     assert second.member.profile == "build"
     assert second.round_index == 1
+    assert "@research lead this" in second.payload["prompt"]
+    assert "@build can add the implementation detail." in second.payload["prompt"]
+
+
+def test_plain_member_reply_does_not_wake_another_bot_round(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research answer the user")
+    _settle_next(room, db, text="The answer is ready for the user.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
 
 
 @pytest.mark.parametrize("value", ["", "pass", "pass.", "(pass)", " ( PASS ). "])
@@ -527,7 +546,17 @@ def test_three_round_bound(room_db: tuple[Path, dict]):
     _append_user(db, event_id="user-1", text="Discuss.")
 
     for index in range(6):
-        _settle_next(room, db, text=f"Reply {index}.")
+        task = _next_task(room, db)
+        peer = "build" if task.member.profile == "research" else "research"
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="settled",
+            result={"text": f"Reply {index}. @{peer}"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        _append_publication(db, publication)
 
     decision = discussion.plan_next_task(
         room,
@@ -559,7 +588,7 @@ def test_ten_message_bound(tmp_path: Path):
     _append_user(db, event_id="user-1", text="Discuss.")
 
     for index in range(discussion.MAX_DISCUSSION_MESSAGES):
-        _settle_next(room, db, text=f"Reply {index}.")
+        _settle_next(room, db, text=f"Reply {index}. @everyone")
 
     decision = discussion.plan_next_task(
         room,

--- a/tests/gateway/test_hosted_room_driver.py
+++ b/tests/gateway/test_hosted_room_driver.py
@@ -1,0 +1,928 @@
+"""Behavior tests for the hosted-room driver state machine."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+from gateway import hosted_room_driver as driver
+
+
+class FakeClock:
+    def __init__(self, value: float = 100.0):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _identity(task_id: str = "task-1", *, turn_id: str = "turn-1"):
+    return driver.TaskIdentity(
+        room_id="room-1",
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=turn_id,
+    )
+
+
+def _payload(
+    *,
+    target_profile: str = "ops",
+    prompt: str = "Inspect the release candidate.",
+    source_event_seq: int = 1,
+):
+    return {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = tmp_path / "state.db"
+    rooms.create_room(
+        path,
+        room_id="room-1",
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=90,
+    )
+    return path
+
+
+def _lease(
+    db,
+    clock,
+    *,
+    gateway="gateway-a",
+    authority_epoch=1,
+    process="process-a",
+    ttl=30,
+):
+    return driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=gateway,
+        authority_epoch=authority_epoch,
+        process_generation=process,
+        ttl_seconds=ttl,
+        clock=clock,
+    )
+
+
+def _admit(db, identity, clock, *, payload=None):
+    return driver.admit_task(
+        db,
+        identity,
+        payload=_payload() if payload is None else payload,
+        clock=clock,
+    )
+
+
+def _open_driver_schema(path: str) -> int:
+    return len(driver.list_tasks(path, room_id="room-1"))
+
+
+def test_two_contenders_have_one_winner(db):
+    clock = FakeClock()
+
+    def contend(process):
+        try:
+            return _lease(db, clock, process=process)
+        except driver.LeaseHeldError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contend, ["process-a", "process-b"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].lease_generation == 1
+
+
+def test_expiry_allows_reclaim_and_fences_stale_renew_and_release(db):
+    clock = FakeClock()
+    first = _lease(db, clock, ttl=5)
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+
+    assert second.reclaimed is True
+    assert second.lease_generation == first.lease_generation + 1
+    with pytest.raises(driver.StaleLeaseError):
+        driver.renew_lease(db, first, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError):
+        driver.release_lease(db, first, clock=clock)
+
+
+def test_nonexistent_and_disbanded_rooms_cannot_lease_or_admit(db):
+    clock = FakeClock()
+    missing = driver.TaskIdentity("missing-room", "task", "thread", "turn")
+
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        driver.acquire_lease(
+            db,
+            room_id="missing-room",
+            gateway_id="gateway-a",
+            authority_epoch=1,
+            process_generation="process-a",
+            ttl_seconds=30,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        _admit(db, missing, clock)
+
+    rooms.disband_room(db, room_id="room-1", now=clock())
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _lease(db, clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _admit(db, _identity(), clock)
+
+
+@pytest.mark.parametrize(
+    ("gateway", "authority_epoch"),
+    [("gateway-b", 1), ("gateway-a", 2)],
+)
+def test_acquire_requires_current_room_authority(db, gateway, authority_epoch):
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        _lease(
+            db,
+            FakeClock(),
+            gateway=gateway,
+            authority_epoch=authority_epoch,
+        )
+
+
+def test_same_process_acquire_and_release_are_idempotent(db):
+    clock = FakeClock()
+    first = _lease(db, clock)
+    repeated = _lease(db, clock)
+
+    assert repeated.lease_generation == first.lease_generation
+    released = driver.release_lease(db, repeated, clock=clock)
+    released_again = driver.release_lease(db, repeated, clock=clock)
+
+    assert released["idempotent"] is False
+    assert released_again["idempotent"] is True
+
+
+def test_renew_extends_only_the_current_lease_generation(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=5)
+
+    clock.advance(2)
+    renewed = driver.renew_lease(db, lease, ttl_seconds=20, clock=clock)
+
+    assert renewed.lease_generation == lease.lease_generation
+    assert renewed.expires_at == 122
+
+
+def test_authority_transfer_fences_lease_and_late_settlement(db):
+    clock = FakeClock()
+    identity = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    old_lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    _admit(db, queued, clock)
+    old_attempt = driver.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=clock(),
+    )
+
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.renew_lease(db, old_lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.start_task(
+            db,
+            queued,
+            old_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.recover_room(db, old_lease, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.settle_task(
+            db,
+            old_attempt,
+            settlement_id="late-settlement",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+
+    new_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-b",
+        authority_epoch=2,
+        process="process-b",
+    )
+    recovery = driver.recover_room(db, new_lease, clock=clock)
+    assert new_lease.lease_generation == old_lease.lease_generation + 1
+    assert recovery["indeterminate"] == [identity]
+    assert recovery["queued"] == [queued]
+
+
+def test_room_disband_fences_active_lease_operations(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    rooms.disband_room(db, room_id="room-1", now=clock())
+
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.renew_lease(db, lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.start_task(
+            db,
+            identity,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.recover_room(db, lease, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.release_lease(db, lease, clock=clock)
+
+
+def test_task_admission_is_idempotent_and_identity_conflicts_fail(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    first = _admit(db, identity, clock)
+    repeated = _admit(db, identity, clock)
+
+    assert first["status"] == "queued"
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-1",
+                thread_id="thread-other",
+                turn_id="turn-other",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+    with pytest.raises(driver.TaskConflictError, match="different payload"):
+        _admit(
+            db,
+            identity,
+            clock,
+            payload=_payload(prompt="A different immutable prompt."),
+        )
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-other",
+                thread_id="thread-1",
+                turn_id="turn-1",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+
+def test_concurrent_task_start_has_one_winner(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+
+    def start(_):
+        try:
+            return driver.start_task(
+                db,
+                identity,
+                lease,
+                expected_cancel_generation=0,
+                clock=clock,
+            )
+        except driver.InvalidTaskTransitionError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, range(2)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].execution_generation == 1
+
+
+def test_stale_lease_cannot_start_or_commit_task(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+    driver.recover_room(db, second, clock=clock)
+
+    with pytest.raises(driver.StaleLeaseError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-old",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+    assert driver.get_task(db, identity)["status"] == "indeterminate"
+
+
+@pytest.mark.parametrize("status", ["settled", "failed"])
+def test_terminal_settlement_is_idempotent(db, status):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    first = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+    repeated = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+
+    assert first["status"] == status
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.TaskConflictError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-2",
+            status=status,
+            result={"text": "changed"},
+            clock=clock,
+        )
+
+
+def test_cancellation_fences_late_success(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    cancelled = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    repeated = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["cancel_generation"] == 1
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.StaleTaskError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="late-success",
+            status="settled",
+            result={"text": "too late"},
+            clock=clock,
+        )
+
+
+def test_release_fails_closed_while_its_task_is_running(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="tasks are running",
+    ):
+        driver.release_lease(db, lease, clock=clock)
+    assert driver.get_task(db, identity)["status"] == "running"
+
+    driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    assert driver.release_lease(db, lease, clock=clock)["idempotent"] is False
+
+
+def test_restart_recovery_never_requeues_indeterminate_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock)
+    _admit(db, queued, clock)
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(driver.LeaseHeldError):
+        _lease(db, clock, gateway="gateway-a", process="new-process")
+
+    clock.advance(5)
+    recovered_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-a",
+        process="new-process",
+    )
+    recovery = driver.recover_room(db, recovered_lease, clock=clock)
+    repeated = driver.recover_room(db, recovered_lease, clock=clock)
+
+    assert recovery == {"queued": [queued], "indeterminate": [running]}
+    assert repeated == recovery
+    with pytest.raises(driver.InvalidTaskTransitionError):
+        driver.start_task(
+            db,
+            running,
+            recovered_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert [task["status"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        "indeterminate",
+        "queued",
+    ]
+
+
+def test_recovery_is_required_before_starting_later_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="recovery must resolve",
+    ):
+        driver.start_task(
+            db,
+            queued,
+            recovered,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+
+
+def test_current_lease_can_commit_verified_indeterminate_receipt(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    attempt = driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    settled = driver.resolve_indeterminate_task(
+        db,
+        running,
+        recovered,
+        expected_execution_generation=attempt.execution_generation,
+        expected_cancel_generation=attempt.cancel_generation,
+        settlement_id="recovered-receipt",
+        status="settled",
+        result={"text": "recovered"},
+        clock=clock,
+    )
+    next_attempt = driver.start_task(
+        db,
+        queued,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert settled["status"] == "settled"
+    assert next_attempt.execution_generation == 1
+
+
+def test_indeterminate_retry_is_explicit_and_advances_execution_generation(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    original = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    requeued = driver.requeue_indeterminate_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        clock=clock,
+    )
+    retried = driver.start_task(
+        db,
+        identity,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert requeued["status"] == "queued"
+    assert retried.execution_generation == original.execution_generation + 1
+
+
+def test_state_survives_sqlite_reopen_and_concurrent_duplicate_admission(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    def admit(_):
+        return _admit(db, identity, clock)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(admit, range(8)))
+
+    assert sum(not result["idempotent"] for result in results) == 1
+    with sqlite3.connect(db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM hosted_room_driver_tasks"
+        ).fetchone()[0]
+    assert count == 1
+    reopened = driver.get_task(db, identity)
+    listed = driver.list_tasks(db, room_id="room-1")
+    assert reopened["identity"] == identity
+    assert reopened["payload"] == _payload()
+    assert listed[0]["payload"] == _payload()
+
+
+def test_unpublished_legacy_driver_schema_fails_closed(db):
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_leases (
+                room_id TEXT PRIMARY KEY,
+                gateway_id TEXT NOT NULL,
+                process_generation TEXT NOT NULL,
+                lease_generation INTEGER NOT NULL,
+                expires_at REAL NOT NULL,
+                acquired_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                released_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_tasks (
+                room_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                turn_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_generation INTEGER NOT NULL,
+                cancel_generation INTEGER NOT NULL,
+                run_gateway_id TEXT,
+                run_process_generation TEXT,
+                run_lease_generation INTEGER,
+                cancel_id TEXT,
+                settlement_id TEXT,
+                settlement_status TEXT,
+                result_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                started_at REAL,
+                terminal_at REAL,
+                indeterminate_at REAL,
+                PRIMARY KEY (room_id, task_id),
+                UNIQUE (room_id, thread_id, turn_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_leases
+               VALUES ('room-1', 'gateway-a', 'old-process', 1,
+                       200, 100, 100, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks
+               (room_id, task_id, thread_id, turn_id, status,
+                execution_generation, cancel_generation,
+                run_gateway_id, run_process_generation, run_lease_generation,
+                created_at, updated_at, started_at)
+               VALUES ('room-1', 'task-1', 'thread-1', 'turn-1', 'running',
+                       1, 0, 'gateway-a', 'old-process', 1, 100, 100, 100)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(driver.DriverStateError, match="unsupported unpublished"):
+        driver.get_task(db, _identity())
+
+
+def test_pre_stopping_schema_is_migrated_without_losing_tasks(db):
+    clock = FakeClock()
+    identity = _identity()
+    _admit(db, identity, clock)
+
+    with sqlite3.connect(db) as conn:
+        current_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+        old_sql = current_sql.replace(", 'stopping'", "")
+        conn.execute("DROP INDEX idx_hosted_room_driver_tasks_status")
+        conn.execute(
+            "ALTER TABLE hosted_room_driver_tasks RENAME TO hosted_room_driver_tasks_current"
+        )
+        conn.execute(old_sql)
+        columns = ", ".join(driver._TASK_COLUMN_ORDER)
+        conn.execute(
+            f"""INSERT INTO hosted_room_driver_tasks ({columns})
+                 SELECT {columns} FROM hosted_room_driver_tasks_current"""
+        )
+        conn.execute("DROP TABLE hosted_room_driver_tasks_current")
+        conn.execute(
+            """CREATE INDEX idx_hosted_room_driver_tasks_status
+               ON hosted_room_driver_tasks(
+                   room_id, status, source_event_seq, created_at, task_id
+               )"""
+        )
+
+    assert driver.get_task(db, identity)["status"] == "queued"
+    lease = _lease(db, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-after-upgrade",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    with sqlite3.connect(db) as conn:
+        table_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+    assert "'stopping'" in table_sql
+
+
+def test_first_schema_creation_is_safe_across_processes(db):
+    with sqlite3.connect(db) as conn:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.commit()
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_open_driver_schema, [str(db)] * 4))
+
+    assert results == [0, 0, 0, 0]
+
+
+def test_tasks_follow_source_event_order_not_admission_time(db):
+    clock = FakeClock()
+    later = _identity("task-2", turn_id="turn-2")
+    earlier = _identity("task-1", turn_id="turn-1")
+    _admit(db, later, clock, payload=_payload(source_event_seq=2))
+    _admit(db, earlier, clock, payload=_payload(source_event_seq=1))
+    lease = _lease(db, clock)
+
+    assert [task["identity"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        earlier,
+        later,
+    ]
+    with pytest.raises(driver.InvalidTaskTransitionError, match="event order"):
+        driver.start_task(
+            db,
+            later,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert (
+        driver.start_task(
+            db,
+            earlier,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        ).identity
+        == earlier
+    )
+
+
+def test_payload_digest_is_verified_on_read(db):
+    identity = _identity()
+    _admit(db, identity, FakeClock())
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET payload_json=REPLACE(payload_json, 'Inspect', 'Replace')
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        )
+        conn.commit()
+
+    with pytest.raises(driver.TaskConflictError, match="integrity"):
+        driver.get_task(db, identity)
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"target_profile": "ops", "prompt": "hello"}, "missing payload fields"),
+        (
+            {**_payload(), "unexpected": True},
+            "unknown payload fields",
+        ),
+        (_payload(target_profile="bad profile"), "invalid target_profile"),
+        (_payload(prompt="   "), "prompt must not be empty"),
+        (_payload(prompt="x" * (driver.MAX_PROMPT_BYTES + 1)), "prompt is too large"),
+        (_payload(source_event_seq=0), "source_event_seq"),
+        (_payload(source_event_seq=True), "source_event_seq"),
+    ],
+)
+def test_invalid_task_payload_is_rejected(db, payload, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        _admit(db, _identity(), FakeClock(), payload=payload)
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: driver.TaskIdentity("bad room", "task", "thread", "turn"),
+            "invalid room_id",
+        ),
+        (
+            lambda: driver.TaskIdentity("room", "", "thread", "turn"),
+            "invalid task_id",
+        ),
+    ],
+)
+def test_invalid_task_identity_is_rejected(factory, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        factory()
+
+
+def test_invalid_lease_clock_ttl_and_settlement_schema_are_rejected(db):
+    clock = FakeClock()
+
+    with pytest.raises(driver.DriverValidationError, match="ttl_seconds"):
+        _lease(db, clock, ttl=0)
+    with pytest.raises(driver.DriverValidationError, match="clock"):
+        _lease(db, lambda: float("nan"))
+    with pytest.raises(driver.DriverValidationError, match="expiry"):
+        _lease(db, FakeClock(1e308), ttl=1e308)
+
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    with pytest.raises(driver.DriverValidationError, match="JSON-serializable"):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-1",
+            status="settled",
+            result={"bad": object()},
+            clock=clock,
+        )
+
+
+def test_renewal_never_shortens_an_active_lease(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=30)
+    clock.advance(1)
+
+    renewed = driver.renew_lease(db, lease, ttl_seconds=2, clock=clock)
+
+    assert renewed.expires_at == lease.expires_at

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -1,0 +1,640 @@
+"""Behavior tests for the gateway-hosted room event log."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+from hermes_state import SessionDB
+
+USER = {"kind": "user", "id": "desktop-user", "display_name": "User"}
+GATEWAY_A = {"kind": "gateway", "id": "gateway-a"}
+GATEWAY_B = {"kind": "gateway", "id": "gateway-b"}
+
+
+def _create_pre_actor_database(path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """CREATE TABLE hosted_rooms (
+                room_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                members_json TEXT NOT NULL,
+                next_seq INTEGER NOT NULL,
+                revision INTEGER NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                disbanded_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_events (
+                room_id TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                event_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (room_id, seq),
+                UNIQUE (room_id, event_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               VALUES ('room-1', 'Legacy', '[]', 2, 1, 1, 1, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               VALUES ('room-1', 1, 'legacy-event', 'message.created', '{}', 1)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_legacy_state(path: str) -> tuple[str, int]:
+    state = rooms.room_state(path, room_id="room-1")
+    return state["authority_gateway_id"], state["latest_seq"]
+
+
+def _create(db, room_id="room-1"):
+    return rooms.create_room(
+        db,
+        room_id=room_id,
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=10,
+    )
+
+
+def test_create_room_is_idempotent_but_conflicts_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    first = _create(db)
+    second = _create(db)
+
+    assert first["idempotent"] is False
+    assert second["idempotent"] is True
+    assert first["room_id"] == second["room_id"] == "room-1"
+
+    with pytest.raises(rooms.RoomConflictError):
+        rooms.create_room(
+            db,
+            room_id="room-1",
+            name="A different room",
+            members=[],
+            authority_gateway_id="gateway-a",
+        )
+
+
+def test_room_state_exposes_authority_and_replay_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    room = _create(db)
+
+    assert room["authority_gateway_id"] == "gateway-a"
+    assert room["authority_epoch"] == 1
+    assert rooms.room_state(db, room_id="room-1") == {
+        **room,
+        "latest_seq": 0,
+    }
+
+
+def test_authority_claim_fences_stale_gateway_events(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    claimed = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=30,
+    )
+    retried = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=40,
+    )
+
+    assert claimed["authority_gateway_id"] == "gateway-b"
+    assert claimed["authority_epoch"] == 2
+    assert claimed["idempotent"] is False
+    assert claimed["claim_event"]["kind"] == "authority.claimed"
+    assert claimed["claim_event"]["authority_epoch"] == 2
+    assert claimed["claim_event"]["payload"] == {
+        "previous_gateway_id": "gateway-a",
+        "authority_gateway_id": "gateway-b",
+        "authority_epoch": 2,
+    }
+    assert retried["authority_epoch"] == 2
+    assert retried["idempotent"] is True
+    assert retried["claim_event"]["seq"] == claimed["claim_event"]["seq"]
+    assert retried["claim_event"]["idempotent"] is True
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_claim"]["event_id"] == "claim-gateway-b"
+    assert state["authority_claim"]["payload"]["previous_gateway_id"] == "gateway-a"
+
+    # An exact retry admitted before takeover stays idempotent and cannot
+    # produce a second side effect, even though its epoch is now stale.
+    repeated = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    assert repeated["seq"] == first["seq"]
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-2-stale",
+            kind="turn.started",
+            actor=GATEWAY_A,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="member-2-stale",
+            kind="message.member",
+            actor={"kind": "member", "id": "ops"},
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"text": "stale result"},
+        )
+
+    current = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="turn-2-current",
+        kind="turn.started",
+        actor=GATEWAY_B,
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"member": "ops"},
+    )
+    assert current["authority_epoch"] == 2
+    current_member = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="member-2-current",
+        kind="message.member",
+        actor={"kind": "member", "id": "ops"},
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"text": "current result"},
+    )
+    assert current_member["authority_epoch"] == 2
+
+
+def test_concurrent_authority_claim_has_one_winner(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def claim(gateway_id):
+        try:
+            return rooms.claim_authority(
+                db,
+                room_id="room-1",
+                expected_gateway_id="gateway-a",
+                expected_epoch=1,
+                new_gateway_id=gateway_id,
+                event_id=f"claim-{gateway_id}",
+            )
+        except rooms.AuthorityConflictError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ["gateway-b", "gateway-c"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0]["authority_epoch"] == 2
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] in {
+        "gateway-b",
+        "gateway-c",
+    }
+
+
+def test_retry_of_successful_but_superseded_claim_is_distinct(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-b",
+    )
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-b",
+        expected_epoch=2,
+        new_gateway_id="gateway-c",
+        event_id="claim-c",
+    )
+
+    with pytest.raises(rooms.AuthoritySupersededError, match="later superseded"):
+        rooms.claim_authority(
+            db,
+            room_id="room-1",
+            expected_gateway_id="gateway-a",
+            expected_epoch=1,
+            new_gateway_id="gateway-b",
+            event_id="claim-b",
+        )
+
+
+def test_authority_scoped_events_require_gateway_and_epoch(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.HostedRoomError, match="authority_gateway_id"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-1",
+            kind="member.unavailable",
+            actor=GATEWAY_A,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="actor.id"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="turn-2",
+            kind="turn.started",
+            actor=GATEWAY_B,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="only valid"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="message-1",
+            kind="message.user",
+            actor=USER,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"text": "hello"},
+        )
+
+
+def test_append_is_idempotent_and_conflicting_event_id_is_rejected(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=20,
+    )
+    repeated = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=30,
+    )
+
+    assert first["seq"] == repeated["seq"] == 1
+    assert repeated["idempotent"] is True
+    assert rooms.read_events(db, room_id="room-1")["latest_seq"] == 1
+
+    with pytest.raises(rooms.EventConflictError):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "changed"},
+        )
+
+
+def test_since_seq_returns_ordered_deltas_and_stable_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(1, 5):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+            now=20 + index,
+        )
+
+    first = rooms.read_events(db, room_id="room-1", since_seq=0, limit=2)
+    assert [event["seq"] for event in first["events"]] == [1, 2]
+    assert first == {
+        "events": first["events"],
+        "cursor": 2,
+        "latest_seq": 4,
+        "has_more": True,
+    }
+
+    second = rooms.read_events(
+        db,
+        room_id="room-1",
+        since_seq=first["cursor"],
+        limit=2,
+    )
+    assert [event["seq"] for event in second["events"]] == [3, 4]
+    assert second["cursor"] == 4
+    assert second["has_more"] is False
+
+    settled = rooms.read_events(db, room_id="room-1", since_seq=4)
+    assert settled["events"] == []
+    assert settled["cursor"] == settled["latest_seq"] == 4
+
+
+def test_room_log_survives_store_reopen(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "persist me"},
+    )
+
+    assert rooms.list_rooms(db)[0]["name"] == "Release room"
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["payload"] == {"text": "persist me"}
+
+
+@pytest.mark.parametrize("session_first", [True, False])
+def test_room_tables_coexist_with_session_db_schema(tmp_path, session_first):
+    db = tmp_path / "state.db"
+    if session_first:
+        SessionDB(db_path=db).close()
+
+    _create(db)
+    rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "shared database"},
+    )
+
+    SessionDB(db_path=db).close()
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["latest_seq"] == 1
+    assert replay["events"][0]["payload"]["text"] == "shared database"
+
+
+def test_concurrent_appends_allocate_one_monotonic_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def append(index):
+        return rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(append, range(24)))
+
+    assert sorted(result["seq"] for result in results) == list(range(1, 25))
+    replay = rooms.read_events(db, room_id="room-1", limit=100)
+    assert [event["seq"] for event in replay["events"]] == list(range(1, 25))
+
+
+def test_rolled_back_append_does_not_consume_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, payload_json, created_at)
+               VALUES ('room-1', 1, 'crash-event', 'message.user',
+                       '{"id":"desktop-user","kind":"user"}', '{}', 20)"""
+        )
+        conn.execute("UPDATE hosted_rooms SET next_seq=2 WHERE room_id='room-1'")
+        conn.rollback()
+    finally:
+        conn.close()
+
+    event = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="after-restart",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "safe"},
+    )
+    assert event["seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"room_id": "../escape"}, "invalid room_id"),
+        ({"event_id": "event id"}, "invalid event_id"),
+        ({"kind": "Message Created"}, "invalid event kind"),
+        ({"kind": "directive.run"}, "cannot append"),
+        ({"actor": {"kind": "member", "id": "ops"}}, "cannot append"),
+        ({"payload": []}, "payload must be an object"),
+    ],
+)
+def test_invalid_event_contract_is_rejected(tmp_path, kwargs, message):
+    db = tmp_path / "state.db"
+    _create(db)
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "kind": "message.user",
+        "actor": USER,
+        "payload": {},
+    }
+    params.update(kwargs)
+
+    with pytest.raises(rooms.HostedRoomError, match=message):
+        rooms.append_event(db, **params)
+
+
+def test_unknown_room_and_invalid_cursor_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.read_events(db, room_id="missing")
+    with pytest.raises(rooms.HostedRoomError, match="since_seq"):
+        rooms.read_events(db, room_id="room-1", since_seq=-1)
+    with pytest.raises(rooms.HostedRoomError, match="ahead"):
+        rooms.read_events(db, room_id="room-1", since_seq=1)
+    with pytest.raises(rooms.HostedRoomError, match="limit"):
+        rooms.read_events(db, room_id="room-1", limit=0)
+
+
+def test_actor_is_part_of_event_idempotency_and_replay(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    event = rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+    )
+
+    assert event["actor"] == USER
+    assert rooms.read_events(db, room_id="room-1")["events"][0]["actor"] == USER
+
+    with pytest.raises(rooms.EventConflictError):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor={"kind": "user", "id": "another-user"},
+            payload={"text": "hello"},
+        )
+
+
+def test_disband_is_idempotent_and_room_id_cannot_be_reused(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = rooms.disband_room(db, room_id="room-1", now=50)
+    repeated = rooms.disband_room(db, room_id="room-1", now=60)
+
+    assert first["room_id"] == "room-1"
+    assert first["disbanded_at"] == 50.0
+    assert first["idempotent"] is False
+    assert first["event"]["kind"] == "room.disbanded"
+    assert first["event"]["seq"] == 1
+    assert first["event"]["payload"] == {"room_id": "room-1"}
+    assert repeated["idempotent"] is True
+    assert repeated["event"]["seq"] == first["event"]["seq"]
+    assert rooms.list_rooms(db) == []
+    deleted = rooms.list_rooms(db, include_disbanded=True)
+    assert deleted[0]["disbanded_at"] == 50.0
+    assert deleted[0]["latest_seq"] == 1
+    state = rooms.room_state(db, room_id="room-1", include_disbanded=True)
+    assert state["disbanded_at"] == 50.0
+    assert state["latest_seq"] == 1
+    replay = rooms.read_events(db, room_id="room-1", include_disbanded=True)
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]
+    with pytest.raises(rooms.RoomConflictError):
+        _create(db)
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.read_events(db, room_id="room-1")
+
+
+def test_pre_actor_draft_database_migrates_with_explicit_legacy_identity(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_gateway_id"] == "legacy"
+    assert state["authority_epoch"] == 1
+    adopted = rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Legacy",
+        members=[],
+        authority_gateway_id="gateway-a",
+        now=2,
+    )
+    assert adopted["authority_gateway_id"] == "gateway-a"
+    assert adopted["authority_epoch"] == 2
+    assert adopted["adopted"] is True
+    assert adopted["claim_event"]["seq"] == 2
+    assert adopted["claim_event"]["payload"]["previous_gateway_id"] == "legacy"
+
+
+def test_draft_schema_migration_is_safe_across_processes(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_read_legacy_state, [str(db)] * 4))
+
+    assert results == [("legacy", 1)] * 4
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+
+
+def test_interrupted_draft_schema_migration_rolls_back_atomically(
+    tmp_path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+    original = rooms._initialize_schema
+
+    def interrupt_after_first_alter(conn):
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+        raise RuntimeError("simulated migration interruption")
+
+    monkeypatch.setattr(rooms, "_initialize_schema", interrupt_after_first_alter)
+    with pytest.raises(RuntimeError, match="simulated migration interruption"):
+        rooms.list_rooms(db)
+    with sqlite3.connect(db) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    assert "authority_gateway_id" not in columns
+
+    monkeypatch.setattr(rooms, "_initialize_schema", original)
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] == "legacy"

--- a/tests/hermes_cli/test_install_identity.py
+++ b/tests/hermes_cli/test_install_identity.py
@@ -1,0 +1,112 @@
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+from pathlib import Path
+import time
+
+from gateway.hosted_rooms import local_authority_gateway_id
+import hermes_cli.install_identity as install_identity
+from hermes_cli.install_identity import read_or_create_install_id
+
+
+def _race_first_install_id(
+    root_value,
+    minted,
+    results,
+    start_barrier=None,
+    writer_entered=None,
+    release_writer=None,
+):
+    root = Path(root_value)
+    install_identity.uuid.uuid4 = lambda: type("FixedUuid", (), {"hex": minted})()
+    if start_barrier is not None:
+        start_barrier.wait(timeout=10)
+    if writer_entered is not None:
+        original_mkstemp = install_identity.tempfile.mkstemp
+
+        def held_mkstemp(*args, **kwargs):
+            writer_entered.set()
+            assert release_writer.wait(timeout=10)
+            return original_mkstemp(*args, **kwargs)
+
+        install_identity.tempfile.mkstemp = held_mkstemp
+    results.put(read_or_create_install_id(root))
+
+
+def test_concurrent_first_use_returns_one_persisted_identity(tmp_path):
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        values = list(executor.map(lambda _: read_or_create_install_id(tmp_path), range(64)))
+
+    assert len(set(values)) == 1
+    assert values[0]
+    assert (tmp_path / "install_id").read_text(encoding="utf-8").strip() == values[0]
+
+
+def test_independent_first_callers_return_the_single_committed_identity(tmp_path, monkeypatch):
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    writer_entered = context.Event()
+    release_writer = context.Event()
+    winner = context.Process(
+        target=_race_first_install_id,
+        args=(
+            str(tmp_path),
+            "a" * 32,
+            results,
+            None,
+            writer_entered,
+            release_writer,
+        ),
+    )
+    loser = context.Process(
+        target=_race_first_install_id,
+        args=(str(tmp_path), "b" * 32, results),
+    )
+
+    winner.start()
+    assert writer_entered.wait(timeout=10)
+    loser.start()
+    time.sleep(0.25)
+    assert loser.is_alive()
+    release_writer.set()
+    processes = [winner, loser]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        install_identity,
+        "_INSTALL_ID_CACHE",
+        {"root": None, "value": None},
+    )
+    assert local_authority_gateway_id() == f"install:{persisted}"
+
+
+def test_concurrent_corrupt_file_repair_returns_one_committed_identity(tmp_path):
+    (tmp_path / "install_id").write_text("corrupt\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_race_first_install_id,
+            args=(str(tmp_path), value, results, barrier),
+        )
+        for value in ("a" * 32, "b" * 32)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -169,6 +169,60 @@ def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
     assert read_turn_marker(marker_home, "session-key") is None
 
 
+def test_hosted_terminal_receipt_commits_before_marker_retire(
+    emits, turn_env, marker_home
+):
+    observed = []
+
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(receipt):
+        observed.append((receipt, read_turn_marker(marker_home, "session-key")))
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert observed[0][0]["status"] == "settled"
+    assert observed[0][1] is not None
+    assert read_turn_marker(marker_home, "session-key") is None
+
+
+def test_hosted_terminal_receipt_failure_keeps_crash_marker(
+    emits, turn_env, marker_home
+):
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(_receipt):
+        raise RuntimeError("state store unavailable")
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert read_turn_marker(marker_home, "session-key") is not None
+
+
 def test_continuation_turn_records_attempt_and_original_prompt(
     emits, turn_env, marker_home
 ):
@@ -261,6 +315,20 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert "fix the flaky test" in text
     assert kwargs["display_kind"] == "auto_continue"
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
+
+
+def test_hosted_room_marker_is_left_to_the_driver(schedule_env, marker_home):
+    record_turn_start(marker_home, "session-key", "hosted prompt")
+
+    result = server._maybe_schedule_auto_continue(
+        "sid",
+        _session(source="bot_room"),
+        "session-key",
+    )
+
+    assert result is None
+    assert not schedule_env
+    assert read_turn_marker(marker_home, "session-key") is not None
 
 
 def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):
@@ -372,5 +440,4 @@ def test_failed_agent_build_leaves_marker_for_retry(
 
 
 # ── End to end: continuation runs a real turn and clears the marker ────
-
 

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -1,0 +1,238 @@
+"""Tests for the gateway-hosted ``groups.*`` JSON-RPC contract."""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    path = tmp_path / ".hermes"
+    path.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(path))
+    return path
+
+
+def _result(envelope):
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def _server_authority():
+    from gateway.hosted_rooms import local_authority_gateway_id
+
+    return local_authority_gateway_id()
+
+
+def _create_room():
+    return _result(
+        srv._methods["groups.create"](
+            1,
+            {
+                "room_id": "room-1",
+                "name": "Release room",
+                "members": [{"profile": "ops", "handle": "ops"}],
+                "authority_gateway_id": "gateway-a",
+            },
+        )
+    )["room"]
+
+
+def test_capabilities_are_honest_about_the_driver_boundary(home):
+    result = _result(srv._methods["groups.capabilities"](1, {}))
+
+    assert result["protocol_version"] == 2
+    assert result["driver"] is False
+    assert result["authority_gateway_id"] == _server_authority()
+    assert "authority_epoch" in result["features"]
+    assert "coordinator_fencing" in result["features"]
+    assert "monotonic_log" in result["features"]
+    assert "groups.state" in result["methods"]
+    assert "groups.send" in result["methods"]
+
+
+def test_create_list_send_and_log_roundtrip(home):
+    room = _create_room()
+    assert room["idempotent"] is False
+
+    listed = _result(srv._methods["groups.list"](2, {}))
+    assert [item["room_id"] for item in listed["rooms"]] == ["room-1"]
+    state = _result(srv._methods["groups.state"](3, {"room_id": "room-1"}))
+    assert state["room"]["authority_gateway_id"] == _server_authority()
+    assert state["room"]["authority_epoch"] == 1
+    assert state["room"]["latest_seq"] == 0
+
+    sent = _result(
+        srv._methods["groups.send"](
+            4,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+    assert sent["accepted"] is True
+    assert sent["driver_started"] is False
+    assert sent["event"]["seq"] == 1
+    assert sent["event"]["kind"] == "message.user"
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+    replay = _result(
+        srv._methods["groups.log"](
+            5,
+            {"room_id": "room-1", "since_seq": 0},
+        )
+    )
+    assert replay["latest_seq"] == replay["cursor"] == 1
+    assert replay["events"][0]["payload"] == {"text": "hello"}
+
+
+def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
+    _create_room()
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "actor": {"kind": "user", "id": "desktop-user"},
+        "payload": {"text": "hello"},
+    }
+    first = _result(srv._methods["groups.send"](2, params))
+    repeated = _result(srv._methods["groups.send"](3, params))
+
+    assert first["event"]["seq"] == repeated["event"]["seq"] == 1
+    assert repeated["event"]["idempotent"] is True
+
+    conflict = srv._methods["groups.send"](
+        4,
+        {**params, "payload": {"text": "different"}},
+    )
+    assert conflict["error"]["code"] == 4111
+    assert "different content" in conflict["error"]["message"]
+
+
+def test_send_does_not_trust_client_supplied_actor_identity(home):
+    _create_room()
+    sent = _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "spoofed-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+
+def test_create_ignores_client_supplied_authority_identity(home):
+    created = _result(
+        srv._methods["groups.create"](
+            1,
+            {"room_id": "legacy-room", "name": "Legacy", "members": []},
+        )
+    )["room"]
+    retried = _result(
+        srv._methods["groups.create"](
+            2,
+            {
+                "room_id": "legacy-room",
+                "name": "Legacy",
+                "members": [],
+                "authority_gateway_id": "spoofed-gateway",
+            },
+        )
+    )["room"]
+
+    assert created["authority_gateway_id"] == _server_authority()
+    assert retried["authority_gateway_id"] == _server_authority()
+    assert retried["idempotent"] is True
+
+
+def test_legacy_room_adoption_emits_one_lineage_receipt(home):
+    from gateway.hosted_rooms import create_room, default_db_path
+
+    members = [{"profile": "ops", "handle": "ops"}]
+    create_room(
+        default_db_path(),
+        room_id="legacy-room",
+        name="Legacy",
+        members=members,
+        authority_gateway_id="legacy",
+        now=1,
+    )
+
+    adopted = _result(
+        srv._methods["groups.create"](
+            2,
+            {"room_id": "legacy-room", "name": "Legacy", "members": members},
+        )
+    )["room"]
+    state = _result(
+        srv._methods["groups.state"](3, {"room_id": "legacy-room"})
+    )["room"]
+
+    assert adopted["adopted"] is True
+    assert adopted["authority_gateway_id"] == _server_authority()
+    assert adopted["authority_epoch"] == 2
+    assert adopted["claim_event"]["payload"] == {
+        "previous_gateway_id": "legacy",
+        "authority_gateway_id": _server_authority(),
+        "authority_epoch": 2,
+    }
+    assert state["authority_claim"]["event_id"] == "system:authority-adopted"
+    assert state["latest_seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("method_name", "params"),
+    [
+        (
+            "groups.create",
+            {
+                "room_id": "",
+                "name": "x",
+                "members": [],
+                "authority_gateway_id": "gateway-a",
+            },
+        ),
+        (
+            "groups.send",
+            {
+                "room_id": "missing",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {},
+            },
+        ),
+        ("groups.log", {"room_id": "missing", "since_seq": 0}),
+    ],
+)
+def test_invalid_or_unknown_room_returns_contract_error(home, method_name, params):
+    result = srv._methods[method_name](1, params)
+    assert result["error"]["code"] in {4110, 4111, 4112}
+
+
+def test_disband_tombstones_room(home):
+    _create_room()
+    first = _result(srv._methods["groups.disband"](3, {"room_id": "room-1"}))
+    repeated = _result(srv._methods["groups.disband"](4, {"room_id": "room-1"}))
+    assert first["tombstone"]["idempotent"] is False
+    assert repeated["tombstone"]["idempotent"] is True
+    assert _result(srv._methods["groups.list"](5, {}))["rooms"] == []
+    deleted = _result(
+        srv._methods["groups.list"](6, {"include_disbanded": True})
+    )["rooms"]
+    assert deleted[0]["disbanded_at"] == first["tombstone"]["disbanded_at"]
+    replay = _result(
+        srv._methods["groups.log"](
+            7,
+            {"room_id": "room-1", "include_disbanded": True},
+        )
+    )
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -491,6 +491,10 @@ def test_crash_recovery_harvests_existing_terminal_receipt(db: Path):
 
 def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -498,7 +502,7 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     state.start_task(
@@ -506,7 +510,7 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(
@@ -522,8 +526,8 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
             }
         ],
     )
-    time.sleep(0.22)
-    runtime = _runtime(db, rpc)
+    now[0] = 101.0
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
@@ -537,6 +541,10 @@ def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
 
 def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -544,7 +552,7 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     old_attempt = state.start_task(
@@ -552,9 +560,9 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
-    time.sleep(0.22)
+    now[0] = 101.0
     current_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -562,18 +570,18 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="manual-recovery",
         ttl_seconds=30,
-        clock=time.time,
+        clock=clock,
     )
-    state.recover_room(db, current_lease, clock=time.time)
+    state.recover_room(db, current_lease, clock=clock)
     state.requeue_indeterminate_task(
         db,
         identity,
         current_lease,
         expected_execution_generation=old_attempt.execution_generation,
         expected_cancel_generation=old_attempt.cancel_generation,
-        clock=time.time,
+        clock=clock,
     )
-    state.release_lease(db, current_lease, clock=time.time)
+    state.release_lease(db, current_lease, clock=clock)
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(
         task_id=identity.task_id,
@@ -588,7 +596,7 @@ def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
             }
         ],
     )
-    runtime = _runtime(db, rpc)
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     assert rpc.submitted.wait(1.0)
@@ -634,6 +642,10 @@ def test_active_recovered_turn_is_never_resubmitted(db: Path):
 
 def test_ambiguous_recovery_remains_indeterminate(db: Path):
     identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
     old_lease = state.acquire_lease(
         db,
         room_id=ROOM_ID,
@@ -641,7 +653,7 @@ def test_ambiguous_recovery_remains_indeterminate(db: Path):
         authority_epoch=BINDING.authority_epoch,
         process_generation="old-process",
         ttl_seconds=0.2,
-        clock=time.time,
+        clock=clock,
     )
     _admit(db, identity)
     state.start_task(
@@ -649,12 +661,12 @@ def test_ambiguous_recovery_remains_indeterminate(db: Path):
         identity,
         old_lease,
         expected_cancel_generation=0,
-        clock=time.time,
+        clock=clock,
     )
     rpc = FakeSessionRPC(auto_complete=False)
     rpc.add_session(active=False, task_id=identity.task_id)
-    time.sleep(0.22)
-    runtime = _runtime(db, rpc)
+    now[0] = 101.0
+    runtime = _runtime(db, rpc, clock=clock)
 
     runtime.start()
     _wait_for(lambda: state.get_task(db, identity)["status"] == "indeterminate")

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -1,0 +1,1001 @@
+"""Runtime tests for the hosted-room session adapter."""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gateway import hosted_room_driver as state
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_driver import (
+    ROOM_SESSION_SOURCE,
+    HostedRoomBinding,
+    HostedRoomRuntime,
+    room_session_title,
+)
+
+
+ROOM_ID = "room-1"
+PROFILE = "ops"
+BINDING = HostedRoomBinding(
+    room_id=ROOM_ID,
+    gateway_id="gateway-a",
+    authority_epoch=1,
+)
+
+
+class RecordingTurnLocks:
+    """Record the profile lock and expose ownership to the fake RPC."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+        self.local = threading.local()
+
+    @contextmanager
+    def __call__(self, profile: str):
+        self.events.append(("lock-enter", profile))
+        self.local.profile = profile
+        try:
+            yield
+        finally:
+            self.events.append(("lock-exit", profile))
+            self.local.profile = None
+
+    def held_for(self, profile: str) -> bool:
+        return getattr(self.local, "profile", None) == profile
+
+
+class FakeSessionRPC:
+    """Normalized in-memory session adapter with no model or network."""
+
+    def __init__(
+        self,
+        *,
+        auto_complete: bool = True,
+        required_lock: RecordingTurnLocks | None = None,
+    ) -> None:
+        self.auto_complete = auto_complete
+        self.required_lock = required_lock
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.sessions: dict[tuple[str, str], dict[str, Any]] = {}
+        self.states: dict[str, dict[str, Any]] = {}
+        self.submitted = threading.Event()
+        self.on_interrupt = None
+        self.on_info = None
+        self.history_failures = 0
+        self._next_id = 1
+        self._lock = threading.Lock()
+
+    def _assert_lock(self, profile: str) -> None:
+        if self.required_lock is not None:
+            assert self.required_lock.held_for(profile)
+
+    def add_session(
+        self,
+        *,
+        profile: str = PROFILE,
+        title: str = room_session_title(ROOM_ID),
+        active: bool = False,
+        task_id: str | None = None,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
+        with self._lock:
+            session_id = f"session-{self._next_id}"
+            self._next_id += 1
+            session = {"session_id": session_id, "title": title}
+            self.sessions[(profile, title)] = session
+            self.states[session_id] = {
+                "active": active,
+                "task_id": task_id,
+                "execution_generation": None,
+                "history": list(history or []),
+                "on_terminal": None,
+                "pending_approval": None,
+            }
+            return session_id
+
+    def complete(
+        self,
+        task_id: str,
+        *,
+        content: str = "Finished once.",
+        status: str = "settled",
+    ) -> None:
+        callback = None
+        receipt = None
+        with self._lock:
+            for session_id, session_state in self.states.items():
+                if session_state["task_id"] != task_id:
+                    continue
+                receipt = {
+                    "role": "assistant",
+                    "task_id": task_id,
+                    "execution_generation": session_state["execution_generation"],
+                    "status": status,
+                    "message_id": f"reply:{task_id}",
+                    "content": content,
+                }
+                session_state["history"].append(receipt)
+                session_state["active"] = False
+                callback = session_state.get("on_terminal")
+                self.calls.append(("complete", {"session_id": session_id}))
+                break
+        if receipt is None:
+            raise AssertionError(f"no active session for {task_id}")
+        if callback is not None:
+            callback({
+                "status": status,
+                "settlement_id": receipt["message_id"],
+                "message_id": receipt["message_id"],
+                "text": content,
+            })
+
+    def resolve_exact(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("resolve_exact", params))
+        with self._lock:
+            session = self.sessions.get((profile, title))
+            return dict(session) if session is not None else None
+
+    def create(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("create", params))
+        session_id = self.add_session(profile=profile, title=title)
+        return {"session_id": session_id, "title": title}
+
+    def resume(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("resume", params))
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal,
+    ):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "prompt": prompt,
+            "source": source,
+            "task": task,
+            "execution_generation": execution_generation,
+            "on_terminal": on_terminal,
+        }
+        self.calls.append(("submit", params))
+        with self._lock:
+            self.states[session_id]["active"] = True
+            self.states[session_id]["task_id"] = task.task_id
+            self.states[session_id]["execution_generation"] = execution_generation
+            self.states[session_id]["on_terminal"] = on_terminal
+        self.submitted.set()
+        if self.auto_complete:
+            self.complete(task.task_id)
+        return {"accepted": True}
+
+    def history(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("history", params))
+        if self.history_failures > 0:
+            self.history_failures -= 1
+            raise RuntimeError("transient history read failed")
+        with self._lock:
+            return [dict(message) for message in self.states[session_id]["history"]]
+
+    def info(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("info", params))
+        with self._lock:
+            session_state = self.states[session_id]
+            result = {
+                "active": session_state["active"],
+                "task_id": session_state["task_id"],
+            }
+            if session_state.get("pending_approval"):
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = dict(
+                    session_state["pending_approval"]
+                )
+        if self.on_info is not None:
+            self.on_info()
+        return result
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ):
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "expected_task_id": expected_task_id,
+        }
+        with self._lock:
+            current = self.states[session_id]
+            if not current["active"] or current["task_id"] != expected_task_id:
+                self.calls.append(("interrupt_skipped", params))
+                return {"interrupted": False}
+            current["active"] = False
+        self.calls.append(("interrupt", params))
+        if self.on_interrupt is not None:
+            self.on_interrupt()
+        return {"interrupted": True}
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    path = tmp_path / "state.db"
+    hosted_rooms.create_room(
+        path,
+        room_id=ROOM_ID,
+        name="Release room",
+        members=[{"profile": PROFILE, "handle": PROFILE}],
+        authority_gateway_id=BINDING.gateway_id,
+        now=time.time(),
+    )
+    return path
+
+
+def _identity(task_id: str = "task-1") -> state.TaskIdentity:
+    return state.TaskIdentity(
+        room_id=ROOM_ID,
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=f"turn-{task_id}",
+    )
+
+
+def _admit(
+    db: Path,
+    identity: state.TaskIdentity,
+    *,
+    prompt: str = "Inspect the release candidate.",
+) -> None:
+    state.admit_task(
+        db,
+        identity,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": prompt,
+            "source_event_seq": 1,
+        },
+        clock=time.time,
+    )
+
+
+def _runtime(
+    db: Path,
+    rpc: FakeSessionRPC,
+    locks: RecordingTurnLocks | None = None,
+    **kwargs,
+) -> HostedRoomRuntime:
+    return HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        rpc=rpc,
+        turn_lock=locks or RecordingTurnLocks(),
+        lease_ttl_seconds=kwargs.pop("lease_ttl_seconds", 0.4),
+        poll_interval_seconds=kwargs.pop("poll_interval_seconds", 0.01),
+        **kwargs,
+    )
+
+
+def _wait_for(predicate, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_runtime_uses_unique_process_generation(db: Path):
+    first = _runtime(db, FakeSessionRPC())
+    second = _runtime(db, FakeSessionRPC())
+
+    assert first.process_generation != second.process_generation
+    assert len(first.process_generation) == 32
+
+
+def test_queued_task_routes_profile_and_credentials_without_overrides(db: Path):
+    identity = _identity()
+    _admit(db, identity, prompt="Use the configured profile credentials.")
+    rpc = FakeSessionRPC()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    create = next(params for method, params in rpc.calls if method == "create")
+    submit = next(params for method, params in rpc.calls if method == "submit")
+    assert create == {
+        "profile": PROFILE,
+        "title": f"Group: {ROOM_ID}",
+        "source": ROOM_SESSION_SOURCE,
+    }
+    assert submit["profile"] == PROFILE
+    assert submit["source"] == ROOM_SESSION_SOURCE
+    assert submit["prompt"] == "Use the configured profile credentials."
+    assert "model" not in create | submit
+    assert "provider" not in create | submit
+    assert state.get_task(db, identity)["result"]["text"] == "Finished once."
+
+
+def test_worker_settles_without_any_client_transport(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    runtime = _runtime(db, FakeSessionRPC())
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+
+    assert runtime.status()["running"] is True
+    assert runtime.status()["cycles"] >= 1
+    assert runtime.stop(timeout=1.0)
+
+
+def test_policy_hooks_prepare_and_publish_terminal_idempotently(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    prepared = []
+    published = []
+    runtime = _runtime(
+        db,
+        FakeSessionRPC(),
+        prepare_room=lambda binding: prepared.append(binding.room_id),
+        publish_terminal=lambda binding, task: published.append(
+            (binding.room_id, task["identity"].task_id, task["status"])
+        ),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert prepared
+    assert published == [(ROOM_ID, identity.task_id, "settled")]
+
+
+def test_transport_resolver_selects_member_transport_without_forking_state(
+    db: Path,
+):
+    identity = _identity()
+    _admit(db, identity)
+    selected = FakeSessionRPC()
+    resolutions = []
+
+    def resolve_transport(binding, task):
+        resolutions.append((binding, task["identity"], task["payload"]))
+        return selected
+
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        transport_resolver=resolve_transport,
+        turn_lock=RecordingTurnLocks(),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.01,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert resolutions
+    assert all(binding == BINDING for binding, _, _ in resolutions)
+    assert all(task_identity == identity for _, task_identity, _ in resolutions)
+    assert any(method == "submit" for method, _ in selected.calls)
+
+
+def test_existing_canonical_session_is_resumed_not_duplicated(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC()
+    session_id = rpc.add_session()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "create"]
+    resume = next(params for method, params in rpc.calls if method == "resume")
+    assert resume == {
+        "profile": PROFILE,
+        "session_id": session_id,
+        "source": ROOM_SESSION_SOURCE,
+    }
+
+
+def test_crash_recovery_harvests_existing_terminal_receipt(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=10,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:recovered",
+                "content": "Recovered durable answer.",
+            }
+        ],
+    )
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["result"]["text"] == (
+        "Recovered durable answer."
+    )
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_expired_attempt_receipt_is_reconciled_under_current_lease(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:expired-recovered",
+                "content": "Recovered after lease expiry.",
+            }
+        ],
+    )
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["result"]["text"] == (
+        "Recovered after lease expiry."
+    )
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    old_attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    time.sleep(0.22)
+    current_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="manual-recovery",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    state.recover_room(db, current_lease, clock=time.time)
+    state.requeue_indeterminate_task(
+        db,
+        identity,
+        current_lease,
+        expected_execution_generation=old_attempt.execution_generation,
+        expected_cancel_generation=old_attempt.cancel_generation,
+        clock=time.time,
+    )
+    state.release_lease(db, current_lease, clock=time.time)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": old_attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply:late-old-attempt",
+                "content": "Late old result.",
+            }
+        ],
+    )
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    time.sleep(0.04)
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["status"] == "running"
+    assert task["execution_generation"] == old_attempt.execution_generation + 1
+
+
+def test_active_recovered_turn_is_never_resubmitted(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=10,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=True, task_id=identity.task_id)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    time.sleep(0.08)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+
+def test_ambiguous_recovery_remains_indeterminate(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "indeterminate")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_post_submit_observation_failure_preserves_recoverable_outcome(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.history_failures = 1
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    _wait_for(
+        lambda: (
+            "observation failed after submit"
+            in str(runtime.status()["last_error"] or "")
+        )
+    )
+    assert state.get_task(db, identity)["status"] == "running"
+    rpc.complete(identity.task_id, content="Recovered after a transient read.")
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["result"]["text"] == "Recovered after a transient read."
+    assert not [call for call in rpc.calls if call[0] == "submit"][1:]
+
+
+def test_cancellation_is_persisted_before_interrupt_and_fences_late_result(
+    db: Path,
+):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    observed_status: list[str] = []
+    rpc.on_interrupt = lambda: observed_status.append(
+        state.get_task(db, identity)["status"]
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    cancelled = runtime.cancel(identity, cancel_id="cancel-user")
+    rpc.complete(identity.task_id, content="Too late.")
+    runtime.wakeup()
+    time.sleep(0.05)
+    assert runtime.stop(timeout=1.0)
+
+    assert cancelled["status"] == "cancelled"
+    assert observed_status == ["stopping"]
+
+
+def test_transient_remote_stop_failure_stays_pending_and_retries(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    original_interrupt = rpc.interrupt
+    attempts = 0
+
+    def flaky_interrupt(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary stop transport failure")
+        return original_interrupt(**kwargs)
+
+    rpc.interrupt = flaky_interrupt
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    stopping = runtime.cancel(identity, cancel_id="cancel-retry")
+    assert stopping["status"] == "stopping"
+    assert state.get_task(db, identity)["status"] == "stopping"
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "cancelled")
+    assert attempts >= 2
+    assert runtime.stop(timeout=1.0)
+    assert state.get_task(db, identity)["status"] == "cancelled"
+
+
+def test_completion_wins_a_race_with_unacknowledged_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    def finish_only_after_stop_intent():
+        if state.get_task(db, identity)["status"] == "stopping":
+            rpc.complete(identity.task_id, content="Already done.")
+
+    rpc.on_info = finish_only_after_stop_intent
+    result = runtime.cancel(identity, cancel_id="cancel-raced")
+
+    assert result["status"] == "settled"
+    assert result["result"]["text"] == "Already done."
+    assert runtime.stop(timeout=1.0)
+
+
+def test_restart_harvests_completion_before_retrying_durable_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.05,
+        clock=time.time,
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    stopping = state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        active=False,
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply-after-stop",
+                "content": "Finished before Stop reached the session.",
+            }
+        ],
+    )
+    time.sleep(0.06)
+    runtime = _runtime(db, rpc, process_generation="new-process")
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    settled = state.get_task(db, identity)
+    assert stopping["status"] == "stopping"
+    assert settled["result"]["text"] == "Finished before Stop reached the session."
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+def test_restart_acknowledges_inactive_local_stop_without_memory_marker(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.05,
+        clock=time.time,
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    time.sleep(0.06)
+    runtime = _runtime(db, rpc, process_generation="new-process")
+
+    cancelled = runtime.cancel(identity, cancel_id="cancel-before-restart")
+
+    assert cancelled["status"] == "cancelled"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+
+def test_pending_local_approval_is_reported_with_safe_choices(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    actions = []
+    runtime = _runtime(
+        db,
+        rpc,
+        pending_action=lambda room_id, member_id, action: actions.append(
+            (room_id, member_id, action)
+        ),
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+    with rpc._lock:
+        rpc.states[session_id]["pending_approval"] = {
+            "request_id": "approval-1",
+            "command": "pytest -q tests/focused",
+            "choices": ["once", "session", "always", "deny"],
+        }
+    runtime.wakeup()
+    _wait_for(lambda: any(action for _room, _member, action in actions))
+
+    _room, member, action = next(
+        item for item in actions if item[2] is not None
+    )
+    assert member == PROFILE
+    assert action["request_id"] == "approval-1"
+    assert action["approval"]["choices"] == ["once", "deny"]
+    assert runtime.stop(timeout=1.0)
+
+
+def test_cancel_never_interrupts_a_newer_task_in_the_same_session(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+
+    def switch_to_newer_task() -> None:
+        with rpc._lock:
+            rpc.states[session_id]["active"] = True
+            rpc.states[session_id]["task_id"] = "task-2"
+
+    rpc.on_info = switch_to_newer_task
+    cancelled = runtime.cancel(identity, cancel_id="cancel-old-task")
+
+    assert cancelled["status"] == "stopping"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+    assert not [call for call in rpc.calls if call[0] == "interrupt_skipped"]
+    assert rpc.states[session_id]["active"] is True
+    assert rpc.states[session_id]["task_id"] == "task-2"
+    assert runtime.stop(timeout=1.0)
+
+
+def test_status_reports_room_blocked_on_unresolved_indeterminate_task(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    time.sleep(0.22)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: ROOM_ID in runtime.status()["blocked_rooms"])
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "indeterminate"
+
+
+def test_authority_loss_stops_terminal_commit(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, lease_ttl_seconds=0.1)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    hosted_rooms.claim_authority(
+        db,
+        room_id=ROOM_ID,
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=time.time(),
+    )
+    rpc.complete(identity.task_id)
+    runtime.wakeup()
+    _wait_for(lambda: runtime.status()["last_error"] is not None)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert "authority changed" in runtime.status()["last_error"]
+
+
+def test_profile_turn_lock_covers_resolve_submit_and_terminal_observation(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    locks = RecordingTurnLocks()
+    rpc = FakeSessionRPC(required_lock=locks)
+    runtime = _runtime(db, rpc, locks)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert locks.events == [("lock-enter", PROFILE), ("lock-exit", PROFILE)]
+    methods = [method for method, _params in rpc.calls]
+    assert methods.index("resolve_exact") < methods.index("submit")
+    assert methods.index("submit") < methods.index("complete")
+    assert "history" not in methods
+
+
+def test_stop_is_bounded_and_does_not_interrupt_active_turn(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, poll_interval_seconds=0.01)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    started = time.monotonic()
+    stopped = runtime.stop(timeout=0.5)
+
+    assert stopped is True
+    assert time.monotonic() - started < 0.5
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -361,7 +361,10 @@ def test_worker_settles_without_any_client_transport(db: Path):
     runtime = _runtime(db, FakeSessionRPC())
 
     runtime.start()
-    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    _wait_for(
+        lambda: state.get_task(db, identity)["status"] == "settled"
+        and runtime.status()["cycles"] >= 1
+    )
 
     assert runtime.status()["running"] is True
     assert runtime.status()["cycles"] >= 1

--- a/tests/tui_gateway/test_hosted_room_prompt_fence.py
+++ b/tests/tui_gateway/test_hosted_room_prompt_fence.py
@@ -1,0 +1,84 @@
+"""Older Desktop clients cannot start a second driver for hosted rooms."""
+
+from __future__ import annotations
+
+from gateway import hosted_rooms
+import tui_gateway.server as server
+
+
+def _stub_session(monkeypatch, *, title):
+    monkeypatch.setattr(
+        server,
+        "_sess_nowait",
+        lambda _params, _rid: (
+            {"id": "session-1", "title": title, "source": "bot_room"},
+            None,
+        ),
+    )
+
+
+def test_direct_prompt_to_hosted_group_session_is_rejected(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    hosted_rooms.create_room(
+        hosted_rooms.default_db_path(),
+        room_id="room-hosted",
+        name="Hosted room",
+        members=[
+            {"member_id": "one", "profile": "one", "handle": "one"},
+            {"member_id": "two", "profile": "two", "handle": "two"},
+        ],
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    _stub_session(monkeypatch, title="Group: room-hosted")
+
+    result = server._methods["prompt.submit"](
+        "request-1", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 4122
+    assert "managed by its gateway" in result["error"]["message"]
+
+
+def test_direct_prompt_to_non_hosted_group_reaches_normal_admission(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: local-only")
+    monkeypatch.setattr(
+        server,
+        "_ensure_active_session_slot",
+        lambda _sid, _session: "normal admission reached",
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-2", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"] == {"code": 4090, "message": "normal admission reached"}
+
+
+def test_direct_prompt_is_refused_when_room_authority_cannot_be_verified(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: room-unknown")
+    monkeypatch.setattr(
+        hosted_rooms,
+        "room_state",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk busy")),
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-3", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 5122
+    assert result["error"]["message"] == (
+        "Could not verify this group. Try again after the gateway recovers."
+    )

--- a/tests/tui_gateway/test_hosted_room_server_rpc.py
+++ b/tests/tui_gateway/test_hosted_room_server_rpc.py
@@ -1,0 +1,148 @@
+"""Tests for the in-process hosted room session adapter."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.hosted_room_driver import TaskIdentity
+from tui_gateway.hosted_room_server_rpc import (
+    HostedRoomServerRPC,
+    HostedRoomSessionError,
+)
+
+
+def _server():
+    sessions = {}
+    calls = []
+
+    def method(name, result):
+        def handler(rid, params):
+            calls.append((name, params))
+            value = result(params) if callable(result) else result
+            return {"id": rid, **value}
+
+        return handler
+
+    methods = {
+        "session.list": method(
+            "session.list",
+            {"result": {"sessions": [{"id": "stored", "resolved_id": "tip", "title": "Group: room"}]}},
+        ),
+        "session.create": method("session.create", {"result": {"session_id": "runtime"}}),
+        "session.resume": method("session.resume", {"result": {"session_id": "runtime"}}),
+        "session.history": method("session.history", {"result": {"messages": [{"role": "assistant"}]}}),
+        "session.interrupt": method("session.interrupt", {"result": {"interrupted": True}}),
+        "approval.respond": method("approval.respond", {"result": {"resolved": 1}}),
+        "prompt.submit": method("prompt.submit", {"result": {"status": "streaming"}}),
+    }
+    server = SimpleNamespace(
+        _methods=methods,
+        _sessions=sessions,
+        _sessions_lock=threading.Lock(),
+        _pending_approval_request_payload=lambda _session_key: None,
+    )
+    return server, calls
+
+
+def test_routes_exact_hidden_session_and_internal_task_proof():
+    server, calls = _server()
+    rpc = HostedRoomServerRPC(server)
+    task = TaskIdentity("room", "task", "thread", "turn")
+    callback = lambda _receipt: None
+
+    assert rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")["session_id"] == "tip"
+    assert rpc.create(profile="ops", title="Group: room", source="bot_room")["session_id"] == "runtime"
+    rpc.submit(
+        profile="ops",
+        session_id="runtime",
+        prompt="Do the work",
+        source="bot_room",
+        task=task,
+        execution_generation=2,
+        on_terminal=callback,
+    )
+
+    create = next(params for method, params in calls if method == "session.create")
+    submit = next(params for method, params in calls if method == "prompt.submit")
+    assert create["hidden"] is True
+    assert create["close_on_disconnect"] is False
+    assert submit["_hosted_task"] == {
+        "room_id": "room",
+        "task_id": "task",
+        "thread_id": "thread",
+        "turn_id": "turn",
+        "execution_generation": 2,
+    }
+    assert submit["_hosted_terminal_callback"] is callback
+
+
+def test_info_and_interrupt_are_exact_task_scoped():
+    server, calls = _server()
+    lock = threading.Lock()
+    server._sessions["runtime"] = {
+        "history_lock": lock,
+        "running": True,
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    assert rpc.info(profile="ops", session_id="runtime", source="bot_room") == {
+        "active": True,
+        "task_id": "task-a",
+    }
+    rpc.interrupt(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        expected_task_id="task-a",
+    )
+    params = next(params for method, params in calls if method == "session.interrupt")
+    assert params["expected_hosted_task_id"] == "task-a"
+
+
+def test_local_approval_snapshot_and_response_use_exact_request():
+    server, calls = _server()
+    server._pending_approval_request_payload = lambda session_key: {
+        "request_id": "approval-1",
+        "command": "pytest -q tests/focused",
+        "choices": ["once", "deny"],
+    } if session_key == "stored-session" else None
+    server._sessions["runtime"] = {
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    info = rpc.info(profile="ops", session_id="runtime", source="bot_room")
+    assert info["status"] == "waiting_for_approval"
+    assert info["pending_approval"]["request_id"] == "approval-1"
+    assert rpc.approve(
+        session_id="runtime",
+        request_id="approval-1",
+        choice="once",
+    ) == {"resolved": 1}
+    params = next(params for method, params in calls if method == "approval.respond")
+    assert params == {
+        "session_id": "runtime",
+        "request_id": "approval-1",
+        "choice": "once",
+        "all": False,
+    }
+
+
+def test_rpc_errors_are_typed():
+    server, _calls = _server()
+    server._methods["session.list"] = lambda rid, _params: {
+        "id": rid,
+        "error": {"code": 4007, "message": "not found"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    with pytest.raises(HostedRoomSessionError) as exc:
+        rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")
+    assert exc.value.code == 4007

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -161,3 +161,35 @@ def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path)
     replayed = service._events("room-1")
     assert replayed == events
 
+
+def test_stop_fence_prevents_the_next_room_member_from_starting(
+    tmp_path: Path, monkeypatch
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    monkeypatch.setattr(service, "local_profiles", lambda: ("default", "ops"))
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "Inspect the release", "thread_id": "thread-1"},
+    )
+    assert len(driver.list_tasks(db, room_id="room-1")) == 1
+
+    assert service.stop_room("room-1", cancel_id="stop-1") == 1
+    service.prepare_room(service.bindings()[0])
+
+    tasks = driver.list_tasks(db, room_id="room-1")
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "cancelled"
+    assert any(
+        event["kind"] == "room.stop_requested"
+        for event in service._events("room-1")
+    )

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -1,0 +1,163 @@
+"""Integration tests for the hosted Discussion coordinator."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+class _FakeRPC:
+    def __init__(self) -> None:
+        self.sessions = {}
+
+    def resolve_exact(self, *, profile, title, source):
+        return self.sessions.get((profile, title))
+
+    def create(self, *, profile, title, source):
+        session = {"session_id": f"{profile}-session", "title": title}
+        self.sessions[(profile, title)] = session
+        return session
+
+    def resume(self, *, profile, session_id, source):
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        on_terminal({"status": "settled", "text": f"reply from {profile}"})
+        return {"accepted": True}
+
+    def history(self, *, profile, session_id, source):
+        return []
+
+    def info(self, *, profile, session_id, source):
+        return {"active": False, "task_id": None}
+
+    def interrupt(self, *, profile, session_id, source, expected_task_id):
+        return {"interrupted": True}
+
+
+def _server():
+    return SimpleNamespace(_methods={}, _sessions={}, _sessions_lock=threading.Lock())
+
+
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached")
+
+
+def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _FakeRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    assert room["room_id"] == "room-1"
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect the release", "thread_id": "thread-1"},
+    )
+    _wait_for(
+        lambda: any(
+            event["kind"] == "message.member"
+            for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+
+    events = service._events("room-1")
+    assert [event["kind"] for event in events][:3] == [
+        "message.user",
+        "message.member",
+        "turn.settled",
+    ]
+    assert events[1]["payload"]["text"] == "reply from ops"
+    assert service.status("room-1")["working"] is False
+
+
+def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    event = hosted_rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    binding = service.bindings()[0]
+    service.prepare_room(binding)
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="crashed",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    attempt = driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    driver.settle_task(
+        db,
+        attempt,
+        settlement_id="reply-1",
+        status="settled",
+        result={"text": "done"},
+        clock=time.time,
+    )
+
+    service.prepare_room(binding)
+    events = service._events("room-1")
+    assert event["seq"] == 1
+    assert sum(row["kind"] == "message.member" for row in events) == 1
+    assert sum(row["kind"] == "turn.settled" for row in events) == 1
+    service.prepare_room(binding)
+    replayed = service._events("room-1")
+    assert replayed == events
+

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -1,0 +1,1033 @@
+"""Runtime adapter for gateway-owned hosted room turns.
+
+The durable state machine lives in :mod:`gateway.hosted_room_driver`.  This
+module owns the process-local worker and a deliberately small, injected session
+adapter.  It does not import the gateway server, construct agents, or depend on
+any client transport.
+
+The adapter normalizes existing internal session RPCs into seven methods. A
+future server integration can implement those methods with the in-process
+handlers while tests use deterministic fakes and no models or network.
+
+One worker serializes rooms deliberately in this first slice. That keeps lease
+and recovery behavior auditable; per-room workers are a later scalability
+change, not an implicit guarantee here. Hosted member sessions intentionally
+reuse ``Group: <room_id>`` so a local-to-hosted migration preserves the same
+canonical transcript instead of forking a second conversation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ContextManager, Protocol, cast
+
+from gateway import hosted_room_driver as state
+
+
+ROOM_SESSION_SOURCE = "bot_room"
+
+
+class InternalSessionRPC(Protocol):
+    """Normalized in-process session operations required by the room driver."""
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        """Return the exact titled session under ``profile``, if it exists."""
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        """Create a session without model or provider overrides."""
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        """Resume the canonical room session."""
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        """Submit one fenced room turn and durably report its terminal result."""
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return normalized session messages in durable order."""
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        """Return normalized live status for a session."""
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        """Interrupt only when the current turn still matches the expected task."""
+
+
+class MemberTransportResolver(Protocol):
+    """Resolve the session transport for one durable room task."""
+
+    def __call__(
+        self,
+        binding: "HostedRoomBinding",
+        task: Mapping[str, Any],
+    ) -> InternalSessionRPC:
+        """Return a local or peer transport without changing task identity."""
+
+
+@dataclass(frozen=True)
+class HostedRoomBinding:
+    """Current server-issued authority coordinate for one hosted room."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class _TerminalReceipt:
+    status: state.TerminalStatus
+    settlement_id: str
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _RecoveryInspection:
+    terminal: _TerminalReceipt | None
+    active: bool
+
+
+class HostedRoomRuntime:
+    """Run queued hosted-room tasks independently of Desktop connections."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | str,
+        rooms: Iterable[HostedRoomBinding] | Callable[[], Iterable[HostedRoomBinding]],
+        turn_lock: Callable[[str], ContextManager[Any]],
+        rpc: InternalSessionRPC | None = None,
+        transport_resolver: MemberTransportResolver | None = None,
+        prepare_room: Callable[[HostedRoomBinding], None] | None = None,
+        publish_terminal: Callable[[HostedRoomBinding, Mapping[str, Any]], None]
+        | None = None,
+        pending_action: Callable[
+            [str, str, Mapping[str, Any] | None], None
+        ]
+        | None = None,
+        clock: Callable[[], float] = time.time,
+        lease_ttl_seconds: float = 30.0,
+        poll_interval_seconds: float = 0.1,
+        process_generation: str | None = None,
+    ) -> None:
+        if lease_ttl_seconds <= 0:
+            raise ValueError("lease_ttl_seconds must be positive")
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+        if rpc is None and transport_resolver is None:
+            raise ValueError("rpc or transport_resolver is required")
+
+        self.db_path = Path(db_path)
+        self.rpc = rpc
+        self.transport_resolver = transport_resolver
+        self.turn_lock = turn_lock
+        self.prepare_room = prepare_room
+        self.publish_terminal = publish_terminal
+        self.pending_action = pending_action
+        self.clock = clock
+        self.lease_ttl_seconds = float(lease_ttl_seconds)
+        self.poll_interval_seconds = float(poll_interval_seconds)
+        self.process_generation = process_generation or uuid.uuid4().hex
+        self._rooms_provider: Callable[[], Iterable[HostedRoomBinding]]
+        if callable(rooms):
+            self._rooms_provider = cast(
+                Callable[[], Iterable[HostedRoomBinding]], rooms
+            )
+        else:
+            room_bindings = tuple(rooms)
+            self._rooms_provider = lambda: room_bindings
+
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._leases: dict[str, state.DriverLease] = {}
+        self._recovered_leases: set[tuple[str, int]] = set()
+        self._ambiguous_rooms: dict[str, float] = {}
+        self._blocked_rooms: set[str] = set()
+        self._status_lock = threading.Lock()
+        self._current_task: state.TaskIdentity | None = None
+        self._last_error: str | None = None
+        self._cycles = 0
+
+    def start(self) -> None:
+        """Start the single dedicated worker thread idempotently."""
+        with self._status_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._wake.set()
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name="hosted-room-driver",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        """Request a bounded clean stop without interrupting accepted turns."""
+        self._stop.set()
+        self._wake.set()
+        with self._status_lock:
+            thread = self._thread
+        if thread is None:
+            return True
+        thread.join(max(0.0, timeout))
+        return not thread.is_alive()
+
+    def wakeup(self) -> None:
+        """Wake the worker after task admission or a room-state change."""
+        self._wake.set()
+
+    def status(self) -> dict[str, Any]:
+        """Return a transport-neutral snapshot of runtime health."""
+        with self._status_lock:
+            thread = self._thread
+            current = self._current_task
+            return {
+                "running": bool(thread and thread.is_alive()),
+                "stopping": self._stop.is_set(),
+                "process_generation": self.process_generation,
+                "current_task": current,
+                "leased_rooms": tuple(sorted(self._leases)),
+                "blocked_rooms": tuple(sorted(self._blocked_rooms)),
+                "last_error": self._last_error,
+                "cycles": self._cycles,
+            }
+
+    def cancel(
+        self,
+        identity: state.TaskIdentity,
+        *,
+        cancel_id: str,
+    ) -> dict[str, Any]:
+        """Persist a stop intent, then commit cancellation after acknowledgement."""
+        before = state.get_task(self.db_path, identity)
+        if before["status"] == "queued":
+            cancelled = state.cancel_task(
+                self.db_path,
+                identity,
+                cancel_id=cancel_id,
+                expected_cancel_generation=before["cancel_generation"],
+                clock=self.clock,
+            )
+            self.wakeup()
+            return cancelled
+
+        stopping = state.begin_task_cancel(
+            self.db_path,
+            identity,
+            cancel_id=cancel_id,
+            expected_cancel_generation=before["cancel_generation"],
+            clock=self.clock,
+        )
+        binding = self._binding_for_room(identity.room_id)
+        try:
+            if binding is not None and self._interrupt_stopping_task(binding, stopping):
+                stopping = state.complete_task_cancel(
+                    self.db_path,
+                    identity,
+                    cancel_id=cancel_id,
+                    expected_cancel_generation=stopping["cancel_generation"],
+                    clock=self.clock,
+                )
+        except Exception as exc:
+            self._record_error(f"stop remains pending: {exc}")
+        stopping = state.get_task(self.db_path, identity)
+        self.wakeup()
+        return stopping
+
+    def retry_indeterminate(self, identity: state.TaskIdentity) -> dict[str, Any]:
+        """Explicitly retry one uncertain attempt under the current room lease."""
+        task = state.get_task(self.db_path, identity)
+        if task["status"] != "indeterminate":
+            raise state.InvalidTaskTransitionError(
+                f"cannot retry task in state '{task['status']}'"
+            )
+        binding = self._binding_for_room(identity.room_id)
+        if binding is None:
+            raise state.RoomUnavailableError("hosted room is unavailable")
+        lease = self._ensure_lease(binding)
+        retried = state.requeue_indeterminate_task(
+            self.db_path,
+            identity,
+            lease,
+            expected_execution_generation=task["execution_generation"],
+            expected_cancel_generation=task["cancel_generation"],
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._blocked_rooms.discard(identity.room_id)
+        self.wakeup()
+        return retried
+
+    def _interrupt_stopping_task(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> bool:
+        transport = self._transport_for(binding, task)
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            # A local accepted turn cannot survive without its canonical
+            # session. Resolution errors raise; an authoritative absence is a
+            # safe Stop acknowledgement. A peer remains uncertain instead.
+            return transport is self.rpc
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        session_id = _session_id(resumed)
+        info = transport.info(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+        )
+        active = bool(info.get("active", info.get("running", False)))
+        if not active:
+            # History was checked immediately before this probe. An exact
+            # local session that is no longer active cannot keep executing, and
+            # after a restart its process-local task marker is expected to be
+            # absent. A peer transport never gets this shortcut: an unreachable
+            # remote run stays uncertain until its own durable status acks Stop.
+            if transport is self.rpc:
+                return True
+            return False
+        if not _info_is_active_for(info, task["identity"], require_exact=True):
+            return False
+        result = transport.interrupt(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+            expected_task_id=task["identity"].task_id,
+        )
+        if result is None:
+            return False
+        return result.get("interrupted") is True or str(result.get("status") or "") in {
+            "cancelled",
+            "interrupted",
+            "stopping",
+        }
+
+    def _settle_stopping_completion(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> bool:
+        """Publish a terminal receipt that arrived before Stop was acknowledged."""
+        transport = self._transport_for(binding, task)
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return False
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        receipt = _find_terminal_receipt(
+            transport.history(
+                profile=profile,
+                session_id=_session_id(resumed),
+                source=ROOM_SESSION_SOURCE,
+            ),
+            task["identity"],
+            int(task["execution_generation"]),
+        )
+        if receipt is None:
+            return False
+        settled = state.settle_stopping_task(
+            self.db_path,
+            task["identity"],
+            lease,
+            expected_execution_generation=int(task["execution_generation"]),
+            expected_cancel_generation=int(task["cancel_generation"]),
+            settlement_id=receipt.settlement_id,
+            status=receipt.status,
+            result=receipt.result,
+            clock=self.clock,
+        )
+        if self.publish_terminal is not None:
+            self.publish_terminal(binding, settled)
+        return True
+
+    def _report_pending_action(
+        self,
+        task: Mapping[str, Any],
+        *,
+        session_id: str,
+        info: Mapping[str, Any],
+    ) -> None:
+        if self.pending_action is None:
+            return
+        payload = task.get("payload") or {}
+        member_id = str(
+            payload.get("target_member_id") or payload.get("target_profile") or ""
+        )
+        approval = info.get("pending_approval") or info.get("approval")
+        action = None
+        if isinstance(approval, Mapping):
+            safe_approval = dict(approval)
+            choices = [
+                choice
+                for choice in safe_approval.get("choices") or ()
+                if choice in {"once", "deny"}
+            ]
+            safe_approval["choices"] = choices or ["once", "deny"]
+            action = {
+                "kind": "approval",
+                "task_id": task["identity"].task_id,
+                "execution_generation": int(task["execution_generation"]),
+                "run_id": info.get("run_id"),
+                "session_id": session_id,
+                "request_id": safe_approval.get("request_id"),
+                "approval": safe_approval,
+            }
+        self.pending_action(task["identity"].room_id, member_id, action)
+
+    def _retry_stopping_tasks(
+        self, binding: HostedRoomBinding, lease: state.DriverLease
+    ) -> bool:
+        pending = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="stopping",
+        )
+        for task in pending:
+            try:
+                lease = self._renew_lease_if_needed(binding, lease)
+                if self._settle_stopping_completion(binding, task, lease):
+                    continue
+                if not self._interrupt_stopping_task(binding, task):
+                    return True
+                state.complete_task_cancel(
+                    self.db_path,
+                    task["identity"],
+                    cancel_id=task["cancel_id"],
+                    expected_cancel_generation=task["cancel_generation"],
+                    clock=self.clock,
+                )
+            except Exception as exc:
+                self._record_error(f"stop retry remains pending: {exc}")
+                return True
+        return False
+
+    def _worker_loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                try:
+                    self._run_cycle()
+                except Exception as exc:  # keep independent rooms serviceable
+                    self._record_error(f"worker cycle failed: {exc}")
+                with self._status_lock:
+                    self._cycles += 1
+                self._wake.wait(self.poll_interval_seconds)
+                self._wake.clear()
+        finally:
+            self._release_idle_leases()
+
+    def _run_cycle(self) -> None:
+        for binding in tuple(self._rooms_provider()):
+            if self._stop.is_set():
+                return
+            try:
+                self._process_room(binding)
+            except state.LeaseHeldError:
+                continue
+            except (state.RoomUnavailableError, state.StaleLeaseError) as exc:
+                self._drop_lease(binding.room_id)
+                with self._status_lock:
+                    self._blocked_rooms.discard(binding.room_id)
+                self._record_error(f"room {binding.room_id}: {exc}")
+            except Exception as exc:
+                self._record_error(f"room {binding.room_id}: {exc}")
+
+    def _process_room(self, binding: HostedRoomBinding) -> None:
+        if self.prepare_room is not None:
+            self.prepare_room(binding)
+        self._inspect_abandoned_attempts(binding)
+        deferred_until = self._ambiguous_rooms.get(binding.room_id)
+        if deferred_until is not None:
+            running = state.list_tasks(
+                self.db_path,
+                room_id=binding.room_id,
+                status="running",
+            )
+            if not running:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+            elif self.clock() < deferred_until:
+                return
+            else:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+        lease = self._ensure_lease(binding)
+        recovery_key = (lease.room_id, lease.lease_generation)
+        if recovery_key not in self._recovered_leases:
+            state.recover_room(self.db_path, lease, clock=self.clock)
+            self._recovered_leases.add(recovery_key)
+        if self._retry_stopping_tasks(binding, lease):
+            with self._status_lock:
+                self._blocked_rooms.add(binding.room_id)
+            return
+        if self._reconcile_indeterminate(binding, lease):
+            return
+
+        queued = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="queued",
+        )
+        for task in queued:
+            if self._stop.is_set():
+                return
+            lease = self._renew_lease_if_needed(binding, lease)
+            attempt = state.start_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_cancel_generation=task["cancel_generation"],
+                clock=self.clock,
+            )
+            self._execute_attempt(binding, task, attempt)
+
+    def _ensure_lease(self, binding: HostedRoomBinding) -> state.DriverLease:
+        with self._status_lock:
+            current = self._leases.get(binding.room_id)
+        if current is not None:
+            try:
+                renewed = self._renew_lease_if_needed(binding, current)
+            except state.StaleLeaseError:
+                self._drop_lease(binding.room_id)
+            else:
+                return renewed
+
+        lease = state.acquire_lease(
+            self.db_path,
+            room_id=binding.room_id,
+            gateway_id=binding.gateway_id,
+            authority_epoch=binding.authority_epoch,
+            process_generation=self.process_generation,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[binding.room_id] = lease
+            self._recovered_leases = {
+                key for key in self._recovered_leases if key[0] != binding.room_id
+            }
+        return lease
+
+    def _renew_lease_if_needed(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+        *,
+        force: bool = False,
+    ) -> state.DriverLease:
+        del binding
+        renew_at = lease.expires_at - (self.lease_ttl_seconds / 2)
+        if not force and self.clock() < renew_at:
+            return lease
+        renewed = state.renew_lease(
+            self.db_path,
+            lease,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[lease.room_id] = renewed
+        return renewed
+
+    def _execute_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        attempt: state.TaskAttempt,
+    ) -> None:
+        profile = task["payload"]["target_profile"]
+        transport = self._transport_for(binding, task)
+        submit_attempted = False
+        with self._status_lock:
+            self._current_task = attempt.identity
+        try:
+            with self.turn_lock(profile):
+                session = self._resolve_or_create(
+                    transport, profile, binding.room_id
+                )
+                # An in-process submit should fail before admission or return
+                # after it, but an unexpected exception at that boundary is
+                # still ambiguous. Never terminalize it as a proven failure.
+                submit_attempted = True
+                def on_terminal(receipt: Mapping[str, Any]) -> None:
+                    status = receipt.get("status")
+                    if status == "cancelled":
+                        self.wakeup()
+                        return
+                    terminal_status: state.TerminalStatus = (
+                        "settled" if status == "settled" else "failed"
+                    )
+                    try:
+                        settled = state.settle_task(
+                            self.db_path,
+                            attempt,
+                            settlement_id=(
+                                receipt.get("settlement_id")
+                                or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                            ),
+                            status=terminal_status,
+                            result={
+                                "message_id": receipt.get("message_id"),
+                                "text": receipt.get("text", ""),
+                                **(
+                                    {"error": receipt.get("error")}
+                                    if receipt.get("error")
+                                    else {}
+                                ),
+                            },
+                            clock=self.clock,
+                        )
+                        if self.publish_terminal is not None:
+                            self.publish_terminal(binding, settled)
+                    except state.StaleTaskError:
+                        try:
+                            current = state.get_task(self.db_path, attempt.identity)
+                            if current["status"] == "stopping":
+                                settled = state.settle_stopping_task(
+                                    self.db_path,
+                                    attempt.identity,
+                                    attempt.lease,
+                                    expected_execution_generation=attempt.execution_generation,
+                                    expected_cancel_generation=int(current["cancel_generation"]),
+                                    settlement_id=(
+                                        receipt.get("settlement_id")
+                                        or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                                    ),
+                                    status=terminal_status,
+                                    result={
+                                        "message_id": receipt.get("message_id"),
+                                        "text": receipt.get("text", ""),
+                                        **(
+                                            {"error": receipt.get("error")}
+                                            if receipt.get("error")
+                                            else {}
+                                        ),
+                                    },
+                                    clock=self.clock,
+                                )
+                                if self.publish_terminal is not None:
+                                    self.publish_terminal(binding, settled)
+                        except (state.StaleLeaseError, state.StaleTaskError):
+                            pass
+                    except state.StaleLeaseError:
+                        # Cancellation, disband, or authority transfer won the
+                        # durable race. The model result is intentionally
+                        # discarded; never turn a correct fence into a worker
+                        # thread exception.
+                        pass
+                    self.wakeup()
+
+                transport.submit(
+                    profile=profile,
+                    session_id=_session_id(session),
+                    prompt=task["payload"]["prompt"],
+                    source=ROOM_SESSION_SOURCE,
+                    task=attempt.identity,
+                    execution_generation=attempt.execution_generation,
+                    on_terminal=on_terminal,
+                )
+                receipt = self._wait_for_terminal(
+                    binding,
+                    task=task,
+                    profile=profile,
+                    session_id=_session_id(session),
+                    attempt=attempt,
+                    transport=transport,
+                )
+                if receipt is None:
+                    return
+                state.settle_task(
+                    self.db_path,
+                    attempt,
+                    settlement_id=receipt.settlement_id,
+                    status=receipt.status,
+                    result=receipt.result,
+                    clock=self.clock,
+                )
+        except (state.StaleLeaseError, state.StaleTaskError) as exc:
+            self._drop_lease(binding.room_id)
+            self._record_error(f"task {attempt.identity.task_id} fenced: {exc}")
+        except Exception as exc:
+            if submit_attempted:
+                self._drop_lease(binding.room_id)
+                self._ambiguous_rooms[binding.room_id] = attempt.lease.expires_at
+                self._record_error(
+                    f"task {attempt.identity.task_id} observation failed after submit: {exc}"
+                )
+            else:
+                self._settle_failure_if_current(attempt, exc)
+        finally:
+            with self._status_lock:
+                self._current_task = None
+
+    def _wait_for_terminal(
+        self,
+        binding: HostedRoomBinding,
+        *,
+        task: Mapping[str, Any],
+        profile: str,
+        session_id: str,
+        attempt: state.TaskAttempt,
+        transport: InternalSessionRPC,
+    ) -> _TerminalReceipt | None:
+        lease = attempt.lease
+        while not self._stop.is_set():
+            task = state.get_task(self.db_path, attempt.identity)
+            if task["status"] in state.TERMINAL_STATUSES:
+                return None
+            if task["status"] == "stopping":
+                try:
+                    lease = self._renew_lease_if_needed(binding, lease)
+                    if self._settle_stopping_completion(binding, task, lease):
+                        return None
+                    if self._interrupt_stopping_task(binding, task):
+                        state.complete_task_cancel(
+                            self.db_path,
+                            attempt.identity,
+                            cancel_id=task["cancel_id"],
+                            expected_cancel_generation=task["cancel_generation"],
+                            clock=self.clock,
+                        )
+                        return None
+                except Exception as exc:
+                    self._record_error(f"stop retry remains pending: {exc}")
+                self._wake.wait(self.poll_interval_seconds)
+                self._wake.clear()
+                continue
+
+            lease = self._renew_lease_if_needed(binding, lease)
+            receipt = _find_terminal_receipt(
+                transport.history(
+                    profile=profile,
+                    session_id=session_id,
+                    source=ROOM_SESSION_SOURCE,
+                ),
+                attempt.identity,
+                attempt.execution_generation,
+            )
+            if receipt is not None:
+                return receipt
+
+            info = transport.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            self._wake.wait(self.poll_interval_seconds)
+            self._wake.clear()
+        return None
+
+    def _inspect_abandoned_attempts(self, binding: HostedRoomBinding) -> None:
+        running = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="running",
+        )
+        for task in running:
+            if task["run_process_generation"] == self.process_generation:
+                continue
+            inspection = self._inspect_recovery_session(binding, task)
+            if inspection.terminal is not None:
+                self._harvest_previous_attempt(binding, task, inspection.terminal)
+            elif inspection.active:
+                # The prior session still owns the turn. Do not contend for its
+                # lease or submit a duplicate prompt.
+                raise state.LeaseHeldError("recovered session turn is still active")
+
+    def _inspect_recovery_session(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> _RecoveryInspection:
+        profile = task["payload"]["target_profile"]
+        transport = self._transport_for(binding, task)
+        with self.turn_lock(profile):
+            session = transport.resolve_exact(
+                profile=profile,
+                title=room_session_title(task["identity"].room_id),
+                source=ROOM_SESSION_SOURCE,
+            )
+            if session is None:
+                return _RecoveryInspection(terminal=None, active=False)
+            session_id = _session_id(session)
+            resumed = transport.resume(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            session_id = _session_id(resumed)
+            receipt = _find_terminal_receipt(
+                transport.history(
+                    profile=profile,
+                    session_id=session_id,
+                    source=ROOM_SESSION_SOURCE,
+                ),
+                task["identity"],
+                task["execution_generation"],
+            )
+            info = transport.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            return _RecoveryInspection(
+                terminal=receipt,
+                active=_info_is_active_for(info, task["identity"]),
+            )
+
+    def _reconcile_indeterminate(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+    ) -> bool:
+        unresolved = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="indeterminate",
+        )
+        for task in unresolved:
+            inspection = self._inspect_recovery_session(binding, task)
+            if inspection.terminal is None:
+                with self._status_lock:
+                    self._blocked_rooms.add(binding.room_id)
+                return True
+            state.resolve_indeterminate_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_execution_generation=task["execution_generation"],
+                expected_cancel_generation=task["cancel_generation"],
+                settlement_id=inspection.terminal.settlement_id,
+                status=inspection.terminal.status,
+                result=inspection.terminal.result,
+                clock=self.clock,
+            )
+        with self._status_lock:
+            self._blocked_rooms.discard(binding.room_id)
+        return False
+
+    def _harvest_previous_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        receipt: _TerminalReceipt,
+    ) -> None:
+        previous_lease = state.DriverLease(
+            room_id=binding.room_id,
+            gateway_id=task["run_gateway_id"],
+            authority_epoch=binding.authority_epoch,
+            process_generation=task["run_process_generation"],
+            lease_generation=task["run_lease_generation"],
+            expires_at=0.0,
+        )
+        previous_attempt = state.TaskAttempt(
+            identity=task["identity"],
+            lease=previous_lease,
+            execution_generation=task["execution_generation"],
+            cancel_generation=task["cancel_generation"],
+        )
+        try:
+            state.settle_task(
+                self.db_path,
+                previous_attempt,
+                settlement_id=receipt.settlement_id,
+                status=receipt.status,
+                result=receipt.result,
+                clock=self.clock,
+            )
+        except (state.StaleLeaseError, state.StaleTaskError):
+            # Once the previous proof has expired, the current state contract
+            # deliberately offers no unsafe "trust this historical output"
+            # escape hatch. The subsequent fenced recovery leaves it
+            # indeterminate for explicit user action.
+            return
+
+    def _binding_for_room(self, room_id: str) -> HostedRoomBinding | None:
+        return next(
+            (
+                binding
+                for binding in self._rooms_provider()
+                if binding.room_id == room_id
+            ),
+            None,
+        )
+
+    def _transport_for(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> InternalSessionRPC:
+        if self.transport_resolver is not None:
+            return self.transport_resolver(binding, task)
+        if self.rpc is None:  # guarded by __init__
+            raise RuntimeError("hosted room transport is unavailable")
+        return self.rpc
+
+    def _resolve_or_create(
+        self,
+        transport: InternalSessionRPC,
+        profile: str,
+        room_id: str,
+    ) -> Mapping[str, Any]:
+        title = room_session_title(room_id)
+        session = transport.resolve_exact(
+            profile=profile,
+            title=title,
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return transport.create(
+                profile=profile,
+                title=title,
+                source=ROOM_SESSION_SOURCE,
+            )
+        return transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+
+    def _settle_failure_if_current(
+        self, attempt: state.TaskAttempt, exc: Exception
+    ) -> None:
+        try:
+            state.settle_task(
+                self.db_path,
+                attempt,
+                settlement_id=f"failure:{attempt.identity.task_id}:{attempt.execution_generation}",
+                status="failed",
+                result={"error": str(exc)},
+                clock=self.clock,
+            )
+        except (state.DriverStateError, state.RoomUnavailableError):
+            pass
+        self._record_error(f"task {attempt.identity.task_id} failed: {exc}")
+
+    def _record_error(self, message: str) -> None:
+        with self._status_lock:
+            self._last_error = message
+
+    def _drop_lease(self, room_id: str) -> None:
+        with self._status_lock:
+            self._leases.pop(room_id, None)
+
+    def _release_idle_leases(self) -> None:
+        for room_id, lease in tuple(self._leases.items()):
+            try:
+                state.release_lease(self.db_path, lease, clock=self.clock)
+            except state.DriverStateError:
+                continue
+            self._drop_lease(room_id)
+
+
+def room_session_title(room_id: str) -> str:
+    """Return the canonical hidden session title for one hosted room."""
+    return f"Group: {room_id}"
+
+
+def _session_id(session: Mapping[str, Any]) -> str:
+    value = session.get("session_id", session.get("id"))
+    if not isinstance(value, str) or not value:
+        raise ValueError("session adapter returned no session_id")
+    return value
+
+
+def _find_terminal_receipt(
+    history: Sequence[Mapping[str, Any]],
+    identity: state.TaskIdentity,
+    execution_generation: int,
+) -> _TerminalReceipt | None:
+    for message in reversed(history):
+        if message.get("task_id") != identity.task_id:
+            continue
+        if message.get("execution_generation") != execution_generation:
+            continue
+        if message.get("role") != "assistant":
+            continue
+        status = message.get("status")
+        if status not in {"settled", "failed"}:
+            continue
+        terminal_status = cast(state.TerminalStatus, status)
+        receipt_id = message.get("message_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            receipt_id = f"reply:{identity.task_id}:{execution_generation}"
+        return _TerminalReceipt(
+            status=terminal_status,
+            settlement_id=receipt_id,
+            result={
+                "message_id": receipt_id,
+                "text": message.get("content", ""),
+            },
+        )
+    return None
+
+
+def _info_is_active_for(
+    info: Mapping[str, Any],
+    identity: state.TaskIdentity,
+    *,
+    require_exact: bool = False,
+) -> bool:
+    if not bool(info.get("active", info.get("running", False))):
+        return False
+    active_task_id = info.get("task_id")
+    if require_exact:
+        return active_task_id == identity.task_id
+    return active_task_id in {None, identity.task_id}
+
+
+@contextlib.contextmanager
+def null_turn_lock(_profile: str) -> Any:
+    """Provide an explicit no-op lock for narrow embedding tests."""
+    yield

--- a/tui_gateway/hosted_room_server_rpc.py
+++ b/tui_gateway/hosted_room_server_rpc.py
@@ -1,0 +1,204 @@
+"""In-process session adapter for the hosted room driver.
+
+The room worker must not depend on a Desktop/WebSocket transport, but it should
+still use the same session handlers as every other TUI/Desktop turn. This
+adapter calls the installed handler registry directly and keeps the extra
+task proof as an in-process-only Python object that JSON clients cannot forge.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from collections.abc import Mapping, Sequence
+from types import ModuleType
+from typing import Any, Callable
+
+from gateway import hosted_room_driver as state
+
+
+class HostedRoomSessionError(RuntimeError):
+    """Raised when an in-process session operation is rejected."""
+
+    def __init__(self, method: str, code: int, message: str) -> None:
+        super().__init__(f"{method} failed: {message}")
+        self.method = method
+        self.code = code
+
+
+class HostedRoomServerRPC:
+    """Normalize the installed server handlers for :class:`HostedRoomRuntime`."""
+
+    def __init__(self, server: ModuleType) -> None:
+        self.server = server
+        self._ids = itertools.count(1)
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        handler = self.server._methods[method]
+        envelope = handler(f"hosted-room-{next(self._ids)}", params)
+        error = envelope.get("error") if isinstance(envelope, dict) else None
+        if isinstance(error, dict):
+            raise HostedRoomSessionError(
+                method,
+                int(error.get("code") or 5000),
+                str(error.get("message") or "gateway rejected the request"),
+            )
+        result = envelope.get("result") if isinstance(envelope, dict) else None
+        if not isinstance(result, dict):
+            raise HostedRoomSessionError(method, 5000, "gateway returned no result")
+        return result
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        del source
+        result = self._call(
+            "session.list",
+            {"profile": profile, "title": title, "include_hidden": True},
+        )
+        rows = result.get("sessions")
+        if not isinstance(rows, list) or not rows:
+            return None
+        row = rows[0]
+        if not isinstance(row, dict):
+            return None
+        session_id = row.get("resolved_id") or row.get("id")
+        return {"session_id": session_id, "title": row.get("title") or title}
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        return self._call(
+            "session.create",
+            {
+                "profile": profile,
+                "title": title,
+                "source": source,
+                "hidden": True,
+                "close_on_disconnect": False,
+            },
+        )
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        del source
+        return self._call(
+            "session.resume",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "omit_messages": True,
+            },
+        )
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "prompt.submit",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "text": prompt,
+                "source": source,
+                "_hosted_task": {
+                    "room_id": task.room_id,
+                    "task_id": task.task_id,
+                    "thread_id": task.thread_id,
+                    "turn_id": task.turn_id,
+                    "execution_generation": execution_generation,
+                },
+                "_hosted_terminal_callback": on_terminal,
+            },
+        )
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        del source
+        result = self._call(
+            "session.history",
+            {"profile": profile, "session_id": session_id},
+        )
+        rows = result.get("messages")
+        return tuple(row for row in rows if isinstance(row, dict)) if isinstance(rows, list) else ()
+
+    def _session_record(self, session_id: str) -> dict[str, Any] | None:
+        with self.server._sessions_lock:
+            record = self.server._sessions.get(session_id)
+            if record is not None:
+                return record
+            for candidate in self.server._sessions.values():
+                if str(candidate.get("session_key") or "") == session_id:
+                    return candidate
+        return None
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        del profile, source
+        record = self._session_record(session_id)
+        if record is None:
+            return {"active": False, "task_id": None}
+        lock = record.get("history_lock")
+        if not isinstance(lock, type(threading.Lock())):
+            return {"active": bool(record.get("running")), "task_id": None}
+        with lock:
+            task = record.get("_hosted_room_task")
+            result = {
+                "active": bool(record.get("running")),
+                "task_id": task.get("task_id") if isinstance(task, dict) else None,
+            }
+            pending_reader = getattr(
+                self.server, "_pending_approval_request_payload", None
+            )
+            pending = (
+                pending_reader(str(record.get("session_key") or ""))
+                if callable(pending_reader)
+                else None
+            )
+            if pending:
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = pending
+            return result
+
+    def approve(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        choice: str,
+    ) -> Mapping[str, Any]:
+        """Resolve one exact local room approval without broad policy changes."""
+        return self._call(
+            "approval.respond",
+            {
+                "session_id": session_id,
+                "request_id": request_id,
+                "choice": choice,
+                "all": False,
+            },
+        )
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        del source
+        return self._call(
+            "session.interrupt",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "expected_hosted_task_id": expected_task_id,
+            },
+        )

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -1,0 +1,266 @@
+"""Production coordinator for same-gateway hosted Discussion rooms."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from collections import Counter
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_driver import HostedRoomBinding, HostedRoomRuntime
+from tui_gateway.hosted_room_server_rpc import HostedRoomServerRPC
+
+
+class HostedRoomService:
+    """Own the hosted Discussion policy and its transport-free worker."""
+
+    def __init__(self, server: ModuleType, *, db_path: Path | str | None = None) -> None:
+        self.server = server
+        self.db_path = Path(db_path or hosted_rooms.default_db_path())
+        self._policy_lock = threading.RLock()
+        self.rpc = HostedRoomServerRPC(server)
+        self.runtime = HostedRoomRuntime(
+            db_path=self.db_path,
+            rooms=self.bindings,
+            rpc=self.rpc,
+            turn_lock=self._turn_lock,
+            prepare_room=self.prepare_room,
+            publish_terminal=self.publish_terminal,
+        )
+
+    @property
+    def root(self) -> Path:
+        return self.db_path.parent
+
+    def local_profiles(self) -> tuple[str, ...]:
+        profiles = {"default"}
+        profiles_dir = self.root / "profiles"
+        if profiles_dir.is_dir():
+            profiles.update(path.name for path in profiles_dir.iterdir() if path.is_dir())
+        return tuple(sorted(profiles))
+
+    def bindings(self) -> tuple[HostedRoomBinding, ...]:
+        return tuple(
+            HostedRoomBinding(
+                room_id=str(room["room_id"]),
+                gateway_id=str(room["authority_gateway_id"]),
+                authority_epoch=int(room["authority_epoch"]),
+            )
+            for room in hosted_rooms.list_rooms(self.db_path)
+        )
+
+    @contextlib.contextmanager
+    def _turn_lock(self, profile: str) -> Iterator[None]:
+        from tools.bot_relay import acquire_turn_lock
+
+        with acquire_turn_lock(self.root, profile):
+            yield
+
+    def start(self) -> None:
+        self.runtime.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        return self.runtime.stop(timeout=timeout)
+
+    def wakeup(self) -> None:
+        self.runtime.wakeup()
+
+    def _events(self, room_id: str) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        cursor = 0
+        while True:
+            page = hosted_rooms.read_events(
+                self.db_path,
+                room_id=room_id,
+                since_seq=cursor,
+                limit=hosted_rooms.MAX_LOG_LIMIT,
+            )
+            rows = page.get("events")
+            if isinstance(rows, list):
+                events.extend(row for row in rows if isinstance(row, dict))
+            next_cursor = int(page.get("cursor") or cursor)
+            if not page.get("has_more"):
+                return events
+            if next_cursor <= cursor:
+                raise RuntimeError("hosted room replay cursor did not advance")
+            cursor = next_cursor
+
+    def _append_plan(self, room_id: str, plan: discussion.PublicationPlan) -> None:
+        for event in plan.events:
+            hosted_rooms.append_event(
+                self.db_path,
+                **event.append_kwargs(room_id),
+            )
+
+    def _publish_terminal_tasks(
+        self,
+        room: Mapping[str, Any],
+        events: list[dict[str, Any]],
+    ) -> bool:
+        changed = False
+        local_profiles = self.local_profiles()
+        for status in ("settled", "failed", "cancelled"):
+            for task in driver.list_tasks(
+                self.db_path,
+                room_id=str(room["room_id"]),
+                status=status,
+            ):
+                plan = discussion.reconstruct_task_plan(
+                    room,
+                    events,
+                    task,
+                    local_profiles=local_profiles,
+                )
+                publication = discussion.plan_publication(
+                    room,
+                    events,
+                    plan,
+                    status=status,
+                    result=task.get("result"),
+                    local_profiles=local_profiles,
+                )
+                before = len(events)
+                self._append_plan(str(room["room_id"]), publication)
+                events = self._events(str(room["room_id"]))
+                changed = changed or len(events) > before
+        return changed
+
+    def _append_room_status(
+        self,
+        room: Mapping[str, Any],
+        decision: discussion.DiscussionDecision,
+    ) -> None:
+        if decision.discussion_event_id is None:
+            return
+        hosted_rooms.append_event(
+            self.db_path,
+            room_id=str(room["room_id"]),
+            event_id=f"dactivity:{decision.discussion_event_id}:{decision.reason}",
+            kind="room.activity",
+            actor={"kind": "gateway", "id": str(room["authority_gateway_id"])},
+            payload={
+                "status": decision.status,
+                "reason_code": decision.reason,
+                "thread_id": decision.thread_id,
+                "discussion_event_id": decision.discussion_event_id,
+            },
+            authority_gateway_id=str(room["authority_gateway_id"]),
+            authority_epoch=int(room["authority_epoch"]),
+        )
+
+    def prepare_room(self, binding: HostedRoomBinding) -> None:
+        with self._policy_lock:
+            room = hosted_rooms.room_state(self.db_path, room_id=binding.room_id)
+            events = self._events(binding.room_id)
+            if self._publish_terminal_tasks(room, events):
+                events = self._events(binding.room_id)
+            decision = discussion.plan_next_task(
+                room,
+                events,
+                local_profiles=self.local_profiles(),
+            )
+            if decision.status == "task" and decision.task is not None:
+                driver.admit_task(
+                    self.db_path,
+                    decision.task.identity,
+                    payload=decision.task.payload,
+                    clock=time.time,
+                )
+            elif decision.status in {"settled", "bounded"}:
+                self._append_room_status(room, decision)
+
+    def publish_terminal(
+        self,
+        binding: HostedRoomBinding,
+        _task: Mapping[str, Any],
+    ) -> None:
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+
+    def create_room(self, *, room_id: str, name: str, members: Any) -> dict[str, Any]:
+        normalized = discussion.validate_roster(
+            members,
+            local_profiles=self.local_profiles(),
+        )
+        room = hosted_rooms.create_room(
+            self.db_path,
+            room_id=room_id,
+            name=name,
+            members=[
+                {
+                    "member_id": member.member_id,
+                    "profile": member.profile,
+                    "handle": member.handle,
+                    **(
+                        {"display_name": member.display_name}
+                        if member.display_name
+                        else {}
+                    ),
+                }
+                for member in normalized
+            ],
+            authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+        )
+        self.runtime.wakeup()
+        return room
+
+    def send(
+        self,
+        *,
+        room_id: str,
+        event_id: str,
+        payload: Any,
+    ) -> dict[str, Any]:
+        normalized = discussion.validate_user_payload(payload)
+        event = hosted_rooms.append_event(
+            self.db_path,
+            room_id=room_id,
+            event_id=event_id,
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=normalized,
+        )
+        binding = next(
+            (candidate for candidate in self.bindings() if candidate.room_id == room_id),
+            None,
+        )
+        if binding is None:
+            raise hosted_rooms.RoomNotFoundError("hosted room not found")
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+        return event
+
+    def stop_room(self, room_id: str, *, cancel_id: str) -> int:
+        cancelled = 0
+        with self._policy_lock:
+            for status in ("queued", "running", "indeterminate"):
+                for task in driver.list_tasks(
+                    self.db_path,
+                    room_id=room_id,
+                    status=status,
+                ):
+                    self.runtime.cancel(task["identity"], cancel_id=cancel_id)
+                    cancelled += 1
+        self.runtime.wakeup()
+        return cancelled
+
+    def status(self, room_id: str | None = None) -> dict[str, Any]:
+        runtime = self.runtime.status()
+        if room_id is None:
+            return runtime
+        tasks = driver.list_tasks(self.db_path, room_id=room_id)
+        counts = Counter(str(task["status"]) for task in tasks)
+        return {
+            "running": runtime["running"],
+            "working": bool(counts.get("running") or counts.get("queued")),
+            "blocked": room_id in runtime["blocked_rooms"] or bool(counts.get("indeterminate")),
+            "counts": dict(counts),
+        }
+

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -173,6 +173,26 @@ class HostedRoomService:
                     payload=decision.task.payload,
                     clock=time.time,
                 )
+                # A stop can race the policy read from another process. Re-read
+                # after admission and cancel before the runtime can execute a
+                # task whose source event is now behind the room stop fence.
+                fresh_events = self._events(binding.room_id)
+                stopped_through_seq = max(
+                    (
+                        int(event["seq"])
+                        for event in fresh_events
+                        if event.get("kind") == "room.stop_requested"
+                    ),
+                    default=0,
+                )
+                if (
+                    decision.source_event_seq is not None
+                    and decision.source_event_seq < stopped_through_seq
+                ):
+                    self.runtime.cancel(
+                        decision.task.identity,
+                        cancel_id=f"stop-fence:{stopped_through_seq}",
+                    )
             elif decision.status in {"settled", "bounded"}:
                 self._append_room_status(room, decision)
 
@@ -238,6 +258,11 @@ class HostedRoomService:
         return event
 
     def stop_room(self, room_id: str, *, cancel_id: str) -> int:
+        hosted_rooms.request_room_stop(
+            self.db_path,
+            room_id=room_id,
+            cancel_id=cancel_id,
+        )
         cancelled = 0
         with self._policy_lock:
             for status in ("queued", "running", "indeterminate"):
@@ -259,8 +284,11 @@ class HostedRoomService:
         counts = Counter(str(task["status"]) for task in tasks)
         return {
             "running": runtime["running"],
-            "working": bool(counts.get("running") or counts.get("queued")),
+            "working": bool(
+                counts.get("running")
+                or counts.get("queued")
+                or counts.get("stopping")
+            ),
             "blocked": room_id in runtime["blocked_rooms"] or bool(counts.get("indeterminate")),
             "counts": dict(counts),
         }
-

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,15 +1,64 @@
 """Hosted-room JSON-RPC contract.
 
-These methods expose durable room identity and an append-only, monotonic room
-log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
-makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
-the log prototype for a complete gateway-side orchestrator.
+These methods expose durable room identity, replay, and the process-owned
+same-gateway Discussion driver. ``groups.capabilities`` keeps that boundary
+machine-readable so older clients stay on the renderer-owned room path.
 """
 
 from .method_ctx import HandlerRegistry
 
+import os
+import threading
+
 _registry = HandlerRegistry()
 method = _registry.method
+
+_service_lock = threading.Lock()
+_bound_server = None
+_service = None
+
+
+def bind_server(server) -> None:
+    """Bind the fully initialized server module without starting a worker."""
+
+    global _bound_server
+    _bound_server = server
+
+
+def start_hosted_room_service():
+    """Start one process-owned hosted room service idempotently."""
+
+    global _service
+    if _bound_server is None:
+        return None
+    from gateway.hosted_rooms import default_db_path
+    from tui_gateway.hosted_room_service import HostedRoomService
+
+    db_path = default_db_path()
+    with _service_lock:
+        if _service is not None and _service.db_path != db_path:
+            _service.stop(timeout=1.0)
+            _service = None
+        if _service is None:
+            _service = HostedRoomService(_bound_server, db_path=db_path)
+        _service.start()
+        return _service
+
+
+def stop_hosted_room_service(*, timeout: float = 5.0) -> bool:
+    """Stop the process-owned worker without interrupting accepted turns."""
+
+    global _service
+    with _service_lock:
+        service = _service
+        _service = None
+    return True if service is None else service.stop(timeout=timeout)
+
+
+def get_hosted_room_service():
+    """Return the active service, if its lifecycle owner started it."""
+
+    return _service
 
 
 @method("groups.capabilities")
@@ -21,11 +70,14 @@ def _(rid, params: dict) -> dict:
         local_authority_gateway_id,
     )
 
+    service = get_hosted_room_service()
+    driver_ready = bool(service and service.runtime.status()["running"])
     return _ok(
         rid,
         {
             "protocol_version": PROTOCOL_VERSION,
-            "driver": False,
+            "driver": driver_ready,
+            "persistent_process": os.getenv("HERMES_DESKTOP") != "1",
             "authority_gateway_id": local_authority_gateway_id(),
             "features": [
                 "authority_epoch",
@@ -45,6 +97,7 @@ def _(rid, params: dict) -> dict:
                 "groups.send",
                 "groups.log",
                 "groups.disband",
+                "groups.stop",
             ],
             "max_log_limit": MAX_LOG_LIMIT,
         },
@@ -85,12 +138,21 @@ def _(rid, params: dict) -> dict:
     )
 
     try:
-        room = create_room(
-            default_db_path(),
-            room_id=params.get("room_id"),
-            name=params.get("name"),
-            members=params.get("members"),
-            authority_gateway_id=local_authority_gateway_id(),
+        service = get_hosted_room_service()
+        room = (
+            service.create_room(
+                room_id=params.get("room_id"),
+                name=params.get("name"),
+                members=params.get("members"),
+            )
+            if service is not None
+            else create_room(
+                default_db_path(),
+                room_id=params.get("room_id"),
+                name=params.get("name"),
+                members=params.get("members"),
+                authority_gateway_id=local_authority_gateway_id(),
+            )
         )
         return _ok(rid, {"room": room})
     except HostedRoomError as exc:
@@ -105,14 +167,21 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
 
     try:
+        room = room_state(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        service = get_hosted_room_service()
         return _ok(
             rid,
             {
-                "room": room_state(
-                    default_db_path(),
-                    room_id=params.get("room_id"),
-                    include_disbanded=params.get("include_disbanded") is True,
-                )
+                "room": room,
+                **(
+                    {"driver_status": service.status(str(room["room_id"]))}
+                    if service is not None and room.get("disbanded_at") is None
+                    else {}
+                ),
             },
         )
     except HostedRoomError as exc:
@@ -133,20 +202,29 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, append_event, default_db_path
 
     try:
-        event = append_event(
-            default_db_path(),
-            room_id=params.get("room_id"),
-            event_id=params.get("event_id"),
-            kind="message.user",
-            actor={"kind": "user", "id": "desktop"},
-            payload=params.get("payload"),
+        service = get_hosted_room_service()
+        event = (
+            service.send(
+                room_id=params.get("room_id"),
+                event_id=params.get("event_id"),
+                payload=params.get("payload"),
+            )
+            if service is not None
+            else append_event(
+                default_db_path(),
+                room_id=params.get("room_id"),
+                event_id=params.get("event_id"),
+                kind="message.user",
+                actor={"kind": "user", "id": "desktop"},
+                payload=params.get("payload"),
+            )
         )
         return _ok(
             rid,
             {
                 "event": event,
                 "accepted": True,
-                "driver_started": False,
+                "driver_started": service is not None,
             },
         )
     except HostedRoomError as exc:
@@ -161,6 +239,12 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, default_db_path, disband_room
 
     try:
+        service = get_hosted_room_service()
+        if service is not None:
+            service.stop_room(
+                str(params.get("room_id") or ""),
+                cancel_id=str(params.get("cancel_id") or "room-disbanded"),
+            )
         tombstone = disband_room(
             default_db_path(),
             room_id=params.get("room_id"),
@@ -170,6 +254,23 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4113, str(exc))
     except Exception as exc:
         return _err(rid, 5114, str(exc))
+
+
+@method("groups.stop")
+def _(rid, params: dict) -> dict:
+    """Durably cancel queued or running work for one hosted room."""
+
+    service = get_hosted_room_service()
+    if service is None:
+        return _err(rid, 4115, "hosted room driver is unavailable")
+    try:
+        count = service.stop_room(
+            str(params.get("room_id") or ""),
+            cancel_id=str(params.get("cancel_id") or "desktop-stop"),
+        )
+        return _ok(rid, {"cancelled": count})
+    except Exception as exc:
+        return _err(rid, 5116, str(exc))
 
 
 @method("groups.log")

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,0 +1,196 @@
+"""Hosted-room JSON-RPC contract.
+
+These methods expose durable room identity and an append-only, monotonic room
+log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
+makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
+the log prototype for a complete gateway-side orchestrator.
+"""
+
+from .method_ctx import HandlerRegistry
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+@method("groups.capabilities")
+def _(rid, params: dict) -> dict:
+    """Describe the hosted-room protocol implemented by this gateway."""
+    from gateway.hosted_rooms import (
+        MAX_LOG_LIMIT,
+        PROTOCOL_VERSION,
+        local_authority_gateway_id,
+    )
+
+    return _ok(
+        rid,
+        {
+            "protocol_version": PROTOCOL_VERSION,
+            "driver": False,
+            "authority_gateway_id": local_authority_gateway_id(),
+            "features": [
+                "authority_epoch",
+                "coordinator_fencing",
+                "room_identity",
+                "monotonic_log",
+                "idempotent_send",
+                "replayable_disband",
+                "typed_events",
+                "actor_identity",
+            ],
+            "methods": [
+                "groups.capabilities",
+                "groups.list",
+                "groups.create",
+                "groups.state",
+                "groups.send",
+                "groups.log",
+                "groups.disband",
+            ],
+            "max_log_limit": MAX_LOG_LIMIT,
+        },
+    )
+
+
+@method("groups.list")
+def _(rid, params: dict) -> dict:
+    """List rooms hosted by this gateway."""
+    try:
+        from gateway.hosted_rooms import default_db_path, list_rooms
+
+        return _ok(
+            rid,
+            {
+                "rooms": list_rooms(
+                    default_db_path(),
+                    include_disbanded=params.get("include_disbanded") is True,
+                )
+            },
+        )
+    except Exception as exc:
+        return _err(rid, 5110, str(exc))
+
+
+@method("groups.create")
+def _(rid, params: dict) -> dict:
+    """Create a hosted room idempotently.
+
+    Required params: ``room_id``, ``name``, and ``members``. Authority is
+    derived from this gateway's stable install identity, never from the client.
+    """
+    from gateway.hosted_rooms import (
+        HostedRoomError,
+        create_room,
+        default_db_path,
+        local_authority_gateway_id,
+    )
+
+    try:
+        room = create_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            name=params.get("name"),
+            members=params.get("members"),
+            authority_gateway_id=local_authority_gateway_id(),
+        )
+        return _ok(rid, {"room": room})
+    except HostedRoomError as exc:
+        return _err(rid, 4110, str(exc))
+    except Exception as exc:
+        return _err(rid, 5111, str(exc))
+
+
+@method("groups.state")
+def _(rid, params: dict) -> dict:
+    """Return one hosted room's replay cursor and fenced authority state."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
+
+    try:
+        return _ok(
+            rid,
+            {
+                "room": room_state(
+                    default_db_path(),
+                    room_id=params.get("room_id"),
+                    include_disbanded=params.get("include_disbanded") is True,
+                )
+            },
+        )
+    except HostedRoomError as exc:
+        return _err(rid, 4114, str(exc))
+    except Exception as exc:
+        return _err(rid, 5115, str(exc))
+
+
+@method("groups.send")
+def _(rid, params: dict) -> dict:
+    """Append one typed event to a hosted room idempotently.
+
+    Required params: ``room_id``, ``event_id``, and object ``payload``. Only
+    inert ``message.user`` events are accepted through this client-facing
+    method. The actor is server-owned rather than trusted from params.
+    Admission is durable; no Bot turn is started by this slice.
+    """
+    from gateway.hosted_rooms import HostedRoomError, append_event, default_db_path
+
+    try:
+        event = append_event(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            event_id=params.get("event_id"),
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=params.get("payload"),
+        )
+        return _ok(
+            rid,
+            {
+                "event": event,
+                "accepted": True,
+                "driver_started": False,
+            },
+        )
+    except HostedRoomError as exc:
+        return _err(rid, 4111, str(exc))
+    except Exception as exc:
+        return _err(rid, 5112, str(exc))
+
+
+@method("groups.disband")
+def _(rid, params: dict) -> dict:
+    """Permanently tombstone a hosted room id."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, disband_room
+
+    try:
+        tombstone = disband_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+        )
+        return _ok(rid, {"tombstone": tombstone})
+    except HostedRoomError as exc:
+        return _err(rid, 4113, str(exc))
+    except Exception as exc:
+        return _err(rid, 5114, str(exc))
+
+
+@method("groups.log")
+def _(rid, params: dict) -> dict:
+    """Return a monotonic room-log delta after ``since_seq``."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, read_events
+
+    try:
+        delta = read_events(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            since_seq=params.get("since_seq", 0),
+            limit=params.get("limit", 100),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        return _ok(rid, delta)
+    except HostedRoomError as exc:
+        return _err(rid, 4112, str(exc))
+    except Exception as exc:
+        return _err(rid, 5113, str(exc))
+
+
+def register(server) -> None:
+    _registry.install(server)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -335,6 +335,57 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    hosted_task = params.get("_hosted_task")
+    hosted_terminal_callback = params.get("_hosted_terminal_callback")
+    internal_hosted_submit = hosted_task is not None or hosted_terminal_callback is not None
+    if internal_hosted_submit:
+        if session.get("source") != "bot_room":
+            return _err(rid, 4120, "hosted room turns require a bot_room session")
+        if not isinstance(hosted_task, dict) or not callable(hosted_terminal_callback):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+        required_hosted_fields = {
+            "room_id",
+            "task_id",
+            "thread_id",
+            "turn_id",
+            "execution_generation",
+        }
+        if set(hosted_task) != required_hosted_fields or not all(
+            isinstance(hosted_task.get(field), str) and hosted_task[field]
+            for field in required_hosted_fields - {"execution_generation"}
+        ) or not isinstance(hosted_task.get("execution_generation"), int):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+    else:
+        # Older Desktop builds know the `Group: <room-id>` session title but
+        # not the hosted authority marker. Once a gateway owns that room, a
+        # direct prompt into its member session would start a second renderer
+        # driver. Fence it server-side instead of trusting client awareness.
+        title = str(session.get("title") or "")
+        if title.startswith("Group: "):
+            room_id = title.removeprefix("Group: ").strip()
+            if room_id:
+                try:
+                    from gateway.hosted_rooms import (
+                        RoomNotFoundError,
+                        default_db_path,
+                        room_state,
+                    )
+
+                    room_state(default_db_path(), room_id=room_id)
+                except RoomNotFoundError:
+                    pass
+                except Exception:
+                    return _err(
+                        rid,
+                        5122,
+                        "Could not verify this group. Try again after the gateway recovers.",
+                    )
+                else:
+                    return _err(
+                        rid,
+                        4122,
+                        "This room is managed by its gateway. Update Hermes Desktop to continue it.",
+                    )
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every
@@ -357,6 +408,12 @@ def _(rid, params: dict) -> dict:
         )
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
+    if internal_hosted_submit and turn_isolation:
+        return _err(
+            rid,
+            4121,
+            "hosted room turns do not support isolated compute workers yet",
+        )
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
@@ -366,6 +423,8 @@ def _(rid, params: dict) -> dict:
         busy_transport = None
         with session["history_lock"]:
             if session.get("running"):
+                if internal_hosted_submit:
+                    return _err(rid, 4091, "hosted room member session is busy")
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
                 # provider interrupt itself must happen after this lock is
@@ -812,6 +871,8 @@ def _(rid, params: dict) -> dict:
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
+        if internal_hosted_submit:
+            session["_hosted_room_task"] = dict(hosted_task)
         _start_inflight_turn(session, text)
 
     if turn_isolation:
@@ -908,7 +969,14 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            terminal_callback=hosted_terminal_callback,
+        )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3332,6 +3332,18 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    expected_hosted_task_id = str(
+        params.get("expected_hosted_task_id") or ""
+    ).strip()
+    if expected_hosted_task_id:
+        with session["history_lock"]:
+            active_task = session.get("_hosted_room_task")
+            if (
+                not session.get("running")
+                or not isinstance(active_task, dict)
+                or active_task.get("task_id") != expected_hosted_task_id
+            ):
+                return _ok(rid, {"status": "not_interrupted", "interrupted": False})
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -318,6 +318,7 @@ _LONG_HANDLERS = frozenset(
         "groups.send",
         "groups.log",
         "groups.disband",
+        "groups.stop",
         # image.generate is a multi-second remote API round-trip.
         "image.generate",
         "projects.discover_repos",
@@ -9186,6 +9187,12 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     same _run_prompt_submit machinery as every other synthesized turn — so
     the client that just resumed streams it live.
     """
+    # Hosted room turns are recovered by their durable task/lease state
+    # machine. Generic session auto-continue would bypass its execution
+    # generation and can duplicate work after a process restart.
+    if session.get("source") == "bot_room":
+        return None
+
     home = _session_home(session)
     marker = read_turn_marker(home, session_key)
     if marker is None:
@@ -9665,7 +9672,12 @@ def _inflight_snapshot(session: dict) -> dict | None:
 
 
 def _emit_terminal_turn_error(
-    sid: str, session: dict, error: Any, error_surface: Optional[dict] = None
+    sid: str,
+    session: dict,
+    error: Any,
+    error_surface: Optional[dict] = None,
+    *,
+    retire_marker: bool = True,
 ) -> None:
     """Close a failed turn with a terminal ``message.complete`` frame.
 
@@ -9718,7 +9730,8 @@ def _emit_terminal_turn_error(
         rendered = ""
     if rendered:
         payload["rendered"] = rendered
-    _retire_turn_marker(session)
+    if retire_marker:
+        _retire_turn_marker(session)
     _emit("message.complete", sid, payload)
 
 
@@ -11957,6 +11970,7 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    terminal_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> bool:
     with session["history_lock"]:
         if session.get("_closing"):
@@ -12006,6 +12020,8 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        terminal_receipt_attempted = False
+        terminal_receipt_committed = terminal_callback is None
         # The conversation runs on a fresh thread, so ContextVars from the RPC
         # dispatcher do not follow automatically. Rebind the exact transport
         # stored on this session generation before any tool can commission a
@@ -12546,7 +12562,26 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
                 if _error_surface:
                     payload["error_surface"] = _error_surface
-            _retire_turn_marker(session, marker_key)
+            if terminal_callback is not None:
+                terminal_receipt_attempted = True
+                terminal_callback(
+                    {
+                        "status": (
+                            "cancelled"
+                            if status == "interrupted"
+                            else "failed" if status == "error" else "settled"
+                        ),
+                        "text": raw if isinstance(raw, str) else str(raw),
+                        **(
+                            {"error": str(result.get("error") or raw)}
+                            if status == "error" and isinstance(result, dict)
+                            else {}
+                        ),
+                    }
+                )
+                terminal_receipt_committed = True
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
@@ -12726,11 +12761,25 @@ def _run_prompt_submit(
             # Keep the partial turn available to the next prompt; the durable
             # inflight record still carries the recoverable error state.
             _restore_agent_history_after_turn_error(session, agent)
+            if terminal_callback is not None and not terminal_receipt_attempted:
+                terminal_receipt_attempted = True
+                try:
+                    terminal_callback(
+                        {"status": "failed", "text": "", "error": str(e)}
+                    )
+                    terminal_receipt_committed = True
+                except Exception:
+                    logger.exception("hosted room terminal receipt commit failed")
             try:
                 # Close the turn with the same terminal error frame shape as
                 # the returned-error path (uniform client handling), retaining
                 # the failed turn for resume replay.
-                _emit_terminal_turn_error(sid, session, e)
+                _emit_terminal_turn_error(
+                    sid,
+                    session,
+                    e,
+                    retire_marker=terminal_receipt_committed,
+                )
                 turn_error_retained = True
             except Exception as emit_exc:
                 print(
@@ -12825,7 +12874,10 @@ def _run_prompt_submit(
             )
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
-            _retire_turn_marker(session, marker_key)
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
+                with session["history_lock"]:
+                    session.pop("_hosted_room_task", None)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
 
@@ -17041,6 +17093,11 @@ from . import (  # noqa: E402
     methods_tools as _methods_tools,
 )
 
+# HandlerRegistry rebinds handler globals onto this module. Publish the hosted
+# service accessor here so methods_groups handlers resolve the lifecycle-owned
+# singleton rather than starting one from an RPC call.
+get_hosted_room_service = _methods_groups.get_hosted_room_service
+
 for _m in (
     _methods_browser_control,
     _methods_session,
@@ -17055,3 +17112,4 @@ for _m in (
 ):
     _m.register(sys.modules[__name__])
 del _m
+_methods_groups.bind_server(sys.modules[__name__])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -309,6 +309,15 @@ _LONG_HANDLERS = frozenset(
         "bot_relay.outbox.drain",
         "bot_relay.deliver",
         "bot_relay.reply",
+        # Hosted-room log calls open the shared state database and may wait on
+        # a concurrent room writer. Keep that bounded wait off the WS reader.
+        "groups.list",
+        "groups.capabilities",
+        "groups.create",
+        "groups.state",
+        "groups.send",
+        "groups.log",
+        "groups.disband",
         # image.generate is a multi-second remote API round-trip.
         "image.generate",
         "projects.discover_repos",
@@ -17024,6 +17033,7 @@ from . import (  # noqa: E402
     methods_bot_relay as _methods_bot_relay,
     methods_complete as _methods_complete,
     methods_config as _methods_config,
+    methods_groups as _methods_groups,
     methods_images as _methods_images,
     methods_profiles as _methods_profiles,
     methods_prompt as _methods_prompt,
@@ -17041,6 +17051,7 @@ for _m in (
     _methods_profiles,
     _methods_images,
     _methods_bot_relay,
+    _methods_groups,
 ):
     _m.register(sys.modules[__name__])
 del _m


### PR DESCRIPTION
## Summary

Bot group chats currently stop progressing when the Desktop that created them
closes, even when every Bot already lives on the same always-on gateway.

Stacked on #95314, this PR moves that same-gateway room loop to the owning
gateway. A user can create a group from Bots on one local or remote gateway,
close Desktop, and later reconnect to the same ordered history while the room
kept working.

Cross-gateway delivery is deliberately not required for this slice. #95314 plus
this PR can ship independently useful autonomous rooms for one gateway.

Turn routing is explicit after the first round: a human can address one, several,
or every Bot normally, while a Bot reply wakes a peer only when it names that
peer. This prevents unbounded room chatter without hiding the shared history.

> [!IMPORTANT]
> This PR depends on #95314's authority and replay contract. Review only the
> commits above the current #95314 head.

## What changed

### Gateway-owned room loop

- Adds a process-owned hosted-room service and a bounded serial discussion
  policy.
- Uses one canonical `Group: <room_id>` session per member profile and each
  profile's existing credentials and model configuration.
- Persists fenced execution leases, immutable task identity, payload digest,
  source event sequence, execution generation, and cancellation generation.
- Starts, settles, fails, cancels, retries, and recovers work idempotently.
- Keeps accepted work alive when the Desktop transport detaches.
- Keeps later rounds opt-in through explicit Bot-to-Bot handle mentions.

### Desktop path

- Detects when every selected Bot belongs to one persistent gateway.
- Creates the hosted room on that gateway and keeps the existing Desktop-driven
  fallback for unsupported or mixed gateways.
- Sends through a persisted outbox, consumes ordered replay, and shows the
  gateway-owned room state.
- Keeps same-gateway screenshot/file staging available to the selected Bots.
- Reopens the room from gateway truth after Desktop relaunch.

### Reliability follow-up

The latest head includes a separate, cherry-pickable reliability commit:

- Distinct room threads arriving before one driver cycle are processed FIFO
  instead of dropping all but the newest event.
- Existing same-thread supersession behavior is preserved.
- Stop writes `room.stop_requested` before cancelling tasks, fencing every
  earlier turn so the next member cannot start.
- A queued-to-running race is re-read and stopped under the new generation.
- A later user message can start fresh room work after the Stop fence.
- A runtime-cycle assertion now waits for the observed counter, removing a
  reproduced test race without changing runtime behavior.

### Turn routing

- A human message without a Bot mention gives every available member one first turn.
- A human message naming one or more Bots limits the first turn to those members.
- A Bot reply does not wake another Bot unless it explicitly names that peer.
- A peer named later receives its bounded unseen transcript delta, including the
  user request and the handoff that called it.
- Existing round and message caps remain the hard backstop.

### Failure behavior

- An active attempt is never blindly resubmitted after restart.
- A terminal receipt left by a crashed process is harvested once.
- Ambiguous post-submit work blocks rather than retrying speculatively.
- Stop remains two-phase: intent is durable first, cancellation commits only
  after the exact member turn is terminal. A real completion may win the race.
- Disband and authority changes cannot commit while Stop is unacknowledged.
- Late receipts from an older execution generation cannot settle newer work.
- Legacy renderer prompts are fenced server-side once the room is hosted.

## Boundaries

- Same-gateway Bots only.
- No automatic authority failover.
- No peer transport or cross-gateway setup.
- No workflow/task-graph semantics; this preserves the existing bounded group
  conversation model.

The next backend draft adds scoped cross-gateway RoomLink. The Desktop draft
negotiates it automatically and falls back to this same-gateway path or the
current Desktop-driven path when peers are unavailable or outdated.

## Validation

Rebased on verified boundary `origin/main@f3cbb262c1`, exact head `350c63f3dd`:

| Check | Result |
|---|---:|
| Hosted-room authority, policy, driver, service, RPC, and lifecycle boundary | 161 passed |
| Focused turn-routing policy | 66 passed |
| Complete bundled Bot Mode plugin suite | 653 passed |
| Runtime deterministic recovery no-retry repetition | 5/5 passed |
| Ruff | passed |
| `git diff --check` | passed |

The hermetic same-gateway UAT ran two Bot profiles through ordered replies,
restarted the driver, and recovered the same history:

`SINGLE_GATEWAY_UAT_OK replies=2 restart_recovered=1 ordered_history=1`

A later full-stack canary exercised the new routing policy with real profiles:
no-mention broadcast (both members at round 0), one-member human targeting, and
an explicit Bot-to-Bot handoff (target peer at round 1):

`DISCUSSION_PROTOCOL_UAT_OK`

Stop racing an in-flight hosted turn is covered at the driver boundary: intent
is durable first, the exact task/generation reaches terminal state, and a real
completion may still win before cancellation.

The full Python suite remains exact-head CI's responsibility; the local minimal
venv lacks unrelated optional ACP/OpenAI/Rich packages.

## Related work

- #95314: required authority and replay parent
- #95163: hosted-room design issue
- #94726 section 5: group-room lifecycle and stall class
- #94697: accepted Bot turn lifetime after viewer detach
- #94570: complementary Stop UX
- #91911: identity and cancellation control-plane direction

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
