### PR TITLE
fix(tools): scope the project .hermes protected-instruction rule to config spellings

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -547,6 +547,32 @@ class TestProtectedInstructionFiles:
         res = self._write(proj / "config.yaml")
         assert res.get("error") and "BLOCKED" in res["error"]
 
+    def test_project_local_hermes_dir_config_yml_also_gated(self, tmp_path, approvals):
+        proj = tmp_path / "proj" / ".hermes"
+        proj.mkdir(parents=True)
+        approvals["answer"] = "deny"
+        res = self._write(proj / "config.yml")
+        assert res.get("error") and "BLOCKED" in res["error"]
+
+    def test_hermes_dir_scratch_file_not_gated(self, tmp_path, approvals):
+        """Transient scripts directly under .hermes/ steer nothing — the
+        parent-dir rule is scoped to config spellings (#95660). The gate is
+        yolo-proof, so an over-broad match meant an unavoidable per-write
+        approval prompt even under approvals.mode=off."""
+        proj = tmp_path / "proj" / ".hermes"
+        proj.mkdir(parents=True)
+        res = self._write(proj / "tmp_update_html.py", "print('hi')\n")
+        assert not res.get("error"), res
+        assert approvals["calls"] == []
+
+    def test_hermes_dir_nested_subdir_file_not_gated(self, tmp_path, approvals):
+        """Files deeper than directly-under-.hermes keep flowing freely."""
+        nested = tmp_path / "proj" / ".hermes" / "scratch" / "gen.py"
+        nested.parent.mkdir(parents=True)
+        res = self._write(nested, "print('hi')\n")
+        assert not res.get("error"), res
+        assert approvals["calls"] == []
+
     def test_checkout_nested_under_hermes_dir_not_gated(self, tmp_path, approvals):
         """A repo living UNDER a .hermes dir (e.g. ~/.hermes/hermes-agent)
         must not have every write gated — only files directly inside a

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -737,6 +737,14 @@ _PROTECTED_INSTRUCTION_BASENAMES = frozenset({
     "agents.md", "claude.md", "soul.md", ".cursorrules",
 })
 
+# Basenames that steer agent behavior when sitting directly inside a
+# project-local ``.hermes/`` dir. The parent-dir rule is scoped to these so
+# transient scratch files under ``.hermes/`` are not per-write approval
+# prompts (#95660).
+_HERMES_DIR_PROTECTED_BASENAMES = frozenset({
+    "config.yaml", "config.yml",
+})
+
 _real_hermes_home_cached: str | None = None
 _real_hermes_home_loaded = False
 
@@ -833,9 +841,18 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
         # Scope: the file's IMMEDIATE parent must be ``.hermes`` — matching
         # any ancestor named .hermes would gate every write inside a
         # checkout that happens to live under ~/.hermes (e.g. the
-        # hermes-agent repo itself at ~/.hermes/hermes-agent).
+        # hermes-agent repo itself at ~/.hermes/hermes-agent) — and the
+        # basename must be a config spelling. The config-shaped guard is
+        # deliberate: matching EVERY file directly under .hermes/ turned
+        # scratch scripts (tmp_check.py etc.) into per-write approval
+        # prompts that even approvals.mode=off cannot silence, since this
+        # gate is yolo-proof by design (#95660).
         parts = candidate.replace("\\", "/").rstrip("/").split("/")
-        if len(parts) >= 2 and parts[-2] == ".hermes":
+        if (
+            len(parts) >= 2
+            and parts[-2] == ".hermes"
+            and parts[-1].lower() in _HERMES_DIR_PROTECTED_BASENAMES
+        ):
             return candidate
     return None
 


### PR DESCRIPTION
## What does this PR do?

Fixes #95660: the protected-instruction gate's project-local `.hermes` rule matched **every** file whose immediate parent is `.hermes/`, so writing a transient scratch script under a project `.hermes/` dir (e.g. `.hermes/tmp_update_html.py`) triggered the yolo-proof approval prompt on every write — dozens of prompts per session, and neither `approvals.mode: off` nor `--yolo` can silence them by design.

The rule's own comment states the intent — protecting `.hermes/config.yaml`-style project context — but the implementation had no basename scoping. This PR adds it: the parent-dir rule now only fires for the config spellings (`config.yaml` / `config.yml`), via a new `_HERMES_DIR_PROTECTED_BASENAMES` set next to the existing `_PROTECTED_INSTRUCTION_BASENAMES`. Everything else about the gate is untouched:

- the global basename rule (AGENTS.md / CLAUDE.md / SOUL.md / `.cursorrules`) anywhere in the tree,
- the immediate-parent scoping (a checkout nested under a `.hermes` ancestor is still free),
- the `~/.hermes` home carve-out (governed by its own guards),
- the yolo-proof approval semantics for files that DO match.

Verified before narrowing that no code path in the repo consumes anything besides config-style files from a project-local `.hermes/` dir (the loaded-from-cwd instruction set in `agent_init` is SOUL.md / `.hermes.md` / AGENTS.md / CLAUDE.md / `.cursorrules` — all covered by the global basename rule; `.hermes/plugins/` sits one level deeper and was never covered by this rule).

## Related Issue

Fixes #95660

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` — new `_HERMES_DIR_PROTECTED_BASENAMES = {"config.yaml", "config.yml"}`; the `.hermes` parent-dir branch of `_protected_instruction_reason` now also requires the basename to be one of those spellings; comment records why over-broad matching was harmful (yolo-proof per-write prompts, #95660).
- `tests/tools/test_file_write_safety.py` — four pins: `.hermes/config.yaml` still gated (existing test), `.hermes/config.yml` gated too, `.hermes/tmp_update_html.py` (the reporter's exact scratch shape) writes cleanly with zero approval calls, `.hermes/scratch/gen.py` (nested subdir) writes cleanly.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_file_write_safety.py -q` — should pass: 62 passed. Red/green: with the `file_tools.py` change stashed, `test_hermes_dir_scratch_file_not_gated` fails (the scratch write is blocked) while the gating pins pass on both sides.
2. Observed behavior change: a write to `<project>/.hermes/tmp_x.py` no longer raises the approval bar under `approvals.mode: off`; a write to `<project>/.hermes/config.yaml` still does, exactly as before.
3. `ruff check` on both changed files should pass. Note: `tests/tools/test_file_tools.py` has 2 mock-plumbing failures that occur identically on unmodified `main` in this environment (pre-existing, unrelated to this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches the `.hermes` parent-dir rule's scoping
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file suite green; the 2 unrelated mock failures are documented above as pre-existing on main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path handling already normalizes backslashes in this rule
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
