### PR TITLE
fix(desktop): route clarify responses through session owner

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -7,9 +7,24 @@ import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
-import { $activeSessionId } from '@/store/session'
+import { $profiles } from '@/store/profile'
+import { $activeSessionId, _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/session'
 
 import { ClarifyTool, readClarifyBatchResult, readClarifyResult } from './clarify-tool'
+
+// The OWNER-socket seam (`requestForOwnedSession` → `requestForSessionProfile`
+// → here). Mocked so the real owner ladder still runs against real fixtures and
+// only the dial is observed; the rest of the gateway store stays actual, so
+// `$gateway` remains the genuine ambient atom every other test in this file
+// drives.
+const gatewayMocks = vi.hoisted(() => ({
+  requestGatewayForAgent: vi.fn(async () => ({ ok: true }))
+}))
+
+vi.mock('@/store/gateway', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  requestGatewayForAgent: gatewayMocks.requestGatewayForAgent
+}))
 
 // The live pending card used to require message-running. Tests that exercise
 // the pending form force that on; the settle-shift case flips it off.
@@ -705,5 +720,125 @@ describe('ClarifyTool batch card', () => {
     expect(screen.getByText('red')).toBeTruthy()
     expect(screen.getByText('Name?')).toBeTruthy()
     expect(screen.getByText('Skipped')).toBeTruthy()
+  })
+})
+
+// ─── Owner routing (#91684 client half) ─────────────────────────────────────
+// The clarify card used to answer on the AMBIENT socket. That socket follows
+// foreground focus, so after a profile / Bot Chat switch it can be profile B
+// while the blocking clarify belongs to profile A — the response lands on a
+// backend that never held the request and the owner stays blocked until the
+// tool times out. Every live clarify.respond now routes by request.sessionId.
+
+const OWNER_CONNECTION_ID = 'conn-profile-a'
+const OWNER_PROFILE = 'profile-a'
+
+/** Profile A owns the clarify's session; the window has since switched to
+ *  profile B, so `$gateway` (ambient) is profile B's socket. */
+function armCrossProfileOwner() {
+  // Two profiles exist → the ambient gateway is not provably the sole backend,
+  // so the legacy single-backend escape hatch stays shut.
+  $profiles.set([{ name: OWNER_PROFILE }, { name: 'profile-b' }] as never)
+  setSessionOwnerHint('session-a', { connectionId: OWNER_CONNECTION_ID, profile: OWNER_PROFILE })
+
+  const ambient = vi.fn().mockResolvedValue({ ok: true })
+
+  $activeSessionId.set('session-a')
+  $gateway.set({ request: ambient } as never)
+
+  return ambient
+}
+
+function expectOwnerCall(nth: number, params: Record<string, unknown>) {
+  expect(gatewayMocks.requestGatewayForAgent).toHaveBeenNthCalledWith(
+    nth,
+    OWNER_CONNECTION_ID,
+    OWNER_PROFILE,
+    'clarify.respond',
+    params
+  )
+}
+
+describe('ClarifyTool owner routing', () => {
+  afterEach(() => {
+    $profiles.set([])
+    _resetSessionOwnerHintsForTests({ storage: true })
+    gatewayMocks.requestGatewayForAgent.mockClear()
+  })
+
+  it('answers a single clarify on the owner socket, never profile B ambient', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    })
+    expectOwnerCall(1, { answer: 'staging', request_id: 'request-1' })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('sends both sequential batch locks on the owner socket, in order', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' },
+        { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
+      ],
+      requestId: 'request-batch',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveBatchProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+    fireEvent.change(screen.getByPlaceholderText('Type your answer…'), { target: { value: 'packet' } })
+    fireEvent.click(screen.getByRole('button', { name: /Confirm and continue/ }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(2)
+    })
+    // The LAST lock resolves the blocked tool, so order is load-bearing.
+    expectOwnerCall(1, { answer: 'red', question_id: 'q0', request_id: 'request-batch' })
+    expectOwnerCall(2, { answer: 'packet', question_id: 'q1', request_id: 'request-batch' })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('sends a batch skip/cancel on the owner socket', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' },
+        { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
+      ],
+      requestId: 'request-batch',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveBatchProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    })
+    expectOwnerCall(1, { answer: '', request_id: 'request-batch' })
+    expect(ambient).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { requestForOwnedSession } from '@/store/session-states'
 
 import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
@@ -469,10 +470,22 @@ function ClarifyToolSinglePending({
       setSubmitting(true)
 
       try {
-        await gateway.request<{ ok?: boolean }>('clarify.respond', {
-          request_id: matchingRequest.requestId,
-          answer
-        })
+        // Route through the session's OWNER (tile route → hint → tagged row);
+        // legacy ambient is allowed only when it is provably the sole backend.
+        // The ambient socket follows foreground focus, so after a profile / Bot
+        // Chat switch it can point at a backend that never held this clarify —
+        // and the owner stays blocked (#91684 client half, like approval.respond).
+        await requestForOwnedSession<{ ok?: boolean }>(
+          matchingRequest.sessionId,
+          // Bound (not wrapped) so the ambient fallback keeps the exact 2-arg
+          // call shape gateway.request callers assert on.
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          {
+            request_id: matchingRequest.requestId,
+            answer
+          }
+        )
         triggerHaptic('submit')
         onAnswered()
         clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
@@ -1011,14 +1024,23 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
       // server-side, so every earlier lock must already be accepted when it
       // lands — a reordered burst could complete the batch with a missing
       // answer.
+      //
+      // Each lock rides the session's OWNER socket, not the ambient one: a
+      // profile / Bot Chat switch re-points ambient at a backend that never
+      // held this batch, which would leave the owner blocked.
       for (const question of questions) {
         const answer = stagedAnswer(question)
 
-        await gateway.request<{ ok?: boolean }>('clarify.respond', {
-          answer: answer ?? '',
-          question_id: question.qid,
-          request_id: request.requestId
-        })
+        await requestForOwnedSession<{ ok?: boolean }>(
+          request.sessionId,
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          {
+            answer: answer ?? '',
+            question_id: question.qid,
+            request_id: request.requestId
+          }
+        )
       }
 
       triggerHaptic('submit')
@@ -1058,7 +1080,16 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
     clearClarifyRequest(request.requestId, request.sessionId)
 
     try {
-      await gateway?.request('clarify.respond', { answer: '', request_id: request.requestId })
+      if (gateway) {
+        // Owner-routed like the locks above — a skip sent to the wrong backend
+        // is a silent no-op that leaves the agent waiting out its timeout.
+        await requestForOwnedSession(
+          request.sessionId,
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          { answer: '', request_id: request.requestId }
+        )
+      }
     } catch {
       // The tool times out on its own; a failed skip must never block the UI.
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop deadlock after switching Bot Chats or profiles while a `clarify` card is pending.

The live clarify request belongs to a concrete `request.sessionId`, but all three response paths used the ambient `$gateway`. After foreground focus switched from profile A to profile B, **Continue** or **Skip** could send `clarify.respond` to profile B's socket even though profile A's backend was blocked waiting for it. The UI appeared to accept the action, while the owner stayed blocked until the clarify timeout.

This routes every live `clarify.respond` through the existing `requestForOwnedSession(request.sessionId, ...)` seam already used by approval responses. It preserves the existing payloads, sequential batch ordering, UI settlement, and error behavior. Missing owner metadata follows the shared fail-closed routing contract; the ambient fallback remains available only when that contract can prove there is a sole backend.

## Related Issue

Follow-up to #91684, which established the same session-owner routing rule for Desktop approval responses.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx`
  - owner-route single-answer submission
  - owner-route each sequential batch answer without reordering
  - owner-route batch Skip/cancel
- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx`
  - model a profile-A-owned session while profile B is the ambient gateway
  - assert the owner route receives exact payloads for single, both batch locks, and Skip
  - assert the ambient profile-B gateway receives no response

## How to Test

1. Open a clarify card in profile A, switch to profile B, return to the card, and submit an answer or Skip.
2. Confirm profile A's blocked turn resumes immediately and profile B receives no stray response.
3. Run the focused regression and owner-router suite:

   ```bash
   npm run test:ui --workspace apps/desktop -- \
     src/components/assistant-ui/clarify-tool.test.tsx \
     src/store/session-states.test.ts \
     src/store/session-states-runtime-map.test.ts \
     src/store/session-request-router.test.ts
   ```

   Result: **4 files passed, 115 tests passed**.

4. Additional checks:
   - `npm run typecheck --workspace apps/desktop` — passed
   - `../../node_modules/.bin/prettier --check src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx` — passed
   - targeted ESLint on the same two files — **0 errors, 18 pre-existing warnings**
   - `git diff --check origin/main...HEAD` — passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing open PRs and issues; no equivalent active Desktop session-owner clarify fix was found
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this renderer-only change; focused Desktop tests are listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] Documentation update is N/A; no user-facing command or config changed
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the change is renderer-side and uses the platform-independent owner router
- [x] Tool descriptions/schemas update is N/A; `clarify.respond` payloads are unchanged

## Activation Notes / Residual Risk

- Local macOS arm64 activation completed from commit `7ebee94c0a5d3c943290260188eab78308f8d568`. The packaged app stamp reports this commit, branch `fix/desktop-clarify-owner-routing`, `dirty: false`, and source `local`.
- `HERMES_DESKTOP_SKIP_BUILD=1 npm run test:desktop:existing` validated the packaged renderer, install stamp, and native `node-pty` payload, then relaunched the worktree app. The app opened with its normal user data and spawned a healthy loopback backend. The existing Hermes gateway was not restarted.
- The final cross-profile clarify interaction remains an explicit manual acceptance check.
- Routing still depends on the existing session-owner metadata and `requestForOwnedSession` fallback contract. This PR intentionally does not invent clarify-specific recovery for stale or missing ownership metadata.
- The component tests prove owner-versus-ambient dispatch and exact payload/order; they do not replace a live multi-profile interactive smoke.
