### PR TITLE
fix(gateway): keep long document names from breaking attachment caching

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2203,6 +2203,27 @@ def get_document_cache_dir() -> Path:
     return d
 
 
+_MAX_CACHE_FILENAME_BYTES = 255
+
+
+def _truncate_filename_part(value: str, max_bytes: int) -> str:
+    """Truncate text at a UTF-8 boundary without splitting a percent escape."""
+    if len(value.encode("utf-8")) <= max_bytes:
+        return value
+    truncated = value.encode("utf-8")[:max_bytes].decode("utf-8", errors="ignore")
+    return re.sub(r"%(?:[0-9A-Fa-f])?$", "", truncated)
+
+
+def _fit_cache_filename(prefix: str, filename: str) -> str:
+    """Fit a prefixed filename within the common filesystem component limit."""
+    name_budget = _MAX_CACHE_FILENAME_BYTES - len(prefix.encode("utf-8"))
+    stem, suffix = os.path.splitext(filename)
+    suffix_bytes = len(suffix.encode("utf-8"))
+    if suffix and suffix_bytes < name_budget:
+        return _truncate_filename_part(stem, name_budget - suffix_bytes) + suffix
+    return _truncate_filename_part(filename, name_budget)
+
+
 def cache_document_from_bytes(data: bytes, filename: str) -> str:
     """
     Save raw document bytes to the cache and return the absolute file path.
@@ -2226,7 +2247,8 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
     safe_name = safe_name.replace("\x00", "").strip()
     if not safe_name or safe_name in {".", ".."}:
         safe_name = "document"
-    cached_name = f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
+    prefix = f"doc_{uuid.uuid4().hex[:12]}_"
+    cached_name = prefix + _fit_cache_filename(prefix, safe_name)
     filepath = cache_dir / cached_name
     # Final safety check: ensure path stays inside cache dir
     if not filepath.resolve().is_relative_to(cache_dir.resolve()):

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -6,8 +6,10 @@ Covers: get_document_cache_dir, cache_document_from_bytes,
 """
 
 import os
+import re
 import time
 from pathlib import Path
+from urllib.parse import quote_plus
 
 import pytest
 
@@ -62,6 +64,48 @@ class TestCacheDocumentFromBytes:
     def test_empty_filename_uses_fallback(self):
         path = cache_document_from_bytes(b"data", "")
         assert "document" in os.path.basename(path)
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "中文" * 70 + ".txt",
+            quote_plus("中文" * 70 + ".txt", safe=""),
+        ],
+    )
+    def test_long_utf8_filename_fits_component_limit(self, filename):
+        path = Path(cache_document_from_bytes(b"payload", filename))
+
+        assert len(path.name.encode("utf-8")) <= 255
+        assert path.suffix == ".txt"
+        assert path.read_bytes() == b"payload"
+
+    def test_truncation_does_not_leave_partial_percent_escape(self):
+        filename = "a" * 233 + "%E4.txt"
+
+        path = Path(cache_document_from_bytes(b"data", filename))
+        stored_name = path.name.split("_", 2)[2]
+        stored_stem = os.path.splitext(stored_name)[0]
+
+        assert not re.search(r"%(?:[0-9A-Fa-f])?$", stored_stem)
+        assert path.suffix == ".txt"
+
+    def test_filename_at_byte_limit_is_preserved(self):
+        filename = "a" * 234 + ".txt"
+
+        path = Path(cache_document_from_bytes(b"data", filename))
+
+        assert len(path.name.encode("utf-8")) == 255
+        assert path.name.endswith(filename)
+
+    def test_truncated_names_remain_collision_safe(self):
+        filename = "文" * 100 + ".pdf"
+
+        first = Path(cache_document_from_bytes(b"first", filename))
+        second = Path(cache_document_from_bytes(b"second", filename))
+
+        assert first != second
+        assert first.read_bytes() == b"first"
+        assert second.read_bytes() == b"second"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Long UTF-8 and percent-encoded document names no longer make the gateway cache fail before an inbound attachment can reach the agent. The cache now budgets the generated prefix and original name in UTF-8 bytes, truncates only at safe boundaries, and preserves the extension when it fits.

### Symptom

`cache_document_from_bytes()` raises an `OSError` when the generated filename exceeds the filesystem component limit. On Windows the focused reproduction returned `Errno 22`; the issue's Linux reproduction returns `Errno 36`.

### Impact

Inbound documents with sufficiently long UTF-8 or percent-encoded names cannot be cached, so the platform-independent gateway attachment path drops or fails that document before agent processing.

### Bug Cause

**Trigger:** `gateway/platforms/base.py:cache_document_from_bytes` receives a filename whose generated cache component exceeds 255 UTF-8 bytes.

**Causal chain:**
1. A platform supplies a long CJK or percent-encoded document filename.
2. `cache_document_from_bytes()` prepends a UUID fragment but writes the complete sanitized name without a component byte budget.
3. The filesystem rejects the path component and the inbound document is not cached.

**Why it is wrong:** Python character length does not represent filesystem component usage for UTF-8 names, and the generated prefix also consumes the component budget.

**Working sibling / contrast:** Short document names already fit the component limit and continue to retain their complete human-readable name.

**Ruled out:** Path traversal is not the cause. The existing containment check accepts these names, and the failure occurs when `write_bytes()` opens an oversized component.

### Fix

Apply a 255-byte component budget after subtracting the generated prefix. Truncate the stem at a valid UTF-8 boundary, remove an incomplete trailing percent escape, preserve a fitting extension, and retain the existing UUID collision protection and containment check.

## Related Issue

Closes #95667

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` - bound document cache components in UTF-8 bytes while preserving safe suffixes.
- `tests/gateway/test_document_cache.py` - cover long CJK, percent encoding, exact byte boundaries, partial escapes, collisions, and cached bytes.

## How to Test

1. Run the focused document cache and media cache suites.
2. Confirm long CJK and percent-encoded names create components no larger than 255 UTF-8 bytes.
3. Confirm generated paths remain distinct and preserve `.txt` or `.pdf` suffixes.

```bash
scripts/run_tests.sh tests/gateway/test_document_cache.py tests/gateway/test_media_cache.py -q
```

Result: 51 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior is internal and covered by tests and helper docstrings
- [x] `cli-config.yaml.example` update: N/A - no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the UTF-8 byte cap is conservative on Windows and matches common POSIX `NAME_MAX`
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - focused automated coverage reproduces and verifies the filesystem-bound failure.
