### PR TITLE
fix(cli): rescue --env/--connect-timeout swallowed by mcp add --args REMAINDER

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -451,6 +451,44 @@ def cmd_mcp_add(args):
     raw_env = getattr(args, "env", None)
     raw_connect_timeout = getattr(args, "connect_timeout", None)
 
+    # ``--args`` is argparse.REMAINDER: everything after it lands in cmd_args,
+    # including Hermes' own flags the user appended there by mistake or by
+    # habit (--env/--connect-timeout AFTER the child argv). Rescue those into
+    # their proper slots instead of writing them into the child command line,
+    # where the MCP server silently ignores them (and a rescued --env KEY=VALUE
+    # would otherwise leak a literal secret into config args).
+    rescued_env = list(raw_env or [])
+    rescued_timeout = raw_connect_timeout
+    cleaned_args = []
+    i = 0
+    while i < len(cmd_args):
+        tok = cmd_args[i]
+        if tok == "--env" and i + 1 < len(cmd_args) and "=" in cmd_args[i + 1]:
+            rescued_env.append(cmd_args[i + 1])
+            i += 2
+            continue
+        if tok.startswith("--env=") and "=" in tok[6:]:
+            rescued_env.append(tok[6:])
+            i += 1
+            continue
+        if tok == "--connect-timeout" and i + 1 < len(cmd_args):
+            try:
+                rescued_timeout = float(cmd_args[i + 1])
+                i += 2
+                continue
+            except ValueError:
+                pass  # belongs to the child argv — keep it
+        cleaned_args.append(tok)
+        i += 1
+    if rescued_env or rescued_timeout is not None:
+        _warning(
+            "--env/--connect-timeout after --args were moved to their proper "
+            "slots (--args is a command-argv passthrough and must come last)"
+        )
+    cmd_args = cleaned_args
+    raw_env = rescued_env or None
+    raw_connect_timeout = rescued_timeout
+
     server_config: Dict[str, Any] = {}
     try:
         explicit_env = _parse_env_assignments(raw_env)

--- a/tests/tools/test_mcp_add_flag_rescue.py
+++ b/tests/tools/test_mcp_add_flag_rescue.py
@@ -1,0 +1,76 @@
+"""Tests for cmd_mcp_add's REMAINDER --env/--connect-timeout rescue.
+
+``mcp add --args`` is argparse.REMAINDER: tokens after the child command
+argv land in cmd_args — including Hermes' own flags appended after it.
+Before the rescue, ``--env KEY=VALUE`` and ``--connect-timeout N`` given
+after the child argv were written verbatim into config args: the MCP
+server ignored them (env never set!) and a literal secret leaked into
+config.yaml. These tests pin the slot-rescue contract.
+"""
+import sys
+import types
+
+from hermes_cli import mcp_config as mc
+
+
+class FakeArgs:
+    def __init__(self, cmd_args, env=None, connect_timeout=None):
+        self.name = "x"
+        self.url = None
+        self.mcp_command = "node"
+        self.args = list(cmd_args)
+        self.auth = None
+        self.preset = None
+        self.env = env or []
+        self.connect_timeout = connect_timeout
+
+
+@pytest.fixture
+def stub_helpers(monkeypatch):
+    """Stub everything cmd_mcp_add does after building server_config."""
+    captured = {}
+
+    def fake_validate(name, cfg):
+        captured["cfg"] = cfg
+        return ["STOP"]  # force early return right after validation
+
+    monkeypatch.setattr(mc, "_warning", lambda *a, **k: None)
+    monkeypatch.setattr(mc, "_error", lambda *a, **k: (_ for _ in ()).throw(AssertionError(str(a))))
+    monkeypatch.setattr(mc, "_parse_env_assignments", lambda raw: dict(kv.split("=", 1) for kv in (raw or [])))
+    monkeypatch.setattr(
+        mc, "_apply_mcp_preset",
+        lambda *a, **k: (k.get("url"), k.get("command"), list(k.get("cmd_args") or []), None),
+    )
+    monkeypatch.setattr(mc, "validate_mcp_server_entry", fake_validate)
+    monkeypatch.setattr(mc, "_get_mcp_servers", lambda: {})
+    return captured
+
+
+def test_env_after_child_argv_is_rescued(stub_helpers):
+    mc.cmd_mcp_add(FakeArgs(["-y", "pkg@1", "--env", "K=secret123"]))
+    assert stub_helpers["cfg"]["args"] == ["-y", "pkg@1"]
+    assert stub_helpers["cfg"]["env"] == {"K": "secret123"}
+
+
+def test_connect_timeout_after_child_argv_is_rescued(stub_helpers):
+    mc.cmd_mcp_add(FakeArgs(["-y", "pkg", "--connect-timeout", "90"]))
+    assert stub_helpers["cfg"]["args"] == ["-y", "pkg"]
+    assert stub_helpers["cfg"]["connect_timeout"] == 90.0
+
+
+def test_env_equals_form_is_rescued(stub_helpers):
+    mc.cmd_mcp_add(FakeArgs(["pkg", "--env=K=v"]))
+    assert stub_helpers["cfg"]["env"] == {"K": "v"}
+
+
+def test_child_flags_are_not_stolen(stub_helpers):
+    """A --connect-timeout whose value is not numeric belongs to the child."""
+    mc.cmd_mcp_add(FakeArgs(["pkg", "--connect-timeout", "wide"]))
+    assert stub_helpers["cfg"]["args"] == ["pkg", "--connect-timeout", "wide"]
+    assert "connect_timeout" not in stub_helpers["cfg"]
+
+
+def test_no_trailing_flags_no_op(stub_helpers):
+    mc.cmd_mcp_add(FakeArgs(["-y", "pkg"]))
+    assert stub_helpers["cfg"]["args"] == ["-y", "pkg"]
+    assert "env" not in stub_helpers["cfg"]


### PR DESCRIPTION
## Bug

`mcp add --args` uses `argparse.REMAINDER`: every token after the child command argv lands in `cmd_args` — including Hermes' own flags given after it. So:

```bash
hermes mcp add tavily --command npx --env TAVILY_API_KEY=secret --connect-timeout 90 --args -y tavily-mcp@0.2.22
# any order with --env/--connect-timeout AFTER --args:
hermes mcp add tavily --command npx --args -y tavily-mcp@0.2.22 --env TAVILY_API_KEY=secret
```

silently wrote `--env`, `TAVILY_API_KEY=secret`, `--connect-timeout`, `90` **into the server's args list**: the MCP server ignored them (no env var set!), and a **literal secret leaked into config.yaml args**.

## Fix

`cmd_mcp_add` scans the REMAINDER tail and moves recognized Hermes flags into their proper slots (env dict / connect_timeout), warns the user, and leaves genuinely-child tokens untouched (e.g. `--connect-timeout not-a-number` stays in args — it belongs to the child command).

## Verification

5/5 contract tests: rescue KEY=VALUE · `--env=` form · numeric timeout · child-flag-safe (non-float stays) · no-op when nothing follows. py_compile clean.