### PR TITLE
fix(cli): preserve launch cwd during relay config reads

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -194,10 +194,10 @@ def _segments_config() -> dict[str, Any]:
                 on_compaction = False
                 max_turns = 0
                 try:
-                    from gateway.run import _load_gateway_config  # late import
+                    from gateway.config_file import load_gateway_config_dict
 
                     telemetry = (
-                        (_load_gateway_config().get("gateway") or {}).get(
+                        (load_gateway_config_dict().get("gateway") or {}).get(
                             "telemetry"
                         )
                         or {}

--- a/gateway/config_file.py
+++ b/gateway/config_file.py
@@ -1,0 +1,56 @@
+"""Side-effect-free reads of gateway settings from config.yaml."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def load_gateway_config_dict(config_path: Path | None = None) -> dict:
+    """Load raw gateway configuration without bootstrapping the daemon."""
+    raw: dict = {}
+    used_canonical = False
+    try:
+        from hermes_cli.config import get_config_path, read_raw_config
+
+        canonical_path = get_config_path()
+        if config_path is None:
+            config_path = canonical_path
+        if config_path == canonical_path:
+            raw = read_raw_config()
+            used_canonical = True
+    except Exception:
+        if config_path is None:
+            return {}
+
+    if not used_canonical:
+        try:
+            if config_path is not None and config_path.exists():
+                import yaml
+
+                with open(config_path, "r", encoding="utf-8") as config_file:
+                    raw = yaml.safe_load(config_file) or {}
+        except Exception:
+            logger.debug("Could not load gateway config from %s", config_path)
+            raw = {}
+
+    try:
+        from hermes_cli import managed_scope
+
+        raw = managed_scope.apply_managed_overlay(
+            raw if isinstance(raw, dict) else {}
+        )
+    except Exception:
+        pass
+    if not isinstance(raw, dict):
+        return {}
+
+    try:
+        from hermes_cli.config import _normalize_root_model_keys
+
+        raw = _normalize_root_model_keys(raw)
+    except Exception:
+        pass
+    return raw

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -22,6 +22,8 @@ import os
 import re
 from typing import Optional
 
+from gateway.config_file import load_gateway_config_dict
+
 # Shape gate for ambient-endpoint token bodies (mode 1b in
 # _resolve_relay_identity_token). Accepts a bearer-token-shaped string:
 # either a multi-segment dotted token (JWT: header.payload.signature) or a
@@ -45,9 +47,7 @@ def relay_url() -> Optional[str]:
     if url:
         return url.rstrip("/")
     try:
-        from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-        cfg = _load_gateway_config()
+        cfg = load_gateway_config_dict()
         url = (cfg.get("gateway") or {}).get("relay_url")
         url = (url or "").strip()
         if url:
@@ -163,9 +163,7 @@ def relay_connection_auth() -> tuple[Optional[str], Optional[str]]:
     secret = os.environ.get("GATEWAY_RELAY_SECRET", "").strip()
     if not (gateway_id and secret):
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (load_gateway_config_dict().get("gateway") or {})
             gateway_id = gateway_id or str(cfg.get("relay_id", "") or "").strip()
             secret = secret or str(cfg.get("relay_secret", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash registration
@@ -190,9 +188,7 @@ def relay_endpoint() -> Optional[str]:
     url = os.environ.get("GATEWAY_RELAY_ENDPOINT", "").strip()
     if not url:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (load_gateway_config_dict().get("gateway") or {})
             url = str(cfg.get("relay_endpoint", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             url = ""
@@ -213,9 +209,7 @@ def relay_route_keys() -> list[str]:
     raw = os.environ.get("GATEWAY_RELAY_ROUTE_KEYS", "").strip()
     if not raw:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (load_gateway_config_dict().get("gateway") or {})
             val = cfg.get("relay_route_keys", "")
             if isinstance(val, (list, tuple)):
                 return [str(k).strip() for k in val if str(k).strip()]
@@ -243,9 +237,7 @@ def relay_instance_id() -> Optional[str]:
     value = os.environ.get("GATEWAY_RELAY_INSTANCE_ID", "").strip()
     if not value:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (load_gateway_config_dict().get("gateway") or {})
             value = str(cfg.get("relay_instance_id", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             value = ""
@@ -274,9 +266,7 @@ def relay_wake_url() -> Optional[str]:
     value = os.environ.get("GATEWAY_RELAY_WAKE_URL", "").strip()
     if not value:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            cfg = (_load_gateway_config().get("gateway") or {})
+            cfg = (load_gateway_config_dict().get("gateway") or {})
             value = str(cfg.get("relay_wake_url", "") or "").strip()
         except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
             value = ""
@@ -388,9 +378,7 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     require_mention = None
     free_response: list[str] = []
     try:
-        from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-        cfg = _load_gateway_config() or {}
+        cfg = load_gateway_config_dict() or {}
         plat_cfg = cfg.get(platform)
         if not isinstance(plat_cfg, dict):
             _gw_platforms = (cfg.get("gateway") or {}).get("platforms") or {}
@@ -550,9 +538,7 @@ def _resolve_relay_identity_token() -> str:
     scope = os.environ.get("GATEWAY_RELAY_IDP_SCOPE", "").strip()
     if not token_url:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
-
-            idp = ((_load_gateway_config().get("gateway") or {}).get("idp") or {})
+            idp = ((load_gateway_config_dict().get("gateway") or {}).get("idp") or {})
             token_url = str(idp.get("token_url", "") or "").strip()
             client_id = client_id or str(idp.get("client_id", "") or "").strip()
             client_secret = client_secret or str(idp.get("client_secret", "") or "").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3658,55 +3658,11 @@ def _load_gateway_config(config_path: "Path | None" = None) -> dict:
     gateway honors administrator-pinned values — neither read_raw_config nor a
     direct yaml.safe_load carries the managed merge on its own. Fail-open.
     """
+    from gateway.config_file import load_gateway_config_dict
+
     if config_path is None:
-        config_path = _gateway_config_home() / 'config.yaml'
-    raw: dict = {}
-    used_canonical = False
-    try:
-        from hermes_cli.config import get_config_path, read_raw_config
-        # Fast path: if _hermes_home agrees with the canonical config
-        # location, reuse the shared cache. Otherwise fall through to a
-        # direct read (keeps test fixtures with a monkeypatched
-        # _hermes_home working).
-        if config_path == get_config_path():
-            raw = read_raw_config()
-            used_canonical = True
-    except Exception:
-        pass
-
-    if not used_canonical:
-        try:
-            if config_path.exists():
-                import yaml
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    raw = yaml.safe_load(f) or {}
-        except Exception:
-            logger.debug("Could not load gateway config from %s", config_path)
-            raw = {}
-
-    # Overlay managed scope. read_raw_config() returns the user's raw YAML
-    # WITHOUT the managed merge (that lives in load_config/_load_config_impl),
-    # so the overlay is required on both paths for the gateway to honor pinned
-    # values. Helper is fail-open and a no-op when no managed scope exists.
-    try:
-        from hermes_cli import managed_scope
-        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
-    except Exception:
-        pass
-    if not isinstance(raw, dict):
-        return {}
-    # Canonicalize model-id aliases (model.name / model.model → model.default)
-    # and migrate stale root-level provider/base_url into the model section.
-    # The gateway bypasses load_config() (it reads raw YAML for speed), so the
-    # normalization that load_config() applies must be replayed here or the
-    # gateway would resolve an empty model for ``model: {name: <id>}`` configs
-    # while the CLI resolves it correctly. See issue #34500. Fail-open.
-    try:
-        from hermes_cli.config import _normalize_root_model_keys
-        raw = _normalize_root_model_keys(raw)
-    except Exception:
-        pass
-    return raw
+        config_path = _gateway_config_home() / "config.yaml"
+    return load_gateway_config_dict(config_path)
 
 
 def _checkpoint_agent_kwargs(config: dict | None) -> dict:

--- a/hermes_cli/gateway_enroll.py
+++ b/hermes_cli/gateway_enroll.py
@@ -67,7 +67,7 @@ def _resolve_connector_url(override: Optional[str]) -> Optional[str]:
     raw = (override or os.environ.get("GATEWAY_RELAY_URL", "")).strip()
     if not raw:
         try:
-            from gateway.run import _load_gateway_config  # late import to avoid cycle
+            from gateway.config_file import load_gateway_config_dict as _load_gateway_config
 
             cfg = (_load_gateway_config().get("gateway") or {})
             raw = str(cfg.get("relay_url", "") or "").strip()

--- a/tests/agent/test_relay_config_isolation.py
+++ b/tests/agent/test_relay_config_isolation.py
@@ -1,0 +1,46 @@
+"""Relay config reads must not bootstrap the messaging gateway."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_segments_config_does_not_mutate_cli_environment(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = str(Path(__file__).parents[2])
+    for key in ("HERMES_QUIET", "TERMINAL_CWD", "_HERMES_GATEWAY"):
+        env.pop(key, None)
+
+    probe = """
+import os
+import sys
+from agent import relay_runtime
+
+assert relay_runtime._segments_config() == {
+    "on_compaction": False,
+    "max_turns": 0,
+}
+assert "gateway.run" not in sys.modules
+assert "HERMES_QUIET" not in os.environ
+assert "TERMINAL_CWD" not in os.environ
+assert "_HERMES_GATEWAY" not in os.environ
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -115,14 +115,14 @@ def _fast_scope_timeout(monkeypatch):
 def _default_config(monkeypatch):
     """No config on disk by default; tests override _segments_config directly."""
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config", lambda: {}, raising=False
+        "gateway.config_file.load_gateway_config_dict", lambda: {}
     )
     relay_runtime._reset_segments_config_for_tests()
 
 
 def _set_segments(monkeypatch, *, on_compaction=False, max_turns=0):
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        "gateway.config_file.load_gateway_config_dict",
         lambda: {
             "gateway": {
                 "telemetry": {

--- a/tests/gateway/relay/test_identity_token_resolver.py
+++ b/tests/gateway/relay/test_identity_token_resolver.py
@@ -36,7 +36,7 @@ def _clean_env(monkeypatch):
     ):
         monkeypatch.delenv(k, raising=False)
     # Never read config.yaml off disk by default.
-    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
+    monkeypatch.setattr("gateway.relay.load_gateway_config_dict", lambda: {})
 
 
 def test_client_credentials_via_env(monkeypatch):
@@ -244,7 +244,7 @@ def test_partial_credentials_client_secret_only_raises_without_get(monkeypatch):
 def test_ambient_via_config_yaml(monkeypatch):
     """Ambient mode also engages when token_url comes from config.yaml, not env."""
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        "gateway.relay.load_gateway_config_dict",
         lambda: {"gateway": {"idp": {"token_url": "https://proxy.local/access-token"}}},
         raising=False,
     )

--- a/tests/gateway/relay/test_relay_multiplatform.py
+++ b/tests/gateway/relay/test_relay_multiplatform.py
@@ -34,7 +34,7 @@ def _clean_env(monkeypatch):
         "GATEWAY_RELAY_BOT_IDS",
     ):
         monkeypatch.delenv(k, raising=False)
-    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
+    monkeypatch.setattr("gateway.relay.load_gateway_config_dict", lambda: {})
 
 
 # ─────────────────────────── identity parsing ───────────────────────────

--- a/tests/gateway/relay/test_relay_policy_send.py
+++ b/tests/gateway/relay/test_relay_policy_send.py
@@ -28,7 +28,7 @@ def _clean_env(monkeypatch):
         "DISCORD_ALLOW_BOTS",
     ):
         monkeypatch.delenv(k, raising=False)
-    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
+    monkeypatch.setattr(relay, "load_gateway_config_dict", lambda: {})
 
 
 # --------------------------------------------------------------------------
@@ -38,9 +38,9 @@ def _clean_env(monkeypatch):
 def test_projection_maps_require_mention_and_free_response(monkeypatch):
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        relay,
+        "load_gateway_config_dict",
         lambda: {"discord": {"require_mention": True, "free_response_channels": ["c-support", "c-help"]}},
-        raising=False,
     )
     pol = relay.relay_relevance_policy()
     assert pol == {
@@ -58,9 +58,9 @@ def test_projection_declares_explicit_require_mention_false(monkeypatch):
     # operator configured to free-respond.
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        relay,
+        "load_gateway_config_dict",
         lambda: {"discord": {"require_mention": False}},
-        raising=False,
     )
     pol = relay.relay_relevance_policy()
     assert pol == {
@@ -85,9 +85,9 @@ def _arm(monkeypatch, *, url="wss://connector.example/relay"):
 def test_send_posts_projected_policy_with_token(monkeypatch):
     _arm(monkeypatch)
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        relay,
+        "load_gateway_config_dict",
         lambda: {"discord": {"require_mention": True, "free_response_channels": ["c-support"]}},
-        raising=False,
     )
     captured = {}
 
@@ -110,9 +110,9 @@ def test_send_skips_when_no_secret(monkeypatch):
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     # no GATEWAY_RELAY_ID / SECRET
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        relay,
+        "load_gateway_config_dict",
         lambda: {"discord": {"require_mention": True}},
-        raising=False,
     )
     called = {"n": 0}
     monkeypatch.setattr(relay, "_post_policy", lambda **k: called.__setitem__("n", called["n"] + 1) or 200)
@@ -123,9 +123,9 @@ def test_send_skips_when_no_secret(monkeypatch):
 def test_send_fail_soft_on_transport_error(monkeypatch):
     _arm(monkeypatch)
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        relay,
+        "load_gateway_config_dict",
         lambda: {"discord": {"require_mention": True}},
-        raising=False,
     )
 
     def _boom(**kwargs):

--- a/tests/gateway/relay/test_self_provision.py
+++ b/tests/gateway/relay/test_self_provision.py
@@ -35,7 +35,7 @@ def _clean_env(monkeypatch):
     ):
         monkeypatch.delenv(k, raising=False)
     # Never read config.yaml off disk in these tests.
-    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
+    monkeypatch.setattr("gateway.relay.load_gateway_config_dict", lambda: {})
 
 
 def _stub_post(captured: dict):


### PR DESCRIPTION
## Summary

- extract raw gateway config reads into a side-effect-free module while preserving the gateway runner compatibility wrapper
- route agent relay segmentation, relay helpers, and gateway enrollment through the side-effect-free reader
- add a subprocess regression proving first-turn segmentation config lookup does not import `gateway.run` or mutate CLI cwd/quiet markers

## Root Cause

`agent.relay_runtime._segments_config()` imported `gateway.run` solely to read `config.yaml`. Importing that daemon entry module executes gateway bootstrap side effects, including `HERMES_QUIET`, `_HERMES_GATEWAY`, and placeholder `TERMINAL_CWD` resolution. In one-shot CLI sessions, this replaced launch-directory discovery with the home fallback before project context was built.

## Testing

- `scripts/run_tests.sh tests/agent/test_relay_config_isolation.py tests/agent/test_relay_session_segments.py tests/gateway/relay tests/gateway/test_checkpoint_config.py tests/hermes_cli/test_gateway_enroll_multiplex_warning.py -q` (262 passed)
- `python -m ruff check` on all changed Python files and relay tests
- `git diff --check`

## Related Issue

Closes #95577