### PR TITLE
fix(tools): stop freezing a profile path into tool schemas at import time

### DIFF
--- a/tests/tools/test_schema_no_import_time_home.py
+++ b/tests/tools/test_schema_no_import_time_home.py
@@ -1,0 +1,53 @@
+"""Regression tests for import-time display_hermes_home() in tool schemas (#95685).
+
+Module-level schema f-strings evaluated ``display_hermes_home()`` once at
+import, freezing whichever profile first imported the module into the tool
+description for the whole process lifetime — every later session in any
+other profile saw the wrong profile's path. The schemas are now
+profile-neutral strings; these pins keep any future schema edit from
+reintroducing a per-profile path (or the import) into these static
+descriptions.
+"""
+
+import re
+
+import tools.cronjob_tools as cronjob_tools
+import tools.skill_manager_tool as skill_manager_tool
+import tools.tts_tool as tts_tool
+
+
+def _schema_text(schema) -> str:
+    parts = [str(schema.get("description") or "")]
+    for prop in (schema.get("parameters", {}).get("properties") or {}).values():
+        parts.append(str(prop.get("description") or ""))
+    return "\n".join(parts)
+
+
+def test_cronjob_schema_is_profile_neutral():
+    text = _schema_text(cronjob_tools.CRONJOB_SCHEMA)
+    assert "profiles/" not in text
+    assert "scripts/ directory in the Hermes home" in text
+
+
+def test_skill_manage_schema_is_profile_neutral():
+    text = _schema_text(skill_manager_tool.SKILL_MANAGE_SCHEMA)
+    assert "profiles/" not in text
+    assert "skills/ directory in the Hermes home" in text
+
+
+def test_tts_schema_is_profile_neutral():
+    text = _schema_text(tts_tool.TTS_SCHEMA if hasattr(tts_tool, "TTS_SCHEMA") else tts_tool.SCHEMA)
+    assert "profiles/" not in text
+    assert "audio_cache/" in text
+
+
+def test_no_import_time_home_call_remains_in_schema_modules():
+    """The static schemas must not call profile-dependent helpers at import.
+
+    Scans the module source for f-string schema descriptions embedding
+    display_hermes_home — the exact regression shape from #95685.
+    """
+    for mod in (cronjob_tools, skill_manager_tool, tts_tool):
+        source = open(mod.__file__, encoding="utf-8").read()
+        fstring_uses = re.findall(r"f\"[^\"]*display_hermes_home\(\)", source)
+        assert not fstring_uses, (mod.__name__, fstring_uses)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -14,8 +14,6 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_constants import display_hermes_home
-
 logger = logging.getLogger(__name__)
 
 # Cadence for the heartbeat that keeps the calling agent's inactivity watchdog
@@ -1874,7 +1872,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "script": {
                 "type": "string",
-                "description": f"Optional script run each tick; stdout is injected into the agent's prompt as context (with no_agent=True the script IS the job). Relative paths resolve under {display_hermes_home()}/scripts/; .sh/.bash via bash, else Python. On update, '' clears."
+                "description": "Optional script run each tick; stdout is injected into the agent's prompt as context (with no_agent=True the script IS the job). Relative paths resolve under the active profile's scripts/ directory in the Hermes home; .sh/.bash via bash, else Python. On update, '' clears."
             },
             "monitor": {
                 "type": "string",

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -41,7 +41,7 @@ import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home
 from utils import atomic_write_text, is_truthy_value
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
@@ -1746,7 +1746,8 @@ SKILL_MANAGE_SCHEMA = {
     "description": (
         "Manage skills (create, update, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
-        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
+        "New skills go to the active profile's skills/ directory in the Hermes home; "
+        "existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -58,7 +58,6 @@ from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
-from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -4507,7 +4506,7 @@ TTS_SCHEMA = {
             },
             "output_path": {
                 "type": "string",
-                "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
+                "description": "Optional custom file path to save the audio. Defaults to the active profile's audio_cache/<timestamp>.mp3 in the Hermes home"
             },
             "speed": {
                 "type": "number",


### PR DESCRIPTION
## What does this PR do?

Fixes #95685: three tool schemas embedded `display_hermes_home()` inside module-level f-strings, so whichever profile's task first imported the module in a gateway process froze *its* `~/.hermes/profiles/<name>` path into the tool description for the lifetime of that process — every later session, in any profile, saw the first profile's path. Beyond being wrong on its face, an agent that trusts the description would act on a path belonging to a different profile (e.g. "New skills go to …/profiles/share-trader/skills/" while running under another profile).

The fix takes the report's first suggested direction — profile-neutral wording — because these are static schema strings evaluated at import; deferring per-session would require a registration-time indirection far beyond the symptom. The three sites:

- `tools/cronjob_tools.py` — `script` field: "Relative paths resolve under the active profile's `scripts/` directory in the Hermes home"
- `tools/skill_manager_tool.py` — schema description: "New skills go to the active profile's `skills/` directory in the Hermes home"
- `tools/tts_tool.py` — `output_path`: "Defaults to the active profile's `audio_cache/<timestamp>.mp3` in the Hermes home"

The now-unused `display_hermes_home` imports are removed from all three modules. Runtime call sites that genuinely need the live path (error messages, resolution logic) are untouched — the lazy call-site pattern in `terminal_tool.py` remains the model for those.

## Related Issue

Fixes #95685

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/cronjob_tools.py` — `script` description f-string → profile-neutral plain string; unused import removed.
- `tools/skill_manager_tool.py` — `SKILL_MANAGE_SCHEMA` description f-string → profile-neutral; `display_hermes_home` dropped from the `hermes_constants` import (the module keeps `get_hermes_home`, which it uses at runtime).
- `tools/tts_tool.py` — `output_path` description f-string → profile-neutral; unused import removed.
- `tests/tools/test_schema_no_import_time_home.py` — new regression file: all three schemas contain no `profiles/` path and carry the neutral wording; a source scan asserts no f-string schema description in these modules embeds `display_hermes_home()` again (the exact regression shape).

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_schema_no_import_time_home.py -q` — should pass: 4 passed. Red/green: with the three tool changes stashed, 3 of the 4 fail (each schema shows the frozen `profiles/<name>` path of the machine's default home, and the source scan finds the f-string call) while one no-op pin passes on both sides; with the changes, 4 passed.
2. Adjacent suites should pass: `pytest tests/tools/test_cronjob_tools.py -q` (71 passed), `pytest tests/tools/test_skill_manager_tool.py -q` (49 passed), `pytest tests/tools/test_tts_command_providers.py -q` (36 passed). `ruff check` on all four changed files should pass.
3. Observed result: importing any of the three modules no longer captures a profile-specific path — the schema text is identical regardless of which profile imports first.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches these schema strings
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file + the three adjacent tool suites green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (descriptions re-worded to be profile-accurate; no parameter semantics changed)
