### PR TITLE
fix(multiplex): keep the default profile's process-env credentials

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -185,14 +185,58 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     return secrets
 
 
+def _is_process_default_home(home: Path) -> bool:
+    """Return True when ``home`` is the home the process was launched under.
+
+    That home's credentials are exactly what the deployment injected into
+    ``os.environ`` (docker ``environment:``, systemd ``Environment=``, ``op
+    run``, plain exports), so reading them back is not a cross-profile leak.
+    Resolved via ``get_process_hermes_home`` so the context-local per-task
+    profile override never makes a secondary profile look like the default.
+    """
+    try:
+        from hermes_constants import get_process_hermes_home
+
+        return home.expanduser().resolve() == get_process_hermes_home().expanduser().resolve()
+    except Exception:
+        return False
+
+
 def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from ``<home>/.env`` plus its external
-    secret sources. Global vars are NOT copied in — ``get_secret`` reads those
-    from ``os.environ`` — so the scope holds only profile secrets."""
-    secrets = load_env_file(Path(hermes_home) / ".env")
+    """Build a profile's secret mapping from ``<home>/.env`` plus external secret sources.
+
+    Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
+    global vars are intentionally NOT copied in — ``get_secret`` reads those
+    from ``os.environ`` directly, so the scope holds only profile secrets.
+
+    The **default** profile additionally inherits the process environment. It
+    owns that environment by construction: the deployment provisioned the
+    process for it, and every non-multiplexed call site resolved credentials
+    from ``os.environ`` before multiplexing existed. Secondary profiles are
+    deliberately NOT seeded, so the fail-closed isolation guarantee that
+    multiplexing exists to provide is untouched — profile B still cannot see
+    profile A's keys. Without this, flipping ``gateway.multiplex_profiles`` on
+    silently strips every process-env credential from the default profile,
+    while ``<home>/.env``-based deployments keep working; the symptom is
+    provider resolution failing with "No usable credentials found" even though
+    the variable is plainly present in the process environment.
+    """
+    home = Path(hermes_home)
+    secrets: Dict[str, str] = {}
+
+    if _is_process_default_home(home):
+        for key, value in os.environ.items():
+            if _is_global_env(key):
+                continue
+            secrets[key] = value
+
+    # ``<home>/.env`` is more specific than the process environment and wins,
+    # matching the pre-multiplex lookup order in ``get_secret`` (scope first,
+    # then ``os.environ``).
+    secrets.update(load_env_file(home / ".env"))
     try:
         from hermes_cli.env_loader import get_secret_source_values
-        external_secrets = get_secret_source_values(Path(hermes_home))
+        external_secrets = get_secret_source_values(home)
     except Exception:
         external_secrets = {}
     secrets.update((k, v) for k, v in external_secrets.items() if not _is_global_env(k))

--- a/tests/gateway/test_multiplex_default_profile_process_env.py
+++ b/tests/gateway/test_multiplex_default_profile_process_env.py
@@ -1,0 +1,129 @@
+"""The default profile keeps its process-environment credentials in multiplex mode.
+
+Turning on ``gateway.multiplex_profiles`` must not strip credentials that the
+deployment injected into ``os.environ`` (docker ``environment:``, systemd
+``Environment=``, ``op run``, plain exports) from the profile the process was
+launched under. Before this was fixed, flipping the flag on made every
+process-env provider key invisible to the default profile — provider resolution
+failed with "No usable credentials found" while the variable was plainly set —
+whereas ``<home>/.env``-based deployments kept working.
+
+The isolation guarantee multiplexing exists to provide is asserted here too:
+secondary profiles are still fail-closed and never inherit the process env.
+"""
+import pytest
+
+from pathlib import Path
+
+from agent import secret_scope as ss
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    """A default profile home plus a secondary profile home underneath it."""
+    default_home = tmp_path / "data"
+    secondary_home = default_home / "profiles" / "tower-ops"
+    secondary_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return default_home, secondary_home
+
+
+class TestDefaultProfileInheritsProcessEnv:
+    def test_default_profile_sees_process_env_credential(self, homes, monkeypatch):
+        default_home, _ = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+
+        scope = ss.build_profile_secret_scope(default_home)
+
+        assert scope.get("OPENCODE_GO_API_KEY") == "sk-from-process-env"
+
+    def test_resolves_through_get_secret_under_multiplex(self, homes, monkeypatch):
+        """The property that actually broke: the real read path, multiplex ON."""
+        default_home, _ = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+        ss.set_multiplex_active(True)
+
+        token = ss.set_secret_scope(ss.build_profile_secret_scope(default_home))
+        try:
+            assert ss.get_secret("OPENCODE_GO_API_KEY") == "sk-from-process-env"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_env_file_overrides_process_env(self, homes, monkeypatch):
+        """``<home>/.env`` is more specific and wins, as it did pre-multiplex."""
+        default_home, _ = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+        (default_home / ".env").write_text(
+            "OPENCODE_GO_API_KEY=sk-from-env-file\n", encoding="utf-8"
+        )
+
+        scope = ss.build_profile_secret_scope(default_home)
+
+        assert scope.get("OPENCODE_GO_API_KEY") == "sk-from-env-file"
+
+    def test_global_env_vars_still_excluded_from_scope(self, homes, monkeypatch):
+        """Globals keep reading os.environ directly; they are not profile secrets."""
+        default_home, _ = homes
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        scope = ss.build_profile_secret_scope(default_home)
+
+        assert "PATH" not in scope
+        assert "HERMES_HOME" not in scope
+
+
+class TestSecondaryProfileStaysIsolated:
+    def test_secondary_profile_does_not_inherit_process_env(self, homes, monkeypatch):
+        """The isolation guarantee: profile B never sees the process env."""
+        _, secondary_home = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+
+        scope = ss.build_profile_secret_scope(secondary_home)
+
+        assert "OPENCODE_GO_API_KEY" not in scope
+
+    def test_secondary_profile_fails_closed_under_multiplex(self, homes, monkeypatch):
+        _, secondary_home = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+        ss.set_multiplex_active(True)
+
+        token = ss.set_secret_scope(ss.build_profile_secret_scope(secondary_home))
+        try:
+            assert ss.get_secret("OPENCODE_GO_API_KEY") is None
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_secondary_profile_uses_its_own_env_file(self, homes, monkeypatch):
+        _, secondary_home = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+        (secondary_home / ".env").write_text(
+            "OPENCODE_GO_API_KEY=sk-secondary\n", encoding="utf-8"
+        )
+
+        scope = ss.build_profile_secret_scope(secondary_home)
+
+        assert scope.get("OPENCODE_GO_API_KEY") == "sk-secondary"
+
+
+class TestPerTaskProfileOverrideDoesNotConfuseDefaultDetection:
+    def test_context_local_home_override_is_ignored(self, homes, monkeypatch):
+        """A per-task override must not make a secondary profile look default."""
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        _, secondary_home = homes
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-from-process-env")
+
+        token = set_hermes_home_override(str(secondary_home))
+        try:
+            scope = ss.build_profile_secret_scope(secondary_home)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "OPENCODE_GO_API_KEY" not in scope


### PR DESCRIPTION
Enabling `gateway.multiplex_profiles` makes every credential the deployment injected into the process environment invisible to the profile the process was launched under.

## Cause

`build_profile_secret_scope` builds a profile's scope from `<home>/.env` alone. Under multiplexing, `get_secret` treats that scope as authoritative and does not fall through to `os.environ`.

That is correct for a **secondary** profile — `os.environ` may hold another profile's value. It is not correct for the **default** profile: the deployment provisioned that process for it. `get_secret`'s own docstring already names this setup as legitimate in the multiplex-off branch:

> single-profile deployments legitimately provide credentials via the process environment (systemd `Environment=`, secret-manager wrappers like `pass-cli run` / `op run`, plain shell exports) rather than `<home>/.env`

Flipping the flag silently withdraws that.

## Symptom

In our deployment all provider and platform keys arrive through the container environment; `<home>/.env` holds only non-credential settings. Enabling multiplexing for one extra bot profile hid `OPENCODE_GO_API_KEY`, `CLIPROXY_API_KEY`, `DEEPSEEK_API_KEY`, `HASS_TOKEN` and the rest from the default profile at once. It surfaces as:

```
Cannot resolve delegation provider 'opencode-go': No usable credentials found
for provider 'opencode-go'. Set OPENCODE_GO_API_KEY.
Fallback to opencode-go failed: provider not configured
```

…while `OPENCODE_GO_API_KEY` is plainly set in the process. The message points at the provider rather than at the scope, so it reads as a provider or credential fault. OAuth-file providers keep working, which hides the blast radius further.

## Fix

Seed the default profile's scope from `os.environ` before overlaying its `.env`, so `.env` still wins on conflict and `_is_global_env` names stay excluded as before.

The default home is resolved with `get_process_hermes_home`, which deliberately ignores the context-local per-task override — so a secondary profile can never be misidentified as the default one. Secondary profiles are untouched and still fail closed; the isolation guarantee multiplexing exists to provide is unchanged.

## Tests

`tests/gateway/test_multiplex_default_profile_process_env.py` covers:

- default-profile inheritance through the real `get_secret` path with multiplexing on
- `<home>/.env` precedence over the process environment
- exclusion of `_is_global_env` names from the scope
- secondary profiles not inheriting the process environment, and still failing closed
- secondary profiles resolving their own `.env`
- a context-local home override not making a secondary profile look default

Against the unpatched module exactly the two regression assertions fail; the six isolation assertions pass both before and after, so the fix does not weaken isolation.