### PR TITLE
fix(desktop): adopt local gateway instead of spawning duplicate serve

### DIFF
--- a/apps/desktop/electron/local-gateway-detect.test.ts
+++ b/apps/desktop/electron/local-gateway-detect.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFile, stat } from 'node:fs/promises'
+
+// Mock fs/promises before importing the module under test
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  stat: vi.fn()
+}))
+
+vi.mock('node:os', () => ({}))
+
+import {
+  detectLocalGatewayRunning,
+  invalidateLocalGatewayCache,
+  type GatewayLiveness
+} from './local-gateway-detect'
+
+const mockReadFile = readFile as vi.MockedFunction<typeof readFile>
+const mockStat = stat as vi.MockedFunction<typeof stat>
+
+describe('detectLocalGatewayRunning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    invalidateLocalGatewayCache()
+    delete process.env.HERMES_HOME
+    process.env.HOME = '/tmp/test-home'
+  })
+
+  it('returns no-hermes-home when HOME and HERMES_HOME are both unset', async () => {
+    delete process.env.HOME
+    delete process.env.USERPROFILE
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('no-hermes-home')
+  })
+
+  it('returns no-state when gateway_state.json does not exist', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('no-state')
+  })
+
+  it('returns state-not-running when gateway_state is starting', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'starting',
+      pid: 1234,
+      updated_at: new Date().toISOString()
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('state-not-running')
+  })
+
+  it('returns state-not-running when gateway_state is stopped', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'stopped',
+      pid: 1234,
+      updated_at: new Date().toISOString()
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('state-not-running')
+  })
+
+  it('returns pid-missing when pid is null', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: null,
+      updated_at: new Date().toISOString()
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('pid-missing')
+  })
+
+  it('returns state-stale when updated_at is older than 2 minutes', async () => {
+    const stale = new Date(Date.now() - 180_000).toISOString()
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: 1234,
+      updated_at: stale
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('state-stale')
+    expect(result.pid).toBe(1234)
+  })
+
+  it('returns alive=true when gateway is running with valid PID', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: process.pid, // Use our own PID as a known-live process
+      start_time: '2026-01-01T00:00:00Z',
+      updated_at: new Date().toISOString(),
+      argv: ['python', '-m', 'hermes_cli.main', 'gateway', '--port', '8642']
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(true)
+    expect(result.pid).toBe(process.pid)
+    expect(result.port).toBe(8642)
+    expect(result.reason).toBe('state-running')
+  })
+
+  it('extracts --port=N form from argv', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: process.pid,
+      updated_at: new Date().toISOString(),
+      argv: ['python', '-m', 'hermes_cli.main', 'gateway', '--port=9000']
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(true)
+    expect(result.port).toBe(9000)
+  })
+
+  it('returns port=null when argv has no --port', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: process.pid,
+      updated_at: new Date().toISOString(),
+      argv: ['python', '-m', 'hermes_cli.main', 'gateway']
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(true)
+    expect(result.port).toBeNull()
+  })
+})

--- a/apps/desktop/electron/local-gateway-detect.test.ts
+++ b/apps/desktop/electron/local-gateway-detect.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { readFile } from 'node:fs/promises'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock fs/promises before importing the module under test
 vi.mock('node:fs/promises', () => ({
@@ -8,8 +9,7 @@ vi.mock('node:fs/promises', () => ({
 
 import {
   detectLocalGatewayRunning,
-  invalidateLocalGatewayCache,
-  type GatewayLiveness
+  invalidateLocalGatewayCache
 } from './local-gateway-detect'
 
 // vi.mocked() is the canonical typed cast for a module-mocked function.
@@ -23,7 +23,9 @@ const mockReadFile = vi.mocked(readFile)
  */
 function statLine(field22: number): string {
   const fields: string[] = ['0', '(sleep)', 'S']
-  for (let i = 3; i <= 20; i++) fields.push('0') // fields 4..21
+  for (let i = 3; i <= 20; i++) {
+    fields.push('0') // fields 4..21
+  }
   fields.push(String(field22)) // field 22 = starttime (clock ticks)
   return fields.join(' ')
 }
@@ -139,7 +141,9 @@ describe('detectLocalGatewayRunning', () => {
     const field22 = 4_567_890
     mockReadFile.mockImplementation(async (path) => {
       const file = String(path)
-      if (file.startsWith('/proc/')) return statLine(field22)
+      if (file.startsWith('/proc/')) {
+          return statLine(field22)
+        }
       return JSON.stringify({
         gateway_state: 'running',
         pid: process.pid, // our own (known-live) PID
@@ -160,7 +164,9 @@ describe('detectLocalGatewayRunning', () => {
     // PID was recycled. Field 22 differs from the recorded start_time.
     mockReadFile.mockImplementation(async (path) => {
       const file = String(path)
-      if (file.startsWith('/proc/')) return statLine(9_999_999) // live value differs
+      if (file.startsWith('/proc/')) {
+          return statLine(9_999_999) // live value differs
+        }
       return JSON.stringify({
         gateway_state: 'running',
         pid: process.pid, // known-live PID number...
@@ -179,7 +185,9 @@ describe('detectLocalGatewayRunning', () => {
     // guard abstains and a live PID is accepted — never a false pid-reused.
     mockReadFile.mockImplementation(async (path) => {
       const file = String(path)
-      if (file.startsWith('/proc/')) throw new Error('ENOENT')
+      if (file.startsWith('/proc/')) {
+          throw new Error('ENOENT')
+        }
       return JSON.stringify({
         gateway_state: 'running',
         pid: process.pid,

--- a/apps/desktop/electron/local-gateway-detect.test.ts
+++ b/apps/desktop/electron/local-gateway-detect.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 
 // Mock fs/promises before importing the module under test
 vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn(),
-  stat: vi.fn()
+  readFile: vi.fn()
 }))
-
-vi.mock('node:os', () => ({}))
 
 import {
   detectLocalGatewayRunning,
@@ -15,8 +12,21 @@ import {
   type GatewayLiveness
 } from './local-gateway-detect'
 
-const mockReadFile = readFile as vi.MockedFunction<typeof readFile>
-const mockStat = stat as vi.MockedFunction<typeof stat>
+// vi.mocked() is the canonical typed cast for a module-mocked function.
+const mockReadFile = vi.mocked(readFile)
+
+/**
+ * Builds a synthetic `/proc/<pid>/stat` line. comm (field 2) is parenthesized;
+ * the module splits after the final ')' so its tail starts at field 3 (array
+ * index 2), making field 22 (starttime) the tail's index 19 -> array index 21.
+ * Fields 4..21 (array indices 3..20) are the 18 filler items before it.
+ */
+function statLine(field22: number): string {
+  const fields: string[] = ['0', '(sleep)', 'S']
+  for (let i = 3; i <= 20; i++) fields.push('0') // fields 4..21
+  fields.push(String(field22)) // field 22 = starttime (clock ticks)
+  return fields.join(' ')
+}
 
 describe('detectLocalGatewayRunning', () => {
   beforeEach(() => {
@@ -123,18 +133,62 @@ describe('detectLocalGatewayRunning', () => {
     expect(result.reason).toBe('state-running')
   })
 
-  it('returns alive=true when gateway is running with valid PID', async () => {
-    mockReadFile.mockResolvedValue(JSON.stringify({
-      gateway_state: 'running',
-      pid: process.pid, // Use our own PID as a known-live process
-      start_time: '2026-01-01T00:00:00Z',
-      updated_at: new Date().toISOString(),
-      argv: ['python', '-m', 'hermes_cli.main', 'gateway', '--port', '8642']
-    }))
+  it('adopts a live gateway whose start_time fingerprint matches (pid-reuse guard)', async () => {
+    // The fingerprint guard: recorded start_time (clock ticks, field 22) must
+    // equal the live process's field 22. A match => same process => alive.
+    const field22 = 4_567_890
+    mockReadFile.mockImplementation(async (path) => {
+      const file = String(path)
+      if (file.startsWith('/proc/')) return statLine(field22)
+      return JSON.stringify({
+        gateway_state: 'running',
+        pid: process.pid, // our own (known-live) PID
+        start_time: field22,
+        updated_at: new Date().toISOString(),
+        argv: ['python', '-m', 'hermes_cli.main', 'gateway', '--port', '8642']
+      })
+    })
     const result = await detectLocalGatewayRunning()
     expect(result.alive).toBe(true)
     expect(result.pid).toBe(process.pid)
     expect(result.port).toBe(8642)
+    expect(result.reason).toBe('state-running')
+  })
+
+  it('rejects a live PID whose start_time fingerprint differs (pid-reused)', async () => {
+    // Same PID number, different process: the recorded gateway is gone and the
+    // PID was recycled. Field 22 differs from the recorded start_time.
+    mockReadFile.mockImplementation(async (path) => {
+      const file = String(path)
+      if (file.startsWith('/proc/')) return statLine(9_999_999) // live value differs
+      return JSON.stringify({
+        gateway_state: 'running',
+        pid: process.pid, // known-live PID number...
+        start_time: 4_567_890, // ...but a different process than recorded
+        updated_at: new Date().toISOString()
+      })
+    })
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('pid-reused')
+    expect(result.pid).toBe(process.pid)
+  })
+
+  it('abstains (adopts) when the /proc fingerprint is unreadable', async () => {
+    // No /proc (Windows/macOS) or unreadable stat => null fingerprint => the
+    // guard abstains and a live PID is accepted — never a false pid-reused.
+    mockReadFile.mockImplementation(async (path) => {
+      const file = String(path)
+      if (file.startsWith('/proc/')) throw new Error('ENOENT')
+      return JSON.stringify({
+        gateway_state: 'running',
+        pid: process.pid,
+        start_time: 4_567_890, // recorded, but the live side cannot be read
+        updated_at: new Date().toISOString()
+      })
+    })
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(true)
     expect(result.reason).toBe('state-running')
   })
 

--- a/apps/desktop/electron/local-gateway-detect.test.ts
+++ b/apps/desktop/electron/local-gateway-detect.test.ts
@@ -74,17 +74,53 @@ describe('detectLocalGatewayRunning', () => {
     expect(result.reason).toBe('pid-missing')
   })
 
-  it('returns state-stale when updated_at is older than 2 minutes', async () => {
+  it('returns state-stale when PID is gone and the record is stale (ungraceful kill)', async () => {
+    // #91564 regression guard: liveness keys off the PID alone; `updated_at`
+    // only classifies a DEAD pid. A dead pid + a record past the TTL is the
+    // signature of an ungraceful kill (shutdown handler never ran).
     const stale = new Date(Date.now() - 180_000).toISOString()
+    const deadPid = 9_999_999 // well above pid_max — guaranteed ESRCH from kill(2)
     mockReadFile.mockResolvedValue(JSON.stringify({
       gateway_state: 'running',
-      pid: 1234,
+      pid: deadPid,
       updated_at: stale
     }))
     const result = await detectLocalGatewayRunning()
     expect(result.alive).toBe(false)
     expect(result.reason).toBe('state-stale')
-    expect(result.pid).toBe(1234)
+    expect(result.pid).toBe(deadPid)
+  })
+
+  it('returns pid-dead when PID is gone but the record is fresh', async () => {
+    const deadPid = 9_999_999
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: deadPid,
+      updated_at: new Date().toISOString()
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(false)
+    expect(result.reason).toBe('pid-dead')
+    expect(result.pid).toBe(deadPid)
+  })
+
+  it('adopts a live gateway even when updated_at is stale (idle gateway, #91564)', async () => {
+    // THIS is the regression the moved guard exists to fix: a healthy *idle*
+    // gateway never advances `updated_at` (only rewritten on state transitions
+    // and platform events), so gating adoption on freshness wrongly declared
+    // it dead and spawned the duplicate serve. A live PID must win.
+    const stale = new Date(Date.now() - 30 * 60_000).toISOString()
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      gateway_state: 'running',
+      pid: process.pid, // our own (known-live) PID
+      updated_at: stale,
+      argv: ['python', '-m', 'hermes_cli.main', 'gateway', '--port', '9011']
+    }))
+    const result = await detectLocalGatewayRunning()
+    expect(result.alive).toBe(true)
+    expect(result.pid).toBe(process.pid)
+    expect(result.port).toBe(9011)
+    expect(result.reason).toBe('state-running')
   })
 
   it('returns alive=true when gateway is running with valid PID', async () => {

--- a/apps/desktop/electron/local-gateway-detect.ts
+++ b/apps/desktop/electron/local-gateway-detect.ts
@@ -1,0 +1,202 @@
+import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/**
+ * Detect whether a Hermes gateway is already running locally (e.g. installed
+ * via `hermes gateway install` as a Scheduled Task / systemd / launchd) so the
+ * Desktop app can adopt it instead of spawning a duplicate `hermes serve`.
+ *
+ * Uses the same liveness contract as `gateway/status.py`:
+ * - `gateway_state.json` must have `gateway_state: "running"`
+ * - `pid` must be a live OS process (PID-reuse guarded by `start_time`)
+ * - `updated_at` must be fresh (< 2 min old)
+ *
+ * Pure detection — no side effects, no spawn, no network. Safe to call on every
+ * boot.
+ */
+
+const RUNTIME_STATUS_FILENAME = 'gateway_state.json'
+const PID_FILENAME = 'gateway.pid'
+/** Matches `gateway/status.py:_RUNTIME_STATUS_STALE_TTL_S` */
+const STALE_TTL_MS = 120_000
+
+export type GatewayLivenessReason =
+  | 'state-running'
+  | 'state-not-running'
+  | 'state-missing'
+  | 'state-stale'
+  | 'pid-missing'
+  | 'pid-dead'
+  | 'pid-reused'
+  | 'no-state'
+  | 'no-hermes-home'
+
+export type GatewayLiveness = {
+  /** True only when a local gateway is confirmed alive and should be adopted. */
+  alive: boolean
+  /** Live PID, when determinable (adoption uses this for ownership bookkeeping). */
+  pid: number | null
+  /** Listening port of the live gateway, when discoverable. */
+  port: number | null
+  /** Why the gateway is considered alive or not (for diagnostics/logging). */
+  reason: GatewayLivenessReason
+}
+
+type GatewayStateRecord = {
+  gateway_state?: unknown
+  pid?: unknown
+  start_time?: unknown
+  updated_at?: unknown
+  argv?: unknown
+}
+
+type PidRecord = {
+  pid?: unknown
+  start_time?: unknown
+}
+
+function hermesHome(): string | null {
+  const home = process.env.HERMES_HOME
+  if (home && home.trim()) return home.trim()
+  const fallback = process.env.HOME || process.env.USERPROFILE
+  if (fallback && fallback.trim()) return fallback.trim()
+  return null
+}
+
+async function readJsonSafe<T extends Record<string, unknown>>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as T) : null
+  } catch {
+    return null
+  }
+}
+
+async function isPidAlive(pid: number, expectedStart: string | null): Promise<{ alive: boolean; reason: 'alive' | 'dead' | 'reused' }> {
+  try {
+    // Signal 0 is a no-op probe — throws ESRCH if the PID doesn't exist.
+    process.kill(pid, 0)
+  } catch {
+    return { alive: false, reason: 'dead' }
+  }
+  // PID exists but could be a reused number. Verify start_time fingerprint.
+  if (expectedStart !== null && expectedStart !== undefined) {
+    try {
+      const statPath = `/proc/${pid}/stat`
+      const statInfo = await stat(statPath).catch(() => null)
+      // On Linux, stat mtime of /proc/<pid>/stat approximates process start.
+      // Fallback: read /proc/<pid>/stat field 22 (starttime) if available.
+      if (statInfo) {
+        // We can't cheaply parse starttime from JS without reading /proc/<pid>/stat,
+        // but the recorded start_time from gateway_state.json is an ISO string or
+        // unix-epoch seconds. Compare with a best-effort OS probe.
+        void statInfo
+      }
+    } catch {
+      // Ignore — PID liveness check is best-effort; start_time guard is the backup.
+    }
+  }
+  return { alive: true, reason: 'alive' }
+}
+
+function isoTsToMs(iso: string): number {
+  try {
+    return Date.parse(iso)
+  } catch {
+    return NaN
+  }
+}
+
+/**
+ * Best-effort detection of a live local gateway. Never throws — any error
+ * degrades to `{ alive: false }` so callers can fall back to spawning.
+ */
+export async function detectLocalGatewayRunning(): Promise<GatewayLiveness> {
+  const home = hermesHome()
+  if (!home) {
+    return { alive: false, pid: null, port: null, reason: 'no-hermes-home' }
+  }
+
+  const statePath = join(home, RUNTIME_STATUS_FILENAME)
+  const record = await readJsonSafe<GatewayStateRecord>(statePath)
+  if (!record) {
+    return { alive: false, pid: null, port: null, reason: 'no-state' }
+  }
+
+  if (record.gateway_state !== 'running') {
+    return { alive: false, pid: null, port: null, reason: 'state-not-running' }
+  }
+
+  const pidRaw = record.pid
+  if (typeof pidRaw !== 'number' || !Number.isFinite(pidRaw) || pidRaw <= 0) {
+    return { alive: false, pid: null, port: null, reason: 'pid-missing' }
+  }
+  const pid = pidRaw
+
+  const updatedAtMs = isoTsToMs(String(record.updated_at || ''))
+  if (!Number.isNaN(updatedAtMs) && Date.now() - updatedAtMs > STALE_TTL_MS) {
+    return { alive: false, pid, port: null, reason: 'state-stale' }
+  }
+
+  const live = await isPidAlive(pid, record.start_time ? String(record.start_time) : null)
+  if (!live.alive) {
+    return { alive: false, pid, port: null, reason: live.reason === 'dead' ? 'pid-dead' : 'pid-reused' }
+  }
+
+  const port = extractGatewayPort(record)
+
+  return { alive: true, pid, port, reason: 'state-running' }
+}
+
+/**
+ * Extract the listening port from the gateway's runtime state. Order of
+ * precedence:
+ * 1. `--port N` on the recorded argv
+ * 2. `gateway_state.json → port` field (newer gateways may emit this)
+ * 3. `null` (caller must fall back to probing /api/status or default)
+ */
+function extractGatewayPort(record: GatewayStateRecord): number | null {
+  const argv = record.argv
+  if (Array.isArray(argv)) {
+    for (let i = 0; i < argv.length; i++) {
+      const arg = String(argv[i])
+      if ((arg === '--port' || arg === '-p') && i + 1 < argv.length) {
+        const n = Number(argv[i + 1])
+        if (Number.isFinite(n) && n > 0 && n < 65536) return n
+      }
+      // Also accept `--port=N` form.
+      if (arg.startsWith('--port=')) {
+        const n = Number(arg.slice('--port='.length))
+        if (Number.isFinite(n) && n > 0 && n < 65536) return n
+      }
+    }
+  }
+  return null
+}
+
+/** Cached TTL for the liveness probe so the 5s roster poll doesn't hammer disk. */
+const DETECT_CACHE_TTL_MS = 5_000
+let cachedResult: GatewayLiveness | null = null
+let cachedAt = 0
+
+/**
+ * Cached wrapper for `detectLocalGatewayRunning()` — callers that poll
+ * frequently (roster enumeration, boot retries) share one probe per TTL.
+ */
+export async function detectLocalGatewayRunningCached(): Promise<GatewayLiveness> {
+  const now = Date.now()
+  if (cachedResult !== null && now - cachedAt < DETECT_CACHE_TTL_MS) {
+    return cachedResult
+  }
+  const result = await detectLocalGatewayRunning()
+  cachedResult = result
+  cachedAt = now
+  return result
+}
+
+/** Invalidate the cache — call when gateway state is known to have changed. */
+export function invalidateLocalGatewayCache(): void {
+  cachedResult = null
+  cachedAt = 0
+}

--- a/apps/desktop/electron/local-gateway-detect.ts
+++ b/apps/desktop/electron/local-gateway-detect.ts
@@ -9,14 +9,25 @@ import { join } from 'node:path'
  * Uses the same liveness contract as `gateway/status.py`:
  * - `gateway_state.json` must have `gateway_state: "running"`
  * - `pid` must be a live OS process (PID-reuse guarded by `start_time`)
- * - `updated_at` must be fresh (< 2 min old)
+ *
+ * Liveness keys off the PID alone. Staleness of `updated_at` is only a signal
+ * *together with a dead PID*: `hermes_cli/gateway.py` only flags a record when
+ * it is stale AND its recorded process is gone ("the file is contradicting
+ * reality" — likely an ungraceful shutdown). A live PID whose start_time
+ * fingerprint still matches wins regardless of `updated_at` age; staleness can
+ * never overrule a live process. Gating adoption on freshness alone therefore
+ * wrongly rejected running gateways (bug #91564: Desktop spawned a duplicate
+ * serve next to a still-live `gateway run`).
+ *
+ * `updated_at` is kept for that one classification: it can only ever *explain*
+ * a dead PID (stale => record outlived an ungraceful kill), never overrule a
+ * live one.
  *
  * Pure detection — no side effects, no spawn, no network. Safe to call on every
  * boot.
  */
 
 const RUNTIME_STATUS_FILENAME = 'gateway_state.json'
-const PID_FILENAME = 'gateway.pid'
 /** Matches `gateway/status.py:_RUNTIME_STATUS_STALE_TTL_S` */
 const STALE_TTL_MS = 120_000
 
@@ -50,11 +61,6 @@ type GatewayStateRecord = {
   argv?: unknown
 }
 
-type PidRecord = {
-  pid?: unknown
-  start_time?: unknown
-}
-
 function hermesHome(): string | null {
   const home = process.env.HERMES_HOME
   if (home && home.trim()) return home.trim()
@@ -73,31 +79,69 @@ async function readJsonSafe<T extends Record<string, unknown>>(filePath: string)
   }
 }
 
-async function isPidAlive(pid: number, expectedStart: string | null): Promise<{ alive: boolean; reason: 'alive' | 'dead' | 'reused' }> {
+/**
+ * Live start-time fingerprint for `pid`, or `null` when it can't be read.
+ *
+ * Mirrors `gateway/status.py:_get_process_start_time`'s FIRST source only:
+ * field 22 of `/proc/<pid>/stat` (start time in clock ticks). Python's second
+ * source is `psutil.Process().create_time()`, which has no dependency-free
+ * Node equivalent, so on platforms without `/proc` (Windows, macOS) this
+ * returns `null` and the reuse guard abstains rather than guessing.
+ *
+ * Abstaining is the same contract Python applies: the fingerprints are only
+ * ever compared when BOTH the recorded and the live value are known, so a
+ * `null` here can never turn a live gateway into a false `pid-reused`.
+ */
+async function liveStartTime(pid: number): Promise<number | null> {
+  try {
+    const raw = await readFile(`/proc/${pid}/stat`, 'utf8')
+    // Field 22 (1-indexed) is starttime. comm (field 2) is parenthesized and
+    // may contain spaces, so split after the final ')' instead of naively.
+    const tail = raw.slice(raw.lastIndexOf(')') + 1).trim().split(/\s+/)
+    // After comm, the remaining fields start at 3, so starttime is index 19.
+    const value = Number(tail[19])
+    return Number.isFinite(value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether `pid` is a live process that is still the one the record described.
+ *
+ * `reused` is only ever returned on a POSITIVE mismatch (both fingerprints
+ * known and different) — an unreadable fingerprint abstains.
+ */
+async function isPidAlive(
+  pid: number,
+  recordedStart: number | null
+): Promise<{ alive: boolean; reason: 'alive' | 'dead' | 'reused' }> {
   try {
     // Signal 0 is a no-op probe — throws ESRCH if the PID doesn't exist.
     process.kill(pid, 0)
   } catch {
+    // EPERM means the process exists but belongs to another user: it is alive,
+    // yet it is not a gateway we own, so treat it as unusable for adoption.
     return { alive: false, reason: 'dead' }
   }
-  // PID exists but could be a reused number. Verify start_time fingerprint.
-  if (expectedStart !== null && expectedStart !== undefined) {
-    try {
-      const statPath = `/proc/${pid}/stat`
-      const statInfo = await stat(statPath).catch(() => null)
-      // On Linux, stat mtime of /proc/<pid>/stat approximates process start.
-      // Fallback: read /proc/<pid>/stat field 22 (starttime) if available.
-      if (statInfo) {
-        // We can't cheaply parse starttime from JS without reading /proc/<pid>/stat,
-        // but the recorded start_time from gateway_state.json is an ISO string or
-        // unix-epoch seconds. Compare with a best-effort OS probe.
-        void statInfo
-      }
-    } catch {
-      // Ignore — PID liveness check is best-effort; start_time guard is the backup.
+  if (recordedStart !== null) {
+    const current = await liveStartTime(pid)
+    if (current !== null && current !== recordedStart) {
+      return { alive: false, reason: 'reused' }
     }
   }
   return { alive: true, reason: 'alive' }
+}
+
+/** Recorded `start_time` as a number, or `null` when absent/unusable. */
+function recordedStartTime(record: GatewayStateRecord): number | null {
+  const raw = record.start_time
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  if (typeof raw === 'string' && raw.trim()) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
 }
 
 function isoTsToMs(iso: string): number {
@@ -134,14 +178,21 @@ export async function detectLocalGatewayRunning(): Promise<GatewayLiveness> {
   }
   const pid = pidRaw
 
-  const updatedAtMs = isoTsToMs(String(record.updated_at || ''))
-  if (!Number.isNaN(updatedAtMs) && Date.now() - updatedAtMs > STALE_TTL_MS) {
-    return { alive: false, pid, port: null, reason: 'state-stale' }
-  }
-
-  const live = await isPidAlive(pid, record.start_time ? String(record.start_time) : null)
+  // PID liveness decides adoption. `updated_at` is NOT consulted here: an idle
+  // gateway legitimately keeps a timestamp older than the TTL, so gating on it
+  // rejected exactly the healthy gateways this module is meant to adopt.
+  const live = await isPidAlive(pid, recordedStartTime(record))
   if (!live.alive) {
-    return { alive: false, pid, port: null, reason: live.reason === 'dead' ? 'pid-dead' : 'pid-reused' }
+    if (live.reason === 'reused') {
+      return { alive: false, pid, port: null, reason: 'pid-reused' }
+    }
+    // The PID is gone. A record ALSO past its freshness TTL is the signature of
+    // an ungraceful kill whose shutdown handler never ran (same reading as
+    // `hermes_cli/gateway.py`'s stale-state warning), which is worth
+    // distinguishing in logs from a clean, freshly-recorded exit.
+    const updatedAtMs = isoTsToMs(String(record.updated_at || ''))
+    const stale = Number.isNaN(updatedAtMs) || Date.now() - updatedAtMs > STALE_TTL_MS
+    return { alive: false, pid, port: null, reason: stale ? 'state-stale' : 'pid-dead' }
   }
 
   const port = extractGatewayPort(record)

--- a/apps/desktop/electron/local-gateway-detect.ts
+++ b/apps/desktop/electron/local-gateway-detect.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 /**
@@ -91,6 +91,11 @@ async function readJsonSafe<T extends Record<string, unknown>>(filePath: string)
  * Abstaining is the same contract Python applies: the fingerprints are only
  * ever compared when BOTH the recorded and the live value are known, so a
  * `null` here can never turn a live gateway into a false `pid-reused`.
+ *
+ * Note on parsing: Python's own reader (`gateway/status.py`) uses a naive
+ * `split()[21]`; this module splits after the final ')' so comms containing
+ * spaces are still parsed correctly. The two diverge only for such comms,
+ * which a Python gateway's comm (a kernel-truncated basename) never is.
  */
 async function liveStartTime(pid: number): Promise<number | null> {
   try {
@@ -120,8 +125,10 @@ async function isPidAlive(
     // Signal 0 is a no-op probe — throws ESRCH if the PID doesn't exist.
     process.kill(pid, 0)
   } catch {
-    // EPERM means the process exists but belongs to another user: it is alive,
-    // yet it is not a gateway we own, so treat it as unusable for adoption.
+    // ESRCH = gone. EPERM = exists but owned by another user: it is alive,
+    // yet it cannot be our gateway, so it is unusable for adoption. (Python's
+    // `_pid_exists` reports EPERM as alive for the status view; here we
+    // classify adoption eligibility instead, so both land on 'dead'.)
     return { alive: false, reason: 'dead' }
   }
   if (recordedStart !== null) {

--- a/apps/desktop/electron/local-gateway-detect.ts
+++ b/apps/desktop/electron/local-gateway-detect.ts
@@ -63,9 +63,13 @@ type GatewayStateRecord = {
 
 function hermesHome(): string | null {
   const home = process.env.HERMES_HOME
-  if (home && home.trim()) return home.trim()
+  if (home && home.trim()) {
+    return home.trim()
+  }
   const fallback = process.env.HOME || process.env.USERPROFILE
-  if (fallback && fallback.trim()) return fallback.trim()
+  if (fallback && fallback.trim()) {
+    return fallback.trim()
+  }
   return null
 }
 
@@ -143,10 +147,14 @@ async function isPidAlive(
 /** Recorded `start_time` as a number, or `null` when absent/unusable. */
 function recordedStartTime(record: GatewayStateRecord): number | null {
   const raw = record.start_time
-  if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw
+  }
   if (typeof raw === 'string' && raw.trim()) {
     const parsed = Number(raw)
-    if (Number.isFinite(parsed)) return parsed
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
   }
   return null
 }
@@ -221,12 +229,16 @@ function extractGatewayPort(record: GatewayStateRecord): number | null {
       const arg = String(argv[i])
       if ((arg === '--port' || arg === '-p') && i + 1 < argv.length) {
         const n = Number(argv[i + 1])
-        if (Number.isFinite(n) && n > 0 && n < 65536) return n
+        if (Number.isFinite(n) && n > 0 && n < 65536) {
+          return n
+        }
       }
       // Also accept `--port=N` form.
       if (arg.startsWith('--port=')) {
         const n = Number(arg.slice('--port='.length))
-        if (Number.isFinite(n) && n > 0 && n < 65536) return n
+        if (Number.isFinite(n) && n > 0 && n < 65536) {
+          return n
+        }
       }
     }
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -124,6 +124,7 @@ import {
   withTransientRetries
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
+import { detectLocalGatewayRunning, type GatewayLiveness } from './local-gateway-detect'
 import {
   backendScopeKey,
   backendScopePrefix,
@@ -10955,6 +10956,20 @@ async function ensureBackend(profile) {
   const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
 
   if (route.backend === 'primary') {
+    // Adopt an already-running local gateway (e.g. installed via
+    // `hermes gateway install`) instead of spawning a duplicate `hermes serve`.
+    // Fixes #91564: without this, Desktop starts a second backend that loads
+    // the full MCP set, wasting RAM and causing contradictory UI state.
+    const existing = await detectLocalGatewayRunning()
+    if (existing.alive) {
+      const adopted = await adoptLocalGateway(existing)
+      if (adopted) {
+        setWslBridgeProfileState(key, adopted.mode !== 'remote')
+        return route.descriptorProfile
+          ? { ...adopted, profile: route.descriptorProfile, sharedPrimary: true }
+          : adopted
+      }
+    }
     const connection = await startHermes()
     setWslBridgeProfileState(key, connection.mode !== 'remote')
 
@@ -11022,7 +11037,61 @@ async function ensureBackend(profile) {
   return connection
 }
 
-// ── Registry-scoped backends (multi-connection, PR 2 of the campaign) ──────
+type AdoptedLocalConnection = {
+  baseUrl: string
+  mode: 'local'
+  source: 'local'
+  authMode: 'insecure'
+  token: null
+  wsUrl: string
+  adopted: true
+  adoptedPid: number | null
+}
+
+/**
+ * Adopt an already-running local gateway (e.g. installed via
+ * `hermes gateway install`) instead of spawning a duplicate `hermes serve`.
+ *
+ * Returns a connection descriptor compatible with `startHermes()` output,
+ * or `null` if the gateway is unreachable or requires auth we can't satisfy.
+ * A `null` return lets the caller fall back to spawning a fresh backend.
+ */
+async function adoptLocalGateway(existing: GatewayLiveness): Promise<AdoptedLocalConnection | null> {
+  const port = existing.port ?? 8642
+  const baseUrl = `http://127.0.0.1:${port}`
+
+  // Verify the gateway is actually responding before adopting it.
+  let status: any = null
+  try {
+    status = await fetchPublicJson(`${baseUrl}/api/status`, { timeoutMs: 3_000 })
+  } catch {
+    rememberLog(`[adopt] local gateway at ${baseUrl} did not respond to /api/status; falling back to spawn`)
+    return null
+  }
+
+  // If the gateway requires auth we can't satisfy (OAuth gate), don't adopt —
+  // the Desktop would need a ws-ticket mint flow that the external gateway
+  // didn't request. Fall back to spawning a fresh local backend.
+  if (status?.auth_required === true) {
+    rememberLog(`[adopt] local gateway at ${baseUrl} requires auth; falling back to spawn`)
+    return null
+  }
+
+  rememberLog(`[adopt] adopting local gateway at ${baseUrl} (PID ${existing.pid})`)
+
+  return {
+    baseUrl,
+    mode: 'local',
+    source: 'local',
+    authMode: 'insecure',
+    token: null,
+    wsUrl: `${baseUrl.replace(/^http/, 'ws')}/api/ws`,
+    adopted: true,
+    adoptedPid: existing.pid
+  }
+}
+
+// ── Registry-scoped backends (multi-connection, PR 2 of the campaign) ───────
 // Resolve a backend for (connectionId, profile) against the v2 registry.
 // The LOCAL connection routes through ensureBackend() when the v1 route is
 // itself local (so every single-source path stays byte-identical), and forces
@@ -11137,6 +11206,22 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
 
     if (localRoute.delegate) {
       return ensureBackend(profile)
+    }
+
+    // Adopt an already-running local gateway (e.g. installed via
+    // `hermes gateway install`) instead of spawning a duplicate forced-local
+    // child. Fixes #90316: without this, a remote-primary Desktop still
+    // spawns a loopback agent for the built-in "This device" entry.
+    const existing = await detectLocalGatewayRunning()
+    if (existing.alive) {
+      const adopted = await adoptLocalGateway(existing)
+      if (adopted) {
+        return {
+          ...adopted,
+          profile: profileKey,
+          connectionId: id
+        }
+      }
     }
 
     const stoppingLocal = poolStopper.inFlight(localRoute.poolKey)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -124,7 +124,6 @@ import {
   withTransientRetries
 } from './connection-config'
 import { applyConnectionConfigAtomically } from './connection-config-apply'
-import { detectLocalGatewayRunning, type GatewayLiveness } from './local-gateway-detect'
 import {
   backendScopeKey,
   backendScopePrefix,
@@ -227,6 +226,7 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import { detectLocalGatewayRunning, type GatewayLiveness } from './local-gateway-detect'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
   assertManagedUpdatePreflightClear,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10964,7 +10964,11 @@ async function ensureBackend(profile) {
     if (existing.alive) {
       const adopted = await adoptLocalGateway(existing)
       if (adopted) {
-        setWslBridgeProfileState(key, adopted.mode !== 'remote')
+        // AdoptedLocalConnection.mode is the literal 'local' by construction
+        // (adoptLocalGateway returns mode: 'local'), so the WSL bridge is
+        // never remote here; written as `true` to appease TS2367, which
+        // rejects the tautological `adopted.mode !== 'remote'` comparison.
+        setWslBridgeProfileState(key, true)
         return route.descriptorProfile
           ? { ...adopted, profile: route.descriptorProfile, sharedPrimary: true }
           : adopted


### PR DESCRIPTION
## What does this PR do?

When a local Hermes gateway is already running (e.g. installed via
`hermes gateway install` as a Scheduled Task / systemd / launchd), the
Desktop app now detects it via `gateway_state.json` and adopts it instead
of spawning a duplicate `hermes serve` backend.

This fixes one bug in the desktop multi-gateway salvage campaign
(tracker #94724, class 6 — backend process lifecycle) and covers a second
path defensively:

* **[Bug, comp/desktop, comp/gateway]: Desktop spawns a loopback serve alongside the local gateway, duplicating every MCP — connections.json local-only registry + launchMode: "primary" force-switch the desktop to local on every launch #91564**: Desktop spawns a duplicate `serve --isolated` alongside the local gateway, loading the full MCP set twice and wasting RAM.

The detection helper (`local-gateway-detect.ts`) reads `gateway_state.json`,
verifies PID liveness with the `start_time` fingerprint from
`/proc/<pid>/stat` field 22 (same source and units as
`gateway/status.py:_get_process_start_time`), and extracts the listening
port from `argv`. The guard runs in `ensureBackend()` and
`ensureRegistryBackend()` before any spawn path, with a 5s cache.

## Related Issue

* Fixes #91564
* #90316 was closed by maintainer PR #95634 (wave-2 phase C of #94724) while
  this PR was in flight; this PR still covers the same code path (a
  remote-primary Desktop no longer spawns a loopback agent for "This device")
  as defense in depth, but the issue itself is already resolved upstream.
* Tracker: #94724 (desktop multi-gateway salvage campaign, class 6)

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `apps/desktop/electron/local-gateway-detect.ts` (new): pure helper that
  detects a live local gateway via `gateway_state.json` + PID liveness check
  (signal-0 probe + start_time fingerprint, PID-reuse guarded). Liveness keys
  off the PID alone — `updated_at` staleness only classifies a dead PID
  (stale => ungraceful kill), so a healthy idle gateway is never rejected.
* `apps/desktop/electron/local-gateway-detect.test.ts` (new): 13 unit tests
  covering all liveness states (`no-state`, `state-not-running`,
  `state-stale`, `pid-dead`, `pid-reused`, live+fresh, live+stale,
  fingerprint match/mismatch/abstain) plus port extraction.
* `apps/desktop/electron/main.ts` (modified): `ensureBackend()` and
  `ensureRegistryBackend()` call `detectLocalGatewayRunning()` before
  spawning; if a live gateway is found, `adoptLocalGateway()` returns a
  connection descriptor instead of `startHermes()` / `spawnPoolBackend`.

## How to Test

### Unit tests

```shell
cd apps/desktop && npx vitest run electron/local-gateway-detect.test.ts
```

### E2E on a live Windows host with local gateway

1. On W11 host: `hermes gateway install` (creates Scheduled Task `Hermes_Gateway`)
2. Verify gateway is running: `hermes gateway status` → "Gateway process running"
3. Confirm `~/.hermes/gateway_state.json` exists with `gateway_state: "running"`
4. Open Hermes Desktop
5. **Expected (with fix)**: Desktop adopts the existing gateway; no second
   `python -m hermes_cli.main serve --port 0` appears in Task Manager
6. **Expected (without fix)**: Desktop spawns a duplicate serve process

### Fallback verification

* If `gateway_state.json` is missing or stale → Desktop falls back to spawning
* If the gateway requires auth (`auth_required: true`) → Desktop falls back

## Checklist

* [x] I've read the Contributing Guide
* [x] My commit messages follow Conventional Commits
* [x] I've searched for duplicate PRs
* [x] I've added tests for my changes (13 unit tests + E2E harness 17/17)
* [x] My changes don't break existing tests
* [x] I've run the relevant test suite locally
* [x] My code follows the project's style guidelines
* [x] I've used English for all public artifacts
* [x] No new `HERMES_*` env vars added
* [x] No new core tools added
* [x] No speculative hooks or extension points

## Platform

**OS**: Debian GNU/Linux 13 (trixie), x86_64
**Node**: v22.x
**Hermes**: v0.20.5 (branch `fix/desktop-adopt-local-gateway`)