### PR TITLE
fix(skills): skip directory-shaped references instead of aborting the whole skill fetch

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1804,3 +1804,51 @@ class TestLoadHermesIndex:
 
         data = hub._load_hermes_index()
         assert data == {"skills": [{"name": "stale"}]}
+
+
+class TestFetchDirectoryShapedReferences:
+    """A directory-shaped Markdown link must not abort the whole install (#95637)."""
+
+    @staticmethod
+    def _make_source(tree_entries, contents):
+        src = GitHubSource(GitHubAuth())
+        src._get_repo_tree = lambda repo: ("main", tree_entries)
+        src._fetch_file_bytes = lambda repo, path: contents.get(path)
+        return src
+
+    @classmethod
+    def _skill_md(cls, body="See [recipes](references/recipes.md) and [index](references/style-recipes/)."):
+        return f"---\nname: demo\ndescription: demo skill\n---\n\n{body}\n"
+
+    def test_directory_reference_is_skipped_not_fatal(self):
+        skill_path = "skills/demo/SKILL.md"
+        src = self._make_source(
+            [
+                {"type": "blob", "path": "skills/demo/references/recipes.md", "mode": "100644"},
+                {"type": "tree", "path": "skills/demo/references/style-recipes", "mode": "040000"},
+            ],
+            {
+                skill_path: self._skill_md(),
+                "skills/demo/references/recipes.md": b"recipe content",
+            },
+        )
+        src._fetch_file_content = lambda repo, path: self._skill_md() if path == skill_path else None
+
+        bundle = src.fetch("owner/repo/skills/demo")
+
+        assert bundle is not None
+        assert bundle.files["references/recipes.md"] == b"recipe content"
+        # The directory pointer itself contributes no bundled entry.
+        assert "references/style-recipes" not in bundle.files
+
+    def test_symlink_reference_still_rejected(self):
+        skill_path = "skills/demo/SKILL.md"
+        src = self._make_source(
+            [
+                {"type": "blob", "path": "skills/demo/references/recipes.md", "mode": "120000"},
+            ],
+            {skill_path: self._skill_md()},
+        )
+        src._fetch_file_content = lambda repo, path: self._skill_md() if path == skill_path else None
+
+        assert src.fetch("owner/repo/skills/demo") is None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -679,6 +679,19 @@ class GitHubSource(SkillSource):
                 if item is None:
                     logger.warning("Referenced skill support file is missing: %s", item_path)
                     return None
+                if item.get("type") == "tree":
+                    # A directory-shaped Markdown link (``[recipes](refs/)``)
+                    # is an index pointer, not a "bundle this exact path"
+                    # instruction — its contents are bundled only when linked
+                    # individually. Skipping must not abort the whole fetch
+                    # (#95637), where one such link made every install of the
+                    # skill die with the generic "Could not fetch from any
+                    # source".
+                    logger.debug(
+                        "Skipping directory-shaped reference in skill bundle: %s",
+                        item_path,
+                    )
+                    continue
                 if item.get("type") != "blob" or item.get("mode") == "120000":
                     logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
                     return None


### PR DESCRIPTION
## What does this PR do?

Fixes the main bug in #95637: `hermes skills install <owner>/<repo>/<path>` aborted with the generic `Error: Could not fetch '<identifier>' from any source.` whenever the skill's `SKILL.md` contained a relative Markdown link pointing at a *directory* (e.g. an index-style `[style recipes](references/style-recipes/)` link).

The chain, exactly as the report traced it: `_referenced_support_paths()` collects the directory-shaped link into the referenced set; `GitHubSource.fetch()` resolves every referenced entry against the repo tree and requires `type == "blob"`; a directory is `type == "tree"`, which hit the "Rejected non-regular file" branch whose `return None` aborted the **entire** fetch — one index link killed the whole install, and the layered swallowing upstream turned it into the generic error with no hint at the real cause.

The fix splits the directory case out of the rejection: a `type == "tree"` referenced entry is now skipped with a debug log (an index pointer is not a "bundle this exact path" instruction — the directory's files are bundled when linked individually), while the security rejection for non-blob/symlink entries (`mode == "120000"`) is unchanged and still aborts. The secondary bug in the report (the `--help` example identifier failing because `fetch()` doesn't apply the search/browse tap-path remapping) is not addressed here — the reporter offered to split it, and it's a separate seam.

## Related Issue

Fixes #95637

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py` — in `GitHubSource.fetch()`'s referenced-file loop, a `type == "tree"` entry now `continue`s with a debug log instead of hitting the "Rejected non-regular file" `return None`; the blob/symlink rejection is untouched. Comment documents the index-pointer semantics (#95637).
- `tests/tools/test_skills_hub.py` — new `TestFetchDirectoryShapedReferences`: a SKILL.md mixing a file link and a trailing-slash directory link installs successfully (file bundled, directory pointer contributes no entry); a symlink-mode (`120000`) reference is still rejected with `fetch()` returning `None` (scope pin).

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_skills_hub.py tests/tools/test_skills_hub_browse_sh.py -q` — should pass: 75 passed. Red/green: with the `skills_hub.py` change stashed, `test_directory_reference_is_skipped_not_fatal` fails (the whole fetch returns `None`) while the symlink-rejection pin passes on both sides.
2. Manual shape (the report's repro): `hermes skills install ConardLi/garden-skills/skills/web-design-engineer --yes` should complete instead of dying with `Could not fetch ... from any source.` — its SKILL.md links `references/style-recipes/` as a directory index while linking the individual recipe files, which resolve as blobs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches the fetch referenced-paths loop
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file + adjacent skills_hub suites green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
