### PR TITLE
feat(photon): native iMessage poll + effect tools

### DIFF
--- a/tests/tools/test_photon_native_tools.py
+++ b/tests/tools/test_photon_native_tools.py
@@ -1,0 +1,137 @@
+"""Tests for the Photon native-message tools (``photon_poll`` / ``photon_effect``).
+
+Both tools must only be *offered* when a live Photon adapter exists in-process
+(the check_fn); handlers must route to ``adapter.send_poll`` /
+``adapter.send_effect``, default the chat to the Photon home channel when none
+is given, and return JSON strings (the registry's normal result shape).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import tools.photon_poll_tool as ppt
+import tools.photon_effect_tool as pet
+from gateway.platforms.base import SendResult
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.sent: list[tuple] = []
+
+    async def send_poll(self, chat_id, title, options, metadata=None):
+        self.sent.append(("poll", chat_id, title, options))
+        return SendResult(success=True, message_id="m1")
+
+    async def send_effect(self, chat_id, text, effect, metadata=None):
+        self.sent.append(("effect", chat_id, text, effect))
+        return SendResult(success=True, message_id="m1")
+
+
+@pytest.fixture(autouse=True)
+def _home_channel(monkeypatch):
+    """Photon home channel resolves without touching real config files."""
+
+    class _Home:
+        chat_id = "any;-;+162****1234"
+
+    class _Config:
+        @staticmethod
+        def get_home_channel(_platform):
+            return _Home()
+
+    import gateway.config as gw_config
+
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: _Config)
+
+
+def test_check_fn_requires_live_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: None)
+    assert ppt._photon_poll_check() is False
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: None)
+    assert pet._photon_effect_check() is False
+
+
+def test_check_fn_passes_with_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert ppt._photon_poll_check() is True
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert pet._photon_effect_check() is True
+
+
+def test_handler_without_live_adapter_errors(monkeypatch) -> None:
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: None)
+    result = json.loads(
+        asyncio.run(ppt._photon_poll({"title": "t", "options": ["a", "b"]}))
+    )
+    assert "live Photon adapter" in result["error"]
+
+
+def test_poll_requires_title_and_options(monkeypatch) -> None:
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert json.loads(asyncio.run(ppt._photon_poll({"options": ["a", "b"]})))[
+        "error"
+    ]
+    assert json.loads(
+        asyncio.run(ppt._photon_poll({"title": "t", "options": ["a"]}))
+    )["error"]
+
+
+def test_poll_sends_with_default_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(ppt._photon_poll({"title": "pick", "options": ["a", "b"]}))
+    )
+    assert result["success"] is True
+    assert fake.sent == [("poll", "any;-;+162****1234", "pick", ["a", "b"])]
+
+
+def test_poll_default_prefers_current_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(ppt, "_live_photon_adapter", lambda: fake)
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-of-current-msg")
+    asyncio.run(ppt._photon_poll({"title": "t", "options": ["a", "b"]}))
+    assert fake.sent[0][1] == "chat-of-current-msg"
+
+
+def test_effect_requires_text_and_effect(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert (
+        json.loads(asyncio.run(pet._photon_effect({"text": "hi"})))["error"]
+        or json.loads(asyncio.run(pet._photon_effect({"effect": "slam"})))["error"]
+    )
+
+
+def test_effect_rejects_unknown_effect(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: _FakeAdapter())
+    result = json.loads(
+        asyncio.run(pet._photon_effect({"text": "hi", "effect": "nope"}))
+    )
+    assert "Unknown effect" in result["error"]
+
+
+def test_effect_sends_with_default_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(pet._photon_effect({"text": "boom", "effect": "slam"}))
+    )
+    assert result["success"] is True
+    assert result["effect"] == "slam"
+    assert fake.sent[0] == ("effect", "any;-;+162****1234", "boom", "slam")
+
+
+def test_adapter_failure_propagates_error(monkeypatch) -> None:
+    class _BoomAdapter(_FakeAdapter):
+        async def send_effect(self, chat_id, text, effect, metadata=None):
+            return SendResult(success=False, error="sidecar down")
+
+    fake = _BoomAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(pet._photon_effect({"text": "boom", "effect": "slam"}))
+    )
+    assert result["error"] == "sidecar down"

--- a/tools/photon_effect_tool.py
+++ b/tools/photon_effect_tool.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Native iMessage bubble/screen effects over Photon.
+
+iMessage bubbles support native send effects (slam, loud, gentle,
+invisible ink, confetti, fireworks, balloons, heart, lasers,
+celebration, sparkles, spotlight, echo). Like ``photon_poll_tool``,
+this is a narrow, genuinely native affordance — it delivers the
+recipient's message with a built-in animation instead of extra text,
+so it is safe to expose as an opt-in toolset that only exists when a
+live Photon adapter is running in this process.
+
+The effects route lives behind the local sidecar ``/send-effect``
+route — see the Photon overlay docs for the patch that wires it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "photon_tools"
+
+_EFFECTS = (
+    "slam",
+    "loud",
+    "gentle",
+    "invisible",
+    "confetti",
+    "fireworks",
+    "balloons",
+    "heart",
+    "lasers",
+    "celebration",
+    "sparkles",
+    "spotlight",
+    "echo",
+)
+
+SCHEMA: Dict[str, Any] = {
+    "name": "photon_effect",
+    "description": (
+        "Send an iMessage with a native bubble/screen effect (Photon "
+        "platform). USE RARELY — only for moments that genuinely warrant "
+        "one: 'confetti'/'fireworks'/'celebration' for big wins, 'slam' or "
+        "'loud' for emphatic statements, 'invisible' for spoilers/secrets "
+        "the recipient must tap to reveal, 'heart' for affection. Most "
+        "messages deserve NO effect."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The message text to send with the effect.",
+            },
+            "effect": {
+                "type": "string",
+                "enum": list(_EFFECTS),
+                "description": (
+                    "Effect name: slam, loud, gentle, invisible, confetti, "
+                    "fireworks, balloons, heart, lasers, celebration, "
+                    "sparkles, spotlight, echo."
+                ),
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional chat to send to (space GUID like 'any;-;+1555…' "
+                    "or bare E.164). Defaults to the chat of the message "
+                    "currently being answered."
+                ),
+            },
+        },
+        "required": ["text", "effect"],
+    },
+}
+
+
+def _live_photon_adapter():
+    """Return the running Photon adapter, or None.
+
+    Mirrors ``photon_poll_tool`` / ``photon_react_tool``.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return runner.adapters.get(Platform.PHOTON)
+    except Exception:
+        return None
+
+
+async def _resolve_chat_id(explicit: str) -> str:
+    chat_id = (explicit or "").strip()
+    if chat_id:
+        return chat_id
+    try:
+        from gateway.session_context import get_session_env
+
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    except Exception:
+        chat_id = ""
+    if chat_id:
+        return chat_id
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+    home = config.get_home_channel("photon")
+    return home.chat_id
+
+
+def _photon_effect_check() -> bool:
+    """Availability check (runs at schema-assembly time): the tool only
+    exists when a live Photon adapter is in this process."""
+    return _live_photon_adapter() is not None
+
+
+async def _photon_effect(args: Dict[str, Any], **kw) -> str:
+    text = str(args.get("text") or "").strip()
+    effect = str(args.get("effect") or "").strip().lower()
+    if not text or not effect:
+        return tool_error("Both 'text' and 'effect' are required.")
+    if effect not in _EFFECTS:
+        return tool_error(
+            f"Unknown effect '{effect}'. Choose one of: {', '.join(_EFFECTS)}."
+        )
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return tool_error(
+            "No live Photon adapter in this process — effects require the "
+            "gateway to be running here."
+        )
+
+    chat_id = await _resolve_chat_id(str(args.get("chat_id") or ""))
+
+    result = await adapter.send_effect(chat_id, text, effect)
+    if getattr(result, "success", True) and not getattr(result, "error", None):
+        return json.dumps(
+            {
+                "success": True,
+                "effect": effect,
+                "message_id": getattr(result, "message_id", None),
+            },
+            ensure_ascii=False,
+        )
+    return tool_error(
+        getattr(result, "error", None)
+        or f"Effect send failed (HTTP {getattr(result, 'raw_response', '?')})."
+    )
+
+
+registry.register(
+    name="photon_effect",
+    toolset=_TOOLSET,
+    schema=SCHEMA,
+    handler=lambda args, **kw: _photon_effect(args, **kw),
+    check_fn=_photon_effect_check,
+    is_async=True,
+    emoji="🎉",
+)

--- a/tools/photon_poll_tool.py
+++ b/tools/photon_poll_tool.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Native iMessage polls over Photon.
+
+``send_message`` is deliberately not agent-callable for cross-platform
+reach (see ``send_message_tool.py``); a poll is a narrower, genuinely
+native affordance — an orange iMessage poll bubble where the recipient
+taps an option instead of typing. That same narrow surface makes it
+safe to expose: it delivers no new text and the recipient's choice
+streams back as a ``poll_option`` event, which the Photon adapter
+turns into the answer resolving a pending ``clarify``.
+
+Like ``photon_react_tool`` this ships as its own opt-in toolset: the
+tool only exists when a live Photon adapter is running in this process
+(the same state ``send_poll`` needs). On every other install the
+toolset is empty and costs zero prompt tokens. The handler still
+re-checks and returns a clear error if the gateway went away
+mid-session.
+
+The native poll (and the option-tap workflow it enables) lives behind
+the local sidecar ``/send-poll`` route — see the Photon overlay docs
+for the patch that wires it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "photon_tools"
+
+SCHEMA: Dict[str, Any] = {
+    "name": "photon_poll",
+    "description": (
+        "Send an interactive iMessage poll card (Photon platform). Use when "
+        "the user faces a genuine either/or choice worth tapping — picking "
+        "between options, voting, deciding. NOT for open questions. Provide "
+        "a short title and 2-4 concise options."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Short question shown above the options.",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 2,
+                "description": "2-4 concise answer options.",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional chat to send to (space GUID like 'any;-;+1555…' "
+                    "or bare E.164). Defaults to the chat of the message "
+                    "currently being answered."
+                ),
+            },
+        },
+        "required": ["title", "options"],
+    },
+}
+
+
+def _live_photon_adapter():
+    """Return the running Photon adapter, or None.
+
+    Mirrors ``send_message_tool._send_via_adapter`` and
+    ``photon_react_tool._live_photon_adapter``: polls route through the
+    gateway's live adapter (which owns the sidecar connection).
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return runner.adapters.get(Platform.PHOTON)
+    except Exception:
+        return None
+
+
+async def _resolve_chat_id(explicit: str) -> str:
+    chat_id = (explicit or "").strip()
+    if chat_id:
+        return chat_id
+    try:
+        from gateway.session_context import get_session_env
+
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    except Exception:
+        chat_id = ""
+    if chat_id:
+        return chat_id
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+    home = config.get_home_channel("photon")
+    return home.chat_id
+
+
+def _photon_poll_check() -> bool:
+    """Availability check (runs at schema-assembly time): the tool only
+    exists when a live Photon adapter is in this process. Mirrors
+    photon_react_tool._photon_react_check."""
+    return _live_photon_adapter() is not None
+
+
+async def _photon_poll(args: Dict[str, Any], **kw) -> str:
+    title = str(args.get("title") or "").strip()
+    options = [str(o).strip() for o in (args.get("options") or []) if str(o).strip()]
+    if not title:
+        return tool_error("A 'title' is required.")
+    if len(options) < 2:
+        return tool_error("Polls need at least two non-empty options.")
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return tool_error(
+            "No live Photon adapter in this process — polls require the "
+            "gateway to be running here."
+        )
+
+    chat_id = await _resolve_chat_id(str(args.get("chat_id") or ""))
+
+    result = await adapter.send_poll(chat_id, title, options)
+    if getattr(result, "success", True) and not getattr(result, "error", None):
+        return json.dumps(
+            {"success": True, "title": title, "options": len(options)},
+            ensure_ascii=False,
+        )
+    return tool_error(
+        getattr(result, "error", None)
+        or f"Poll send failed (HTTP {getattr(result, 'raw_response', '?')})."
+    )
+
+
+registry.register(
+    name="photon_poll",
+    toolset=_TOOLSET,
+    schema=SCHEMA,
+    handler=lambda args, **kw: _photon_poll(args, **kw),
+    check_fn=_photon_poll_check,
+    is_async=True,
+    emoji="📊",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -289,6 +289,19 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    # Native iMessage interactions over Photon — each tool is only offered
+    # when a live Photon adapter is running in this process (the tools'
+    # check_fn enforces it at schema-assembly time; listing them here just
+    # names the bucket). Polls deliver an interactive tap-option card whose
+    # selection streams back as a `poll_option` event and can resolve a
+    # pending `clarify`; effects send a text bubble with a native iMessage
+    # animation. See tools/photon_poll_tool.py and tools/photon_effect_tool.py.
+    "photon_tools": {
+        "description": "Native iMessage polls + bubble effects over Photon (live gateway only)",
+        "tools": ["photon_poll", "photon_effect"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",


### PR DESCRIPTION
## What does this PR do?

Adds two opt-in core tools for native iMessage interactions over Photon:

- **`photon_poll`** — sends an interactive native poll (orange tap-option card). The recipient's selection streams back as a `poll_option` event, which the Photon adapter turns into the answer that resolves a pending `clarify`. Wraps `adapter.send_poll`.
- **`photon_effect`** — sends a text bubble with a native iMessage bubble/screen effect (slam, loud, gentle, invisible ink, confetti, fireworks, balloons, heart, lasers, celebration, sparkles, spotlight, echo). Wraps `adapter.send_effect`.

Both follow the `photon_react_tool` (#94321) pattern: they live in their own opt-in toolset (`photon_tools`) that is only exposed when a live Photon adapter is running in this process (check_fn), the chat defaults to the conversation being answered then the Photon home channel, and handlers return JSON strings — the registry's normal result shape (`_normalize_handler_result` rejects plain dicts).

This also retires a bug class carried by the local plugin implementations of these tools: the plugins bridged async handlers into thread-pool execution with an `asyncio.run(...) if not asyncio.get_event_loop().is_running()` dance, which crashes with `RuntimeError: no current event loop` in worker threads on modern Python. Core tools with `is_async=True` are awaited natively by the registry, so the wrapper — and the crash — are gone by construction.

## Related Issue

No issue — direct feature + bug-class fix with reproduction (the local plugins crashed on every invocation in the VPS gateway's thread pool; fixed locally first, now upstreamed clean).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/photon_poll_tool.py` — new: photon_poll tool (schema, live-adapter check_fn, handler → `adapter.send_poll`).
- `tools/photon_effect_tool.py` — new: photon_effect tool (validated effect enum, handler → `adapter.send_effect`).
- `toolsets.py` — new `photon_tools` toolset listing both.
- `tests/tools/test_photon_native_tools.py` — 10 tests: check_fn gating (with/without adapter), validation errors, chat defaulting (current chat beats home channel), SendResult success/error propagation, unknown-effect rejection.

## How to Test

1. `pytest tests/tools/test_photon_native_tools.py -v` → 10 passed.
2. Registry smoke test: import both modules, assert `registry.get_entry(name)` present with `is_async=True`.
3. Live (done on iMessage before this PR): poll via sidecar `/send-poll` renders as a native poll & option taps stream back; `/send-effect` animates a bubble. The handlers here are thin wrappers over the same `send_poll`/`send_effect` adapter methods.
4. `ruff check tools/photon_poll_tool.py tools/photon_effect_tool.py tests/tools/test_photon_native_tools.py` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted tests (10 passed); not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (host) + iOS iMessage via Photon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A