### PR TITLE
feat(update): image-managed installs refuse in-place updates via a baked provenance marker (#91277 Phase 3, salvage #92545)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -311,7 +311,11 @@ RUN mkdir -p /opt/hermes/bin && \
 # `s6-setuidgid hermes` in its run script. If HERMES_UID is unset, services
 # run as the default hermes user (UID 10000).
 
-# ---------- Bake build-time git revision ----------
+# ---------- Bake image provenance + build-time git revision ----------
+# The versioned, non-secret provenance marker is the authoritative runtime
+# signal that this filesystem came from an immutable image.  It deliberately
+# lives outside both /opt/hermes (which operators sometimes bind-mount as a
+# checkout) and /opt/data (the mutable HERMES_HOME volume).
 # .dockerignore excludes .git, so `git rev-parse HEAD` from inside the
 # container always returns nothing — meaning `hermes dump` reports
 # "(unknown)" and the startup banner drops its `· upstream <sha>` suffix.
@@ -324,14 +328,18 @@ RUN mkdir -p /opt/hermes/bin && \
 # banner.get_git_banner_state() try the baked SHA first, then fall back
 # to live `git rev-parse` for source installs (unchanged behaviour).
 #
-# The arg is optional — local `docker build` without --build-arg simply
-# omits the file, and the runtime falls back to live-git lookup.  CI
+# The arg is optional — local `docker build` without --build-arg omits the
+# SHA file (and records a null provenance revision), so build-info falls back
+# to live-git lookup.  CI
 # (.github/workflows/docker.yml) passes ${{ github.sha }} so
 # every published image has it.
 ARG HERMES_GIT_SHA=
-RUN if [ -n "${HERMES_GIT_SHA}" ]; then \
+RUN set -eu; \
+    if [ -n "${HERMES_GIT_SHA}" ]; then \
         printf '%s\n' "${HERMES_GIT_SHA}" > /opt/hermes/.hermes_build_sha; \
-    fi
+    fi; \
+    mkdir -p /etc/hermes; \
+    HERMES_GIT_SHA="${HERMES_GIT_SHA}" python3 -c 'import json, os, pathlib, tomllib; project = tomllib.loads(pathlib.Path("/opt/hermes/pyproject.toml").read_text(encoding="utf-8"))["project"]; marker = pathlib.Path("/etc/hermes/image-provenance.json"); marker.write_text(json.dumps({"schema": 1, "deployment_kind": "image", "manager": "docker", "image": "nousresearch/hermes-agent", "version": project["version"], "revision": os.environ.get("HERMES_GIT_SHA") or None}, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8"); marker.chmod(0o444)'
 
 # ---------- s6-overlay service wiring ----------
 # Static services declared at build time: main-hermes + dashboard.

--- a/hermes_cli/image_provenance.py
+++ b/hermes_cli/image_provenance.py
@@ -1,0 +1,137 @@
+"""Image-authored deployment provenance for immutable Hermes runtimes.
+
+The published image bakes ``/etc/hermes/image-provenance.json`` outside both
+``$HERMES_HOME`` and the mutable checkout.  A bind-mounted checkout (including
+``.git``) therefore cannot hide the build fact, and environment or config
+values cannot forge it.
+
+Absence preserves every pre-existing source/package install path.  Presence
+fails closed: an unreadable, non-regular, or malformed marker still means the
+runtime is image-managed; it is an integrity defect, never permission to
+mutate the image in place.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+IMAGE_PROVENANCE_PATH = Path("/etc/hermes/image-provenance.json")
+IMAGE_PROVENANCE_SCHEMA = 1
+
+
+@dataclass(frozen=True)
+class ImageProvenance:
+    """Validated provenance, or a fail-closed description of an invalid one."""
+
+    schema: int
+    deployment_kind: str
+    manager: str
+    image: Optional[str]
+    version: Optional[str]
+    revision: Optional[str]
+    marker_path: str
+    valid: bool = True
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _invalid(path: Path, reason: str) -> ImageProvenance:
+    return ImageProvenance(
+        schema=IMAGE_PROVENANCE_SCHEMA,
+        deployment_kind="image",
+        manager="unknown",
+        image=None,
+        version=None,
+        revision=None,
+        marker_path=str(path),
+        valid=False,
+        error=reason,
+    )
+
+
+def read_image_provenance(
+    marker_path: Optional[Path] = None,
+) -> Optional[ImageProvenance]:
+    """Read the baked marker without consulting environment or config.
+
+    ``None`` has one precise meaning: ``lstat`` proved that no marker exists.
+    Every other filesystem or validation failure returns an invalid
+    :class:`ImageProvenance`, so callers refuse image mutation closed.  In
+    particular, ``lstat`` makes a dangling symlink visibly *present* and the
+    regular-file check rejects symlinks, directories, and device nodes.
+
+    ``marker_path`` is a dependency-injection seam for tests and alternate
+    image builders.  Normal callers always use the image-owned absolute path.
+    This function never raises.
+    """
+
+    path = IMAGE_PROVENANCE_PATH
+    try:
+        path = Path(marker_path) if marker_path is not None else path
+    except BaseException as exc:
+        return _invalid(path, f"marker_presence_unreadable:{type(exc).__name__}")
+
+    try:
+        marker_stat = path.lstat()
+    except FileNotFoundError:
+        return None
+    except BaseException as exc:
+        # Permission errors and other lookup failures do not prove absence.
+        return _invalid(path, f"marker_presence_unreadable:{type(exc).__name__}")
+
+    if not stat.S_ISREG(marker_stat.st_mode):
+        return _invalid(path, "marker_not_regular_file")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        # The file may disappear between lstat/read; it was nevertheless
+        # observed present, so the decision remains fail-closed.
+        return _invalid(path, f"marker_unreadable:{type(exc).__name__}")
+
+    if not isinstance(payload, dict):
+        return _invalid(path, "marker_not_object")
+
+    schema = payload.get("schema")
+    # ``bool`` is an ``int`` subclass in Python.  Schema ``true`` must not be
+    # accepted as schema 1, hence the exact type check.
+    if type(schema) is not int or schema != IMAGE_PROVENANCE_SCHEMA:
+        return _invalid(path, "unsupported_marker_schema")
+    if payload.get("deployment_kind") != "image":
+        return _invalid(path, "invalid_deployment_kind")
+
+    manager = payload.get("manager")
+    if not isinstance(manager, str) or not manager.strip():
+        return _invalid(path, "missing_manager")
+
+    def _optional_string(name: str) -> Optional[str]:
+        value = payload.get(name)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError(name)
+        value = value.strip()
+        return value or None
+
+    try:
+        image = _optional_string("image")
+        version = _optional_string("version")
+        revision = _optional_string("revision")
+    except TypeError as exc:
+        return _invalid(path, f"invalid_{exc.args[0]}")
+
+    return ImageProvenance(
+        schema=IMAGE_PROVENANCE_SCHEMA,
+        deployment_kind="image",
+        manager=manager.strip(),
+        image=image,
+        version=version,
+        revision=revision,
+        marker_path=str(path),
+    )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10725,12 +10725,8 @@ def cmd_update(args):
     ``sys.exit`` or unhandled exceptions).
     """
     from hermes_cli.config import (
-        detect_install_method,
-        format_docker_update_message,
         is_managed,
-        is_nix_install_method,
         managed_error,
-        recommended_update_command_for_method,
     )
 
     if is_managed():
@@ -10753,20 +10749,23 @@ def cmd_update(args):
         print_update_plan(collect_runtime_inventory())
         return
 
-    # Docker users can't ``git pull`` — the image excludes ``.git`` from
-    # the build context.  Bail with a friendly explanation pointing at
-    # ``docker pull`` BEFORE any of the apply-path / check-path branches
-    # below get a chance to error out with misleading "Not a git
-    # repository" text.  See format_docker_update_message() for the full
-    # rationale and tag-pinning / config-persistence notes.
-    install_method = detect_install_method(PROJECT_ROOT)
-    if install_method == "docker":
-        print(format_docker_update_message())
-        sys.exit(1)
+    # Image-managed / package-managed admission gate (#91277 Phase 3): one
+    # shared decision for every mutation surface. Consults the baked image
+    # provenance marker first (authoritative, fail-closed on malformed),
+    # then the pre-existing docker/nix/apt heuristics. Prints the real
+    # update command, records a `refused` receipt so fleet tooling sees the
+    # blocked attempt, and exits 2 (refused-by-contract, distinct from
+    # exit 1 errors).
+    from hermes_cli.update_contract import (
+        evaluate_update_admission,
+        record_refusal_receipt,
+    )
 
-    if is_nix_install_method(install_method) or install_method == "apt":
-        print(recommended_update_command_for_method(install_method))
-        sys.exit(1)
+    refusal = evaluate_update_admission(PROJECT_ROOT)
+    if refusal is not None:
+        print(refusal.message)
+        record_refusal_receipt(refusal)
+        sys.exit(2)
 
     if getattr(args, "check", False):
         # --check honors --branch so the "any new commits?" answer matches

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3371,24 +3371,19 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     Installs that can't honor non-default branches (e.g. Docker) surface a
     one-line notice instead of silently dropping the flag.
     """
-    from hermes_cli.config import (
-        detect_install_method,
-        is_nix_install_method,
-        recommended_update_command_for_method,
+    # Shared admission gate (#91277 Phase 3): same marker-first decision as
+    # the apply path, so --check can never report git state for an install
+    # whose real update mechanism is an image pull.
+    from hermes_cli.update_contract import (
+        evaluate_update_admission,
+        record_refusal_receipt,
     )
-    method = detect_install_method(_m().PROJECT_ROOT)
-    if method == "docker":
-        # Docker can't ``git fetch`` from within the container.  Surface the
-        # same long-form ``docker pull`` guidance ``hermes update`` (apply
-        # path) uses — telling the user to "reinstall via curl" or that
-        # ".git is missing" would point them at the wrong remediation.
-        from hermes_cli.config import format_docker_update_message
-        print(format_docker_update_message())
-        sys.exit(1)
 
-    if is_nix_install_method(method) or method == "apt":
-        print(recommended_update_command_for_method(method))
-        sys.exit(1)
+    refusal = evaluate_update_admission(_m().PROJECT_ROOT)
+    if refusal is not None:
+        print(refusal.message)
+        record_refusal_receipt(refusal)
+        sys.exit(2)
 
     git_dir = _m().PROJECT_ROOT / ".git"
     if not git_dir.exists():

--- a/hermes_cli/update_contract.py
+++ b/hermes_cli/update_contract.py
@@ -1,0 +1,138 @@
+"""Image-managed install refusal contract (#91277 Phase 3).
+
+One shared admission gate for every surface that can start an in-place
+``hermes update`` mutation (CLI apply, CLI --check, dashboard update
+endpoint). The decision layers:
+
+1. **Baked provenance marker** (``/etc/hermes/image-provenance.json``,
+   written by the image build — see :mod:`hermes_cli.image_provenance`):
+   authoritative ground truth that this filesystem came from an immutable
+   image. Fail-closed: a present-but-malformed marker still refuses.
+2. **Filesystem heuristics** (``detect_install_method()``): the pre-existing
+   docker/nix/apt detection, kept as the fallback for images built before
+   the marker existed and for package-managed installs that have no image
+   marker at all.
+
+A refusal prints the real update command for the deployment kind, records a
+``refused`` receipt (so fleet tooling sees "this install cannot self-update,
+use <command>" instead of a silent non-update), and exits 2 on CLI surfaces.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UpdateRefusal:
+    """Why an in-place update is refused, and what to run instead."""
+
+    code: str              # image-marker | image-marker-invalid | docker | nix | apt
+    message: str           # full user-facing text (multi-line ok)
+    update_command: str    # the one-line remediation command
+
+
+def evaluate_update_admission(project_root: Path) -> Optional[UpdateRefusal]:
+    """Return an :class:`UpdateRefusal` when in-place update must not run.
+
+    ``None`` means the install is eligible for in-place update (git checkout
+    or unknown-but-mutable). Never raises; on any internal error it falls
+    back to the heuristic layer only.
+    """
+    # Layer 1: baked provenance marker — authoritative when present.
+    try:
+        from hermes_cli.image_provenance import read_image_provenance
+
+        provenance = read_image_provenance()
+        if provenance is not None:
+            from hermes_cli.config import (
+                format_docker_update_message,
+                recommended_update_command_for_method,
+            )
+
+            if not provenance.valid:
+                # Present but malformed: still image-managed — an integrity
+                # defect is never permission to mutate the image in place.
+                command = recommended_update_command_for_method("docker")
+                return UpdateRefusal(
+                    code="image-marker-invalid",
+                    message=(
+                        "✗ This install is image-managed, but its provenance "
+                        f"marker is invalid ({provenance.error}).\n"
+                        "  In-place update is disabled. Update by pulling a "
+                        f"new image:\n    {command}"
+                    ),
+                    update_command=command,
+                )
+            manager = provenance.manager
+            if manager == "docker":
+                return UpdateRefusal(
+                    code="image-marker",
+                    message=format_docker_update_message(),
+                    update_command=recommended_update_command_for_method("docker"),
+                )
+            command = recommended_update_command_for_method(manager)
+            return UpdateRefusal(
+                code="image-marker",
+                message=command,
+                update_command=command,
+            )
+    except Exception as exc:
+        logger.debug("Image provenance check failed (using heuristics): %s", exc)
+
+    # Layer 2: pre-existing filesystem heuristics, verbatim semantics.
+    try:
+        from hermes_cli.config import (
+            detect_install_method,
+            format_docker_update_message,
+            is_nix_install_method,
+            recommended_update_command_for_method,
+        )
+
+        method = detect_install_method(project_root)
+        if method == "docker":
+            return UpdateRefusal(
+                code="docker",
+                message=format_docker_update_message(),
+                update_command=recommended_update_command_for_method("docker"),
+            )
+        if is_nix_install_method(method) or method == "apt":
+            command = recommended_update_command_for_method(method)
+            return UpdateRefusal(
+                code=method if method == "apt" else "nix",
+                message=command,
+                update_command=command,
+            )
+    except Exception as exc:
+        logger.debug("Install-method admission check failed: %s", exc)
+    return None
+
+
+def record_refusal_receipt(refusal: UpdateRefusal) -> None:
+    """Write a minimal ``refused`` receipt for a blocked update attempt.
+
+    Gives fleet tooling a durable record that an update was ATTEMPTED and
+    refused ("not updatable in place, use <command>") instead of a silent
+    nothing. Best-effort; never raises.
+    """
+    try:
+        from hermes_cli.update_receipt import (
+            begin_update_receipt,
+            finalize_update_receipt,
+            record_step,
+        )
+
+        begin_update_receipt()
+        record_step(
+            "admission",
+            False,
+            f"not updatable in place ({refusal.code}); use: {refusal.update_command}",
+        )
+        finalize_update_receipt("refused", stop_reason=refusal.code)
+    except Exception as exc:
+        logger.debug("Could not record refusal receipt: %s", exc)

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -152,6 +152,21 @@ def collect_runtime_inventory() -> UpdatePlan:
         if managed:
             plan.install_method = managed
         plan.updatable_in_place = method in ("git", "unknown") and not managed
+        # Baked image provenance (#91277 Phase 3): when the image marker is
+        # present it is authoritative — a bind-mounted checkout inside a
+        # container can look like `git` to the heuristics while the running
+        # filesystem is actually an immutable image. Fail-closed: an invalid
+        # marker still flips the plan to not-updatable.
+        try:
+            from hermes_cli.image_provenance import read_image_provenance
+
+            provenance = read_image_provenance()
+            if provenance is not None:
+                plan.updatable_in_place = False
+                if provenance.valid and provenance.manager:
+                    plan.install_method = provenance.manager
+        except Exception as exc:
+            logger.debug("Image provenance probe failed: %s", exc)
         plan.update_mechanism = recommended_update_command_for_method(method)
     except Exception as exc:
         logger.debug("Install-method probe failed: %s", exc)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5064,31 +5064,33 @@ async def update_hermes():
             "update_command": "managed outside dashboard",
         }
 
-    install_method = detect_install_method(PROJECT_ROOT)
-    if install_method == "docker":
-        message = format_docker_update_message()
-        _record_completed_action("hermes-update", message, exit_code=1)
-        return {
-            "ok": False,
-            "pid": None,
-            "name": "hermes-update",
-            "error": "docker_update_unsupported",
-            "message": message,
-            "update_command": recommended_update_command_for_method(install_method),
-        }
+    # Shared admission gate (#91277 Phase 3): marker-first, then the
+    # docker/nix/apt heuristics — one decision with the CLI paths. The
+    # response keeps the pre-existing per-kind error codes the dashboard UI
+    # already keys on.
+    from hermes_cli.update_contract import (
+        evaluate_update_admission,
+        record_refusal_receipt,
+    )
 
-    if is_nix_install_method(install_method) or install_method == "apt":
-        message = recommended_update_command_for_method(install_method)
-        _record_completed_action("hermes-update", message, exit_code=1)
+    refusal = evaluate_update_admission(PROJECT_ROOT)
+    if refusal is not None:
+        _record_completed_action("hermes-update", refusal.message, exit_code=1)
+        record_refusal_receipt(refusal)
+        error_code = {
+            "docker": "docker_update_unsupported",
+            "image-marker": "docker_update_unsupported",
+            "image-marker-invalid": "docker_update_unsupported",
+            "apt": "apt_update_required",
+            "nix": "nix_update_unsupported",
+        }.get(refusal.code, "update_not_in_place")
         return {
             "ok": False,
             "pid": None,
             "name": "hermes-update",
-            "error": (
-                "apt_update_required" if install_method == "apt" else "nix_update_unsupported"
-            ),
-            "message": message,
-            "update_command": message,
+            "error": error_code,
+            "message": refusal.message,
+            "update_command": refusal.update_command,
         }
 
     existing = _ACTION_PROCS.get("hermes-update")

--- a/tests/hermes_cli/test_cmd_update_apt.py
+++ b/tests/hermes_cli/test_cmd_update_apt.py
@@ -27,7 +27,8 @@ def test_cmd_update_apt_prints_pkg_guidance_without_git(
     with pytest.raises(SystemExit) as excinfo:
         cmd_update(SimpleNamespace(check=False))
 
-    assert excinfo.value.code == 1
+    # exit 2 = refused-by-contract (#91277 Phase 3), distinct from exit-1 errors
+    assert excinfo.value.code == 2
     assert "pkg upgrade hermes-agent" in capsys.readouterr().out
     assert mock_run.call_args_list == []
 
@@ -40,6 +41,7 @@ def test_cmd_update_check_apt_prints_pkg_guidance_without_git(
     with pytest.raises(SystemExit) as excinfo:
         _cmd_update_check()
 
-    assert excinfo.value.code == 1
+    # exit 2 = refused-by-contract (#91277 Phase 3)
+    assert excinfo.value.code == 2
     assert "pkg upgrade hermes-agent" in capsys.readouterr().out
     assert mock_run.call_args_list == []

--- a/tests/hermes_cli/test_cmd_update_docker.py
+++ b/tests/hermes_cli/test_cmd_update_docker.py
@@ -33,11 +33,14 @@ from hermes_cli.main import _cmd_update_check, cmd_update
 def test_cmd_update_in_docker_prints_guidance_and_exits(
     mock_run, _mock_method, _mock_managed, capsys
 ):
-    """``hermes update`` inside Docker → friendly message + exit 1, no git calls."""
+    """``hermes update`` inside Docker → friendly message + exit 2, no git calls.
+
+    Exit 2 = refused-by-contract (#91277 Phase 3), distinct from exit-1 errors.
+    """
     with pytest.raises(SystemExit) as excinfo:
         cmd_update(SimpleNamespace(check=False))
 
-    assert excinfo.value.code == 1
+    assert excinfo.value.code == 2
     out = capsys.readouterr().out
     # Spot-check the key guidance — exhaustive wording is locked in by the
     # config-module test below to keep these CLI tests resilient to copy edits.

--- a/tests/hermes_cli/test_update_contract.py
+++ b/tests/hermes_cli/test_update_contract.py
@@ -1,0 +1,177 @@
+"""Image-managed refusal contract tests (#91277 Phase 3).
+
+Marker semantics (image_provenance.py, salvaged from #92545 @andrexibiza):
+absent → None; present-and-valid → provenance; present-but-broken →
+fail-closed invalid. Admission gate (update_contract.py): marker first,
+docker/nix/apt heuristics second; refusals record a `refused` receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.image_provenance import read_image_provenance
+from hermes_cli.update_contract import (
+    UpdateRefusal,
+    evaluate_update_admission,
+    record_refusal_receipt,
+)
+
+
+def _valid_marker(tmp_path: Path) -> Path:
+    marker = tmp_path / "image-provenance.json"
+    marker.write_text(json.dumps({
+        "schema": 1,
+        "deployment_kind": "image",
+        "manager": "docker",
+        "image": "nousresearch/hermes-agent",
+        "version": "1.0.0",
+        "revision": "a" * 40,
+    }))
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# Marker reader
+# ---------------------------------------------------------------------------
+
+
+def test_reader_absent_marker_means_none(tmp_path):
+    assert read_image_provenance(tmp_path / "nope.json") is None
+
+
+def test_reader_valid_marker(tmp_path):
+    provenance = read_image_provenance(_valid_marker(tmp_path))
+    assert provenance is not None and provenance.valid
+    assert provenance.manager == "docker"
+    assert provenance.version == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    "payload,reason_prefix",
+    [
+        ("not json {", "marker_unreadable"),
+        (json.dumps([1, 2]), "marker_not_object"),
+        (json.dumps({"schema": True, "deployment_kind": "image", "manager": "docker"}), "unsupported_marker_schema"),
+        (json.dumps({"schema": 2, "deployment_kind": "image", "manager": "docker"}), "unsupported_marker_schema"),
+        (json.dumps({"schema": 1, "deployment_kind": "source", "manager": "docker"}), "invalid_deployment_kind"),
+        (json.dumps({"schema": 1, "deployment_kind": "image", "manager": "  "}), "missing_manager"),
+    ],
+)
+def test_reader_fails_closed_on_malformed(tmp_path, payload, reason_prefix):
+    marker = tmp_path / "image-provenance.json"
+    marker.write_text(payload)
+    provenance = read_image_provenance(marker)
+    assert provenance is not None and not provenance.valid
+    assert provenance.error.startswith(reason_prefix)
+
+
+def test_reader_rejects_symlink_marker(tmp_path):
+    real = _valid_marker(tmp_path)
+    link = tmp_path / "link.json"
+    try:
+        link.symlink_to(real)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+    provenance = read_image_provenance(link)
+    assert provenance is not None and not provenance.valid
+    assert provenance.error == "marker_not_regular_file"
+
+
+# ---------------------------------------------------------------------------
+# Admission gate
+# ---------------------------------------------------------------------------
+
+
+def test_admission_marker_refuses_even_on_git_checkout(tmp_path, monkeypatch):
+    """The bind-mounted-checkout case: heuristics say git, marker says image
+    — the marker wins."""
+    import hermes_cli.image_provenance as ip
+
+    monkeypatch.setattr(ip, "IMAGE_PROVENANCE_PATH", _valid_marker(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda *a, **k: "git"
+    )
+    refusal = evaluate_update_admission(tmp_path)
+    assert refusal is not None
+    assert refusal.code == "image-marker"
+    assert "docker pull" in refusal.update_command
+
+
+def test_admission_invalid_marker_fails_closed(tmp_path, monkeypatch):
+    import hermes_cli.image_provenance as ip
+
+    bad = tmp_path / "image-provenance.json"
+    bad.write_text("corrupted {{{")
+    monkeypatch.setattr(ip, "IMAGE_PROVENANCE_PATH", bad)
+    refusal = evaluate_update_admission(tmp_path)
+    assert refusal is not None
+    assert refusal.code == "image-marker-invalid"
+    assert "docker pull" in refusal.update_command
+
+
+def test_admission_no_marker_falls_back_to_heuristics(tmp_path, monkeypatch):
+    import hermes_cli.image_provenance as ip
+
+    monkeypatch.setattr(ip, "IMAGE_PROVENANCE_PATH", tmp_path / "absent.json")
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda *a, **k: "docker"
+    )
+    refusal = evaluate_update_admission(tmp_path)
+    assert refusal is not None and refusal.code == "docker"
+
+
+def test_admission_git_checkout_no_marker_is_admitted(tmp_path, monkeypatch):
+    import hermes_cli.image_provenance as ip
+
+    monkeypatch.setattr(ip, "IMAGE_PROVENANCE_PATH", tmp_path / "absent.json")
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda *a, **k: "git"
+    )
+    assert evaluate_update_admission(tmp_path) is None
+
+
+def test_admission_apt_and_nix_refuse(tmp_path, monkeypatch):
+    import hermes_cli.image_provenance as ip
+
+    monkeypatch.setattr(ip, "IMAGE_PROVENANCE_PATH", tmp_path / "absent.json")
+    for method, code in (("apt", "apt"), ("nix", "nix")):
+        def _detect(*a, _m=method, **k):
+            return _m
+
+        monkeypatch.setattr("hermes_cli.config.detect_install_method", _detect)
+        refusal = evaluate_update_admission(tmp_path)
+        assert refusal is not None and refusal.code == code
+
+
+# ---------------------------------------------------------------------------
+# Refusal receipt
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_receipt_written_as_refused(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.update_receipt as ur
+
+    monkeypatch.setattr(ur, "_receipt_dir", lambda: tmp_path / "receipts")
+
+    record_refusal_receipt(
+        UpdateRefusal(
+            code="image-marker",
+            message="msg",
+            update_command="docker pull nousresearch/hermes-agent:latest",
+        )
+    )
+    receipts = list((tmp_path / "receipts").glob("*.json"))
+    receipts = [p for p in receipts if p.name != "latest.json"]
+    assert receipts, "a refusal receipt must be written"
+    data = json.loads(receipts[0].read_text())
+    assert data["outcome"] == "refused"
+    assert data["stop_reason"] == "image-marker"
+    steps = {s["name"]: s for s in data["steps"]}
+    assert "admission" in steps and steps["admission"]["ok"] is False
+    assert "docker pull" in steps["admission"]["detail"]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1173,6 +1173,11 @@ class TestWebServerEndpoints:
 
         # Bypass the managed-externally gate so we reach the docker install check.
         monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: False)
+        # The shared admission gate (#91277 Phase 3) resolves the install
+        # method through hermes_cli.config directly.
+        monkeypatch.setattr(
+            "hermes_cli.config.detect_install_method", lambda *_a, **_k: "docker"
+        )
         monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "docker")
         monkeypatch.setattr(web_server, "_spawn_hermes_action", fail_spawn)
         web_server._ACTION_PROCS.pop("hermes-update", None)
@@ -1208,6 +1213,12 @@ class TestWebServerEndpoints:
             raise AssertionError("APT-managed update guard should not spawn hermes update")
 
         monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: False)
+        # The shared admission gate (#91277 Phase 3) resolves the install
+        # method through hermes_cli.config directly, so patch it there (the
+        # web_server module alias only feeds the /update/check endpoint).
+        monkeypatch.setattr(
+            "hermes_cli.config.detect_install_method", lambda *_a, **_k: "apt"
+        )
         monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "apt")
         monkeypatch.setattr(web_server, "_spawn_hermes_action", fail_spawn)
         web_server._ACTION_PROCS.pop("hermes-update", None)

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -260,6 +260,10 @@ uv pip install -e ".[all]"
 Rolling back may cause config incompatibilities if new options were added. Run `hermes config check` after rolling back and remove any unrecognized options from `config.yaml` if you encounter errors.
 :::
 
+### Image-managed installs (Docker): the provenance marker
+
+Published Docker images bake a small read-only marker (`/etc/hermes/image-provenance.json`) that authoritatively identifies the filesystem as image-managed. `hermes update`, `hermes update --check`, and the dashboard's Update button all consult it before touching anything: on an image-managed install they refuse cleanly (exit code 2), print the actual update command (`docker pull nousresearch/hermes-agent:latest`), and write a `refused` receipt so fleet tooling can see the attempt happened. The marker wins even when a source checkout is bind-mounted into the container — the refusal is based on what the running filesystem *is*, not what it looks like. A damaged marker still refuses (fail-closed). Nix- and apt-managed installs refuse through the same gate using the existing detection.
+
 ### Note for Nix users
 
 Nix is no longer an explicitly supported install path (best-effort only) — see [Nix Setup](./nix-setup.md). If you installed via Nix flake, updates are managed through the Nix package manager:


### PR DESCRIPTION
## Summary

Image-managed installs (Docker, and package-managed Nix/apt) now refuse in-place updates through ONE shared admission gate on every mutation surface — `hermes update`, `update --check`, and the dashboard's Update button — backed by an authoritative provenance marker baked into the image (#91277 Phase 3; marker bake + fail-closed reader salvaged from #92545 by @andrexibiza with his authorship preserved).

Before: the three surfaces each carried their own copy of the docker/nix/apt heuristics; a bind-mounted checkout inside a container looked like `git` and could admit a mutation against an immutable image; refused attempts left no record.

## Changes

- **Dockerfile + `hermes_cli/image_provenance.py`** (@andrexibiza's commit, cherry-picked): the image build bakes `/etc/hermes/image-provenance.json` (outside both the bind-mountable checkout and the HERMES_HOME volume); the reader is fail-closed — absent means "not image-managed", present-but-malformed still means image-managed.
- **`hermes_cli/update_contract.py`** (new, ~130 LOC): `evaluate_update_admission()` — marker first, then the pre-existing docker/nix/apt heuristics verbatim; `record_refusal_receipt()` writes a `refused` receipt ("not updatable in place (<code>); use: <command>").
- **Three call sites route through the gate**: `cmd_update` (apply), `_cmd_update_check`, dashboard `update_hermes` endpoint (keeps its per-kind error codes). CLI refusals exit 2 (refused-by-contract) instead of 1.
- **`update_inventory.py`**: `--plan`/receipts honor the marker — `updatable_in_place=False` even when a bind-mounted checkout fools the heuristics.
- Docs: provenance-marker section in updating.md (same PR).
- 15 new tests (reader absent/valid/6 malformed shapes/symlink; gate marker-beats-git, fail-closed, heuristic fallback, git admitted, apt/nix; receipt shape).

Deliberately NOT taken from #92545: the pre-import bootstrap kernel, dashboard correlation-ID arbitration, Desktop UI + i18n, PID prober (~6,700 of its ~6,960 lines) — scope creep vs. the carve-out; closing comment will credit and explain.

## Validation

| | Result |
|---|---|
| New suite | 15/15 passed |
| A/B (edits stashed, tests kept) | collection error on merge-base — module absent, feature provably new |
| Sibling suites (update_inventory, serve inventory) | 22/22 passed |
| Live E2E | real `hermes update` subprocesses with a real marker file: apply → exit 2 + docker-pull guidance; `--check` → identical; receipts on disk as `refused`/`image-marker`; marker corrupted in place → still refuses (fail-closed); marker removed → git checkout admitted through the gate (exit 0) |

**Live repro:** on merge-base a marker on disk changes nothing (no reader exists) and refusals leave no receipt; at head all five phases hold.

Advances #91277 Phase 3. Credit: @andrexibiza (#92545).

## Infographic

![Image provenance seal](https://v3b.fal.media/files/b/0aa7e912/MIaIwCjsVFXYh8u7nY7Y4_3x7Ti5O5.png)
