### PR TITLE
fix(kanban): make create-path idempotency guard status-blind

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3192,10 +3192,11 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
-    If ``idempotency_key`` is provided and a non-archived task with the
-    same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    If ``idempotency_key`` is provided and a task with the same key
+    already exists (regardless of status — archived rows match too:
+    admitted-once means admitted-forever), returns the existing task's
+    id instead of creating a duplicate. Useful for retried webhooks /
+    automation that should not double-write.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3398,10 +3399,13 @@ def create_task(
     # and to avoid holding a write lock during the lookup. Race is
     # acceptable: two concurrent creators with the same key might both
     # insert, at which point both rows exist but the next lookup stabilises.
+    # The lookup is STATUS-BLIND: archived rows match too. Admitted-once
+    # means admitted-forever — a retried webhook replaying a key whose
+    # task has since been archived must get that task's id back, never a
+    # fresh duplicate row (the #64 double-admission mechanism).
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -473,6 +473,41 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
+def test_create_task_idempotency_guard_is_status_blind(kanban_home):
+    """create_task's idempotency guard must match ARCHIVED rows too.
+
+    Admitted-once means admitted-forever: a retried webhook / automation
+    replaying an ``idempotency_key`` whose task was since archived must get
+    the archived task's id back, never a fresh duplicate row (the #64
+    double-admission mechanism). Mirrors the hermes-scripts gate ledger
+    semantics (fa05180).
+    """
+    key = "issue-ben/cv-7"
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="original", idempotency_key=key)
+
+        # Second create with the same key while non-archived → same id.
+        again = kb.create_task(conn, title="replayed", idempotency_key=key)
+        assert again == first
+
+        # Archive it, then replay the key once more — must STILL return the
+        # archived row's id and must NOT insert a new row.
+        kb.complete_task(conn, first, result="done")
+        assert kb.archive_task(conn, first)
+        assert kb.get_task(conn, first).status == "archived"
+
+        replay = kb.create_task(conn, title="replayed-after-archive", idempotency_key=key)
+        assert replay == first, (
+            "create_task with a key whose task is archived must return the "
+            "archived task's id, not create a duplicate"
+        )
+
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+        ).fetchone()[0]
+        assert rows == 1, f"expected exactly one row for key {key!r}, found {rows}"
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")


### PR DESCRIPTION
## Summary

The `create_task` idempotency guard filtered `status != 'archived'`, so a replayed `idempotency_key` whose task had since been archived created a fresh duplicate row — admitted-once must mean admitted-forever.

## Changes
- `hermes_cli/kanban_db.py`: removed the `AND status != 'archived'` filter from the guard SELECT (~line 3401); the guard is now status-blind — archived rows match too. Inline comment documents the invariant and the #64 double-admission mechanism it closes.
- Docstring (~line 3195) updated to document status-blind matching.
- `tests/hermes_cli/test_kanban_db.py`: new regression test `test_create_task_idempotency_guard_is_status_blind` — create with a key existing on an archived row returns the archived id and inserts no new row.

## Test plan
- [x] New test RED on base (duplicate created: `t_dc13b02b` != `t_41b9046f`), GREEN after the fix
- [x] Full `tests/hermes_cli/test_kanban_db.py`: 31 passed, 1 skipped
- [x] `tests/hermes_cli/test_kanban_core_functionality.py` + swarm suite: 26 passed; 3 failures are pre-existing on pristine origin/main (verified by stash — live-system guard artifacts, unrelated)

## Notes for reviewers
- Sibling work (separate cards, not in this PR): a UNIQUE index on `idempotency_key` + INSERT OR IGNORE convergence (needs a migration for 7 existing duplicate keys on the live estate; duplicate purge lands first).
- Sibling card t_a886791d owns the UNIQUE index decision; t_e548b1d2 owns the race convergence. This PR is deliberately the minimal storage-layer slice: guard semantics only, no schema change.