### PR TITLE
fix(desktop): Close All stays closed and group tiles stop occluding bot chats (#94137, #89834)

### DIFF
--- a/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
+++ b/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
@@ -7,17 +7,17 @@ let fixture: MockBackendFixture | null = null
 async function openBots(page: MockBackendFixture['page']): Promise<void> {
   const tab = page.getByRole('button', { name: 'Bots', exact: true }).or(page.getByRole('tab', { name: 'Bots', exact: true })).first()
   await tab.click()
-  await expect(page.getByRole('button', { name: 'New agent or group chat' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'New bot or group chat' })).toBeVisible()
 }
 
 async function createAgent(page: MockBackendFixture['page'], name: string, title: string): Promise<void> {
-  await page.getByRole('button', { name: 'New agent or group chat' }).click()
-  await page.getByRole('menuitem', { name: 'New Agent' }).click()
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Bot' }).click()
 
-  const dialog = page.getByRole('dialog', { name: 'New Agent' })
+  const dialog = page.getByRole('dialog', { name: 'New Bot' })
   await dialog.getByPlaceholder('inbox-triage').fill(name)
   await dialog.getByPlaceholder('Inbox Triage').fill(title)
-  await dialog.getByRole('button', { name: 'Create Agent' }).click()
+  await dialog.getByRole('button', { name: 'Create Bot' }).click()
   await expect(dialog).toBeHidden({ timeout: 30_000 })
   await expect(page.getByRole('button', { name: new RegExp(`^${title}\\b`) }).first()).toBeVisible({ timeout: 30_000 })
 }
@@ -40,7 +40,7 @@ test('local bot replaces an open group main workspace', async () => {
   await createAgent(page, 'programmer', 'Programmer')
   await createAgent(page, 'reviewer', 'Reviewer')
 
-  await page.getByRole('button', { name: 'New agent or group chat' }).click()
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
   await page.getByRole('menuitem', { name: 'New Group Chat' }).click()
 
   const dialog = page.getByRole('dialog', { name: 'New Group Chat' })
@@ -50,24 +50,20 @@ test('local bot replaces an open group main workspace', async () => {
   await dialog.getByRole('textbox', { name: 'Group name' }).fill('Programmer, Reviewer')
   await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
 
-  const groupTitle = page.getByText('Programmer, Reviewer — group chat', { exact: true }).filter({ visible: true })
+  const groupTab = page.getByRole('tab', { name: /Programmer, Reviewer Close/ })
   const groupComposer = page.getByRole('textbox', { name: 'Message Programmer, Reviewer' }).filter({ visible: true })
-  await expect(groupTitle).toBeVisible({ timeout: 20_000 })
+  await expect(groupTab).toBeVisible({ timeout: 20_000 })
+  await expect(groupTab).toHaveAttribute('aria-selected', 'true')
   await expect(groupComposer).toBeVisible()
 
   const programmer = page.getByRole('button', { name: /^Programmer\b/ }).filter({ visible: true }).first()
   await programmer.click()
 
-  await expect(groupTitle).toHaveCount(0, { timeout: 20_000 })
+  const botChatTab = page.getByRole('tab', { name: /Bot Chat Close/ }).filter({ visible: true })
+  await expect(botChatTab).toBeVisible({ timeout: 30_000 })
+  await expect(botChatTab).toHaveAttribute('aria-selected', 'true')
+  await expect(groupTab).toHaveCount(0)
   await expect(groupComposer).toHaveCount(0)
-  await expect(page.getByRole('tab', { name: /New session/ }).filter({ visible: true })).toBeVisible()
+  await expect(page.getByText(/Waking up Programmer/i)).toHaveCount(0)
   await expect(page.locator('[data-slot="composer-root"] [contenteditable="true"]').filter({ visible: true }).first()).toBeVisible()
-  await expect
-    .poll(() =>
-      page
-        .getByText('Programmer', { exact: true })
-        .filter({ visible: true })
-        .evaluateAll(nodes => nodes.some(node => node.getBoundingClientRect().left > window.innerWidth * 0.65)),
-    )
-    .toBe(true)
 })

--- a/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
+++ b/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
@@ -1,6 +1,5 @@
-import { expect, test } from './test'
-
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
 
 let fixture: MockBackendFixture | null = null
 
@@ -44,9 +43,11 @@ test('local bot replaces an open group main workspace', async () => {
   await page.getByRole('menuitem', { name: 'New Group Chat' }).click()
 
   const dialog = page.getByRole('dialog', { name: 'New Group Chat' })
+
   for (const title of ['Programmer', 'Reviewer']) {
     await dialog.getByText(title, { exact: true }).locator('xpath=ancestor::label').getByRole('checkbox').click()
   }
+
   await dialog.getByRole('textbox', { name: 'Group name' }).fill('Programmer, Reviewer')
   await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
 

--- a/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
+++ b/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
@@ -1,5 +1,73 @@
-import { test } from '@playwright/test'
+import { expect, test } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+
+let fixture: MockBackendFixture | null = null
+
+async function openBots(page: MockBackendFixture['page']): Promise<void> {
+  const tab = page.getByRole('button', { name: 'Bots', exact: true }).or(page.getByRole('tab', { name: 'Bots', exact: true })).first()
+  await tab.click()
+  await expect(page.getByRole('button', { name: 'New agent or group chat' })).toBeVisible()
+}
+
+async function createAgent(page: MockBackendFixture['page'], name: string, title: string): Promise<void> {
+  await page.getByRole('button', { name: 'New agent or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Agent' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'New Agent' })
+  await dialog.getByPlaceholder('inbox-triage').fill(name)
+  await dialog.getByPlaceholder('Inbox Triage').fill(title)
+  await dialog.getByRole('button', { name: 'Create Agent' }).click()
+  await expect(dialog).toBeHidden({ timeout: 30_000 })
+  await expect(page.getByRole('button', { name: new RegExp(`^${title}\\b`) }).first()).toBeVisible({ timeout: 30_000 })
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
 
 test('local bot replaces an open group main workspace', async () => {
-  throw new Error('RED: real group-to-local-bot Electron interaction is not implemented yet')
+  test.setTimeout(180_000)
+  const page = fixture!.page
+
+  await openBots(page)
+  await createAgent(page, 'programmer', 'Programmer')
+  await createAgent(page, 'reviewer', 'Reviewer')
+
+  await page.getByRole('button', { name: 'New agent or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Group Chat' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'New Group Chat' })
+  for (const title of ['Programmer', 'Reviewer']) {
+    await dialog.getByText(title, { exact: true }).locator('xpath=ancestor::label').getByRole('checkbox').click()
+  }
+  await dialog.getByRole('textbox', { name: 'Group name' }).fill('Programmer, Reviewer')
+  await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
+
+  const groupTitle = page.getByText('Programmer, Reviewer — group chat', { exact: true }).filter({ visible: true })
+  const groupComposer = page.getByRole('textbox', { name: 'Message Programmer, Reviewer' }).filter({ visible: true })
+  await expect(groupTitle).toBeVisible({ timeout: 20_000 })
+  await expect(groupComposer).toBeVisible()
+
+  const programmer = page.getByRole('button', { name: /^Programmer\b/ }).filter({ visible: true }).first()
+  await programmer.click()
+
+  await expect(groupTitle).toHaveCount(0, { timeout: 20_000 })
+  await expect(groupComposer).toHaveCount(0)
+  await expect(page.getByRole('tab', { name: /New session/ }).filter({ visible: true })).toBeVisible()
+  await expect(page.locator('[data-slot="composer-root"] [contenteditable="true"]').filter({ visible: true }).first()).toBeVisible()
+  await expect
+    .poll(() =>
+      page
+        .getByText('Programmer', { exact: true })
+        .filter({ visible: true })
+        .evaluateAll(nodes => nodes.some(node => node.getBoundingClientRect().left > window.innerWidth * 0.65)),
+    )
+    .toBe(true)
 })

--- a/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
+++ b/apps/desktop/e2e/group-to-local-bot-handoff.spec.ts
@@ -1,0 +1,5 @@
+import { test } from '@playwright/test'
+
+test('local bot replaces an open group main workspace', async () => {
+  throw new Error('RED: real group-to-local-bot Electron interaction is not implemented yet')
+})

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -100,6 +100,7 @@ vi.mock('@/store/session-color', () => ({
 }))
 vi.mock('@/store/session-states', () => ({
   $sessionTiles: atom<unknown[]>([]),
+  closeAllOpenSessionTiles: vi.fn(),
   openSessionTile: vi.fn()
 }))
 vi.mock('@/store/windows', () => ({

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,7 +44,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionTiles } from '@/store/session-states'
+import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
 
@@ -415,6 +415,10 @@ function useSessionActions({
                   label: t.zones.closeAll,
                   onSelect: () => {
                     triggerHaptic('selection')
+                    // Persist-close session tiles before dismissing the
+                    // remaining tree panes, or Bot Mode rehydrates them
+                    // from the shared tile bucket (#94137).
+                    closeAllOpenSessionTiles(tabPaneId)
                     closeAllTreeTabs(tabPaneId)
                   }
                 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -30,6 +30,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
+import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
 import { useWindowControlsOverlap } from '../../geometry'
@@ -149,7 +150,12 @@ function ZoneMenu({
         {paneTabCloseItems(kit, {
           counts: treeTabCloseTargets(targetId),
           onClose: paneId !== undefined ? () => closeTabPane(paneId) : undefined,
-          onCloseAll: () => closeAllTreeTabs(targetId),
+          onCloseAll: () => {
+            // Persist-close session tiles first so Bot Mode cannot
+            // rehydrate them from the shared tile bucket (#94137).
+            closeAllOpenSessionTiles(targetId)
+            closeAllTreeTabs(targetId)
+          },
           onCloseOthers: () => closeOtherTreeTabs(targetId),
           onCloseToRight: () => closeTreeTabsToRight(targetId)
         })}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5983,7 +5983,7 @@ async function openRosterBot(bot) {
   saveSelectedRosterBot(bot)
   setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
 
-  $groupChatWorkspace.set(null)
+  dismissGroupChatForLocalBotOpen()
 
   if ($botUnread.get()[key]) {
     const next = { ...$botUnread.get() }
@@ -14034,6 +14034,20 @@ function releaseStaleOpenBotChat(focusedStoredId) {
   if (stale) {
     $openBotChat.set(null)
   }
+}
+
+/** Bot-open handoff: capture the selected group and retire its registered
+ * main tab (or clear the in-panel selection) before async source prep /
+ * canonical open. */
+function dismissGroupChatForLocalBotOpen() {
+  const group = $groupChatWorkspace.get()
+
+  if (!group) {
+    return null
+  }
+
+  closeGroupChatMainTab(group)
+  return group
 }
 
 /** Main-window wrapper: seats the member roster reactively (live roster +

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5756,20 +5756,45 @@ async function findExistingCanonicalChat(owner) {
  *  persistence job is done by the eager session.title write below on modern
  *  gateways; older gateways that reject the eager write keep a narrow
  *  compat kickoff, else the pruner reaps the empty lazy session and the
- *  chat never survives its own creation. */
-function createCanonicalChat(owner, { kickoff = false } = {}) {
+ *  chat never survives its own creation.
+ *
+ *  `openingStillCurrent` (click-path opens): a staleness probe consulted
+ *  before every navigation — when the user has already moved on (opened a
+ *  group, clicked another bot), the create still completes registry-side
+ *  but never steals the workspace (#89834 family). */
+function createCanonicalChat(owner, { kickoff = false, openingStillCurrent = null } = {}) {
   const { bot, name, key, route } = botOwner(owner)
   const inflight = canonicalCreations.get(key)
 
   if (inflight) {
-    return inflight
+    if (!openingStillCurrent) {
+      return inflight.run
+    }
+
+    return inflight.run.then(async sid => {
+      if (sid && openingStillCurrent() && typeof host.openSession === 'function') {
+        await host.openSession(sid, {
+          ...(route ? { route } : {}),
+          profile: name,
+          intent: 'main',
+          keepAllProfilesScope: route ? true : false,
+          workspaceMode: 'bots',
+          workspaceOwnerKey: botWorkspaceOwnerKey(bot),
+          tabTitle: CANONICAL_CHAT_TITLE
+        })
+      }
+      return sid
+    })
   }
+
+  const flight = { run: null }
+  const canNavigate = () => !openingStillCurrent || openingStillCurrent()
 
   const run = (async () => {
     const existing = await findExistingCanonicalChat(owner)
 
     if (existing?.id) {
-      if (typeof host.openSession === 'function') {
+      if (typeof host.openSession === 'function' && canNavigate()) {
         // The exact-lookup gateway reports the compression-lineage tip as
         // resolved_id; open the tip, the registry row stays the identity.
         await openStoredBotChat(owner, existing.resolved_id || existing.id, existing)
@@ -5834,13 +5859,16 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
     // an unmounted session left the intro reply invisible until reopen.
     let opened = false
 
-    if (sid && typeof host.openSession === 'function') {
+    if (sid && typeof host.openSession === 'function' && canNavigate()) {
       try {
         await host.openSession(sid, {
           ...(route ? { route } : {}),
           profile: name,
           intent: 'main',
-          keepAllProfilesScope: route ? true : false
+          keepAllProfilesScope: route ? true : false,
+          ...(openingStillCurrent
+            ? { workspaceMode: 'bots', workspaceOwnerKey: botWorkspaceOwnerKey(bot), tabTitle: CANONICAL_CHAT_TITLE }
+            : {})
         })
         opened = true
       } catch {
@@ -5863,19 +5891,22 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
         try {
           await requestForBot(bot, 'prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
 
-          if (!opened && sid && typeof host.openSession === 'function') {
+          if (!opened && sid && typeof host.openSession === 'function' && canNavigate()) {
             await host.openSession(sid, {
               ...(route ? { route } : {}),
               profile: name,
               intent: 'main',
-              keepAllProfilesScope: route ? true : false
+              keepAllProfilesScope: route ? true : false,
+              ...(openingStillCurrent
+                ? { workspaceMode: 'bots', workspaceOwnerKey: botWorkspaceOwnerKey(bot), tabTitle: CANONICAL_CHAT_TITLE }
+                : {})
             })
           }
         } catch {
           // The chat already exists under the canonical title — the next click
           // finds it by name instead of making a second Bot Chat.
         }
-      } else if (!opened && sid && typeof host.openSession === 'function') {
+      } else if (!opened && sid && typeof host.openSession === 'function' && canNavigate()) {
         // No intro turn: still finish mounting the chat when the first open
         // raced the (now titled) row.
         try {
@@ -5883,7 +5914,10 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
             ...(route ? { route } : {}),
             profile: name,
             intent: 'main',
-            keepAllProfilesScope: route ? true : false
+            keepAllProfilesScope: route ? true : false,
+            ...(openingStillCurrent
+              ? { workspaceMode: 'bots', workspaceOwnerKey: botWorkspaceOwnerKey(bot), tabTitle: CANONICAL_CHAT_TITLE }
+              : {})
           })
         } catch {
           /* row is titled and persistent — the next click opens it by name */
@@ -5892,9 +5926,14 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
     }
 
     return sid || null
-  })().finally(() => canonicalCreations.delete(key))
+  })().finally(() => {
+    if (canonicalCreations.get(key) === flight) {
+      canonicalCreations.delete(key)
+    }
+  })
 
-  canonicalCreations.set(key, run)
+  flight.run = run
+  canonicalCreations.set(key, flight)
 
   return run
 }
@@ -5907,10 +5946,13 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
  *  anywhere in this path — remote bots included. The owner route rides
  *  every RPC (requestForBot) and the open (openStoredBotChat), so a remote
  *  bot's chat opens without re-homing Desktop's chrome. */
-async function openBotCanonicalChat(owner) {
+async function openBotCanonicalChat(owner, openingStillCurrent = null) {
   const existing = await findExistingCanonicalChat(owner)
 
   if (existing?.id && typeof host.openSession === 'function') {
+    if (openingStillCurrent && !openingStillCurrent()) {
+      return null
+    }
     const openedId = existing.resolved_id || existing.id
     await openStoredBotChat(owner, openedId, existing)
     // Both identities matter downstream: the durable registry row names the
@@ -5920,7 +5962,7 @@ async function openBotCanonicalChat(owner) {
     return { registryId: String(existing.id), openedId: String(openedId) }
   }
 
-  const created = await createCanonicalChat(owner)
+  const created = await createCanonicalChat(owner, { openingStillCurrent })
   return created ? { registryId: String(created), openedId: String(created) } : null
 }
 
@@ -5978,12 +6020,39 @@ async function openRosterBot(bot) {
   // has actually fronted a new owner; a failed home open must not steal the
   // center from a group the user was reading.
   const previousGroup = $groupChatWorkspace.get()
+  const previousGroupRef = previousGroup
+    ? { group: previousGroup, roomId: String($groupChats.get()[previousGroup]?.roomId || '') }
+    : null
 
   haptic('tap')
   saveSelectedRosterBot(bot)
   setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
 
-  dismissGroupChatForLocalBotOpen()
+  const dismissedGroup = bot.remoteSource ? null : dismissGroupChatForLocalBotOpen()
+
+  if (!dismissedGroup) {
+    $groupChatWorkspace.set(null)
+  }
+
+  const restorePreviousGroup = () => {
+    if (!previousGroupRef || $groupChatWorkspace.get()) {
+      return
+    }
+
+    const restoreRef = dismissedGroup || previousGroupRef
+    const rooms = $groupChats.get()
+    const currentGroup = restoreRef.roomId
+      ? Object.keys(rooms).find(name => !rooms[name]?.tombstone && String(rooms[name]?.roomId || '') === restoreRef.roomId)
+      : liveGroupChatNames().includes(restoreRef.group)
+        ? restoreRef.group
+        : null
+
+    if (!currentGroup) {
+      return
+    }
+
+    openGroupChat(currentGroup)
+  }
 
   if ($botUnread.get()[key]) {
     const next = { ...$botUnread.get() }
@@ -5998,9 +6067,7 @@ async function openRosterBot(bot) {
   } catch (error) {
     if (generation === botOpenGeneration) {
       $openBotChat.set(null)
-      if (previousGroup && !$groupChatWorkspace.get()) {
-        $groupChatWorkspace.set(previousGroup)
-      }
+      restorePreviousGroup()
       syncBotsHomeWorkspace()
 
       notifyBotOpenFailure(error, bot, `Could not reach ${bot.connectionLabel || 'the gateway'}`)
@@ -6014,7 +6081,7 @@ async function openRosterBot(bot) {
   }
 
   try {
-    const opened = await openBotCanonicalChat(bot)
+    const opened = await openBotCanonicalChat(bot, () => generation === botOpenGeneration)
 
     if (generation !== botOpenGeneration) {
       return false
@@ -6040,9 +6107,7 @@ async function openRosterBot(bot) {
   } catch (error) {
     if (generation === botOpenGeneration) {
       $openBotChat.set(null)
-      if (previousGroup && !$groupChatWorkspace.get()) {
-        $groupChatWorkspace.set(previousGroup)
-      }
+      restorePreviousGroup()
       syncBotsHomeWorkspace()
 
       notifyBotOpenFailure(error, bot, `Could not open ${displayName(bot, meta)}'s chat — try again`)
@@ -6055,9 +6120,7 @@ async function openRosterBot(bot) {
   // do not navigate the current workspace or create a draft on the wrong owner.
   if (typeof host.newChat !== 'function') {
     $openBotChat.set(null)
-    if (previousGroup && !$groupChatWorkspace.get()) {
-      $groupChatWorkspace.set(previousGroup)
-    }
+    restorePreviousGroup()
     syncBotsHomeWorkspace()
     return false
   }
@@ -14046,8 +14109,9 @@ function dismissGroupChatForLocalBotOpen() {
     return null
   }
 
+  const roomId = String($groupChats.get()[group]?.roomId || '')
   closeGroupChatMainTab(group)
-  return group
+  return { group, roomId }
 }
 
 /** Main-window wrapper: seats the member roster reactively (live roster +

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -189,5 +189,5 @@ test('ActiveNowStrip renders above the roster, is a live region, and is click-ac
   const open = source.slice(openStart, openStart + 3200)
 
   assert.match(open, /await prepareBotSource\(bot\)/)
-  assert.match(open, /await openBotCanonicalChat\(bot\)/)
+  assert.match(open, /await openBotCanonicalChat\(bot, \(\) => generation === botOpenGeneration\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
@@ -147,6 +147,7 @@ globalThis.__home = {
   $botChatFocused,
   $botsHomeFronted,
   $groupChatWorkspace,
+  $groupChats,
   $lastRoster,
   $lastSources,
   $openBotChat,
@@ -556,10 +557,11 @@ test('a missing profile-scoped draft API returns to the home without navigating'
   assert.ok(t.botsHomeVisible(), 'the owner home remains the visible recovery surface')
 })
 
-test('a bot chat opens from its canonical name-registry row without closing the prior group tab', async () => {
+test('a local bot chat retires the prior group tab before taking the center', async () => {
   const t = load()
   t.setPluginCtx({ storage: { set: () => undefined } })
   t.$botsPaneVisible.set(true)
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', log: [], watermarks: {}, sessions: {} } })
   t.host.openSession = async () => undefined
   t.host.request = async method => {
     if (method === 'session.list') {
@@ -578,7 +580,7 @@ test('a bot chat opens from its canonical name-registry row without closing the 
 
   assert.equal(result, true)
   assert.equal(t.$groupChatWorkspace.get(), null)
-  assert.equal(groupEntry.disposed, false, 'opening a canonical chat must not close an unrelated group tab')
+  assert.equal(groupEntry.disposed, true, 'the local bot chat must release the group workspace owner')
   assert.equal(t.$openBotChat.get()?.key, 'local::writer')
   assert.equal(t.$openBotChat.get()?.openedRegistryId, 'bot-chat')
 })
@@ -587,6 +589,7 @@ test('a failed canonical-chat open preserves the visible group owner', async () 
   const t = load()
   t.setPluginCtx({ storage: { set: () => undefined } })
   t.$botsPaneVisible.set(true)
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', log: [], watermarks: {}, sessions: {} } })
   t.host.openSession = async () => {
     throw new Error('gateway unavailable')
   }
@@ -604,9 +607,112 @@ test('a failed canonical-chat open preserves the visible group owner', async () 
 
   assert.equal(result, false)
   assert.equal(t.$groupChatWorkspace.get(), 'Launch room')
-  assert.equal(groupEntry.disposed, false, 'a failed transition cannot retire the surface still on screen')
+  assert.equal(groupEntry.disposed, true, 'the stale group tab was retired before the attempted open')
+  const restoredGroup = t.opened.filter(entry => entry.id === 'hermes-bots:group:launch-room').at(-1)
+  assert.notEqual(restoredGroup, groupEntry)
+  assert.equal(restoredGroup.disposed, false, 'a failed transition re-registers the group tab')
   assert.equal(t.$openBotChat.get(), null)
   assert.equal(t.notifications.at(-1).kind, 'error')
+})
+
+test('a failed remote canonical open re-fronts the preserved group tab', async () => {
+  const t = load()
+  t.setPluginCtx({ storage: { set: () => undefined } })
+  t.$botsPaneVisible.set(true)
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', log: [], watermarks: {}, sessions: {} } })
+  t.openGroupChat('Launch room')
+  const groupEntry = t.opened.find(entry => entry.id === 'hermes-bots:group:launch-room')
+  t.host.openSession = async () => {
+    throw new Error('hydration failed after fronting Bot Chat')
+  }
+
+  const result = await t.openRosterBot({
+    connectionId: 'work-vps',
+    connectionLabel: 'Work',
+    name: 'researcher',
+    remoteSource: true
+  })
+
+  assert.equal(result, false)
+  assert.equal(groupEntry.disposed, false, 'remote open preserves the original tab')
+  assert.equal(t.$groupChatWorkspace.get(), 'Launch room')
+  assert.equal(
+    t.opened.filter(entry => entry.id === 'hermes-bots:group:launch-room').length,
+    2,
+    're-opening the same workspace id re-fronts the preserved group tab'
+  )
+})
+
+test('a failed remote open cannot restore a group disbanded while the tab was preserved', async () => {
+  const t = load()
+  t.setPluginCtx({ storage: { set: () => undefined } })
+  t.$botsPaneVisible.set(true)
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', log: [], watermarks: {}, sessions: {} } })
+  t.openGroupChat('Launch room')
+
+  let rejectOpen
+  let markOpenStarted
+  const openStarted = new Promise(resolve => {
+    markOpenStarted = resolve
+  })
+  t.host.openSession = () =>
+    new Promise((resolve, reject) => {
+      rejectOpen = reject
+      markOpenStarted()
+    })
+
+  const opening = t.openRosterBot({
+    connectionId: 'work-vps',
+    connectionLabel: 'Work',
+    name: 'researcher',
+    remoteSource: true
+  })
+  await openStarted
+
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', tombstone: true } })
+  t.closeGroupChatMainTab('Launch room')
+  rejectOpen(new Error('gateway unavailable'))
+
+  assert.equal(await opening, false)
+  assert.equal(t.$groupChatWorkspace.get(), null)
+  assert.equal(t.$openBotChat.get(), null)
+})
+
+test('a failed local open cannot re-register a group tombstoned after retirement', async () => {
+  const t = load()
+  t.setPluginCtx({ storage: { set: () => undefined } })
+  t.$botsPaneVisible.set(true)
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', log: [], watermarks: {}, sessions: {} } })
+  t.host.request = async method => {
+    if (method === 'session.list') {
+      return { sessions: [{ id: 'bot-chat', title: 'Bot Chat', message_count: 4 }] }
+    }
+
+    return {}
+  }
+
+  let rejectOpen
+  let markOpenStarted
+  const openStarted = new Promise(resolve => {
+    markOpenStarted = resolve
+  })
+  t.host.openSession = () =>
+    new Promise((resolve, reject) => {
+      rejectOpen = reject
+      markOpenStarted()
+    })
+
+  t.openGroupChat('Launch room')
+  const opening = t.openRosterBot({ connectionId: 'local', name: 'writer' })
+  await openStarted
+
+  t.$groupChats.set({ 'Launch room': { roomId: 'r-launch', tombstone: true } })
+  rejectOpen(new Error('gateway unavailable'))
+
+  assert.equal(await opening, false)
+  assert.equal(t.$groupChatWorkspace.get(), null)
+  assert.equal(t.opened.filter(entry => entry.id === 'hermes-bots:group:launch-room').length, 1)
+  assert.equal(t.$openBotChat.get(), null)
 })
 
 test('choosing a group prevents a stale canonical-chat open from closing it later', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -131,7 +131,7 @@ test('a superseded roster open may create the canonical row but never navigate i
     }
   })
 
-  assert.equal(await runtime.createCanonicalChat('ops', () => current), 'new-stored')
+  assert.equal(await runtime.createCanonicalChat('ops', { openingStillCurrent: () => current }), 'new-stored')
   assert.deepEqual(opens, [])
 })
 
@@ -156,10 +156,10 @@ test('a newer same-bot open replaces the in-flight creation navigation guard', a
     }
   })
 
-  const first = runtime.createCanonicalChat('ops', () => firstCurrent)
+  const first = runtime.createCanonicalChat('ops', { openingStillCurrent: () => firstCurrent })
   await createStarted
   firstCurrent = false
-  const second = runtime.createCanonicalChat('ops', () => true)
+  const second = runtime.createCanonicalChat('ops', { openingStillCurrent: () => true })
   releaseCreate()
 
   assert.equal(await first, 'shared-stored')

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -14,6 +14,7 @@ function loadCanonicalCreation({ openSession, request }) {
     botOwner: name => (typeof name === 'string'
       ? { bot: { name }, key: name, name, route: null }
       : { bot: name, key: name?.name, name: name?.name, route: name?.route || null }),
+    botWorkspaceOwnerKey: bot => `bot:local::${bot.name}`,
     requestForBot: (_bot, method, params) => context.host.request(method, params),
     window: { setTimeout: callback => callback() }
   }
@@ -114,4 +115,54 @@ test('regression: a failed intro still returns the created registry row', async 
   // The chat exists under the canonical title — the next click finds it by
   // NAME (the registry), so a failed kickoff can never orphan or fork it.
   assert.equal(await runtime.createCanonicalChat('newbie', { kickoff: true }), 'new-bot-chat')
+})
+
+test('a superseded roster open may create the canonical row but never navigate it', async () => {
+  const opens = []
+  let current = true
+  const runtime = loadCanonicalCreation({
+    openSession: async (id, options) => opens.push({ id, options }),
+    request: async method => {
+      if (method === 'session.create') {
+        current = false
+        return { stored_session_id: 'new-stored', session_id: 'new-runtime' }
+      }
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.createCanonicalChat('ops', () => current), 'new-stored')
+  assert.deepEqual(opens, [])
+})
+
+test('a newer same-bot open replaces the in-flight creation navigation guard', async () => {
+  const opens = []
+  let releaseCreate
+  let markCreateStarted
+  let firstCurrent = true
+  const createStarted = new Promise(resolve => {
+    markCreateStarted = resolve
+  })
+  const runtime = loadCanonicalCreation({
+    openSession: async (id, options) => opens.push({ id, options }),
+    request: async method => {
+      if (method === 'session.create') {
+        markCreateStarted()
+        return new Promise(resolve => {
+          releaseCreate = () => resolve({ stored_session_id: 'shared-stored', session_id: 'shared-runtime' })
+        })
+      }
+      return {}
+    }
+  })
+
+  const first = runtime.createCanonicalChat('ops', () => firstCurrent)
+  await createStarted
+  firstCurrent = false
+  const second = runtime.createCanonicalChat('ops', () => true)
+  releaseCreate()
+
+  assert.equal(await first, 'shared-stored')
+  assert.equal(await second, 'shared-stored')
+  assert.equal(opens.length, 1, 'the newer current click owns the shared creation navigation')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-registry.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-registry.test.mjs
@@ -125,10 +125,11 @@ test('the open path never reads or writes a stored pointer', () => {
   assert.doesNotMatch(section, /preferred_session_ids/, 'no id-verification RPC on the canonical path')
 })
 
-test('openBotCanonicalChat takes only the bot owner — identity needs nothing else', () => {
+test('openBotCanonicalChat takes owner identity plus only an optional navigation-freshness guard', () => {
   // The owner is the bot's name (local) or its roster row carrying the
-  // immutable connection route (remote). Still no pins, no session ids.
-  assert.match(source, /async function openBotCanonicalChat\(owner\) \{/)
+  // immutable connection route (remote). The optional callback controls only
+  // whether an async result may still navigate; it carries no identity.
+  assert.match(source, /async function openBotCanonicalChat\(owner, openingStillCurrent = null\) \{/)
 })
 
 // ── 2. no registry row → create ─────────────────────────────────────────────

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
@@ -3,348 +3,147 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import vm from 'node:vm'
 
-// #89834 — opening a local bot while a group owns the main workspace must
-// retire that group's registered main tab (and clear the selection atom)
-// BEFORE any async source prep / canonical open. Remote bots stay put.
-//
-// Behavioral seam (same style as profile-prewarm): render real BotRow /
-// ActiveNow open handlers and assert close-before-open ordering. Source
-// regex is not the load-bearing proof.
-
-const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
-
-function sourceBetween(start, end) {
-  const from = source.indexOf(start)
-  const to = source.indexOf(end, from)
-
-  assert.notEqual(from, -1, `missing ${start}`)
-  assert.notEqual(to, -1, `missing ${end}`)
-
-  return source.slice(from, to)
+// #89834 — local open invokes registered group main-tab closer before canonical open.
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const atom = i => {
+  let v = i
+  return { get: () => v, set: n => { v = typeof n === 'function' ? n(v) : n }, listen: () => () => {} }
 }
-
-// ACTIVE_WINDOW_S through activeBots (includes botActivitySession + workerActiveAt).
-function activeBotsSource() {
-  return sourceBetween('const ACTIVE_WINDOW_S', '// ── bot row ─')
-}
-
-function handoffHelpersSource() {
-  return (
-    sourceBetween('function closeGroupChatMainTab(group) {', '/** Local-bot open handoff:') +
-    sourceBetween('function dismissGroupChatForLocalBotOpen() {', '/** Main-window wrapper:')
-  )
-}
-
-/** Extract `bot => { ... }` assigned to ActiveNowStrip's onOpen in BotsPane. */
-function activeNowOnOpenSource() {
-  const strip = source.indexOf('jsx(ActiveNowStrip, {')
-  assert.ok(strip >= 0, 'ActiveNowStrip mount must remain in BotsPane')
-
-  const key = source.indexOf('onOpen: bot => {', strip)
-  assert.ok(key > strip, 'ActiveNowStrip onOpen handler must remain inline')
-
-  const start = key + 'onOpen: '.length
-  assert.equal(source.slice(start, start + 'bot => {'.length), 'bot => {')
-
-  let i = start + 'bot => {'.length
-  let depth = 1
-
-  while (i < source.length && depth > 0) {
-    const ch = source[i]
-    if (ch === '{') depth += 1
-    else if (ch === '}') depth -= 1
-    i += 1
+const jsx = (t, p = {}) => ({ type: t, props: p })
+const find = (tree, pred) => {
+  if (tree == null || typeof tree !== 'object') return null
+  if (Array.isArray(tree)) {
+    for (const c of tree) { const f = find(c, pred); if (f) return f }
+    return null
   }
-
-  assert.equal(depth, 0, 'ActiveNowStrip onOpen braces must balance')
-  return source.slice(start, i)
+  return pred(tree) ? tree : find(tree.props?.children, pred)
 }
 
-function atom(initial) {
-  let value = initial
-  return {
-    get: () => value,
-    set: next => {
-      value = typeof next === 'function' ? next(value) : next
-    }
-  }
-}
-
-function node(type, props = {}) {
-  return { type, props }
-}
-
-function findButton(tree, predicate = () => true) {
-  const visit = value => {
-    if (value == null || typeof value !== 'object') return null
-    if (Array.isArray(value)) {
-      for (const child of value) {
-        const found = visit(child)
-        if (found) return found
-      }
-      return null
-    }
-    if (value.type === 'button' && predicate(value)) return value
-    return visit(value.props?.children)
-  }
-  return visit(tree)
-}
-
-function loadCallers() {
-  const timeline = []
-  const notifications = []
-  const groupChatMainTabs = new Map()
-  const $groupChatWorkspace = atom(null)
-  const $selectedBot = atom('default')
-  const $botUnread = atom({})
-  const $botMeta = atom({})
-  const $focusedBotProfile = atom('default')
-  const $lastRoster = atom([])
-
-  const prepareSource = sourceBetween('async function prepareBotSource(', 'function displayName(')
-  const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
-  const activeNowSource = sourceBetween(
-    'function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpen }) {',
-    '/** Assign a bot to a group-chat membership'
-  )
-
-  const context = {
-    BotFace: 'BotFace',
-    ContextMenu: 'ContextMenu',
-    ContextMenuContent: 'ContextMenuContent',
-    ContextMenuItem: 'ContextMenuItem',
-    ContextMenuSeparator: 'ContextMenuSeparator',
-    ContextMenuTrigger: 'ContextMenuTrigger',
-    ROSTER_KEY: ['hermes-bots', 'roster'],
-    groupChatMainTabs,
-    $groupChatWorkspace,
-    $selectedBot,
-    $botUnread,
-    $botMeta,
-    $focusedBotProfile,
-    $lastRoster,
-    botAppearance: () => ({ shape: 'round', color: '#000', image: null }),
-    botGroups: () => [],
-    botHandle: value => value,
-    botOpenGeneration: 0,
-    botRosterKey: bot => bot.name,
-    botRosterMeta: (bot, metaByName) => metaByName?.[bot.name] ?? null,
-    cn: (...values) => values.filter(Boolean).join(' '),
-    createCanonicalChat: async () => null,
-    displayName: (bot, _meta) => bot?.title || bot?.name || 'bot',
-    duplicateBot: async () => 'copy',
-    haptic: () => undefined,
-    isBackfilledFacePng: () => false,
-    previewKind: () => ({ fromBot: false, sender: null }),
-    generatedSessionTitle: () => null,
-    openBotCanonicalChat: async (...args) => {
-      timeline.push({ type: 'openBotCanonicalChat', args })
-      return 'stored-chat'
+function load() {
+  const timeline = [], notifications = []
+  const host = {
+    state: {
+      profile: { get: () => 'other', listen: () => {} },
+      gateway: { get: () => 'open', listen: () => {} },
+      connectionId: { get: () => 'local', listen: () => {} }
     },
-    ACTIVE_WINDOW_S: 90,
-    A2A_PREFIX_RE: /^$/,
-    useEffect: () => undefined,
-    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
-    host: {
-      state: { gateway: atom('open'), profile: atom('default') },
-      ensureAgent: async () => undefined,
-      activeConnectionId: () => 'local',
-      warmAgent: () => undefined,
-      warmProfile: () => undefined,
-      request: async () => ({ profiles: [], sessions: [] }),
-      notify: payload => notifications.push(payload),
-      notifyError: () => undefined,
-      newChat: () => timeline.push({ type: 'newChat' }),
-      navigate: () => timeline.push({ type: 'navigate' })
-    },
-    jsx: node,
-    jsxs: node,
-    onEdit: () => undefined,
-    queryClient: { invalidateQueries: () => undefined },
-    relativeTime: () => 'now',
-    saveBotMeta: () => undefined,
-    showsHandle: () => false,
-    stripPreviewMarkdown: text => String(text || ''),
-    useValue: store => store.get(),
-    allMeta: {},
-    timeline,
-    notifications
+    request: async m => m === 'session.create'
+      ? { stored_session_id: 'stored-chat', session_id: 'rt-chat' }
+      : { profiles: [], sessions: [] },
+    notify: p => notifications.push(p),
+    notifyError: () => {}, openSession: async () => {}, ensureAgent: async () => {},
+    activeConnectionId: () => 'local', warmAgent: () => {}, warmProfile: () => {},
+    newChat: () => timeline.push({ type: 'newChat' }),
+    navigate: () => timeline.push({ type: 'navigate' })
   }
-
-  // Bind Map + atoms on the sandbox so helper source closes over the live bindings.
-  context.groupChatMainTabs = groupChatMainTabs
-  context.$groupChatWorkspace = $groupChatWorkspace
-
-  const code = [
-    activeBotsSource(),
-    handoffHelpersSource(),
-    prepareSource,
-    botRowSource,
-    activeNowSource,
-    'const openActiveNow = ' + activeNowOnOpenSource() + ';',
-    'globalThis.__callers = { BotRow, ActiveNowStrip, openActiveNow, dismissGroupChatForLocalBotOpen, closeGroupChatMainTab };'
-  ].join('\n')
-
-  vm.runInNewContext(code, context)
-
-  const registerGroupMainTab = group => {
+  const ui = 'Button Checkbox Codicon ConfirmDialog ContextMenu ContextMenuContent ContextMenuItem ContextMenuSeparator ContextMenuTrigger CopyButton Dialog DialogContent DialogDescription DialogFooter DialogHeader DialogTitle DropdownMenu DropdownMenuContent DropdownMenuItem DropdownMenuTrigger EmptyState GlyphSpinner Input ScrollArea SearchField Select SelectContent SelectItem SelectTrigger SelectValue Switch Textarea Tip'.split(' ')
+  const ctx = {
+    atom, jsx, jsxs: jsx, cn: (...a) => a.filter(Boolean).join(' '), haptic: () => {},
+    useEffect: () => {}, useRef: i => ({ current: typeof i === 'function' ? i() : i }),
+    useState: i => [typeof i === 'function' ? i() : i, () => {}],
+    useValue: s => (s && typeof s.get === 'function' ? s.get() : s),
+    useQuery: () => ({ data: [], isLoading: false, isFetching: false, refetch: () => {} }),
+    ...Object.fromEntries(ui.map(n => [n, n])),
+    PALETTE_AREA: 'palette', COMPOSER_AREAS: { middleware: 'middleware' },
+    profileColor: () => '#000', queryClient: { invalidateQueries: () => {} }, relativeTime: () => 'now',
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => {} } },
+    setTimeout, clearTimeout, console, Date, Math, JSON, Promise, Map, Set, URL, Error,
+    Array, Object, String, Boolean, Number, RegExp, host
+  }
+  const code = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`\nglobalThis.__h={BotRow,ActiveNowStrip,BotsPane,openGroupChat,groupChatMainTabs,$groupChatWorkspace};`)
+  vm.runInNewContext(code, ctx, { filename: 'plugin.js' })
+  // Live binding: handlers resolve this mutable global at call time.
+  ctx.openBotCanonicalChat = async (...a) => { timeline.push({ type: 'openBotCanonicalChat', args: a }); return 'stored-chat' }
+  const api = ctx.__h
+  const registerGroup = group => {
     let closed = 0
-    $groupChatWorkspace.set(group)
-    groupChatMainTabs.set(group, () => {
-      closed += 1
-      timeline.push({ type: 'mainTabClose', group })
-    })
-    return {
-      closed: () => closed,
-      isRegistered: () => groupChatMainTabs.has(group)
-    }
+    ctx.host.openWorkspace = () => () => { closed += 1; timeline.push({ type: 'mainTabClose', group }) }
+    api.openGroupChat(group)
+    assert.equal(api.$groupChatWorkspace.get(), group)
+    assert.ok(api.groupChatMainTabs.has(group))
+    return { closed: () => closed, registered: () => api.groupChatMainTabs.has(group) }
   }
-
-  return {
-    ...context.__callers,
-    $groupChatWorkspace,
-    $selectedBot,
-    groupChatMainTabs,
-    timeline,
-    notifications,
-    registerGroupMainTab,
-    renderBotRow(bot) {
-      const tree = context.__callers.BotRow({ bot, onEdit: () => undefined })
-      const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
-      return row
-    },
-    renderActiveNowChip(bot, { gatewayState = 'open', activeProfile = 'other' } = {}) {
-      // Force the bot into the strip via a fresh last_session inside the window.
-      const rosterBot = {
-        ...bot,
-        last_session: bot.last_session || {
-          id: 'live',
-          last_active: Math.floor(Date.now() / 1000) - 5
-        }
-      }
-      const tree = context.__callers.ActiveNowStrip({
-        roster: [rosterBot],
-        activeProfile,
-        gatewayState,
-        metaByName: {},
-        onOpen: context.__callers.openActiveNow
-      })
-      const chip = findButton(tree, button => String(button.props?.title || '').includes(bot.name) ||
-        String(button.props?.title || '').includes(bot.title || ''))
-      assert.ok(chip, 'Active Now chip must render for the seeded bot')
-      return chip
-    }
+  const botRow = bot => {
+    const tree = api.BotRow({ bot, onEdit: () => {} })
+    const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
+    assert.equal(typeof row.props.onClick, 'function')
+    return row
   }
+  // Real Active Now onOpen from BotsPane (not a hand-copied fragment).
+  const strip = find(api.BotsPane(), n => n?.props && typeof n.props.onOpen === 'function' && 'roster' in n.props)
+  assert.ok(strip, 'BotsPane mounts ActiveNowStrip with onOpen')
+  const onOpen = strip.props.onOpen
+  const activeChip = bot => {
+    const b = { ...bot, last_session: bot.last_session || { id: 'live', last_active: Math.floor(Date.now() / 1000) - 5 } }
+    const tree = api.ActiveNowStrip({ roster: [b], activeProfile: 'other', gatewayState: 'open', metaByName: {}, onOpen })
+    const chip = find(tree, n => n.type === 'button' && /Open /.test(String(n.props?.title || ''))
+      && (String(n.props.title).includes(bot.name) || String(n.props.title).includes(bot.title || '')))
+    assert.ok(chip, 'Active Now chip renders')
+    return chip
+  }
+  return { api, timeline, notifications, registerGroup, botRow, activeChip }
 }
 
-test('BotRow local open closes the group main tab before canonical open', async () => {
-  const runtime = loadCallers()
-  const tab = runtime.registerGroupMainTab('Core')
-  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
+const drain = async () => { await new Promise(r => setImmediate(r)); await new Promise(r => setImmediate(r)) }
+const assertCloseBeforeOpen = tl => {
+  const c = tl.findIndex(e => e.type === 'mainTabClose'), o = tl.findIndex(e => e.type === 'openBotCanonicalChat')
+  assert.ok(c >= 0, 'registered main-tab closer must run')
+  assert.ok(o >= 0, 'local open must reach canonical chat')
+  assert.ok(c < o, 'close must precede canonical open')
+}
+const remote = { name: 'research', title: 'Research', remoteSource: true, sourceScoped: true, connectionId: 'work', connectionLabel: 'Work' }
 
-  await row.props.onClick()
-
+test('BotRow local open closes group main tab before canonical open', async () => {
+  const r = load(), tab = r.registerGroup('Core')
+  await r.botRow({ name: 'alpha', title: 'Alpha' }).props.onClick()
   assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
-  assert.equal(runtime.$groupChatWorkspace.get(), null, 'group selection atom must clear')
-  assert.equal(tab.isRegistered(), false, 'closer entry must be retired')
-  assert.ok(
-    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
-    'local open must proceed to canonical chat'
-  )
-
-  const closeAt = runtime.timeline.findIndex(entry => entry.type === 'mainTabClose')
-  const openAt = runtime.timeline.findIndex(entry => entry.type === 'openBotCanonicalChat')
-  assert.ok(closeAt >= 0 && openAt >= 0 && closeAt < openAt, 'close must precede canonical open')
+  assert.equal(r.api.$groupChatWorkspace.get(), null)
+  assert.equal(tab.registered(), false)
+  assertCloseBeforeOpen(r.timeline)
 })
 
-test('BotRow remote open leaves the group main tab open', async () => {
-  const runtime = loadCallers()
-  const tab = runtime.registerGroupMainTab('Core')
-  const row = runtime.renderBotRow({
-    name: 'research',
-    title: 'Research',
-    remoteSource: true,
-    sourceScoped: true,
-    connectionId: 'work',
-    connectionLabel: 'Work'
-  })
-
-  await row.props.onClick()
-
+test('BotRow remote open does not dismiss group main tab', async () => {
+  const r = load(), tab = r.registerGroup('Core')
+  await r.botRow(remote).props.onClick()
   assert.equal(tab.closed(), 0, 'remote open must not dismiss the group tab')
-  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
-  assert.equal(tab.isRegistered(), true)
-  assert.equal(
-    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
-    false,
-    'remote open must not hop into a canonical chat'
-  )
-  assert.ok(runtime.notifications.some(n => /Stay in this chat/.test(n.message || '')))
+  assert.equal(r.api.$groupChatWorkspace.get(), 'Core')
+  assert.equal(tab.registered(), true)
+  assert.equal(r.timeline.some(e => e.type === 'openBotCanonicalChat'), false)
+  assert.ok(r.notifications.some(n => /Stay in this chat/.test(n.message || '')))
 })
 
-test('Active Now local open closes the group main tab before canonical open', async () => {
-  const runtime = loadCallers()
-  const tab = runtime.registerGroupMainTab('Ops')
-  const chip = runtime.renderActiveNowChip({ name: 'alpha', title: 'Alpha' })
-
-  await chip.props.onClick()
-  // Active Now fires canonical open inside an async IIFE — drain microtasks.
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
-
+test('Active Now local open closes group main tab before canonical open', async () => {
+  const r = load(), tab = r.registerGroup('Ops')
+  await r.activeChip({ name: 'alpha', title: 'Alpha' }).props.onClick()
+  await drain()
   assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
-  assert.equal(tab.isRegistered(), false)
-  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
-
-  const closeAt = runtime.timeline.findIndex(entry => entry.type === 'mainTabClose')
-  const openAt = runtime.timeline.findIndex(entry => entry.type === 'openBotCanonicalChat')
-  assert.ok(closeAt >= 0 && openAt >= 0 && closeAt < openAt, 'close must precede canonical open')
+  assert.equal(r.api.$groupChatWorkspace.get(), null)
+  assert.equal(tab.registered(), false)
+  assertCloseBeforeOpen(r.timeline)
 })
 
-test('Active Now remote open leaves the group main tab open', async () => {
-  const runtime = loadCallers()
-  const tab = runtime.registerGroupMainTab('Ops')
-  const chip = runtime.renderActiveNowChip({
-    name: 'research',
-    title: 'Research',
-    remoteSource: true,
-    sourceScoped: true,
-    connectionId: 'work',
-    connectionLabel: 'Work'
-  })
-
-  await chip.props.onClick()
-  await new Promise(resolve => setImmediate(resolve))
-
-  assert.equal(tab.closed(), 0)
-  assert.equal(runtime.$groupChatWorkspace.get(), 'Ops')
-  assert.equal(tab.isRegistered(), true)
-  assert.equal(
-    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
-    false
-  )
-  assert.ok(runtime.notifications.some(n => /Stay in this chat/.test(n.message || '')))
+test('Active Now remote open does not dismiss group main tab', async () => {
+  const r = load(), tab = r.registerGroup('Ops')
+  await r.activeChip(remote).props.onClick(); await drain()
+  assert.equal(tab.closed(), 0, 'remote open must not dismiss the group tab')
+  assert.equal(r.api.$groupChatWorkspace.get(), 'Ops')
+  assert.equal(tab.registered(), true)
 })
 
-test('local BotRow open with no main-tab registration still clears in-panel selection', async () => {
-  const runtime = loadCallers()
-  runtime.$groupChatWorkspace.set('Legacy')
-  assert.equal(runtime.groupChatMainTabs.has('Legacy'), false)
-
-  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
-  await row.props.onClick()
-
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
-  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
-})
-
-test('local BotRow open with no group selected is safe and still opens chat', async () => {
-  const runtime = loadCallers()
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
-
-  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
-  await assert.doesNotReject(async () => row.props.onClick())
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
-  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
+test('no group / old-host: local open is safe and still opens chat', async () => {
+  const r = load()
+  assert.equal(r.api.$groupChatWorkspace.get(), null)
+  await assert.doesNotReject(() => r.botRow({ name: 'alpha', title: 'Alpha' }).props.onClick())
+  assert.ok(r.timeline.some(e => e.type === 'openBotCanonicalChat'))
+  r.api.$groupChatWorkspace.set('Legacy')
+  assert.equal(r.api.groupChatMainTabs.has('Legacy'), false)
+  await r.botRow({ name: 'beta', title: 'Beta' }).props.onClick()
+  assert.equal(r.api.$groupChatWorkspace.get(), null)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
@@ -3,47 +3,43 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import vm from 'node:vm'
 
-// #89834 — local open invokes registered group main-tab closer before canonical open.
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
-const atom = i => {
-  let v = i
-  return { get: () => v, set: n => { v = typeof n === 'function' ? n(v) : n }, listen: () => () => {} }
+const atom = initial => {
+  let value = initial
+  return { get: () => value, set: next => { value = typeof next === 'function' ? next(value) : next }, listen: () => () => {} }
 }
-const jsx = (t, p = {}) => ({ type: t, props: p })
-const find = (tree, pred) => {
+const jsx = (type, props = {}) => ({ type, props })
+const find = (tree, predicate) => {
   if (tree == null || typeof tree !== 'object') return null
   if (Array.isArray(tree)) {
-    for (const c of tree) { const f = find(c, pred); if (f) return f }
+    for (const child of tree) { const match = find(child, predicate); if (match) return match }
     return null
   }
-  return pred(tree) ? tree : find(tree.props?.children, pred)
+  return predicate(tree) ? tree : find(tree.props?.children, predicate)
 }
 
-function load() {
-  const timeline = [], notifications = []
+function load({ rejectOpen = false, rejectPrepare = false } = {}) {
+  const timeline = []
   const host = {
     state: {
-      profile: { get: () => 'other', listen: () => {} },
+      profile: { get: () => 'default', listen: () => {} },
       gateway: { get: () => 'open', listen: () => {} },
       connectionId: { get: () => 'local', listen: () => {} }
     },
-    request: async m => m === 'session.create'
-      ? { stored_session_id: 'stored-chat', session_id: 'rt-chat' }
-      : { profiles: [], sessions: [] },
-    notify: p => notifications.push(p),
-    notifyError: () => {}, openSession: async () => {}, ensureAgent: async () => {},
+    request: async () => ({ profiles: [], sessions: [] }),
+    notify: () => {}, notifyError: error => timeline.push({ type: 'error', error }),
+    openSession: async () => {}, ensureAgent: async () => {}, requestProfile: async () => ({}),
     activeConnectionId: () => 'local', warmAgent: () => {}, warmProfile: () => {},
-    newChat: () => timeline.push({ type: 'newChat' }),
-    navigate: () => timeline.push({ type: 'navigate' })
+    newChat: () => timeline.push({ type: 'newChat' }), navigate: () => {}
   }
   const ui = 'Button Checkbox Codicon ConfirmDialog ContextMenu ContextMenuContent ContextMenuItem ContextMenuSeparator ContextMenuTrigger CopyButton Dialog DialogContent DialogDescription DialogFooter DialogHeader DialogTitle DropdownMenu DropdownMenuContent DropdownMenuItem DropdownMenuTrigger EmptyState GlyphSpinner Input ScrollArea SearchField Select SelectContent SelectItem SelectTrigger SelectValue Switch Textarea Tip'.split(' ')
-  const ctx = {
-    atom, jsx, jsxs: jsx, cn: (...a) => a.filter(Boolean).join(' '), haptic: () => {},
-    useEffect: () => {}, useRef: i => ({ current: typeof i === 'function' ? i() : i }),
-    useState: i => [typeof i === 'function' ? i() : i, () => {}],
-    useValue: s => (s && typeof s.get === 'function' ? s.get() : s),
+  const context = {
+    atom, jsx, jsxs: jsx, cn: (...values) => values.filter(Boolean).join(' '), haptic: () => {},
+    useEffect: () => {}, useMemo: fn => fn(), useRef: value => ({ current: typeof value === 'function' ? value() : value }),
+    useState: value => [typeof value === 'function' ? value() : value, () => {}],
+    useValue: store => store?.get ? store.get() : store,
     useQuery: () => ({ data: [], isLoading: false, isFetching: false, refetch: () => {} }),
-    ...Object.fromEntries(ui.map(n => [n, n])),
+    ...Object.fromEntries(ui.map(name => [name, name])),
     PALETTE_AREA: 'palette', COMPOSER_AREAS: { middleware: 'middleware' },
     profileColor: () => '#000', queryClient: { invalidateQueries: () => {} }, relativeTime: () => 'now',
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => {} } },
@@ -57,93 +53,68 @@ function load() {
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat(`\nglobalThis.__h={BotRow,ActiveNowStrip,BotsPane,openGroupChat,groupChatMainTabs,$groupChatWorkspace};`)
-  vm.runInNewContext(code, ctx, { filename: 'plugin.js' })
-  // Live binding: handlers resolve this mutable global at call time.
-  ctx.openBotCanonicalChat = async (...a) => { timeline.push({ type: 'openBotCanonicalChat', args: a }); return 'stored-chat' }
-  const api = ctx.__h
+    .concat('\nglobalThis.__h={BotRow,BotsPane,openRosterBot,openGroupChat,groupChatMainTabs,$groupChatWorkspace,$groupChats};')
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+  context.openBotCanonicalChat = async bot => {
+    timeline.push({ type: 'canonicalOpen', bot })
+    if (rejectOpen) throw new Error('canonical open failed')
+    return { registryId: 'stored-chat', openedId: 'stored-chat' }
+  }
+  if (rejectPrepare) context.prepareBotSource = async () => { throw new Error('source preparation failed') }
+  const api = context.__h
   const registerGroup = group => {
-    let closed = 0
-    ctx.host.openWorkspace = () => () => { closed += 1; timeline.push({ type: 'mainTabClose', group }) }
+    api.$groupChats.set({ ...api.$groupChats.get(), [group]: { log: [], watermarks: {}, sessions: {}, stranded: {} } })
+    host.openWorkspace = id => () => timeline.push({ type: 'workspaceClose', id })
     api.openGroupChat(group)
-    assert.equal(api.$groupChatWorkspace.get(), group)
-    assert.ok(api.groupChatMainTabs.has(group))
-    return { closed: () => closed, registered: () => api.groupChatMainTabs.has(group) }
+    return { closed: () => timeline.filter(event => event.type === 'workspaceClose' && event.id.includes(':group:')).length }
   }
   const botRow = bot => {
     const tree = api.BotRow({ bot, onEdit: () => {} })
-    const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
-    assert.equal(typeof row.props.onClick, 'function')
-    return row
+    return tree.type === 'button' ? tree : tree.props.children[0].props.children
   }
-  // Real Active Now onOpen from BotsPane (not a hand-copied fragment).
-  const strip = find(api.BotsPane(), n => n?.props && typeof n.props.onOpen === 'function' && 'roster' in n.props)
-  assert.ok(strip, 'BotsPane mounts ActiveNowStrip with onOpen')
-  const onOpen = strip.props.onOpen
-  const activeChip = bot => {
-    const b = { ...bot, last_session: bot.last_session || { id: 'live', last_active: Math.floor(Date.now() / 1000) - 5 } }
-    const tree = api.ActiveNowStrip({ roster: [b], activeProfile: 'other', gatewayState: 'open', metaByName: {}, onOpen })
-    const chip = find(tree, n => n.type === 'button' && /Open /.test(String(n.props?.title || ''))
-      && (String(n.props.title).includes(bot.name) || String(n.props.title).includes(bot.title || '')))
-    assert.ok(chip, 'Active Now chip renders')
-    return chip
-  }
-  return { api, timeline, notifications, registerGroup, botRow, activeChip }
+  const activeOnOpen = find(api.BotsPane(), node => node?.props && typeof node.props.onOpen === 'function' && 'roster' in node.props).props.onOpen
+  return { api, timeline, registerGroup, botRow, activeOnOpen }
 }
 
-const drain = async () => { await new Promise(r => setImmediate(r)); await new Promise(r => setImmediate(r)) }
-const assertCloseBeforeOpen = tl => {
-  const c = tl.findIndex(e => e.type === 'mainTabClose'), o = tl.findIndex(e => e.type === 'openBotCanonicalChat')
-  assert.ok(c >= 0, 'registered main-tab closer must run')
-  assert.ok(o >= 0, 'local open must reach canonical chat')
-  assert.ok(c < o, 'close must precede canonical open')
+const drain = async () => { await new Promise(resolve => setImmediate(resolve)); await new Promise(resolve => setImmediate(resolve)) }
+const bot = { name: 'alpha', title: 'Alpha' }
+const assertCloseBeforeOpen = runtime => {
+  const closed = runtime.timeline.findIndex(event => event.type === 'workspaceClose' && event.id.includes(':group:'))
+  const opened = runtime.timeline.findIndex(event => event.type === 'canonicalOpen')
+  assert.ok(closed >= 0 && opened >= 0 && closed < opened)
 }
-const remote = { name: 'research', title: 'Research', remoteSource: true, sourceScoped: true, connectionId: 'work', connectionLabel: 'Work' }
 
-test('BotRow local open closes group main tab before canonical open', async () => {
-  const r = load(), tab = r.registerGroup('Core')
-  await r.botRow({ name: 'alpha', title: 'Alpha' }).props.onClick()
-  assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
-  assert.equal(r.api.$groupChatWorkspace.get(), null)
-  assert.equal(tab.registered(), false)
-  assertCloseBeforeOpen(r.timeline)
+test('central owner open closes the registered group tab before canonical open', async () => {
+  const runtime = load(), tab = runtime.registerGroup('Core')
+  assert.equal(await runtime.api.openRosterBot(bot), true)
+  assert.equal(tab.closed(), 1)
+  assert.equal(runtime.api.groupChatMainTabs.has('Core'), false)
+  assertCloseBeforeOpen(runtime)
 })
 
-test('BotRow remote open does not dismiss group main tab', async () => {
-  const r = load(), tab = r.registerGroup('Core')
-  await r.botRow(remote).props.onClick()
-  assert.equal(tab.closed(), 0, 'remote open must not dismiss the group tab')
-  assert.equal(r.api.$groupChatWorkspace.get(), 'Core')
-  assert.equal(tab.registered(), true)
-  assert.equal(r.timeline.some(e => e.type === 'openBotCanonicalChat'), false)
-  assert.ok(r.notifications.some(n => /Stay in this chat/.test(n.message || '')))
+test('BotRow and Active Now both delegate through the central owner open', async () => {
+  for (const invoke of [runtime => runtime.botRow(bot).props.onClick(), runtime => runtime.activeOnOpen(bot)]) {
+    const runtime = load(); runtime.registerGroup('Core'); invoke(runtime); await drain(); assertCloseBeforeOpen(runtime)
+  }
 })
 
-test('Active Now local open closes group main tab before canonical open', async () => {
-  const r = load(), tab = r.registerGroup('Ops')
-  await r.activeChip({ name: 'alpha', title: 'Alpha' }).props.onClick()
-  await drain()
-  assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
-  assert.equal(r.api.$groupChatWorkspace.get(), null)
-  assert.equal(tab.registered(), false)
-  assertCloseBeforeOpen(r.timeline)
+test('failed canonical open restores the group fallback and surfaces an error', async () => {
+  const runtime = load({ rejectOpen: true }), tab = runtime.registerGroup('Core')
+  assert.equal(await runtime.api.openRosterBot(bot), false)
+  assert.equal(tab.closed(), 1)
+  assert.equal(runtime.api.$groupChatWorkspace.get(), 'Core')
+  assert.equal(runtime.api.groupChatMainTabs.has('Core'), true)
+  assert.ok(runtime.timeline.some(event => event.type === 'error'))
 })
 
-test('Active Now remote open does not dismiss group main tab', async () => {
-  const r = load(), tab = r.registerGroup('Ops')
-  await r.activeChip(remote).props.onClick(); await drain()
-  assert.equal(tab.closed(), 0, 'remote open must not dismiss the group tab')
-  assert.equal(r.api.$groupChatWorkspace.get(), 'Ops')
-  assert.equal(tab.registered(), true)
+test('failed source preparation restores the group fallback', async () => {
+  const runtime = load({ rejectPrepare: true }); runtime.registerGroup('Core')
+  assert.equal(await runtime.api.openRosterBot({ ...bot, sourceScoped: true, connectionId: 'local' }), false)
+  assert.equal(runtime.api.$groupChatWorkspace.get(), 'Core')
 })
 
-test('no group / old-host: local open is safe and still opens chat', async () => {
-  const r = load()
-  assert.equal(r.api.$groupChatWorkspace.get(), null)
-  await assert.doesNotReject(() => r.botRow({ name: 'alpha', title: 'Alpha' }).props.onClick())
-  assert.ok(r.timeline.some(e => e.type === 'openBotCanonicalChat'))
-  r.api.$groupChatWorkspace.set('Legacy')
-  assert.equal(r.api.groupChatMainTabs.has('Legacy'), false)
-  await r.botRow({ name: 'beta', title: 'Beta' }).props.onClick()
-  assert.equal(r.api.$groupChatWorkspace.get(), null)
+test('owner open with no selected group is safe', async () => {
+  const runtime = load()
+  assert.equal(await runtime.api.openRosterBot(bot), true)
+  assert.equal(runtime.timeline.some(event => event.type === 'workspaceClose' && event.id.includes(':group:')), false)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #89834 — opening a local bot while a group owns the main workspace must
+// retire that group's registered main tab (and clear the selection atom)
+// BEFORE any async source prep / canonical open. Remote bots stay put.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, typeof value === 'function' ? value(values.get(slot)) : value)
+    }
+    values.set(slot, initial)
+    return slot
+  }
+
+  const timeline = []
+  const context = {
+    atom,
+    setTimeout: fn => {
+      fn()
+      return 0
+    },
+    clearTimeout: () => undefined,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: {
+      getElementById: () => null,
+      createElement: () => ({}),
+      head: { appendChild: () => undefined }
+    },
+    host: {
+      request: async () => ({}),
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      },
+      notify: payload => timeline.push({ type: 'notify', payload }),
+      notifyError: () => undefined,
+      openSession: async id => {
+        timeline.push({ type: 'openSession', id })
+      },
+      openWorkspace: undefined
+    }
+  }
+
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__handoff = {\n' +
+        '  openGroupChat,\n' +
+        '  closeGroupChatMainTab,\n' +
+        '  dismissGroupChatForLocalBotOpen,\n' +
+        '  $groupChatWorkspace,\n' +
+        '  $selectedBot,\n' +
+        '  groupChatMainTabs\n' +
+        '};\n'
+    )
+
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  context.plugin.register({
+    storage: { get: () => null, set: () => undefined },
+    register: () => undefined
+  })
+
+  return { ...context.__handoff, host: context.host, timeline }
+}
+
+test('local handoff closes the registered group main tab before any canonical open', () => {
+  const runtime = load()
+  let closed = 0
+
+  runtime.host.openWorkspace = () => {
+    timelineCloseHook()
+    return () => {
+      closed += 1
+      runtime.timeline.push({ type: 'mainTabClose' })
+    }
+  }
+
+  // openWorkspace's closer is what host.openWorkspace returns; capture via openGroupChat.
+  function timelineCloseHook() {
+    /* placeholder so openWorkspace is feature-detected */
+  }
+
+  runtime.openGroupChat('Core')
+  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
+  assert.equal(typeof runtime.groupChatMainTabs.get('Core'), 'function')
+
+  // Shared boundary used by BotRow + Active Now for local bots only.
+  runtime.dismissGroupChatForLocalBotOpen()
+
+  assert.equal(closed, 1, 'registered main-tab closer must run')
+  assert.equal(runtime.$groupChatWorkspace.get(), null, 'group selection atom must clear')
+  assert.equal(runtime.groupChatMainTabs.has('Core'), false, 'closer entry must be retired')
+  assert.equal(
+    runtime.timeline.some(entry => entry.type === 'openSession'),
+    false,
+    'handoff itself must not open a canonical chat'
+  )
+})
+
+test('remote bots do not dismiss the selected group workspace', () => {
+  const runtime = load()
+  let closed = 0
+
+  runtime.host.openWorkspace = () => () => {
+    closed += 1
+  }
+
+  runtime.openGroupChat('Core')
+  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
+
+  // Remote path must leave the group tab alone (stay-and-@).
+  // The shared dismiss helper is local-only; callers skip it for remoteSource.
+  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
+  assert.equal(closed, 0)
+  assert.equal(runtime.groupChatMainTabs.has('Core'), true)
+})
+
+test('local handoff with no main-tab registration still clears in-panel selection safely', () => {
+  const runtime = load()
+  // Older host: no openWorkspace → openGroupChat only sets the selection atom.
+  runtime.openGroupChat('Ops')
+  assert.equal(runtime.$groupChatWorkspace.get(), 'Ops')
+  assert.equal(runtime.groupChatMainTabs.has('Ops'), false)
+
+  runtime.dismissGroupChatForLocalBotOpen()
+
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
+})
+
+test('local handoff with no group selected is a no-op', () => {
+  const runtime = load()
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
+
+  assert.doesNotThrow(() => runtime.dismissGroupChatForLocalBotOpen())
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
+})
+
+test('BotRow and Active Now both route local opens through the shared handoff', () => {
+  // Structural guard so the two call sites cannot drift apart again.
+  assert.match(pluginSource, /function dismissGroupChatForLocalBotOpen\s*\(/)
+  assert.match(
+    pluginSource,
+    /dismissGroupChatForLocalBotOpen\s*\(\s*\)[\s\S]*?openBotCanonicalChat/
+  )
+
+  const botRowOpen = pluginSource.slice(
+    pluginSource.indexOf('function BotRow('),
+    pluginSource.indexOf('function ActiveNowStrip(')
+  )
+  const activeNowOpen = pluginSource.slice(
+    pluginSource.indexOf('jsx(ActiveNowStrip,'),
+    pluginSource.indexOf('jsx(ActiveNowStrip,') + 2500
+  )
+
+  assert.match(botRowOpen, /dismissGroupChatForLocalBotOpen\s*\(/)
+  assert.match(activeNowOpen, /dismissGroupChatForLocalBotOpen\s*\(/)
+  // Remote path must not call the dismiss helper before the remote early-return.
+  assert.match(botRowOpen, /if\s*\(\s*bot\.remoteSource\s*\)/)
+  assert.match(activeNowOpen, /if\s*\(\s*bot\.remoteSource\s*\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-to-local-bot-handoff.test.mjs
@@ -6,169 +6,345 @@ import vm from 'node:vm'
 // #89834 — opening a local bot while a group owns the main workspace must
 // retire that group's registered main tab (and clear the selection atom)
 // BEFORE any async source prep / canonical open. Remote bots stay put.
+//
+// Behavioral seam (same style as profile-prewarm): render real BotRow /
+// ActiveNow open handlers and assert close-before-open ordering. Source
+// regex is not the load-bearing proof.
 
-const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function load() {
-  const values = new Map()
-  const atom = initial => {
-    const slot = {
-      get: () => values.get(slot),
-      set: value => values.set(slot, typeof value === 'function' ? value(values.get(slot)) : value)
-    }
-    values.set(slot, initial)
-    return slot
-  }
+function sourceBetween(start, end) {
+  const from = source.indexOf(start)
+  const to = source.indexOf(end, from)
 
-  const timeline = []
-  const context = {
-    atom,
-    setTimeout: fn => {
-      fn()
-      return 0
-    },
-    clearTimeout: () => undefined,
-    PALETTE_AREA: 'palette',
-    COMPOSER_AREAS: { middleware: 'middleware' },
-    document: {
-      getElementById: () => null,
-      createElement: () => ({}),
-      head: { appendChild: () => undefined }
-    },
-    host: {
-      request: async () => ({}),
-      state: {
-        profile: { get: () => 'default', listen: () => undefined },
-        gateway: { listen: () => undefined }
-      },
-      notify: payload => timeline.push({ type: 'notify', payload }),
-      notifyError: () => undefined,
-      openSession: async id => {
-        timeline.push({ type: 'openSession', id })
-      },
-      openWorkspace: undefined
-    }
-  }
+  assert.notEqual(from, -1, `missing ${start}`)
+  assert.notEqual(to, -1, `missing ${end}`)
 
-  const source = pluginSource
-    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
-    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
-    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
-    .replace(/^import .* from 'react'\r?\n/m, '')
-    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
-    .replace('export default {', 'globalThis.plugin = {')
-    .concat(
-      '\nglobalThis.__handoff = {\n' +
-        '  openGroupChat,\n' +
-        '  closeGroupChatMainTab,\n' +
-        '  dismissGroupChatForLocalBotOpen,\n' +
-        '  $groupChatWorkspace,\n' +
-        '  $selectedBot,\n' +
-        '  groupChatMainTabs\n' +
-        '};\n'
-    )
-
-  vm.runInNewContext(source, context, { filename: 'plugin.js' })
-  context.plugin.register({
-    storage: { get: () => null, set: () => undefined },
-    register: () => undefined
-  })
-
-  return { ...context.__handoff, host: context.host, timeline }
+  return source.slice(from, to)
 }
 
-test('local handoff closes the registered group main tab before any canonical open', () => {
-  const runtime = load()
-  let closed = 0
+// ACTIVE_WINDOW_S through activeBots (includes botActivitySession + workerActiveAt).
+function activeBotsSource() {
+  return sourceBetween('const ACTIVE_WINDOW_S', '// ── bot row ─')
+}
 
-  runtime.host.openWorkspace = () => {
-    timelineCloseHook()
-    return () => {
+function handoffHelpersSource() {
+  return (
+    sourceBetween('function closeGroupChatMainTab(group) {', '/** Local-bot open handoff:') +
+    sourceBetween('function dismissGroupChatForLocalBotOpen() {', '/** Main-window wrapper:')
+  )
+}
+
+/** Extract `bot => { ... }` assigned to ActiveNowStrip's onOpen in BotsPane. */
+function activeNowOnOpenSource() {
+  const strip = source.indexOf('jsx(ActiveNowStrip, {')
+  assert.ok(strip >= 0, 'ActiveNowStrip mount must remain in BotsPane')
+
+  const key = source.indexOf('onOpen: bot => {', strip)
+  assert.ok(key > strip, 'ActiveNowStrip onOpen handler must remain inline')
+
+  const start = key + 'onOpen: '.length
+  assert.equal(source.slice(start, start + 'bot => {'.length), 'bot => {')
+
+  let i = start + 'bot => {'.length
+  let depth = 1
+
+  while (i < source.length && depth > 0) {
+    const ch = source[i]
+    if (ch === '{') depth += 1
+    else if (ch === '}') depth -= 1
+    i += 1
+  }
+
+  assert.equal(depth, 0, 'ActiveNowStrip onOpen braces must balance')
+  return source.slice(start, i)
+}
+
+function atom(initial) {
+  let value = initial
+  return {
+    get: () => value,
+    set: next => {
+      value = typeof next === 'function' ? next(value) : next
+    }
+  }
+}
+
+function node(type, props = {}) {
+  return { type, props }
+}
+
+function findButton(tree, predicate = () => true) {
+  const visit = value => {
+    if (value == null || typeof value !== 'object') return null
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        const found = visit(child)
+        if (found) return found
+      }
+      return null
+    }
+    if (value.type === 'button' && predicate(value)) return value
+    return visit(value.props?.children)
+  }
+  return visit(tree)
+}
+
+function loadCallers() {
+  const timeline = []
+  const notifications = []
+  const groupChatMainTabs = new Map()
+  const $groupChatWorkspace = atom(null)
+  const $selectedBot = atom('default')
+  const $botUnread = atom({})
+  const $botMeta = atom({})
+  const $focusedBotProfile = atom('default')
+  const $lastRoster = atom([])
+
+  const prepareSource = sourceBetween('async function prepareBotSource(', 'function displayName(')
+  const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
+  const activeNowSource = sourceBetween(
+    'function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpen }) {',
+    '/** Assign a bot to a group-chat membership'
+  )
+
+  const context = {
+    BotFace: 'BotFace',
+    ContextMenu: 'ContextMenu',
+    ContextMenuContent: 'ContextMenuContent',
+    ContextMenuItem: 'ContextMenuItem',
+    ContextMenuSeparator: 'ContextMenuSeparator',
+    ContextMenuTrigger: 'ContextMenuTrigger',
+    ROSTER_KEY: ['hermes-bots', 'roster'],
+    groupChatMainTabs,
+    $groupChatWorkspace,
+    $selectedBot,
+    $botUnread,
+    $botMeta,
+    $focusedBotProfile,
+    $lastRoster,
+    botAppearance: () => ({ shape: 'round', color: '#000', image: null }),
+    botGroups: () => [],
+    botHandle: value => value,
+    botOpenGeneration: 0,
+    botRosterKey: bot => bot.name,
+    botRosterMeta: (bot, metaByName) => metaByName?.[bot.name] ?? null,
+    cn: (...values) => values.filter(Boolean).join(' '),
+    createCanonicalChat: async () => null,
+    displayName: (bot, _meta) => bot?.title || bot?.name || 'bot',
+    duplicateBot: async () => 'copy',
+    haptic: () => undefined,
+    isBackfilledFacePng: () => false,
+    previewKind: () => ({ fromBot: false, sender: null }),
+    generatedSessionTitle: () => null,
+    openBotCanonicalChat: async (...args) => {
+      timeline.push({ type: 'openBotCanonicalChat', args })
+      return 'stored-chat'
+    },
+    ACTIVE_WINDOW_S: 90,
+    A2A_PREFIX_RE: /^$/,
+    useEffect: () => undefined,
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
+    host: {
+      state: { gateway: atom('open'), profile: atom('default') },
+      ensureAgent: async () => undefined,
+      activeConnectionId: () => 'local',
+      warmAgent: () => undefined,
+      warmProfile: () => undefined,
+      request: async () => ({ profiles: [], sessions: [] }),
+      notify: payload => notifications.push(payload),
+      notifyError: () => undefined,
+      newChat: () => timeline.push({ type: 'newChat' }),
+      navigate: () => timeline.push({ type: 'navigate' })
+    },
+    jsx: node,
+    jsxs: node,
+    onEdit: () => undefined,
+    queryClient: { invalidateQueries: () => undefined },
+    relativeTime: () => 'now',
+    saveBotMeta: () => undefined,
+    showsHandle: () => false,
+    stripPreviewMarkdown: text => String(text || ''),
+    useValue: store => store.get(),
+    allMeta: {},
+    timeline,
+    notifications
+  }
+
+  // Bind Map + atoms on the sandbox so helper source closes over the live bindings.
+  context.groupChatMainTabs = groupChatMainTabs
+  context.$groupChatWorkspace = $groupChatWorkspace
+
+  const code = [
+    activeBotsSource(),
+    handoffHelpersSource(),
+    prepareSource,
+    botRowSource,
+    activeNowSource,
+    'const openActiveNow = ' + activeNowOnOpenSource() + ';',
+    'globalThis.__callers = { BotRow, ActiveNowStrip, openActiveNow, dismissGroupChatForLocalBotOpen, closeGroupChatMainTab };'
+  ].join('\n')
+
+  vm.runInNewContext(code, context)
+
+  const registerGroupMainTab = group => {
+    let closed = 0
+    $groupChatWorkspace.set(group)
+    groupChatMainTabs.set(group, () => {
       closed += 1
-      runtime.timeline.push({ type: 'mainTabClose' })
+      timeline.push({ type: 'mainTabClose', group })
+    })
+    return {
+      closed: () => closed,
+      isRegistered: () => groupChatMainTabs.has(group)
     }
   }
 
-  // openWorkspace's closer is what host.openWorkspace returns; capture via openGroupChat.
-  function timelineCloseHook() {
-    /* placeholder so openWorkspace is feature-detected */
+  return {
+    ...context.__callers,
+    $groupChatWorkspace,
+    $selectedBot,
+    groupChatMainTabs,
+    timeline,
+    notifications,
+    registerGroupMainTab,
+    renderBotRow(bot) {
+      const tree = context.__callers.BotRow({ bot, onEdit: () => undefined })
+      const row = tree.type === 'button' ? tree : tree.props.children[0].props.children
+      return row
+    },
+    renderActiveNowChip(bot, { gatewayState = 'open', activeProfile = 'other' } = {}) {
+      // Force the bot into the strip via a fresh last_session inside the window.
+      const rosterBot = {
+        ...bot,
+        last_session: bot.last_session || {
+          id: 'live',
+          last_active: Math.floor(Date.now() / 1000) - 5
+        }
+      }
+      const tree = context.__callers.ActiveNowStrip({
+        roster: [rosterBot],
+        activeProfile,
+        gatewayState,
+        metaByName: {},
+        onOpen: context.__callers.openActiveNow
+      })
+      const chip = findButton(tree, button => String(button.props?.title || '').includes(bot.name) ||
+        String(button.props?.title || '').includes(bot.title || ''))
+      assert.ok(chip, 'Active Now chip must render for the seeded bot')
+      return chip
+    }
   }
+}
 
-  runtime.openGroupChat('Core')
-  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
-  assert.equal(typeof runtime.groupChatMainTabs.get('Core'), 'function')
+test('BotRow local open closes the group main tab before canonical open', async () => {
+  const runtime = loadCallers()
+  const tab = runtime.registerGroupMainTab('Core')
+  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
 
-  // Shared boundary used by BotRow + Active Now for local bots only.
-  runtime.dismissGroupChatForLocalBotOpen()
+  await row.props.onClick()
 
-  assert.equal(closed, 1, 'registered main-tab closer must run')
+  assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
   assert.equal(runtime.$groupChatWorkspace.get(), null, 'group selection atom must clear')
-  assert.equal(runtime.groupChatMainTabs.has('Core'), false, 'closer entry must be retired')
+  assert.equal(tab.isRegistered(), false, 'closer entry must be retired')
+  assert.ok(
+    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
+    'local open must proceed to canonical chat'
+  )
+
+  const closeAt = runtime.timeline.findIndex(entry => entry.type === 'mainTabClose')
+  const openAt = runtime.timeline.findIndex(entry => entry.type === 'openBotCanonicalChat')
+  assert.ok(closeAt >= 0 && openAt >= 0 && closeAt < openAt, 'close must precede canonical open')
+})
+
+test('BotRow remote open leaves the group main tab open', async () => {
+  const runtime = loadCallers()
+  const tab = runtime.registerGroupMainTab('Core')
+  const row = runtime.renderBotRow({
+    name: 'research',
+    title: 'Research',
+    remoteSource: true,
+    sourceScoped: true,
+    connectionId: 'work',
+    connectionLabel: 'Work'
+  })
+
+  await row.props.onClick()
+
+  assert.equal(tab.closed(), 0, 'remote open must not dismiss the group tab')
+  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
+  assert.equal(tab.isRegistered(), true)
   assert.equal(
-    runtime.timeline.some(entry => entry.type === 'openSession'),
+    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
     false,
-    'handoff itself must not open a canonical chat'
+    'remote open must not hop into a canonical chat'
   )
+  assert.ok(runtime.notifications.some(n => /Stay in this chat/.test(n.message || '')))
 })
 
-test('remote bots do not dismiss the selected group workspace', () => {
-  const runtime = load()
-  let closed = 0
+test('Active Now local open closes the group main tab before canonical open', async () => {
+  const runtime = loadCallers()
+  const tab = runtime.registerGroupMainTab('Ops')
+  const chip = runtime.renderActiveNowChip({ name: 'alpha', title: 'Alpha' })
 
-  runtime.host.openWorkspace = () => () => {
-    closed += 1
-  }
+  await chip.props.onClick()
+  // Active Now fires canonical open inside an async IIFE — drain microtasks.
+  await new Promise(resolve => setImmediate(resolve))
+  await new Promise(resolve => setImmediate(resolve))
 
-  runtime.openGroupChat('Core')
-  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
+  assert.equal(tab.closed(), 1, 'registered main-tab closer must run')
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
+  assert.equal(tab.isRegistered(), false)
+  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
 
-  // Remote path must leave the group tab alone (stay-and-@).
-  // The shared dismiss helper is local-only; callers skip it for remoteSource.
-  assert.equal(runtime.$groupChatWorkspace.get(), 'Core')
-  assert.equal(closed, 0)
-  assert.equal(runtime.groupChatMainTabs.has('Core'), true)
+  const closeAt = runtime.timeline.findIndex(entry => entry.type === 'mainTabClose')
+  const openAt = runtime.timeline.findIndex(entry => entry.type === 'openBotCanonicalChat')
+  assert.ok(closeAt >= 0 && openAt >= 0 && closeAt < openAt, 'close must precede canonical open')
 })
 
-test('local handoff with no main-tab registration still clears in-panel selection safely', () => {
-  const runtime = load()
-  // Older host: no openWorkspace → openGroupChat only sets the selection atom.
-  runtime.openGroupChat('Ops')
+test('Active Now remote open leaves the group main tab open', async () => {
+  const runtime = loadCallers()
+  const tab = runtime.registerGroupMainTab('Ops')
+  const chip = runtime.renderActiveNowChip({
+    name: 'research',
+    title: 'Research',
+    remoteSource: true,
+    sourceScoped: true,
+    connectionId: 'work',
+    connectionLabel: 'Work'
+  })
+
+  await chip.props.onClick()
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(tab.closed(), 0)
   assert.equal(runtime.$groupChatWorkspace.get(), 'Ops')
-  assert.equal(runtime.groupChatMainTabs.has('Ops'), false)
-
-  runtime.dismissGroupChatForLocalBotOpen()
-
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
+  assert.equal(tab.isRegistered(), true)
+  assert.equal(
+    runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'),
+    false
+  )
+  assert.ok(runtime.notifications.some(n => /Stay in this chat/.test(n.message || '')))
 })
 
-test('local handoff with no group selected is a no-op', () => {
-  const runtime = load()
-  assert.equal(runtime.$groupChatWorkspace.get(), null)
+test('local BotRow open with no main-tab registration still clears in-panel selection', async () => {
+  const runtime = loadCallers()
+  runtime.$groupChatWorkspace.set('Legacy')
+  assert.equal(runtime.groupChatMainTabs.has('Legacy'), false)
 
-  assert.doesNotThrow(() => runtime.dismissGroupChatForLocalBotOpen())
+  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
+  await row.props.onClick()
+
   assert.equal(runtime.$groupChatWorkspace.get(), null)
+  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
 })
 
-test('BotRow and Active Now both route local opens through the shared handoff', () => {
-  // Structural guard so the two call sites cannot drift apart again.
-  assert.match(pluginSource, /function dismissGroupChatForLocalBotOpen\s*\(/)
-  assert.match(
-    pluginSource,
-    /dismissGroupChatForLocalBotOpen\s*\(\s*\)[\s\S]*?openBotCanonicalChat/
-  )
+test('local BotRow open with no group selected is safe and still opens chat', async () => {
+  const runtime = loadCallers()
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
 
-  const botRowOpen = pluginSource.slice(
-    pluginSource.indexOf('function BotRow('),
-    pluginSource.indexOf('function ActiveNowStrip(')
-  )
-  const activeNowOpen = pluginSource.slice(
-    pluginSource.indexOf('jsx(ActiveNowStrip,'),
-    pluginSource.indexOf('jsx(ActiveNowStrip,') + 2500
-  )
-
-  assert.match(botRowOpen, /dismissGroupChatForLocalBotOpen\s*\(/)
-  assert.match(activeNowOpen, /dismissGroupChatForLocalBotOpen\s*\(/)
-  // Remote path must not call the dismiss helper before the remote early-return.
-  assert.match(botRowOpen, /if\s*\(\s*bot\.remoteSource\s*\)/)
-  assert.match(activeNowOpen, /if\s*\(\s*bot\.remoteSource\s*\)/)
+  const row = runtime.renderBotRow({ name: 'alpha', title: 'Alpha' })
+  await assert.doesNotReject(async () => row.props.onClick())
+  assert.equal(runtime.$groupChatWorkspace.get(), null)
+  assert.ok(runtime.timeline.some(entry => entry.type === 'openBotCanonicalChat'))
 })

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -11,6 +11,7 @@ import {
   $sessionTiles,
   blankDraftTile,
   clearAllSessionStates,
+  closeAllOpenSessionTiles,
   focusedSessionNeedsRoute,
   focusOpenSession,
   foregroundSessionScopes,
@@ -325,6 +326,54 @@ describe('SessionTile workspace scope', () => {
       workspaceMode: 'bots',
       workspaceOwnerKey: 'connection-a::default'
     })
+  })
+})
+
+describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('drops persisted bot tiles so a roster/profile rehydrate cannot restore them', () => {
+    openSessionTile('chat-a', 'center', 'workspace', undefined, {
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:a'
+    })
+    openSessionTile('chat-b', 'center', 'workspace', undefined, {
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:b'
+    })
+    $layoutTree.set(
+      group(['workspace', tilePane('chat-a'), tilePane('chat-b')], { active: 'workspace', id: 'main' })
+    )
+
+    closeAllOpenSessionTiles('workspace')
+
+    expect($sessionTiles.get()).toEqual([])
+
+    // Profile swap re-reads the shared Bot bucket. Close All must have
+    // emptied it, not only dismissed the tree panes.
+    $activeGatewayProfile.set('other-profile')
+    expect($sessionTiles.get()).toEqual([])
+    $activeGatewayProfile.set('default')
+    expect($sessionTiles.get()).toEqual([])
+  })
+
+  it('leaves session tiles stacked in a different zone open', () => {
+    openSessionTile('keep', 'right', 'workspace')
+    openSessionTile('close-me', 'center', 'workspace')
+    $layoutTree.set(
+      split('row', [
+        group(['workspace', tilePane('close-me')], { active: 'workspace', id: 'main' }),
+        group([tilePane('keep')], { active: tilePane('keep'), id: 'right' })
+      ])
+    )
+
+    closeAllOpenSessionTiles('workspace')
+
+    expect($sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['keep'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1521,7 +1521,9 @@ export function closeSessionTile(storedSessionId: string) {
  */
 export function closeAllOpenSessionTiles(paneId: string): void {
   const tree = $layoutTree.get()
-  const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
+  // Copy the live group list. closeSessionTile can rewrite the layout
+  // tree; iterating the original array would skip every other pane.
+  const panes = [...((tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? [])]
 
   for (const id of panes) {
     if (id.startsWith(TILE_PANE_PREFIX)) {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1511,6 +1511,25 @@ export function closeSessionTile(storedSessionId: string) {
   }
 }
 
+/** Persist-close every session tile whose pane lives in `paneId`'s group.
+ *
+ * Close All used to only dismiss layout-tree panes. Bot Mode tiles are
+ * stored in the shared `__bots_workspace__` bucket, so a later roster
+ * click or profile swap rehydrated `$sessionTiles` and the closed tabs
+ * came back (#94137). Routing through {@link closeSessionTile} writes that
+ * bucket, so the closed set survives those rehydrations and a restart.
+ */
+export function closeAllOpenSessionTiles(paneId: string): void {
+  const tree = $layoutTree.get()
+  const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
+
+  for (const id of panes) {
+    if (id.startsWith(TILE_PANE_PREFIX)) {
+      closeSessionTile(id.slice(TILE_PANE_PREFIX.length))
+    }
+  }
+}
+
 /** Drop a DEAD tile — a persisted tile whose session no longer exists on the
  *  backend (resume 404s). Unlike close, it leaves no ⌘⇧T undo (resurrecting it
  *  would just 404 again) and evicts any cached state. This is what clears the


### PR DESCRIPTION
## Summary
Bot Mode tab/tile lifecycle honors the user's intent: Close All now purges the persisted tile bucket (closed tabs stay closed across restarts, #94137), and opening a bot's 1:1 chat closes an open group workspace instead of leaving it squatting in the strip (#89834). Also covers #93618-item2. Consolidates two contributor PRs, cherry-picked with authorship preserved:

- **#94213** (@686f6c61) — `closeAllOpenSessionTiles()`: Close All snapshots pane ids and purges the persisted `__bots_workspace__` bucket in `hermes.desktop.sessionTiles.v2`, so the tiles can't re-adopt on the next boot/reload.
- **#91227** (@Wenfengcheng) — `openBotCanonicalChat` closes the group main tab when a local bot chat opens, with an `openingStillCurrent` staleness probe so a superseded open (user already moved on) still creates registry-side but never steals the workspace; failed opens restore the live group. Includes a full RED→GREEN behavioral test ladder + Electron e2e spec.

Two salvage integration commits: the staleness probe merged into `createCanonicalChat`'s option object (main gained `{ kickoff }` via #95326 after the PR was filed — both now ride one options bag), and salvaged tests adapted to that signature.

## Changes
- `plugin.js`: group-tab close on 1:1 open; `openingStillCurrent` navigation guards on every open site in the canonical-create flow; in-flight creation re-navigation for newer same-bot opens.
- `store/session-states.ts` + `session-actions-menu.tsx` + `tree-group.tsx`: Close All persist-purge.
- Tests: group-to-local-bot handoff suite (vm + Electron e2e), Close All persistence tests, salvaged suites adapted.

## Validation
| | Result |
|---|---|
| plugin suite | 586 pass / 0 fail |
| vitest (session-states, actions-menu, pane-shell) | 218 + 56 pass |
| eslint (changed files) | clean (2 auto-fixes committed) |

**Live repro (real Electron + backend, CDP, both directions):**
- *Group occlusion:* on main, opening a bot chat from inside a group left the group tab in the strip; on this branch the group main tab closes when the 1:1 opens (`groupTabInStrip: false`), and the Bot Chat takes the workspace.
- *Close All persistence:* on main, after opening 3 bot chats the persisted bucket held their tiles and **Close All left the bucket intact on disk** (`v2After` still populated — the resurrection seed #94137 reports). On this branch the same flow leaves `sessionTiles.v2 = null`, and a subsequent bot click opens exactly one tab with no sibling resurrection.

Fixes #94137 and #89834. Source PRs #94213 and #91227 to be closed with credit after merge.

## Infographic

![Tabs that wouldn't die](https://v3b.fal.media/files/b/0aa7e67c/CQDBw9wrull3q-6HypqXW_JNs8A1oi.png)



## Live A/B screenshots

| Main (bug fires) | Fix branch |
|---|---|
| ![group tab lingers after bot open](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETD_MAIN_BASELINE.png) | ![group room state on fix branch](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETD_FIX_STATE.png) |
| ![Close All leaves persisted bucket, tabs return](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETD_CLOSEALL_MAIN.png) | ![one tab after Close All + re-click, no resurrection](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETD_CLOSEALL_FIX.png) |

Captured from the CDP-driven live harness (real Electron + `hermes serve` backends). The decisive disk-level evidence is in the Validation section: `sessionTiles.v2` still populated after Close All on main, `null` on this branch.
