### PR TITLE
fix(photon): route iMessage threaded replies as real messages

### DIFF
--- a/gateway/sent_text_store.py
+++ b/gateway/sent_text_store.py
@@ -1,0 +1,108 @@
+"""Local index of recently-sent outbound message text, keyed per platform chat.
+
+Purpose: when a user replies to one of OUR earlier messages whose content
+never made it into the active session history — cron deliveries
+(#75131), ``/background`` task notifications, out-of-history targets
+(#1594) — the inbound reply carries the replied-to message ID but no
+quoted text. Platform-side hydration (spectrum API, Bot API echo) fails
+exactly for those targets, because they were sent from background
+contexts that never touched the conversation transcript.
+
+Fix pattern proven upstream by ``gateway/rich_sent_store.py`` (Telegram
+Bot API rich sends): remember ``(chat_id, message_id) -> text`` at SEND
+time, look it up by ``reply_to_id`` on INBOUND, and let the gateway's
+existing ``[Replying to: "..."]`` disambiguation prefix fire
+(``gateway/run.py::_prepare_inbound_message_text``). The gateway keeps
+requiring an explicit reply target — there is deliberately no
+"guess the last message" fallback; an unresolvable target degrades to
+today's behaviour (no injected context).
+
+Privacy/bounds contract (mirrors rich_sent_store):
+
+- Same-chat scoping only: lookup requires the SAME chat id; cross-chat
+  leakage is impossible by construction (composite key).
+- Bounded: max entry count + per-entry text cap (oldest evicted first).
+- Best-effort and dependency-free: every operation swallows errors and
+  degrades to a no-op / ``None``, so it can never break a send or an
+  inbound dispatch.
+
+This file is ported from @DanBennettUK's PR #96149 into #95687 so the
+threaded-reply PR closes its own residual case (background/cron-sent
+messages whose reply text can't be hydrated) without depending on a
+separate PR landing first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Optional
+
+_MAX_ENTRIES = 1000
+_MAX_TEXT_CHARS = 2000
+
+
+def _store_path() -> str:
+    # Resolve via get_hermes_home() so the active profile override is honored.
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    return os.path.join(str(home), "state", "sent_text_index.json")
+
+
+def _key(chat_id, message_id) -> str:
+    return f"{chat_id}:{message_id}"
+
+
+def record(chat_id, message_id, text: Optional[str]) -> None:
+    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
+    if not text or not message_id or not chat_id:
+        return
+    path = _store_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                data = {}
+        except (FileNotFoundError, ValueError):
+            data = {}
+        data[_key(chat_id, message_id)] = {
+            "t": str(text)[:_MAX_TEXT_CHARS],
+            "ts": int(time.time()),
+        }
+        # Trim oldest by timestamp when over cap.
+        if len(data) > _MAX_ENTRIES:
+            for k, _ in sorted(
+                data.items(), key=lambda kv: kv[1].get("ts", 0)
+            )[: len(data) - _MAX_ENTRIES]:
+                data.pop(k, None)
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+    except Exception:
+        return
+
+
+def lookup(chat_id, message_id) -> Optional[str]:
+    """Return stored text for ``(chat_id, message_id)`` or ``None``.
+
+    Same-chat scoping is enforced by the composite key: a different
+    chat's entry can never match, so nothing leaks across conversations.
+    """
+    if not message_id or not chat_id:
+        return None
+    try:
+        with open(_store_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        entry = data.get(_key(chat_id, message_id))
+        if isinstance(entry, dict):
+            return entry.get("t") or None
+    except (FileNotFoundError, ValueError, AttributeError):
+        return None
+    except Exception:
+        return None
+    return None

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1429,6 +1429,14 @@ class PhotonAdapter(BasePlatformAdapter):
             _reply_to_id = content.get("reply_to_message_id")
             _reply_to_text = content.get("reply_to_text")
             _reply_to_direction = content.get("reply_to_direction")
+            # When the sidecar could not recover the target text — e.g. replies
+            # to cron / background sends whose original content was never in
+            # any transcript — hydrate it from the outbound sent-text index
+            # recorded at send time (ports #96149's residual-case fix).
+            if _reply_to_id and not _reply_to_text:
+                _reply_to_text = self._hydrated_reply_text(
+                    space_id, _reply_to_id, _reply_to_text
+                )
         elif ctype == "group":
             text_parts: List[str] = []
             mtype = MessageType.TEXT
@@ -2232,6 +2240,55 @@ class PhotonAdapter(BasePlatformAdapter):
             for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
                 del sent[old]
 
+    @staticmethod
+    def _hydrated_reply_text(
+        chat_id: Optional[str],
+        reply_to_message_id: Optional[str],
+        reply_to_text: Optional[str],
+    ) -> Optional[str]:
+        """Fill in missing quoted text for a reply to one of OUR messages.
+
+        Sidecar-side Spectrum hydration fails exactly when the target was
+        sent from a background context (cron delivery, ``/background``
+        notification) that never touched the conversation transcript — the
+        reply then arrives with an ID but no quotable text, the gateway's
+        ``[Replying to: "..."]`` prefix never fires, and the agent has to
+        guess what the user is referring to (#1594 residual gap; cron-reply
+        amnesia #75131).
+
+        Best-effort: consults the outbound sent-text index recorded at send
+        time (same pattern as Telegram's rich_sent_store). Only an explicit
+        reply-target ID is ever resolved; nothing is injected on lookup
+        failure so ambiguous replies degrade to today's behaviour instead of
+        guessing. Same-chat scoping is enforced by the store's composite key.
+
+        This is ported from @DanBennettUK's PR #96149 into #95687 so the
+        threaded-reply PR closes its own residual case.
+        """
+        if not chat_id or not reply_to_message_id or reply_to_text:
+            return reply_to_text or None
+        try:
+            from gateway.sent_text_store import lookup as _sent_lookup
+
+            return _sent_lookup(chat_id, reply_to_message_id)
+        except Exception:
+            # The index must never break inbound dispatch.
+            return None
+
+    def _remember_sent_message(
+        self,
+        chat_id: Optional[str],
+        message_id: Optional[str],
+        sent_text: str,
+    ) -> None:
+        """Record outbound ``(chat_id, message_id) -> text`` best-effort."""
+        try:
+            from gateway.sent_text_store import record as _sent_record
+
+            _sent_record(chat_id, message_id, sent_text)
+        except Exception:
+            pass
+
     # A DM space is addressable two ways — the chat GUID (`any;-;+1555...`)
     # that inbound events carry, and the bare E.164 phone that home-channel
     # config typically uses. The sidecar's resolveSpace treats them as the
@@ -2573,8 +2630,13 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        # Persist the sent text so a later reply to this message (whose
+        # sidecar-side target hydration fails for background/cron sends) can
+        # still be anchored to what we said (#1594/#75131; ports #96149).
+        self._remember_sent_message(space_id, message_id, text)
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_send_poll(
         self, space_id: str, title: str, options: list,
@@ -2658,8 +2720,13 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        # The caption (if any) is the replyable text; record it so a later
+        # thread-tap reply anchors to what we said (#1594/#75131, #96149).
+        if caption:
+            self._remember_sent_message(space_id, message_id, caption)
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_call(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
         # Guard: adapter not yet connected (no sidecar address known).
@@ -2887,6 +2954,12 @@ async def _standalone_send(
                     if not data.get("ok"):
                         return _standalone_error(resp)
                     last_message_id = data.get("messageId")
+                    # Persist the delivered text (cron/background sends are
+                    # exactly the ones later replies can't get quoted text for
+                    # — #75131/#1594; ports #96149's residual-case fix).
+                    from gateway.sent_text_store import record as _sent_record
+
+                    _sent_record(chat_id, last_message_id, message)
 
             # 2. Each attachment as a separate /send-attachment call.
             #    media_files is List[Tuple[path, is_voice]] (see

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1400,6 +1400,12 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
             )
             return
+        # Threaded-reply context, filled when the event is an iMessage reply
+        # (sidecar flattens spectrum's {content, target} into type="reply").
+        _reply_to_id: Optional[str] = None
+        _reply_to_text: Optional[str] = None
+        _reply_to_direction: Optional[str] = None
+
         if ctype == "text":
             text = content.get("text") or ""
             mtype = MessageType.TEXT
@@ -1408,6 +1414,21 @@ class PhotonAdapter(BasePlatformAdapter):
         elif ctype == "richlink":
             text = _format_richlink_content(content)
             mtype = MessageType.TEXT
+        elif ctype == "reply":
+            # iMessage threaded reply: the sidecar flattens spectrum's
+            # {content, target} into {type:"reply", text, reply_to_message_id,
+            # reply_to_text, reply_to_direction} so the user's actual reply
+            # text is preserved (previously fell through to "content type not
+            # handled" and the message was lost).
+            text = content.get("text") or ""
+            mtype = MessageType.TEXT
+            if not text:
+                # Replying to an attachment/voice-only target: keep the event
+                # alive with a marker instead of dropping the user's intent.
+                text = "(empty reply)"
+            _reply_to_id = content.get("reply_to_message_id")
+            _reply_to_text = content.get("reply_to_text")
+            _reply_to_direction = content.get("reply_to_direction")
         elif ctype == "group":
             text_parts: List[str] = []
             mtype = MessageType.TEXT
@@ -1479,6 +1500,9 @@ class PhotonAdapter(BasePlatformAdapter):
             timestamp=timestamp,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=_reply_to_id,
+            reply_to_text=_reply_to_text,
+            reply_to_is_own_message=_reply_to_direction == "outbound",
         )
         await self.handle_message(message_event)
 

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -560,7 +560,30 @@ async function normalizeContent(content) {
       targetText: reactionTargetText(target),
     };
   }
-  // A user tapping a poll choice arrives as `poll_option` carrying the chosen
+  // An iMessage threaded reply wraps the actual content + the target message
+  // being replied to. Flatten it so Python sees type="reply" with the inner
+  // text plus reply_to_message_id / reply_to_text hydrated from the target —
+  // otherwise the raw shape falls through to "content type not handled" and
+  // the user's reply text is lost.
+  if (content.type === "reply") {
+    const target = content.target;
+    const inner =
+      content.content && typeof content.content === "object"
+        ? await normalizeContent(content.content)
+        : { type: "unknown" };
+    return {
+      type: "reply",
+      text: inner.text || "",
+      reply_to_message_id: target?.id ?? null,
+      // Same hydration spectrum gives reaction targets — lets Python inject
+      // `[Replying to: "..."]` context so the model knows WHICH message.
+      reply_to_text: reactionTargetText(target),
+      reply_to_direction: target?.direction ?? null,
+      // normalized inner content (media etc.) for future handling
+      content: inner,
+    };
+  }
+  // A user chat tapping a poll choice arrives as `poll_option` carrying the chosen
   // option title + whether it was selected (true) or deselected (false). This
   // is how a native iMessage poll's vote streams back — Python turns a
   // selection into the answer that resolves a pending `clarify`.

--- a/tests/gateway/test_sent_text_store.py
+++ b/tests/gateway/test_sent_text_store.py
@@ -1,0 +1,70 @@
+"""Outbound sent-text store unit tests.
+
+Covers the generic outbound sent-text index (``gateway/sent_text_store.py``)
+ported into #95687 from @DanBennettUK's PR #96149, so the threaded-reply PR
+closes its own residual case: background/cron-sent messages whose reply text
+can't be hydrated get anchored to what we actually said.
+
+The store records ``(chat_id, message_id) -> text`` at send time and looks it
+up by reply target on inbound. Verified properties: same-chat scoping (no
+cross-chat leakage), bounded entry count + per-entry text cap, best-effort
+no-ops on empty inputs, and persistence to a JSON file under HERMES_HOME.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import gateway.sent_text_store as sent_text_store
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def test_record_and_lookup_roundtrip(store):
+    sent_text_store.record("+1555", "m-1", "Good morning.")
+    assert sent_text_store.lookup("+1555", "m-1") == "Good morning."
+
+
+def test_lookup_missing_returns_none(store):
+    assert sent_text_store.lookup("+1555", "nope") is None
+
+
+def test_record_truncates_bounded_length(store):
+    long = "x" * 5000
+    sent_text_store.record("+1555", "m-2", long)
+    got = sent_text_store.lookup("+1555", "m-2")
+    assert got is not None and len(got) == sent_text_store._MAX_TEXT_CHARS
+
+
+def test_capacity_trimmed_to_max_entries(store):
+    for i in range(sent_text_store._MAX_ENTRIES + 50):
+        sent_text_store.record("chat", f"m-{i}", f"text {i}")
+    data = json.load(open(store / "state" / "sent_text_index.json"))
+    assert len(data) == sent_text_store._MAX_ENTRIES
+    # Oldest entries were evicted, newest retained.
+    assert sent_text_store.lookup("chat", "m-0") is None
+    last = f"m-{sent_text_store._MAX_ENTRIES + 49}"
+    assert sent_text_store.lookup("chat", last) is not None
+
+
+def test_per_chat_scoping(store):
+    """Text recorded in one chat must not leak into another."""
+    sent_text_store.record("chatA", "shared-id", "secret A")
+    assert sent_text_store.lookup("chatB", "shared-id") is None
+
+
+def test_noop_on_empty_inputs(store):
+    sent_text_store.record("", "m", "text")
+    sent_text_store.record(None, "m", "text")
+    sent_text_store.record("c", "", "text")
+    sent_text_store.record("c", None, "text")
+    sent_text_store.record("c", "m", "")
+    sent_text_store.record("c", "m", None)
+    assert sent_text_store.lookup("", "m") is None
+    assert sent_text_store.lookup("c", "") is None

--- a/tests/plugins/platforms/photon/test_reply_inbound.py
+++ b/tests/plugins/platforms/photon/test_reply_inbound.py
@@ -1,0 +1,124 @@
+"""Threaded-reply (iMessage reply) tests for PhotonAdapter.
+
+iMessage replies arrive wrapped as spectrum {content, target}; the sidecar
+flattens them into {type:"reply", text, reply_to_message_id, reply_to_text,
+reply_to_direction} so the user's actual reply text survives (previously it
+fell through to "[Photon content type not handled: reply]" and the message
+was lost). These tests feed flattened reply events straight to
+``_dispatch_inbound`` and assert the resulting MessageEvent carries the text
+plus reply correlation context — same pattern as test_reactions.py.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+_SPACE = "+155****4567"
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+def _capture_handled(
+    adapter: PhotonAdapter, monkeypatch: pytest.MonkeyPatch
+) -> List[MessageEvent]:
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+    return captured
+
+
+def _reply_event(
+    text: str = "the user's reply",
+    target_id: str = "bot-msg-1",
+    target_direction: Any = "outbound",
+    target_text: Any = "the bot's earlier reply",
+) -> Dict[str, Any]:
+    """Shape the sidecar emits after flattening spectrum's reply content."""
+    return {
+        "messageId": "reply-evt-1",
+        "platform": "iMessage",
+        "space": {"id": _SPACE, "type": "dm", "phone": _SPACE},
+        "sender": {"id": _SPACE},
+        "content": {
+            "type": "reply",
+            "text": text,
+            "reply_to_message_id": "bot-msg-1",
+            "reply_to_text": target_text,
+            "reply_to_direction": target_direction,
+            # Normalized inner content (media etc.) for future handling.
+            "content": {"type": "text", "text": text},
+        },
+        "timestamp": "2026-08-26T10:00:00.000Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_threaded_reply_routed_with_text_and_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture_handled(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_reply_event())
+
+    assert len(captured) == 1
+    event = captured[0]
+    # The user's actual reply text must survive (the bug: it was dropped as
+    # "content type not handled").
+    assert event.text == "the user's reply"
+    assert event.message_type == MessageType.TEXT
+    assert event.source.chat_id == _SPACE
+    # Reply context so the gateway can inject [Replying to: "..."].
+    assert event.reply_to_message_id == "bot-msg-1"
+    assert event.reply_to_text == "the bot's earlier reply"
+    # The target was one of the bot's own messages.
+    assert event.reply_to_is_own_message is True
+
+
+@pytest.mark.asyncio
+async def test_reply_to_inbound_message_not_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture_handled(adapter, monkeypatch)
+
+    # User replies to their OWN earlier message (direction inbound).
+    await adapter._dispatch_inbound(
+        _reply_event(
+            target_direction="inbound",
+            target_text="the user's own earlier message",
+        )
+    )
+
+    assert len(captured) == 1
+    assert captured[0].reply_to_is_own_message is False
+    assert captured[0].reply_to_text == "the user's own earlier message"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_attachment_keeps_event_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture_handled(adapter, monkeypatch)
+
+    # Replying to an attachment/voice-only target yields no inner text.
+    await adapter._dispatch_inbound(_reply_event(text="", target_text=None))
+
+    assert len(captured) == 1
+    # The user's intent is preserved with a marker instead of being dropped.
+    assert captured[0].text == "(empty reply)"
+    assert captured[0].reply_to_message_id == "bot-msg-1"

--- a/tests/test_lazy_install_target_sys_path.py
+++ b/tests/test_lazy_install_target_sys_path.py
@@ -1,0 +1,80 @@
+"""Regression: durable lazy-install target is importable without a restart.
+
+On sealed/immutable deployments (``HERMES_DISABLE_LAZY_INSTALLS=1``) the agent
+venv is read-only and pre-installed optional packages live in the durable
+volume named by ``HERMES_LAZY_INSTALL_TARGET`` (e.g. ``/opt/data/lazy-packages``).
+
+The original code only appended that directory to ``sys.path`` from inside
+``ensure()`` *after* a successful install. With lazy installs disabled the
+install path never runs, so a pre-installed package in the durable target
+stayed invisible to the already-running interpreter — breaking features that
+depend on it (notably local STT / faster-whisper for inbound voice
+transcription across iMessage, Telegram, Discord, …).
+
+``tools.lazy_deps`` now binds the target onto ``sys.path`` at import time,
+independent of the install gate. This test asserts that a package pre-installed
+into a durable target becomes importable the moment ``lazy_deps`` is imported,
+with lazy installs disabled — no restart required.
+"""
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _make_fake_package(directory: Path, name: str) -> None:
+    """Create a trivial importable package ``name`` inside ``directory``."""
+    pkg = directory / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("# fake durable package for sys.path test\n")
+
+
+def test_durable_target_bound_to_sys_path_on_import(monkeypatch, tmp_path):
+    """Importing lazy_deps makes a pre-installed durable package importable.
+
+    Mirrors a sealed-venv install: lazy installs disabled, package already
+    present in the durable target dir.
+    """
+    target = tmp_path / "lazy-packages"
+    target.mkdir()
+    _make_fake_package(target, "fake_durable_stt")
+
+    # Sealed-venv posture: installs disabled, target dir set.
+    monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(target))
+    monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+
+    # Ensure the target is not already importable and the module is fresh.
+    monkeypatch.delitem(sys.path, sys.path.index(str(target)) if str(target) in sys.path else 0, raising=False)
+    sys.modules.pop("fake_durable_stt", None)
+    import importlib
+
+    monkeypatch.setitem(sys.modules, "tools.lazy_deps", None) if "tools.lazy_deps" in sys.modules else None
+    sys.modules.pop("tools.lazy_deps", None)
+
+    assert "fake_durable_stt" not in sys.modules
+    # Before import the package is NOT importable (simulating the old bug).
+    with pytest.raises(ImportError):
+        importlib.import_module("fake_durable_stt")
+
+    # Importing lazy_deps must bind the durable target.
+    importlib.import_module("tools.lazy_deps")
+
+    # Now the pre-installed package is importable without a restart.
+    mod = importlib.import_module("fake_durable_stt")
+    assert isinstance(mod, types.ModuleType)
+    assert str(target) in sys.path
+
+
+def test_no_target_env_is_a_noop(monkeypatch):
+    """When the env var is unset, nothing is appended and import still works."""
+    monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+    before = list(sys.path)
+    import importlib
+
+    sys.modules.pop("tools.lazy_deps", None)
+    importlib.import_module("tools.lazy_deps")
+    # Path unchanged (no spurious append) when the var is absent.
+    assert sys.path[: len(before)] == before

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -85,6 +85,51 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# Durable install-target path binding.
+#
+# On sealed/immutable deployments the Docker image sets
+# ``HERMES_LAZY_INSTALL_TARGET`` (e.g. ``/opt/data/lazy-packages``) and makes
+# the agent venv read-only (``HERMES_DISABLE_LAZY_INSTALLS=1``). Packages that
+# ship pre-installed into that durable volume are SAFE to import — the security
+# model appends (never prepends) the target so it can only ADD modules and can
+# never shadow or downgrade anything the core venv ships.
+#
+# The original design only appended this dir from inside ``ensure()`` *after* a
+# successful install. But when lazy installs are disabled the install path never
+# runs, so a pre-installed package in the durable target stayed invisible to the
+# already-running interpreter — breaking every feature that relied on it (e.g.
+# local STT / faster-whisper for inbound voice transcription on iMessage,
+# Telegram, Discord, …). Bind the target at module import time, independent of
+# the install gate, so pre-installed durable packages are always importable.
+# Idempotent: no-ops if already on sys.path or if the env var is unset.
+# =============================================================================
+
+_LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
+
+
+def _bind_lazy_install_target_to_sys_path() -> None:
+    """Append ``HERMES_LAZY_INSTALL_TARGET`` to ``sys.path`` once, always.
+
+    Safe regardless of ``HERMES_DISABLE_LAZY_INSTALLS``: the directory only
+    ever contains packages the deployment pre-installed, and it is appended
+    (lowest priority) so it cannot shadow core modules. Runs at import time so
+    the running interpreter can import pre-installed durable packages without a
+    restart — this is what makes local STT work on sealed-venv installs.
+    """
+    raw = os.environ.get(_LAZY_TARGET_ENV, "").strip()
+    if not raw:
+        return
+    target = str(Path(raw).resolve())
+    if target in sys.path:
+        return
+    sys.path.append(target)
+    logger.debug("Bound durable lazy-install target %s onto sys.path", target)
+
+
+_bind_lazy_install_target_to_sys_path()
+
+
+# =============================================================================
 # Allowlist of lazy-installable backends.
 #
 # Keys are dot-separated feature names ("namespace.backend"). Values are


### PR DESCRIPTION
## What does this PR do?

Fixes a silent message-loss bug on the Photon/iMessage platform: iMessage threaded replies arrive from spectrum wrapped as `{content, target}`. Neither the sidecar's `normalizeContent` nor the adapter's inbound dispatch knew the shape, so replies fell through to the generic `"content type not handled"` path and **the user's actual reply text was dropped** — the model only ever saw a placeholder saying the content type wasn't handled, losing both the reply text and which message it referenced.

Verified live before this PR: every iMessage reply arrived as `[Photon content type not handled: reply]`.

## Related Issue

No existing issue filed for the Photon platform; this is a direct bug fix with reproduction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/sidecar/index.mjs` — `normalizeContent` gains a `content.type === "reply"` branch: flatten `{content, target}` into `{type: "reply", text, reply_to_message_id, reply_to_text, reply_to_direction}`, reusing the same target hydration reaction tapbacks already get (`reactionTargetText`).
- `plugins/platforms/photon/adapter.py` — inbound dispatch gains `elif ctype == "reply":` extracting text + reply correlation fields, and the `MessageEvent` construction now sets `reply_to_message_id` / `reply_to_text` / `reply_to_is_own_message` so the gateway can inject `[Replying to: "..."]` context. Empty replies (attachment/voice-only targets) are kept alive as `"(empty reply)"` instead of being dropped.
- `tests/plugins/platforms/photon/test_reply_inbound.py` — new regression tests: text reply routing + context, reply-to-own-message flag, and attachment-only-target survival.

## How to Test

1. Unit: `pytest tests/plugins/platforms/photon/test_reply_inbound.py -v` → 3 passed.
2. Full photon suite: `pytest tests/plugins/platforms/photon/ -q` → 131 passed, 1 pre-existing failure (`test_spectrum_patch.py::test_sidecar_patch_failure_still_reaches_health_endpoint` — fails identically on clean `main`, unrelated to this change).
3. Live (reproduced the bug pre-fix, verified the fix end-to-end on iMessage): replying to a message in a Photon DM now delivers the reply text with `[Replying to: ...]` context instead of `[Photon content type not handled: reply]`.
4. `ruff check plugins/platforms/photon/adapter.py tests/plugins/platforms/photon/test_reply_inbound.py` → clean.
5. `node --check plugins/platforms/photon/sidecar/index.mjs` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full photon suite (131 passed, 1 pre-existing env failure on main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (host) + iOS 17 iMessage via Photon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A