### PR TITLE
fix(telegram): extend the reconnect-wait guard from send() to every other send_*/edit_message call

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -951,6 +951,40 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         return False
 
+    # Sentinel distinguishing "still disconnected after the wait" from a
+    # real return value (including None) a delegated call might produce.
+    _RECONNECT_FAILED = object()
+
+    async def _await_reconnection_or_delegate(self, method: str, *args, **kwargs):
+        """Retry ``method`` on a live replacement, or wait like ``send()`` does.
+
+        Every ``send_*``/``edit_message`` call used to fail immediately with
+        ``retryable=False`` when ``self._bot`` was None, instead of tolerating
+        a transient 10-20s blip the way ``send()`` does — the reply then sat
+        in the delivery ledger until the next gateway boot. This mirrors
+        ``send()``'s own guard so callers get the same behavior:
+
+        * a live replacement adapter already exists → delegate immediately.
+        * otherwise wait up to ``_RECONNECT_WAIT_SECONDS`` for reconnection.
+        * once waited: delegate to a replacement if one appeared, otherwise
+          give up.
+
+        Returns the delegated call's result if delegation happened, ``None``
+        if this instance itself reconnected (caller proceeds using
+        ``self._bot``), or ``_RECONNECT_FAILED`` if still disconnected.
+        """
+        live = self._replacement_telegram_adapter()
+        if live is not None:
+            return await getattr(live, method)(*args, **kwargs)
+        if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+            return self._RECONNECT_FAILED
+        live = self._replacement_telegram_adapter()
+        if not self._bot and live is not None:
+            return await getattr(live, method)(*args, **kwargs)
+        if not self._bot:
+            return self._RECONNECT_FAILED
+        return None
+
     def _should_drop_delayed_delivery(self) -> bool:
         """True once teardown/fatal-error started — delayed flushes must not dispatch.
 
@@ -5661,7 +5695,17 @@ class TelegramAdapter(BasePlatformAdapter):
         edits target the most recent visible message.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "edit_message", chat_id, message_id, content,
+                finalize=finalize, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
@@ -6223,7 +6267,13 @@ class TelegramAdapter(BasePlatformAdapter):
         same retry pattern to the non-streaming control paths.
         """
         if not self._bot:
-            raise RuntimeError("Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "_send_message_with_thread_fallback", **kwargs,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                raise RuntimeError("Not connected")
+            if outcome is not None:
+                return outcome
 
         message_thread_id = kwargs.get("message_thread_id")
         try:
@@ -6262,7 +6312,17 @@ class TelegramAdapter(BasePlatformAdapter):
         needs user input (stash restore, config migration).
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_update_prompt", chat_id, prompt, default,
+                session_key=session_key, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
         try:
             default_hint = f" (default: {default})" if default else ""
             text = self.format_message(f"⚕ *Update needs your input:*\n\n{prompt}{default_hint}")
@@ -6318,7 +6378,19 @@ class TelegramAdapter(BasePlatformAdapter):
         agent thread — same mechanism as the text ``/approve`` flow.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_exec_approval", chat_id, command, session_key,
+                description=description, metadata=metadata,
+                allow_permanent=allow_permanent, allow_session=allow_session,
+                smart_denied=smart_denied,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             text = self._format_exec_approval(command, description, smart_denied)
@@ -6386,7 +6458,17 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Render a three-button slash-command confirmation prompt."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_slash_confirm", chat_id, title, message, session_key,
+                confirm_id, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             preview = self.format_message(self._truncate_preview(message, 3800))
@@ -6449,7 +6531,17 @@ class TelegramAdapter(BasePlatformAdapter):
         the gateway's text-intercept and resolves the clarify.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_clarify", chat_id, question, choices, clarify_id,
+                session_key, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             text = f"❓ {_html.escape(question)}"
@@ -6526,7 +6618,18 @@ class TelegramAdapter(BasePlatformAdapter):
         Edits the same message in-place as the user navigates.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_model_picker", chat_id, providers, current_model,
+                current_provider, session_key, on_model_selected,
+                metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             from hermes_cli.providers import get_label
@@ -6600,7 +6703,17 @@ class TelegramAdapter(BasePlatformAdapter):
         choice dict: ``{"value": str, "label": str, "is_current": bool}``.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_choice_picker", chat_id, title, choices, session_key,
+                on_choice_selected, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             buttons = []
@@ -7718,8 +7831,18 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
-        
+            outcome = await self._await_reconnection_or_delegate(
+                "send_voice", chat_id, audio_path, caption=caption,
+                reply_to=reply_to, metadata=metadata, **kwargs,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
+
         try:
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
@@ -8005,7 +8128,17 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Telegram photo."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_image_file", chat_id, image_path, caption=caption,
+                reply_to=reply_to, metadata=metadata, **kwargs,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             if not os.path.exists(image_path):
@@ -8100,7 +8233,18 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a document/file natively as a Telegram file attachment."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_document", chat_id, file_path, caption=caption,
+                file_name=file_name, reply_to=reply_to, metadata=metadata,
+                **kwargs,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             if not os.path.exists(file_path):
@@ -8154,7 +8298,17 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a video natively as a Telegram video message."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_video", chat_id, video_path, caption=caption,
+                reply_to=reply_to, metadata=metadata, **kwargs,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         try:
             if not os.path.exists(video_path):
@@ -8208,7 +8362,17 @@ class TelegramAdapter(BasePlatformAdapter):
         Falls back to downloading and uploading as file (supports up to 10MB).
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            outcome = await self._await_reconnection_or_delegate(
+                "send_image", chat_id, image_url, caption=caption,
+                reply_to=reply_to, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
 
         from tools.url_safety import is_safe_url
         if not is_safe_url(image_url):
@@ -8305,8 +8469,18 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an animated GIF natively as a Telegram animation (auto-plays inline)."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
-        
+            outcome = await self._await_reconnection_or_delegate(
+                "send_animation", chat_id, animation_url, caption=caption,
+                reply_to=reply_to, metadata=metadata,
+            )
+            if outcome is self._RECONNECT_FAILED:
+                return SendResult(
+                    success=False, error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            if outcome is not None:
+                return outcome
+
         try:
             _anim_thread = self._metadata_thread_id(metadata)
             reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)

--- a/tests/gateway/test_telegram_reconnect_wait_coverage.py
+++ b/tests/gateway/test_telegram_reconnect_wait_coverage.py
@@ -1,0 +1,396 @@
+"""Every Telegram send_*/edit_message call must wait for reconnect too.
+
+test_telegram_send_reconnect_wait.py pinned send()'s contract: a transient
+10-20s blip must be tolerated (wait for _bot or a replacement adapter) instead
+of failing immediately with retryable=False, which otherwise strands the
+reply in the delivery ledger until the next gateway boot.
+
+That fix was never extended past send() — edit_message and every send_*
+helper (approval prompts, model/choice pickers, clarify, media sends) still
+failed fast. This file pins the shared _await_reconnection_or_delegate()
+mechanism (mirroring send_reconnect_wait.py's own scenarios) and then proves
+each real call site is actually wired through it with the correct method
+name and arguments — not just that the shared helper works in isolation.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._rich_send_disabled = True
+    adapter.send_typing = AsyncMock()
+    adapter._RECONNECT_WAIT_SECONDS = 0.6
+    adapter._RECONNECT_POLL_INTERVAL = 0.05
+    return adapter
+
+
+def _connected_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    return bot
+
+
+# ---------------------------------------------------------------------------
+# The shared mechanism (_await_reconnection_or_delegate), exercised through
+# a representative real call site (edit_message) — same scenarios as
+# send_reconnect_wait.py, proving the extracted helper behaves identically.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shared_guard_waits_and_falls_through_when_bot_returns():
+    adapter = _make_adapter()
+    adapter._bot = None
+
+    async def restore_bot() -> None:
+        await asyncio.sleep(0.12)
+        adapter._bot = _connected_bot()
+        adapter._bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=99))
+
+    asyncio.get_running_loop().create_task(restore_bot())
+    result = await adapter.edit_message("123", "1", "hello")
+
+    assert result.success is True
+    adapter._bot.edit_message_text.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_guard_delegates_to_replacement_installed_mid_wait():
+    old = _make_adapter()
+    old._bot = None
+
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    live._bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=99))
+    live._RECONNECT_WAIT_SECONDS = 0.01
+
+    runner = MagicMock()
+    runner.adapters = {}
+    old.gateway_runner = runner
+
+    async def install_replacement() -> None:
+        await asyncio.sleep(0.12)
+        runner.adapters[old.platform] = live
+
+    asyncio.get_running_loop().create_task(install_replacement())
+    result = await old.edit_message("123", "1", "hello")
+
+    assert result.success is True
+    live._bot.edit_message_text.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_guard_delegates_immediately_when_replacement_already_live():
+    old = _make_adapter()
+    old._bot = None
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    live._bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=99))
+    runner = MagicMock()
+    runner.adapters = {old.platform: live}
+    old.gateway_runner = runner
+    old._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait when replacement is already live")
+    )
+
+    result = await old.edit_message("123", "1", "hello")
+
+    assert result.success is True
+    live._bot.edit_message_text.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_guard_timeout_is_retryable_not_connected():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._RECONNECT_WAIT_SECONDS = 0.15
+    adapter._RECONNECT_POLL_INTERVAL = 0.05
+
+    result = await adapter.edit_message("123", "1", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_shared_guard_permanent_fatal_fails_immediately_without_wait():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._set_fatal_error("telegram_auth_error", "invalid token", retryable=False)
+    adapter._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait on permanent fatal")
+    )
+
+    result = await adapter.edit_message("123", "1", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Wiring: every remaining call site must actually invoke the shared guard
+# with its own method name and arguments when disconnected, instead of
+# failing fast — proven without needing to mock each method's own deep
+# success-path business logic.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_update_prompt_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_update_prompt("123", "prompt", "default", session_key="s1", metadata={"m": 1})
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_update_prompt", "123", "prompt", "default", session_key="s1", metadata={"m": 1},
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_exec_approval("123", "rm -rf /tmp/x", "s1")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_exec_approval", "123", "rm -rf /tmp/x", "s1",
+        description="dangerous command", metadata=None,
+        allow_permanent=True, allow_session=True, smart_denied=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_slash_confirm_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_slash_confirm("123", "title", "message", "s1", "cid")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_slash_confirm", "123", "title", "message", "s1", "cid", metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_clarify("123", "question?", ["a", "b"], "cid", "s1")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_clarify", "123", "question?", ["a", "b"], "cid", "s1", metadata=None,
+    )
+    # The clarify-state write (self._clarify_state[...]) lives inside the try
+    # block past this guard — proving the guard returns early confirms it
+    # never runs on THIS (disconnected) instance for a delegated call.
+    assert "cid" not in adapter._clarify_state
+
+
+@pytest.mark.asyncio
+async def test_send_model_picker_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+    on_selected = MagicMock()
+
+    result = await adapter.send_model_picker("123", ["p1"], "m1", "p1", "s1", on_selected)
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_model_picker", "123", ["p1"], "m1", "p1", "s1", on_selected, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+    on_selected = MagicMock()
+
+    result = await adapter.send_choice_picker("123", "title", [{"value": "a"}], "s1", on_selected)
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_choice_picker", "123", "title", [{"value": "a"}], "s1", on_selected, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_voice_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_voice("123", "/tmp/x.ogg")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_voice", "123", "/tmp/x.ogg", caption=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_image_file_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_image_file("123", "/tmp/x.png")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_image_file", "123", "/tmp/x.png", caption=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_document_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_document("123", "/tmp/x.pdf")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_document", "123", "/tmp/x.pdf", caption=None, file_name=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_video_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_video("123", "/tmp/x.mp4")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_video", "123", "/tmp/x.mp4", caption=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_image_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_image("123", "https://example.com/x.png")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_image", "123", "https://example.com/x.png", caption=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_animation_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = SendResult(success=True, message_id="mocked")
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter.send_animation("123", "https://example.com/x.gif")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "send_animation", "123", "https://example.com/x.gif", caption=None, reply_to=None, metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_message_returns_retryable_not_connected_when_reconnect_fails():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=adapter._RECONNECT_FAILED)
+
+    result = await adapter.edit_message("123", "1", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# _send_message_with_thread_fallback: raises RuntimeError instead of
+# returning a SendResult, so it needs its own contract-preserving check —
+# reached directly by _handle_callback_query, not only through the six
+# guarded send_* prompt methods above.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thread_fallback_wired_through_shared_guard():
+    adapter = _make_adapter()
+    adapter._bot = None
+    sentinel = MagicMock(message_id=7)
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=sentinel)
+
+    result = await adapter._send_message_with_thread_fallback(chat_id="123", text="hi")
+
+    assert result is sentinel
+    adapter._await_reconnection_or_delegate.assert_awaited_once_with(
+        "_send_message_with_thread_fallback", chat_id="123", text="hi",
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_fallback_raises_not_connected_when_reconnect_fails():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._await_reconnection_or_delegate = AsyncMock(return_value=adapter._RECONNECT_FAILED)
+
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await adapter._send_message_with_thread_fallback(chat_id="123", text="hi")
+
+
+@pytest.mark.asyncio
+async def test_thread_fallback_waits_and_succeeds_when_bot_returns():
+    adapter = _make_adapter()
+    adapter._bot = None
+
+    async def restore_bot() -> None:
+        await asyncio.sleep(0.12)
+        adapter._bot = _connected_bot()
+
+    asyncio.get_running_loop().create_task(restore_bot())
+    result = await adapter._send_message_with_thread_fallback(chat_id="123", text="hi")
+
+    assert result.message_id == 42
+    adapter._bot.send_message.assert_awaited()


### PR DESCRIPTION
## Summary

#94498 fixed `send()` so a transient ~10-20s Telegram network blip waits for reconnection (or delegates to a live replacement adapter the background reconnect watcher installed) instead of failing immediately with `retryable=False` — the delivery ledger otherwise held the reply until the next gateway boot, hours later.

That fix never reached any other outbound method. Every one of these still failed fast on the exact same `self._bot is None` condition, with no wait and no retry:

- `edit_message` — streaming edits and finalization.
- `_send_message_with_thread_fallback` — the shared helper for control-style sends, reached both by the six prompt methods below **and directly by `_handle_callback_query`** (inline-button callback replies).
- `send_update_prompt`, `send_exec_approval`, `send_slash_confirm`, `send_clarify`, `send_model_picker`, `send_choice_picker` — every interactive inline-keyboard prompt.
- `send_voice`, `send_image_file`, `send_document`, `send_video`, `send_image`, `send_animation` — every media send.

Many of these ARE the final reply to the user (an approval prompt, a clarify question, a generated image), so the same "stuck until next gateway boot" symptom `send()`'s fix targeted applies here too — just on a different call path.

## Changes

- Extracted the wait/delegate mechanics `send()` already had (previously inlined there only) into a shared `_await_reconnection_or_delegate(method, *args, **kwargs)` helper: delegates immediately to a live replacement adapter if one exists, otherwise waits up to `_RECONNECT_WAIT_SECONDS` and then delegates or gives up, matching `send()`'s exact behavior including `retryable=not self._is_permanent_fatal()` on the give-up path.
- Wired all 13 call sites above through it, preserving each method's own return contract: the `send_*`/`edit_message` methods still return `SendResult`; `_send_message_with_thread_fallback` still raises `RuntimeError("Not connected")` on give-up rather than returning a `SendResult` (its existing, different contract).

## Deliberately out of scope

`send_multiple_images` returns `None` — it has no `SendResult`/`retryable` contract a caller acts on, so the delivery-ledger rationale behind this fix doesn't apply to it. Left unchanged.

## Test plan

- [x] New `tests/gateway/test_telegram_reconnect_wait_coverage.py`: 5 tests pinning `_await_reconnection_or_delegate`'s behavior against `edit_message` as a representative call site (mirroring `test_telegram_send_reconnect_wait.py`'s own scenarios for `send()`: waits-and-succeeds, delegates-to-replacement-mid-wait, delegates-immediately-when-already-live, timeout-is-retryable, permanent-fatal-fails-without-waiting), plus one wiring test per remaining call site (13) proving each real method actually invokes the shared guard with its own correct method name and arguments when disconnected — without needing to mock each method's own deep success-path business logic.
- [x] Mutation-verified: reverted the fix, confirmed 20/21 new tests fail (the one exception is explained in the PR — it happens to hold under the old code too since `SendResult.retryable` already defaulted to `False`, so it isn't discriminating for that one scenario, but still validates real behavior post-fix); reapplied the fix, confirmed all 21 pass.
- [x] `pytest tests/gateway/ -k telegram` — 689/691 passing (2 pre-existing skips), no regressions.
- [x] `pytest tests/tools/test_telegram_send_message_caption.py tests/tools/test_send_message_telegram_proxy.py tests/hermes_cli/test_telegram_managed_bot.py` — 20/20 passing.
- [x] `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_reconnect_wait_coverage.py` — clean.