### PR TITLE
feat(credentials): configure manual DEAD retention

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import random
 import threading
@@ -99,6 +100,27 @@ _TERMINAL_AUTH_REASONS = frozenset({
 # the cleanup.  They remain in the pool marked DEAD until an explicit re-auth
 # write-side sync (``_save_codex_tokens`` etc.) clears the status.
 DEAD_MANUAL_PRUNE_TTL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+def _manual_dead_prune_ttl_seconds() -> Optional[float]:
+    """Return the manual-DEAD retention TTL, or None when pruning is disabled."""
+    config = _load_config_safe()
+    pool_config = config.get("credential_pool") if isinstance(config, dict) else None
+    if not isinstance(pool_config, dict):
+        return float(DEAD_MANUAL_PRUNE_TTL_SECONDS)
+    if pool_config.get("prune_dead_manual_entries") is False:
+        return None
+    ttl_hours = pool_config.get("dead_manual_prune_ttl_hours")
+    if isinstance(ttl_hours, bool) or not isinstance(ttl_hours, (int, float)):
+        return float(DEAD_MANUAL_PRUNE_TTL_SECONDS)
+    try:
+        ttl_hours = float(ttl_hours)
+    except OverflowError:
+        return float(DEAD_MANUAL_PRUNE_TTL_SECONDS)
+    if not math.isfinite(ttl_hours) or not 0 <= ttl_hours <= 8760:
+        return float(DEAD_MANUAL_PRUNE_TTL_SECONDS)
+    return float(ttl_hours) * 60 * 60
+
 
 AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
@@ -1969,8 +1991,18 @@ class CredentialPool:
                 # would just be undone by ``_seed_from_singletons`` on the
                 # next load anyway.
                 if _is_manual_source(entry.source):
-                    dead_at = entry.last_status_at or 0
-                    if dead_at and now - dead_at > DEAD_MANUAL_PRUNE_TTL_SECONDS:
+                    dead_at = entry.last_status_at
+                    if isinstance(dead_at, bool) or not isinstance(dead_at, (int, float)):
+                        dead_at = None
+                    else:
+                        try:
+                            dead_at = float(dead_at)
+                        except OverflowError:
+                            dead_at = None
+                    if dead_at is not None and not math.isfinite(dead_at):
+                        dead_at = None
+                    prune_ttl = _manual_dead_prune_ttl_seconds()
+                    if dead_at and prune_ttl is not None and now - dead_at > prune_ttl:
                         _label = entry.label or entry.id[:8]
                         logger.warning(
                             "credential pool: pruning DEAD manual entry %s "

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -29,6 +29,16 @@ runtime:
   nofile_soft_limit: 4096
 
 # =============================================================================
+# Credential Pool Retention
+# =============================================================================
+# Manual credentials marked DEAD after permanent authentication failures stay
+# excluded from rotation. They are pruned on a later availability check after
+# this retention window; changing this setting never deletes entries directly.
+credential_pool:
+  prune_dead_manual_entries: true  # false keeps manual DEAD entries indefinitely
+  dead_manual_prune_ttl_hours: 24  # finite number from 0 to 8760; 0 = next availability check
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from hermes_cli.cli_output import line_input
 
+from datetime import datetime, timezone
 import math
 import sys
 import time
@@ -15,7 +16,9 @@ from agent.credential_pool import (
     CUSTOM_POOL_PREFIX,
     SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE,
+    STATUS_DEAD,
     STATUS_EXHAUSTED,
+    _TERMINAL_AUTH_REASONS,
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
     STRATEGY_RANDOM,
@@ -214,6 +217,32 @@ def _classify_exhausted_status(entry) -> tuple[str, bool]:
 
     return "exhausted", True
 
+
+
+def _format_dead_status(entry) -> str:
+    """Render only canonical, non-secret metadata for terminal credentials."""
+    if entry.last_status != STATUS_DEAD:
+        return ""
+    reason = getattr(entry, "last_error_reason", None)
+    reason = reason.strip().lower() if isinstance(reason, str) else ""
+    if reason not in _TERMINAL_AUTH_REASONS:
+        reason = "permanent_auth_failure"
+    timestamp = getattr(entry, "last_status_at", None)
+    if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+        return f" dead {reason}"
+    try:
+        timestamp = float(timestamp)
+    except OverflowError:
+        return f" dead {reason}"
+    if not math.isfinite(timestamp):
+        return f" dead {reason}"
+    try:
+        rendered_timestamp = datetime.fromtimestamp(timestamp, timezone.utc).isoformat(
+            timespec="seconds"
+        ).replace("+00:00", "Z")
+    except (OSError, OverflowError, ValueError):
+        return f" dead {reason}"
+    return f" dead {reason} (at {rendered_timestamp})"
 
 
 def _format_exhausted_status(entry) -> str:
@@ -553,7 +582,7 @@ def auth_list_command(args) -> None:
             marker = "  "
             if current is not None and entry.id == current.id:
                 marker = "← "
-            status = _format_exhausted_status(entry)
+            status = _format_dead_status(entry) or _format_exhausted_status(entry)
             source = _display_source(entry.source)
             print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
         print()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,10 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "credential_pool": {
+        "prune_dead_manual_entries": True,
+        "dead_manual_prune_ttl_hours": 24,
+    },
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -559,8 +559,132 @@ def test_dead_manual_entry_pruned_after_24h(tmp_path, monkeypatch):
     assert persisted[0]["id"] == "cred-ok"
 
 
+def test_dead_manual_entry_is_retained_when_pruning_is_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        "credential_pool:\n  prune_dead_manual_entries: false\n",
+        encoding="utf-8",
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-old-dead",
+                        "label": "ancient-dead",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "stale",
+                        "refresh_token": "stale",
+                        "last_status": "dead",
+                        "last_status_at": time.time() - (25 * 3600),
+                        "last_error_reason": "token_invalidated",
+                    },
+                    {
+                        "id": "cred-ok",
+                        "label": "healthy",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "healthy-at",
+                        "refresh_token": "healthy-rt",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    assert load_pool("openai-codex").select().id == "cred-ok"
+    persisted = json.loads((hermes_home / "auth.json").read_text())["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in persisted] == ["cred-old-dead", "cred-ok"]
 
 
+def test_oversized_dead_timestamp_is_retained_without_crashing_availability_check(
+    tmp_path, monkeypatch
+):
+    """Malformed persisted status metadata must not break credential rotation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    hermes_home = tmp_path / "hermes"
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-dead-huge-time",
+                        "label": "dead-huge-time",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "stale",
+                        "last_status": "dead",
+                        "last_status_at": 10**1000,
+                        "last_error_reason": "token_revoked",
+                    },
+                    {
+                        "id": "cred-ok",
+                        "label": "healthy",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "healthy-at",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    assert load_pool("openai-codex").select().id == "cred-ok"
+    persisted = json.loads((hermes_home / "auth.json").read_text())["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in persisted] == ["cred-dead-huge-time", "cred-ok"]
+
+
+def test_credential_pool_retention_defaults_are_exposed_in_config_defaults():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["credential_pool"] == {
+        "prune_dead_manual_entries": True,
+        "dead_manual_prune_ttl_hours": 24,
+    }
+
+
+@pytest.mark.parametrize(
+    ("configured_hours", "expected_seconds"),
+    [
+        (0, 0),
+        (1.5, 5400),
+        (8760, 8760 * 3600),
+        (True, 24 * 3600),
+        ("1", 24 * 3600),
+        (-1, 24 * 3600),
+        (8761, 24 * 3600),
+        (10**1000, 24 * 3600),
+        (float("nan"), 24 * 3600),
+        (float("inf"), 24 * 3600),
+    ],
+)
+def test_manual_dead_prune_ttl_accepts_only_finite_hour_values(
+    monkeypatch, configured_hours, expected_seconds
+):
+    from agent import credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "_load_config_safe",
+        lambda: {"credential_pool": {"dead_manual_prune_ttl_hours": configured_hours}},
+    )
+
+    assert credential_pool._manual_dead_prune_ttl_seconds() == expected_seconds
 
 
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -294,6 +294,64 @@ def test_auth_list_includes_non_registry_configured_provider(
     assert "private-groq (1 credentials):" in capsys.readouterr().out
 
 
+def test_auth_list_redacts_unsafe_dead_metadata(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        "credential_pool:\n  prune_dead_manual_entries: false\n",
+        encoding="utf-8",
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "dead-credential",
+                        "label": "dead-entry",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "secret-access-token",
+                        "last_status": "dead",
+                        "last_status_at": 1_700_000_000,
+                        "last_error_reason": "provider said secret-access-token",
+                        "last_error_message": "raw provider message secret-access-token",
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    auth_list_command(type("Args", (), {"provider": "openai-codex"})())
+
+    output = capsys.readouterr().out
+    assert "dead permanent_auth_failure (at 2023-11-14T22:13:20Z)" in output
+    assert "secret-access-token" not in output
+    assert "raw provider message" not in output
+
+
+def test_auth_list_omits_oversized_dead_timestamp():
+    from agent.credential_pool import STATUS_DEAD
+    from hermes_cli.auth_commands import _format_dead_status
+
+    entry = type(
+        "Entry",
+        (),
+        {
+            "last_status": STATUS_DEAD,
+            "last_error_reason": "token_revoked",
+            "last_status_at": 10**10000,
+        },
+    )()
+
+    assert _format_dead_status(entry) == " dead token_revoked"
+
+
 def test_interactive_auth_add_accepts_non_registry_configured_provider(
     tmp_path, monkeypatch
 ):

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -149,6 +149,18 @@ Provider-supplied `reset_at` timestamps override these default cooldowns.
 
 The `has_retried_429` flag resets on every successful API call, so a single transient 429 doesn't trigger rotation.
 
+### Manual DEAD retention
+
+A manual credential marked `DEAD` after a permanent authentication failure is never selected for rotation. By default, Hermes removes it on a later availability check after 24 hours. This cleanup is intentionally not triggered by saving settings.
+
+```yaml
+credential_pool:
+  prune_dead_manual_entries: true       # false retains manual DEAD entries
+  dead_manual_prune_ttl_hours: 24       # finite numeric value from 0 to 8760
+```
+
+Set `dead_manual_prune_ttl_hours: 0` to make an existing manual `DEAD` entry eligible for removal on its next availability check. Set `prune_dead_manual_entries: false` to retain it indefinitely. CLI listing exposes only the canonical terminal reason (or `permanent_auth_failure`) and a valid UTC timestamp; it never displays the raw provider error message or token.
+
 ## Custom Endpoint Pools
 
 Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from the `providers:` dict in config.yaml (or the legacy `custom_providers` list, which is auto-migrated).
@@ -190,7 +202,7 @@ Hermes automatically discovers credentials from multiple sources and seeds the p
 | Custom endpoint config | `model.api_key` in config.yaml | Yes (custom endpoints) |
 | Manual entries | Added via `hermes auth add` | Persisted in auth.json |
 
-Auto-seeded entries are updated on each pool load — if you remove an env var, its pool entry is automatically pruned. Manual entries (added via `hermes auth add`) are never auto-pruned.
+Auto-seeded entries are updated on each pool load — if you remove an env var, its pool entry is automatically pruned. Manual entries (added via `hermes auth add`) are not auto-pruned for source changes; manual entries marked `DEAD` use the configurable retention cleanup described above.
 
 Borrowed runtime secrets (for example env vars, Bitwarden/Vault/keyring/systemd references, and custom config values) are reference-only at the `auth.json` boundary. Hermes can use the resolved value in memory for the current run, but it persists only metadata such as the source ref, label, status, request counters, and a non-reversible fingerprint. Manual entries and Hermes-owned OAuth/device-code state keep the durable tokens they need to refresh.
 


### PR DESCRIPTION
## Summary

- make retention of terminal manual credential-pool entries configurable
- preserve the existing 24-hour pruning default while allowing pruning to be disabled or set from 0 to 8760 hours
- keep terminal entries excluded from rotation and expose only safe, canonical terminal metadata in `hermes auth list`
- tolerate malformed, non-finite, and oversized persisted retention/timestamp values without disrupting credential selection

## Scope

Related to #54487. This replaces the focused retention portion of #67647 without its unrelated configuration-locking and profile-scoping changes.

## Verification

- `uv run --no-sync pytest -q tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py` — 101 passed
- `uv run --no-sync ruff check agent/credential_pool.py hermes_cli/auth_commands.py hermes_cli/config_defaults.py tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py` — passed
- `cli-config.yaml.example` YAML parse — passed
- `git diff --check` — passed

No production services, credentials, or live configuration were changed.