### PR TITLE
fix(cron): accept repeat="forever" and reject other non-numeric strings cleanly

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2006,6 +2006,28 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
+    # Accept a non-int repeat: the tool schema's own description text uses
+    # the word "forever" for the omitted/None case ("forever for
+    # recurring"), so a caller (human or LLM) plausibly passes the literal
+    # string "forever" rather than omitting the field entirely. Recognize
+    # that (and its common synonyms) as None; coerce a numeric-looking
+    # string; reject anything else with a clear error instead of letting
+    # the `repeat <= 0` comparison below crash with a raw TypeError
+    # (issue #95706).
+    if isinstance(repeat, str):
+        normalized_repeat = repeat.strip().lower()
+        if normalized_repeat in ("", "forever", "infinite", "none", "null"):
+            repeat = None
+        else:
+            try:
+                repeat = int(repeat)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid repeat value {repeat!r}: expected an integer "
+                    f"repeat count, or omit the field entirely for forever/"
+                    f"recurring (do not pass the literal string \"forever\")."
+                ) from None
+
     # Normalize repeat: treat 0 or negative values as None (infinite)
     if repeat is not None and repeat <= 0:
         repeat = None

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -242,6 +242,40 @@ class TestJobCRUD:
         job = create_job(prompt="One-shot", schedule="1h")
         assert job["repeat"]["times"] == 1
 
+    def test_repeat_forever_string_normalizes_to_infinite_not_a_crash(self, tmp_cron_dir):
+        """Regression for issue #95706: the tool schema's own description
+        text uses the word "forever" for the omitted/None case ("forever
+        for recurring"), making repeat="forever" a plausible value for a
+        caller to pass explicitly. Previously this crashed with a raw
+        TypeError ('<=' not supported between instances of 'str' and
+        'int') from the `repeat <= 0` normalization step."""
+        job = create_job(prompt="Recurring", schedule="0 11 * * 1", repeat="forever")
+        assert job["repeat"]["times"] is None
+
+    def test_repeat_forever_variant_strings_all_normalize(self, tmp_cron_dir):
+        for value in ("Forever", "FOREVER", "infinite", "", "none", "null"):
+            job = create_job(prompt="Recurring", schedule="0 11 * * 1", repeat=value)
+            assert job["repeat"]["times"] is None, f"failed for repeat={value!r}"
+
+    def test_repeat_numeric_string_coerces(self, tmp_cron_dir):
+        job = create_job(prompt="Recurring", schedule="0 11 * * 1", repeat="3")
+        assert job["repeat"]["times"] == 3
+
+    def test_repeat_invalid_string_raises_clear_error_not_typeerror(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="Invalid repeat value"):
+            create_job(prompt="Recurring", schedule="0 11 * * 1", repeat="nonsense")
+
+        assert load_jobs() == []
+
+    def test_repeat_int_and_none_unaffected(self, tmp_cron_dir):
+        """Sanity: the fix must not change behavior for the documented,
+        correct usage (a real int, or omitting repeat entirely)."""
+        job_int = create_job(prompt="Recurring", schedule="0 11 * * 1", repeat=5)
+        assert job_int["repeat"]["times"] == 5
+
+        job_none = create_job(prompt="Recurring", schedule="0 11 * * 1", repeat=None)
+        assert job_none["repeat"]["times"] is None
+
     def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
         monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)


### PR DESCRIPTION
Fixes #95706.

## Root cause

`create_job()`'s repeat normalization (`if repeat is not None and repeat <= 0: repeat = None`) assumed `repeat` was always an int or `None`. Passing the literal string `"forever"` crashed with a raw `TypeError: '<=' not supported between instances of 'str' and 'int'` before the job was created.

This is a genuinely easy mistake: the cronjob tool schema's own description text reads "Omit for defaults (once for one-shot, **forever** for recurring)" -- right there in the schema a caller reads before deciding what to pass, making the literal string `"forever"` a plausible but incorrect value to send explicitly.

## Fix

Added a normalization step before the existing check: a string `repeat` is recognized as a case-insensitive synonym for "no limit" (`forever`, `infinite`, `none`, `null`, or empty) and mapped to `None`; a numeric-looking string (`"3"`) is coerced to int; anything else raises a clear `ValueError` naming the invalid value, instead of an uncaught `TypeError`. Real int/`None` input is completely unaffected.

## Verification

Verified directly against the issue's own exact reproduction (script + `no_agent=True` + `repeat="forever"`) -- job now creates successfully with `repeat.times` correctly `None`. Also verified: a genuinely invalid string now raises a clear error; a numeric string coerces; real int/None is unaffected.

Added 5 regression tests to the existing test file (using a cron-expression schedule, not a duration-shaped one like `"30m"` -- those parse as one-shot and auto-override repeat to 1, which would have masked what these tests check). Verified as genuine regressions by reverting just the fix and confirming 4/5 new tests fail with the exact reported TypeError.

85/85 pass in the modified test file; 34/34 in a related existing test file (no regression).