### PR TITLE
fix(desktop): resolve session owners from cron/messaging slices and route clarify responses through the owner (salvage #95633 + #95652)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,7 +22,7 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
+import { $sessions, knownSessionOwner, ownerLookupSessionRows, sessionMatchesStoredId } from '@/store/session'
 import {
   requestForSessionProfile,
   type SessionOwnerScope,
@@ -178,7 +178,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   const requestSessionGateway = useCallback(
     <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
       const knownOwner: SessionOwnerScope =
-        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner($sessions.get(), storedIdRef.current)
+        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner(ownerLookupSessionRows(), storedIdRef.current)
 
       // A bare profile is the legacy/unknown tile shape. Preserve its ambient
       // behavior; only a composite route is strong enough to retarget a tile

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { $sessions, knownSessionOwner } from '@/store/session'
+import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
@@ -80,7 +80,7 @@ export function useSessionTileDelegate({
     const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
       const owner =
         sessionTileOwnerRoute(storedSessionId) ??
-        knownSessionOwner($sessions.get(), storedSessionId) ??
+        knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
         (await resolveSessionOwner(storedSessionId))
 
       return owner

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -32,7 +32,10 @@ vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => (
 const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
 const { $connectionsRegistry } = await import('@/store/connection-registry-state')
 const { $profiles } = await import('@/store/profile')
-const { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } = await import('@/store/session')
+
+const { _resetSessionOwnerHintsForTests, setCronSessions, setMessagingSessions, setSessionOwnerHint, setSessions } =
+  await import('@/store/session')
+
 const { isSessionOwnerResolutionError } = await import('@/store/session-owner-resolution')
 const { $sessionTiles } = await import('@/store/session-states')
 const { makeSessionInfo } = await import('@/test/session-info')
@@ -59,6 +62,8 @@ beforeEach(() => {
 afterEach(() => {
   $connectionsRegistry.set(null)
   setSessions([])
+  setCronSessions([])
+  setMessagingSessions([])
   $sessionTiles.set([])
   $profiles.set([])
   _resetSessionOwnerHintsForTests({ storage: true })
@@ -151,6 +156,41 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
     })
     expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('homelab', 'worker', 'session.activate', {
       session_id: 'stored-hidden'
+    })
+  })
+
+  it('resolves owners from the cron and messaging sidebar slices, not just recents (cron approval.respond)', async () => {
+    // A scheduler-minted cron session has no tile, no hint, and no row in
+    // $sessions — its row lives in the sidebar's cron slice. The row rung must
+    // see that slice, or the approval raised inside a cron chat fails closed
+    // with SessionOwnerResolutionError and can never be answered.
+    setCronSessions([makeSessionInfo({ id: 'stored-cron', profile: 'omar', source: 'cron' })])
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(
+      request('approval.respond', { choice: 'once', request_id: 'req-1', session_id: 'stored-cron' })
+    ).resolves.toEqual({ profiled: true })
+    expect(gatewayMocks.requestGatewayForProfile).toHaveBeenLastCalledWith(
+      'omar',
+      'approval.respond',
+      {
+        choice: 'once',
+        request_id: 'req-1',
+        session_id: 'stored-cron'
+      },
+      undefined,
+      undefined
+    )
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(probe.resolveSessionOwner).not.toHaveBeenCalled()
+
+    // Messaging slice, connection-tagged row → exact route.
+    setMessagingSessions([makeSessionInfo({ connection_id: 'homelab', id: 'stored-tg', profile: 'bots' })])
+
+    await expect(request('prompt.submit', { session_id: 'stored-tg', text: 'hi' })).resolves.toEqual({ routed: true })
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('homelab', 'bots', 'prompt.submit', {
+      session_id: 'stored-tg',
+      text: 'hi'
     })
   })
 })

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -35,7 +35,7 @@ import type { MutableRefObject } from 'react'
 
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
-import { $sessions, getSessionOwnerHint, knownSessionOwner } from '@/store/session'
+import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
@@ -76,7 +76,7 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     let owner: SessionOwnerScope = resolveSessionRpcOwner({
       routingSessionId,
       sessionOwnerHint: storedSessionId => getSessionOwnerHint(storedSessionId),
-      sessionRowOwner: storedSessionId => knownSessionOwner($sessions.get(), storedSessionId),
+      sessionRowOwner: storedSessionId => knownSessionOwner(ownerLookupSessionRows(), storedSessionId),
       tileOwnerRoute: sessionTileOwnerRoute
     })
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -7,9 +7,24 @@ import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
-import { $activeSessionId } from '@/store/session'
+import { $profiles } from '@/store/profile'
+import { $activeSessionId, _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/session'
 
 import { ClarifyTool, readClarifyBatchResult, readClarifyResult } from './clarify-tool'
+
+// The OWNER-socket seam (`requestForOwnedSession` → `requestForSessionProfile`
+// → here). Mocked so the real owner ladder still runs against real fixtures and
+// only the dial is observed; the rest of the gateway store stays actual, so
+// `$gateway` remains the genuine ambient atom every other test in this file
+// drives.
+const gatewayMocks = vi.hoisted(() => ({
+  requestGatewayForAgent: vi.fn(async () => ({ ok: true }))
+}))
+
+vi.mock('@/store/gateway', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  requestGatewayForAgent: gatewayMocks.requestGatewayForAgent
+}))
 
 // The live pending card used to require message-running. Tests that exercise
 // the pending form force that on; the settle-shift case flips it off.
@@ -705,5 +720,125 @@ describe('ClarifyTool batch card', () => {
     expect(screen.getByText('red')).toBeTruthy()
     expect(screen.getByText('Name?')).toBeTruthy()
     expect(screen.getByText('Skipped')).toBeTruthy()
+  })
+})
+
+// ─── Owner routing (#91684 client half) ─────────────────────────────────────
+// The clarify card used to answer on the AMBIENT socket. That socket follows
+// foreground focus, so after a profile / Bot Chat switch it can be profile B
+// while the blocking clarify belongs to profile A — the response lands on a
+// backend that never held the request and the owner stays blocked until the
+// tool times out. Every live clarify.respond now routes by request.sessionId.
+
+const OWNER_CONNECTION_ID = 'conn-profile-a'
+const OWNER_PROFILE = 'profile-a'
+
+/** Profile A owns the clarify's session; the window has since switched to
+ *  profile B, so `$gateway` (ambient) is profile B's socket. */
+function armCrossProfileOwner() {
+  // Two profiles exist → the ambient gateway is not provably the sole backend,
+  // so the legacy single-backend escape hatch stays shut.
+  $profiles.set([{ name: OWNER_PROFILE }, { name: 'profile-b' }] as never)
+  setSessionOwnerHint('session-a', { connectionId: OWNER_CONNECTION_ID, profile: OWNER_PROFILE })
+
+  const ambient = vi.fn().mockResolvedValue({ ok: true })
+
+  $activeSessionId.set('session-a')
+  $gateway.set({ request: ambient } as never)
+
+  return ambient
+}
+
+function expectOwnerCall(nth: number, params: Record<string, unknown>) {
+  expect(gatewayMocks.requestGatewayForAgent).toHaveBeenNthCalledWith(
+    nth,
+    OWNER_CONNECTION_ID,
+    OWNER_PROFILE,
+    'clarify.respond',
+    params
+  )
+}
+
+describe('ClarifyTool owner routing', () => {
+  afterEach(() => {
+    $profiles.set([])
+    _resetSessionOwnerHintsForTests({ storage: true })
+    gatewayMocks.requestGatewayForAgent.mockClear()
+  })
+
+  it('answers a single clarify on the owner socket, never profile B ambient', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    })
+    expectOwnerCall(1, { answer: 'staging', request_id: 'request-1' })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('sends both sequential batch locks on the owner socket, in order', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' },
+        { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
+      ],
+      requestId: 'request-batch',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveBatchProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+    fireEvent.change(screen.getByPlaceholderText('Type your answer…'), { target: { value: 'packet' } })
+    fireEvent.click(screen.getByRole('button', { name: /Confirm and continue/ }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(2)
+    })
+    // The LAST lock resolves the blocked tool, so order is load-bearing.
+    expectOwnerCall(1, { answer: 'red', question_id: 'q0', request_id: 'request-batch' })
+    expectOwnerCall(2, { answer: 'packet', question_id: 'q1', request_id: 'request-batch' })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('sends a batch skip/cancel on the owner socket', async () => {
+    const ambient = armCrossProfileOwner()
+
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' },
+        { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
+      ],
+      requestId: 'request-batch',
+      sessionId: 'session-a'
+    })
+    renderClarify(<ClarifyTool {...liveBatchProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    await waitFor(() => {
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    })
+    expectOwnerCall(1, { answer: '', request_id: 'request-batch' })
+    expect(ambient).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { requestForOwnedSession } from '@/store/session-states'
 
 import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
@@ -469,10 +470,22 @@ function ClarifyToolSinglePending({
       setSubmitting(true)
 
       try {
-        await gateway.request<{ ok?: boolean }>('clarify.respond', {
-          request_id: matchingRequest.requestId,
-          answer
-        })
+        // Route through the session's OWNER (tile route → hint → tagged row);
+        // legacy ambient is allowed only when it is provably the sole backend.
+        // The ambient socket follows foreground focus, so after a profile / Bot
+        // Chat switch it can point at a backend that never held this clarify —
+        // and the owner stays blocked (#91684 client half, like approval.respond).
+        await requestForOwnedSession<{ ok?: boolean }>(
+          matchingRequest.sessionId,
+          // Bound (not wrapped) so the ambient fallback keeps the exact 2-arg
+          // call shape gateway.request callers assert on.
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          {
+            request_id: matchingRequest.requestId,
+            answer
+          }
+        )
         triggerHaptic('submit')
         onAnswered()
         clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
@@ -1011,14 +1024,23 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
       // server-side, so every earlier lock must already be accepted when it
       // lands — a reordered burst could complete the batch with a missing
       // answer.
+      //
+      // Each lock rides the session's OWNER socket, not the ambient one: a
+      // profile / Bot Chat switch re-points ambient at a backend that never
+      // held this batch, which would leave the owner blocked.
       for (const question of questions) {
         const answer = stagedAnswer(question)
 
-        await gateway.request<{ ok?: boolean }>('clarify.respond', {
-          answer: answer ?? '',
-          question_id: question.qid,
-          request_id: request.requestId
-        })
+        await requestForOwnedSession<{ ok?: boolean }>(
+          request.sessionId,
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          {
+            answer: answer ?? '',
+            question_id: question.qid,
+            request_id: request.requestId
+          }
+        )
       }
 
       triggerHaptic('submit')
@@ -1058,7 +1080,16 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
     clearClarifyRequest(request.requestId, request.sessionId)
 
     try {
-      await gateway?.request('clarify.respond', { answer: '', request_id: request.requestId })
+      if (gateway) {
+        // Owner-routed like the locks above — a skip sent to the wrong backend
+        // is a silent no-op that leaves the agent waiting out its timeout.
+        await requestForOwnedSession(
+          request.sessionId,
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'clarify.respond',
+          { answer: '', request_id: request.requestId }
+        )
+      }
     } catch {
       // The tool times out on its own; a failed skip must never block the UI.
     }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -47,6 +47,7 @@ import {
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -957,6 +958,10 @@ export function openTileGatewayScopes(): Set<string> {
  * exact unique owner hint (stamped when a routed create returns / at open
  * time; persisted), then the session row's owner (an exact route when the row
  * is connection-tagged, else its bare profile, else the hint's profile). The
+ * row rung searches every source-scoped slice (recents, cron, messaging), not
+ * just recents — a cron session's approval.respond used to find no owner here
+ * and fail closed on registry-topology installs even though its row (with its
+ * `profile` stamp) was already loaded for the sidebar's cron section. The
  * hint outranks the row for the same reason as contrib/wiring's ladder: a
  * row can be stamped from the ambient profile and carries no connection.
  * Returns undefined when no owner is known — the caller fails closed
@@ -972,7 +977,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   return (
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
-    knownSessionOwner($sessions.get(), storedSessionId)
+    knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
   )
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -634,6 +634,32 @@ export const $messagingPlatformTotals = atom<Record<string, number>>({})
 // True when the combined seed fetch hit MESSAGING_SECTION_LIMIT, so at least
 // one platform may have more rows on disk than were loaded.
 export const $messagingTruncated = atom<boolean>(false)
+
+/**
+ * Every session row the renderer knows, for OWNER lookups. The sidebar splits
+ * its fetch into three source-scoped slices ($sessions / $cronSessions /
+ * $messagingSessions), and each slice's rows carry the same `profile` (and,
+ * when tagged, `connection_id`) stamps — but the owner ladder's row rung only
+ * searched recents. A cron or messaging session's approval.respond (or any
+ * session-scoped RPC) therefore found no owner, and on a registry-topology
+ * install failed closed with SessionOwnerResolutionError even though the row
+ * naming its owner was already in memory, one atom over. Concatenation order
+ * mirrors lookup priority: recents first (they can carry fresher optimistic
+ * connection tags), then the cron and messaging slices.
+ */
+export function ownerLookupSessionRows(): SessionInfo[] {
+  const cron = $cronSessions.get()
+  const messaging = $messagingSessions.get()
+
+  // Recents-only stays the common case; keep its array identity (no copy) so
+  // per-list memo caches (lineageAliases) keyed on the reference still hit.
+  if (!cron.length && !messaging.length) {
+    return $sessions.get()
+  }
+
+  return [...$sessions.get(), ...cron, ...messaging]
+}
+
 // Whether a profile's last session page was CAPPED by the request limit, keyed
 // by profile name — i.e. more rows exist on disk than were loaded. Replaces the
 // old exact per-profile totals: rendering `loaded/total` in the sidebar cost a

--- a/contributors/emails/epeterpanz@gmail.com
+++ b/contributors/emails/epeterpanz@gmail.com
@@ -1,0 +1,1 @@
+epeterpanz

--- a/contributors/emails/laroberts@hchb.com
+++ b/contributors/emails/laroberts@hchb.com
@@ -1,0 +1,1 @@
+lukeroberts


### PR DESCRIPTION
## Cron and messaging approvals are answerable again

**User-facing outcome:** approval prompts (clarify questions) on cron and messaging sessions can be answered again on registry installs. Since #95407, the desktop owner lookup only consulted the Recents (`$sessions`) slice, so any session that lived solely in the cron or messaging sidebar slices resolved no owner and its approvals were unanswerable (P1 regression, tracker #94724).

## Regression attribution

The regression was introduced by our own #95407 merge (commit `07b87f1470`), which scoped owner resolution to the Recents slice. This PR charges that honestly: the bug is ours, the fix is contributed.

## What this salvages

- **#95633** by @lukeroberts — `fix(desktop): resolve session owners from the cron and messaging sidebar slices`. `ownerLookupSessionRows()` now unions `$sessions + $cronSessions + $messagingSessions`. No ambient fallback added; fail-closed behavior preserved. Includes a regression test that fails on unfixed main.
- **#95652** by @epeterpanz — `fix(desktop): route clarify responses through session owner`. On main, `clarify-tool.tsx` sent `clarify.respond` through the ambient `$gateway` (premise verified at head: `useStore($gateway)` + `gateway.request('clarify.respond', …)`); it now routes through the resolved session owner. Complementary, zero file overlap, and depends on #95633 for cron sessions to resolve at all.

Both commits cherry-picked with original authorship preserved; contributor email mappings added under `contributors/emails/`.

## Verification (A/B at head)

- **Red on main:** #95633's regression test applied to unfixed `origin/main` (`9aa7530f7`): `1 failed | 6 passed` in `session-rpc-dispatcher.test.ts`.
- **Green at head:** `session-rpc-dispatcher.test.ts` + `session.test.ts` + `session-states.test.ts` + `clarify-tool.test.tsx`: **178/178 passed**. Adjacent `session-owner-resolution.test.ts` + `session-request-router.test.ts`: **25/25 passed**.

Live repro: real renderer owner-resolution stack — production error fired verbatim on main for a cron session; control row in recents resolved (slice-scoping proven); PR regression test fails on unfixed main; 144/144 post-fix.

## Credits

- @lukeroberts (#95633) — owner-lookup slice union + regression test
- @epeterpanz (#95652) — clarify.respond owner routing + tests

## Infographic

![Cron approvals answerable again](https://v3b.fal.media/files/b/0aa7e7f4/k7aOyqXEaVEygzq-0vtpV_LwU3xKg5.png)
