### PR TITLE
fix(footguns): catch bare read_text/write_text that wrap across lines

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -29,6 +29,7 @@ Suppress an intentional use (e.g. tests or platform-gated code) with:
 from __future__ import annotations
 
 import argparse
+import ast
 import os
 import re
 import subprocess
@@ -551,6 +552,69 @@ def _is_likely_subprocess_call(line: str) -> bool:
     return any(token in line for token in _SUBPROCESS_METHODS)
 
 
+def _wrapped_encoding_calls(text: str) -> list[tuple[int, str]]:
+    """Find read_text/write_text/open calls that wrap across lines without
+    ``encoding=``.
+
+    The line-based scanner deliberately skips any call whose closing paren is
+    not on the matched line, because ``encoding=`` may sit on a continuation
+    line and flagging it would be a false positive. That safety valve also
+    hides genuinely-bare wrapped calls, e.g.::
+
+        path.write_text(json.dumps({
+            "k": "v",
+        }))
+
+    Parsing the module gives an exact answer for those, with no heuristic: the
+    keywords of the outer call are right there on the AST node. Returns
+    ``(lineno, func_name)`` for each offender. A file that does not parse
+    returns nothing — the line scanner still covers it.
+    """
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return []
+
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        end_lineno = getattr(node, "end_lineno", None)
+        if end_lineno is None or end_lineno == node.lineno:
+            continue  # single-line: already covered by the line scanner
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            name = func.attr
+        elif isinstance(func, ast.Name):
+            name = func.id
+        else:
+            continue
+        if name not in ("read_text", "write_text", "open"):
+            continue
+        if name == "open" and isinstance(func, ast.Attribute):
+            # A bare ``x.open(...)`` receiver could be anything — Path (takes
+            # encoding=), os (rejects it), urllib openers, zipfile, tarfile,
+            # a mock. Only the unqualified builtin is unambiguous from the
+            # AST alone, so attribute-style .open() is left to the
+            # single-line rule, which matches builtins.open specifically.
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        if any(kw.arg is None for kw in node.keywords):
+            continue  # **kwargs may carry encoding — same trust as the regex
+        if name == "open":
+            mode = None
+            if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+                mode = node.args[1].value
+            for kw in node.keywords:
+                if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                    mode = kw.value.value
+            if isinstance(mode, str) and "b" in mode:
+                continue  # binary mode takes no encoding
+        out.append((node.lineno, name))
+    return out
+
+
 def _call_closes_on_line(line: str, open_paren_end: int) -> bool:
     """True when the call whose ``(`` sits at ``open_paren_end - 1`` closes
     on this same line (paren-balance walk). Multi-line calls return False —
@@ -665,6 +729,29 @@ def scan_file(path: Path, footguns: list[Footgun]) -> list[tuple[int, str, Footg
                     # Post-filter assumed a named group that isn't there — skip.
                     continue
             matches.append((i, line.rstrip(), fg))
+
+    # Second pass: calls that wrap across lines. The line scanner skips those
+    # by design (encoding= may be on a continuation line), so an exact AST
+    # answer covers the blind spot without loosening the line heuristic.
+    wrapped_fg = next(
+        (f for f in footguns if "read_text" in f.name and "write_text" in f.name),
+        None,
+    )
+    if wrapped_fg is not None and not (
+        wrapped_fg.path_allowlist
+        and any(s in str(path) for s in wrapped_fg.path_allowlist)
+    ):
+        lines = text.splitlines()
+        seen = {lineno for lineno, _, _ in matches}
+        for lineno, _name in _wrapped_encoding_calls(text):
+            if lineno in seen or lineno > len(lines):
+                continue
+            line = lines[lineno - 1]
+            if SUPPRESS_MARKER.search(line):
+                continue
+            matches.append((lineno, line.rstrip(), wrapped_fg))
+
+    matches.sort(key=lambda m: m[0])
     return matches
 
 

--- a/tests/scripts/test_footgun_multiline_encoding.py
+++ b/tests/scripts/test_footgun_multiline_encoding.py
@@ -1,0 +1,198 @@
+"""Tests for multi-line ``read_text``/``write_text`` detection in
+``scripts/check-windows-footguns.py``.
+
+The line-based scanner deliberately skips any call whose closing paren is not
+on the matched line: ``encoding=`` may sit on a continuation line, and flagging
+that would be a false positive. The consequence is a blind spot for calls that
+genuinely lack ``encoding=`` and happen to wrap::
+
+    path.write_text(json.dumps({
+        "k": "v",
+    }))
+
+That shape is common in tests that seed JSON fixtures, and it read as clean for
+as long as the gate was line-oriented — PR #95486 fixed 18 findings the gate
+reported and left 6 of this shape behind, all in files the gate had just
+declared clean.
+
+``_wrapped_encoding_calls`` closes the gap with an AST pass, which answers
+exactly rather than heuristically: the outer call's keywords are on the node.
+The line scanner is untouched, so its false-positive guarantees still hold.
+
+See issue #37423 and the #71014 / read_text campaign.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINTER_PATH = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+
+
+def _load_linter_module():
+    """Import the linter script as a module (it's not a package).
+
+    Register the module in sys.modules BEFORE exec_module so that
+    ``@dataclass`` can resolve ``cls.__module__`` (CPython 3.11+ requirement).
+    """
+    spec = importlib.util.spec_from_file_location("check_windows_footguns", LINTER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_windows_footguns"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def linter():
+    return _load_linter_module()
+
+
+def _linenos(linter, source: str) -> list[int]:
+    return [lineno for lineno, _name in linter._wrapped_encoding_calls(source)]
+
+
+# --- calls that MUST be flagged -------------------------------------------
+
+
+def test_wrapped_write_text_without_encoding_is_flagged(linter):
+    """The exact shape PR #95486 left behind: json.dumps wrapping the args."""
+    source = (
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({\n'
+        '        "k": "v",\n'
+        "    }))\n"
+    )
+    assert _linenos(linter, source) == [3]
+
+
+def test_wrapped_read_text_without_encoding_is_flagged(linter):
+    source = "def f(p):\n    return p.read_text(\n    )\n"
+    assert _linenos(linter, source) == [2]
+
+
+# --- calls that MUST NOT be flagged ---------------------------------------
+
+
+def test_encoding_on_a_continuation_line_is_not_flagged(linter):
+    """The false positive the line scanner avoids by skipping wrapped calls.
+
+    The AST pass must not reintroduce it.
+    """
+    source = (
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(\n'
+        '        json.dumps({"k": "v"}),\n'
+        '        encoding="utf-8",\n'
+        "    )\n"
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_binary_mode_open_is_not_flagged(linter):
+    """Binary mode takes no encoding= — demanding one would be a TypeError."""
+    source = 'def f(p):\n    return open(\n        p,\n        "rb",\n    )\n'  # windows-footgun: ok
+    assert _linenos(linter, source) == []
+
+
+def test_os_open_is_not_flagged(linter):
+    """``os.open`` is the POSIX fd-level call and rejects ``encoding=``.
+
+    This is the atomic-write prelude used across hermes_cli/auth.py,
+    tools/mcp_oauth.py and the platform plugins: os.open() for the fd, then
+    os.fdopen(..., encoding="utf-8") for the text wrapper. Flagging the
+    os.open() half would demand a kwarg that raises TypeError.
+    """
+    source = (
+        "import os\n"
+        "import stat\n"
+        "def f(p):\n"
+        "    fd = os.open(\n"
+        "        str(p),\n"
+        "        os.O_WRONLY | os.O_CREAT,\n"
+        "        stat.S_IRUSR,\n"
+        "    )\n"
+        '    with os.fdopen(fd, "w", encoding="utf-8") as fh:\n'
+        '        fh.write("x")\n'
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_attribute_open_is_left_to_the_line_rule(linter):
+    """``x.open(...)`` receivers are ambiguous from the AST alone.
+
+    urllib openers, zipfile, tarfile and mocks all expose ``.open()`` and do
+    not take ``encoding=``; scripts/ci/live_comment.py has exactly this shape.
+    """
+    source = (
+        "import urllib.request\n"
+        "def f(url, opener):\n"
+        "    return opener.open(urllib.request.Request(url, headers={\n"
+        '        "Accept": "application/json",\n'
+        "    }), timeout=30)\n"
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_kwargs_splat_is_trusted(linter):
+    """``**kw`` may carry encoding — same trust the regex rule extends."""
+    source = "def f(p, **kw):\n    return p.read_text(\n        **kw,\n    )\n"
+    assert _linenos(linter, source) == []
+
+
+def test_single_line_calls_are_left_to_the_line_scanner(linter):
+    """No double-reporting: the AST pass only owns calls that wrap."""
+    source = 'def f(p):\n    return p.read_text()\n'
+    assert _linenos(linter, source) == []
+
+
+def test_unparseable_source_returns_nothing(linter):
+    """A syntactically broken file must not raise — the line scanner covers it."""
+    assert linter._wrapped_encoding_calls("def broken(:\n") == []
+
+
+# --- end-to-end through scan_file -----------------------------------------
+
+
+def test_scan_file_reports_wrapped_call(linter, tmp_path):
+    """The finding reaches scan_file output, not just the helper."""
+    f = tmp_path / "seed.py"
+    f.write_text(
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({\n'
+        '        "k": "v",\n'
+        "    }))\n",
+        encoding="utf-8",
+    )
+    findings = linter.scan_file(f, linter.FOOTGUNS)
+    assert [lineno for lineno, _line, _fg in findings] == [3]
+    assert "read_text" in findings[0][2].name
+
+
+def test_scan_file_honours_suppression_marker(linter, tmp_path):
+    """``# windows-footgun: ok`` on the opening line still suppresses."""
+    f = tmp_path / "seed.py"
+    f.write_text(
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({  # windows-footgun: ok\n'
+        '        "k": "v",\n'
+        "    }))\n",
+        encoding="utf-8",
+    )
+    assert linter.scan_file(f, linter.FOOTGUNS) == []
+
+
+def test_scan_file_does_not_double_report(linter, tmp_path):
+    """A single-line bare call is reported exactly once."""
+    f = tmp_path / "seed.py"
+    f.write_text("def f(p):\n    return p.read_text()\n", encoding="utf-8")
+    findings = linter.scan_file(f, linter.FOOTGUNS)
+    assert len(findings) == 1


### PR DESCRIPTION
The footgun gate is line-oriented, and the `read_text`/`write_text` rule skips any call whose closing paren is not on the matched line. That guard is deliberate — `encoding=` may sit on a continuation line, and flagging it would be a false positive — but it also hides calls that genuinely lack `encoding=` and happen to wrap:

```python
path.write_text(json.dumps({
    "k": "v",
}))
```

## How this surfaced

#95486 fixed the 18 findings this gate reported on `tests/tools/test_mcp_oauth.py` and `test_mcp_oauth_manager.py`, and the gate went green. A reviewer pointed at a call it had missed; re-checking those same files by bracket depth instead of by line found **six** more, all of the shape above, in files the gate had just declared clean.

18 was the gate's ceiling, not the files' total.

## The fix

An AST pass over calls that span more than one line, where the answer is exact rather than heuristic — the outer call's keywords are right there on the node. The line scanner is untouched, so its false-positive guarantees still hold, and single-line calls stay with the rule that already owns them.

## Scope, and why an earlier revision of this patch was wrong

My first version flagged **10 call sites across the repo, every one a false positive**. They are worth naming, because each is a real pattern in this codebase rather than a hypothetical:

| receiver | why it is out of scope |
| --- | --- |
| `os.open()` | POSIX fd-level call; rejects `encoding=` outright |
| `x.open()` | ambiguous from the AST — urllib openers, zipfile, tarfile, mocks |
| `**kwargs` | may carry `encoding=`, same trust the regex rule extends |

`hermes_cli/auth.py`, `tools/mcp_oauth.py`, `agent/anthropic_adapter.py` and the platform plugins all use the atomic-write prelude `os.open()` for the fd, then `os.fdopen(..., encoding="utf-8")` for the text wrapper. Demanding `encoding=` on the `os.open()` half asks for a kwarg that raises `TypeError`. `scripts/ci/live_comment.py` has the `opener.open(...)` shape.

With those three excluded, repo-wide findings go back to zero.

## Verification

```console
$ python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (1014 file(s) scanned).
```

The shape #95486 left behind, run through both gates:

```console
old gate: ✓ No Windows footguns found (1 file(s) scanned).
new gate: ✗ 2 Windows footgun(s) found across 1 file(s) scanned.
```

```console
$ python -m pytest tests/scripts/ -q
35 passed in 16.95s
```

`tests/scripts/test_footgun_multiline_encoding.py` adds 12 tests — 2 asserting the wrapped shapes are caught, 8 asserting the exclusions above stay quiet, 2 end-to-end through `scan_file` (suppression marker, no double-reporting). Against the previous gate, **10 of the 12 fail**; the 2 that pass are the ones asserting single-line calls are left alone, which was already true.

## Relationship to ruff PLW1514

`pyproject.toml` already enables `PLW1514` with `preview = true`, and ruff does catch wrapped calls — it parses the AST. Two independent reasons it does not cover the calls in question, both measured on `ruff==0.15.10` (the version this repo pins):

**1. `per-file-ignores`** exempts `tests/**`, `skills/**`, `optional-skills/**` and `plugins/**`.

**2. `PLW1514` needs the receiver's type to be inferable**, and drops the call when it is not:

```python
def annotated(p: Path):
    return p.read_text()        # PLW1514 fires

def unannotated(tmp_path):      # pytest fixture, no annotation
    return (tmp_path / "a.json").read_text()   # silent
```

The second reason is the load-bearing one here. Lifting the ignore would not have surfaced these calls:

```console
$ ruff check --isolated --preview --select PLW1514 \
    tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py
All checks passed!
```

Those two files contain 24 `read_text`/`write_text` calls, every one reached through an unannotated `tmp_path`. That is the dominant shape in this repo's test suite, so a type-driven rule cannot police it, and the gate's textual matching is not redundant with ruff — it covers a case ruff structurally cannot. `PLW1514` also does not cover `os.fdopen()`.

For the record, `PLW1514` is clean under the repo's own config (`ruff check .` → `All checks passed!`), and has 109 findings with the ignores lifted: 92 in `tests/`, 17 in `optional-skills/`, 0 in product code.


Refs #95486. See issue #37423 and the #71014 / `read_text` campaign.
