### PR TITLE
fix(gateway): stop WhatsApp bot chats from leaking internal traces

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1031,6 +1031,45 @@ def _has_platform_display_override(user_config: dict, platform_key: str, setting
     return isinstance(platform_cfg, dict) and setting in platform_cfg
 
 
+def _customer_facing_whatsapp_bot_turn(event: Any) -> bool:
+    """Return whether a WhatsApp bot turn came from an external participant.
+
+    Bot-mode WhatsApp chats are commonly customer-facing. The bridge marks
+    linked-device messages typed by the owner explicitly; every other bot-mode
+    inbound must be treated as external rather than inheriting operator-facing
+    diagnostics.
+    """
+    source = getattr(event, "source", None)
+    if getattr(source, "platform", None) != Platform.WHATSAPP:
+        return False
+    try:
+        from gateway.platforms.whatsapp_common import _get_wsecret
+
+        mode = str(_get_wsecret("WHATSAPP_MODE", "self-chat") or "self-chat")
+    except Exception:
+        # An unreadable trust mode must not expose operator diagnostics.
+        mode = "bot"
+    if mode.strip().lower() != "bot":
+        return False
+    metadata = getattr(event, "metadata", None)
+    return not bool(
+        isinstance(metadata, dict) and metadata.get("whatsapp_from_owner") is True
+    )
+
+
+def _requires_explicit_internal_display_opt_in(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    source: Any,
+) -> bool:
+    """Require a per-platform opt-in before exposing internals to bot chats."""
+    return bool(
+        getattr(source, "_customer_facing_bot_turn", False)
+        and not _has_platform_display_override(user_config, platform_key, setting)
+    )
+
+
 def _resolve_gateway_display_bool(
     user_config: dict,
     platform_key: str,
@@ -5310,6 +5349,8 @@ class TurnRunner:
 
     def _status_callback_sync(self, event_type: str, message: str) -> None:
         ctx = self._ctx
+        if getattr(ctx.source, "_customer_facing_bot_turn", False):
+            return
         if not ctx._status_adapter or not ctx._run_still_current():
             return
         prepared_message = _prepare_gateway_status_message(
@@ -16482,6 +16523,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _deliver_platform_notice(self, source, content: str) -> None:
         """Deliver a setup/operational notice using platform-specific privacy rules."""
+        if getattr(source, "_customer_facing_bot_turn", False):
+            logger.debug(
+                "Suppressing operator notice in customer-facing WhatsApp bot chat"
+            )
+            return
         adapter = self._adapter_for_source(source)
         if not adapter:
             return
@@ -16997,6 +17043,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         7. Return response
         """
         source = event.source
+        # Stamp a turn-local trust classification once, inside the profile's
+        # secret scope. Downstream notice/progress rails consume this marker;
+        # SessionSource serialization intentionally ignores dynamic attrs.
+        source._customer_facing_bot_turn = _customer_facing_whatsapp_bot_turn(event)
 
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
@@ -20865,18 +20915,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Mattermost requires explicit per-platform opt-in because this is
             # scratch text, not ordinary final-answer content.
             try:
+                _reasoning_config = _load_gateway_config()
                 _show_reasoning_effective = _resolve_gateway_display_bool(
-                    _load_gateway_config(),
+                    _reasoning_config,
                     _platform_config_key(source.platform),
                     "show_reasoning",
                     default=bool(getattr(self, "_show_reasoning", False)),
                     platform=source.platform,
                     require_platform_override_for={Platform.MATTERMOST},
                 )
+                if _requires_explicit_internal_display_opt_in(
+                    _reasoning_config,
+                    _platform_config_key(source.platform),
+                    "show_reasoning",
+                    source,
+                ):
+                    _show_reasoning_effective = False
             except Exception:
                 _show_reasoning_effective = (
                     False
-                    if source.platform == Platform.MATTERMOST
+                    if (
+                        source.platform == Platform.MATTERMOST
+                        or getattr(source, "_customer_facing_bot_turn", False)
+                    )
                     else getattr(self, "_show_reasoning", False)
                 )
             if _show_reasoning_effective and response and not _intentional_silence:
@@ -28708,6 +28769,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
+        if _requires_explicit_internal_display_opt_in(
+            user_config, platform_key, "tool_progress", source
+        ):
+            progress_mode = "off"
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
@@ -28722,6 +28787,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             allow_generic: bool = False,
         ) -> str:
             """Return off|raw|generic for a gateway visibility surface."""
+            if _requires_explicit_internal_display_opt_in(
+                user_config, platform_key, setting, source
+            ):
+                return "off"
             if require_platform_override_for:
                 current_platform = _gateway_platform_value(source.platform)
                 platform_only = {

--- a/tests/gateway/test_whatsapp_bot_confidentiality.py
+++ b/tests/gateway/test_whatsapp_bot_confidentiality.py
@@ -1,0 +1,99 @@
+"""Confidentiality boundaries for customer-facing WhatsApp bot turns."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    GatewayRunner,
+    TurnRunner,
+    _customer_facing_whatsapp_bot_turn,
+    _requires_explicit_internal_display_opt_in,
+)
+
+
+def _event(*, platform=Platform.WHATSAPP, from_owner=False):
+    return SimpleNamespace(
+        source=SimpleNamespace(platform=platform),
+        metadata={"whatsapp_from_owner": True} if from_owner else {},
+    )
+
+
+def test_customer_facing_bot_turn_excludes_owner_and_self_chat(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_MODE", "bot")
+
+    assert _customer_facing_whatsapp_bot_turn(_event()) is True
+    assert _customer_facing_whatsapp_bot_turn(_event(from_owner=True)) is False
+    assert _customer_facing_whatsapp_bot_turn(_event(platform=Platform.TELEGRAM)) is False
+
+    monkeypatch.setenv("WHATSAPP_MODE", "self-chat")
+    assert _customer_facing_whatsapp_bot_turn(_event()) is False
+
+
+def test_customer_facing_turn_requires_per_platform_opt_in_for_internal_display():
+    source = SimpleNamespace(_customer_facing_bot_turn=True)
+
+    assert (
+        _requires_explicit_internal_display_opt_in(
+            {}, "whatsapp", "tool_progress", source
+        )
+        is True
+    )
+    assert (
+        _requires_explicit_internal_display_opt_in(
+            {
+                "display": {
+                    "tool_progress": "all",
+                    "platforms": {"whatsapp": {"tool_progress": "new"}},
+                }
+            },
+            "whatsapp",
+            "tool_progress",
+            source,
+        )
+        is False
+    )
+
+
+def test_regular_turn_does_not_require_extra_internal_display_opt_in():
+    source = SimpleNamespace(_customer_facing_bot_turn=False)
+
+    assert (
+        _requires_explicit_internal_display_opt_in(
+            {}, "whatsapp", "tool_progress", source
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_customer_facing_bot_turn_drops_operator_notices():
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner.config = None
+    source = SimpleNamespace(
+        platform=Platform.WHATSAPP,
+        chat_id="customer@s.whatsapp.net",
+        _customer_facing_bot_turn=True,
+    )
+
+    await runner._deliver_platform_notice(source, "Type /sethome")
+
+    adapter.send.assert_not_awaited()
+
+
+def test_customer_facing_bot_turn_drops_status_callbacks():
+    runner = object.__new__(TurnRunner)
+    status_adapter = MagicMock()
+    runner._ctx = SimpleNamespace(
+        source=SimpleNamespace(_customer_facing_bot_turn=True),
+        _status_adapter=status_adapter,
+    )
+
+    runner._status_callback_sync("lifecycle", "internal retry details")
+
+    assert status_adapter.mock_calls == []


### PR DESCRIPTION
## What does this PR do?

Prevents external participants in WhatsApp bot-mode chats from receiving operator-facing setup notices, tool-call previews, reasoning, interim assistant commentary, and status callbacks. Without this boundary, customer-facing chats can receive terminal commands, session-search previews, memory-related progress, and the `/sethome` setup nudge instead of only the intended assistant reply.

### Symptom

A WhatsApp bot-mode conversation without a configured home channel can send the inbound participant a `/sethome` notice and editable tool-progress content such as terminal command previews. Other internal display rails can also publish reasoning, interim commentary, or status messages into the same chat.

### Impact

External participants can receive operational details and agent working traces that were intended for the Hermes operator. The exact deployment blast radius is unknown; the reported failure affects WhatsApp bot mode when a non-owner participant starts an agent turn.

### Bug Cause

**Trigger:** `gateway/run.py:_handle_message` when `WHATSAPP_MODE=bot` receives a message without `whatsapp_from_owner` metadata.

**Causal chain:**
1. The WhatsApp bridge identifies owner-typed messages, but the shared gateway did not classify all other bot-mode inbound turns as customer-facing.
2. The home-channel notice and progress/status rails therefore inherited operator-facing defaults, including WhatsApp's editable tool-progress mode.
3. The participant received setup notices and tool-call previews alongside the final assistant reply.

**Why it is wrong:** Adapter authorization answers who may talk to the bot, not whether that participant is the operator. Treating every authorized participant as operator-trusted crosses the bot-mode confidentiality boundary.

**Working sibling / contrast:** WhatsApp self-chat turns remain operator-facing, and owner-typed bot-mode messages already carry `whatsapp_from_owner`. Those trusted paths retain their existing display behavior.

**Ruled out:** The traces are not appended by `_sanitize_gateway_final_response`; they travel on separate notice, progress, reasoning, interim-message, and status callback rails. Regex-stripping the final answer would miss those rails and could remove legitimate user-requested content.

### Fix

Classify non-owner WhatsApp bot-mode turns once at gateway ingress using the profile-scoped WhatsApp mode and the bridge's owner metadata. Suppress operational notices and status callbacks for those turns, and require an explicit `display.platforms.whatsapp.<setting>` opt-in before exposing tool progress, reasoning, interim commentary, or long-running notifications. Self-chat, owner-typed bot turns, other platforms, and explicit WhatsApp display overrides retain their existing behavior.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `gateway/run.py` - classify customer-facing WhatsApp bot turns and gate every internal notice/display rail at the shared gateway boundary.
- `tests/gateway/test_whatsapp_bot_confidentiality.py` - cover bot/self-chat/owner classification, explicit opt-in behavior, notice suppression, and status suppression.

## How to Test

1. Run the focused gateway confidentiality, notice, display, filtering, and WhatsApp regression suites.
2. Confirm all 171 tests pass.

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_bot_confidentiality.py tests/gateway/test_notice_delivery.py tests/gateway/test_display_config.py tests/gateway/test_telegram_noise_filter.py tests/gateway/test_whatsapp_from_owner.py tests/gateway/test_whatsapp_formatting.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration contract changed
- [x] `cli-config.yaml.example` update: N/A - no config key was added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered: the change uses shared Python logic and profile-scoped configuration reads
- [x] Tool description/schema update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - automated behavior tests exercise the delivery boundaries directly.

