### PR TITLE
fix(desktop): don't kill a live macOS backend on parent-marker timezone drift

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19350,9 +19350,26 @@ def _is_serve_orphaned(
     try:
         if expected_start_marker is not None:
             probe = process_start_marker or _process_start_marker
-            return not _parent_start_markers_match(
-                probe(int(desktop_pid)), expected_start_marker
-            )
+            actual_marker = probe(int(desktop_pid))
+            if _parent_start_markers_match(actual_marker, expected_start_marker):
+                return False
+            if actual_marker.startswith("ps:") and expected_start_marker.startswith("ps:"):
+                # `ps -o lstart=` is a timezone/locale-rendered wall-clock
+                # string (macOS's only marker format -- no /proc stat or
+                # Win32 GetProcessTimes equivalent). The SAME process
+                # instant renders differently before/after a TZ change
+                # while the Electron parent stays alive uninterrupted, so
+                # a mismatch here is not proof the parent died -- it's
+                # exactly the "inconclusive" case this function's own
+                # docstring already promises to keep serving through.
+                # Degrade to the PID-only check rather than exiting
+                # (issue #95693).
+                if pid_exists is None:
+                    from gateway.status import _pid_exists
+
+                    pid_exists = _pid_exists
+                return not bool(pid_exists(int(desktop_pid)))
+            return True
 
         if pid_exists is None:
             from gateway.status import _pid_exists
@@ -19404,6 +19421,15 @@ def _start_parent_death_watchdog() -> None:
     def _loop() -> None:
         while not _is_serve_orphaned(desktop_pid, start_marker):
             time.sleep(poll)
+        try:
+            _log.warning(
+                "Parent-death watchdog: desktop PID %s appears orphaned "
+                "(expected_start_marker=%r); exiting.",
+                desktop_pid,
+                start_marker,
+            )
+        except Exception:
+            pass
         os._exit(0)
 
     threading.Thread(target=_loop, daemon=True, name="serve-parent-watchdog").start()

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -57,3 +57,78 @@ def test_parent_watchdog_preserves_legacy_exact_windows_marker():
         )
         is False
     )
+
+
+def test_parent_watchdog_does_not_kill_a_live_parent_on_macos_timezone_drift():
+    """Regression for issue #95693: `ps -o lstart=` is a timezone/locale-
+    rendered wall-clock string on macOS (the only marker format for
+    platforms without a dedicated linux:/win: branch). The exact
+    evidence from the report -- the SAME process instant rendered
+    under EDT (cached by Electron before a TZ change) vs. CEST (probed
+    by a freshly-spawned backend after) -- must not be treated as proof
+    the parent died; it must degrade to the PID-only check instead."""
+    expected = "ps:Thu Aug 20 22:33:11 2026"  # EDT (UTC-4), Electron's cached marker
+    actual = "ps:Fri Aug 21 04:33:11 2026"  # CEST (UTC+2), same instant, freshly probed
+
+    assert (
+        _is_serve_orphaned(
+            4242,
+            expected,
+            pid_exists=lambda _pid: True,  # parent is genuinely still alive
+            process_start_marker=lambda _pid: actual,
+        )
+        is False
+    )
+
+
+def test_parent_watchdog_still_detects_a_genuinely_dead_parent_despite_ps_marker_mismatch():
+    """The degrade-to-PID-only fallback must still correctly detect a
+    genuinely dead parent -- the fix must not silently disable orphan
+    detection for macOS, only stop treating a TZ-driven marker mismatch
+    as automatic proof of death."""
+    expected = "ps:Thu Aug 20 22:33:11 2026"
+    actual = "ps:Fri Aug 21 04:33:11 2026"
+
+    assert (
+        _is_serve_orphaned(
+            4242,
+            expected,
+            pid_exists=lambda _pid: False,  # parent is genuinely gone
+            process_start_marker=lambda _pid: actual,
+        )
+        is True
+    )
+
+
+def test_parent_watchdog_exact_ps_marker_match_still_short_circuits():
+    """Sanity: an exact ps: marker match (the common, no-TZ-change case)
+    must still resolve to not-orphaned directly, without needing the
+    PID-only fallback at all."""
+    marker = "ps:Thu Aug 20 22:33:11 2026"
+
+    assert (
+        _is_serve_orphaned(
+            4242,
+            marker,
+            pid_exists=lambda _pid: False,  # must be irrelevant -- short-circuits on match
+            process_start_marker=lambda _pid: marker,
+        )
+        is False
+    )
+
+
+def test_parent_watchdog_still_rejects_recycled_pid_via_stable_linux_marker():
+    """Sanity/no-regression: the linux: marker format is a stable,
+    timezone-independent integer (starttime jiffies from /proc stat) --
+    a mismatch there still correctly proves a dead/recycled parent PID
+    and must NOT be softened by this fix, which is scoped specifically
+    to the ps: (macOS) format."""
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "linux:12345",
+            pid_exists=lambda _pid: True,  # even if a PID now exists (reused), still orphaned
+            process_start_marker=lambda _pid: "linux:99999",
+        )
+        is True
+    )


### PR DESCRIPTION
Fixes #95693.

## Root cause

`_process_start_marker()`'s macOS fallback fingerprints the parent Electron process with `ps -p <pid> -o lstart=` -- a timezone/locale-rendered wall-clock string, not a stable identity value like the `linux:`/`win:` markers other platforms produce. Electron caches its marker once for the app's lifetime; the Python backend re-probes on every spawn. If the system timezone changes while Electron stays alive, the two renderings of the SAME instant diverge byte-for-byte, `_parent_start_markers_match()` reports a mismatch, and `_is_serve_orphaned()` treats it as definitive proof of death -- `os._exit(0)` fires within ~5ms of boot, silently (bypasses atexit/logging flush).

`_is_serve_orphaned()`'s own docstring already promises fail-safe behavior for inconclusive probes. A `ps:` marker mismatch is exactly that case -- it's a rendering artifact, not identity -- but was being treated as positive proof instead.

## Fix

Implemented the issue's own suggested fix #3 (safest, lowest-risk -- no cross-language coordination with the Electron/TypeScript side needed): when both markers use the `ps:` prefix and don't match, degrade to the PID-only liveness check instead of declaring the backend orphaned. A mismatch between stable formats (`linux:`/`win:`) still correctly proves a dead/recycled parent and is untouched -- scoped specifically to `ps:`.

Also implemented suggested fix #4: a warning log line before `os._exit(0)`, naming the desktop PID and expected marker -- the issue calls the current silent exit "the single biggest cost of this bug."

## Verification

Verified directly against the issue's own live-instance evidence (the exact EDT vs CEST marker pair for the same instant) -- confirms the fix correctly returns `False` for a genuinely-alive parent. Also verified: a genuinely dead parent behind a `ps:` mismatch is still detected; an exact `ps:` match still short-circuits; a `linux:` marker mismatch (recycled PID) still correctly returns `True`.

Added 4 regression tests to the existing test file. Verified as a genuine regression by reverting just the fix and confirming the exact-evidence test fails.

9/9 pass in the modified test file; 3/3 in a related boot-handshake test file (no regression).