### PR TITLE
fix(search_files): default to literal patterns with re: opt-in

### DIFF
--- a/tests/tools/test_search_auto_multiline.py
+++ b/tests/tools/test_search_auto_multiline.py
@@ -21,7 +21,10 @@ def proj(tmp_path, monkeypatch):
 
 class TestAutoMultiline:
     def test_newline_regex_matches_across_lines(self, proj):
-        r = json.loads(search_tool(r"def setup\(\):\n    init_db\(\)", path=str(proj), task_id="t-ml"))
+        # ``re:`` opts the pattern out of the default ``re.escape`` so the
+        # user-crafted regex (escaped parens + a newline) reaches rg with
+        # its semantics intact.
+        r = json.loads(search_tool(r"re:def setup\(\):\n    init_db\(\)", path=str(proj), task_id="t-ml"))
         assert "error" not in r
         assert r["total_count"] >= 1
         assert "multiline" in r.get("warning", "")

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -83,7 +83,10 @@ class TestSearchErrorGuard:
     def test_hard_error_is_surfaced(self, method, match_tree):
         # An invalid regex makes rg/grep exit 2 with only diagnostics in
         # stdout. The guard MUST surface it — not return empty matches.
-        res = _search(_ops(match_tree), method, "[", match_tree)
+        # ``re:`` opts the pattern out of the default ``re.escape`` so the
+        # malformed regex reaches rg/grep unchanged and exercises the
+        # error-surfacing path.
+        res = _search(_ops(match_tree), method, "re:[unclosed", match_tree)
         assert res.error is not None, "search error was silently swallowed"
         assert "Search failed" in res.error
         assert not res.matches
@@ -130,3 +133,70 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+class TestSafeSearchPattern:
+    """The default literal escape + ``re:`` opt-in for callers that want
+    real regex semantics. Regression coverage for the unescaped-pattern
+    injection bug — see _safe_search_pattern's docstring."""
+
+    @pytest.fixture
+    def literal_tree(self, tmp_path):
+        """A tree whose files contain literal regex metacharacters."""
+        (tmp_path / "a.txt").write_text("host.com? yes\n")
+        (tmp_path / "b.txt").write_text("c++ is great\n")
+        (tmp_path / "c.txt").write_text("[bracket] literal\n")
+        (tmp_path / "d.txt").write_text("literal [frx here\n")
+        return tmp_path
+
+    def test_literal_metachars_find_matches(self, literal_tree):
+        for pattern, expected_file in [
+            ("host.com?", "a.txt"),
+            ("c++",      "b.txt"),
+            ("[bracket]","c.txt"),
+            ("[frx",     "d.txt"),  # original repro pattern — must not crash
+        ]:
+            res = _ops(literal_tree).search(
+                pattern=pattern, path=str(literal_tree), target="content",
+            )
+            assert res.error is None, f"{pattern!r} errored: {res.error}"
+            assert any(m.path.endswith(expected_file) for m in res.matches), (
+                f"{pattern!r} did not match {expected_file}; "
+                f"got {[m.path for m in res.matches]}"
+            )
+
+    def test_plain_alphanumeric_unchanged(self, literal_tree):
+        # No-metachar pattern: re.escape is a no-op, behavior is identical
+        # to the pre-fix path.
+        res = _ops(literal_tree).search(
+            pattern="bracket", path=str(literal_tree), target="content",
+        )
+        assert res.error is None
+        assert any(m.path.endswith("c.txt") for m in res.matches)
+
+    def test_regex_opt_in_still_works(self, literal_tree):
+        # ``re:`` prefix opts out of literal-mode; real regex semantics land.
+        (literal_tree / "def.txt").write_text("def hello():\n    pass\n")
+        res = _ops(literal_tree).search(
+            pattern=r"re:def\s+\w+", path=str(literal_tree), target="content",
+        )
+        assert res.error is None
+        assert any(m.path.endswith("def.txt") for m in res.matches)
+
+    def test_regex_opt_in_malformed_still_surfaces_error(self, literal_tree):
+        # Opt-in + malformed regex must still surface the parse error.
+        res = _ops(literal_tree).search(
+            pattern="re:[unclosed", path=str(literal_tree), target="content",
+        )
+        assert res.error is not None
+        assert "Search failed" in res.error
+
+    def test_unit_escape_and_opt_in(self):
+        from tools.file_operations import _safe_search_pattern
+        # Plain string: escaped.
+        assert _safe_search_pattern("frx") == "frx"
+        assert _safe_search_pattern("[frx") == r"\[frx"
+        assert _safe_search_pattern("host.com?") == r"host\.com\?"
+        # Opt-in: prefix stripped, body NOT escaped.
+        assert _safe_search_pattern("re:def\\s+\\w+") == "def\\s+\\w+"
+        assert _safe_search_pattern("re:[frx") == "[frx"

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -36,9 +36,24 @@ class TestZeroMatchProbe:
         assert "a.py" in w and "b.py" in w
 
     def test_regex_metachar_literal_hint(self, proj):
+        # A pattern with regex metacharacters now defaults to literal
+        # matching — the main search finds the literal match without
+        # needing the probe-driven hint. The probe still fires for
+        # patterns the user *opted into* as real regex (``re:``) that
+        # have no matches in the file.
         d = proj / "proj"
         (d / "meta.py").write_text("result = lookup[key+1]\n")
         r = json.loads(search_tool("lookup[key+1]", path=str(d), task_id="t-zm"))
+        assert r["total_count"] >= 1
+        assert "meta.py" not in r.get("warning", "")  # no hint needed
+
+    def test_regex_opt_in_metachar_zero_match_gets_literal_hint(self, proj):
+        # When the user opts into real regex (``re:``) and the pattern
+        # has no matches, the probe's literal-match hint still fires —
+        # so the user can see "you wrote regex but the literal exists".
+        d = proj / "proj"
+        (d / "meta.py").write_text("result = lookup[key+1]\n")
+        r = json.loads(search_tool("re:lookup[key+1]", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "literal match" in r.get("warning", "")
         assert "meta.py" in r.get("warning", "")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -853,6 +853,32 @@ def _pattern_has_regex_newline(pattern: str) -> bool:
     return "\n" in pattern or bool(_REGEX_NEWLINE_ESCAPE_RE.search(pattern))
 
 
+# Sentinel that opts a content-search pattern OUT of the default literal
+# escaping. The rest of the codebase (curator.py, approval.py,
+# skill_linter.py, hermes_state_search.py, honcho/oauth.py) uses
+# ``re.escape`` on user-supplied regexes for the same reason; this
+# opt-in keeps the documented "regex" semantics of search_files
+# reachable without making every literal-pattern call remember to escape.
+_PATTERN_REGEX_OPT_IN = "re:"
+
+
+def _safe_search_pattern(pattern: str) -> str:
+    """Return ``pattern`` safe to hand to rg/grep as a regex.
+
+    rg treats the pattern as a regex by default, so a user-provided
+    literal like ``[frx`` or ``host.com?`` parses as an invalid character
+    class / quantifier and crashes the search. Wrap with ``re.escape``
+    so metacharacters match literally — the common case for agent search
+    queries. Callers that genuinely want regex semantics (e.g.
+    ``def\\s+\\w+``, ``TODO|FIXME``) can opt in with the ``re:`` prefix;
+    the sentinel is stripped and the remainder is passed through to rg
+    unescaped.
+    """
+    if pattern.startswith(_PATTERN_REGEX_OPT_IN):
+        return pattern[len(_PATTERN_REGEX_OPT_IN):]
+    return re.escape(pattern)
+
+
 def _is_line_oriented_newline_error(error: Optional[str]) -> bool:
     """Return True for rg's hard error when multiline mode is required."""
     if not error:
@@ -2911,9 +2937,14 @@ class ShellFileOperations(FileOperations):
             return shown + (f" (+{extra} more)" if extra > 0 else "")
 
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        # Probe the same regex-escaped pattern the main search uses, so the
+        # probes never crash on a user-supplied metacharacter (defect class
+        # that hit the main rg path) and never silently disagree with what
+        # the main search actually looked for.
+        safe_pattern = _safe_search_pattern(pattern)
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(safe_pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2930,7 +2961,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(safe_pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2944,7 +2975,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_arg(safe_pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3157,7 +3188,12 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. Wrap pattern in _safe_search_pattern so a
+        # literal like "[frx" matches the user-typed string instead of
+        # parsing as an unclosed character class. The helper has an "re:"
+        # opt-in for callers that actually want regex semantics (see
+        # _safe_search_pattern's docstring).
+        cmd_parts.append(self._escape_shell_arg(_safe_search_pattern(pattern)))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3300,7 +3336,12 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. Wrap pattern in _safe_search_pattern so a
+        # literal like "[frx" matches the user-typed string instead of
+        # parsing as an unclosed character class. The helper has an "re:"
+        # opt-in for callers that actually want regex semantics (see
+        # _safe_search_pattern's docstring).
+        cmd_parts.append(self._escape_shell_arg(_safe_search_pattern(pattern)))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
## Summary

search_files passed user-supplied patterns verbatim to ripgrep, so any
literal containing regex metacharacters (`{`, `(`, `[`, `?`, `+`, etc.)
crashed the search with `rg: regex parse error` instead of matching the
typed string. The live offender was an alternation like

    (?:const foldersOnly|navigate\('/designs', { replace)

where the `{` opened a quantifier context that ripgrep could not parse.
ripgrep exited 2 and the wrapper surfaced it as a hard `Search failed:`
error, burning a turn on what was meant to be a literal lookup.

## Fix

Wrap user patterns in `re.escape()` by default so a literal like `[frx`
or `host.com?` matches the typed string. Callers that genuinely want
regex semantics (e.g. `def\s+\w+`, `TODO|FIXME`) opt in with the
`re:` prefix; the sentinel is stripped and the remainder is passed
through to rg/grep unescaped. Probes that earlier used the raw pattern
also route through the same helper so they never disagree with what
the main search actually looks for.

## Regression coverage

In `tests/tools/test_search_error_guard.py`:

- literal metacharacters (`host.com?`, `c++`, `[bracket]`, `[frx`) match files
- plain alphanumeric patterns behave as before
- `re:` opt-in still surfaces real regex matches
- `re:` + malformed regex still surfaces the original parse error
- unit test pins `_safe_search_pattern`'s escape and opt-in semantics

Existing search_files tests continue to pass after their literal patterns
are re-tagged with `re:` where the call genuinely relied on regex
semantics.

## Why this approach

A recovery path (auto-retry with `rg -F` on parse error) only treats the
symptom. Wrapping the input by default means a literal pattern never
*reaches* the regex engine in the first place, eliminating the entire
class of bug. The `re:` opt-in keeps the documented "regex" semantics
of `search_files` reachable for callers that actually need them.

Refs: kanban t_fba6e470, t_8c3e6aab.
