### PR TITLE
fix(update): the stale-backend sweep no longer kills SSH-owned backends or respawns foreign-home impostors (#92012 + #94030)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -360,24 +360,27 @@ def _kill_stale_dashboard_processes(
     # When the Hermes Desktop Electron app spawns this dashboard as a
     # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
     # path can skip killing the desktop-managed process.  (#37532)
-    exclude: set[int] | None = None
+    exclude: set[int] = set()
     raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
     if raw_pid:
         # The desktop may manage several backends (one per active profile) and
         # passes them comma-separated; a lone int still parses for back-compat.
-        parsed: set[int] = set()
         for part in raw_pid.split(","):
             part = part.strip()
             if not part:
                 continue
             try:
-                parsed.add(int(part))
+                exclude.add(int(part))
             except (ValueError, TypeError):
                 pass
-        if parsed:
-            exclude = parsed
 
-    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude)
+    # An SSH-owned backend belongs to an attached Desktop client even when the
+    # updater runs from an unrelated remote shell with no Desktop child PID.
+    # Honor the same validated ownership records as the orphan reaper; killing
+    # one permanently strands that client's fixed SSH port-forward.
+    exclude |= _lock_owned_serve_pids()
+
+    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude or None)
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -374,11 +374,12 @@ def _kill_stale_dashboard_processes(
             except (ValueError, TypeError):
                 pass
 
-    # An SSH-owned backend belongs to an attached Desktop client even when the
-    # updater runs from an unrelated remote shell with no Desktop child PID.
-    # Honor the same validated ownership records as the orphan reaper; killing
-    # one permanently strands that client's fixed SSH port-forward.
-    exclude |= _lock_owned_serve_pids()
+    if restart_managed:
+        # An SSH-owned backend belongs to an attached Desktop client even when
+        # the updater runs from an unrelated remote shell with no Desktop child
+        # PID. Honor the same validated ownership records as the orphan reaper;
+        # killing one permanently strands that client's fixed SSH port-forward.
+        exclude |= _lock_owned_serve_pids()
 
     pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude or None)
     if not pids:

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -274,27 +274,60 @@ def _profile_key_for_respawn(
     return "profile:default"
 
 
+def _normalized_home_for_compare(home: str) -> str:
+    """Resolve *home* for install-identity comparison (#94030).
+
+    Same normalization ``_profile_key_for_respawn`` applies to ``home:``
+    keys, so symlinked / differently-spelled roots compare equal.
+    """
+    try:
+        return os.path.normcase(str(Path(home).resolve()))
+    except (OSError, RuntimeError, ValueError):
+        return os.path.normcase(home)
+
+
 def _filter_dashboard_respawn_candidates(
     candidates: list[tuple[int, list[str], str | None]],
+    *,
+    own_home: str | None = None,
 ) -> list[list[str]]:
     """Select which killed manual backends to respawn after ``hermes update``.
 
-    Each candidate is ``(pid, argv, hermes_home)``.
+    Each candidate is ``(pid, argv, hermes_home)``.  *own_home* is the
+    updating install's home; it defaults to this process's
+    ``get_hermes_home()`` and exists as a parameter so tests can pin it.
 
-    Rules (#78821):
+    Rules (#78821, #94030):
     1. Never resurrect Desktop ephemeral ``serve|dashboard --port 0``
        backends — Desktop (``HERMES_DESKTOP_CHILD_PID``) owns their
        lifecycle.  These are also the PPID-1 orphans that previously
        multiplied across updates because ``--port 0`` always binds a
        fresh free port.
-    2. Dedupe by normalized cmdline (identical argv → one respawn).
-    3. Cap at most one managed backend per profile / ``HERMES_HOME``.
+    2. Never replay a backend from a **foreign** ``HERMES_HOME``.  The
+       respawn below is argv-only (no ``env=`` replay), so a foreign
+       backend would come back running on the *updating* install's home
+       and steal the foreign install's fixed port, leaving its own
+       supervisor (launchd/systemd/...) to crash-loop on ``EADDRINUSE``
+       (#94030).  A foreign install's backend is owned by that install's
+       supervisor/user.  An unreadable home (``None``) stays eligible —
+       keep the pre-#94030 behaviour when we cannot tell.
+    3. Dedupe by normalized cmdline (identical argv → one respawn).
+    4. Cap at most one managed backend per profile / ``HERMES_HOME``.
 
     Intentionally does **not** blanket-skip every PPID-1 process: a prior
     ``hermes update`` respawn detaches with ``start_new_session=True``, so
     fixed-port manual backends are reparented to init and must still be
     eligible for the next update's #40449 restart.
     """
+    if own_home is None:
+        try:
+            from hermes_constants import get_hermes_home
+
+            own_home = str(get_hermes_home())
+        except Exception:
+            own_home = ""
+    own_key = _normalized_home_for_compare(own_home) if own_home else ""
+
     selected: list[list[str]] = []
     seen_cmdlines: set[tuple[str, ...]] = set()
     seen_profiles: set[str] = set()
@@ -303,6 +336,8 @@ def _filter_dashboard_respawn_candidates(
         if not argv:
             continue
         if _is_ephemeral_port_zero_backend(argv):
+            continue
+        if own_key and hermes_home and _normalized_home_for_compare(hermes_home) != own_key:
             continue
         norm = _normalize_dashboard_cmdline(argv)
         if norm in seen_cmdlines:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -88,7 +88,7 @@ def _ps_runner(stdout: str):
     return _side_effect
 
 
-def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+def _write_valid_ssh_backend_lock(tmp_path, monkeypatch) -> int:
     pid = 4242
     ownership_id = "a" * 32
     spawn_nonce = "b" * 16
@@ -110,6 +110,11 @@ def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeyp
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    return pid
+
+
+def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+    pid = _write_valid_ssh_backend_lock(tmp_path, monkeypatch)
 
     def assert_owned_pid_is_excluded(*, exclude_pids=None):
         assert exclude_pids is not None
@@ -121,6 +126,25 @@ def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeyp
         side_effect=assert_owned_pid_is_excluded,
     ):
         result = _kill_stale_dashboard_processes(restart_managed=True)
+
+    assert result == {"matched": [], "killed": [], "failed": []}
+
+
+def test_explicit_stop_does_not_spare_backend_owned_by_valid_ssh_lock(
+    tmp_path,
+    monkeypatch,
+):
+    pid = _write_valid_ssh_backend_lock(tmp_path, monkeypatch)
+
+    def assert_owned_pid_is_not_excluded(*, exclude_pids=None):
+        assert exclude_pids is None or pid not in exclude_pids
+        return []
+
+    with patch(
+        "hermes_cli.main._find_stale_dashboard_pids",
+        side_effect=assert_owned_pid_is_not_excluded,
+    ):
+        result = _kill_stale_dashboard_processes(restart_managed=False)
 
     assert result == {"matched": [], "killed": [], "failed": []}
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -14,6 +14,7 @@ History:
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import subprocess
 import sys
@@ -85,6 +86,43 @@ def _ps_runner(stdout: str):
         # Any other subprocess.run (e.g. taskkill) — benign success stub.
         return MagicMock(returncode=0, stdout="", stderr="")
     return _side_effect
+
+
+def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+    pid = 4242
+    ownership_id = "a" * 32
+    spawn_nonce = "b" * 16
+    lock_dir = tmp_path / "desktop-ssh" / ownership_id
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "backend.lock.json").write_text(json.dumps({
+        "schemaVersion": 2,
+        "protocolVersion": 1,
+        "ownershipId": ownership_id,
+        "spawnNonce": spawn_nonce,
+        "tokenFingerprint": "c" * 32,
+        "pid": pid,
+        "port": 46369,
+        "profile": "default",
+        "hermesPath": "/opt/hermes/bin/hermes",
+        "hermesHome": str(tmp_path),
+        "logPath": f"{tmp_path}/desktop-ssh/{ownership_id}/{spawn_nonce}.log",
+        "startedAt": "2026-08-21T15:27:39Z",
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+
+    def assert_owned_pid_is_excluded(*, exclude_pids=None):
+        assert exclude_pids is not None
+        assert pid in exclude_pids
+        return []
+
+    with patch(
+        "hermes_cli.main._find_stale_dashboard_pids",
+        side_effect=assert_owned_pid_is_excluded,
+    ):
+        result = _kill_stale_dashboard_processes(restart_managed=True)
+
+    assert result == {"matched": [], "killed": [], "failed": []}
 
 
 class TestFindStaleDashboardPids:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -633,10 +633,13 @@ class TestFilterDashboardRespawnCandidates:
         home = "/tmp/hermes-home-a"
         a = ["hermes", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, home),
-            (2, b, home),
-        ])
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, home),
+                (2, b, home),
+            ],
+            own_home=home,
+        )
         assert out == [a]
 
     def test_profile_flag_and_profiles_home_share_cap(self):
@@ -656,22 +659,108 @@ class TestFilterDashboardRespawnCandidates:
         a = ["hermes", "--profile", "default", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
         home = "/home/u/.hermes"
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, home),
-            (2, b, home),
-        ])
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, home),
+                (2, b, home),
+            ],
+            own_home=home,
+        )
         assert out == [a]
 
-    def test_distinct_dot_hermes_homes_do_not_share_cap(self):
+    def test_foreign_home_backend_is_not_replayed(self):
+        """A backend from another HERMES_HOME is never respawned (#94030).
+
+        Its supervisor/user owns its lifecycle; an argv-only replay would
+        run on the updating install's home and steal the foreign install's
+        fixed port.  Supersedes the old "distinct homes don't share a cap"
+        pin — a foreign home is no longer replayed at all.
+        """
         from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
 
         a = ["hermes", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, "/home/u/.hermes"),
-            (2, b, "/work/project/.hermes"),
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, "/home/u/.hermes"),
+                (2, b, "/work/project/.hermes"),
+            ],
+            own_home="/home/u/.hermes",
+        )
+        assert out == [a]
+
+    def test_skips_sidecar_fixed_port_serve_on_foreign_home(self):
+        """The reported case: launchd-supervised sidecar serve, fixed port."""
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = [
+            "/Users/u/.hermes-sidecar/hermes-agent/venv/bin/python",
+            "-m", "hermes_cli.main",
+            "serve", "--host", "127.0.0.1", "--port", "9118", "--skip-build",
+        ]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, "/Users/u/.hermes-lifeos")],
+            own_home="/Users/u/.hermes",
+        )
+        assert out == []
+
+    def test_matching_hermes_home_is_kept(self):
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = ["hermes", "serve", "--host", "127.0.0.1", "--port", "9118"]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, "/Users/u/.hermes")],
+            own_home="/Users/u/.hermes",
+        )
+        assert out == [argv]
+
+    def test_symlinked_hermes_home_compares_equal(self, tmp_path):
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        real = tmp_path / "real-home"
+        real.mkdir()
+        link = tmp_path / "linked-home"
+        try:
+            link.symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        argv = ["hermes", "serve", "--port", "9118"]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, str(real))],
+            own_home=str(link),
+        )
+        assert out == [argv]
+
+    def test_unknown_home_stays_eligible(self):
+        """Unreadable HERMES_HOME (env probe failed) keeps pre-#94030 behaviour."""
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = ["hermes", "dashboard", "--port", "8300"]
+        out = _filter_dashboard_respawn_candidates(
+            [(1, argv, None)],
+            own_home="/home/u/.hermes",
+        )
+        assert out == [argv]
+
+    def test_own_home_defaults_to_get_hermes_home(self, monkeypatch):
+        from pathlib import Path
+
+        import hermes_constants
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        monkeypatch.setattr(
+            hermes_constants, "get_hermes_home", lambda: Path("/home/u/.hermes")
+        )
+        argv = ["hermes", "serve", "--port", "9118"]
+        foreign = _filter_dashboard_respawn_candidates([
+            (1, argv, "/Users/u/.hermes-lifeos"),
         ])
-        assert out == [a, b]
+        assert foreign == []
+        own = _filter_dashboard_respawn_candidates([
+            (1, argv, "/home/u/.hermes"),
+        ])
+        assert own == [argv]
 
     def test_keeps_fixed_port_serve(self):
         from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates


### PR DESCRIPTION
## Summary

`hermes update`'s stale-backend sweep now honors the same ownership records its sibling code paths already honor — closing the two remaining kill/respawn holes the #63206 merge's sweep surfaced (#92012, #94030; salvages of #92014 by @fangliquanflq and #94044 by @liuhao1024, all three commits cherry-picked with authorship preserved). Fleet relevance (#91277): both bugs strand remote clients — one kills the Desktop's SSH-owned backend, the other replaces a sidecar install's backend with an impostor on the wrong HERMES_HOME.

## Changes

- **#92012 half** (@fangliquanflq): `_kill_stale_dashboard_processes(restart_managed=True)` — the `hermes update` path — now excludes PIDs claimed by a valid `backend.lock.json` (`_lock_owned_serve_pids()`, the exact guard the orphan reaper already used; the update path simply never called it). The canonical failure was a remote `hermes update` killing the backend an SSH-attached Desktop owned, stranding its port-forward. `--stop` intentionally does NOT spare lock-owned backends — a stop stays a stop.
- **#94030 half** (@liuhao1024): `_filter_dashboard_respawn_candidates()` never replays a backend from a foreign `HERMES_HOME` — the argv-only respawn drops the environment, so a sidecar install's backend came back running on the updating install's home and stole the sidecar's fixed port (supervisor crash-loop on EADDRINUSE, Desktop silently talking to the wrong backend). Foreign installs' supervisors own their lifecycles. Symlinked homes compare equal; unreadable homes stay eligible (pre-fix behavior preserved when we can't tell).

Both compose cleanly with the #63206 serve-collector machinery that merged yesterday (ledger rows respect the same exclusions; the new relaunch rung is install-scoped by construction).

## Validation

| | Result |
|---|---|
| Combined suite | 42 passed, 2 skipped (their 2 + 8 new tests together) |
| A/B (dashboard_procs.py reverted to merge-base, tests kept) | 7 FAILED — both bug shapes proven |
| Sibling suites (serve inventory, lifecycle flags) | 61 passed, 2 skipped |
| Live E2E | real `backend.lock.json` on disk (validator-conformant): honored by the update path, ignored by `--stop`; foreign-home candidate refused for replay, own-home kept — all against real function calls, no mocked ownership records |

**Live repro:** the A/B run fires both bugs on merge-base (update path ignores a real lock; foreign home replayed); at head both guards hold. Note: the live E2E also caught that #92014's own mocked test would pass against an invalid lock — the real validator requires the `/{ownershipId}/{spawnNonce}.log` logPath shape, which the E2E now exercises with a conformant record.

Fixes #92012. Fixes #94030. Credit: @fangliquanflq, @liuhao1024.

## Infographic

![Operation spare the owned](https://v3b.fal.media/files/b/0aa7e65e/ToXSqmUpupvc-iLEXX67F_XpPcgpUq.png)
