### PR TITLE
fix(desktop): keep secondary-gateway publication from relabeling the primary socket (salvage #95396 + guard)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -652,6 +652,12 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewaySwitching.get()).toBe(false)
     // The switch committed: the registry remembers the new source as last-used.
     expect(setLastUsed).toHaveBeenCalledWith('coder-remote')
+
+    // Publishing the secondary must not relabel the primary socket. Returning
+    // to its source should reuse that socket, not dial the secondary endpoint.
+    const socketsAfterSwitch = FakeWebSocket.instances.length
+    await expect(requestGatewayForAgent('primary-vps', 'default', 'ping')).resolves.toEqual({ pong: true })
+    expect(FakeWebSocket.instances).toHaveLength(socketsAfterSwitch)
   })
 
   it('a Settings switch superseded while reading its descriptor cannot publish over a newer Sessions switch', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -33,7 +33,6 @@ import {
   reportPrimaryGatewayState,
   setPrimaryGateway,
   setPrimaryGatewayConnection,
-  setPrimaryGatewayConnectionId,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
@@ -191,7 +190,6 @@ export function useGatewayBoot({
             }
           : null
       )
-      setPrimaryGatewayConnectionId(next?.connectionId)
     }
 
     if (!desktop) {

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -45,6 +45,7 @@ const {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
+  ensureGatewayForProfile,
   openGatewayForAgent,
   pruneSecondaryGateways,
   setPrimaryGateway,
@@ -105,6 +106,25 @@ describe('primary gateway registry scope', () => {
 
     expect(activeGatewayConnectionId()).toBeNull()
     expect(setApiRequestConnection).toHaveBeenLastCalledWith(null)
+  })
+
+  it('ignores primary connection-id writes while a secondary registry scope is active (#95628 hardening)', async () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+    setPrimaryGatewayConnectionId('primary-vps')
+
+    // Foreground Gateway B's composite scope (connectionId 'homelab').
+    await expect(ensureGatewayForAgent('homelab', 'default')).resolves.toBe(true)
+
+    // Presentation-layer write while the secondary is foregrounded: the id
+    // describes the secondary, not the primary. It must be dropped — accepting
+    // it relabels the primary socket and poisons ambient routing.
+    setPrimaryGatewayConnectionId('homelab')
+
+    // Back on the primary route, its registry identity is intact.
+    await ensureGatewayForProfile('default')
+
+    expect(activeGatewayConnectionId()).toBe('primary-vps')
+    expect(setApiRequestConnection).toHaveBeenLastCalledWith('primary-vps')
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -261,6 +261,17 @@ export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'defa
 }
 
 export function setPrimaryGatewayConnectionId(connectionId: null | string | undefined): void {
+  // Hardening for #95628: while the active route is a secondary scope, the
+  // window is looking at a NON-primary socket — any connection id flowing
+  // through presentation-layer code at that moment describes the secondary,
+  // not the primary. Accepting it would relabel the primary socket, so every
+  // ambient API/WebSocket helper (and new-session routing) silently lands on
+  // the wrong backend. The primary's own identity is (re)published by its
+  // boot/reconnect path, which runs with the primary route active.
+  if (!isActivePrimary()) {
+    return
+  }
+
   g.primaryConnectionId = (connectionId ?? '').trim() || null
 
   if (g.activeKey === g.primaryProfile) {


### PR DESCRIPTION
# fix(desktop): new chats actually go to the gateway you selected

**User-facing outcome:** starting a new session while a non-primary (secondary) gateway connection is selected now routes that session to the gateway you selected — not silently to the primary/local backend. Fixes #95628.

Honest note: #95628 was reported against our own recent campaign window (tracker #94724) — this closes that regression gap.

## What was wrong

The Sessions source-switch publication path in `use-gateway-boot.ts` called `setPrimaryGatewayConnectionId(next?.connectionId)` when foregrounding a **secondary** source, relabeling the primary socket with the secondary's registry identity. Ambient API/WebSocket helpers and new-session routing then resolved to the wrong backend.

## Changes

1. **Salvaged #95396** (credit: @david-bartos-phrase — cherry-picked with authorship preserved): remove the secondary-publication write that relabeled the primary socket, plus a regression assertion in `use-gateway-boot.test.tsx` that returning to the primary source reuses its socket instead of dialing the secondary endpoint.
2. **Ours-authored hardening:** `setPrimaryGatewayConnectionId()` now ignores writes while the active key is a composite secondary scope (`!isActivePrimary()`), so any future presentation-layer write cannot poison primary routing. Regression test in `gateway-connection-scope.test.ts` is **sabotage-proven**: with the guard reverted, the test fails (`1 failed | 9 passed`); with the guard, it passes.

## Evidence

Live repro: isolated Desktop instance (CDP :9333) + two-gateway rig — before: new session under selected Gateway B served by local backend (local agent.log turn, B logs empty); after: prompt accepted + turn finished on Gateway B, local state.db empty. (Frames + screenshots archived under `/tmp/regress-95628/`.)

## Verification

- Targeted suites: `use-gateway-boot.test.tsx`, `gateway.test.ts`, `session-request-router.test.ts`, `gateway-connection-scope.test.ts` — **4 files, 77/77 passed**
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.electron.json --noEmit` — clean
- Sabotage check on the new guard test — fails without the guard, passes with it
- Stale-base gate: branch base = current `origin/main`, diff shows only the 4 intended files

Supersedes #95396.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa7e800/Sk-O2JYo-foxY_Ceexigu_REQyDqCy.png)
