### PR TITLE
fix(desktop): per-gateway auth survives, corrupt registry entries quarantine, remote primaries stop spawning ghost backends (wave-2 phase C, #94724)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -1808,3 +1808,116 @@ test('migrateV1ToRegistry carries v1 remote headers into the registry entry', ()
     'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'id' }
   })
 })
+
+// --- normalizeRegistry per-entry quarantine (#94246 remainder) ---
+//
+// One malformed entry must never cost the user the rest of the registry, and
+// malformed entries are USER DATA: they are preserved under `quarantined`
+// (with the raw entry verbatim) instead of being silently deleted on the next
+// registry write. "Only deleting connections.json recovers" was the reported
+// failure shape; the recovery must never be data loss.
+
+test('normalizeRegistry quarantines malformed entries instead of silently dropping them', () => {
+  const registry = normalizeRegistry({
+    version: 2,
+    primary: 'a',
+    connections: [
+      { id: 'local', kind: 'local', label: 'This device' },
+      { id: 'a', kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119' },
+      { id: 'c', kind: 'remote', label: 'No URL entry' },
+      { kind: 'nonsense', label: 'Mystery box', extra: 'still my data' },
+      { id: 's', kind: 'ssh', label: 'No host ssh' }
+    ]
+  })
+
+  // Healthy entries all load.
+  assert.deepEqual(
+    registry.connections.map(c => c.id),
+    ['local', 'a']
+  )
+  assert.equal(registry.primary, 'a')
+
+  // The malformed ones are preserved verbatim, with reasons.
+  assert.equal((registry.quarantined || []).length, 3)
+
+  const reasons = registry.quarantined!.map(q => q.reason).sort()
+
+  assert.deepEqual(reasons, ['entry-missing-ssh-host', 'entry-missing-url', 'entry-unrecognized-kind'])
+
+  const mystery = registry.quarantined!.find(q => q.reason === 'entry-unrecognized-kind')
+
+  assert.deepEqual(mystery!.entry, { kind: 'nonsense', label: 'Mystery box', extra: 'still my data' })
+})
+
+test('normalizeRegistry preserves previously quarantined entries across round trips', () => {
+  const first = normalizeRegistry({
+    version: 2,
+    connections: [{ id: 'c', kind: 'remote', label: 'No URL entry' }]
+  })
+
+  assert.equal((first.quarantined || []).length, 1)
+
+  // Simulate write → read → normalize again (what every registry save does).
+  const second = normalizeRegistry(JSON.parse(JSON.stringify(first)))
+
+  assert.equal((second.quarantined || []).length, 1)
+  assert.deepEqual(second.quarantined![0].entry, { id: 'c', kind: 'remote', label: 'No URL entry' })
+})
+
+test('normalizeRegistry quarantines an entry that explodes during normalization (no whole-load abort)', () => {
+  const poisoned: any = { id: 'boom', kind: 'remote', url: 'http://10.0.0.9:9119' }
+
+  Object.defineProperty(poisoned, 'label', {
+    enumerable: true,
+    get() {
+      throw new Error('poisoned entry')
+    }
+  })
+
+  const registry = normalizeRegistry({
+    version: 2,
+    primary: 'a',
+    connections: [poisoned, { id: 'a', kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119' }]
+  })
+
+  // The healthy entry still loads and keeps primary; the poisoned one is
+  // quarantined rather than aborting the whole registry load.
+  assert.deepEqual(
+    registry.connections.filter(c => c.kind === 'remote').map(c => c.id),
+    ['a']
+  )
+  assert.equal(registry.primary, 'a')
+  assert.equal((registry.quarantined || []).length, 1)
+  assert.equal(registry.quarantined![0].reason, 'entry-normalization-failed')
+})
+
+test('normalizeRegistry keeps a clean registry free of the quarantined key and caps quarantine growth', () => {
+  const clean = normalizeRegistry({
+    version: 2,
+    connections: [{ id: 'a', kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119' }]
+  })
+
+  assert.equal('quarantined' in clean, false)
+
+  const flooded = normalizeRegistry({
+    version: 2,
+    connections: Array.from({ length: 100 }, (_, i) => ({ id: `q${i}`, kind: 'remote', label: `No URL ${i}` }))
+  })
+
+  assert.ok((flooded.quarantined || []).length <= 20)
+})
+
+test('normalizeRegistry quarantines non-object junk items that could still be user data', () => {
+  const registry = normalizeRegistry({
+    version: 2,
+    connections: ['{ mangled json fragment }', null, false, { id: 'a', kind: 'remote', label: 'A', url: 'http://x:1' }]
+  })
+
+  assert.deepEqual(
+    registry.connections.map(c => c.kind),
+    ['local', 'remote']
+  )
+  // null/false carry no data and are dropped; the string is preserved.
+  assert.equal((registry.quarantined || []).length, 1)
+  assert.equal(registry.quarantined![0].entry, '{ mangled json fragment }')
+})

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -73,6 +73,22 @@ export interface RegistryConnection {
   remoteProfile?: string
 }
 
+/**
+ * A registry entry that failed normalization (#94246). The raw entry is USER
+ * DATA — it is preserved verbatim here (and re-persisted on every write)
+ * instead of being silently dropped, so a malformed/corrupt entry never
+ * requires "delete connections.json" recovery and never loses the user's
+ * connection material.
+ */
+export interface QuarantinedRegistryEntry {
+  reason: string
+  entry: unknown
+}
+
+/** Upper bound on preserved quarantine entries so a pathological file cannot
+ * grow the registry without limit. Oldest-first within one load pass. */
+export const REGISTRY_QUARANTINE_CAP = 20
+
 export interface ConnectionRegistry {
   version: typeof REGISTRY_VERSION
   /** id of the connection that owns the window/primary backend. */
@@ -83,6 +99,8 @@ export interface ConnectionRegistry {
    * so registries written before multi-source switching still normalize. */
   lastUsed: string
   connections: RegistryConnection[]
+  /** Entries preserved from a malformed load — absent when empty. */
+  quarantined?: QuarantinedRegistryEntry[]
 }
 
 // ── Labels and ids ──────────────────────────────────────────────────────────
@@ -1043,16 +1061,56 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
   const seenLabels = new Set<string>()
   const seenIds = new Set<string>()
   const connections: RegistryConnection[] = []
+  const quarantined: QuarantinedRegistryEntry[] = []
+
+  const quarantine = (reason: string, entry: unknown) => {
+    if (quarantined.length < REGISTRY_QUARANTINE_CAP) {
+      quarantined.push({ reason, entry })
+    }
+  }
+
+  // Entries quarantined by a previous load are user data too — carry them
+  // through every subsequent normalize/write cycle rather than dropping them
+  // the first time the file is rewritten.
+  if (Array.isArray(parsed.quarantined)) {
+    for (const item of parsed.quarantined) {
+      if (item && typeof item === 'object' && 'entry' in (item as Record<string, unknown>)) {
+        quarantine(String((item as Record<string, unknown>).reason || 'unknown'), (item as Record<string, unknown>).entry)
+      }
+    }
+  }
+
+  // Best-effort plain-data copy for entries that blew up mid-normalization —
+  // the raw object may carry whatever poisoned it, so never persist it as-is.
+  const safeEntryCopy = (item: unknown) => {
+    try {
+      return JSON.parse(JSON.stringify(item))
+    } catch {
+      return { unserializable: true }
+    }
+  }
 
   for (const item of rawConnections) {
-    if (!item || typeof item !== 'object') {
+    if (!item) {
+      continue // null/false/'' carry no user data
+    }
+
+    if (typeof item !== 'object') {
+      // A string/number here is usually a mangled hand-edit — still user data.
+      quarantine('entry-malformed', item)
+
       continue
     }
 
+    // One bad entry must never abort the whole registry load (#94246): any
+    // unexpected throw quarantines THIS entry and the loop moves on.
+    try {
     const entry = item as Record<string, unknown>
     const kind = entry.kind
 
     if (kind !== 'local' && kind !== 'remote' && kind !== 'cloud' && kind !== 'ssh') {
+      quarantine('entry-unrecognized-kind', item)
+
       continue
     }
 
@@ -1086,6 +1144,8 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
       const url = String(entry.url || '').trim()
 
       if (!url) {
+        quarantine('entry-missing-url', item)
+
         continue
       }
 
@@ -1111,6 +1171,8 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
       const ssh = normalizeSshConfig({ ...entry, mode: 'ssh' })
 
       if (!ssh) {
+        quarantine('entry-missing-ssh-host', item)
+
         continue
       }
 
@@ -1119,6 +1181,9 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
     }
 
     connections.push(clean)
+    } catch {
+      quarantine('entry-normalization-failed', safeEntryCopy(item))
+    }
   }
 
   if (!connections.some(c => c.kind === 'local')) {
@@ -1129,13 +1194,19 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
   const primary = connections.some(c => c.id === storedPrimary) ? storedPrimary : LOCAL_CONNECTION_ID
   const storedLastUsed = String(parsed.lastUsed || '').trim()
 
-  return {
+  const normalized: ConnectionRegistry = {
     version: REGISTRY_VERSION,
     primary,
     launchMode: parsed.launchMode === 'last-used' ? 'last-used' : 'primary',
     lastUsed: connections.some(c => c.id === storedLastUsed) ? storedLastUsed : primary,
     connections
   }
+
+  if (quarantined.length > 0) {
+    normalized.quarantined = quarantined
+  }
+
+  return normalized
 }
 
 /**

--- a/apps/desktop/electron/desktop-remote-route.test.ts
+++ b/apps/desktop/electron/desktop-remote-route.test.ts
@@ -305,3 +305,90 @@ test('local route does not inherit an unrelated registry SSH connection', () => 
 test('local config without overrides returns null', () => {
   assert.equal(resolveDesktopRemoteRoute({ config: { mode: 'local' }, registry: registry('local', []) }), null)
 })
+
+// --- Registry-primary transport gating (#91564 / #90316) ---
+//
+// "Make primary" on a registered remote gateway only writes connections.json;
+// the v1 config.mode stays 'local'. The route resolver must still expose that
+// remote transport, or startHermes() spawns a loopback `hermes serve` the
+// desktop never uses (duplicated MCP sets, port squat, respawn-on-poll).
+
+test('falls back to a REMOTE registry primary when the v1 mode is local (#91564/#90316)', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local' },
+    profile: null,
+    registry: registry('gw-b', [
+      { id: 'gw-b', kind: 'remote', label: 'Gateway B', url: 'https://gw-b.test', authMode: 'token', token: tokenB }
+    ])
+  })
+
+  assert.equal(route?.kind, 'remote')
+  assert.equal(route?.source, 'registry')
+  assert.equal(route?.connectionId, 'gw-b')
+  assert.equal((route as any)?.url, 'https://gw-b.test')
+  assert.deepEqual((route as any)?.token, tokenB)
+})
+
+test('falls back to a CLOUD registry primary when the v1 mode is local', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local' },
+    profile: null,
+    registry: registry('cloud-1', [
+      {
+        id: 'cloud-1',
+        kind: 'cloud',
+        label: 'Hermes Cloud',
+        url: 'https://agent.hermes.cloud',
+        authMode: 'oauth',
+        org: 'nous'
+      }
+    ])
+  })
+
+  assert.equal(route?.kind, 'cloud')
+  assert.equal(route?.source, 'registry')
+  assert.equal((route as any)?.authMode, 'oauth')
+  assert.equal((route as any)?.org, 'nous')
+})
+
+test('falls back to an SSH registry primary when the v1 mode is local', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local' },
+    profile: null,
+    registry: registry('spark', [
+      { id: 'spark', kind: 'ssh', label: 'Spark', host: 'spark1', user: 'tek', port: 2222, token: tokenA }
+    ])
+  })
+
+  assert.equal(route?.kind, 'ssh')
+  assert.equal(route?.source, 'registry')
+  assert.equal(route?.connectionId, 'spark')
+  assert.equal((route as any)?.ssh?.host, 'spark1')
+  assert.equal((route as any)?.ssh?.port, 2222)
+})
+
+test('a LOCAL registry primary keeps resolving local (null route)', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local' },
+    profile: null,
+    registry: registry('local', [
+      { id: 'gw-b', kind: 'remote', label: 'Gateway B', url: 'https://gw-b.test', authMode: 'token', token: tokenB }
+    ])
+  })
+
+  assert.equal(route, null)
+})
+
+test('the v1 global remote still outranks the registry primary', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'remote', remote: { url: 'https://global.test', authMode: 'token', token: tokenA } },
+    profile: null,
+    registry: registry('gw-b', [
+      { id: 'global', kind: 'remote', label: 'Global', url: 'https://global.test', token: tokenA },
+      { id: 'gw-b', kind: 'remote', label: 'Gateway B', url: 'https://gw-b.test', authMode: 'token', token: tokenB }
+    ])
+  })
+
+  assert.equal(route?.source, 'settings')
+  assert.equal((route as any)?.url, 'https://global.test')
+})

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -9,7 +9,7 @@ import {
 import type { ConnectionRegistry } from './connection-registry'
 import { matchingConnectionId, type StoredRoute } from './connection-route-identity'
 
-type RouteSource = 'env' | 'profile' | 'settings'
+type RouteSource = 'env' | 'profile' | 'registry' | 'settings'
 
 interface SshRouteConfig {
   host: string
@@ -133,7 +133,14 @@ export function resolveDesktopRemoteRoute({
   }
 
   if (!modeIsRemoteLike(config.mode)) {
-    return null
+    // Registry-primary fallback (#91564/#90316): "Make primary" on a
+    // registered remote/cloud/ssh gateway only rewrites connections.json —
+    // the v1 config.mode stays 'local'. Without this rung the primary boot
+    // resolves local and spawns a loopback `hermes serve` the desktop never
+    // uses (it dials the registry primary separately): duplicated MCP sets,
+    // port squat, and a respawn on every poll. A 'local' registry primary
+    // still resolves null, so genuinely-local desktops are untouched.
+    return resolveRegistryPrimaryRoute(registry)
   }
 
   const kind = config.mode === 'cloud' ? 'cloud' : 'remote'
@@ -152,4 +159,54 @@ export function resolveDesktopRemoteRoute({
     },
     matchingConnectionId(registry, route, 'primary')
   )
+}
+
+/**
+ * Lowest-precedence rung: the v2 registry PRIMARY's own transport. Returns
+ * null unless the primary names a remote/cloud/ssh entry — i.e. only when the
+ * user explicitly made a non-local registered gateway their primary.
+ */
+function resolveRegistryPrimaryRoute(registry: ConnectionRegistry): DesktopRemoteRoute | null {
+  const primaryId = String(registry?.primary || '').trim()
+
+  if (!primaryId) {
+    return null
+  }
+
+  const entry = (registry.connections || []).find(connection => connection.id === primaryId)
+
+  if (!entry) {
+    return null
+  }
+
+  if (entry.kind === 'ssh') {
+    const ssh = normalizeSshConfig({ ...entry, mode: 'ssh' })
+
+    if (!ssh) {
+      return null
+    }
+
+    return { connectionId: entry.id, kind: 'ssh', source: 'registry', ssh, token: entry.token }
+  }
+
+  if (entry.kind !== 'remote' && entry.kind !== 'cloud') {
+    return null
+  }
+
+  const url = String(entry.url || '').trim()
+
+  if (!url) {
+    return null
+  }
+
+  return {
+    authMode: normAuthMode(entry.authMode),
+    connectionId: entry.id,
+    headers: entry.headers,
+    kind: entry.kind,
+    org: entry.kind === 'cloud' ? String(entry.org || '').trim() || undefined : undefined,
+    source: 'registry',
+    token: entry.token,
+    url
+  }
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9021,7 +9021,19 @@ function readDesktopConnectionsRegistry() {
     tightenSecretFileMode(DESKTOP_CONNECTIONS_REGISTRY_PATH)
     registry = normalizeRegistry(JSON.parse(fs.readFileSync(DESKTOP_CONNECTIONS_REGISTRY_PATH, 'utf8')))
   } catch {
+    // Whole-file corruption (truncated write, mangled hand-edit). The
+    // degraded local-only registry keeps boot working, but the file BYTES are
+    // the user's connection data — preserve them in a sidecar BEFORE any
+    // later write (drift reconcile, connection save) overwrites the file
+    // (#94246: recovery must never be data loss).
+    preserveCorruptRegistrySidecar()
     registry = normalizeRegistry(null)
+  }
+
+  if (registry?.quarantined?.length) {
+    rememberLog(
+      `[connections] ${registry.quarantined.length} malformed registry entr${registry.quarantined.length === 1 ? 'y was' : 'ies were'} quarantined (kept under "quarantined" in connections.json); healthy connections loaded normally.`
+    )
   }
 
   // Heal v1 -> v2 drift: the v1 global route names a remote this registry has
@@ -9050,6 +9062,31 @@ function readDesktopConnectionsRegistry() {
   connectionRegistryCacheMtime = mtime
 
   return registry
+}
+
+// Copy an unparseable connections.json aside (once per corruption event) so a
+// later registry write can never destroy the only copy of the user's saved
+// connections (#94246). Best effort: failure to preserve must not block boot.
+function preserveCorruptRegistrySidecar() {
+  try {
+    const rawText = fs.readFileSync(DESKTOP_CONNECTIONS_REGISTRY_PATH, 'utf8')
+
+    if (!rawText.trim()) {
+      return
+    }
+
+    const sidecar = `${DESKTOP_CONNECTIONS_REGISTRY_PATH}.corrupt-${new Date().toISOString().replace(/[:.]/g, '-')}`
+
+    if (!fs.existsSync(sidecar)) {
+      fs.writeFileSync(sidecar, rawText, { mode: 0o600 })
+    }
+
+    rememberLog(
+      `[connections] connections.json could not be parsed; preserved the original file at ${sidecar} and continuing with a local-only registry. No connection data was deleted.`
+    )
+  } catch {
+    // The read itself failed (missing file, permissions) — nothing to save.
+  }
 }
 
 function writeDesktopConnectionsRegistry(registry) {
@@ -9098,7 +9135,16 @@ function sanitizeConnectionsRegistry(registry = readDesktopConnectionsRegistry()
     launchMode: registry.launchMode,
     lastUsed: registry.lastUsed,
     secureTokenStorage,
-    connections: registry.connections.map(sanitizeRegistryConnection)
+    connections: registry.connections.map(sanitizeRegistryConnection),
+    // Surface quarantined-entry NOTICES only (reason + best-effort label) —
+    // the raw entries can carry token envelopes and stay in the file (#94246).
+    quarantined: (registry.quarantined || []).map(q => ({
+      reason: String(q?.reason || 'unknown'),
+      label:
+        q && q.entry && typeof q.entry === 'object' && typeof (q.entry as any).label === 'string'
+          ? (q.entry as any).label
+          : ''
+    }))
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -150,6 +150,7 @@ import {
   upsertConnection
 } from './connection-registry'
 import type { RosterProfileMetadata } from './connection-registry'
+import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
@@ -1316,7 +1317,7 @@ function registerMediaProtocol() {
         method
       }),
     fetchRemoteWithCookies: (url, headers, method) => {
-      const oauthSession = getOauthSession()
+      const oauthSession = getOauthSessionForUrl(url)
 
       if (!oauthSession) {
         throw new Error('OAuth session partition is unavailable.')
@@ -6913,7 +6914,7 @@ function installMediaPermissions() {
 //     "is the user signed in at all?" gate / display signal.
 // ---------------------------------------------------------------------------
 
-const OAUTH_SESSION_PARTITION = 'persist:hermes-remote-oauth'
+const OAUTH_SESSION_PARTITION = LEGACY_OAUTH_PARTITION
 
 function getOauthSession() {
   if (oauthSession || !app.isReady()) {
@@ -6923,6 +6924,47 @@ function getOauthSession() {
   oauthSession = session.fromPartition(OAUTH_SESSION_PARTITION)
 
   return oauthSession
+}
+
+// Per-connection cookie jars (#92183). A NON-primary v2 registry remote with
+// cookie auth rides its own partition so two registered gateways can never
+// evict — or be handed — each other's session cookies (Chromium jars ignore
+// the port, so two dashboards on one VPN host used to collide in the shared
+// jar above). The primary / v1 remote / cloud / portal flows keep the legacy
+// shared partition; see oauth-partition.ts for the full rules.
+const oauthSessionsByPartition = new Map()
+
+function resolveOauthPartitionForUrl(url) {
+  try {
+    return resolveOauthPartition(url, {
+      registry: readDesktopConnectionsRegistry(),
+      v1RemoteUrl: readDesktopConnectionConfig()?.remote?.url
+    })
+  } catch {
+    // A broken registry read must never take cookie auth down with it.
+    return OAUTH_SESSION_PARTITION
+  }
+}
+
+function getOauthSessionForUrl(url) {
+  const partition = resolveOauthPartitionForUrl(url)
+
+  if (partition === OAUTH_SESSION_PARTITION) {
+    return getOauthSession()
+  }
+
+  if (!app.isReady()) {
+    return null
+  }
+
+  let sess = oauthSessionsByPartition.get(partition)
+
+  if (!sess) {
+    sess = session.fromPartition(partition)
+    oauthSessionsByPartition.set(partition, sess)
+  }
+
+  return sess
 }
 
 // Cold-start cookie-jar warm-up. A `persist:` partition materialized via
@@ -6938,19 +6980,23 @@ function getOauthSession() {
 // throwaway cookies.get(). The promise is memoized so every caller awaits the
 // same single warm-up. Best-effort — any error resolves so we fall back to the
 // live read (which then does its own bounded re-check).
-let oauthCookieWarmup: Promise<void> | null = null
+// Memoized per PARTITION: per-connection jars (#92183) hydrate independently.
+const oauthCookieWarmups = new Map()
 
-function warmOauthCookieStore() {
-  if (oauthCookieWarmup) {
-    return oauthCookieWarmup
+function warmOauthCookieStore(url?) {
+  const partition = resolveOauthPartitionForUrl(url)
+  const pending = oauthCookieWarmups.get(partition)
+
+  if (pending) {
+    return pending
   }
 
-  oauthCookieWarmup = (async () => {
-    const sess = getOauthSession()
+  const warmup = (async () => {
+    const sess = getOauthSessionForUrl(url)
 
     if (!sess) {
       // App not ready yet — don't memoize a no-op; let a later call retry.
-      oauthCookieWarmup = null
+      oauthCookieWarmups.delete(partition)
 
       return
     }
@@ -6966,7 +7012,9 @@ function warmOauthCookieStore() {
     }
   })()
 
-  return oauthCookieWarmup
+  oauthCookieWarmups.set(partition, warmup)
+
+  return warmup
 }
 
 // Bare + prefixed variants of the session cookies live in
@@ -6974,7 +7022,7 @@ function warmOauthCookieStore() {
 // that module for details.
 
 async function hasOauthSessionCookie(baseUrl) {
-  const sess = getOauthSession()
+  const sess = getOauthSessionForUrl(baseUrl)
 
   if (!sess) {
     return false
@@ -7007,7 +7055,7 @@ async function hasOauthSessionCookie(baseUrl) {
 // re-login every ~15 min. Used for the Settings "connected" indicator and as a
 // cheap early-out before attempting a network round-trip in resolveRemoteBackend.
 async function hasLiveOauthSession(baseUrl) {
-  const sess = getOauthSession()
+  const sess = getOauthSessionForUrl(baseUrl)
 
   if (!sess) {
     return false
@@ -7043,7 +7091,7 @@ async function hasLiveOauthSession(baseUrl) {
   // trusting a negative, force the store to hydrate and re-read a couple of
   // times with a short backoff. A genuinely signed-out user still resolves
   // false quickly (≤ ~180ms); a signed-in user racing the load now wins.
-  await warmOauthCookieStore()
+  await warmOauthCookieStore(baseUrl)
 
   for (const delayMs of [30, 60, 90]) {
     if (await readLive()) {
@@ -7057,7 +7105,7 @@ async function hasLiveOauthSession(baseUrl) {
 }
 
 async function clearOauthSession(baseUrl) {
-  const sess = getOauthSession()
+  const sess = getOauthSessionForUrl(baseUrl)
 
   if (!sess) {
     return
@@ -7104,7 +7152,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
       return
     }
 
-    const sess = getOauthSession()
+    const sess = getOauthSessionForUrl(baseUrl)
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))
@@ -7237,7 +7285,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 // authed REST against a gated gateway, including minting WS tickets.
 function fetchJsonViaOauthSession(url, options: any = {}) {
   return new Promise((resolve, reject) => {
-    const sess = getOauthSession()
+    const sess = getOauthSessionForUrl(url)
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))
@@ -7488,7 +7536,7 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
 // is cleared once the response headers arrive.
 function downloadViaOauthSessionToFile(url, ctx, options: any = {}) {
   return new Promise((resolve, reject) => {
-    const sess = getOauthSession()
+    const sess = getOauthSessionForUrl(url)
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -150,7 +150,6 @@ import {
   upsertConnection
 } from './connection-registry'
 import type { RosterProfileMetadata } from './connection-registry'
-import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
@@ -247,6 +246,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10092,7 +10092,31 @@ function globalRemoteActive() {
 
   const mode = readDesktopConnectionConfig().mode
 
-  return modeIsRemoteLike(mode) || mode === 'ssh'
+  if (modeIsRemoteLike(mode) || mode === 'ssh') {
+    return true
+  }
+
+  // Registry-primary transport (#91564/#90316): a registered remote/cloud/ssh
+  // gateway promoted to primary via connections.json makes the primary
+  // backend remote even while the v1 config.mode still says 'local'. Every
+  // consumer of this flag ("one remote host serves every profile") must see
+  // that, or the local-entry routes delegate into a primary that now dials
+  // remote — respawning the exact loopback children the resolver rung in
+  // desktop-remote-route.ts eliminates.
+  return registryPrimaryIsRemote()
+}
+
+// True when the v2 registry PRIMARY names a non-local connection. Mirrors the
+// registry fallback rung in resolveDesktopRemoteRoute.
+function registryPrimaryIsRemote() {
+  try {
+    const registry = readDesktopConnectionsRegistry()
+    const entry = registry.connections.find(c => c.id === registry.primary)
+
+    return Boolean(entry && (entry.kind === 'remote' || entry.kind === 'cloud' || entry.kind === 'ssh'))
+  } catch {
+    return false
+  }
 }
 
 // True when the PRIMARY profile's backend resolves to a remote/cloud host —

--- a/apps/desktop/electron/oauth-partition.test.ts
+++ b/apps/desktop/electron/oauth-partition.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+
+// #92183 — two basic-auth (cookie-flow) gateways registered in the v2
+// connections registry must not share one cookie jar. Chromium cookie jars
+// ignore the port, so two gateways on the same VPN host (different ports)
+// evict each other's `hermes_session*` cookies when they ride the single
+// shared `persist:hermes-remote-oauth` partition — and, worse, gateway A's
+// cookie is silently PRESENTED to gateway B on every request. The resolver
+// under test keys the jar on the registry connection's identity instead.
+
+const registry = (primary: string, connections: any[]) => ({ primary, connections })
+
+const remote = (id: string, url: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  kind: 'remote',
+  label: id,
+  url,
+  authMode: 'oauth',
+  ...extra
+})
+
+describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
+  it('gives two same-host different-port registry gateways DISTINCT partitions (eviction fix)', () => {
+    const reg = registry('local', [
+      { id: 'local', kind: 'local' },
+      remote('conn-a', 'https://10.27.27.7:9119'),
+      remote('conn-b', 'https://10.27.27.7:9220')
+    ])
+
+    const a = resolveOauthPartition('https://10.27.27.7:9119', { registry: reg })
+    const b = resolveOauthPartition('https://10.27.27.7:9220', { registry: reg })
+
+    expect(a).not.toBe(LEGACY_OAUTH_PARTITION)
+    expect(b).not.toBe(LEGACY_OAUTH_PARTITION)
+    // Fail closed: B's requests must never ride a jar that can hold A's cookie.
+    expect(a).not.toBe(b)
+  })
+
+  it('scopes a full request URL (REST/ws-ticket path) to its connection jar via longest base-url prefix', () => {
+    const reg = registry('local', [
+      remote('conn-a', 'https://gw.example.com'),
+      remote('conn-b', 'https://gw.example.com/team-b')
+    ])
+
+    const a = resolveOauthPartition('https://gw.example.com/api/auth/ws-ticket', { registry: reg })
+    const b = resolveOauthPartition('https://gw.example.com/team-b/api/auth/ws-ticket', { registry: reg })
+
+    expect(a).not.toBe(b)
+    expect(b).toContain('conn-b')
+  })
+
+  it('keeps the v1 primary remote on the LEGACY partition so upgrades do not sign the user out', () => {
+    const reg = registry('mig-1', [remote('mig-1', 'https://gw-a.example.com')])
+
+    expect(
+      resolveOauthPartition('https://gw-a.example.com', {
+        registry: reg,
+        v1RemoteUrl: 'https://gw-a.example.com'
+      })
+    ).toBe(LEGACY_OAUTH_PARTITION)
+  })
+
+  it('keeps the registry PRIMARY connection on the legacy partition', () => {
+    const reg = registry('conn-a', [
+      remote('conn-a', 'https://gw-a.example.com'),
+      remote('conn-b', 'https://gw-b.example.com')
+    ])
+
+    expect(resolveOauthPartition('https://gw-a.example.com/api/status', { registry: reg })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://gw-b.example.com/api/status', { registry: reg })).not.toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('keeps cloud connections on the legacy partition (silent portal cascade needs the shared jar)', () => {
+    const reg = registry('local', [
+      { id: 'cloud-1', kind: 'cloud', url: 'https://agent.nousresearch.com', authMode: 'oauth' }
+    ])
+
+    expect(resolveOauthPartition('https://agent.nousresearch.com/api/status', { registry: reg })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('keeps token-auth registry remotes on the legacy partition (no cookies involved)', () => {
+    const reg = registry('local', [remote('tok-1', 'https://gw-t.example.com', { authMode: 'token' })])
+
+    expect(resolveOauthPartition('https://gw-t.example.com', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
+  })
+
+  it('falls back to the legacy partition for unmatched, portal, and malformed inputs', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw-a.example.com')])
+
+    expect(resolveOauthPartition('https://portal.nousresearch.com/api/agents', { registry: reg })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('not a url', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
+    expect(resolveOauthPartition('', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
+    expect(resolveOauthPartition('https://gw-a.example.com', { registry: null as any })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://gw-a.example.com', { registry: { primary: 'x', connections: 'junk' } as any })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('does not treat a hostname PREFIX as a base-url match', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw.example.com')])
+
+    expect(resolveOauthPartition('https://gw.example.com.evil.tld/login', { registry: reg })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('normalizes trailing slashes and default ports when matching entry URLs', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw-a.example.com:443/')])
+
+    const got = resolveOauthPartition('https://gw-a.example.com/api/auth/ws-ticket', { registry: reg })
+
+    expect(got).not.toBe(LEGACY_OAUTH_PARTITION)
+    expect(got).toContain('conn-a')
+  })
+
+  it('produces a deterministic, partition-safe name from hostile connection ids', () => {
+    const reg = registry('local', [remote('we ird/id:€', 'https://gw-a.example.com')])
+
+    const got = resolveOauthPartition('https://gw-a.example.com', { registry: reg })
+
+    expect(got.startsWith('persist:')).toBe(true)
+    expect(got).not.toMatch(/[\s/€]/)
+    expect(resolveOauthPartition('https://gw-a.example.com', { registry: reg })).toBe(got)
+  })
+
+  it('breaks same-URL ties deterministically (identical jar for identical gateway)', () => {
+    const reg = registry('local', [
+      remote('zeta', 'https://gw-a.example.com'),
+      remote('alpha', 'https://gw-a.example.com')
+    ])
+
+    const got = resolveOauthPartition('https://gw-a.example.com', { registry: reg })
+
+    expect(got).toContain('alpha')
+  })
+})

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -1,0 +1,159 @@
+/**
+ * oauth-partition.ts
+ *
+ * Per-connection cookie-jar isolation for cookie-authenticated (OAuth /
+ * dashboard basic-auth) remote gateways (#92183).
+ *
+ * Historically every cookie-mode remote rode ONE Electron session partition
+ * (`persist:hermes-remote-oauth`) — the jar was keyed on the auth *mode*, not
+ * on the connection's identity. Chromium cookie jars scope by host and ignore
+ * the port, so two registered gateways on the same host (the #92183 VPN
+ * setup: one box, two dashboards) fought over the same `hermes_session*`
+ * cookies: signing in to gateway B evicted gateway A's session, and A's
+ * cookie was silently PRESENTED to B on every request — a cross-connection
+ * credential leak.
+ *
+ * This module is the pure decision seam: given a request/base URL and a
+ * snapshot of the v2 connections registry, decide which session partition the
+ * request must ride. Rules:
+ *
+ *   - A NON-primary v2 registry `remote` entry with cookie auth
+ *     (`authMode: 'oauth'`, which covers dashboard basic/password providers —
+ *     they authenticate via session cookies too) gets its own partition
+ *     derived from the connection id. Fail closed: its requests can never see
+ *     another connection's cookies, and its login window can never evict them.
+ *   - The registry PRIMARY and the v1 single-connection remote stay on the
+ *     LEGACY shared partition, so existing signed-in users are not signed out
+ *     by the upgrade.
+ *   - `cloud` entries stay on the legacy partition: the silent per-agent
+ *     cascade deliberately shares one jar with the Nous Portal session.
+ *   - Token-auth remotes, portal URLs, and anything unmatched or malformed
+ *     fall back to the legacy partition (cookie-free flows are unaffected).
+ *
+ * Kept free of `electron` imports so it unit-tests in the electron vitest
+ * project; main.ts owns session.fromPartition() and injects nothing here.
+ */
+
+export const LEGACY_OAUTH_PARTITION = 'persist:hermes-remote-oauth'
+
+const CONNECTION_PARTITION_PREFIX = `${LEGACY_OAUTH_PARTITION}:conn:`
+
+export interface PartitionRegistrySnapshot {
+  primary?: unknown
+  connections?: unknown
+}
+
+export interface ResolveOauthPartitionOptions {
+  registry?: PartitionRegistrySnapshot | null
+  /** v1 single-connection remote URL (connection.json `remote.url`), when set. */
+  v1RemoteUrl?: unknown
+}
+
+/**
+ * Normalize a URL for base-url matching: lowercased scheme+host, explicit
+ * default ports elided (URL does this), trailing slashes trimmed, query and
+ * fragment dropped. Returns null for anything that is not a plain http(s) URL.
+ */
+function normalizeForMatch(raw: unknown): string | null {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(raw.trim())
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+
+    const path = parsed.pathname.replace(/\/+$/, '')
+
+    return `${parsed.protocol}//${parsed.host}${path}`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * True when `requestNorm` is the entry base URL itself or a path underneath
+ * it. Both sides are pre-normalized; the '/' requirement is what stops
+ * `https://gw.example.com.evil.tld` from matching `https://gw.example.com`.
+ */
+function matchesBase(requestNorm: string, baseNorm: string): boolean {
+  return requestNorm === baseNorm || requestNorm.startsWith(`${baseNorm}/`)
+}
+
+/** Partition names must stay printable/simple; connection ids are user data. */
+function sanitizePartitionComponent(id: string): string {
+  return encodeURIComponent(id).replace(/%/g, '_')
+}
+
+/**
+ * Decide the Electron session partition a cookie-authenticated request against
+ * `requestUrl` must ride. See the module header for the rules.
+ */
+export function resolveOauthPartition(requestUrl: unknown, opts: ResolveOauthPartitionOptions = {}): string {
+  const requestNorm = normalizeForMatch(requestUrl)
+
+  if (!requestNorm) {
+    return LEGACY_OAUTH_PARTITION
+  }
+
+  const registry = opts.registry
+
+  if (!registry || typeof registry !== 'object' || !Array.isArray(registry.connections)) {
+    return LEGACY_OAUTH_PARTITION
+  }
+
+  const primaryId = typeof registry.primary === 'string' ? registry.primary : ''
+  const v1Norm = normalizeForMatch(opts.v1RemoteUrl)
+
+  let best: { baseNorm: string; id: string } | null = null
+
+  for (const entry of registry.connections) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+
+    const id = typeof (entry as any).id === 'string' ? (entry as any).id.trim() : ''
+
+    // Only NON-primary v2 `remote` entries with cookie-flow auth get their own
+    // jar. Cloud entries need the shared portal jar; token entries never use
+    // cookies; the primary (and the v1 remote it migrated from) keeps the
+    // legacy jar so an upgrade does not sign the user out.
+    if (!id || id === primaryId) {
+      continue
+    }
+
+    if ((entry as any).kind !== 'remote' || (entry as any).authMode !== 'oauth') {
+      continue
+    }
+
+    const baseNorm = normalizeForMatch((entry as any).url)
+
+    if (!baseNorm || (v1Norm && baseNorm === v1Norm)) {
+      continue
+    }
+
+    if (!matchesBase(requestNorm, baseNorm)) {
+      continue
+    }
+
+    // Longest base-url prefix wins (sub-path gateways behind one proxy);
+    // identical URLs tie-break on the lexicographically smallest id so the
+    // choice is deterministic across processes and launches.
+    if (
+      !best ||
+      baseNorm.length > best.baseNorm.length ||
+      (baseNorm.length === best.baseNorm.length && id < best.id)
+    ) {
+      best = { baseNorm, id }
+    }
+  }
+
+  if (!best) {
+    return LEGACY_OAUTH_PARTITION
+  }
+
+  return `${CONNECTION_PARTITION_PREFIX}${sanitizePartitionComponent(best.id)}`
+}

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1365,3 +1365,52 @@ test('remote SSH ownership capability requires both secure bootstrap flags', asy
   const unsupported = fakeSsh([[/serve --help/, 'NO\n']])
   assert.equal(await remoteSupportsSshOwnership(unsupported, '/x/hermes'), false)
 })
+
+test('cleanupStale escalates to SIGKILL when the backend survives the graceful wait (#91668 quit-during-active-turn)', async () => {
+  // A serve mid-turn (in-flight LLM call, live MCP children) can ride out
+  // SIGTERM well past the 5s graceful wait. Before-quit races the whole
+  // teardown against 6s and then closes SSH — so a give-up here reparents
+  // the still-running backend to pid 1: exactly the #91668 leak. The
+  // graceful-wait failure must escalate to SIGKILL and still drop the lock.
+  const ssh = fakeSsh([
+    [/print\("OWNED"/, 'OWNED\n'],
+    [(cmd: string) => /kill 9 &&/.test(cmd), new Error('exit 1: pid alive after graceful wait')]
+  ])
+
+  await cleanupStale(ssh, OWNERSHIP_ID, {
+    pid: 9,
+    spawnNonce: SPAWN_NONCE,
+    hermesPath: '/x/hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+
+  assert.ok(
+    ssh.calls.some(c => /kill -9 9\b/.test(c)),
+    'must escalate to SIGKILL after the graceful wait fails'
+  )
+  assert.ok(
+    ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)),
+    'lockfile must still be dropped after the forced kill'
+  )
+})
+
+test('cleanupStale keeps the lockfile when even SIGKILL cannot confirm the pid died', async () => {
+  const ssh = fakeSsh([
+    [/print\("OWNED"/, 'OWNED\n'],
+    [(cmd: string) => /kill 9 &&/.test(cmd), new Error('exit 1: pid alive after graceful wait')],
+    [(cmd: string) => /kill -9 9\b/.test(cmd), new Error('exit 1: unkillable (D-state)')]
+  ])
+
+  await assert.rejects(
+    cleanupStale(ssh, OWNERSHIP_ID, {
+      pid: 9,
+      spawnNonce: SPAWN_NONCE,
+      hermesPath: '/x/hermes',
+      logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+    }),
+    /Could not terminate/
+  )
+
+  // The record must survive so the next connect's reap pass retries.
+  assert.ok(!ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
+})

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -506,11 +506,27 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
       ).trim()
 
       void result
-    } catch (cause) {
-      const error: any = new Error('Could not terminate the stale SSH backend.')
-      error.kind = 'transient-transport-error'
-      error.cause = cause
-      throw error
+    } catch {
+      // A backend mid-turn (in-flight LLM call, live MCP children) can ride
+      // out SIGTERM past the 5s graceful wait — and before-quit races this
+      // whole teardown against 6s before closing SSH, so giving up here
+      // reparents the still-running serve to pid 1: the #91668 leak, now on
+      // the quit-during-active-turn path. Escalate to SIGKILL and require a
+      // confirmed exit before treating the record as reclaimed.
+      try {
+        await ssh.exec(
+          `kill -9 ${Number(lock.pid)} 2>/dev/null; ` +
+            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
+            `i=$((i+1)); [ "$i" -ge 20 ] && exit 1; sleep 0.1; done`
+        )
+      } catch (cause) {
+        // Even SIGKILL could not confirm death (D-state, permissions). Keep
+        // the lockfile so the next connect's reap pass retries.
+        const error: any = new Error('Could not terminate the stale SSH backend.')
+        error.kind = 'transient-transport-error'
+        error.cause = cause
+        throw error
+      }
     }
   }
 

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -178,3 +178,59 @@ describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094
     expect(activeGateway()).toBe(gatewayMocks.instances[0])
   })
 })
+
+describe('profile switch mid-WS-handshake (#92434 close-candidate pin)', () => {
+  // Reported shape: Bot ↔ Default switching killed the socket until an app
+  // restart. The activation-epoch guard (applyActive) + open-socket-publish
+  // rule mean a switch-back that lands while the outgoing switch's handshake
+  // is still pending must win the route, and the late-completing dial must
+  // neither steal the foreground nor leave its socket permanently broken.
+  it('a switch-back during a pending handshake wins; the late dial neither steals the route nor breaks the socket', async () => {
+    const getConnection = vi.fn(async ({ profile }: { profile: string }) => ({
+      authMode: 'token',
+      baseUrl: `https://${profile}.invalid`,
+      mode: 'local',
+      profile,
+      token: 'fake-test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    }))
+
+    installDesktop({ getConnection })
+
+    let releaseDial: () => void = () => undefined
+
+    gatewayMocks.connect.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDial = resolve
+        })
+    )
+
+    // 1. Default → Bot: the secondary's WS handshake starts and stays pending.
+    const botActivation = ensureGatewayForProfile('bot')
+
+    await vi.waitFor(() => expect(gatewayMocks.connect).toHaveBeenCalledTimes(1))
+
+    // 2. The user switches back to Default while that handshake is mid-flight.
+    await ensureGatewayForProfile('default')
+
+    const primary = activeGateway()
+
+    expect(primary).toBeTruthy()
+
+    // 3. The Bot handshake completes AFTER the switch-back.
+    releaseDial()
+    await botActivation
+
+    // The stale activation must not steal the foreground route (epoch guard).
+    expect(activeGateway()).toBe(primary)
+
+    // 4. No permanent break: switching to Bot again activates the (already
+    // open) socket — no app restart, no duplicate socket/serve.
+    await ensureGatewayForProfile('bot')
+
+    expect(activeGateway()).toBe(gatewayMocks.instances[0])
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+    expect(gatewayMocks.instances).toHaveLength(1)
+  })
+})

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -88,6 +88,7 @@ def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
                     # First connect succeeds (sets _ready), then dies.
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                     raise RuntimeError("backend outage begins")
                 if not state["backend_up"]:

--- a/tests/tools/test_mcp_reconnect_log_hygiene.py
+++ b/tests/tools/test_mcp_reconnect_log_hygiene.py
@@ -68,6 +68,7 @@ def test_retry_attempts_log_debug_transitions_warn(monkeypatch, tmp_path, caplog
                 if state["transport_calls"] == 1:
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                 raise ConnectionError("backend down")
 

--- a/tests/tools/test_mcp_reconnect_retry_reset.py
+++ b/tests/tools/test_mcp_reconnect_retry_reset.py
@@ -62,6 +62,7 @@ def test_reconnect_counter_resets_after_successful_session(monkeypatch, tmp_path
                     # First connect: succeed (sets _ready), then fail.
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                     raise RuntimeError("blip 1")
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1421,6 +1421,73 @@ class TestReconnection:
 
         asyncio.run(_test())
 
+    def test_reconnect_failures_after_initial_success_use_reconnect_budget(self):
+        """A server that already registered tools must not be re-classified
+        as "never connected" just because a later reconnect attempt fails
+        while ``_ready`` is momentarily clear (#94654).
+
+        ``_MAX_INITIAL_CONNECT_RETRIES`` is 3 and ``_MAX_RECONNECT_RETRIES``
+        is 5. Four consecutive post-success reconnect failures exceed the
+        (buggy) initial-connect ladder but not the reconnect budget, so this
+        distinguishes the two code paths.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        run_count = 0
+        target_server = None
+
+        async def patched_run_stdio(self_srv, config):
+            nonlocal run_count, target_server
+            run_count += 1
+            if target_server is not self_srv:
+                return None
+            if run_count == 1:
+                # Initial connection succeeds and registers tools. Setting
+                # ``_ever_connected`` mirrors what the real ``_run_stdio``
+                # does right after a successful ``_discover_tools()`` call;
+                # guarded because the pre-fix class has no such slot.
+                self_srv.session = MagicMock()
+                self_srv._tools = []
+                self_srv._ready.set()
+                try:
+                    self_srv._ever_connected = True
+                except AttributeError:
+                    pass
+                return "reconnect"
+            if run_count <= 5:
+                # Four consecutive failures on later reconnect attempts --
+                # a flapping transport, not a server that never connected.
+                raise ConnectionError("reconnect attempt failed")
+            self_srv._shutdown_event.set()
+            await self_srv._shutdown_event.wait()
+
+        async def patched_wait_parked(self_srv, timeout=None):
+            # If the code under test parks early, unblock immediately
+            # instead of waiting out the real park interval.
+            self_srv._shutdown_event.set()
+            return "shutdown"
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch.object(
+                     MCPServerTask, "_wait_for_reconnect_or_shutdown",
+                     patched_wait_parked,
+                 ), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({"command": "test"})
+
+            assert server._was_parked is False, (
+                "server parked after only 4 reconnect failures following a "
+                "successful initial connection -- it was misclassified as "
+                "never having connected and re-entered the initial-connect "
+                "ladder instead of the (larger) reconnect budget"
+            )
+
+        asyncio.run(_test())
 
     def test_preflight_probe_runs_on_initial_http_connect(self):
         """The content-type preflight probe fires on the first HTTP connect."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1444,15 +1444,11 @@ class TestReconnection:
             if run_count == 1:
                 # Initial connection succeeds and registers tools. Setting
                 # ``_ever_connected`` mirrors what the real ``_run_stdio``
-                # does right after a successful ``_discover_tools()`` call;
-                # guarded because the pre-fix class has no such slot.
+                # does right after a successful ``_discover_tools()`` call.
                 self_srv.session = MagicMock()
                 self_srv._tools = []
                 self_srv._ready.set()
-                try:
-                    self_srv._ever_connected = True
-                except AttributeError:
-                    pass
+                self_srv._ever_connected = True
                 return "reconnect"
             if run_count <= 5:
                 # Four consecutive failures on later reconnect attempts --

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1448,7 +1448,17 @@ class TestReconnection:
                 self_srv.session = MagicMock()
                 self_srv._tools = []
                 self_srv._ready.set()
-                self_srv._ever_connected = True
+                # Guarded set: MCPServerTask uses __slots__, so on pre-fix
+                # code (no ``_ever_connected`` slot) a bare assignment raises
+                # AttributeError *inside this mock* while ``_ready`` is still
+                # set — which detours run() into the reconnect ladder and lets
+                # the test pass vacuously on the buggy code. The guard keeps
+                # the regression test biting: pre-fix the flag simply doesn't
+                # exist and the misclassification fires.
+                try:
+                    self_srv._ever_connected = True
+                except AttributeError:
+                    pass
                 return "reconnect"
             if run_count <= 5:
                 # Four consecutive failures on later reconnect attempts --

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2396,6 +2396,7 @@ class MCPServerTask:
         "_reconnect_retries", "_session_proven", "_was_parked",
         "_inflight_tasks", "_reconnecting", "_suspect_reason",
         "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
+        "_ever_connected",
     )
 
     def __init__(self, name: str):
@@ -2426,6 +2427,12 @@ class MCPServerTask:
         # keeps getting charged and still reaches the park instead of
         # hot-cycling respawns forever.
         self._session_proven: bool = False
+        # Set once tools have ever been registered and never cleared again,
+        # unlike ``_ready`` (which is cleared on every reconnect cycle). Used
+        # to tell a genuine first-connection failure from a later reconnect
+        # failure that merely happens to occur while ``_ready`` is
+        # momentarily clear — see the ``initial_retries`` ladder in run().
+        self._ever_connected: bool = False
         # True while parked (reconnect budget exhausted) or after a park,
         # until the session proves healthy again — used to log the
         # parked→revived transition exactly once.
@@ -3335,6 +3342,7 @@ class MCPServerTask:
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
+                    self._ever_connected = True
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -3706,6 +3714,7 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
+                        self._ever_connected = True
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -3771,6 +3780,7 @@ class MCPServerTask:
                             self.session = session
                             await self._discover_tools()
                             self._ready.set()
+                            self._ever_connected = True
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
                             # isn't gated on a stale failure count (#16788).
@@ -3818,6 +3828,7 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
+                        self._ever_connected = True
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -4116,9 +4127,14 @@ class MCPServerTask:
 
                 # If this is the first connection attempt, retry with backoff
                 # before giving up. A transient DNS/network blip at startup
-                # should not permanently kill the server.
+                # should not permanently kill the server. Gated on
+                # ``_ever_connected`` rather than ``_ready`` — ``_ready`` is
+                # cleared on every reconnect cycle (see below), so a server
+                # that already registered tools once and then dropped would
+                # otherwise be misclassified as never having connected and
+                # re-enter this initial-connect ladder (#94654).
                 # (Ported from Kilo Code's MCP resilience fix.)
-                if not self._ready.is_set():
+                if not self._ever_connected:
                     if failure_class == "permanent":
                         # Deterministic failure (bad command, non-MCP URL,
                         # 401/403): every retry hits the same wall. Park

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4133,6 +4133,7 @@ class MCPServerTask:
                 # that already registered tools once and then dropped would
                 # otherwise be misclassified as never having connected and
                 # re-enter this initial-connect ladder (#94654).
+                # ``_ever_connected`` itself is set once and never cleared.
                 # (Ported from Kilo Code's MCP resilience fix.)
                 if not self._ever_connected:
                     if failure_class == "permanent":


### PR DESCRIPTION
## Summary
Multi-gateway auth and registry stop failing at the edges: cookie-auth sessions are partitioned per connection (signing into gateway B no longer evicts gateway A's session), one malformed connections.json entry is quarantined instead of aborting the whole registry load ("only deleting connections.json recovers" is dead — the bad entry is preserved and surfaced, healthy entries load), remote registry primaries no longer spawn an unused loopback `hermes serve` child, an MCP server that drops AFTER registering is no longer misclassified as an initial-connect failure (and parked), and an owned SSH backend that survives the graceful quit wait gets SIGKILL escalation.

Wave-2 Phase C of tracker #94724. Fixes #92183, the #94246 remainder, the remote-primary halves of #91564/#90316, #94671's report, and the #91668 remainder.

## Salvaged contributor work (authorship preserved)
- #94671 @chelsealong — MCP `_ever_connected` latch (3 commits); our hardening commit fixes their regression test which passed VACUOUSLY on main (`__slots__` swallowed the mock attribute)

## Our fixes
- #92183 — new `oauth-partition.ts`: cookie jars keyed per connection id, all 8 gateway jar boundaries in main.ts wired through it; legacy jar retained for primary/v1/cloud/portal so nobody gets signed out on upgrade. Note: non-primary cookie-auth secondaries re-authenticate once after upgrade (fresh per-connection jars — fail closed by design).
- #94246 — per-entry quarantine in `normalizeRegistry`: reasons + raw entry preserved (cap 20), corrupt-file sidecar written before any overwrite, notice surfaced; never silently deletes user data.
- #91564/#90316 — registry-primary rung in `resolveDesktopRemoteRoute`: "Make primary" on a remote entry now routes remote instead of leaving v1-mode local and spawning a loopback serve nobody uses. Local-entry routes still force pooled local children; #94915's REST hide-sweep verified untouched. (#90316's roster-enumeration half was already fixed on main Aug 17 — verified, not rebuilt.)
- #91668 remainder — SIGKILL escalation when the owned SSH backend outlives the graceful quit wait.

## Adjudicated (no code change needed)
- **#92434 close-candidate:** the phase A/B activation-epoch + open-socket-publish guards already prevent the reported permanent Bot↔Default break. New pin test reproduces the exact mid-handshake switch-back scenario and passes; sabotage run neutering the epoch check makes it fail (proof the test bites).

## Validation
Per-fix A/B (fails at origin/main or under sabotage, passes at head): #94671 hardened test fires the exact "parking" log line on main; #92183 suite 5-failed under sabotage → 11/11; #94246 4-failed on main code → 87 passed; #91564 TDD red → 21 passed. Suites: electron 1857, ui-store 1268, targeted MCP pytest 147, tsc clean both configs.

**Live repro:** unit-level A/B on extracted seams; a real two-basic-auth-gateway pair and live SSH remote are not available in this environment — flagged rather than silently downgraded. The registry-quarantine and loopback-spawn paths are pure electron logic fully exercised by the suites.

## Infographic

![Auth & Registry Hardening](https://v3b.fal.media/files/b/0aa7e63f/vjjZOXbGYL070PcaBouUa_0pccIuDu.png)
