### PR TITLE
fix(desktop): include route scope in gateway dial errors

### DIFF
--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -50,6 +50,7 @@ const {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   pruneSecondaryGateways,
   setPrimaryGateway
 } = await import('./gateway')
@@ -176,6 +177,48 @@ describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094
     await ensureGatewayForProfile('work')
 
     expect(activeGateway()).toBe(gatewayMocks.instances[0])
+  })
+})
+
+describe('connection-scoped dial failure identity (#95421)', () => {
+  it('logs the route scope while preserving the original dial error', async () => {
+    const dialError = new Error('backend unreachable')
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      authMode: 'token',
+      connectionId,
+      profile,
+      wsUrl: `wss://${connectionId}.invalid/ws`
+    }))
+
+    installDesktop({ getConnectionFor })
+    gatewayMocks.connect.mockRejectedValue(dialError)
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      await expect(openGatewayForAgent('work', 'default')).rejects.toBe(dialError)
+      await expect(openGatewayForAgent('homelab', 'default')).rejects.toBe(dialError)
+
+      const messages = errorSpy.mock.calls.map(([message]) => String(message))
+
+      expect(messages).toHaveLength(2)
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('scope="conn:work::default"'),
+          expect.stringContaining('scope="conn:homelab::default"')
+        ])
+      )
+      expect(messages.every(message => message.includes('profile="default"'))).toBe(true)
+      expect(new Set(messages).size).toBe(2)
+      expect(messages.join(' ')).not.toContain('wss://')
+
+      for (const [, error] of errorSpy.mock.calls) {
+        expect(error).toBe(dialError)
+      }
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -503,7 +503,7 @@ async function openSecondary(entry: Secondary): Promise<void> {
       // reconnectSecondary classifies failures by message ("No connection
       // with id", "no longer exists") to fail-stop permanent conditions, and
       // wrapping here would break that. Callers decide surfacing (#81094).
-      console.error(`[gateway] dial for profile "${entry.profile}" failed:`, error)
+      console.error(`[gateway] dial failed for scope="${entry.scope}" profile="${entry.profile}":`, error)
       throw error
     }
 


### PR DESCRIPTION
## Related Issue

Fixes #95421

## What does this PR do?

Registry connections can expose the same profile name. When two such gateway dials failed, the existing log only showed the profile, so both failures looked identical.

This change adds the existing route scope to the shared dial-failure log. It keeps the original `Error` object unchanged and rethrows that same object, so reconnect classification and caller behavior stay the same.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Include both `entry.scope` and `entry.profile` in `openSecondary()` dial-failure logs.
- Add a regression test for `work/default` and `homelab/default` failures.
- Verify that logs omit the WebSocket URL and that logging and callers receive the same original error.

## How to Test

1. Run `fnm exec --using v22.22.3 npx vitest run src/store/gateway.test.ts` (`1 file, 6 tests passed`).
2. Run `fnm exec --using v22.22.3 npm run typecheck` (`passed`).
3. Run `fnm exec --using v22.22.3 npx eslint src/store/gateway.ts src/store/gateway.test.ts` (`0 errors, 0 warnings`).
4. Run `fnm exec --using v22.22.3 npm run test:ui` (`611 files, 5995 tests passed`).
5. Run `git diff --check origin/main...HEAD` (no errors).

## Checklist

### Code

- [x] Read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Searched for existing PRs and confirmed this is not a duplicate
- [x] This PR contains only changes related to this bug
- [ ] Full Python `pytest tests/ -q` suite (not run; this change only touches Desktop TypeScript)
- [x] Added a regression test for the bug
- [x] Tested on macOS 26.5.1 with Node 22.22.3

### Documentation & Housekeeping

- [x] Documentation — N/A, no user-facing behavior or setup changed
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture or workflow changed
- [x] Cross-platform impact considered — the change only formats a platform-neutral log message
- [x] Tool descriptions and schemas — N/A, no model tool behavior changed

## Screenshots / Logs

N/A — covered by the focused regression test.