### PR TITLE
fix(desktop): paint the sent message and streamed progress without waiting on rAF (#95545)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -3,6 +3,7 @@ import { type MutableRefObject, useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $activeSessionStoredIdRotation,
   $currentFastMode,
@@ -29,7 +30,7 @@ import {
   setSessionTileDelegate
 } from '@/store/session-states'
 
-import { useSessionStateCache } from './use-session-state-cache'
+import { isViewSyncCriticalTransition, useSessionStateCache, VIEW_SYNC_FALLBACK_MS } from './use-session-state-cache'
 
 type Cache = ReturnType<typeof useSessionStateCache>
 
@@ -688,5 +689,162 @@ describe('useSessionStateCache — reconnect busy reconcile (#93059)', () => {
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.busy).toBe(false)
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.awaitingResponse).toBe(false)
     expect($sessionStates.get()['runtime-1']?.busy).toBe(false)
+  })
+})
+
+// #95545: the chat pane rendered blank right after sending on Windows. The
+// optimistic user bubble and every busy (streaming) update were published to
+// the view only via requestAnimationFrame; Electron throttles rAF to ~0 for
+// blurred/occluded windows, and Windows focus transitions are not all visible
+// to Page Visibility — so a send landing while the window was unfocused at the
+// instant of Enter waited for a frame that never came, and long tool runs
+// showed no heartbeat from a blurred window.
+describe('useSessionStateCache — send→render publish vs. throttled rAF (#95545)', () => {
+  afterEach(() => {
+    cleanup()
+    $messages.set([])
+    $sessionStates.set({})
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('paints the optimistic user bubble synchronously on send even when rAF never fires', () => {
+    // A parked rAF: Chromium pauses frame callbacks for a renderer it
+    // considers hidden (blurred/occluded on Windows). Pre-fix this send-arm
+    // state was non-critical (busy=true) and waited on that frame — the pane
+    // stayed blank right after Enter until the window earned a frame again.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    let cache!: Cache
+    render(<ViewHarness activeSessionId="send-runtime" onReady={value => (cache = value)} />)
+
+    act(() => {
+      cache.updateSessionState('send-runtime', state => ({
+        ...state,
+        // seedOptimistic's exact shape: optimistic user row + busy arm, before
+        // any backend acceptance.
+        messages: [userMessage('user-optimistic', 'hello from the send edge')],
+        awaitingResponse: true,
+        busy: true,
+        sawAssistantPayload: false,
+        streamId: null,
+        turnLive: false
+      }))
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(['user-optimistic'])
+  })
+
+  it('paints streamed progress via the timer fallback while rAF is parked', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.useFakeTimers()
+
+    let cache!: Cache
+    render(<ViewHarness activeSessionId="stream-runtime" onReady={value => (cache = value)} />)
+
+    // Backend accepted the turn: the normal mid-stream shape (turnLive +
+    // sawAssistantPayload) stays coalesced while busy.
+    act(() => {
+      cache.updateSessionState('stream-runtime', state => ({
+        ...state,
+        messages: [assistantText('assistant-stream', 'first chunk')],
+        awaitingResponse: true,
+        busy: true,
+        sawAssistantPayload: true,
+        streamId: 'assistant-stream-1',
+        turnLive: true
+      }))
+    })
+
+    // Coalesced behind the parked frame: nothing published yet.
+    expect($messages.get()).toEqual([])
+
+    // The fallback timer (not the frame) delivers the paint.
+    act(() => {
+      vi.advanceTimersByTime(VIEW_SYNC_FALLBACK_MS + 1)
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(['assistant-stream'])
+  })
+
+  it('keeps frame-batched coalescing when rAF runs normally', () => {
+    vi.useFakeTimers()
+    let rafCallback: FrameRequestCallback | null = null
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      rafCallback = callback
+
+      return 42
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    let cache!: Cache
+    render(<ViewHarness activeSessionId="frame-runtime" onReady={value => (cache = value)} />)
+
+    act(() => {
+      cache.updateSessionState('frame-runtime', state => ({
+        ...state,
+        messages: [assistantText('assistant-frame', 'streamed on the frame')],
+        awaitingResponse: true,
+        busy: true,
+        sawAssistantPayload: true,
+        streamId: 'assistant-frame-1',
+        turnLive: true
+      }))
+    })
+
+    // Still coalesced until the frame arrives...
+    expect($messages.get()).toEqual([])
+
+    act(() => {
+      rafCallback?.(16)
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(['assistant-frame'])
+
+    // The frame won: the fallback timer was cancelled and must not fire a
+    // second publish (a cancelled fake-timer handle never runs).
+    act(() => {
+      vi.advanceTimersByTime(VIEW_SYNC_FALLBACK_MS * 10)
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(['assistant-frame'])
+  })
+})
+
+describe('isViewSyncCriticalTransition — send→render publish gating (#95545)', () => {
+  it('treats the optimistic send arm (Enter → first backend accept) as critical', () => {
+    const armed = {
+      ...createClientSessionState(),
+      awaitingResponse: true,
+      busy: true,
+      sawAssistantPayload: false,
+      turnLive: false
+    }
+
+    expect(isViewSyncCriticalTransition(armed)).toBe(true)
+  })
+
+  it('keeps live mid-stream updates non-critical so they coalesce on the frame', () => {
+    const streaming = {
+      ...createClientSessionState(),
+      awaitingResponse: true,
+      busy: true,
+      sawAssistantPayload: true,
+      turnLive: true
+    }
+
+    expect(isViewSyncCriticalTransition(streaming)).toBe(false)
+  })
+
+  it('keeps terminal and needs-input transitions critical', () => {
+    // Idle (busy=false) — turn finished, failed, or never armed.
+    expect(isViewSyncCriticalTransition(createClientSessionState())).toBe(true)
+
+    const needsInput = { ...createClientSessionState(), busy: true, needsInput: true }
+
+    expect(isViewSyncCriticalTransition(needsInput)).toBe(true)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -27,6 +27,45 @@ import { SessionStateCache } from '../session-state-cache'
 
 import { chatMessageArraysEquivalent } from './use-session-actions/utils'
 
+/**
+ * How long a busy (streaming) transcript update may wait on
+ * `requestAnimationFrame` before a timer forces the publish.
+ *
+ * Chromium pauses rAF for a renderer it considers hidden, and Electron's
+ * throttling on Windows does not track every focus/occlusion transition
+ * (Page Visibility misses them) — so a stream flush landing while the window
+ * is blurred or occluded could otherwise wait for a frame that never comes
+ * until the user refocuses. Mirrors the delta queue's timer-based delivery
+ * (use-message-stream), so streamed progress paints even while frames are
+ * parked. In a healthy window the rAF fires within one frame — long before
+ * this timer — so the fallback is inert in the common case.
+ */
+export const VIEW_SYNC_FALLBACK_MS = 120
+
+/**
+ * A session-state update that must reach the view synchronously, never
+ * through the deferred frame publish.
+ *
+ * - `!state.busy`: terminal transitions (turn finished, failed, needs input)
+ *   must paint immediately — Electron throttles rAF to ~0 while a window is
+ *   backgrounded, occluded, or unfocused, which stranded the deferred flush
+ *   (the "new chat stuck on Thinking until refocus / F5" bug).
+ * - `state.needsInput`: the agent is waiting on the user; same class.
+ * - Send edge (#95545): between Enter and the backend's first `message.start`
+ *   the optimistic user bubble is the only content the turn will produce for
+ *   a while. If its publish waits on rAF and the window is blurred/occluded
+ *   at the instant of send — common on Windows, where the backend spawning
+ *   child/console processes (e.g. `uv` for a stdio MCP server) or a
+ *   notification can steal focus — the chat pane renders blank right after
+ *   sending. `turnLive` / `sawAssistantPayload` are stamped by the first
+ *   backend acceptance, so this predicate is true only during the optimistic
+ *   arm; once the turn is live, streamed content coalesces on the frame
+ *   publish as before.
+ */
+export function isViewSyncCriticalTransition(state: ClientSessionState): boolean {
+  return !state.busy || state.needsInput || (state.awaitingResponse && !state.turnLive && !state.sawAssistantPayload)
+}
+
 interface SessionStateCacheOptions {
   activeSessionId: string | null
   busyRef: MutableRefObject<boolean>
@@ -124,9 +163,22 @@ export function useSessionStateCache({
   const sessionStateCache = sessionStateByRuntimeIdRef.current
   const pendingViewStateRef = useRef<{ sessionId: string; state: ClientSessionState } | null>(null)
   const viewSyncRafRef = useRef<number | null>(null)
+  const viewSyncTimerRef = useRef<number | null>(null)
   // Runtime id whose transcript currently occupies `$messages` — lets the
   // flush below tell a same-session refresh from a thread switch.
   const viewSessionIdRef = useRef<string | null>(null)
+
+  const cancelViewSync = useCallback(() => {
+    if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
+      window.cancelAnimationFrame(viewSyncRafRef.current)
+      viewSyncRafRef.current = null
+    }
+
+    if (viewSyncTimerRef.current !== null && typeof window !== 'undefined') {
+      window.clearTimeout(viewSyncTimerRef.current)
+      viewSyncTimerRef.current = null
+    }
+  }, [])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -195,12 +247,8 @@ export function useSessionStateCache({
     // repaint over the chat the user just switched to (#47709 / #47743).
     pendingViewStateRef.current = null
     viewSessionIdRef.current = null
-
-    if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
-      window.cancelAnimationFrame(viewSyncRafRef.current)
-      viewSyncRafRef.current = null
-    }
-  }, [])
+    cancelViewSync()
+  }, [cancelViewSync])
 
   const flushPendingViewState = useCallback(() => {
     const pending = pendingViewStateRef.current
@@ -275,23 +323,24 @@ export function useSessionStateCache({
       // stranded in `pendingViewStateRef` indefinitely — that's the "new chat
       // stuck on Thinking until I refocus / F5" bug. Flush these synchronously
       // (cancelling any in-flight RAF, since we're about to publish the latest
-      // state anyway). The plain busy heartbeat stays RAF-batched: that
-      // coalescing exists only to keep periodic `session.info` updates from
-      // churning `$messages` and jerking the scroll position while reading.
-      const isCriticalTransition = !state.busy || state.needsInput
+      // state anyway). The send edge belongs to the same class (#95545): the
+      // optimistic user bubble is staged while `busy` is still true, so it
+      // would wait for a frame that a Windows renderer blurred/occluded at the
+      // instant of Enter may never deliver — the "chat pane renders blank
+      // right after sending" report. The plain busy heartbeat stays
+      // RAF-batched: that coalescing exists only to keep periodic
+      // `session.info` updates from churning `$messages` and jerking the
+      // scroll position while reading.
+      const isCriticalTransition = isViewSyncCriticalTransition(state)
 
       if (isCriticalTransition) {
-        if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
-          window.cancelAnimationFrame(viewSyncRafRef.current)
-          viewSyncRafRef.current = null
-        }
-
+        cancelViewSync()
         flushPendingViewState()
 
         return
       }
 
-      if (viewSyncRafRef.current !== null) {
+      if (viewSyncRafRef.current !== null || viewSyncTimerRef.current !== null) {
         return
       }
 
@@ -301,22 +350,30 @@ export function useSessionStateCache({
         return
       }
 
-      viewSyncRafRef.current = window.requestAnimationFrame(() => {
-        viewSyncRafRef.current = null
+      // Deferred publish, frame-batched with a TIMER fallback. Chromium pauses
+      // rAF for a renderer it considers hidden, and on Windows focus /
+      // occlusion transitions are not all visible to Page Visibility (see the
+      // delta queue's flush-on-focus listeners in use-message-stream) — so an
+      // rAF-only gate can strand streamed progress while the user watches a
+      // long tool run from a blurred window. Whichever of the two fires first
+      // publishes; the other is cancelled, so a healthy frame cadence behaves
+      // exactly as before (one paint per frame, the timer never wins).
+      const runFlush = () => {
+        cancelViewSync()
         flushPendingViewState()
-      })
+      }
+
+      viewSyncRafRef.current = window.requestAnimationFrame(runFlush)
+      viewSyncTimerRef.current = window.setTimeout(runFlush, VIEW_SYNC_FALLBACK_MS)
     },
-    [flushPendingViewState]
+    [cancelViewSync, flushPendingViewState]
   )
 
   useEffect(
     () => () => {
-      if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
-        window.cancelAnimationFrame(viewSyncRafRef.current)
-        viewSyncRafRef.current = null
-      }
+      cancelViewSync()
     },
-    []
+    [cancelViewSync]
   )
 
   const updateSessionState = useCallback(


### PR DESCRIPTION
## Problem

On Windows Desktop, the chat pane sometimes renders **completely blank right after sending** (pressing Enter): the user's own message never appears, no streaming, no tool status, no "working" indicator — and the only recovery is restarting the app (the agent keeps running in the background). Separately, during long tool executions (~10–30 s) the UI shows no visible progress or heartbeat.

## Root cause

In the send→render path (`use-session-state-cache.syncSessionStateToView`), **every busy transcript update — including the optimistic user bubble seeded the instant Enter is pressed — was published to the view only via `requestAnimationFrame`**:

- The send-arm state (`busy: true`, `awaitingResponse: true`) was *not* a "critical transition", so the optimistic message was staged behind an rAF.
- Chromium/Electron throttles `requestAnimationFrame` to ~0 while a window is backgrounded, occluded, or unfocused, and on Windows focus/occlusion transitions are **not all visible to Page Visibility** — the delta queue in `use-message-stream` already documents this and flushes on `focus`/`visibilitychange` for exactly that reason; the view-sync publish never got the same treatment.
- So a send landing while the window was momentarily unfocused at the instant of Enter (common on Windows: the backend spawning child/console processes for a stdio MCP server, notifications, taskbar interaction) waited for a frame that never came. Every subsequent busy update staged behind the same parked frame → **blank pane right after sending, no heartbeat during long tool runs**.

## Fix

Two changes in `use-session-state-cache.ts`:

1. **Send edge is now a critical transition** — `isViewSyncCriticalTransition(state)` treats the optimistic arm (`busy && awaitingResponse && !turnLive && !sawAssistantPayload`, i.e. Enter until the backend's first `message.start`) like turn-end/needs-input: it publishes **synchronously**, so the user's own message is always visible immediately, unconditionally.
2. **Bounded timer fallback for busy publishes** — the deferred view-sync publish now schedules a 120 ms `setTimeout` alongside the rAF; whichever fires first flushes and cancels the other. A healthy window behaves exactly as before (rAF wins in one frame, one paint per frame, heartbeat coalescing preserved — the equivalence gate already blocks no-op publishes); a throttled renderer still paints streamed progress within the timer's clamp.

## Regression tests

`use-session-state-cache.test.tsx` gains a `#95545` describe block that stubs `requestAnimationFrame` to **never fire** (parked frames, the throttled-renderer condition) and asserts:

- the optimistic user bubble reaches `$messages` synchronously on the send arm,
- a live mid-stream update is still coalesced (not published synchronously) but arrives via the timer fallback,
- with a healthy frame cadence the rAF wins and the fallback timer is cancelled (no double publish),
- the pure `isViewSyncCriticalTransition` gating cases.

Sabotage-verified: all 5 new tests fail on pre-fix code and pass with the fix.

## Verification

- `vitest run src/app/session src/app/chat` — **143 files / 1545 tests passed**
- `tsc -p . --noEmit`, `tsc -p tsconfig.electron.json --noEmit`, `tsc -p tsconfig.e2e.json --noEmit` — clean
- `eslint` on the changed files — clean

## Notes / exclusions

- No backend, store-schema, or IPC changes; renderer-only.
- The rAF-vs-timer coalescing contract for heartbeat churn (scroll-jerk protection) is preserved — the timer only ever wins when frames are parked.

Closes #95545


## Reviewer status

**UNCERTAIN (needs-repro):** the trigger — a send landing while the window is momentarily unfocused/backgrounded at the instant of Enter (Chromium parks `requestAnimationFrame` to ~0 for blurred/occluded windows; some Windows focus transitions are invisible to Page Visibility) — is reproduced at the unit level (parked-rAF stub: optimistic bubble now publishes synchronously; 5/5 new tests fail pre-fix, pass post-fix), but end-to-end confirmation from the reporter is pending. Repro details / screen recording requested on #95545 — **awaiting reporter repro confirmation**. If the reporter cannot reproduce with the current build, this PR stays as-is pending their evidence.
