### PR TITLE
fix(gateway): default ntfy display tier to LOW to stop progress-chunk spam

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -171,6 +171,13 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "wecom":           _TIER_LOW,
     "wecom_callback":  _TIER_LOW,
     "dingtalk":        _TIER_LOW,
+    # ntfy is a push-notification platform with no message-editing support
+    # (the adapter has no edit_message; each publish is a permanent message),
+    # so it stays TIER_LOW just like signal/photon/bluebubbles. Without this
+    # entry ntfy inherited the noisy global defaults (tool_progress='all',
+    # interim_assistant_messages=true, long_running_notifications=true) and
+    # published every progress chunk as its own permanent push.
+    "ntfy":            _TIER_LOW,
 
     # Tier 4 — batch or non-interactive delivery
     "email":           _TIER_MINIMAL,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -133,11 +133,22 @@ class TestPlatformDefaults:
 
 
     def test_low_tier_platforms(self):
-        """Signal, BlueBubbles, etc. default to 'off' tool progress."""
+        """Signal, BlueBubbles, ntfy, etc. default to 'off' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
+        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud", "ntfy"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
+
+    def test_ntfy_low_tier_silences_chatter(self):
+        """ntfy (no message editing) must not inherit the noisy global defaults."""
+        from gateway.display_config import resolve_display_setting
+
+        # Each of these defaults to the "noisy" global value without the
+        # platform entry — exactly the ntfy-spam bug this guards against.
+        assert resolve_display_setting({}, "ntfy", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "ntfy", "long_running_notifications") is False
+        assert resolve_display_setting({}, "ntfy", "tool_progress") == "off"
+        assert resolve_display_setting({}, "ntfy", "streaming") is False
 
 
     def test_telegram_mobile_chatter_defaults(self):


### PR DESCRIPTION
## Summary

The ntfy integration is a Tier-3 platform (the adapter has no `edit_message` — every publish is a permanent message), like signal/photon/bluebubbles. But unlike those platforms it had no `_PLATFORM_DEFAULTS` entry, so it silently inherited the noisy global defaults (`tool_progress='all'`, `interim_assistant_messages=true`, `long_running_notifications=true`) and published **every progress chunk from long-running jobs as its own permanent push notification**.

This PR adds `ntfy: _TIER_LOW` to `_PLATFORM_DEFAULTS` so only high-signal messages (final results, errors, explicit alerts) are pushed to ntfy, while routine progress chatter stays silent.

## Motivation

- Long agent runs emit many `progress_chunk` events; with ntfy wired as a home channel these became per-step permanent pushes to the user's phone.
- The operational rule is minimal noise (at most one reminder/injection per session); progress spam directly violates that.
- Other Tier-3 platforms already default to quiet tiers — ntfy was simply missing its entry.

## Changes

- `gateway/display_config.py`: add `"ntfy": _TIER_LOW` to `_PLATFORM_DEFAULTS` (with a comment explaining why).
- `tests/gateway/test_display_config.py`: include `ntfy` in the low-tier platform tests + new test that ntfy's `tool_progress` resolves to `"off"`.

## Testing

- Full unit test suite: **21/21 green** locally.
