### PR TITLE
fix(desktop): show a deferred local gateway at rest on the fleet rail, not unreachable

### DIFF
--- a/apps/desktop/e2e/fleet-rail-remote-primary.spec.ts
+++ b/apps/desktop/e2e/fleet-rail-remote-primary.spec.ts
@@ -1,0 +1,364 @@
+/**
+ * E2E: the fleet profile rail when the registry PRIMARY is a remote gateway.
+ *
+ * The workspace boots straight onto "Homelab" (a real second `hermes serve`
+ * this spec spawns) and Electron deliberately does not start a local backend
+ * — "This device" is connect-on-demand. The rail must still show This device
+ * at rest with its real squares (inventoried from the profiles directory),
+ * without the amber "unreachable" mark; the first click dials it; and after
+ * switching back to Homelab the group must repaint from a fresh roster, not
+ * the boot snapshot.
+ *
+ * Prerequisite: `npm run build` (dist/) and a Python venv for both backends.
+ */
+
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as net from 'node:net'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  type Sandbox,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig,
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { type ElectronApplication, expect, type Page, test } from './test'
+
+const DESKTOP_ROOT = path.resolve(import.meta.dirname, '..')
+const REPO_ROOT = path.resolve(DESKTOP_ROOT, '..', '..')
+
+const REMOTE_LABEL = 'Homelab'
+const REMOTE_ID = 'homelab'
+const REMOTE_TOKEN = 'e2e-fleet-remote-primary-token'
+const LOCAL_NAMED_PROFILE = 'research'
+
+interface RemoteGateway {
+  url: string
+  close: () => Promise<void>
+}
+
+function findHermesBinary(): string {
+  const venv = path.join(REPO_ROOT, '.venv', 'bin', 'hermes')
+
+  if (fs.existsSync(venv)) {
+    return venv
+  }
+
+  const result = spawnSync('which', ['hermes'], { encoding: 'utf8' })
+
+  if (result.status === 0 && result.stdout.trim()) {
+    return result.stdout.trim()
+  }
+
+  throw new Error('hermes binary not found: create the repo venv (uv sync) or put hermes on PATH')
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as net.AddressInfo
+      server.close(() => resolve(port))
+    })
+  })
+}
+
+function seedProfiles(home: string, names: string[]): void {
+  for (const name of names) {
+    const dir = path.join(home, 'profiles', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'config.yaml'), '', 'utf8')
+  }
+}
+
+async function startRemoteGateway(root: string, mockUrl: string, profiles: string[]): Promise<RemoteGateway> {
+  const home = path.join(root, 'homelab-home')
+  fs.mkdirSync(home, { recursive: true })
+  writeMockProviderConfig(home, mockUrl)
+  writeEnvFile(home)
+  seedProfiles(home, profiles)
+
+  const port = await freePort()
+  const url = `http://127.0.0.1:${port}`
+
+  const child: ChildProcess = spawn(
+    findHermesBinary(),
+    ['serve', '--host', '127.0.0.1', '--port', String(port), '--skip-build'],
+    {
+      cwd: REPO_ROOT,
+      detached: true,
+      env: { ...process.env, HERMES_HOME: home, HERMES_DASHBOARD_SESSION_TOKEN: REMOTE_TOKEN },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  let log = ''
+  child.stdout?.on('data', (chunk: Buffer) => {
+    log += chunk.toString()
+  })
+  child.stderr?.on('data', (chunk: Buffer) => {
+    log += chunk.toString()
+  })
+
+  const deadline = Date.now() + 90_000
+
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`remote hermes serve exited early (${child.exitCode}):\n${log}`)
+    }
+
+    try {
+      const response = await fetch(`${url}/api/status`, { headers: { 'X-Hermes-Session-Token': REMOTE_TOKEN } })
+
+      if (response.ok) {
+        break
+      }
+    } catch {
+      // not up yet
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+
+  if (Date.now() >= deadline) {
+    throw new Error(`remote hermes serve never became ready:\n${log}`)
+  }
+
+  return {
+    url,
+    close: async () => {
+      if (child.pid && child.exitCode === null) {
+        try {
+          process.kill(-child.pid, 'SIGTERM')
+        } catch {
+          child.kill('SIGTERM')
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 500))
+    },
+  }
+}
+
+/** Registry whose PRIMARY is the remote gateway — the local entry is on demand. */
+function writeConnectionsRegistry(sandbox: Sandbox, remoteUrl: string): void {
+  fs.writeFileSync(
+    path.join(sandbox.userDataDir, 'connections.json'),
+    JSON.stringify(
+      {
+        version: 2,
+        primary: REMOTE_ID,
+        launchMode: 'primary',
+        lastUsed: REMOTE_ID,
+        connections: [
+          { id: 'local', kind: 'local', label: 'This device' },
+          {
+            id: REMOTE_ID,
+            kind: 'remote',
+            label: REMOTE_LABEL,
+            url: remoteUrl,
+            authMode: 'token',
+            token: { encoding: 'plain', value: REMOTE_TOKEN },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    { encoding: 'utf8', mode: 0o600 },
+  )
+}
+
+// FLEET_RAIL_SCREENSHOT_DIR=<dir> saves full-window captures at the key
+// states — for review; never part of the assertions.
+async function capture(page: Page, name: string): Promise<void> {
+  const dir = process.env.FLEET_RAIL_SCREENSHOT_DIR
+
+  if (!dir) {
+    return
+  }
+
+  fs.mkdirSync(dir, { recursive: true })
+  await page.screenshot({ path: path.join(dir, `${name}.png`) })
+
+  // A close-up of the strip + statusbar, where the change is actually visible.
+  const box = await rail(page).boundingBox()
+
+  if (box) {
+    const viewport = page.viewportSize() ?? { height: box.y + box.height + 40, width: box.x + box.width }
+    const x = Math.max(0, box.x - 8)
+    const y = Math.max(0, box.y - 12)
+    await page.screenshot({
+      clip: { height: Math.min(viewport.height - y, box.height + 48), width: Math.min(viewport.width - x, 420), x, y },
+      path: path.join(dir, `${name}-rail.png`),
+    })
+  }
+}
+
+const botsTab = (page: Page) => page.getByRole('button', { name: /^bots$/i }).or(page.getByText(/^bots$/i)).first()
+const sessionsTab = (page: Page) => page.getByRole('button', { name: /^sessions$/i }).or(page.getByText(/^sessions$/i)).first()
+
+const rail = (page: Page) => page.locator('[data-slot="profile-rail"]')
+const gatewayGroup = (page: Page, id: string) => rail(page).locator(`[data-slot="profile-rail-gateway"][data-connection-id="${id}"]`)
+
+const unreachableMark = (page: Page, id: string) =>
+  rail(page).locator(`[data-slot="profile-rail-divider"][data-connection-id="${id}"] [data-slot="profile-rail-unreachable"]`)
+
+const activeGatewayLabel = (page: Page) => page.getByRole('button', { name: /^Registered gateways: / })
+
+/** Local `hermes serve` children spawned by this Electron app (by HERMES_HOME). */
+function localBackendCount(hermesHome: string): number {
+  const result = spawnSync('pgrep', ['-f', `hermes_cli.main --profile .* serve`], { encoding: 'utf8' })
+
+  if (result.status !== 0) {
+    return 0
+  }
+
+  let count = 0
+
+  for (const pid of result.stdout.split('\n').map(line => line.trim()).filter(Boolean)) {
+    try {
+      const environ = fs.readFileSync(`/proc/${pid}/environ`, 'utf8')
+
+      if (environ.includes(`HERMES_HOME=${hermesHome}\0`)) {
+        count += 1
+      }
+    } catch {
+      // process gone or unreadable
+    }
+  }
+
+  return count
+}
+
+test.describe('fleet profile rail — remote primary, This device on demand', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let mock: Awaited<ReturnType<typeof startMockServer>>
+  let sandbox: Sandbox
+  let remote: RemoteGateway
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async () => {
+    test.setTimeout(240_000)
+    mock = await startMockServer()
+    sandbox = createSandbox('fleet-remote-primary')
+    writeMockProviderConfig(sandbox.hermesHome, mock.url)
+    writeEnvFile(sandbox.hermesHome)
+    // A named profile on This device: it must appear on the strip from the
+    // profiles directory alone, before any local backend has ever run.
+    seedProfiles(sandbox.hermesHome, [LOCAL_NAMED_PROFILE])
+
+    remote = await startRemoteGateway(sandbox.root, mock.url, ['inbox'])
+    writeConnectionsRegistry(sandbox, remote.url)
+
+    ;({ app, page } = await launchDesktop(buildAppEnv(sandbox)))
+    await waitForAppReady({ app, page } as MockBackendFixture, 120_000)
+    await expect(page.locator('[data-slot="statusbar"]').getByText('ready', { exact: true })).toBeVisible({ timeout: 120_000 })
+    await page.waitForTimeout(2_000)
+  })
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => undefined)
+    await remote?.close()
+    await mock?.close()
+    sandbox?.cleanup()
+  })
+
+  test('boots onto the remote primary with This device at rest — real squares, no unreachable mark, no local backend', async () => {
+    await expect(activeGatewayLabel(page)).toHaveAttribute('aria-label', `Registered gateways: ${REMOTE_LABEL}`, { timeout: 60_000 })
+    await expect(gatewayGroup(page, 'local')).toBeVisible({ timeout: 60_000 })
+    await capture(page, '1-boot-on-remote-primary-this-device-at-rest')
+    await expect(gatewayGroup(page, REMOTE_ID)).toHaveAttribute('data-active', 'true')
+
+    // This device: at rest, reachable (connect-on-demand is not a failure),
+    // and its named square is already there — read from disk, not a backend.
+    const local = gatewayGroup(page, 'local')
+    await expect(local).toBeVisible({ timeout: 60_000 })
+    await expect(local).toHaveAttribute('data-active', 'false')
+    await expect(local.getByRole('button', { name: `${LOCAL_NAMED_PROFILE} · This device` })).toBeVisible({ timeout: 60_000 })
+    await expect(local).toHaveAttribute('data-reachable', 'true')
+    await expect(unreachableMark(page, 'local')).toHaveCount(0)
+
+    // …and Electron has NOT started a local backend to learn that.
+    if (localBackendCount(sandbox.hermesHome) !== 0) {
+      const ps = spawnSync('ps', ['-eo', 'pid,ppid,etimes,args'], { encoding: 'utf8' }).stdout
+        .split('\n')
+        .filter(line => line.includes('hermes_cli.main'))
+        .join('\n')
+
+      let log = ''
+
+      try {
+        log = fs.readFileSync(path.join(sandbox.hermesHome, 'logs', 'desktop.log'), 'utf8')
+      } catch {
+        log = '(no desktop.log)'
+      }
+
+      console.log(`--- hermes processes ---\n${ps}\n--- desktop.log ---\n${log.slice(-12_000)}`)
+    }
+
+    expect(localBackendCount(sandbox.hermesHome)).toBe(0)
+  })
+
+  test('Bot Mode lists This device at boot, before any local backend has run', async () => {
+    await botsTab(page).click()
+    await page.waitForTimeout(3_000)
+    await capture(page, '1b-bot-mode-lists-this-device-at-boot')
+    // Bot Mode groups by gateway: the local group carries its home bot and
+    // the named `research` profile — rows that only exist because the roster
+    // seeded them from the profiles directory.
+    await expect(page.getByText(/^this device$/i).first()).toBeVisible({ timeout: 60_000 })
+    await expect(page.getByText('Research', { exact: true })).toBeVisible({ timeout: 60_000 })
+    await expect(page.getByText('Inbox', { exact: true })).toBeVisible()
+    expect(localBackendCount(sandbox.hermesHome)).toBe(0)
+    await sessionsTab(page).click()
+    await expect(gatewayGroup(page, 'local')).toBeVisible()
+  })
+
+  test('the first click on a This-device square dials it and re-homes there', async () => {
+    test.setTimeout(180_000)
+    await gatewayGroup(page, 'local').getByRole('button', { name: `${LOCAL_NAMED_PROFILE} · This device` }).click()
+
+    await expect(activeGatewayLabel(page)).toHaveAttribute('aria-label', 'Registered gateways: This device', { timeout: 120_000 })
+    const local = gatewayGroup(page, 'local')
+    await expect(local).toHaveAttribute('data-active', 'true', { timeout: 30_000 })
+    await capture(page, '2-after-click-re-homed-on-this-device')
+    await expect(local.getByRole('button', { name: LOCAL_NAMED_PROFILE, exact: true })).toHaveAttribute('aria-pressed', 'true', { timeout: 30_000 })
+    await expect(gatewayGroup(page, REMOTE_ID)).toHaveAttribute('data-active', 'false')
+    await expect(gatewayGroup(page, REMOTE_ID)).toHaveAttribute('data-reachable', 'true')
+
+    // Now a local backend exists — the click is what started it.
+    expect(localBackendCount(sandbox.hermesHome)).toBeGreaterThan(0)
+  })
+
+  test('switching back to the remote leaves This device at rest and reachable — not the stale boot snapshot', async () => {
+    test.setTimeout(180_000)
+    await gatewayGroup(page, REMOTE_ID).getByRole('button', { name: `inbox · ${REMOTE_LABEL}` }).click()
+
+    await expect(activeGatewayLabel(page)).toHaveAttribute('aria-label', `Registered gateways: ${REMOTE_LABEL}`, { timeout: 120_000 })
+    await expect(gatewayGroup(page, REMOTE_ID)).toHaveAttribute('data-active', 'true', { timeout: 30_000 })
+
+    const local = gatewayGroup(page, 'local')
+    await expect(local).toHaveAttribute('data-active', 'false', { timeout: 30_000 })
+    await page.waitForTimeout(1_500)
+    await capture(page, '3-switched-back-this-device-still-reachable')
+    await expect(local.getByRole('button', { name: `${LOCAL_NAMED_PROFILE} · This device` })).toBeVisible()
+    await expect(local).toHaveAttribute('data-reachable', 'true')
+    await expect(unreachableMark(page, 'local')).toHaveCount(0)
+
+    // Hold a few seconds: no later roster pass may flip it back.
+    await page.waitForTimeout(5_000)
+    await expect(local).toHaveAttribute('data-reachable', 'true')
+    await expect(unreachableMark(page, 'local')).toHaveCount(0)
+  })
+})

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   parseRemoteProfileListing,
+  profileInventoryFromNames,
   reconcileAppliedGlobalConnection,
   reconcileRegistryDrift,
   REGISTRY_VERSION,
@@ -811,6 +812,17 @@ test('shouldRetrySshInventory: first try, cooldown, then retry; cache never retr
   assert.equal(shouldRetrySshInventory(false, 1_000, 30_000, 60_000), false)
   assert.equal(shouldRetrySshInventory(false, 1_000, 61_000, 60_000), true)
   assert.equal(shouldRetrySshInventory(true, 1_000, 120_000, 60_000), false)
+})
+
+test('profileInventoryFromNames: a local profiles/ directory listing seeds the same roster names as the SSH probe', () => {
+  // The disk read feeds directory entries straight in — no newline joining.
+  const inventory = profileInventoryFromNames(['omar', '.DS_Store', 'work.rollback-old', 'default', '', 'Bad Name', 'zeta'])
+
+  assert.deepEqual(inventory, ['default', 'omar', 'zeta'])
+  // Always at least the root home, even for an install with no named profiles.
+  assert.deepEqual(profileInventoryFromNames([]), ['default'])
+  // The SSH parser is the same rule over `ls` output.
+  assert.deepEqual(parseRemoteProfileListing('omar\nzeta\n'), profileInventoryFromNames(['omar', 'zeta']))
 })
 
 test('parseRemoteProfileListing: Mini/Spark dirs become roster names and drop rollbacks', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -623,10 +623,21 @@ const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
 /** Turn `ls ~/.hermes/profiles` output into roster names. Always includes
  *  `default`. Drops rollback snapshots and junk lines. */
 export function parseRemoteProfileListing(text: string): string[] {
+  return profileInventoryFromNames(String(text || '').split(/\r?\n/))
+}
+
+/**
+ * Roster names from a Hermes home's `profiles/` directory entries — the
+ * credential-free inventory both the SSH probe (`ls` over the tunnel) and the
+ * local disk read share. Always includes `default` (the root home is an agent
+ * too); drops rollback snapshots, dotfiles and anything that is not a valid
+ * profile id. Sorted for a stable strip.
+ */
+export function profileInventoryFromNames(entries: Iterable<string>): string[] {
   const names = new Set<string>(['default'])
 
-  for (const raw of String(text || '').split(/\r?\n/)) {
-    const name = raw.trim()
+  for (const raw of entries) {
+    const name = String(raw ?? '').trim()
 
     if (!name || name.startsWith('.') || name.endsWith('.rollback-old')) {
       continue

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -133,6 +133,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   parseBackendScopeKey,
+  profileInventoryFromNames,
   reconcileAppliedGlobalConnection,
   reconcileRegistryDrift,
   registrySourceOwnsPrimaryBackend,
@@ -253,7 +254,8 @@ import {
   buildRegistryProfileRoutes,
   isLocalEnumerationFailure,
   localRouteFallbackProfiles,
-  undialedSshRouteSeeds
+  undialedSshRouteSeeds,
+  withoutDeferredLocalRoutes
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
 import { createPoolStopper } from './pool-stop'
@@ -13651,6 +13653,11 @@ ipcMain.handle('hermes:plugin-profile-routes', async (_event, rawProfileNames) =
     ? enumerations.find(({ connection }) => connection.id === localSource.id)
     : undefined
 
+  // A DEFERRED local (connect-on-demand) is seeded into the roster from disk
+  // for display only; publishing it as a route would let the relay sweep
+  // dial — and spawn — the backend the deferral exists to avoid.
+  agents = withoutDeferredLocalRoutes(agents, localSource?.id, localEnumeration?.error)
+
   const localFallbackProfiles = localSource
     ? localRouteFallbackProfiles(
         agents,
@@ -13962,6 +13969,60 @@ async function probeSshProfileInventory(connection) {
   }
 }
 
+/**
+ * Whether this Desktop could start a local backend at all — the cheap,
+ * spawn-free subset of resolveHermesBackend's ladder (developer checkout
+ * override, dev source root, the canonical install venv, `hermes` on PATH).
+ * No python is executed: this runs inside the roster enumeration Bot Mode
+ * polls every few seconds.
+ */
+function localRuntimeAvailable(): boolean {
+  const overrideRoot = process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT)
+
+  if (overrideRoot && isHermesSourceRoot(overrideRoot)) {
+    return true
+  }
+
+  if (!IS_PACKAGED && isHermesSourceRoot(SOURCE_REPO_ROOT)) {
+    return true
+  }
+
+  if (fileExists(getVenvPython(VENV_ROOT))) {
+    return true
+  }
+
+  return process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1' && Boolean(findOnPath(process.env.HERMES_DESKTOP_HERMES || 'hermes'))
+}
+
+/**
+ * The local install's profile names straight from `$HERMES_HOME/profiles`,
+ * without touching (or spawning) a backend. Null when no local Hermes runtime
+ * is available — a remote-gateway-only Desktop must not mint a phantom
+ * `default` agent for "This device" (the Aug 17 2026 duplicate-main-agent
+ * report). Mirrors `listRemoteHermesProfiles` for SSH sources.
+ */
+function readLocalProfileInventory(): null | string[] {
+  if (!localRuntimeAvailable() || !directoryExists(HERMES_HOME)) {
+    return null
+  }
+
+  const profilesDir = path.join(HERMES_HOME, 'profiles')
+  let entries: string[] = []
+
+  try {
+    if (directoryExists(profilesDir)) {
+      entries = fs
+        .readdirSync(profilesDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+    }
+  } catch {
+    entries = []
+  }
+
+  return profileInventoryFromNames(entries)
+}
+
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
   // One dead source must not wedge the whole roster: ensureRegistryBackend on
   // an unreachable remote can block up to the 45s readiness timeout, and the
@@ -14023,7 +14084,15 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             })
 
             if (shouldDeferLocalEnumeration(localRoute, backendPool.keys(), connection.id)) {
-              return { connection, profiles: null, error: 'connect-on-demand' }
+              // Still no spawn — but a sleeping local install is not an
+              // unreachable one. Inventory its profiles from disk (the same
+              // credential-free `profiles/` listing the SSH probe takes over
+              // the tunnel) so the fleet rail and Bot Mode show This device
+              // at rest, "on demand", with its real squares, instead of an
+              // amber "unreachable" dot and no bots until the first click.
+              // `profiles: null` stays for desktops with no local runtime:
+              // there is genuinely nothing to seed there.
+              return { connection, profiles: readLocalProfileInventory(), error: 'connect-on-demand' }
             }
           }
 

--- a/apps/desktop/electron/plugin-profile-routes.test.ts
+++ b/apps/desktop/electron/plugin-profile-routes.test.ts
@@ -7,7 +7,8 @@ import {
   localRouteFallbackProfiles,
   type ProfileRouteConfig,
   registryGatewayWsUrl,
-  undialedSshRouteSeeds
+  undialedSshRouteSeeds,
+  withoutDeferredLocalRoutes
 } from './plugin-profile-routes'
 
 function config(overrides: Partial<ProfileRouteConfig> = {}): ProfileRouteConfig {
@@ -312,5 +313,29 @@ describe('undialedSshRouteSeeds', () => {
         [{ id: 'homelab', kind: 'ssh', remoteProfile: 'venture' }]
       )
     ).toEqual([])
+  })
+})
+
+describe('withoutDeferredLocalRoutes', () => {
+  const agents = [
+    { connectionId: 'local', profile: 'default' },
+    { connectionId: 'local', profile: 'omar' },
+    { connectionId: 'pandora', profile: 'default' }
+  ]
+
+  it('keeps a connect-on-demand local out of the plugin route table (display-only roster rows)', () => {
+    // A relay sweep dials every published route — a deferred local must not be one.
+    expect(withoutDeferredLocalRoutes(agents, 'local', 'connect-on-demand')).toEqual([
+      { connectionId: 'pandora', profile: 'default' }
+    ])
+  })
+
+  it('leaves an enumerated or genuinely failed local alone', () => {
+    expect(withoutDeferredLocalRoutes(agents, 'local', undefined)).toEqual(agents)
+    expect(withoutDeferredLocalRoutes(agents, 'local', 'timed out')).toEqual(agents)
+  })
+
+  it('is a no-op without a registered local source', () => {
+    expect(withoutDeferredLocalRoutes(agents, null, 'connect-on-demand')).toEqual(agents)
   })
 })

--- a/apps/desktop/electron/plugin-profile-routes.ts
+++ b/apps/desktop/electron/plugin-profile-routes.ts
@@ -61,6 +61,28 @@ export function isLocalEnumerationFailure(error?: string): boolean {
   return Boolean(error) && error !== 'connect-on-demand'
 }
 
+/**
+ * Drop the local source's rows when its enumeration was deferred
+ * (`connect-on-demand`: the registry primary is remote and no local child is
+ * pooled). The roster still carries those rows — inventoried from the profiles
+ * directory — so the fleet rail and Bot Mode can show This device at rest;
+ * but they must not become plugin routes, because relay sweeps dial every
+ * published route and would spawn the very backend the deferral exists to
+ * avoid. A clicked bot is dialed by its own (connectionId, profile), not
+ * through this table, so nothing the user can reach is lost.
+ */
+export function withoutDeferredLocalRoutes<T extends RegistryProfileRouteAgent>(
+  agents: T[],
+  localConnectionId: null | string | undefined,
+  localEnumerationError?: string
+): T[] {
+  if (!localConnectionId || localEnumerationError !== 'connect-on-demand') {
+    return agents
+  }
+
+  return agents.filter(agent => agent.connectionId !== localConnectionId)
+}
+
 /** Return cached local profile names only when the local roster read failed. */
 export function localRouteFallbackProfiles(
   agents: RegistryProfileRouteAgent[],

--- a/apps/desktop/src/app/chat/sidebar/fleet-rail.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/fleet-rail.test.ts
@@ -56,6 +56,38 @@ describe('buildRestGroups', () => {
     expect(vps?.named).toEqual([])
   })
 
+  it('keeps a connect-on-demand gateway at rest — reachable, with its seeded squares — not marked unreachable', () => {
+    // This device while the registry primary is remote: Electron does not
+    // dial it, but inventories its profiles from disk and tags the source
+    // connect-on-demand (same as an undialed SSH box). That is a sleeping
+    // source, not a failed one — no amber dot, real named squares.
+    const onDemand: DesktopAgentRoster = {
+      agents: roster.agents,
+      sources: roster.sources.map(source =>
+        source.connectionId === 'local' ? { ...source, error: 'connect-on-demand' } : source
+      )
+    }
+
+    const [local] = buildRestGroups({ activeConnectionId: 'pandora', connections, roster: onDemand })
+
+    expect(local.connectionId).toBe('local')
+    expect(local.reachable).toBe(true)
+    expect(local.named.map(agent => agent.profile)).toEqual(['omer'])
+
+    // A desktop with no local runtime at all: nothing to seed (profiles null →
+    // reachable false from Electron) but the deferral is still not a failure.
+    const noRuntime: DesktopAgentRoster = {
+      agents: roster.agents.filter(agent => agent.connectionId !== 'local'),
+      sources: roster.sources.map(source =>
+        source.connectionId === 'local' ? { ...source, reachable: false, error: 'connect-on-demand' } : source
+      )
+    }
+
+    const [bare] = buildRestGroups({ activeConnectionId: 'pandora', connections, roster: noRuntime })
+    expect(bare.reachable).toBe(true)
+    expect(bare.named).toEqual([])
+  })
+
   it('shows every gateway with just its default before the roster has loaded', () => {
     const groups = buildRestGroups({ activeConnectionId: 'pandora', connections, roster: null })
 

--- a/apps/desktop/src/app/chat/sidebar/fleet-rail.ts
+++ b/apps/desktop/src/app/chat/sidebar/fleet-rail.ts
@@ -91,7 +91,10 @@ export function buildRestGroups({
       connectionId: connection.id,
       kind: connection.kind,
       label: connection.label,
-      reachable: source?.reachable ?? true,
+      // "connect-on-demand" is a source Electron chose not to dial yet (an
+      // SSH box, or This device while the primary is remote) — at rest, not
+      // unreachable. Only a probe that actually failed earns the amber dot.
+      reachable: source ? source.reachable || source.error === 'connect-on-demand' : true,
       defaultAgent: toAgent(DEFAULT_PROFILE, defaultRow?.handle),
       named
     })

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -258,6 +258,45 @@ describe('ProfileRail fleet mode', () => {
     expect(within(vps as HTMLElement).getByRole('button', { name: 'default · VPS' })).toBeTruthy()
   })
 
+  it('re-enumerates the fleet as soon as the active gateway changes', async () => {
+    armFleet()
+    await renderFleet()
+
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+
+    // A switch dials (and pools) the target — the roster the strip painted at
+    // boot may still call that source connect-on-demand. The last-used write
+    // that ends a switch raises no registry event, so the rail must re-pull on
+    // the activation itself, ignoring the 60s stale window.
+    await act(async () => {
+      activeConnectionId.set('local')
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows a connect-on-demand gateway at rest without the unreachable mark', async () => {
+    armFleet()
+    getAgentRoster.mockResolvedValue({
+      agents: roster.agents,
+      sources: roster.sources.map(source =>
+        source.connectionId === 'local' ? { ...source, error: 'connect-on-demand' } : source
+      )
+    })
+    const container = await renderFleet()
+
+    const local = container.querySelector('[data-slot="profile-rail-gateway"][data-connection-id="local"]')
+    expect(local?.getAttribute('data-reachable')).toBe('true')
+    expect(
+      container.querySelector(
+        '[data-slot="profile-rail-divider"][data-connection-id="local"] [data-slot="profile-rail-unreachable"]'
+      )
+    ).toBeNull()
+    expect(within(local as HTMLElement).getByRole('button', { name: 'omer · This device' })).toBeTruthy()
+  })
+
   it('re-homes onto the exact (gateway, profile) when an at-rest square is clicked', async () => {
     armFleet()
     await renderFleet()

--- a/apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts
@@ -1,12 +1,16 @@
 import { useEffect } from 'react'
 
+import { $activeConnectionId } from '@/store/connections'
 import { refreshFleetRoster } from '@/store/fleet-roster'
 
 /**
  * Keep the fleet roster fresh for the profile rail while more than one
  * gateway is registered: pull on mount, when the window regains focus or
- * visibility, and immediately when the connection registry changes. No timer
- * — the multi-connection contract rules out periodic fleet polling from the
+ * visibility, immediately when the connection registry changes, and
+ * immediately after the active gateway changes — a switch is what dials (and
+ * pools) a source that was connect-on-demand a moment ago, and the last-used
+ * write it ends with raises no registry event. No timer — the
+ * multi-connection contract rules out periodic fleet polling from the
  * sidebar, and a 60s stale window in the store absorbs focus churn.
  */
 export function useFleetRoster(enabled: boolean): void {
@@ -28,11 +32,15 @@ export function useFleetRoster(enabled: boolean): void {
     window.addEventListener('focus', onFocus)
     document.addEventListener('visibilitychange', onVisibility)
     const offRegistry = window.hermesDesktop?.connections?.onChanged?.(() => void refreshFleetRoster({ force: true }))
+    // listen (not subscribe): the mount pull above already covers the current
+    // source; this fires only when the active gateway actually moves.
+    const offActive = $activeConnectionId.listen(() => void refreshFleetRoster({ force: true }))
 
     return () => {
       window.removeEventListener('focus', onFocus)
       document.removeEventListener('visibilitychange', onVisibility)
       offRegistry?.()
+      offActive()
     }
   }, [enabled])
 }

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -191,8 +191,11 @@ that live on one gateway.
   **Rename**, **Edit SOUL.md** and **Delete**, all executed on the square's
   own gateway; the delete confirmation names the machine.
 - A gateway the last enumeration could not reach keeps its squares, marked
-  with an amber dot on its glyph — a sleeping box is still yours. Two
-  registrations of one backend collapse to a single group. Past thirteen
+  with an amber dot on its glyph — a sleeping box is still yours. A gateway
+  Desktop simply has not dialed yet (an SSH box, or **This device** while the
+  primary is a remote gateway) is not "unreachable": its squares come from the
+  profile directory listing and sit at rest without the dot; the first click
+  dials it. Two registrations of one backend collapse to a single group. Past thirteen
   squares across the fleet, the strip condenses into one menu sectioned by
   gateway.
 - The selected gateway survives a quit and relaunch only when **Settings →
@@ -316,7 +319,10 @@ multi-gateway roster is the reference consumer.
   gateway auth/origin guard is blocking `/api/ws`.
 - **A remote gateway is missing from the roster** — its backend is down or
   unreachable; the roster lists it under gateways with the error. SSH connections
-  show *connect-on-demand* until first use — that's by design, not a failure.
+  — and **This device** while the primary is a remote gateway — show
+  *connect-on-demand* until first use, with their profiles read from the
+  profile directory rather than a running backend. That's by design, not a
+  failure; the first click on one of their squares starts the backend.
 - **"Update Hermes Desktop to chat with agents on other connections"** — the
   app predates the multi-connection stack; update the desktop app itself.
 - **Duplicate device names** — not possible; names are enforced unique at


### PR DESCRIPTION
## What does this PR do?

On a Desktop whose registry **primary is a remote gateway** (launch mode *primary*, e.g. a Tailscale box), the fleet profile rail from #95591 painted **This device** with the amber *unreachable* dot, showed only its `default` square, and Bot Mode listed no local bots at all — until the user clicked a This-device square. After clicking, the dot "went away" (only because the active gateway is not drawn at rest), and switching to another gateway brought it straight back. Symptom reported on Linux (Hyprland), Electron 40, reproduced end-to-end below.

Three things stack up:

1. **Deferred ≠ unreachable.** Since #91564 (`1e9a12a71f`) a remote primary does not spawn a loopback `hermes serve`, and `enumerateRegistryAgentSources` deliberately skips `local` as `connect-on-demand` until a forced-local child is pooled. `hermes:agents:roster` then reports `reachable: profiles !== null` → **false**, and — unlike SSH sources, which `rememberSshEnumeration` seeds with `default` / a cached list — `kind === 'local'` returns early with nothing. The rail (and the Capabilities scope selector, and Bot Mode's row merge) only see "no rows, unreachable".
2. **The rail's roster never refreshes after a switch.** `refreshFleetRoster` runs on mount / focus / visibility / `connections.onChanged` with a 60 s stale window. A switch ends in `setLastUsed`, which raises no `onChanged`; so the strip kept painting the boot snapshot. Bot Mode has its own 5 s poll, which is why the two disagreed.
3. Seeding local rows naively would re-introduce the phantom spawn #91564 removed: the Bots relay sweep (`relayConnections` → `profiles.list` on one route per connection) dials every published plugin route. Caught by the new e2e (a local backend appeared 330 ms after boot) and fixed below.

### Changes

- **`electron/main.ts` / `connection-registry.ts`** — when local enumeration is deferred, inventory its profiles **from `$HERMES_HOME/profiles` on disk** (the same credential-free listing `listRemoteHermesProfiles` takes over SSH; shared parser `profileInventoryFromNames`). No backend is touched or spawned. `profiles: null` is kept when no local runtime is available at all (`localRuntimeAvailable()`: developer-checkout override, dev source root, canonical install venv, or `hermes` on PATH — no python is executed; this runs inside the roster enumeration Bot Mode polls), so a remote-gateway-only Desktop still mints no phantom `default` agent (Aug 17 report).
- **`electron/plugin-profile-routes.ts`** — `withoutDeferredLocalRoutes`: the seeded rows are display-only. They reach `hermes:agents:roster` (rail, Bot Mode, Capabilities) but **not** `hermes:plugin-profile-routes`, so relay sweeps cannot dial — and spawn — the deferred backend. A clicked bot is dialed by its own `(connectionId, profile)` (`botConnectionRoute`), so nothing reachable is lost; the source shows *On demand* exactly like an undialed SSH box.
- **`sidebar/fleet-rail.ts`** — `connect-on-demand` is *at rest*, not unreachable. Only a probe that actually failed earns the amber dot.
- **`sidebar/use-fleet-roster.ts`** — force a roster re-pull when `$activeConnectionId` changes (`listen`, so no extra IPC on mount or same-source clicks).
- Docs: `multi-connection-desktop.md` describes the on-demand local.

### Before / after (captured by the new e2e, real backends)

Boot with the registry primary on `Homelab` (a second real `hermes serve`); This device has a named profile `research` on disk and no backend running:

![rail before/after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/fleet-rail-remote-primary/fleet-rail-remote-primary/rail-before-after.png)

Bot Mode at the same boot — This device's home bot and `Research`, still with no local backend started:

![bot mode at boot](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/fleet-rail-remote-primary/fleet-rail-remote-primary/bot-mode-at-boot-crop.png)

After clicking a This-device square (which starts the backend) and switching back to Homelab — the strip repaints from a fresh roster, not the boot snapshot:

![switched back](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/fleet-rail-remote-primary/fleet-rail-remote-primary/switched-back-rail.png)

## Related Issue

Follow-up to #95591 (fleet profile rail). Keeps the #91564 / #90316 contract: a remote registry primary never spawns a loopback backend on its own.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

- `apps/desktop/electron/main.ts` — `localRuntimeAvailable`, `readLocalProfileInventory`; deferred local returns the disk inventory with `error: 'connect-on-demand'`; plugin routes drop deferred-local rows.
- `apps/desktop/electron/connection-registry.ts` — `profileInventoryFromNames` (SSH parser now delegates to it).
- `apps/desktop/electron/plugin-profile-routes.ts` — `withoutDeferredLocalRoutes`.
- `apps/desktop/src/app/chat/sidebar/fleet-rail.ts` — on-demand sources are reachable.
- `apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts` — refresh on active-gateway change.
- Tests: `connection-registry.test.ts`, `plugin-profile-routes.test.ts`, `fleet-rail.test.ts`, `profile-rail-fleet.test.tsx` (+2), new `e2e/fleet-rail-remote-primary.spec.ts`.
- Docs: `website/docs/user-guide/multi-connection-desktop.md`.

## How to Test

1. `cd apps/desktop && npm run test:ui` — 611 files / 6004 tests pass; `npx vitest run --project electron` — 1861 pass.
2. `npm run typecheck && npm run lint` — clean.
3. E2E, real backends: `npm run build && npx playwright test e2e/fleet-rail-remote-primary.spec.ts e2e/fleet-profile-rail.spec.ts --reporter=list` — 9/9. The new spec registers the spawned `hermes serve` as the **primary**, seeds `profiles/research` on This device, then asserts: This device at rest with `research · This device`, `data-reachable="true"`, no `profile-rail-unreachable` mark, **and zero local `hermes serve` processes for the sandbox `HERMES_HOME`** (via `/proc/<pid>/environ`); Bot Mode lists This device + Research at boot; the first click spawns and re-homes; switching back leaves This device reachable and holds for 5 s. Run with the fix stashed, the first test fails exactly as reported (amber mark, no named square) — that is the "before" capture above.
4. Manually: register a remote gateway, make it primary, restart Desktop. This device should sit at rest on the strip with its real squares and appear in Bot Mode as *On demand*; the first click starts it.

Tested on Arch Linux (Hyprland), Electron 40, Node 26, Python 3.11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Desktop suites run (`test:ui`, electron project, `typecheck`, `lint`, Playwright e2e); no Python changes
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (Hyprland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/multi-connection-desktop.md`)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the disk inventory uses the same `HERMES_HOME` resolution as the backend spawn (Windows `LOCALAPPDATA`/registry paths included); the e2e's process check is Linux-only (`/proc`) and the spec already requires a POSIX `hermes serve`
- [x] Tool descriptions/schemas — N/A
