### PR TITLE
feat(mcp-catalog): add Compartment offline agentic memory (stdio, live-verified)

### DIFF
--- a/optional-mcps/compartment/manifest.yaml
+++ b/optional-mcps/compartment/manifest.yaml
@@ -1,0 +1,110 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: compartment
+description: >-
+  Offline agentic vector memory: encrypted, hybrid search, no cloud (stdio).
+source: https://github.com/MaxFreedomPollard/Compartment
+
+# Compartment is a local encrypted memory vault (Apache-2.0, PyPI:
+# `compartment`). Fully offline: the embedding model ships inside the wheel,
+# the vault is AEAD-encrypted at rest including vectors, and the server is
+# stdio-only with no ports and no network at runtime. One default vault is
+# shared by every agent on the machine, so memories stored from Hermes are
+# recallable from any other MCP client and vice versa. The same install
+# carries the Compartment panel app (menu bar on macOS, notification area
+# on Windows, a window on Linux); `compartment init` seeds the vault with
+# the bundled starter pack by default (starter@1.5.0, 6,665 starting
+# memories at the pinned release), editable and forgettable like anything
+# the agent stores, and starting memories never carry an expiry.
+#
+# Live-verified at the pinned SHA: clean clone + this exact bootstrap, then
+# an MCP probe over stdio. initialize returns serverInfo compartment 4.8.0,
+# tools/list returns all 14 tools, and a store/search round-trip on a
+# scratch vault recalls the stored memory. The server also starts and lists
+# tools before a vault exists; memory tools answer with lock-state guidance
+# until `compartment init` has been run (see post_install), so the
+# install-time probe succeeds pre-setup.
+transport:
+  type: stdio
+  command: "${INSTALL_DIR}/.venv/bin/compartment"
+  args:
+    - "--caller"
+    - "hermes"
+    - "serve"
+
+# Pinned per catalog dependency policy: full commit SHA. This SHA is the
+# v4.8.0 release (2026-08-20, the current release: memory expiry, panel
+# app can run the whole setup, integrate writes absolute paths); it passes
+# the policy's two-week age line on 2026-09-03. Bumping the pin is a PR to
+# this manifest.
+#
+# The bootstrap is POSIX-shaped (same as the n8n entry): macOS and Linux
+# install through it as-is. Windows has no `python3`/`.venv/bin`, so
+# post_install documents the direct path there (pip install + `hermes
+# mcp add`); the engine's dependencies are wheels-only on all three OSes.
+install:
+  type: git
+  url: https://github.com/MaxFreedomPollard/Compartment.git
+  ref: 77f08e490477068f6ff8348f6d29e998118fea2d
+  bootstrap:
+    - "python3 -m venv .venv"
+    - ".venv/bin/pip install ."
+
+# No account, no API key, no cloud service. The vault is encrypted with a
+# passphrase the user creates locally via `compartment init`; it never
+# passes through Hermes or this manifest.
+auth:
+  type: none
+
+# Tool selection at install time:
+# 14 hand-built tools (store/search, graph relations, status/diagnostics);
+# memory_store carries optional expiry (`expires: 2w` or a date). Nothing
+# is auto-generated, so `default_enabled` is left unset and the
+# install-time checklist starts with everything pre-checked, and users
+# deselect what they don't want. Tool descriptions are agent-first: they
+# tell the model when to recall before answering and what is worth
+# storing, so automatic tool use works without prompt changes.
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - compartment
+    - memory
+    - agentic memory
+    - vector memory
+
+post_install: |
+  Requires Python 3.11+ on PATH as `python3`. One-time vault setup (you
+  choose the passphrase that encrypts everything; it cannot be recovered
+  if lost):
+
+    ~/.hermes/mcp-installs/compartment/.venv/bin/compartment init
+
+  init seeds the vault with the bundled starter pack by default
+  (starter@1.5.0, 6,665 starting memories, editable and forgettable like
+  anything the agent stores), so recall answers usefully from the first
+  session. It also starts the Compartment panel app and enables it at
+  login: menu bar on macOS, notification area on Windows, a window on
+  Linux. Add --no-app for headless boxes. On macOS, `init --keychain`
+  stores a reboot-surviving credential; otherwise the vault comes up
+  locked after a restart and `compartment unlock` (or the panel) reopens
+  it. Until unlocked, the memory tools answer with lock-state guidance
+  instead of failing.
+
+  Already running Compartment on this machine? The catalog server shares
+  the same default vault; skip init.
+
+  Windows: the catalog bootstrap is POSIX-shaped, so install directly
+  with `py -m pip install compartment`, then register the same server:
+
+    hermes mcp add compartment --command compartment --args --caller hermes serve
+
+  Everything else (init, starter pack, panel app, shared vault) works
+  the same there.
+
+  Restart your Hermes session so the tools load. For the deeper native
+  integration (a `hermes memory setup` provider with automatic capture):
+
+    ~/.hermes/mcp-installs/compartment/.venv/bin/compartment integrate hermes

--- a/optional-mcps/compartment/manifest.yaml
+++ b/optional-mcps/compartment/manifest.yaml
@@ -35,10 +35,11 @@ transport:
     - "serve"
 
 # Pinned per catalog dependency policy: full commit SHA. This SHA is the
-# v4.8.0 release (2026-08-20, the current release: memory expiry, panel
-# app can run the whole setup, integrate writes absolute paths); it passes
-# the policy's two-week age line on 2026-09-03. Bumping the pin is a PR to
-# this manifest.
+# v4.8.0 release (2026-08-20: memory expiry, panel app can run the whole
+# setup, integrate writes absolute paths); it passes the policy's two-week
+# age line on 2026-09-03. The current release is v4.9.2 (2026-08-26), a
+# hardening release for the vault's unlock-credential path, pin-eligible
+# 2026-09-09. Bumping the pin is a PR to this manifest.
 #
 # The bootstrap is POSIX-shaped (same as the n8n entry): macOS and Linux
 # install through it as-is. Windows has no `python3`/`.venv/bin`, so

--- a/optional-mcps/compartment/manifest.yaml
+++ b/optional-mcps/compartment/manifest.yaml
@@ -37,9 +37,13 @@ transport:
 # Pinned per catalog dependency policy: full commit SHA. This SHA is the
 # v4.8.0 release (2026-08-20: memory expiry, panel app can run the whole
 # setup, integrate writes absolute paths); it passes the policy's two-week
-# age line on 2026-09-03. The current release is v4.9.2 (2026-08-26), a
-# hardening release for the vault's unlock-credential path, pin-eligible
-# 2026-09-09. Bumping the pin is a PR to this manifest.
+# age line on 2026-09-03. The current release is v4.9.4 (2026-09-02): the
+# memory graph names every entity, the panel gains a Dashboard button, and
+# the server runs under mcp 1.x and 2.x from one wheel (mcp 2.0 removed
+# mcp.server.fastmcp; the import now follows whichever module the installed
+# SDK has, so this bootstrap's `pip install .` resolves against any current
+# mcp). v4.9.4 is pin-eligible 2026-09-16. Bumping the pin is a PR to this
+# manifest.
 #
 # The bootstrap is POSIX-shaped (same as the n8n entry): macOS and Linux
 # install through it as-is. Windows has no `python3`/`.venv/bin`, so


### PR DESCRIPTION
## What does this PR do?

Adds `optional-mcps/compartment/manifest.yaml`, a stdio catalog entry for [Compartment](https://github.com/MaxFreedomPollard/Compartment): offline agentic vector memory in an encrypted local vault. Apache-2.0, on PyPI as `compartment`, pure-Python engine with wheels-only dependencies (pynacl, argon2-cffi, onnxruntime, tokenizers, numpy, usearch, mcp), the embedding model bundled inside the wheel, no ports, no network at runtime, no API key, no account. I build and maintain it. This is the catalog's first memory entry, and its second stdio entry after n8n.

What users get: `hermes mcp install compartment`, then one `compartment init` (post_install walks through it). That yields 14 memory tools over stdio, a vault pre-seeded with the bundled starter pack (starter@1.5.0, 6,665 starting memories, all editable and forgettable like anything the agent stores), and the Compartment panel app started and enabled at login on all three systems: menu bar on macOS, notification area on Windows, a window on Linux, with `--no-app` for headless boxes. One default vault is shared by every agent on the machine, so what Hermes stores is recallable from Claude, Cline, or the CLI and vice versa. Tool descriptions are agent-first (they tell the model when to recall and what to store), so automatic tool use works without prompt changes.

The manifest follows the catalog contracts: the git install pins the full 40-char SHA of the v4.9.5 release (memory expiry via `memory_store`'s `expires` field, app-driven setup, absolute-path agent registration, a memory graph that names every entity, and a server that runs under mcp 1.x and 2.x from one wheel); the launch command is `${INSTALL_DIR}`-anchored into the bootstrapped venv; and the 14-tool surface is hand-built with nothing auto-generated, so `default_enabled` is left unset and the install checklist starts fully checked, the same shape as the linear entry. The pinned release is dated 2026-09-03 and has been past the dependency policy's two-week age line since 2026-09-17, the day the pin moved up from v4.8.0 with a fresh live verification (logs below); the current release is v4.10.0 (2026-09-16), pin-eligible 2026-09-30; the manifest comment states the dates.

Placement-wise this sits at the catalog rung of the Contribution Rubric's Footprint Ladder: no core surface, no new model tool, one reviewed manifest pointing at a SHA-pinned repo the vendor maintains. Compartment's deeper Hermes integration ships separately as a standalone provider plugin (`compartment integrate hermes` installs it into `~/.hermes/plugins/`) per CONTRIBUTING's memory-provider guidance; the catalog entry is the zero-setup discovery surface, and both share the same vault.

## Related Issue

No tracked issue; a self-contained catalog addition, same shape as the recent catalog-entry commits.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/compartment/manifest.yaml` (new file, the entire diff)

## How to Test

1. Sandbox so nothing touches your real setup: `export HERMES_HOME="$(mktemp -d)" HERMES_OPTIONAL_MCPS="<this-checkout>/optional-mcps"`
2. `hermes mcp catalog` — the compartment row renders with name, `available` status, and description.
3. `hermes mcp install compartment` — clones at the pinned SHA into `$HERMES_HOME/mcp-installs/compartment`, bootstraps the venv, probes the server (it starts and lists all 14 tools before any vault exists), and writes the `mcp_servers.compartment` block.
4. `hermes mcp test compartment` — Hermes's own connection test completes the handshake; memory tools answer with lock-state guidance until `compartment init` is run.
5. `pytest tests/hermes_cli/test_mcp_catalog.py -q` passed with this entry in the tree at submission (35 tests then). On 2026-09-17 both shipped-catalog contract tests were replayed against upstream main's parser with the v4.9.5 entry in the tree: 66 manifests parse, every git install pinned to a full SHA.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_mcp_catalog.py -q` (the file that gates catalog manifests) at submission, and replayed both shipped-catalog contract tests at the v4.9.5 pin on 2026-09-17. The change is one catalog YAML file; no code paths are touched.
- [x] Tests: covered by the existing shipped-catalog contract tests, which validate every manifest in `optional-mcps/` at PR time by design
- [x] I've tested on my platform: macOS 26.2, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: the catalog UIs render entries from the manifest itself
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS and Linux install through the catalog bootstrap as-is (`python3` + `.venv/bin`, the same POSIX shape as the existing n8n entry; the engine's dependencies are wheels-only on all three OSes). Windows has no `python3`/`.venv/bin` for the bootstrap, so post_install documents the direct path there: `py -m pip install compartment`, then `hermes mcp add compartment --command compartment --args --caller hermes serve`; init, starter pack, panel app, and the shared vault work the same
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

End-to-end through the `hermes` CLI itself (v0.20.5, macOS), sandboxed with a temp `HERMES_HOME` and `HERMES_OPTIONAL_MCPS` pointing at this branch's `optional-mcps/`; sandbox paths shown as `$HERMES_HOME`:

<details>
<summary><code>hermes mcp catalog</code> / <code>install</code> / <code>test</code> (real CLI, non-interactive)</summary>

```
$ hermes mcp catalog
  Name               Status                   Description
  ------------------ ------------------------ -----------
  compartment        available                Offline agentic vector memory: encrypted, hybrid search, no cloud (stdio).

$ hermes mcp install compartment
  Installing MCP 'compartment'
  Offline agentic vector memory: encrypted, hybrid search, no cloud (stdio).
  Source: https://github.com/MaxFreedomPollard/Compartment
  Cloning https://github.com/MaxFreedomPollard/Compartment.git (15c3e25547c237bfc253e340a627d9af59b0b984) → $HERMES_HOME/mcp-installs/compartment
  $ python3 -m venv .venv
  $ .venv/bin/pip install .
  Probing 'compartment' for available tools...
  ✓ Installed 'compartment' (enabled). Start a new Hermes session to load its tools.
  [post_install text prints here]

$ hermes mcp list
  Name             Transport                      Tools        Status
  compartment      $HERMES_HOME/mcp-installs/...  all          ✓ enabled

$ hermes mcp test compartment
  Transport: stdio → $HERMES_HOME/mcp-installs/compartment/.venv/bin/compartment
  Auth: none
  ✓ Connected
  ✓ Tools discovered: 14

$ $HERMES_HOME/mcp-installs/compartment/.venv/bin/compartment --version
4.9.5

# config.yaml written by the install:
mcp_servers:
  compartment:
    command: $HERMES_HOME/mcp-installs/compartment/.venv/bin/compartment
    args:
      - --caller
      - hermes
      - serve
    enabled: true
```

</details>

<details>
<summary>MCP probe at the pinned SHA, v4.9.5 (initialize, tools/list, starter seeding, store/search round-trip)</summary>

```
$ git clone https://github.com/MaxFreedomPollard/Compartment.git
$ git checkout 15c3e25547c237bfc253e340a627d9af59b0b984
pinned: 15c3e25547c237bfc253e340a627d9af59b0b984 2026-09-03 00:48:28 -0400 Release 4.9.5
$ python3 -m venv .venv && .venv/bin/pip install .
installed version: 4.9.5
mcp SDK resolved by `pip install .`: 2.2.0

# MCP probe over stdio, BEFORE any vault exists
initialize OK: serverInfo=compartment 4.9.5
tools/list OK: 14 tools
memory_status (no vault): {"locked": true, "message": "Vault is locked.
  Run `compartment unlock` on the machine, or enable a keychain credential."}

$ .venv/bin/compartment --vault <scratch> init --no-app
Compartment 4.9.5 - creating vault
Embedding model: bge-small-en-v1.5-int8 (bundled, offline)
starter@1.5.0: 6665 starting memories
vault ready (6665 memories in 'main' - editable and forgettable like
  anything the agent stores)
Vault ready: 6665 records, projected RAM ~219MB.

# MCP probe over stdio, AFTER init
initialize OK: serverInfo=compartment 4.9.5
tools/list OK: 14 tools
memory_status -> {"locked": false, "records": 6665, ...}
memory_store -> {"id": "453236da8b8c4a159e14ce75e453740e", "duplicate": false, "namespace": "main"}
memory_search -> recalls the stored probe memory as the top hit
```

</details>


