### PR TITLE
ACP core is provider-neutral: shared bridge, scheme rails, review guard (salvage #88470, part 1 of #74743 split)

### DIFF
--- a/agent/acp_openai_bridge.py
+++ b/agent/acp_openai_bridge.py
@@ -1,0 +1,287 @@
+"""OpenAI-shape bridge shared by Hermes' ACP clients.
+
+An ACP agent (``copilot --acp``, and the ACP CLIs that reach Hermes as
+providers) speaks the Agent Client Protocol, which has no OpenAI-style
+``tools``/``tool_calls`` channel: a prompt is text, and a response is text plus
+the agent's *own* tool notifications. Hermes' agentic surface — ``memory``,
+``todo``, ``skill_manage`` and friends — is dispatched from OpenAI-shaped
+``tool_calls``, so on an ACP provider it can only work if the schemas travel
+*into* the prompt as text and the calls are parsed back *out* of the response
+text.
+
+``agent/copilot_acp_client.py`` already carried a private copy of that bridge.
+This module is that code, lifted verbatim into one place so every ACP client
+shares it instead of re-deriving the wire contract:
+
+* :func:`render_tool_bridge_sections` — prompt sections describing the
+  forwarded tools and the ``<tool_call>{...}</tool_call>`` contract.
+* :func:`extract_tool_calls_from_text` — parse those blocks back into
+  ``ChatCompletionMessageToolCall`` objects and return the response text with
+  the blocks stripped.
+* :func:`completion_to_stream_chunks` — re-shape a one-shot ACP response as
+  OpenAI stream chunks for callers that asked for ``stream=True`` (an ACP turn
+  is inherently one-shot from Hermes' perspective).
+
+The one axis clients differ on is *which* tools they forward, so
+``render_tool_bridge_sections`` takes an optional allowlist. A CLI with no tools
+of its own (Copilot) forwards everything Hermes offers; a CLI that is an
+autonomous agent with its own read/edit/execute tools must forward only Hermes'
+agent-level tools, because re-offering the overlapping ones makes Hermes re-run
+work the agent already finished.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+TOOL_CALL_JSON_RE = re.compile(
+    r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}",
+    re.DOTALL,
+)
+
+# The contract sentence shared by every ACP client: how to emit a call.
+TOOL_CALL_CONTRACT = (
+    "Available tools (OpenAI function schema). "
+    "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+    "containing id/type/function{name,arguments}. arguments must be a JSON string."
+)
+
+__all__ = [
+    "TOOL_CALL_BLOCK_RE",
+    "TOOL_CALL_JSON_RE",
+    "TOOL_CALL_CONTRACT",
+    "StreamChunks",
+    "build_openai_tool_call",
+    "tool_specs_from_openai_tools",
+    "render_tool_bridge_sections",
+    "extract_tool_calls_from_text",
+    "completion_to_stream_chunks",
+]
+
+
+class StreamChunks(list):
+    """Stream chunks that can still carry response-level attributes.
+
+    Hermes reads provider-level extras off the object returned by
+    ``chat.completions.create`` (e.g. ``hermes_projected_messages``, consumed by
+    ``agent/provider_projection.py``). A plain list of chunks would silently drop
+    them on the ``stream=True`` path, so ACP clients return this instead and copy
+    the extras onto it.
+    """
+
+
+def completion_to_stream_chunks(completion: SimpleNamespace) -> StreamChunks:
+    """Convert a one-shot ACP response into OpenAI-style stream chunks.
+
+    Response-level attributes other than ``choices``/``usage``/``model`` are
+    copied onto the returned object so nothing a caller reads off the completion
+    is lost when it asked to stream.
+    """
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=getattr(message, "reasoning_content", None),
+        reasoning=getattr(message, "reasoning", None),
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    chunks = StreamChunks([data_chunk, usage_chunk])
+    for key, value in vars(completion).items():
+        if key not in ("choices", "usage", "model"):
+            setattr(chunks, key, value)
+    return chunks
+
+
+def build_openai_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ChatCompletionMessageToolCall:
+    """Build an OpenAI-compatible tool-call object for downstream handling."""
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def tool_specs_from_openai_tools(
+    tools: list[dict[str, Any]] | None,
+    *,
+    allowlist: Iterable[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Flatten OpenAI ``tools`` into ``{name, description, parameters}`` specs.
+
+    Malformed entries are skipped. When ``allowlist`` is given, only tools whose
+    name is in it survive — that is how a client forwards just Hermes'
+    agent-level tools instead of the whole toolset.
+    """
+    allowed = {str(n).strip() for n in allowlist} if allowlist is not None else None
+    specs: list[dict[str, Any]] = []
+    for t in tools or []:
+        if not isinstance(t, dict):
+            continue
+        fn = t.get("function") or {}
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        name = name.strip()
+        if allowed is not None and name not in allowed:
+            continue
+        specs.append(
+            {
+                "name": name,
+                "description": fn.get("description", ""),
+                "parameters": fn.get("parameters", {}),
+            }
+        )
+    return specs
+
+
+def render_tool_bridge_sections(
+    tools: list[dict[str, Any]] | None,
+    tool_choice: Any = None,
+    *,
+    allowlist: Iterable[str] | None = None,
+) -> list[str]:
+    """Prompt sections that carry the forwarded tool schemas + choice hint.
+
+    Returns an empty list when no tool survives filtering and no choice hint was
+    requested, so callers can splice the result into their section list
+    unconditionally.
+    """
+    specs = tool_specs_from_openai_tools(tools, allowlist=allowlist)
+    sections: list[str] = []
+    if specs:
+        sections.append(
+            TOOL_CALL_CONTRACT + "\n" + json.dumps(specs, ensure_ascii=False)
+        )
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+    return sections
+
+
+def extract_tool_calls_from_text(
+    text: str,
+) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    """Pull ``<tool_call>`` blocks out of an ACP response.
+
+    Returns ``(tool_calls, cleaned_text)`` where ``cleaned_text`` is the
+    response with the consumed blocks removed, so the assistant message doesn't
+    show raw JSON to the user.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[ChatCompletionMessageToolCall] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"acp_call_{len(extracted)+1}"
+
+        extracted.append(
+            build_openai_tool_call(
+                call_id=call_id,
+                name=fn_name.strip(),
+                arguments=fn_args,
+            )
+        )
+
+    for m in TOOL_CALL_BLOCK_RE.finditer(text):
+        raw = m.group(1)
+        _try_add_tool_call(raw)
+        consumed_spans.append((m.start(), m.end()))
+
+    # Only try bare-JSON fallback when no XML blocks were found.
+    if not extracted:
+        for m in TOOL_CALL_JSON_RE.finditer(text):
+            raw = m.group(0)
+            _try_add_tool_call(raw)
+            consumed_spans.append((m.start(), m.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -814,9 +814,10 @@ def init_agent(
     # providers have exceptions (for example Copilot's gpt-5-mini still
     # uses chat completions). Also auto-upgrade for direct OpenAI URLs
     # (api.openai.com) since all newer tool-calling models prefer
-    # Responses there. ACP runtimes are excluded: CopilotACPClient
-    # handles its own routing and does not implement the Responses API
-    # surface.
+    # Responses there. ACP runtimes are excluded: an ACP client handles
+    # its own routing and does not implement the Responses API surface.
+    # Keyed on the `acp://` scheme, not one vendor, so every ACP client
+    # is covered.
     # When api_mode was explicitly provided, respect it — the user
     # knows what their endpoint supports (#10473).
     # Exception: Azure OpenAI serves gpt-5.x on /chat/completions and
@@ -826,7 +827,7 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -382,6 +382,29 @@ def _resolve_review_runtime(
         return parent
 
 
+def _parent_can_emit_tool_calls(agent: Any) -> bool:
+    """Whether a fork inheriting ``agent``'s runtime could act at all.
+
+    The review fork's entire job is to emit ``memory`` / ``skill_manage`` tool
+    calls. A provider that IS an autonomous agent reaches Hermes through a client
+    shim, and a shim that cannot carry Hermes tool calls back turns the fork into
+    a guaranteed no-op — one that still pays for a full agent spawn (a whole CLI
+    process, sometimes a JVM) on every review cadence. The in-tree ACP client CAN
+    carry them (it uses the text bridge in ``agent/acp_openai_bridge.py``); this
+    exists so a shim that can't declares ``SUPPORTS_HERMES_TOOL_CALLS = False``
+    and is skipped instead of burning a spawn. Anything that doesn't say
+    otherwise is assumed capable, so ordinary providers are unaffected.
+    """
+    client = getattr(agent, "client", None)
+    for candidate in (client, type(client) if client is not None else None):
+        if candidate is None:
+            continue
+        supported = getattr(candidate, "SUPPORTS_HERMES_TOOL_CALLS", None)
+        if supported is not None:
+            return bool(supported)
+    return True
+
+
 def _msg_text(m: Dict) -> str:
     c = m.get("content")
     if isinstance(c, str):
@@ -1117,6 +1140,29 @@ def _run_review_in_thread(
         _set_approval_callback(_bg_review_auto_deny)
     except Exception:
         pass
+
+    # An agent-as-provider whose client can't carry Hermes tool calls back would
+    # produce a fork that spawns a whole agent and then cannot write anything.
+    # Don't spawn it — point at the override that does work. Checked BEFORE the
+    # thread-scoped silence below so the warning is not swallowed, and
+    # cheap-check-first so the normal path never resolves the runtime twice.
+    # Fixes the class, not one provider: any future agent-as-provider client
+    # inherits the guard.
+    if not _parent_can_emit_tool_calls(agent) and not bool(
+        _resolve_review_runtime(agent, task_cfg).get("routed")
+    ):
+        logger.warning(
+            "Background review skipped: provider %r cannot emit Hermes tool calls, "
+            "so the review fork could not write memories or skills. Set "
+            "auxiliary.background_review.{provider,model} to route the review to "
+            "a normal model.",
+            getattr(agent, "provider", "?"),
+        )
+        try:
+            _set_approval_callback(None)
+        except Exception:
+            pass
+        return
 
     review_agent = None
     review_messages: List[Dict] = []

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -84,6 +84,7 @@ from agent.prompt_caching import (
     strip_anthropic_cache_control,
     strip_anthropic_tool_cache_control,
 )
+from agent.provider_projection import splice_provider_projection
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -6780,6 +6781,15 @@ def run_conversation(
                     assistant_message.content = "\n".join(parts)
                 else:
                     assistant_message.content = str(raw)
+
+            # ── Agent-as-provider projection ──────────────────────────────
+            # A provider that IS an agent ran its own tools inside its own
+            # session before we got here: splice that work into the transcript
+            # as completed call/result rows and tick the skill-review nudge
+            # with the iterations Hermes never saw. Appended before this turn's
+            # assistant message, so the order reads call → result → answer.
+            # No-op for ordinary providers; see agent/provider_projection.py.
+            splice_provider_projection(agent, response, messages)
 
             try:
                 from hermes_cli.lifecycle import (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3143,13 +3143,14 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
-                # returns a plain SimpleNamespace — not an iterable
-                # stream.  Mirror the ACP exclusion used for Responses
-                # API upgrade (lines ~1083-1085).
+                # An ACP client communicates via subprocess stdio and returns a
+                # plain SimpleNamespace — not an iterable stream.  Keyed on the
+                # `acp://` scheme rather than one vendor, so any ACP client is
+                # excluded.  Mirror the ACP exclusion used for Responses API
+                # upgrade (lines ~1083-1085).
                 elif (
                     agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -21,20 +21,17 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from openai.types.chat.chat_completion_message_tool_call import (
-    ChatCompletionMessageToolCall,
-    Function,
+from agent.acp_openai_bridge import (
+    completion_to_stream_chunks as _completion_to_stream_chunks,
+    extract_tool_calls_from_text as _extract_tool_calls_from_text,
+    render_tool_bridge_sections as _render_tool_bridge_sections,
 )
-
 from agent.file_safety import get_read_block_error, get_write_denied_error, is_write_approval_required
 from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
-
-_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
-_TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
 # Stderr fingerprint of the deprecated `gh copilot` CLI extension
 # (https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension).
@@ -203,34 +200,9 @@ def _format_messages_as_prompt(
     if model:
         sections.append(f"Hermes requested model hint: {model}")
 
-    if isinstance(tools, list) and tools:
-        tool_specs: list[dict[str, Any]] = []
-        for t in tools:
-            if not isinstance(t, dict):
-                continue
-            fn = t.get("function") or {}
-            if not isinstance(fn, dict):
-                continue
-            name = fn.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            tool_specs.append(
-                {
-                    "name": name.strip(),
-                    "description": fn.get("description", ""),
-                    "parameters": fn.get("parameters", {}),
-                }
-            )
-        if tool_specs:
-            sections.append(
-                "Available tools (OpenAI function schema). "
-                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
-                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
-                + json.dumps(tool_specs, ensure_ascii=False)
-            )
-
-    if tool_choice is not None:
-        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+    # Copilot has no tools of its own that would collide with Hermes', so it
+    # forwards the whole toolset (no allowlist).
+    sections.extend(_render_tool_bridge_sections(tools, tool_choice))
 
     transcript: list[str] = []
     for message in messages:
@@ -285,140 +257,6 @@ def _render_message_content(content: Any) -> str:
                     parts.append(text.strip())
         return "\n".join(parts).strip()
     return str(content).strip()
-
-
-def _build_openai_tool_call(
-    *,
-    call_id: str,
-    name: str,
-    arguments: str,
-) -> ChatCompletionMessageToolCall:
-    """Build an OpenAI-compatible tool-call object for downstream handling."""
-    return ChatCompletionMessageToolCall(
-        id=call_id,
-        call_id=call_id,
-        response_item_id=None,
-        type="function",
-        function=Function(name=name, arguments=arguments),
-    )
-
-
-def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
-    """Convert a one-shot ACP response into OpenAI-style stream chunks."""
-    choice = completion.choices[0]
-    message = choice.message
-    tool_call_deltas = None
-    if message.tool_calls:
-        tool_call_deltas = []
-        for index, tool_call in enumerate(message.tool_calls):
-            tool_call_deltas.append(
-                SimpleNamespace(
-                    index=index,
-                    id=getattr(tool_call, "id", None),
-                    type=getattr(tool_call, "type", "function"),
-                    function=SimpleNamespace(
-                        name=getattr(tool_call.function, "name", None),
-                        arguments=getattr(tool_call.function, "arguments", None),
-                    ),
-                )
-            )
-
-    delta = SimpleNamespace(
-        role="assistant",
-        content=message.content or None,
-        tool_calls=tool_call_deltas,
-        reasoning_content=message.reasoning_content,
-        reasoning=message.reasoning,
-    )
-    data_chunk = SimpleNamespace(
-        choices=[
-            SimpleNamespace(
-                index=0,
-                delta=delta,
-                finish_reason=choice.finish_reason,
-            )
-        ],
-        model=completion.model,
-        usage=None,
-    )
-    usage_chunk = SimpleNamespace(
-        choices=[],
-        model=completion.model,
-        usage=completion.usage,
-    )
-    return [data_chunk, usage_chunk]
-
-
-def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
-    if not isinstance(text, str) or not text.strip():
-        return [], ""
-
-    extracted: list[ChatCompletionMessageToolCall] = []
-    consumed_spans: list[tuple[int, int]] = []
-
-    def _try_add_tool_call(raw_json: str) -> None:
-        try:
-            obj = json.loads(raw_json)
-        except Exception:
-            return
-        if not isinstance(obj, dict):
-            return
-        fn = obj.get("function")
-        if not isinstance(fn, dict):
-            return
-        fn_name = fn.get("name")
-        if not isinstance(fn_name, str) or not fn_name.strip():
-            return
-        fn_args = fn.get("arguments", "{}")
-        if not isinstance(fn_args, str):
-            fn_args = json.dumps(fn_args, ensure_ascii=False)
-        call_id = obj.get("id")
-        if not isinstance(call_id, str) or not call_id.strip():
-            call_id = f"acp_call_{len(extracted)+1}"
-
-        extracted.append(
-            _build_openai_tool_call(
-                call_id=call_id,
-                name=fn_name.strip(),
-                arguments=fn_args,
-            )
-        )
-
-    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
-        raw = m.group(1)
-        _try_add_tool_call(raw)
-        consumed_spans.append((m.start(), m.end()))
-
-    # Only try bare-JSON fallback when no XML blocks were found.
-    if not extracted:
-        for m in _TOOL_CALL_JSON_RE.finditer(text):
-            raw = m.group(0)
-            _try_add_tool_call(raw)
-            consumed_spans.append((m.start(), m.end()))
-
-    if not consumed_spans:
-        return extracted, text.strip()
-
-    consumed_spans.sort()
-    merged: list[tuple[int, int]] = []
-    for start, end in consumed_spans:
-        if not merged or start > merged[-1][1]:
-            merged.append((start, end))
-        else:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-
-    parts: list[str] = []
-    cursor = 0
-    for start, end in merged:
-        if cursor < start:
-            parts.append(text[cursor:start])
-        cursor = max(cursor, end)
-    if cursor < len(text):
-        parts.append(text[cursor:])
-
-    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
-    return extracted, cleaned
-
 
 
 def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:

--- a/agent/provider_projection.py
+++ b/agent/provider_projection.py
@@ -1,0 +1,70 @@
+"""Fold an agent-as-provider's own activity back into Hermes' turn state.
+
+Most providers are models: they ask Hermes to run a tool and Hermes runs it, so
+the transcript and the loop's counters see every tool iteration. Some providers
+are *agents* — an ACP CLI reached through a client shim, or the codex
+app-server, which takes an analogous path in ``agent/codex_runtime.py``. They
+execute their own read/edit/execute tools inside their own session, and by the
+time Hermes sees the response that work is already done.
+
+Those calls must never come back as pending ``tool_calls`` — Hermes would re-run
+finished work. But two subsystems go blind if they are merely summarised into
+the ``reasoning`` field:
+
+* the **self-improvement loop**, which distils memories and skills by replaying
+  ``messages`` — a one-line activity feed teaches it nothing;
+* the **skill-review nudge**, whose counter (``_iters_since_skill``) only moves
+  on Hermes tool iterations, of which there are none.
+
+So the provider client hands both back on the completion object and this helper
+applies them: ``hermes_projected_messages`` (already-completed
+``assistant(tool_calls=[…])`` + ``tool(result)`` history rows) and
+``hermes_provider_tool_iterations`` (how many tool iterations happened inside
+the provider). Clients that set neither are unaffected, which is every ordinary
+OpenAI-compatible provider.
+
+The splice is append-only and rows go through ``append_message`` like every
+other live-transcript append, so they carry a timestamp and persist the same way
+the codex projection path's rows do.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agent.message_metadata import append_message
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["splice_provider_projection"]
+
+
+def splice_provider_projection(
+    agent: Any, response: Any, messages: list[dict[str, Any]]
+) -> int:
+    """Append the provider's projected history rows and tick the nudge counter.
+
+    Returns the number of rows spliced. Tolerates absent/garbage attributes so a
+    third-party OpenAI-compatible client can't break the turn.
+    """
+    projected = getattr(response, "hermes_projected_messages", None)
+    rows = [m for m in projected if isinstance(m, dict)] if isinstance(projected, list) else []
+    for row in rows:
+        append_message(messages, row)
+    if rows:
+        logger.debug(
+            "spliced %d provider-projected transcript row(s) from %s",
+            len(rows),
+            getattr(agent, "provider", "?"),
+        )
+
+    raw_iters = getattr(response, "hermes_provider_tool_iterations", 0)
+    try:
+        iterations = int(raw_iters or 0)
+    except (TypeError, ValueError):
+        iterations = 0
+    if iterations > 0:
+        agent._iters_since_skill = getattr(agent, "_iters_since_skill", 0) + iterations
+
+    return len(rows)

--- a/contributors/emails/alexander.prendota@gmail.com
+++ b/contributors/emails/alexander.prendota@gmail.com
@@ -1,0 +1,1 @@
+AlexanderPrendota

--- a/tests/agent/test_acp_openai_bridge.py
+++ b/tests/agent/test_acp_openai_bridge.py
@@ -1,0 +1,212 @@
+"""The ACP text bridge is what makes Hermes' own tools reachable on an ACP provider.
+
+ACP has no OpenAI ``tools``/``tool_calls`` channel, so ``memory``,
+``skill_manage``, ``todo`` and friends only work if the schemas travel into the
+prompt as text and the calls are parsed back out of the response text. These
+tests pin both halves plus the streaming shape, and check that the in-tree
+consumer (``agent/copilot_acp_client.py``) still produces the same prompt it did
+when it owned a private copy of this code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from agent.acp_openai_bridge import (  # noqa: E402
+    StreamChunks,
+    completion_to_stream_chunks,
+    extract_tool_calls_from_text,
+    render_tool_bridge_sections,
+    tool_specs_from_openai_tools,
+)
+
+_TOOLS = [
+    {"type": "function", "function": {"name": "memory", "description": "d1", "parameters": {"a": 1}}},
+    {"type": "function", "function": {"name": "read_file", "description": "d2", "parameters": {}}},
+]
+
+
+# ── prompt side ──────────────────────────────────────────────────────────────
+
+
+def test_specs_are_flattened_and_malformed_entries_skipped():
+    specs = tool_specs_from_openai_tools(
+        [*_TOOLS, "junk", None, {"function": None}, {"function": {"name": "  "}}]
+    )
+    assert [s["name"] for s in specs] == ["memory", "read_file"]
+    assert specs[0] == {"name": "memory", "description": "d1", "parameters": {"a": 1}}
+
+
+def test_allowlist_forwards_only_the_named_tools():
+    """An agent-as-provider runs its own read/edit tools; re-offering them would
+    make Hermes re-run finished work, so those clients forward an allowlist."""
+    specs = tool_specs_from_openai_tools(_TOOLS, allowlist=["memory"])
+    assert [s["name"] for s in specs] == ["memory"]
+    # No allowlist at all means "forward everything" — not "forward nothing".
+    assert len(tool_specs_from_openai_tools(_TOOLS)) == 2
+    assert tool_specs_from_openai_tools(_TOOLS, allowlist=[]) == []
+
+
+def test_rendered_sections_carry_the_contract_and_the_schemas():
+    sections = render_tool_bridge_sections(_TOOLS, {"type": "function"})
+    assert len(sections) == 2
+    assert "<tool_call>" in sections[0]
+    payload = json.loads(sections[0].split("\n", 1)[1])
+    assert [s["name"] for s in payload] == ["memory", "read_file"]
+    assert sections[1].startswith("Tool choice hint:")
+
+
+def test_no_tools_and_no_choice_render_nothing():
+    """Callers splice the result unconditionally, so it must be safe to be empty."""
+    assert render_tool_bridge_sections(None) == []
+    assert render_tool_bridge_sections([]) == []
+    assert render_tool_bridge_sections([{"function": {}}]) == []
+
+
+# ── response side ────────────────────────────────────────────────────────────
+
+
+def test_tool_call_block_is_parsed_and_stripped_from_the_text():
+    calls, cleaned = extract_tool_calls_from_text(
+        'Sure.\n<tool_call>{"id": "c1", "type": "function", "function": '
+        '{"name": "memory", "arguments": "{\\"action\\": \\"add\\"}"}}</tool_call>\nDone.'
+    )
+    assert [c.function.name for c in calls] == ["memory"]
+    assert calls[0].id == "c1"
+    assert json.loads(calls[0].function.arguments) == {"action": "add"}
+    # The user must not see the raw JSON.
+    assert "<tool_call>" not in cleaned
+    assert cleaned == "Sure.\nDone."
+
+
+def test_multiple_blocks_are_all_parsed():
+    text = "".join(
+        f'<tool_call>{{"id": "c{i}", "type": "function", '
+        f'"function": {{"name": "todo", "arguments": "{{}}"}}}}</tool_call>'
+        for i in range(3)
+    )
+    calls, cleaned = extract_tool_calls_from_text(text)
+    assert [c.id for c in calls] == ["c0", "c1", "c2"]
+    assert cleaned == ""
+
+
+def test_non_string_arguments_are_json_encoded_and_missing_ids_synthesised():
+    calls, _ = extract_tool_calls_from_text(
+        '<tool_call>{"type": "function", "function": '
+        '{"name": "todo", "arguments": {"op": "list"}}}</tool_call>'
+    )
+    assert calls[0].function.arguments == '{"op": "list"}'
+    assert calls[0].id == "acp_call_1"
+
+
+def test_bare_json_is_a_fallback_only_when_no_block_matched():
+    bare = '{"id": "c9", "type": "function", "function": {"name": "memory", "arguments": "{}"}}'
+    calls, cleaned = extract_tool_calls_from_text(f"before {bare} after")
+    assert [c.id for c in calls] == ["c9"]
+    assert cleaned == "before\nafter"
+
+    # With a real block present the bare-JSON scan must not double-count.
+    both = f'<tool_call>{bare}</tool_call> and {bare}'
+    calls, _ = extract_tool_calls_from_text(both)
+    assert len(calls) == 1
+
+
+def test_malformed_and_empty_input_never_raises():
+    assert extract_tool_calls_from_text("") == ([], "")
+    assert extract_tool_calls_from_text(None) == ([], "")
+    calls, cleaned = extract_tool_calls_from_text("<tool_call>{not json}</tool_call>plain")
+    assert calls == []
+    assert cleaned == "plain"
+    # Well-formed JSON that isn't a tool call is ignored, text preserved.
+    calls, cleaned = extract_tool_calls_from_text('<tool_call>{"function": 5}</tool_call>hi')
+    assert calls == []
+    assert cleaned == "hi"
+
+
+# ── streaming shape ──────────────────────────────────────────────────────────
+
+
+def _completion(**extras):
+    message = SimpleNamespace(
+        content="hello",
+        tool_calls=[
+            SimpleNamespace(
+                id="c1", type="function",
+                function=SimpleNamespace(name="memory", arguments="{}"),
+            )
+        ],
+        reasoning=None,
+        reasoning_content=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=SimpleNamespace(total_tokens=3),
+        model="acp",
+        **extras,
+    )
+
+
+def test_stream_chunks_carry_the_delta_then_the_usage():
+    chunks = completion_to_stream_chunks(_completion())
+    assert len(chunks) == 2
+    delta = chunks[0].choices[0].delta
+    assert delta.content == "hello"
+    assert delta.tool_calls[0].function.name == "memory"
+    assert delta.tool_calls[0].index == 0
+    assert chunks[0].choices[0].finish_reason == "tool_calls"
+    # Usage arrives on its own trailing chunk, as OpenAI does it.
+    assert chunks[0].usage is None
+    assert chunks[1].usage.total_tokens == 3
+    assert chunks[1].choices == []
+
+
+def test_response_level_extras_survive_the_stream_conversion():
+    """Hermes reads provider extras off the returned object; a plain list would
+    drop them and silently disable the projection on stream=True."""
+    chunks = completion_to_stream_chunks(
+        _completion(hermes_projected_messages=[{"role": "tool", "content": "x"}])
+    )
+    assert isinstance(chunks, StreamChunks)
+    assert isinstance(chunks, list)
+    assert chunks.hermes_projected_messages == [{"role": "tool", "content": "x"}]
+
+
+def test_a_text_only_completion_streams_without_tool_call_deltas():
+    completion = _completion()
+    completion.choices[0].message.tool_calls = []
+    completion.choices[0].finish_reason = "stop"
+    chunks = completion_to_stream_chunks(completion)
+    assert chunks[0].choices[0].delta.tool_calls is None
+
+
+# ── the in-tree consumer still speaks the same wire ──────────────────────────
+
+
+def test_copilot_prompt_still_carries_the_contract_and_the_tools():
+    """copilot-acp lost its private copy of the bridge; its prompt must not
+    change shape."""
+    from agent.copilot_acp_client import _format_messages_as_prompt
+
+    prompt = _format_messages_as_prompt(
+        [{"role": "user", "content": "hi"}], model="gpt-5", tools=_TOOLS,
+    )
+    assert "<tool_call>{...}</tool_call>" in prompt
+    assert '"name": "memory"' in prompt
+    assert '"name": "read_file"' in prompt  # copilot forwards everything
+    assert "Hermes requested model hint: gpt-5" in prompt
+    assert "hi" in prompt
+
+
+def test_copilot_prompt_omits_the_tool_section_when_there_are_no_tools():
+    from agent.copilot_acp_client import _format_messages_as_prompt
+
+    prompt = _format_messages_as_prompt([{"role": "user", "content": "hi"}])
+    assert "Available tools" not in prompt
+    assert "Tool choice hint" not in prompt

--- a/tests/agent/test_acp_provider_rails.py
+++ b/tests/agent/test_acp_provider_rails.py
@@ -1,0 +1,91 @@
+"""Two core decisions must key on the ``acp://`` scheme, not on one vendor.
+
+An ACP client talks to a CLI over subprocess stdio: it returns a plain
+completion object rather than an iterable stream, and it does not implement the
+Responses API surface. Both exclusions used to spell out ``acp://copilot``,
+which meant the next ACP client silently inherited the wrong defaults — a
+Responses upgrade its shim cannot serve, and a streaming call that tries to
+iterate a ``SimpleNamespace``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class _FakeCompletions:
+    """Returns a whole completion — exactly what an ACP shim does.
+
+    ``stream=True`` is not honoured (an ACP turn is one-shot), so if the loop
+    ever tries to stream this, iterating the result raises.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok", reasoning=None, tool_calls=[]),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        )
+
+
+class _FakeClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+
+def _agent(monkeypatch, base_url: str, **kwargs):
+    from run_agent import AIAgent
+
+    client = _FakeClient()
+    monkeypatch.setattr("run_agent.OpenAI", lambda **_kw: client)
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda *a, **k: [])
+    agent = AIAgent(
+        model="gpt-5",  # a model that would normally trigger the Responses upgrade
+        api_key="test-key",
+        base_url=base_url,
+        platform="cli",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_memory=True,
+        **kwargs,
+    )
+    return agent, client
+
+
+def test_an_acp_base_url_is_not_upgraded_to_the_responses_api(monkeypatch):
+    agent, _ = _agent(monkeypatch, "acp://somevendor")
+    assert agent.api_mode == "chat_completions"
+
+
+def test_a_non_acp_url_still_upgrades(monkeypatch):
+    """Guard against the exclusion being widened into a blanket opt-out."""
+    agent, _ = _agent(monkeypatch, "https://api.openai.com/v1")
+    assert agent.api_mode == "codex_responses"
+
+
+def test_an_acp_provider_turn_never_asks_for_a_stream(monkeypatch):
+    """A display consumer is present, so streaming would otherwise be chosen."""
+    agent, client = _agent(
+        monkeypatch, "acp://somevendor", stream_delta_callback=lambda *_a, **_k: None
+    )
+    assert agent._has_stream_consumers()
+
+    result = agent.run_conversation("hi")
+
+    assert result["final_response"].startswith("ok")
+    assert client.chat.completions.calls, "the client was never called"
+    assert not any(c.get("stream") for c in client.chat.completions.calls)

--- a/tests/agent/test_background_review_tool_call_guard.py
+++ b/tests/agent/test_background_review_tool_call_guard.py
@@ -1,0 +1,125 @@
+"""The background-review fork must not spawn when it could only no-op.
+
+The review fork's whole job is to emit ``memory`` / ``skill_manage`` tool calls,
+and by default it inherits the parent's live runtime. When the parent provider IS
+an autonomous agent reached through a client shim that cannot carry Hermes tool
+calls back, that fork is a guaranteed no-op — one that still pays for a full
+agent spawn (a whole CLI process, sometimes a JVM) on every review cadence.
+
+So: a client declaring ``SUPPORTS_HERMES_TOOL_CALLS = False`` skips the fork with
+a log line pointing at the ``auxiliary.background_review`` override. A client
+that can emit tool calls is unaffected, as are ordinary providers whose clients
+say nothing at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import agent.background_review as bg  # noqa: E402
+
+
+def _fake_parent(client, *, runtime=None) -> SimpleNamespace:
+    """The minimal parent-agent surface _run_review_in_thread touches pre-fork."""
+    return SimpleNamespace(
+        provider="acp-agent",
+        model="acp-agent",
+        client=client,
+        session_id="s1",
+        platform="cli",
+        request_overrides={},
+        max_tokens=None,
+        acp_command="acp-agent",
+        acp_args=["--acp"],
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        reasoning_config=None,
+        _credential_pool=None,
+        _current_main_runtime=lambda: runtime or {
+            "api_key": "k",
+            "base_url": "acp://agent",
+            "api_mode": "chat_completions",
+        },
+        _emit_auxiliary_failure=lambda *_a, **_k: None,
+        _safe_print=lambda *_a, **_k: None,
+        background_review_callback=None,
+    )
+
+
+def _run(agent, task_cfg=None):
+    """Run the worker with AIAgent patched; return the AIAgent mock."""
+    with (
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.AIAgent") as mock_aiagent,
+        patch("tools.terminal_tool.set_approval_callback"),
+    ):
+        bg._run_review_in_thread(
+            agent, [{"role": "user", "content": "hi"}], "review please", task_cfg
+        )
+    return mock_aiagent
+
+
+def test_fork_is_skipped_when_the_provider_cannot_emit_tool_calls(caplog):
+    client = MagicMock()
+    client.SUPPORTS_HERMES_TOOL_CALLS = False
+    with caplog.at_level(logging.WARNING, logger=bg.logger.name):
+        mock_aiagent = _run(_fake_parent(client))
+    mock_aiagent.assert_not_called()
+    # The user needs to know which knob makes the review work again.
+    assert "auxiliary.background_review" in caplog.text
+
+
+def test_fork_is_spawned_when_the_provider_can_emit_tool_calls():
+    client = MagicMock()
+    client.SUPPORTS_HERMES_TOOL_CALLS = True
+    assert _run(_fake_parent(client)).called
+
+
+def test_ordinary_providers_are_unaffected():
+    # A plain OpenAI-style client says nothing about the capability.
+    class _PlainClient:
+        pass
+
+    assert _run(_fake_parent(_PlainClient())).called
+
+
+def test_the_capability_is_read_off_the_class_too():
+    """Clients declare it as a class attribute; an instance need not set it."""
+
+    class _IncapableClient:
+        SUPPORTS_HERMES_TOOL_CALLS = False
+
+    assert bg._parent_can_emit_tool_calls(_fake_parent(_IncapableClient())) is False
+    assert bg._parent_can_emit_tool_calls(_fake_parent(None)) is True
+
+
+def test_an_incapable_provider_still_reviews_when_the_review_is_routed_away():
+    """``auxiliary.background_review.{provider,model}`` sends the fork to a normal
+    model, so the parent's shim no longer matters."""
+
+    class _IncapableClient:
+        SUPPORTS_HERMES_TOOL_CALLS = False
+
+    routed = {
+        "provider": "openai",
+        "model": "gpt-5",
+        "api_key": "k",
+        "base_url": None,
+        "api_mode": "chat_completions",
+        "credential_pool": None,
+        "request_overrides": {},
+        "max_tokens": None,
+        "command": None,
+        "args": [],
+        "routed": True,
+    }
+    with patch.object(bg, "_resolve_review_runtime", return_value=routed):
+        assert _run(_fake_parent(_IncapableClient())).called

--- a/tests/agent/test_provider_projection.py
+++ b/tests/agent/test_provider_projection.py
@@ -1,0 +1,213 @@
+"""Agent-as-provider transcript projection + skill-nudge tick.
+
+A provider that IS an agent executes its own tools inside its own session. Those
+calls never come back as pending ``tool_calls`` (Hermes would re-run finished
+work), so two subsystems would otherwise be blind to them:
+
+  * the self-improvement loop, which distils skills/memories from ``messages``;
+  * the skill-review nudge, whose counter only moves on Hermes tool iterations.
+
+``splice_provider_projection`` closes both gaps. The helper is unit tested here,
+and the wiring is exercised for real: the last tests drive a whole
+``AIAgent.run_conversation`` turn against an in-process fake client and assert on
+the resulting transcript and counters, so they fail if the loop ever stops
+applying the projection.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from agent.provider_projection import splice_provider_projection  # noqa: E402
+
+_PROJECTED = [
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "acp_s1_t1",
+                "type": "function",
+                "function": {"name": "acpagent_edit", "arguments": '{"path": "main.py"}'},
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "acp_s1_t1",
+        "name": "acpagent_edit",
+        "content": "1 file changed",
+    },
+]
+
+
+def _projected_rows():
+    """Fresh copies — the splice stamps a timestamp onto the dicts it appends."""
+    return [dict(row) for row in _PROJECTED]
+
+
+def _agent(iters: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(provider="acp-agent", _iters_since_skill=iters)
+
+
+def _response(**attrs):
+    return SimpleNamespace(**attrs)
+
+
+# ── unit ─────────────────────────────────────────────────────────────────────
+
+
+def test_projected_rows_are_appended_and_the_nudge_ticks():
+    agent = _agent()
+    messages = [{"role": "user", "content": "edit main.py"}]
+    spliced = splice_provider_projection(
+        agent,
+        _response(hermes_projected_messages=_projected_rows(), hermes_provider_tool_iterations=1),
+        messages,
+    )
+    assert spliced == 2
+    assert messages[1]["tool_calls"][0]["function"]["name"] == "acpagent_edit"
+    assert messages[2]["content"] == "1 file changed"
+    assert agent._iters_since_skill == 1
+
+
+def test_rows_are_stamped_like_every_other_live_transcript_append():
+    """They go through ``append_message``; an unstamped row persists differently
+    from the ones the loop appends itself."""
+    messages: list = []
+    splice_provider_projection(
+        _agent(), _response(hermes_projected_messages=_projected_rows()), messages
+    )
+    assert all(isinstance(m.get("timestamp"), float) for m in messages)
+
+
+def test_iterations_accumulate_across_calls():
+    agent = _agent(iters=2)
+    splice_provider_projection(agent, _response(hermes_provider_tool_iterations=3), [])
+    assert agent._iters_since_skill == 5
+
+
+def test_ordinary_provider_response_is_a_no_op():
+    agent = _agent(iters=1)
+    messages = [{"role": "user", "content": "hi"}]
+    # A normal OpenAI completion carries neither attribute.
+    assert splice_provider_projection(agent, SimpleNamespace(choices=[]), messages) == 0
+    assert messages == [{"role": "user", "content": "hi"}]
+    assert agent._iters_since_skill == 1
+
+
+def test_garbage_attributes_cannot_break_the_turn():
+    agent = _agent()
+    messages: list = []
+    assert splice_provider_projection(
+        agent,
+        _response(
+            hermes_projected_messages="not-a-list",
+            hermes_provider_tool_iterations="lots",
+        ),
+        messages,
+    ) == 0
+    assert messages == []
+    assert agent._iters_since_skill == 0
+
+    # A list with non-dict entries keeps only the usable rows.
+    assert splice_provider_projection(
+        agent,
+        _response(hermes_projected_messages=[{"role": "tool", "content": "ok"}, "junk", None]),
+        messages,
+    ) == 1
+    assert [m["role"] for m in messages] == ["tool"]
+
+
+# ── wired into the real conversation loop ────────────────────────────────────
+
+
+class _FakeAgentProviderCompletions:
+    """One canned completion, shaped like what an ACP client returns."""
+
+    def __init__(self, projected, iterations):
+        self._projected = projected
+        self._iterations = iterations
+
+    def create(self, **_kwargs):
+        message = SimpleNamespace(content="Edited main.py.", tool_calls=[], reasoning=None)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="stop")],
+            usage=None,
+            hermes_projected_messages=self._projected,
+            hermes_provider_tool_iterations=self._iterations,
+        )
+
+
+class _FakeAgentProviderClient:
+    def __init__(self, projected, iterations):
+        self.chat = SimpleNamespace(
+            completions=_FakeAgentProviderCompletions(projected, iterations)
+        )
+
+
+def _run_turn(monkeypatch, *, projected, iterations):
+    """Drive one real ``run_conversation`` turn against the fake client."""
+    from run_agent import AIAgent
+
+    monkeypatch.setattr(
+        "run_agent.OpenAI",
+        lambda **_kw: _FakeAgentProviderClient(projected, iterations),
+    )
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda *a, **k: [])
+
+    agent = AIAgent(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:8080/v1",
+        platform="cli",
+        max_iterations=3,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+    agent._disable_streaming = True
+    result = agent.run_conversation("edit main.py")
+    return agent, result
+
+
+def test_provider_work_lands_in_the_transcript_through_the_real_loop(monkeypatch):
+    _agent_, result = _run_turn(monkeypatch, projected=_projected_rows(), iterations=1)
+
+    messages = result["messages"]
+    tool_rows = [
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "tool" and m.get("name") == "acpagent_edit"
+    ]
+    assert tool_rows, messages
+    assert "1 file changed" in tool_rows[0]["content"]
+
+    # The projected call precedes its result, and both precede the final answer.
+    idx_call = next(
+        i for i, m in enumerate(messages)
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    idx_result = messages.index(tool_rows[0])
+    assert idx_call < idx_result < len(messages) - 1
+
+
+def test_provider_iterations_tick_the_skill_nudge_through_the_real_loop(monkeypatch):
+    """Isolated from the loop's own per-iteration bump by running the same turn
+    with and without provider iterations."""
+    agent_with, _ = _run_turn(monkeypatch, projected=_projected_rows(), iterations=1)
+    agent_without, _ = _run_turn(monkeypatch, projected=[], iterations=0)
+    assert agent_with._iters_since_skill - agent_without._iters_since_skill == 1
+
+
+def test_ordinary_provider_turn_is_unchanged(monkeypatch):
+    """A completion without the attributes must not gain rows or counter ticks."""
+    _agent_, result = _run_turn(monkeypatch, projected=[], iterations=0)
+    assert not [
+        m for m in result["messages"]
+        if isinstance(m, dict) and str(m.get("name") or "").startswith("acpagent_")
+    ]


### PR DESCRIPTION
## Summary
Part 1 of the #74743 split: provider-neutral ACP core with no vendor integration attached. One shared OpenAI text bridge replaces private copies, two vendor-keyed core exclusions become scheme-keyed, the background-review fork refuses to spawn when it could only no-op, and agent-as-provider tool work is spliced back into the turn.

Salvage of #88470 by @AlexanderPrendota (JetBrains), cherry-picked onto current main with authorship preserved (4 commits).

## Changes
- `agent/acp_openai_bridge.py` (new): the Copilot ACP text bridge lifted verbatim into a shared module — prompt sections, `<tool_call>` parsing, stream-chunk shaping; `copilot-acp` migrated onto it (−176 lines, wire shape pinned by test).
- `agent/agent_init.py` + `agent/conversation_loop.py`: Responses-upgrade and streaming exclusions key on the `acp://` scheme instead of `acp://copilot`; a non-ACP URL still upgrades (pinned).
- `agent/background_review.py`: clients declaring `SUPPORTS_HERMES_TOOL_CALLS = False` skip the review fork (which could only no-op) unless the review is routed to a normal model; silent clients assumed capable — ordinary providers unaffected.
- `agent/provider_projection.py` (new): `splice_provider_projection()` — append-only splice of provider-executed tool call/result rows via `append_message` + skill-nudge counter tick; no-op for ordinary providers.
- 4 new test files, 30 tests, including real `run_conversation` turns against an in-process fake client.

## Validation
| | Before (main agent/ files) | After |
|---|---|---|
| New tests | 6 failed (all three seams live) | 30 passed |
| Existing copilot-acp + background-review tests | — | 41 passed |
| Cache/alternation safety | — | splice is append-only, rows stamped via `append_message`; no past-context mutation |

**Live repro:** sabotage A/B — new suites against main's `agent/` fail on the vendor-keyed streaming rail, the missing review guard, and the missing projection; all green with the salvage.

Context: this is exactly the carve-out Teknium requested on #74743 (bridge + projection + review-fork guard, copilot-acp as in-tree proof consumer). Part 2 (registration seam) remains a separate discussion on #74743.

## Infographic

![ACP core goes neutral](https://v3b.fal.media/files/b/0aa7e793/vmvjPn-5W6kZTrCIgiIqI_Z8E7PTNg.png)
