### PR TITLE
fix(desktop): resolve session owners from the cron and messaging sidebar slices

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,7 +22,7 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
+import { $sessions, knownSessionOwner, ownerLookupSessionRows, sessionMatchesStoredId } from '@/store/session'
 import {
   requestForSessionProfile,
   type SessionOwnerScope,
@@ -178,7 +178,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   const requestSessionGateway = useCallback(
     <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
       const knownOwner: SessionOwnerScope =
-        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner($sessions.get(), storedIdRef.current)
+        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner(ownerLookupSessionRows(), storedIdRef.current)
 
       // A bare profile is the legacy/unknown tile shape. Preserve its ambient
       // behavior; only a composite route is strong enough to retarget a tile

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { $sessions, knownSessionOwner } from '@/store/session'
+import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
@@ -80,7 +80,7 @@ export function useSessionTileDelegate({
     const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
       const owner =
         sessionTileOwnerRoute(storedSessionId) ??
-        knownSessionOwner($sessions.get(), storedSessionId) ??
+        knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
         (await resolveSessionOwner(storedSessionId))
 
       return owner

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -32,7 +32,10 @@ vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => (
 const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
 const { $connectionsRegistry } = await import('@/store/connection-registry-state')
 const { $profiles } = await import('@/store/profile')
-const { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } = await import('@/store/session')
+
+const { _resetSessionOwnerHintsForTests, setCronSessions, setMessagingSessions, setSessionOwnerHint, setSessions } =
+  await import('@/store/session')
+
 const { isSessionOwnerResolutionError } = await import('@/store/session-owner-resolution')
 const { $sessionTiles } = await import('@/store/session-states')
 const { makeSessionInfo } = await import('@/test/session-info')
@@ -59,6 +62,8 @@ beforeEach(() => {
 afterEach(() => {
   $connectionsRegistry.set(null)
   setSessions([])
+  setCronSessions([])
+  setMessagingSessions([])
   $sessionTiles.set([])
   $profiles.set([])
   _resetSessionOwnerHintsForTests({ storage: true })
@@ -151,6 +156,41 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
     })
     expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('homelab', 'worker', 'session.activate', {
       session_id: 'stored-hidden'
+    })
+  })
+
+  it('resolves owners from the cron and messaging sidebar slices, not just recents (cron approval.respond)', async () => {
+    // A scheduler-minted cron session has no tile, no hint, and no row in
+    // $sessions — its row lives in the sidebar's cron slice. The row rung must
+    // see that slice, or the approval raised inside a cron chat fails closed
+    // with SessionOwnerResolutionError and can never be answered.
+    setCronSessions([makeSessionInfo({ id: 'stored-cron', profile: 'omar', source: 'cron' })])
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(
+      request('approval.respond', { choice: 'once', request_id: 'req-1', session_id: 'stored-cron' })
+    ).resolves.toEqual({ profiled: true })
+    expect(gatewayMocks.requestGatewayForProfile).toHaveBeenLastCalledWith(
+      'omar',
+      'approval.respond',
+      {
+        choice: 'once',
+        request_id: 'req-1',
+        session_id: 'stored-cron'
+      },
+      undefined,
+      undefined
+    )
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(probe.resolveSessionOwner).not.toHaveBeenCalled()
+
+    // Messaging slice, connection-tagged row → exact route.
+    setMessagingSessions([makeSessionInfo({ connection_id: 'homelab', id: 'stored-tg', profile: 'bots' })])
+
+    await expect(request('prompt.submit', { session_id: 'stored-tg', text: 'hi' })).resolves.toEqual({ routed: true })
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('homelab', 'bots', 'prompt.submit', {
+      session_id: 'stored-tg',
+      text: 'hi'
     })
   })
 })

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -35,7 +35,7 @@ import type { MutableRefObject } from 'react'
 
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
-import { $sessions, getSessionOwnerHint, knownSessionOwner } from '@/store/session'
+import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
@@ -76,7 +76,7 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     let owner: SessionOwnerScope = resolveSessionRpcOwner({
       routingSessionId,
       sessionOwnerHint: storedSessionId => getSessionOwnerHint(storedSessionId),
-      sessionRowOwner: storedSessionId => knownSessionOwner($sessions.get(), storedSessionId),
+      sessionRowOwner: storedSessionId => knownSessionOwner(ownerLookupSessionRows(), storedSessionId),
       tileOwnerRoute: sessionTileOwnerRoute
     })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -47,6 +47,7 @@ import {
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -957,6 +958,10 @@ export function openTileGatewayScopes(): Set<string> {
  * exact unique owner hint (stamped when a routed create returns / at open
  * time; persisted), then the session row's owner (an exact route when the row
  * is connection-tagged, else its bare profile, else the hint's profile). The
+ * row rung searches every source-scoped slice (recents, cron, messaging), not
+ * just recents — a cron session's approval.respond used to find no owner here
+ * and fail closed on registry-topology installs even though its row (with its
+ * `profile` stamp) was already loaded for the sidebar's cron section. The
  * hint outranks the row for the same reason as contrib/wiring's ladder: a
  * row can be stamped from the ambient profile and carries no connection.
  * Returns undefined when no owner is known — the caller fails closed
@@ -972,7 +977,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   return (
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
-    knownSessionOwner($sessions.get(), storedSessionId)
+    knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
   )
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -634,6 +634,32 @@ export const $messagingPlatformTotals = atom<Record<string, number>>({})
 // True when the combined seed fetch hit MESSAGING_SECTION_LIMIT, so at least
 // one platform may have more rows on disk than were loaded.
 export const $messagingTruncated = atom<boolean>(false)
+
+/**
+ * Every session row the renderer knows, for OWNER lookups. The sidebar splits
+ * its fetch into three source-scoped slices ($sessions / $cronSessions /
+ * $messagingSessions), and each slice's rows carry the same `profile` (and,
+ * when tagged, `connection_id`) stamps — but the owner ladder's row rung only
+ * searched recents. A cron or messaging session's approval.respond (or any
+ * session-scoped RPC) therefore found no owner, and on a registry-topology
+ * install failed closed with SessionOwnerResolutionError even though the row
+ * naming its owner was already in memory, one atom over. Concatenation order
+ * mirrors lookup priority: recents first (they can carry fresher optimistic
+ * connection tags), then the cron and messaging slices.
+ */
+export function ownerLookupSessionRows(): SessionInfo[] {
+  const cron = $cronSessions.get()
+  const messaging = $messagingSessions.get()
+
+  // Recents-only stays the common case; keep its array identity (no copy) so
+  // per-list memo caches (lineageAliases) keyed on the reference still hit.
+  if (!cron.length && !messaging.length) {
+    return $sessions.get()
+  }
+
+  return [...$sessions.get(), ...cron, ...messaging]
+}
+
 // Whether a profile's last session page was CAPPED by the request limit, keyed
 // by profile name — i.e. more rows exist on disk than were loaded. Replaces the
 // old exact per-profile totals: rendering `loaded/total` in the sidebar cost a


### PR DESCRIPTION
## Symptom

On a Desktop install with a connection registry (even the default single `local` entry), answering a command approval inside a **cron session** fails on every choice with:

> Session owner could not be resolved for "67663e85" (approval.respond): no owner route, hint, connection-tagged row or profile probe named the backend that holds this session, and routing it to the active gateway would be a guess

The agent stays blocked in `_await_gateway_decision()` until its timeout and the tool is BLOCKED. The same approval in a normal (tiled) chat works fine.

## Root cause

The owner ladder's **row rung** only searched `$sessions` (the recents slice). The sidebar fetches cron- and messaging-sourced sessions as their own slices (`$cronSessions` / `$messagingSessions`), so a scheduler-minted cron session has:

- no **tile route** (never opened as a tile),
- no **owner hint** (hints are stamped by renderer-side create/open, not the cron scheduler),
- no **row** the rung could see — its row (with its `profile` stamp) was sitting in `$cronSessions`, one atom over.

`assertSessionOwnerResolved` (#91684's fail-closed gate) then correctly refuses the ambient socket — but the owner *was* knowable the whole time. The approval bar's path (`requestForOwnedSession`) has no async REST-probe rung, so nothing downstream recovered.

## Fix

`ownerLookupSessionRows()` in `store/session.ts` returns the union of the three source-scoped slices for OWNER lookups (recents first, preserving lookup priority for fresher optimistic connection tags). The common recents-only case returns `$sessions.get()` by reference so memo caches keyed on array identity (`lineageAliases`) still hit.

All four row-rung call sites now use it:
- `app/contrib/session-rpc-dispatcher.ts` (the window's one session-RPC dispatcher)
- `store/session-states.ts` `knownOwnerForSession` (approval bar / native notification path)
- `app/contrib/hooks/use-session-tile-delegate.ts`
- `app/chat/session-tile-actions.ts`

No change to fail-closed semantics: a genuinely unknown owner still throws `SessionOwnerResolutionError`; this only lets already-loaded cron/messaging rows name their owner like recents rows always could.

## Testing

- New dispatcher test: cron-slice row routes `approval.respond` by its profile (and a connection-tagged messaging row routes exact) — fails on `main`, passes with the fix.
- `vitest run` on the dispatcher, session, session-states, wiring-routing, tile-delegate and owner-resolution suites: 125 passed.
- `tsc -p . --noEmit` clean, eslint clean.

Hit in production on a single-local-backend Windows install: the weekday cron job's chat raised `approval.request` for a gated command and the approval could never be submitted.