### PR TITLE
feat(ci): add executable workflow delivery gates

### DIFF
--- a/scripts/ci/acceptance_gate.py
+++ b/scripts/ci/acceptance_gate.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Freeze acceptance criteria and verify deterministic criterion→proof coverage."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_ID_RE = re.compile(r"^AC-[1-9][0-9]*$")
+
+
+def _criteria_list(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        payload = payload.get("criteria")
+    if not isinstance(payload, list):
+        raise ValueError("criteria must be a JSON array or an object with a criteria array")
+    return payload
+
+
+def _canonical(criteria: list[dict[str, Any]]) -> bytes:
+    normalized: list[dict[str, str]] = []
+    for item in criteria:
+        if not isinstance(item, dict):
+            raise ValueError("each criterion must be an object")
+        criterion_id = item.get("id")
+        text = item.get("text")
+        if not isinstance(criterion_id, str) or not isinstance(text, str) or not text.strip():
+            raise ValueError("each criterion requires string id and non-empty text")
+        normalized.append({"id": criterion_id.strip(), "text": text.strip()})
+    return json.dumps(normalized, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def canonical_hash(criteria: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(_canonical(criteria)).hexdigest()
+
+
+def freeze(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return canonical_hash(_criteria_list(payload))
+
+
+def verify(
+    criteria: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+    *,
+    expected_sha: str,
+    expected_hash: str,
+) -> dict[str, Any]:
+    ids = [item.get("id") for item in criteria if isinstance(item, dict)]
+    counts = Counter(ids)
+    expected_ids = {item for item in ids if isinstance(item, str)}
+    invalid_expected_ids = sorted({item for item in expected_ids if not _ID_RE.fullmatch(item)})
+    duplicate_expected_ids = sorted(item for item, count in counts.items() if isinstance(item, str) and count > 1)
+
+    try:
+        actual_hash = canonical_hash(criteria)
+    except (TypeError, ValueError):
+        actual_hash = ""
+    criteria_mutated = actual_hash != expected_hash
+
+    evidence_ids = [item.get("criterion_id") for item in evidence if isinstance(item, dict)]
+    evidence_counts = Counter(evidence_ids)
+    duplicates = sorted(item for item, count in evidence_counts.items() if isinstance(item, str) and count > 1)
+    unknown = sorted({item for item in evidence_ids if isinstance(item, str) and item not in expected_ids})
+
+    passed_ids: set[str] = set()
+    failed: set[str] = set()
+    wrong_sha: set[str] = set()
+    wrong_criteria_hash: set[str] = set()
+    empty_proof: set[str] = set()
+    for item in evidence:
+        if not isinstance(item, dict):
+            continue
+        criterion_id = item.get("criterion_id")
+        if not isinstance(criterion_id, str) or criterion_id not in expected_ids:
+            continue
+        if item.get("status") != "passed":
+            failed.add(criterion_id)
+        if item.get("sha") != expected_sha:
+            wrong_sha.add(criterion_id)
+        if item.get("criteria_hash") != expected_hash:
+            wrong_criteria_hash.add(criterion_id)
+        proof = item.get("proof")
+        if not isinstance(proof, str) or not proof.strip():
+            empty_proof.add(criterion_id)
+        if (
+            item.get("status") == "passed"
+            and item.get("sha") == expected_sha
+            and item.get("criteria_hash") == expected_hash
+            and isinstance(proof, str)
+            and proof.strip()
+            and evidence_counts[criterion_id] == 1
+        ):
+            passed_ids.add(criterion_id)
+
+    missing = sorted(expected_ids - passed_ids)
+    result = {
+        "passed": False,
+        "criteria_hash": actual_hash,
+        "criteria_mutated": criteria_mutated,
+        "invalid_expected_ids": invalid_expected_ids,
+        "duplicate_expected_ids": duplicate_expected_ids,
+        "missing": missing,
+        "duplicates": duplicates,
+        "unknown": unknown,
+        "failed": sorted(failed),
+        "wrong_sha": sorted(wrong_sha),
+        "wrong_criteria_hash": sorted(wrong_criteria_hash),
+        "empty_proof": sorted(empty_proof),
+    }
+    result["passed"] = not any(
+        (
+            criteria_mutated,
+            invalid_expected_ids,
+            duplicate_expected_ids,
+            missing,
+            duplicates,
+            unknown,
+            failed,
+            wrong_sha,
+            wrong_criteria_hash,
+            empty_proof,
+        )
+    )
+    return result
+
+
+def _load(path: str) -> Any:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    freeze_parser = sub.add_parser("freeze")
+    freeze_parser.add_argument("criteria")
+
+    verify_parser = sub.add_parser("verify")
+    verify_parser.add_argument("criteria")
+    verify_parser.add_argument("evidence")
+    verify_parser.add_argument("--sha", required=True)
+    verify_parser.add_argument("--criteria-hash", required=True)
+
+    args = parser.parse_args()
+    if args.command == "freeze":
+        print(freeze(Path(args.criteria)))
+        return 0
+
+    criteria = _criteria_list(_load(args.criteria))
+    evidence_payload = _load(args.evidence)
+    evidence = evidence_payload.get("evidence") if isinstance(evidence_payload, dict) else evidence_payload
+    if not isinstance(evidence, list):
+        raise ValueError("evidence must be a JSON array or object with an evidence array")
+    result = verify(criteria, evidence, expected_sha=args.sha, expected_hash=args.criteria_hash)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/reclassify_workflow.py
+++ b/scripts/ci/reclassify_workflow.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Mechanically reclassify a workflow diff before validation gates.
+
+The detector is deliberately conservative: an unknown or empty diff fails
+closed into the complete route. It can consume explicit paths/counts locally or
+the corresponding environment variables in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import PurePosixPath
+
+_MAX_SMALL_FILES = 5
+_MAX_SMALL_LINES = 200
+
+_DEPENDENCY_FILES = {
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "pyproject.toml",
+    "uv.lock",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "poetry.lock",
+    "Pipfile",
+    "Pipfile.lock",
+    "Cargo.toml",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+    "Gemfile",
+    "Gemfile.lock",
+}
+
+_SENSITIVE_COMPONENTS = {
+    "auth",
+    "authentication",
+    "authorization",
+    "iam",
+    "permission",
+    "permissions",
+    "secret",
+    "secrets",
+    "credential",
+    "credentials",
+    "payment",
+    "payments",
+    "billing",
+    "upload",
+    "uploads",
+    "migration",
+    "migrations",
+    "schema",
+    "schemas",
+    "infra",
+    "infrastructure",
+    "network",
+    "security",
+    "oauth",
+    "sso",
+    "session",
+    "sessions",
+    "cookie",
+    "cookies",
+    "export",
+    "exports",
+    "scripts",
+    "tests",
+}
+
+_SENSITIVE_FILES = {
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    ".env",
+    ".env.example",
+}
+
+_CONTENT_PATTERNS = {
+    "auth": re.compile(r"\b(?:auth(?:entication|orization)?|oauth|sso)\b", re.I),
+    "permission": re.compile(r"\b(?:permission|role|rbac|acl|admin)\b", re.I),
+    "secret": re.compile(r"\b(?:secret|credential|api[_-]?key|access[_-]?token|private[_-]?key)\b", re.I),
+    "sensitive_data": re.compile(r"\b(?:pii|personal[_ -]?data|sensitive[_ -]?data|encrypt|decrypt)\b", re.I),
+    "payment": re.compile(r"\b(?:payment|billing|stripe|invoice)\b", re.I),
+    "upload": re.compile(r"\b(?:upload|multipart|file[_ -]?input)\b", re.I),
+    "migration": re.compile(r"\b(?:migration|schema|alter table|create table)\b", re.I),
+    "public_contract": re.compile(r"\b(?:public api|openapi|graphql|webhook|export)\b", re.I),
+    "network": re.compile(r"\b(?:iam|firewall|cors|network|subnet|security group)\b", re.I),
+}
+
+
+def _normalize(path: str) -> str:
+    return path.strip().replace("\\", "/").lstrip("./")
+
+
+def _path_reason(path: str) -> str | None:
+    normalized = _normalize(path)
+    if not normalized:
+        return None
+    name = PurePosixPath(normalized).name
+    if name in _DEPENDENCY_FILES or name.endswith((".lock", ".lockb")):
+        return f"dependency_or_lockfile:{normalized}"
+    if name in _SENSITIVE_FILES or normalized.startswith((".github/", "deploy/", "deployment/", "terraform/", "k8s/", "helm/")):
+        return f"sensitive_path:{normalized}"
+    components = {part.lower().replace("-", "_") for part in PurePosixPath(normalized).parts}
+    if components & _SENSITIVE_COMPONENTS:
+        return f"sensitive_path:{normalized}"
+    lower_name = name.lower().replace("-", "_")
+    if any(token in lower_name for token in _SENSITIVE_COMPONENTS):
+        return f"sensitive_path:{normalized}"
+    return None
+
+
+def classify(
+    files: list[str],
+    *,
+    added: int,
+    deleted: int,
+    initial_route: str = "standard",
+    patch_text: str = "",
+) -> dict[str, object]:
+    if initial_route not in {"direct", "standard", "complete"}:
+        raise ValueError("initial_route must be direct, standard, or complete")
+    normalized = sorted({_normalize(path) for path in files if _normalize(path)})
+    reasons: list[str] = []
+    if not normalized:
+        reasons.append("empty_diff")
+    for path in normalized:
+        if reason := _path_reason(path):
+            reasons.append(reason)
+    for label, pattern in _CONTENT_PATTERNS.items():
+        if pattern.search(patch_text):
+            reasons.append(f"sensitive_content:{label}")
+
+    reasons = sorted(set(reasons))
+    sensitive = bool(reasons)
+    changed_lines = max(0, added) + max(0, deleted)
+    small_by_size = (
+        len(normalized) <= _MAX_SMALL_FILES
+        and changed_lines <= _MAX_SMALL_LINES
+    )
+    parallel_allowed = small_by_size and not sensitive
+    readers = ["general_review"]
+    if sensitive:
+        readers.append("downstream_security")
+    schedule = "parallel_review_launch_qa" if parallel_allowed else "readers_then_execution"
+
+    return {
+        "sensitive": sensitive,
+        "route": initial_route,
+        "small_by_size": small_by_size,
+        "parallel_allowed": parallel_allowed,
+        "changed_files": len(normalized),
+        "changed_lines": changed_lines,
+        "required_readers": readers,
+        "schedule": schedule,
+        "reasons": reasons,
+    }
+
+
+def _env_int(name: str, default: int = 0) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Changed paths; stdin is used when omitted")
+    parser.add_argument(
+        "--initial-route",
+        choices=("direct", "standard", "complete"),
+        default=os.environ.get("INITIAL_ROUTE", "standard"),
+    )
+    parser.add_argument("--added", type=int, default=None)
+    parser.add_argument("--deleted", type=int, default=None)
+    parser.add_argument("--patch-file")
+    parser.add_argument("--github-output", action="store_true")
+    args = parser.parse_args(argv)
+
+    paths = args.paths or sys.stdin.read().splitlines()
+    patch_text = ""
+    if args.patch_file:
+        with open(args.patch_file, encoding="utf-8", errors="replace") as handle:
+            patch_text = handle.read()
+    added = args.added if args.added is not None else _env_int("DIFF_ADDED")
+    deleted = args.deleted if args.deleted is not None else _env_int("DIFF_DELETED")
+    result = classify(
+        paths,
+        added=added,
+        deleted=deleted,
+        initial_route=args.initial_route,
+        patch_text=patch_text,
+    )
+
+    print(json.dumps(result, sort_keys=True))
+    output_path = os.environ.get("GITHUB_OUTPUT") if args.github_output else None
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key in (
+                "sensitive",
+                "small_by_size",
+                "parallel_allowed",
+                "route",
+                "schedule",
+            ):
+                value = result[key]
+                if isinstance(value, bool):
+                    value = str(value).lower()
+                handle.write(f"{key}={value}\n")
+            handle.write(f"required_readers={json.dumps(result['required_readers'])}\n")
+            handle.write(f"reasons={json.dumps(result['reasons'])}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/workflow_metrics.py
+++ b/scripts/ci/workflow_metrics.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Append validated workflow mission metrics to a JSONL file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+_ROUTES = {"direct", "standard", "complete"}
+_OUTCOMES = {"passed", "failed", "blocked", "rolled_back"}
+_REQUIRED = {
+    "mission_id",
+    "route",
+    "changed_files",
+    "changed_lines",
+    "sensitive",
+    "required_readers",
+    "replays",
+    "duration_seconds",
+    "outcome",
+}
+
+
+def validate_record(record: dict[str, Any]) -> list[str]:
+    errors = sorted(_REQUIRED - record.keys())
+    if record.get("route") not in _ROUTES:
+        errors.append("route")
+    if record.get("outcome") not in _OUTCOMES:
+        errors.append("outcome")
+    if not isinstance(record.get("mission_id"), str) or not record.get("mission_id", "").strip():
+        errors.append("mission_id")
+    for key in ("changed_files", "changed_lines", "replays"):
+        value = record.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(key)
+    duration = record.get("duration_seconds")
+    if not isinstance(duration, (int, float)) or isinstance(duration, bool) or duration < 0:
+        errors.append("duration_seconds")
+    if not isinstance(record.get("sensitive"), bool):
+        errors.append("sensitive")
+    readers = record.get("required_readers")
+    if not isinstance(readers, list) or any(not isinstance(item, str) or not item for item in readers):
+        errors.append("required_readers")
+    return sorted(set(errors))
+
+
+def append_record(path: Path, record: dict[str, Any]) -> None:
+    errors = validate_record(record)
+    if errors:
+        raise ValueError(f"invalid workflow metric fields: {', '.join(errors)}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("record", help="JSON record file")
+    parser.add_argument("--output", required=True, help="append-only JSONL destination")
+    args = parser.parse_args()
+    record = json.loads(Path(args.record).read_text(encoding="utf-8"))
+    if not isinstance(record, dict):
+        raise ValueError("record must be a JSON object")
+    append_record(Path(args.output), record)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_acceptance_gate.py
+++ b/tests/ci/test_acceptance_gate.py
@@ -1,0 +1,95 @@
+"""Tests for the deterministic acceptance-criteria gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "acceptance_gate.py"
+_spec = importlib.util.spec_from_file_location("acceptance_gate", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load acceptance_gate.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+canonical_hash = _mod.canonical_hash
+freeze = _mod.freeze
+verify = _mod.verify
+
+
+def _criteria():
+    return [
+        {"id": "AC-1", "text": "The targeted command succeeds."},
+        {"id": "AC-2", "text": "The result is bound to the frozen SHA."},
+    ]
+
+
+def test_freeze_is_deterministic_and_order_sensitive(tmp_path: Path):
+    path = tmp_path / "criteria.json"
+    path.write_text(json.dumps({"criteria": _criteria()}), encoding="utf-8")
+
+    first = freeze(path)
+    second = freeze(path)
+
+    assert first == second
+    assert first == canonical_hash(_criteria())
+    assert len(first) == 64
+
+
+def test_all_expected_criteria_must_have_green_proof_on_same_sha_and_hash():
+    criteria = _criteria()
+    criteria_hash = canonical_hash(criteria)
+    evidence = [
+        {"criterion_id": "AC-1", "status": "passed", "sha": "abc123", "criteria_hash": criteria_hash, "proof": "pytest test_one"},
+        {"criterion_id": "AC-2", "status": "passed", "sha": "abc123", "criteria_hash": criteria_hash, "proof": "browser gate"},
+    ]
+
+    result = verify(criteria, evidence, expected_sha="abc123", expected_hash=criteria_hash)
+
+    assert result["passed"] is True
+    assert result["missing"] == []
+
+
+def test_missing_unknown_duplicate_failed_and_wrong_binding_all_block():
+    criteria = _criteria()
+    criteria_hash = canonical_hash(criteria)
+    evidence = [
+        {"criterion_id": "AC-1", "status": "failed", "sha": "abc123", "criteria_hash": criteria_hash, "proof": "pytest"},
+        {"criterion_id": "AC-1", "status": "passed", "sha": "abc123", "criteria_hash": criteria_hash, "proof": "duplicate"},
+        {"criterion_id": "AC-999", "status": "passed", "sha": "abc123", "criteria_hash": criteria_hash, "proof": "unknown"},
+        {"criterion_id": "AC-2", "status": "passed", "sha": "other", "criteria_hash": "0" * 64, "proof": "wrong binding"},
+    ]
+
+    result = verify(criteria, evidence, expected_sha="abc123", expected_hash=criteria_hash)
+
+    assert result["passed"] is False
+    assert result["duplicates"] == ["AC-1"]
+    assert result["unknown"] == ["AC-999"]
+    assert result["failed"] == ["AC-1"]
+    assert result["wrong_sha"] == ["AC-2"]
+    assert result["wrong_criteria_hash"] == ["AC-2"]
+
+
+def test_mutated_criteria_are_rejected_by_frozen_hash():
+    original = _criteria()
+    frozen_hash = canonical_hash(original)
+    mutated = [*original]
+    mutated[0] = {"id": "AC-1", "text": "A weaker target succeeds."}
+
+    result = verify(mutated, [], expected_sha="abc123", expected_hash=frozen_hash)
+
+    assert result["passed"] is False
+    assert result["criteria_mutated"] is True
+
+
+def test_invalid_criterion_ids_and_duplicate_expected_ids_are_rejected():
+    result = verify(
+        [{"id": "one", "text": "bad"}, {"id": "one", "text": "duplicate"}],
+        [],
+        expected_sha="abc123",
+        expected_hash="0" * 64,
+    )
+
+    assert result["passed"] is False
+    assert result["invalid_expected_ids"] == ["one"]
+    assert result["duplicate_expected_ids"] == ["one"]

--- a/tests/ci/test_reclassify_workflow.py
+++ b/tests/ci/test_reclassify_workflow.py
@@ -1,0 +1,122 @@
+"""Tests for the workflow risk reclassification detector."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "reclassify_workflow.py"
+_spec = importlib.util.spec_from_file_location("reclassify_workflow", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load reclassify_workflow.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+classify = _mod.classify
+
+
+def test_tiny_auth_diff_adds_security_gates_without_replacing_route():
+    result = classify(
+        ["auth/session.py"],
+        added=2,
+        deleted=1,
+        initial_route="direct",
+    )
+
+    assert result["sensitive"] is True
+    assert result["route"] == "direct"
+    assert result["small_by_size"] is True
+    assert result["parallel_allowed"] is False
+    assert result["required_readers"] == ["general_review", "downstream_security"]
+    assert result["schedule"] == "readers_then_execution"
+    assert "sensitive_path:auth/session.py" in result["reasons"]
+
+
+def test_dependency_change_adds_gates_even_when_only_one_line():
+    result = classify(
+        ["package-lock.json"],
+        added=1,
+        deleted=0,
+        initial_route="standard",
+    )
+
+    assert result["sensitive"] is True
+    assert result["route"] == "standard"
+    assert result["small_by_size"] is True
+    assert result["parallel_allowed"] is False
+    assert "dependency_or_lockfile:package-lock.json" in result["reasons"]
+
+
+def test_clean_small_diff_allows_parallel_exception():
+    result = classify(
+        ["docs/typo.md", "agent/formatting.py"],
+        added=8,
+        deleted=3,
+        initial_route="direct",
+    )
+
+    assert result["sensitive"] is False
+    assert result["route"] == "direct"
+    assert result["small_by_size"] is True
+    assert result["parallel_allowed"] is True
+    assert result["required_readers"] == ["general_review"]
+    assert result["schedule"] == "parallel_review_launch_qa"
+
+
+def test_clean_large_diff_waits_for_review():
+    result = classify(
+        [f"agent/module_{i}.py" for i in range(6)],
+        added=120,
+        deleted=90,
+        initial_route="standard",
+    )
+
+    assert result["sensitive"] is False
+    assert result["route"] == "standard"
+    assert result["small_by_size"] is False
+    assert result["parallel_allowed"] is False
+    assert result["schedule"] == "readers_then_execution"
+
+
+def test_permission_keyword_in_patch_promotes_clean_path():
+    result = classify(
+        ["agent/policy.py"],
+        added=3,
+        deleted=0,
+        patch_text="+ required_permission = 'admin'\n",
+    )
+
+    assert result["sensitive"] is True
+    assert "sensitive_content:permission" in result["reasons"]
+
+
+def test_empty_diff_fails_closed_without_replacing_route():
+    result = classify([], added=0, deleted=0, initial_route="direct")
+
+    assert result["sensitive"] is True
+    assert result["route"] == "direct"
+    assert result["small_by_size"] is True
+    assert result["parallel_allowed"] is False
+    assert "empty_diff" in result["reasons"]
+
+
+def test_guard_code_and_tests_are_self_protecting_sensitive_paths():
+    result = classify(
+        [
+            "scripts/ci/reclassify_workflow.py",
+            "tests/ci/test_reclassify_workflow.py",
+        ],
+        added=1,
+        deleted=0,
+        initial_route="direct",
+    )
+
+    assert result["sensitive"] is True
+    assert result["parallel_allowed"] is False
+    assert result["required_readers"] == ["general_review", "downstream_security"]
+    assert "sensitive_path:scripts/ci/reclassify_workflow.py" in result["reasons"]
+    assert "sensitive_path:tests/ci/test_reclassify_workflow.py" in result["reasons"]
+
+
+def test_initial_route_is_required_and_closed_enum():
+    for route in ("direct", "standard", "complete"):
+        assert classify(["agent/x.py"], added=1, deleted=0, initial_route=route)["route"] == route

--- a/tests/ci/test_workflow_metrics.py
+++ b/tests/ci/test_workflow_metrics.py
@@ -1,0 +1,53 @@
+"""Tests for append-only workflow mission metrics."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "workflow_metrics.py"
+_spec = importlib.util.spec_from_file_location("workflow_metrics", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Failed to load workflow_metrics.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+append_record = _mod.append_record
+validate_record = _mod.validate_record
+
+
+def _record():
+    return {
+        "mission_id": "mission-1",
+        "route": "direct",
+        "changed_files": 1,
+        "changed_lines": 3,
+        "sensitive": False,
+        "required_readers": ["general_review"],
+        "replays": 0,
+        "duration_seconds": 12.5,
+        "outcome": "passed",
+    }
+
+
+def test_valid_record_appends_jsonl_without_overwriting(tmp_path: Path):
+    path = tmp_path / "metrics.jsonl"
+
+    append_record(path, _record())
+    second = _record()
+    second["mission_id"] = "mission-2"
+    append_record(path, second)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["mission_id"] for line in lines] == ["mission-1", "mission-2"]
+
+
+def test_invalid_record_is_rejected():
+    record = _record()
+    record["route"] = "invented"
+    record["duration_seconds"] = -1
+
+    errors = validate_record(record)
+
+    assert "route" in errors
+    assert "duration_seconds" in errors


### PR DESCRIPTION
## Summary
- add a self-protecting risk reclassification detector for workflow changes
- add deterministic acceptance-criteria freezing and SHA-bound evidence verification
- add validated append-only workflow mission metrics

## Safety contracts
- changes under scripts/ci/** and tests/ci/** are always sensitive
- the detector preserves the framed route and only adds required readers/gates
- size and risk are independent: parallel_allowed = small_by_size AND NOT sensitive
- acceptance criteria are immutable by hash and every green proof binds criteria hash + code SHA

## Verification
- uv run --with ruff ruff check scripts/ci/acceptance_gate.py scripts/ci/reclassify_workflow.py scripts/ci/workflow_metrics.py tests/ci/test_acceptance_gate.py tests/ci/test_reclassify_workflow.py tests/ci/test_workflow_metrics.py
- uv run --with pytest pytest -q tests/ci/test_acceptance_gate.py tests/ci/test_reclassify_workflow.py tests/ci/test_workflow_metrics.py tests/ci/test_classify_changes.py
- 56 passed
- acceptance gate passed on commit e56c6ff8 with frozen criteria hash 06ff4dab0860142b19e727f228e4fff31e08a188015bd40c99ae111911a0cd08

## Scope
Only the six workflow gate files are included; unrelated dirty-tree Signalix and Discord work is excluded.