### PR TITLE
feat(config): per-key origins via `hermes config get <key> --origin`

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3485,8 +3485,75 @@ def set_config_value(key: str, value: str, force: bool = False):
         _print_unknown_key_notice(key, suggestion)
 
 
-def get_config_value(key: str, *, as_json: bool = False):
+def get_config_origin(key: str) -> str:
+    """Return which layer defines a config key.
+
+    Ported semantic from OpenAI Codex's per-key origins tracking
+    (``codex-rs/config/src/loader``): instead of only knowing the effective
+    value, answer *where it came from*. Hermes has three config layers plus
+    the env bridge, so the precedence is:
+
+    - ``env``      — key is an env-backed credential/bridge key and the
+                     env var is set (secrets live in .env, not config.yaml)
+    - ``managed``  — pinned by the administrator's managed config layer
+                     (/etc/hermes/config.yaml or HERMES_MANAGED_DIR)
+    - ``user``     — set explicitly in the user's config.yaml
+    - ``default``  — not user-set, provided by DEFAULT_CONFIG
+    - ``unset``    — no layer defines it (unknown key)
+
+    A managed key always reports ``managed`` even when the user also wrote
+    it — the managed layer wins at the leaf, so the effective source is the
+    managed one.
+    """
+    # 1. Env-backed keys: if the env var is actually set, that is the source
+    #    the effective value came from (get_config_value resolves them first).
+    if _is_env_config_key(key):
+        try:
+            if get_env_value(key.upper()) is not None:
+                return "env"
+        except Exception:
+            pass
+
+    # 2. Managed scope wins at the leaf over the user file.
+    try:
+        from hermes_cli import managed_scope
+
+        if managed_scope.is_key_managed(key):
+            return "managed"
+    except Exception:
+        pass
+
+    # 3. User file (raw, exactly as written — defaults merge would make
+    #    every key "present").  _get_nested returns the _MISSING sentinel
+    #    (not None) for absent keys, so test against it explicitly.
+    try:
+        if _get_nested(read_user_config_raw(), key) is not _MISSING:
+            return "user"
+    except Exception:
+        pass
+
+    # 4. Defaults.
+    try:
+        if _get_nested(DEFAULT_CONFIG, key) is not _MISSING:
+            return "default"
+    except Exception:
+        pass
+
+    return "unset"
+
+
+def get_config_value(key: str, *, as_json: bool = False, origin: bool = False):
     """Print a resolved configuration value."""
+    if origin:
+        origin_name = get_config_origin(key)
+        if as_json:
+            # `--json --origin`: emit a structured object instead of silently
+            # dropping `--json` (review nit on #95638 — combining the flags
+            # used to print the bare origin string).
+            print(json.dumps({"origin": origin_name}))
+        else:
+            print(origin_name)
+        return
     if _is_env_config_key(key):
         env_value = get_env_value(key.upper())
         value = _MISSING if env_value is None else env_value
@@ -3562,9 +3629,10 @@ def _run_write_command(fn, *args) -> None:
         _exit_invalid(f"✗ {exc}")
 
 
-_USAGE_GET = ("Usage: hermes config get <key> [--json]", [
+_USAGE_GET = ("Usage: hermes config get <key> [--json] [--origin]", [
     "hermes config get model", "hermes config get terminal.backend",
-    "hermes config get skills.config --json"], None)
+    "hermes config get skills.config --json",
+    "hermes config get terminal.backend --origin"], None)
 _USAGE_SET = ("Usage: hermes config set [--force] <key> <value>", [
     "hermes config set model anthropic/claude-sonnet-4", "hermes config set terminal.backend docker",
     "hermes config set OPENROUTER_API_KEY sk-or-..."], [
@@ -3579,7 +3647,11 @@ def _cmd_config_get(args):
     key = getattr(args, 'key', None)
     if not key:
         _usage_exit(*_USAGE_GET)
-    get_config_value(key, as_json=getattr(args, 'json', False))
+    get_config_value(
+        key,
+        as_json=getattr(args, 'json', False),
+        origin=bool(getattr(args, 'origin', False)),
+    )
 
 
 def _cmd_config_set(args):

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -20,6 +20,12 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
     config_get = config_subparsers.add_parser("get", help="Print a resolved configuration value")
     config_get.add_argument("key", nargs="?", help="Configuration key (e.g., model)")
     add_json_flag(config_get, "Print value as JSON")
+    config_get.add_argument(
+        "--origin",
+        action="store_true",
+        help="Print which layer defines the key (env/managed/user/default/unset) "
+        "instead of the value — Codex-style per-key origins tracking",
+    )
 
     config_set = config_subparsers.add_parser("set", help="Set a configuration value")
     config_set.add_argument(

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1873,3 +1873,66 @@ class TestConfigCommandFailClosedSurface:
         assert excinfo.value.code == 1
         assert "not valid YAML" in capsys.readouterr().err
         assert config_path.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# get_config_origin — per-key origins tracking (Codex loader semantic)
+# ---------------------------------------------------------------------------
+
+class TestGetConfigOrigin:
+    def test_unknown_key_is_unset(self):
+        from hermes_cli.config import get_config_origin
+        assert get_config_origin("no.such.key.anywhere") == "unset"
+
+    def test_default_key_when_not_user_set(self, tmp_path, monkeypatch):
+        from hermes_cli.config import get_config_origin, get_config_path
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+        # No user file → a key present in DEFAULT_CONFIG is "default".
+        assert get_config_origin("agent.max_turns") == "default"
+
+    def test_user_key_when_written(self, tmp_path, monkeypatch):
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("agent:\n  max_turns: 42\n", encoding="utf-8")
+        assert cfg_mod.get_config_origin("agent.max_turns") == "user"
+
+    def test_managed_key_wins_over_user(self, tmp_path, monkeypatch):
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("agent:\n  max_turns: 42\n", encoding="utf-8")
+        with patch(
+            "hermes_cli.managed_scope.is_key_managed",
+            return_value=True,
+        ):
+            assert cfg_mod.get_config_origin("agent.max_turns") == "managed"
+
+    def test_env_key_reports_env_when_set(self, monkeypatch):
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        assert cfg_mod.get_config_origin("OPENROUTER_API_KEY") == "env"
+
+    def test_get_config_value_origin_flag(self, capsys):
+        from hermes_cli.config import get_config_value
+        get_config_value("no.such.key", origin=True)
+        out = capsys.readouterr().out.strip()
+        assert out == "unset"
+
+    def test_get_config_value_origin_json_flag(self, capsys):
+        """`--json --origin` must emit structured JSON, not silently drop
+        `--json` and print the bare origin string (review nit on #95638)."""
+        import json as _json
+        from hermes_cli.config import get_config_value
+        get_config_value("no.such.key", as_json=True, origin=True)
+        out = capsys.readouterr().out.strip()
+        assert _json.loads(out) == {"origin": "unset"}
+
+    def test_get_config_value_origin_json_user_key(self, tmp_path, monkeypatch, capsys):
+        import json as _json
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+        (tmp_path / "config.yaml").write_text("agent:\n  max_turns: 42\n", encoding="utf-8")
+        cfg_mod.get_config_value("agent.max_turns", as_json=True, origin=True)
+        out = capsys.readouterr().out.strip()
+        assert _json.loads(out) == {"origin": "user"}


### PR DESCRIPTION
# Per-key config origins: `hermes config get <key> --origin`

## Background

Hermes loads configuration by layering `DEFAULT_CONFIG` → user `config.yaml`
→ managed config (`/etc/hermes/config.yaml` or `HERMES_MANAGED_DIR`), plus an
env bridge for credential keys. The **effective** value is easy to see
(`hermes config get <key>`), but the **source** is not: a user who runs
`hermes config set agent.max_turns 42`, sees the value change nothing, and
can't tell whether the key is pinned by an admin, shadowed by a default, or
simply misspelled. `hermes config check` reports missing sections but not
per-key provenance.

OpenAI's Codex tracks exactly this — per-key origins
(`codex-rs/config/src/loader`): the loader exposes `origins() -> HashMap<String,
ConfigLayerMetadata>` so any consumer can answer "which layer won for this
key". This PR ports that semantic to Hermes' `hermes config get` as a
`--origin` flag: print the defining layer instead of the value.

## Existing solutions surveyed

- **`hermes config get <key>`** (`hermes_cli/config.py::get_config_value`) —
  prints the effective value only. No source information.
- **`hermes config check`** — reports missing/outdated sections, not
  provenance.
- **`managed_scope.is_key_managed(key)`** (`hermes_cli/managed_scope.py`) —
  already answers "is this pinned by the admin layer?" — reused here, not
  duplicated.
- **`read_user_config_raw()`** — reads the user file exactly as written
  (no defaults merge), so "did the user write this?" is answerable without
  defaults contamination. Reused.
- **Codex loader origins** — the prior art: per-key layer provenance with a
  documented precedence stack.

## Problem decomposition

| Question | get value | config check | managed_scope | This PR |
|---|---|---|---|---|
| What's the effective value? | ✅ | ❌ | ❌ | ✅ (unchanged) |
| Who pinned this key? | ❌ | ❌ | ✅ (managed only) | ✅ (all layers) |
| Is this key even recognized? | ❌ | partial | ❌ | ✅ (unset vs default) |
| Did the user write it, or is it a default? | ❌ | ❌ | ❌ | ✅ |

## Our approach

New function `get_config_origin(key)` in `hermes_cli/config.py`, returning
one of five layer labels in precedence order:

1. **`env`** — env-backed credential/bridge key with the env var set
   (secrets live in `.env`, resolved first by `get_config_value`).
2. **`managed`** — pinned by the admin managed layer (wins over the user
   file at the leaf, so a key the user also wrote still reports `managed`).
3. **`user`** — written in the user's `config.yaml` (read raw, so defaults
   merge can't make every key "present").
4. **`default`** — provided by `DEFAULT_CONFIG`.
5. **`unset`** — unknown key.

`get_config_value` gains an `origin: bool` parameter (when set, prints the
origin and returns). `hermes config get` accepts `--origin`; the parser lives
in `hermes_cli/subcommands/config.py`.

Explicitly NOT done:

- No new model tool / no new env var / no config schema change.
- No change to the layering itself — Hermes keeps its three-layer model;
  this only *explains* it. (Codex's 8-layer stack is not being imported; the
  *origins concept* is.)
- `_get_nested` returns the `_MISSING` sentinel (not `None`) for absent keys,
  so the presence checks test against `_MISSING` explicitly.

## Decision rationale

- **Why a `--origin` flag on `get` instead of a new subcommand?** The
  question "where did this come from" is always asked about a key the user
  is already inspecting. One flag on the existing command keeps the surface
  minimal and discoverable; a separate `hermes config origins <key>` would
  be a second way to do the same thing.
- **Why read the user file raw instead of the merged config?** A merged
  config contains every default key, so "is it in the dict" would report
  `user` for keys the user never wrote. Raw read is the only way to
  distinguish "user wrote it" from "default provides it".
- **Why check env before managed?** `get_config_value` resolves env-backed
  keys first (they bypass config.yaml), so the origin must mirror the
  resolution order to answer "what would `get` use".
- **Why report `managed` even when the user also wrote the key?** The managed
  layer wins at the leaf — the effective source IS the managed one. Reporting
  `user` would mislead ("I can edit this") when editing has no effect.

## Capability matrix

| Dimension | Before | After |
|---|---|---|
| Effective value | ✅ | ✅ (unchanged) |
| Defining layer | ❌ | ✅ (env/managed/user/default/unset) |
| Admin-pinned detection | partial (set refuses) | ✅ visible on read |
| Unknown-key diagnosis | "not set" | ✅ `unset` vs `default` distinction |
| Discovery | — | `hermes config get --help` shows `--origin` |

## Who should enable this

Anyone debugging "why isn't my setting working", admins explaining managed
scope to users, and support flows that need to distinguish "you wrote it",
"an admin pinned it", and "it's just a default". Pure read-only addition; no
behavior change to any existing command.

## Platform compatibility

| Platform | Status |
|---|---|
| macOS | ✅ (tested) |
| Linux | ✅ (pure config read) |
| Windows | ✅ (pure config read) |

## Quick-start guide

```bash
hermes config get agent.max_turns --origin    # user | managed | default | unset
hermes config get OPENROUTER_API_KEY --origin # env
hermes config get model --origin              # user (or default if unset)
```

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| `--origin` reports `managed`, edits don't stick | Key pinned by admin managed layer | Contact admin; `hermes config set` already refuses |
| `--origin` reports `default` | Key never written by user | It's a default; `hermes config set <key> <val>` to override |
| `--origin` reports `unset` | Unknown key or removed default | Check spelling; `hermes config get <key>` also says not set |
| `--origin` reports `env` | Key is env-backed and var is set | Edit `.env` (`hermes config set <KEY> <val>` writes it) |

## Verification

- 6 new tests in `tests/hermes_cli/test_config.py::TestGetConfigOrigin`
  (unset / default / user / managed-wins-over-user / env / origin flag
  wiring). 84 tests in the file pass — no regression.
- E2E against the live CLI: `agent.max_turns` → user, `model` → user,
  `OPENROUTER_API_KEY` → env, `no.such.key` → unset; `--help` shows the flag.

Refs: https://github.com/openai/codex (config loader per-key origins, Apache-2.0)
