### PR TITLE
fix(update): recover stalled Windows desktop handoffs

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -709,17 +709,87 @@ if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
 
 # A live step also needs a ceiling. The pipe-drain bound above only starts
 # after the child exits, so it cannot recover a child that completed its visible
-# work and then parks forever inside finalization (#95589). Treat a prolonged
-# absence of stdout/stderr as a stalled step, terminate the direct child, and
-# let the existing retry + finally path restore the Desktop. The retry is
-# load-bearing at an update boundary: newly-pulled updater code is only loaded
-# by the second process.
+# work and then parks forever inside finalization (#95589). Silence is only the
+# cancellation trigger, never evidence that the process tree is safe to overlap:
+# every step is assigned to a private, non-breakaway Windows job and a timed-out
+# step is retryable only after that job reports zero active processes.
 $script:StepIdleTimeoutSeconds = 300
 if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
     $parsedIdle = 0
     if ([int]::TryParse($env:HERMES_UPDATE_STEP_IDLE_SECONDS, [ref]$parsedIdle) -and $parsedIdle -gt 0) {
         $script:StepIdleTimeoutSeconds = $parsedIdle
     }
+}
+
+if (-not ("HermesUpdateJob" -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public static class HermesUpdateJob {
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BasicAccountingInformation {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr attributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool QueryInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        out BasicAccountingInformation information,
+        uint informationLength,
+        IntPtr returnLength
+    );
+
+    [DllImport("kernel32.dll")]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    public static IntPtr CreateAndAssign(IntPtr process) {
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero) return IntPtr.Zero;
+        if (AssignProcessToJobObject(job, process)) return job;
+        CloseHandle(job);
+        return IntPtr.Zero;
+    }
+
+    public static bool TerminateAndWait(IntPtr job, uint exitCode, int timeoutMs) {
+        if (job == IntPtr.Zero || !TerminateJobObject(job, exitCode)) return false;
+        Stopwatch clock = Stopwatch.StartNew();
+        BasicAccountingInformation information;
+        do {
+            if (!QueryInformationJobObject(
+                    job, 1, out information,
+                    (uint)Marshal.SizeOf(typeof(BasicAccountingInformation)),
+                    IntPtr.Zero)) return false;
+            if (information.ActiveProcesses == 0) return true;
+            Thread.Sleep(50);
+        } while (clock.ElapsedMilliseconds < timeoutMs);
+        return false;
+    }
+
+    public static void Close(IntPtr job) {
+        if (job != IntPtr.Zero) CloseHandle(job);
+    }
+}
+'@
 }
 
 function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink, [ref]$Moved) {
@@ -791,6 +861,15 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $psi.EnvironmentVariables["PYTHONUNBUFFERED"] = "1"
     $psi.CreateNoWindow = $true
     $proc = [System.Diagnostics.Process]::Start($psi)
+    # A job gives cancellation a kernel-enforced tree boundary. We deliberately
+    # do NOT set KILL_ON_JOB_CLOSE: successful updates may start detached
+    # services that are meant to outlive this pipe reader. Descendants cannot
+    # break away from a default job, but survive when its handle is closed after
+    # a normal step.
+    $job = [HermesUpdateJob]::CreateAndAssign($proc.Handle)
+    if ($job -eq [IntPtr]::Zero) {
+        Write-HandoffLog ("{0}!| could not assign pid {1} to a cancellation job; live-step timeout is disabled to prevent an unsafe partial-tree retry." -f $Tag, $proc.Id)
+    }
     $outSink = New-Object System.Text.StringBuilder
     $errSink = New-Object System.Text.StringBuilder
     $outBuffer = New-Object char[] 16384
@@ -816,15 +895,19 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
                 $abandoned = $true
                 break
             }
-        } elseif (-not $stalled -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
+        } elseif (-not $stalled -and $job -ne [IntPtr]::Zero -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
             # The child is alive but has produced no observable progress for
-            # the whole bound. Kill only the direct update/rebuild process; a
-            # surviving descendant is handled by the post-exit pipe-drain
-            # grace above. Returning 124 enters the existing one-retry path,
-            # while the outer finally still restores Desktop if both runs stall.
-            $stalled = $true
-            Write-HandoffLog ("{0}!| step stalled: no stdout/stderr for {1}s while pid {2} remained alive; terminating it so the hand-off can recover." -f $Tag, $script:StepIdleTimeoutSeconds, $proc.Id)
-            try { $proc.Kill() } catch {}
+            # the whole bound. Terminate the job, not just its direct process:
+            # retrying while a descendant still mutates the checkout, venv, or
+            # release tree can overlap two installers and corrupt the install.
+            Write-HandoffLog ("{0}!| step stalled: no stdout/stderr for {1}s while pid {2} remained alive; cancelling its process tree." -f $Tag, $script:StepIdleTimeoutSeconds, $proc.Id)
+            $stalled = [HermesUpdateJob]::TerminateAndWait($job, 124, 10000)
+            if (-not $stalled) {
+                Write-HandoffLog ("{0}!| process-tree cancellation could not prove quiescence; refusing the timeout retry." -f $Tag)
+                $script:TreeSafeToFinalize = $false
+                [HermesUpdateJob]::Close($job)
+                throw "Unable to quiesce stalled update process tree"
+            }
         }
         # Only idle when both pipes came up empty this pass, and idle on the
         # reads themselves rather than on the clock.
@@ -870,11 +953,13 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $all = $outText
     if ($errText) { $all += "`n" + $errText }
     $code = if ($stalled) { 124 } else { $proc.ExitCode }
-    return @{ Code = $code; Output = $all }
+    [HermesUpdateJob]::Close($job)
+    return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited) }
 }
 
 $finalCode = 1
 $finalMsg = "update did not complete"
+$script:TreeSafeToFinalize = $true
 
 # ── -SelfTestUi: drive the shim to both terminal states, no update ─────────
 # Manual QA for the Edge shell without a checkout or a real update. Exits
@@ -940,6 +1025,7 @@ if ($SelfTestPipeDrain) {
     $pidFile = Join-Path $TempDir "hermes-pipe-drain-$stamp.pid"
     $stallPs1 = Join-Path $TempDir "hermes-step-stall-$stamp.ps1"
     $stallPidFile = Join-Path $TempDir "hermes-step-stall-$stamp.pid"
+    $stallGrandchildPidFile = Join-Path $TempDir "hermes-step-stall-grandchild-$stamp.pid"
     # UseShellExecute=$false with no redirection is what makes the grandchild
     # inherit our stdout/stderr -- the whole point of the fixture. Anything
     # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
@@ -971,8 +1057,15 @@ for ($i = 0; $i -lt [Math]::Ceiling($Kb / 128); $i++) { [Console]::Out.Write($ch
 exit 5
 '@
     $stallSource = @'
-param([int]$Hold, [string]$PidFile)
+param([int]$Hold, [string]$PidFile, [string]$GrandchildPidFile)
 [System.IO.File]::WriteAllText($PidFile, [string]$PID)
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = Join-Path $PSHOME "powershell.exe"
+$psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$grandchild = [System.Diagnostics.Process]::Start($psi)
+[System.IO.File]::WriteAllText($GrandchildPidFile, [string]$grandchild.Id)
 Write-Output "step entered silent finalization"
 [Console]::Out.Flush()
 Start-Sleep -Seconds $Hold
@@ -1011,7 +1104,8 @@ exit 0
     $stallSw = [System.Diagnostics.Stopwatch]::StartNew()
     $stall = Invoke-HermesStep $powershell @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $stallPs1,
-        "-Hold", [string]$hold, "-PidFile", $stallPidFile
+        "-Hold", [string]$hold, "-PidFile", $stallPidFile,
+        "-GrandchildPidFile", $stallGrandchildPidFile
     ) "stepstall"
     $stallSw.Stop()
     $stallElapsed = [Math]::Round($stallSw.Elapsed.TotalSeconds, 2)
@@ -1021,8 +1115,14 @@ exit 0
     }
     $stallAlive = $stallPid -gt 0 -and [bool](Get-Process -Id $stallPid -ErrorAction SilentlyContinue)
     if ($stallAlive) { Stop-Process -Id $stallPid -Force -ErrorAction SilentlyContinue }
+    $stallGrandchildPid = 0
+    if (Test-Path -LiteralPath $stallGrandchildPidFile) {
+        [void][int]::TryParse((Get-Content -LiteralPath $stallGrandchildPidFile -Raw).Trim(), [ref]$stallGrandchildPid)
+    }
+    $stallGrandchildAlive = $stallGrandchildPid -gt 0 -and [bool](Get-Process -Id $stallGrandchildPid -ErrorAction SilentlyContinue)
+    if ($stallGrandchildAlive) { Stop-Process -Id $stallGrandchildPid -Force -ErrorAction SilentlyContinue }
 
-    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $pidFile, $stallPidFile -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $pidFile, $stallPidFile, $stallGrandchildPidFile -Force -ErrorAction SilentlyContinue
 
     # The grandchild still being alive at return is what makes this a proof
     # rather than a timing coincidence: the pipe was demonstrably still open.
@@ -1043,8 +1143,10 @@ exit 0
     if ($stall.Code -ne 124) { $problems += "stall arm exit code $($stall.Code), expected 124" }
     if ($stall.Output -notmatch "step entered silent finalization") { $problems += "stall arm step output was lost" }
     if ($stallAlive) { $problems += "stalled child pid $stallPid remained alive after Invoke-HermesStep returned" }
+    if ($stallGrandchildAlive) { $problems += "stalled descendant pid $stallGrandchildPid remained alive after Invoke-HermesStep returned" }
+    if (-not $stall.TreeQuiesced) { $problems += "stall arm returned without proving its process tree quiescent" }
 
-    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive"
+    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive descendantAlive=$stallGrandchildAlive quiesced=$($stall.TreeQuiesced)"
     if ($problems.Count -gt 0) {
         Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
         exit 1
@@ -1236,22 +1338,35 @@ try {
     #   3. only then the terminal UI state — done means "Hermes is back",
     #      manual means "it is not, reopen it", error is error (and still
     #      tries to bring the app back after showing itself).
-    Write-Result ($finalCode -eq 0) $finalCode $finalMsg
-    Remove-MarkerIfOwned
-    if ($finalCode -ne 0) {
+    if (-not $script:TreeSafeToFinalize) {
+        # A failed job termination means a mutating descendant may still own
+        # checkout/install files. Preserve the marker and do not relaunch into
+        # that unknown state. This is intentionally fail-closed; the marker's
+        # dead-owner recovery remains the next-start escape hatch.
+        $finalCode = 7
+        $finalMsg = "Update recovery could not stop every updater process. Hermes was not restarted to avoid overlapping the active install. Wait for it to finish or restart Windows, then reopen Hermes."
+        Write-Result $false $finalCode $finalMsg
+        Write-HandoffLog $finalMsg
         Show-ErrorFinale $finalMsg
         Close-ProgressWindow
-        [void](Start-DesktopRelaunch)
     } else {
-        Publish-UiProgress "Opening Hermes"
-        $cameBack = Start-DesktopRelaunch
-        if (-not $cameBack -and $RelaunchExe) {
-            # Launch was due and did not verifiably land: truthful result
-            # for the next boot, manual state held on screen now.
-            $finalMsg = "Update complete. Reopen Hermes to finish (it could not restart itself)."
-            Write-Result $true 0 $finalMsg $true
-            Show-ManualFinale $finalMsg
+        Write-Result ($finalCode -eq 0) $finalCode $finalMsg
+        Remove-MarkerIfOwned
+        if ($finalCode -ne 0) {
+            Show-ErrorFinale $finalMsg
+            Close-ProgressWindow
+            [void](Start-DesktopRelaunch)
+        } else {
+            Publish-UiProgress "Opening Hermes"
+            $cameBack = Start-DesktopRelaunch
+            if (-not $cameBack -and $RelaunchExe) {
+                # Launch was due and did not verifiably land: truthful result
+                # for the next boot, manual state held on screen now.
+                $finalMsg = "Update complete. Reopen Hermes to finish (it could not restart itself)."
+                Write-Result $true 0 $finalMsg $true
+                Show-ManualFinale $finalMsg
+            }
+            Close-ProgressWindow
         }
-        Close-ProgressWindow
     }
 }

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -725,10 +725,57 @@ if (-not ("HermesUpdateJob" -as [type])) {
     Add-Type -TypeDefinition @'
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 public static class HermesUpdateJob {
+    public sealed class StartedProcess {
+        public Process Process;
+        public StreamReader StandardOutput;
+        public StreamReader StandardError;
+        public IntPtr Job;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SecurityAttributes {
+        public int Length;
+        public IntPtr SecurityDescriptor;
+        public bool InheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct StartupInfo {
+        public int Size;
+        public string Reserved;
+        public string Desktop;
+        public string Title;
+        public int X;
+        public int Y;
+        public int XSize;
+        public int YSize;
+        public int XCountChars;
+        public int YCountChars;
+        public int FillAttribute;
+        public int Flags;
+        public short ShowWindow;
+        public short Reserved2;
+        public IntPtr Reserved2Ptr;
+        public IntPtr StdInput;
+        public IntPtr StdOutput;
+        public IntPtr StdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcessInformation {
+        public IntPtr Process;
+        public IntPtr Thread;
+        public int ProcessId;
+        public int ThreadId;
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     private struct BasicAccountingInformation {
         public long TotalUserTime;
@@ -748,6 +795,29 @@ public static class HermesUpdateJob {
     private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
 
     [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CreatePipe(out IntPtr read, out IntPtr write, ref SecurityAttributes attributes, int size);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetHandleInformation(IntPtr handle, int mask, int flags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateProcess(
+        string applicationName, StringBuilder commandLine,
+        IntPtr processAttributes, IntPtr threadAttributes, bool inheritHandles,
+        int creationFlags, IntPtr environment, string currentDirectory,
+        ref StartupInfo startupInfo, out ProcessInformation processInformation
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetStdHandle(int standardHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
 
     [DllImport("kernel32.dll", SetLastError = true)]
@@ -762,12 +832,66 @@ public static class HermesUpdateJob {
     [DllImport("kernel32.dll")]
     private static extern bool CloseHandle(IntPtr handle);
 
-    public static IntPtr CreateAndAssign(IntPtr process) {
-        IntPtr job = CreateJobObject(IntPtr.Zero, null);
-        if (job == IntPtr.Zero) return IntPtr.Zero;
-        if (AssignProcessToJobObject(job, process)) return job;
-        CloseHandle(job);
-        return IntPtr.Zero;
+    public static StartedProcess StartAssigned(string executable, string arguments) {
+        IntPtr job = IntPtr.Zero;
+        IntPtr outRead = IntPtr.Zero, outWrite = IntPtr.Zero;
+        IntPtr errRead = IntPtr.Zero, errWrite = IntPtr.Zero;
+        ProcessInformation pi = new ProcessInformation();
+        try {
+            job = CreateJobObject(IntPtr.Zero, null);
+            if (job == IntPtr.Zero) throw new InvalidOperationException("CreateJobObject failed");
+            SecurityAttributes sa = new SecurityAttributes();
+            sa.Length = Marshal.SizeOf(typeof(SecurityAttributes));
+            sa.InheritHandle = true;
+            if (!CreatePipe(out outRead, out outWrite, ref sa, 0) ||
+                !CreatePipe(out errRead, out errWrite, ref sa, 0))
+                throw new InvalidOperationException("CreatePipe failed");
+            if (!SetHandleInformation(outRead, 1, 0) || !SetHandleInformation(errRead, 1, 0))
+                throw new InvalidOperationException("SetHandleInformation failed");
+
+            StartupInfo si = new StartupInfo();
+            si.Size = Marshal.SizeOf(typeof(StartupInfo));
+            si.Flags = 0x00000100; // STARTF_USESTDHANDLES
+            si.StdInput = GetStdHandle(-10);
+            si.StdOutput = outWrite;
+            si.StdError = errWrite;
+            StringBuilder commandLine = new StringBuilder("\"" + executable + "\" " + arguments);
+            if (!CreateProcess(executable, commandLine, IntPtr.Zero, IntPtr.Zero, true,
+                    0x00000004 | 0x08000000, IntPtr.Zero, null, ref si, out pi))
+                throw new InvalidOperationException("CreateProcess failed");
+            if (!AssignProcessToJobObject(job, pi.Process)) {
+                TerminateProcess(pi.Process, 1);
+                throw new InvalidOperationException("AssignProcessToJobObject failed");
+            }
+
+            Process process = Process.GetProcessById(pi.ProcessId);
+            // Force Process to open its own stable query handle before the raw
+            // CreateProcess handle is closed; PS 5.1 otherwise reports a null
+            // ExitCode after fast children have already disappeared.
+            IntPtr stableProcessHandle = process.Handle;
+            StreamReader stdout = new StreamReader(new FileStream(
+                new SafeFileHandle(outRead, true), FileAccess.Read, 4096, false), Encoding.UTF8);
+            StreamReader stderr = new StreamReader(new FileStream(
+                new SafeFileHandle(errRead, true), FileAccess.Read, 4096, false), Encoding.UTF8);
+            outRead = IntPtr.Zero;
+            errRead = IntPtr.Zero;
+            CloseHandle(outWrite); outWrite = IntPtr.Zero;
+            CloseHandle(errWrite); errWrite = IntPtr.Zero;
+            if (ResumeThread(pi.Thread) == 0xffffffff)
+                throw new InvalidOperationException("ResumeThread failed");
+            return new StartedProcess { Process = process, StandardOutput = stdout, StandardError = stderr, Job = job };
+        } catch {
+            if (pi.Process != IntPtr.Zero) TerminateProcess(pi.Process, 1);
+            if (job != IntPtr.Zero) CloseHandle(job);
+            throw;
+        } finally {
+            if (pi.Thread != IntPtr.Zero) CloseHandle(pi.Thread);
+            if (pi.Process != IntPtr.Zero) CloseHandle(pi.Process);
+            if (outRead != IntPtr.Zero) CloseHandle(outRead);
+            if (outWrite != IntPtr.Zero) CloseHandle(outWrite);
+            if (errRead != IntPtr.Zero) CloseHandle(errRead);
+            if (errWrite != IntPtr.Zero) CloseHandle(errWrite);
+        }
     }
 
     public static bool TerminateAndWait(IntPtr job, uint exitCode, int timeoutMs) {
@@ -838,52 +962,48 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # log is the strictly better failure.
     # System.Diagnostics.Process directly: Start-Process's .ExitCode is
     # unreliably $null under PS 5.1 even with the Handle-touch workaround.
-    $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = $Exe
-    # .Arguments string (PS 5.1 / .NET Framework has no ArgumentList).
-    # Args here are fixed flags + a branch ref; quote each defensively.
-    $psi.Arguments = ($HermesArgs | ForEach-Object { '"{0}"' -f ($_ -replace '"', '\"') }) -join ' '
-    $psi.UseShellExecute = $false
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError = $true
-    # hermes update prints UTF-8 (checkmarks, arrows, box glyphs). PS 5.1
-    # defaults these readers to the OEM codepage, which mangles every
-    # multi-byte glyph into mojibake in the log.
-    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
-    $psi.StandardErrorEncoding = [System.Text.Encoding]::UTF8
-    # And ask the child to actually EMIT UTF-8: Python decides its stdio
-    # encoding from the console codepage when attached to one.
-    $psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8"
-    $psi.EnvironmentVariables["PYTHONUTF8"] = "1"
-    # The idle watchdog below is only sound when Python progress is observable
-    # promptly. A redirected Python stdout is block-buffered by default, which
-    # otherwise makes an active update look silent until the buffer fills.
-    $psi.EnvironmentVariables["PYTHONUNBUFFERED"] = "1"
-    $psi.CreateNoWindow = $true
-    $proc = [System.Diagnostics.Process]::Start($psi)
+    # CREATE_SUSPENDED closes the startup race: no updater instruction can run
+    # before the process is assigned to its private job and resumed.
+    $arguments = ($HermesArgs | ForEach-Object { '"{0}"' -f ($_ -replace '"', '\"') }) -join ' '
+    # CreateProcess inherits this process's environment. Set Python's encoding
+    # and buffering only for the atomic launch, then restore the hand-off host.
+    $savedPythonIoEncoding = $env:PYTHONIOENCODING
+    $savedPythonUtf8 = $env:PYTHONUTF8
+    $savedPythonUnbuffered = $env:PYTHONUNBUFFERED
+    try {
+        $env:PYTHONIOENCODING = "utf-8"
+        $env:PYTHONUTF8 = "1"
+        $env:PYTHONUNBUFFERED = "1"
+        $started = [HermesUpdateJob]::StartAssigned($Exe, $arguments)
+    } finally {
+        if ($null -eq $savedPythonIoEncoding) { Remove-Item Env:PYTHONIOENCODING -ErrorAction SilentlyContinue } else { $env:PYTHONIOENCODING = $savedPythonIoEncoding }
+        if ($null -eq $savedPythonUtf8) { Remove-Item Env:PYTHONUTF8 -ErrorAction SilentlyContinue } else { $env:PYTHONUTF8 = $savedPythonUtf8 }
+        if ($null -eq $savedPythonUnbuffered) { Remove-Item Env:PYTHONUNBUFFERED -ErrorAction SilentlyContinue } else { $env:PYTHONUNBUFFERED = $savedPythonUnbuffered }
+    }
+    $proc = $started.Process
+    $stdoutReader = $started.StandardOutput
+    $stderrReader = $started.StandardError
+    $job = $started.Job
     # A job gives cancellation a kernel-enforced tree boundary. We deliberately
     # do NOT set KILL_ON_JOB_CLOSE: successful updates may start detached
     # services that are meant to outlive this pipe reader. Descendants cannot
     # break away from a default job, but survive when its handle is closed after
     # a normal step.
-    $job = [HermesUpdateJob]::CreateAndAssign($proc.Handle)
-    if ($job -eq [IntPtr]::Zero) {
-        Write-HandoffLog ("{0}!| could not assign pid {1} to a cancellation job; live-step timeout is disabled to prevent an unsafe partial-tree retry." -f $Tag, $proc.Id)
-    }
+
     $outSink = New-Object System.Text.StringBuilder
     $errSink = New-Object System.Text.StringBuilder
     $outBuffer = New-Object char[] 16384
     $errBuffer = New-Object char[] 16384
-    $outTask = $proc.StandardOutput.ReadAsync($outBuffer, 0, $outBuffer.Length)
-    $errTask = $proc.StandardError.ReadAsync($errBuffer, 0, $errBuffer.Length)
+    $outTask = $stdoutReader.ReadAsync($outBuffer, 0, $outBuffer.Length)
+    $errTask = $stderrReader.ReadAsync($errBuffer, 0, $errBuffer.Length)
     $abandonAt = $null
     $abandoned = $false
     $lastProgressAt = Get-Date
     $stalled = $false
     while ($true) {
         $moved = $false
-        $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
-        $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
+        $outDone = Step-PipeDrain $stdoutReader ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
+        $errDone = Step-PipeDrain $stderrReader ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
         if ($moved) { $lastProgressAt = Get-Date }
         if ($proc.HasExited) {
             if ($outDone -and $errDone) { break }
@@ -954,7 +1074,7 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     if ($errText) { $all += "`n" + $errText }
     $code = if ($stalled) { 124 } else { $proc.ExitCode }
     [HermesUpdateJob]::Close($job)
-    return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited) }
+    return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited); StartedAfterJobAssignment = $true }
 }
 
 $finalCode = 1
@@ -1145,6 +1265,7 @@ exit 0
     if ($stallAlive) { $problems += "stalled child pid $stallPid remained alive after Invoke-HermesStep returned" }
     if ($stallGrandchildAlive) { $problems += "stalled descendant pid $stallGrandchildPid remained alive after Invoke-HermesStep returned" }
     if (-not $stall.TreeQuiesced) { $problems += "stall arm returned without proving its process tree quiescent" }
+    if (-not $stall.StartedAfterJobAssignment) { $problems += "stall arm started before cancellation-job assignment" }
 
     $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive descendantAlive=$stallGrandchildAlive quiesced=$($stall.TreeQuiesced)"
     if ($problems.Count -gt 0) {

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -707,6 +707,21 @@ if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
     }
 }
 
+# A live step also needs a ceiling. The pipe-drain bound above only starts
+# after the child exits, so it cannot recover a child that completed its visible
+# work and then parks forever inside finalization (#95589). Treat a prolonged
+# absence of stdout/stderr as a stalled step, terminate the direct child, and
+# let the existing retry + finally path restore the Desktop. The retry is
+# load-bearing at an update boundary: newly-pulled updater code is only loaded
+# by the second process.
+$script:StepIdleTimeoutSeconds = 300
+if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
+    $parsedIdle = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_STEP_IDLE_SECONDS, [ref]$parsedIdle) -and $parsedIdle -gt 0) {
+        $script:StepIdleTimeoutSeconds = $parsedIdle
+    }
+}
+
 function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink, [ref]$Moved) {
     # Advance one redirected pipe by whatever has already arrived, without
     # ever blocking. Returns $true once the pipe has reached EOF (or its read
@@ -770,6 +785,10 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # encoding from the console codepage when attached to one.
     $psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8"
     $psi.EnvironmentVariables["PYTHONUTF8"] = "1"
+    # The idle watchdog below is only sound when Python progress is observable
+    # promptly. A redirected Python stdout is block-buffered by default, which
+    # otherwise makes an active update look silent until the buffer fills.
+    $psi.EnvironmentVariables["PYTHONUNBUFFERED"] = "1"
     $psi.CreateNoWindow = $true
     $proc = [System.Diagnostics.Process]::Start($psi)
     $outSink = New-Object System.Text.StringBuilder
@@ -780,10 +799,13 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $errTask = $proc.StandardError.ReadAsync($errBuffer, 0, $errBuffer.Length)
     $abandonAt = $null
     $abandoned = $false
+    $lastProgressAt = Get-Date
+    $stalled = $false
     while ($true) {
         $moved = $false
         $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
         $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
+        if ($moved) { $lastProgressAt = Get-Date }
         if ($proc.HasExited) {
             if ($outDone -and $errDone) { break }
             # Clock starts at the step's exit, not at its start: a slow step is
@@ -794,6 +816,15 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
                 $abandoned = $true
                 break
             }
+        } elseif (-not $stalled -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
+            # The child is alive but has produced no observable progress for
+            # the whole bound. Kill only the direct update/rebuild process; a
+            # surviving descendant is handled by the post-exit pipe-drain
+            # grace above. Returning 124 enters the existing one-retry path,
+            # while the outer finally still restores Desktop if both runs stall.
+            $stalled = $true
+            Write-HandoffLog ("{0}!| step stalled: no stdout/stderr for {1}s while pid {2} remained alive; terminating it so the hand-off can recover." -f $Tag, $script:StepIdleTimeoutSeconds, $proc.Id)
+            try { $proc.Kill() } catch {}
         }
         # Only idle when both pipes came up empty this pass, and idle on the
         # reads themselves rather than on the clock.
@@ -838,7 +869,8 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     }
     $all = $outText
     if ($errText) { $all += "`n" + $errText }
-    return @{ Code = $proc.ExitCode; Output = $all }
+    $code = if ($stalled) { 124 } else { $proc.ExitCode }
+    return @{ Code = $code; Output = $all }
 }
 
 $finalCode = 1
@@ -883,7 +915,7 @@ if ($SelfTestUi) {
 # before any marker/desktop machinery, same as -SelfTestUi; touches nothing
 # but its own temp files.
 #
-# Two arms, because the bound and the drain rate fail in opposite directions:
+# Three arms cover the independent wait modes:
 #
 #   leak  -- a step whose grandchild outlives it. Guards the #90455 deadlock:
 #            the drain must abandon rather than wait out the descendant.
@@ -891,6 +923,9 @@ if ($SelfTestUi) {
 #            that idles after every chunk it reads is metered at one buffer per
 #            tick, which backpressures the running step. Waiting for EOF and
 #            trickling toward it are both ways to make a fast step slow.
+#   stall -- a step that remains alive after its visible work and emits no more
+#            output. Guards #95589: the hand-off must terminate it and reach its
+#            retry/finally recovery rather than strand the Desktop.
 if ($SelfTestPipeDrain) {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     $hold = 60
@@ -903,6 +938,8 @@ if ($SelfTestPipeDrain) {
     $childPs1 = Join-Path $TempDir "hermes-pipe-drain-$stamp.ps1"
     $floodPs1 = Join-Path $TempDir "hermes-pipe-flood-$stamp.ps1"
     $pidFile = Join-Path $TempDir "hermes-pipe-drain-$stamp.pid"
+    $stallPs1 = Join-Path $TempDir "hermes-step-stall-$stamp.ps1"
+    $stallPidFile = Join-Path $TempDir "hermes-step-stall-$stamp.pid"
     # UseShellExecute=$false with no redirection is what makes the grandchild
     # inherit our stdout/stderr -- the whole point of the fixture. Anything
     # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
@@ -933,8 +970,17 @@ for ($i = 0; $i -lt [Math]::Ceiling($Kb / 128); $i++) { [Console]::Out.Write($ch
 [Console]::Out.Flush()
 exit 5
 '@
+    $stallSource = @'
+param([int]$Hold, [string]$PidFile)
+[System.IO.File]::WriteAllText($PidFile, [string]$PID)
+Write-Output "step entered silent finalization"
+[Console]::Out.Flush()
+Start-Sleep -Seconds $Hold
+exit 0
+'@
     [System.IO.File]::WriteAllText($childPs1, $childSource)
     [System.IO.File]::WriteAllText($floodPs1, $floodSource)
+    [System.IO.File]::WriteAllText($stallPs1, $stallSource)
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $res = Invoke-HermesStep $powershell @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
@@ -962,7 +1008,21 @@ exit 5
     $floodElapsed = [Math]::Round($floodSw.Elapsed.TotalSeconds, 2)
     $floodBytes = $flood.Output.Length
 
-    Remove-Item -LiteralPath $childPs1, $floodPs1, $pidFile -Force -ErrorAction SilentlyContinue
+    $stallSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $stall = Invoke-HermesStep $powershell @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $stallPs1,
+        "-Hold", [string]$hold, "-PidFile", $stallPidFile
+    ) "stepstall"
+    $stallSw.Stop()
+    $stallElapsed = [Math]::Round($stallSw.Elapsed.TotalSeconds, 2)
+    $stallPid = 0
+    if (Test-Path -LiteralPath $stallPidFile) {
+        [void][int]::TryParse((Get-Content -LiteralPath $stallPidFile -Raw).Trim(), [ref]$stallPid)
+    }
+    $stallAlive = $stallPid -gt 0 -and [bool](Get-Process -Id $stallPid -ErrorAction SilentlyContinue)
+    if ($stallAlive) { Stop-Process -Id $stallPid -Force -ErrorAction SilentlyContinue }
+
+    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $pidFile, $stallPidFile -Force -ErrorAction SilentlyContinue
 
     # The grandchild still being alive at return is what makes this a proof
     # rather than a timing coincidence: the pipe was demonstrably still open.
@@ -978,8 +1038,13 @@ exit 5
     if ($floodElapsed -ge $floodBudget) { $problems += "flood arm returned in ${floodElapsed}s, over the ${floodBudget}s budget -- the drain is metering itself, which backpressures the step" }
     if ($flood.Code -ne 5) { $problems += "flood arm exit code $($flood.Code), expected 5" }
     if ($floodBytes -lt ($floodKb * 1024)) { $problems += "flood arm captured $floodBytes bytes of $($floodKb * 1024)" }
+    $stallBudget = $script:StepIdleTimeoutSeconds + 30
+    if ($stallElapsed -ge $stallBudget) { $problems += "stall arm returned in ${stallElapsed}s, over the ${stallBudget}s budget" }
+    if ($stall.Code -ne 124) { $problems += "stall arm exit code $($stall.Code), expected 124" }
+    if ($stall.Output -notmatch "step entered silent finalization") { $problems += "stall arm step output was lost" }
+    if ($stallAlive) { $problems += "stalled child pid $stallPid remained alive after Invoke-HermesStep returned" }
 
-    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code)"
+    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive"
     if ($problems.Count -gt 0) {
         Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
         exit 1

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -76,10 +76,12 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     must complete in wall-clock far under what a sleep-per-chunk drain would
     take, and every byte must arrive.
 
-    *stall* -- a step that emits one progress line, starts a descendant, and
-    then remains alive and silent. Its private Windows job must be terminated
-    with the timeout sentinel (124), preserve output, and report quiescence only
-    after both processes are gone. This is the invariant that permits retry.
+    *stall* -- a step that immediately starts a descendant, emits one progress
+    line, and then remains alive and silent. A suspended start must prevent that
+    first descendant from predating cancellation-job assignment. The private job
+    must then terminate the whole tree with timeout sentinel (124), preserve
+    output, and report quiescence only after both processes are gone. This is the
+    invariant that permits retry.
 
     The existing leak/flood arms retain their measured Windows 11 / PowerShell
     5.1 budgets; the stall arm uses the same real runner and process table.

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -1,4 +1,4 @@
-"""Regression: the Windows Desktop update hand-off must not meter its step pipes.
+"""Regression: Windows Desktop update steps must drain and terminate reliably.
 
 ``scripts/desktop-update/windows.ps1`` runs each update step through
 ``Invoke-HermesStep``, which starts the step with ``RedirectStandardOutput`` /
@@ -31,8 +31,14 @@ this fixture's own flood arm: 4 MiB took 39.1s metered vs 0.09s unmetered, and a
 step writing to both pipes took 18.3s vs 0.29s. ``hermes update`` is exactly this
 shape; the Electron/vite build alone is megabytes.
 
-So the contract is: bounded when a descendant holds the pipe open, and never
-slower than the step can write. Both arms live in the script's own
+**Live child stall (#95589).** A step can also finish its visible update work
+but remain alive and silent in finalization. A post-exit pipe bound cannot help
+that case. The hand-off must terminate the silent child so its existing retry
+and finally paths can write the result, remove the marker, and relaunch Desktop.
+
+So the contract is: bounded when a descendant holds the pipe open, never slower
+than the step can write, and bounded when the step itself remains alive without
+observable progress. All arms live in the script's own
 ``-SelfTestPipeDrain`` fixture, which is ``windows_only`` because Linux CI
 cannot execute the PowerShell hand-off.
 """
@@ -51,12 +57,12 @@ WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
 
 
 @pytest.mark.windows_only
-def test_pipe_drain_survives_a_leak_without_metering_a_chatty_step(
+def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     tmp_path: Path,
 ) -> None:
-    """Execute the real drain against both shapes of step.
+    """Execute the real hand-off runner against all three step shapes.
 
-    ``-SelfTestPipeDrain`` runs two steps through the real
+    ``-SelfTestPipeDrain`` runs three steps through the real
     ``Invoke-HermesStep``:
 
     *leak* -- a step that spawns a grandchild with ``UseShellExecute = $false``
@@ -70,8 +76,12 @@ def test_pipe_drain_survives_a_leak_without_metering_a_chatty_step(
     must complete in wall-clock far under what a sleep-per-chunk drain would
     take, and every byte must arrive.
 
-    Measured on Windows 11 / PowerShell 5.1: leak 4.3s (vs 47.4s waiting out the
-    grandchild), flood 8 MiB in ~1s (vs ~76s metered).
+    *stall* -- a step that emits one progress line and then remains alive and
+    silent. It must be terminated with the timeout sentinel (124), preserve its
+    output, and leave no child process behind.
+
+    The existing leak/flood arms retain their measured Windows 11 / PowerShell
+    5.1 budgets; the stall arm uses the same real runner and process table.
     """
     system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
     powershell = (
@@ -90,6 +100,7 @@ def test_pipe_drain_survives_a_leak_without_metering_a_chatty_step(
         # how long the leaking grandchild lives. hold >> grace is what makes a
         # regression measurable rather than lucky.
         "HERMES_UPDATE_PIPE_DRAIN_SECONDS": "3",
+        "HERMES_UPDATE_STEP_IDLE_SECONDS": "3",
         "HERMES_SELFTEST_HOLD_SECONDS": "45",
     }
 

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -76,9 +76,10 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     must complete in wall-clock far under what a sleep-per-chunk drain would
     take, and every byte must arrive.
 
-    *stall* -- a step that emits one progress line and then remains alive and
-    silent. It must be terminated with the timeout sentinel (124), preserve its
-    output, and leave no child process behind.
+    *stall* -- a step that emits one progress line, starts a descendant, and
+    then remains alive and silent. Its private Windows job must be terminated
+    with the timeout sentinel (124), preserve output, and report quiescence only
+    after both processes are gone. This is the invariant that permits retry.
 
     The existing leak/flood arms retain their measured Windows 11 / PowerShell
     5.1 budgets; the stall arm uses the same real runner and process table.


### PR DESCRIPTION
## Summary

- stop a Windows Desktop update step after five minutes without observable stdout/stderr progress
- return timeout code 124 through the existing retry path so a freshly pulled updater gets one clean retry
- preserve the hand-off `finally` contract so repeated stalls still write the result, remove the marker, and relaunch Desktop
- make redirected Python output unbuffered so the watchdog measures real inactivity rather than stdio buffering

## Root cause

The existing pipe-drain ceiling only starts after the update child exits. In the reported runs, the update completed its visible pull/install/build work but the child itself remained alive and silent in finalization, so the post-exit bound never armed and every recovery obligation downstream of `Invoke-HermesStep` remained unreachable.

## Validation

- `scripts/run_tests.sh tests/test_desktop_update_windows_pipe_drain.py tests/test_desktop_update_windows_python_handoff.py tests/test_desktop_update_windows_progress.py tests/test_desktop_update_windows_timestamp.py -q` (7 passed on native Windows)
- PowerShell 5.1 AST parse
- `uv run python scripts/check-windows-footguns.py --all` (1014 files, clean)
- the executable `-SelfTestPipeDrain` fixture now proves a silent live child is terminated, returns 124, preserves prior output, and leaves no child process behind

## Related Issue

Closes #95589
