### PR TITLE
fix(desktop): keep SSH serve teardown across re-entrant quit

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -4,6 +4,7 @@ import {
   applyConnectionChange,
   commitConnectionFailure,
   resolveTerminalConnection,
+  sshQuitShouldBlock,
   teardownSshState
 } from './connection-apply'
 
@@ -88,6 +89,48 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('sshQuitShouldBlock', () => {
+  it('waits when connections exist and teardown has not finished', () => {
+    expect(
+      sshQuitShouldBlock({ teardownDone: false, connectionCount: 1, bootstrapPending: 0, inFlight: null })
+    ).toBe(true)
+  })
+
+  it('waits when bootstrap is still running', () => {
+    expect(
+      sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 1, inFlight: null })
+    ).toBe(true)
+  })
+
+  it('waits when the map is empty but a remote kill is already in flight', () => {
+    expect(
+      sshQuitShouldBlock({
+        teardownDone: false,
+        connectionCount: 0,
+        bootstrapPending: 0,
+        inFlight: Promise.resolve()
+      })
+    ).toBe(true)
+  })
+
+  it('does not block a second quit after teardown finished', () => {
+    expect(
+      sshQuitShouldBlock({
+        teardownDone: true,
+        connectionCount: 1,
+        bootstrapPending: 1,
+        inFlight: Promise.resolve()
+      })
+    ).toBe(false)
+  })
+
+  it('does not block quit when there is nothing to tear down', () => {
+    expect(
+      sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 0, inFlight: null })
+    ).toBe(false)
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -61,6 +61,21 @@ async function resolveTerminalConnectionForSender(webContentsId, getTarget, ensu
   )
 }
 
+/** A second before-quit must still wait for an in-flight remote kill.
+ *
+ *  teardownSshConnection deletes the sshConnections entry first, then
+ *  SSH-execs kill. backendShutdown's finally() calls app.quit() and
+ *  re-enters before-quit with an empty map. Without `inFlight`, Electron
+ *  exits while disconnect is running and the detached serve --isolated
+ *  stays at pid 1 (post-#95085 leftover on #91668: window X on Windows). */
+function sshQuitShouldBlock({ teardownDone, connectionCount, bootstrapPending, inFlight }) {
+  if (teardownDone) {
+    return false
+  }
+
+  return connectionCount > 0 || bootstrapPending > 0 || Boolean(inFlight)
+}
+
 async function teardownSshState(state, { cleanupRemote }) {
   // Remote process first, while the SSH channel can still exec kill.
   // Then drop the local forward and close the transport. Each step is
@@ -91,5 +106,6 @@ export {
   commitConnectionFailure,
   resolveTerminalConnection,
   resolveTerminalConnectionForSender,
+  sshQuitShouldBlock,
   teardownSshState
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,7 +86,7 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange, teardownSshState } from './connection-apply'
+import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -9511,6 +9511,7 @@ const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PA
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
 let sshQuitTeardownDone = false
+let sshQuitTeardownPromise: Promise<void> | null = null
 let backendQuitTeardownDone = false
 
 function sshScopeKey(profile) {
@@ -16336,20 +16337,39 @@ app.on('before-quit', event => {
     })
   }
 
-  if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
+  // backendShutdown.finally() re-enters before-quit. teardownSshConnection
+  // already deleted the map entries, so size===0 would skip the kill wait
+  // and let window-X quit finish while SSH exec is still running (#91668).
+  if (
+    sshQuitShouldBlock({
+      teardownDone: sshQuitTeardownDone,
+      connectionCount: sshConnections.size,
+      bootstrapPending: sshBootstrapCoordinator.promises().length,
+      inFlight: sshQuitTeardownPromise
+    })
+  ) {
     event.preventDefault()
-    const scopes = [...sshConnections.keys()]
 
-    const pending = Promise.allSettled([
-      ...scopes.map(scope => teardownSshConnection(scope || null)),
-      ...sshBootstrapCoordinator.promises()
-    ])
+    if (!sshQuitTeardownPromise) {
+      const scopes = [...sshConnections.keys()]
+      const pending = Promise.allSettled([
+        ...scopes.map(scope => teardownSshConnection(scope || null)),
+        ...sshBootstrapCoordinator.promises()
+      ])
 
-    // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
-    // The previous 4s race could close SSH first and leave serve --isolated
-    // reparented to pid 1.
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 6_000))]).then(async () => {
-      await sshBootstrapCoordinator.forceCleanupAll()
+      // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
+      // The previous 4s race could close SSH first and leave serve --isolated
+      // reparented to pid 1. Latch this promise BEFORE those deletes land so
+      // a re-entrant quit still waits.
+      sshQuitTeardownPromise = Promise.race([
+        pending,
+        new Promise<void>(resolve => setTimeout(resolve, 6_000))
+      ]).then(async () => {
+        await sshBootstrapCoordinator.forceCleanupAll()
+      })
+    }
+
+    void sshQuitTeardownPromise.then(() => {
       sshQuitTeardownDone = true
       app.quit()
     })


### PR DESCRIPTION
## What does this PR do?

#95085 landed the owned `serve --isolated` kill on quit (`disconnect` via `cleanupStale` while SSH can still `exec kill`). @jps1226 retested a Windows Desktop build of current main (`d0351e3230`) against a Linux SSH gateway: closing the window with **X** exited the Desktop process, but the owned remote backend and `backend.lock.json` stayed, including multiple live backends for the same profile scope.

`before-quit` starts SSH teardown and local `backendShutdown` in parallel. `backendShutdown.finally()` calls `app.quit()` and re-enters `before-quit`. `teardownSshConnection` deletes the `sshConnections` entry *before* the remote kill finishes, so the second pass saw `size === 0` and did not wait. Electron then exited while `ssh.exec(kill)` was still in flight.

`sshQuitShouldBlock` also treats an in-flight teardown as a reason to `preventDefault`, even when the map is already empty. The 6s wait for `cleanupStale` is unchanged.

This is the post-#95085 leftover on #91668. It does not replace a live SSH re-test; it is the quit-race that made that re-test fail.

## Related Issue

#91668 (remainder after #95085)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/connection-apply.ts`: `sshQuitShouldBlock` — wait when connections, bootstrap, or an in-flight teardown exist
- `apps/desktop/electron/main.ts`: latch `sshQuitTeardownPromise` on the first `before-quit`; re-entrant quits wait on it
- `apps/desktop/electron/connection-apply.test.ts`: empty map + in-flight still blocks; done teardown does not

## How to Test

```text
cd apps/desktop
npx vitest run --project electron electron/connection-apply.test.ts
# 14 passed
```

1. Connect Desktop (Windows or Linux client) to a Linux SSH gateway with an owned `serve --isolated`.
2. Close the window with X (not only Cmd+Q / the menu Quit path).
3. On the gateway, the owned backend PID should be gone and `backend.lock.json` for that ownership id removed.
4. A second connect should not leave two live backends for the same profile scope.

Not e2e-tested here against a live POSIX SSH host.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — quit-race unit tests; live close/X confirmation still needs a POSIX SSH gateway.
