### PR TITLE
feat(desktop): name each chat's owner in the All-profiles sidebar view

### DIFF
--- a/apps/desktop/e2e/all-profiles-owner-lead.spec.ts
+++ b/apps/desktop/e2e/all-profiles-owner-lead.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * E2E: the All-profiles view names each chat's owner.
+ *
+ * One gateway — the Electron-managed local backend with mock inference —
+ * carrying three named profiles beside default, each holding real sessions
+ * the real agent wrote. Switching the sidebar to "Show all profiles" merges
+ * them into one list: every one-line row from a named profile leads with that
+ * profile's name, default-profile rows carry no mark, and the mark takes the
+ * profile's colour while the row is hovered or selected.
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists, and the
+ * repo's Python venv (`.venv`) must exist (and be active for `uv run`) for
+ * the backend and the session builder.
+ *
+ * OWNER_LEAD_SCREENSHOT_DIR=<dir> saves sidebar captures at the key states
+ * (single scope, merged at rest, hovered, selected) for design review; never
+ * part of the assertions. OWNER_LEAD_SCREENSHOT_ONLY=1 skips the lead
+ * assertions so the same spec can capture a build that predates the feature.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  type Sandbox,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig,
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { type ElectronApplication, expect, type Page, test } from './test'
+
+// Fictional profiles and chats — nothing here comes from a real install.
+const DEFAULT_SESSIONS = ['Plan the week', 'Tidy the downloads folder']
+const PROFILE_SESSIONS: Record<string, string[]> = {
+  inbox: ['Draft the release notes', 'Reply to the vendor thread'],
+  ops: ['Check the deploy logs', 'Rotate the staging certificate'],
+  research: ['Compare the two vector stores'],
+}
+
+const screenshotOnly = process.env.OWNER_LEAD_SCREENSHOT_ONLY === '1'
+
+/** Seed `<home>/profiles/<name>/` so the backend's /api/profiles lists it. */
+function seedProfiles(home: string, names: string[]): void {
+  for (const name of names) {
+    const dir = path.join(home, 'profiles', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'config.yaml'), '', 'utf8')
+  }
+}
+
+/** Real sessions in one profile home, written by the real agent against the
+ *  mock provider. The first turn doubles as the title the sidebar shows. */
+async function seedSessions(home: string, mockUrl: string, titles: string[]): Promise<void> {
+  writeMockProviderConfig(home, mockUrl)
+  writeEnvFile(home)
+  const builder = await RealSessionBuilder.start(home)
+
+  try {
+    for (const title of titles) {
+      await builder.createSession({ title, turns: [title] })
+    }
+  } finally {
+    await builder.close()
+  }
+}
+
+test.describe('All-profiles view — owner lead on every row', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let mock: Awaited<ReturnType<typeof startMockServer>>
+  let sandbox: Sandbox
+  let app: ElectronApplication
+  let page: Page
+
+  const sidebar = () => page.locator('[data-slot="sidebar"]')
+  const row = (title: string) => sidebar().locator('button').filter({ hasText: title }).first()
+  const leads = () => sidebar().locator('[data-profile-lead]')
+
+  // Off the list, over the empty chat pane — Electron reports no viewport
+  // size, so the window's known 1220×800 bounds stand in for it.
+  const parkPointer = () => page.mouse.move(900, 400)
+
+  async function capture(name: string): Promise<void> {
+    const dir = process.env.OWNER_LEAD_SCREENSHOT_DIR
+
+    if (!dir) {
+      return
+    }
+
+    fs.mkdirSync(dir, { recursive: true })
+    await sidebar().screenshot({ path: path.join(dir, `${name}.png`) })
+  }
+
+  test.beforeAll(async () => {
+    test.setTimeout(300_000)
+    mock = await startMockServer()
+    sandbox = createSandbox('owner-lead')
+    seedProfiles(sandbox.hermesHome, Object.keys(PROFILE_SESSIONS))
+    await seedSessions(sandbox.hermesHome, mock.url, DEFAULT_SESSIONS)
+
+    for (const [name, titles] of Object.entries(PROFILE_SESSIONS)) {
+      await seedSessions(path.join(sandbox.hermesHome, 'profiles', name), mock.url, titles)
+    }
+
+    ;({ app, page } = await launchDesktop(buildAppEnv(sandbox)))
+    await waitForAppReady({ app, page } as MockBackendFixture, 120_000)
+    await expect(page.locator('[data-slot="statusbar"]').getByText('ready', { exact: true })).toBeVisible({ timeout: 120_000 })
+    // Playwright-driven Electron reports no hover-capable pointer on some
+    // Linux desktops, which switches off every `@media (hover: hover)` rule —
+    // the sidebar's whole hover vocabulary, this feature's included. Declare
+    // one so the hover state is real and testable everywhere.
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Emulation.setEmulatedMedia', {
+      features: [
+        { name: 'hover', value: 'hover' },
+        { name: 'pointer', value: 'fine' },
+      ],
+    })
+  })
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => undefined)
+    await mock?.close()
+    sandbox?.cleanup()
+  })
+
+  test('a single-profile scope marks nothing', async () => {
+    await expect(row('Plan the week')).toBeVisible({ timeout: 60_000 })
+    await expect(row('Draft the release notes')).toHaveCount(0)
+    await expect(leads()).toHaveCount(0)
+    await capture('scope-default')
+  })
+
+  test('the merged list leads every named-profile row with its owner', async () => {
+    await page.getByRole('button', { name: 'Show all profiles' }).click()
+    await expect(row('Draft the release notes')).toBeVisible({ timeout: 60_000 })
+    await expect(row('Compare the two vector stores')).toBeVisible()
+    await expect(row('Check the deploy logs')).toBeVisible()
+    await expect(row('Plan the week')).toBeVisible()
+    // Park the pointer off the list so the capture shows the resting state.
+    await parkPointer()
+    await capture('all-profiles-rest')
+
+    if (screenshotOnly) {
+      return
+    }
+
+    await expect(row('Draft the release notes').locator('[data-profile-lead="inbox"]')).toBeVisible()
+    await expect(row('Compare the two vector stores').locator('[data-profile-lead="research"]')).toBeVisible()
+    await expect(row('Check the deploy logs').locator('[data-profile-lead="ops"]')).toBeVisible()
+    // The lead is the first thing on the title line.
+    await expect(row('Draft the release notes')).toContainText(/inbox\s*›\s*Draft the release notes/)
+    // The default profile is never marked.
+    await expect(row('Plan the week').locator('[data-profile-lead]')).toHaveCount(0)
+    await expect(row('Tidy the downloads folder').locator('[data-profile-lead]')).toHaveCount(0)
+  })
+
+  test('hover and selection paint the lead in the profile colour', async () => {
+    const target = row('Check the deploy logs')
+    const lead = target.locator('[data-profile-lead="ops"]')
+    const color = () => lead.evaluate(el => getComputedStyle(el).color)
+
+    const rest = screenshotOnly ? '' : await color()
+    await target.hover()
+    await capture('all-profiles-hover')
+
+    if (!screenshotOnly) {
+      await expect.poll(color).not.toBe(rest)
+    }
+
+    await target.click()
+
+    if (screenshotOnly) {
+      await page.waitForTimeout(5_000)
+    } else {
+      await expect(lead).toHaveClass(/font-medium/, { timeout: 60_000 })
+    }
+
+    await parkPointer()
+    await capture('all-profiles-selected')
+
+    if (!screenshotOnly) {
+      // Selected keeps the colour after the pointer leaves — it never falls
+      // back to the resting grey.
+      await expect.poll(color).not.toBe(rest)
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1820,6 +1820,9 @@ export function ChatSidebar({
                   !recentsVirtualizes && 'compact:min-h-0 compact:flex-none compact:overflow-visible'
                 )}
                 sessions={displayAgentSessions}
+                // Every row in the merged list names its owner — unless a profile
+                // group header or a single-profile narrowing already does.
+                showProfileTags={showAllProfiles && !profileGrouped && profileFilter.length !== 1}
                 sortable={!showAllProfiles && agentSessions.length > 1}
               />
             )}

--- a/apps/desktop/src/app/chat/sidebar/profile-lead.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-lead.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { setProfileColor } from '@/store/profile'
+
+import { ProfileLead, profileLeadLabel } from './profile-lead'
+
+afterEach(() => {
+  cleanup()
+  setProfileColor('inbox', null)
+})
+
+const lead = (container: HTMLElement) => container.querySelector<HTMLElement>('[data-profile-lead]') as HTMLElement
+
+describe('profileLeadLabel', () => {
+  it('prints a short name whole', () => {
+    expect(profileLeadLabel('inbox')).toBe('inbox')
+    expect(profileLeadLabel('fourteen-chars')).toBe('fourteen-chars')
+  })
+
+  it('elides a name past the cap so it cannot take the title room', () => {
+    expect(profileLeadLabel('research-assistant')).toBe('research-assi…')
+  })
+})
+
+describe('ProfileLead', () => {
+  it('names the profile and hides the separator from assistive tech', () => {
+    const { container } = render(<ProfileLead profile="inbox" selected={false} />)
+
+    expect(lead(container).dataset.profileLead).toBe('inbox')
+    expect(lead(container).textContent?.startsWith('inbox')).toBe(true)
+    expect(lead(container).querySelector('[aria-hidden="true"]')?.textContent?.trim()).toBe('›')
+  })
+
+  it('carries the deterministic profile colour for the hover and selected states', () => {
+    const { container } = render(<ProfileLead profile="inbox" selected={false} />)
+
+    expect(lead(container).style.getPropertyValue('--profile-lead-color')).toMatch(/^hsl\(/)
+  })
+
+  it('prefers a user-picked colour override, the same one the rail square wears', () => {
+    setProfileColor('inbox', 'hsl(30 68% 58%)')
+
+    const { container } = render(<ProfileLead profile="inbox" selected={false} />)
+
+    expect(lead(container).style.getPropertyValue('--profile-lead-color')).toBe('hsl(30 68% 58%)')
+  })
+
+  it('is quiet at rest and only colours on hover', () => {
+    const { container } = render(<ProfileLead profile="inbox" selected={false} />)
+
+    expect(lead(container).className).toContain('text-(--ui-text-quaternary)')
+    expect(lead(container).className).toContain('group-hover:text-(--profile-lead-color)')
+    expect(lead(container).className).not.toContain('font-medium')
+  })
+
+  it('keeps the colour while selected, with a little weight so it survives the pointer leaving', () => {
+    const { container } = render(<ProfileLead profile="inbox" selected />)
+
+    expect(lead(container).className).toContain('font-medium')
+    expect(lead(container).className).not.toContain('group-hover:')
+    expect(lead(container).className).not.toContain('text-(--ui-text-quaternary)')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-lead.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-lead.tsx
@@ -1,0 +1,48 @@
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+
+import { resolveProfileColor } from '@/lib/profile-color'
+import { cn } from '@/lib/utils'
+import { $profileColors, normalizeProfileKey } from '@/store/profile'
+
+/** Longest profile name the lead spells out. Past this it elides — a long
+ *  name would otherwise take the room the title needs. */
+const PROFILE_LEAD_MAX_CHARS = 14
+
+/** The name as the lead prints it: whole when short, elided past the cap. */
+export function profileLeadLabel(name: string): string {
+  return name.length > PROFILE_LEAD_MAX_CHARS ? `${name.slice(0, PROFILE_LEAD_MAX_CHARS - 1)}…` : name
+}
+
+/** The owning profile's name ahead of a one-line row title — `inbox ›` — for
+ *  lists that mix profiles (the All-profiles view). Quiet by default: the same
+ *  grey as the row's age. While the row is hovered or selected it takes the
+ *  profile's own colour, the colour of that profile's rail square, so the
+ *  mark points at the rail exactly when you engage with a row and stays out
+ *  of the way while you scan. Text rather than a swatch: it reads without
+ *  colour, and it lines up under the status dot whatever the ages to the
+ *  right are doing. Callers skip it for the default profile — a mark on every
+ *  row that says "the normal one" is noise. */
+export function ProfileLead({ profile, selected }: { profile: null | string | undefined; selected: boolean }) {
+  const colors = useStore($profileColors)
+  const key = normalizeProfileKey(profile)
+  const color = resolveProfileColor(key, colors)
+
+  return (
+    <span
+      className={cn(
+        'transition-colors duration-100',
+        selected
+          ? 'font-medium text-(--profile-lead-color)'
+          : 'text-(--ui-text-quaternary) group-hover:text-(--profile-lead-color)'
+      )}
+      data-profile-lead={key}
+      style={{ '--profile-lead-color': color ?? 'var(--ui-text-tertiary)' } as React.CSSProperties}
+    >
+      {profileLeadLabel(key)}
+      <span aria-hidden="true" className="mx-1 opacity-60">
+        ›
+      </span>
+    </span>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -50,7 +50,7 @@ vi.mock('@/i18n', () => ({
   })
 }))
 
-vi.mock('@/app/chat/profile-tag', () => ({ ProfileTag: () => null }))
+vi.mock('@/app/chat/profile-tag', () => ({ ProfileTag: () => <span data-testid="profile-tag" /> }))
 vi.mock('@/app/chat/session-drag', () => ({ startSessionDrag: vi.fn() }))
 // PlatformAvatar is intentionally NOT mocked (do not reintroduce this — see
 // #67500, Gille's third pass): it's a forwardRef component that spreads its
@@ -437,5 +437,74 @@ describe('Inbox-style session card', () => {
 
     expect(workspace.className).toMatch(/\btruncate\b/)
     expect(screen.getByText('133 messages')).toBeTruthy()
+  })
+})
+
+// The All-profiles view (`showProfile`): the one-line row names its owner in
+// the title line, the card keeps the trailing chip, and the default profile
+// is never marked. Colour states are pinned in profile-lead.test.tsx.
+describe('SidebarSessionRow profile lead', () => {
+  const renderTagged = (
+    session: SessionInfo,
+    extra?: { card?: boolean; isSelected?: boolean; showProfile?: boolean }
+  ) =>
+    render(
+      <SidebarSessionRow
+        card={extra?.card}
+        isPinned={false}
+        isSelected={extra?.isSelected ?? false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
+        onToggleUnread={noop}
+        session={session}
+        showProfile={extra?.showProfile ?? true}
+        unread={false}
+      />
+    )
+
+  const lead = (container: HTMLElement) => container.querySelector<HTMLElement>('[data-profile-lead]')
+
+  it('leads the one-line title with the owning profile instead of a trailing chip', () => {
+    const { container } = renderTagged(makeSession({ profile: 'inbox', title: 'Draft the release notes' }))
+    const mark = lead(container) as HTMLElement
+
+    expect(mark.dataset.profileLead).toBe('inbox')
+    // Part of the title line itself — ahead of the title, scrolling with it
+    // on hover — not a column of its own.
+    const line = container.querySelector<HTMLElement>('.hover-marquee-inner') as HTMLElement
+
+    expect(line.contains(mark)).toBe(true)
+    expect(line.textContent?.startsWith('inbox')).toBe(true)
+    expect(line.textContent?.endsWith('Draft the release notes')).toBe(true)
+    expect(screen.queryByTestId('profile-tag')).toBeNull()
+  })
+
+  it('paints the lead in the profile colour once the row is selected', () => {
+    const { container } = renderTagged(makeSession({ profile: 'inbox', title: 'Draft' }), { isSelected: true })
+
+    expect((lead(container) as HTMLElement).className).toContain('font-medium')
+  })
+
+  it('carries no mark for the default profile', () => {
+    const { container } = renderTagged(makeSession({ profile: 'default', title: 'Plain' }))
+
+    expect(lead(container)).toBeNull()
+    expect(screen.queryByTestId('profile-tag')).toBeNull()
+  })
+
+  it('marks nothing outside a mixed-profile list', () => {
+    const { container } = renderTagged(makeSession({ profile: 'inbox', title: 'Plain' }), { showProfile: false })
+
+    expect(lead(container)).toBeNull()
+    expect(screen.queryByTestId('profile-tag')).toBeNull()
+  })
+
+  it('keeps the chip on the card and adds no lead', () => {
+    const { container } = renderTagged(makeSession({ profile: 'inbox', title: 'Plain' }), { card: true })
+
+    expect(lead(container)).toBeNull()
+    expect(screen.queryByTestId('profile-tag')).not.toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -46,6 +46,7 @@ import {
   SidebarRowLeadGlyph,
   SidebarRowShell
 } from './chrome'
+import { ProfileLead } from './profile-lead'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 import { sessionRowDetails } from './session-row-details'
 import { resolveSessionRowClick } from './session-row-gesture'
@@ -69,9 +70,12 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
-  /** Tag the row with its owning profile (initial chip + tooltip). Used by
-   *  flat cross-profile lists — Pinned and search results in the All-profiles
-   *  view — where no group header communicates ownership (#66003). */
+  /** Tag the row with its owning profile. The one-line row leads its title
+   *  with the profile's name (`inbox ›`), grey at rest and the profile's
+   *  colour while hovered or selected; the card keeps the initial chip in its
+   *  header cluster. Set by every list in the All-profiles view — recents,
+   *  Pinned and search results — where no group header communicates
+   *  ownership (#66003). Default-profile rows carry no mark either way. */
   showProfile?: boolean
   /** Inbox-style card: workspace header, title + last-message preview, and a
    *  model · size footer. The flat recents list opts in via the filter menu;
@@ -170,6 +174,11 @@ function SidebarSessionRowImpl({
   // every row that says "the normal one" is noise. Named profiles only.
   const hasProfileTag = normalizeProfileKey(session.profile) !== 'default'
   const pinnedProfile = hasProfileTag && rowMeta.includes('profile')
+  // In a list that mixes profiles the one-line row names its owner in the
+  // title itself (ProfileLead) rather than parking a chip in the trailing
+  // slot, where the ages' differing widths leave a ragged column. The card
+  // keeps the chip: its header cluster is a straight column of its own.
+  const leadsWithProfile = showProfile && hasProfileTag && !card
   // The branch's PR, if the row was asked to show one. A selector, not a plain
   // useStore: a repo's PRs land as a single map write, and only the rows on
   // those branches should repaint.
@@ -200,7 +209,7 @@ function SidebarSessionRowImpl({
   // to the left of the kebab's own column: never flush right, never swapping.
   const trailing: { key: string; node: React.ReactNode }[] = []
 
-  if ((showProfile || pinnedProfile) && hasProfileTag) {
+  if ((showProfile || pinnedProfile) && hasProfileTag && !leadsWithProfile) {
     trailing.push({ key: 'profile', node: <ProfileTag profile={session.profile} /> })
   }
 
@@ -499,7 +508,10 @@ function SidebarSessionRowImpl({
                         onPointerEnter={armMarquee}
                         onPointerLeave={disarmMarquee}
                       >
-                        <span className="hover-marquee-inner">{title}</span>
+                        <span className="hover-marquee-inner">
+                          {leadsWithProfile && <ProfileLead profile={session.profile} selected={isSelected} />}
+                          {title}
+                        </span>
                       </SidebarRowLabel>
                     </OverflowTip>
                     {/* Session-list density (#68119): comfortable adds one

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -174,6 +174,14 @@ that live on one gateway.
   returns to its default profile and the layers pill shows **All profiles on
   this gateway**. **Cmd/Ctrl+1–9** continue to switch profiles within the
   active gateway.
+- In **All profiles on this gateway** every chat in the sidebar leads with
+  the profile it belongs to — `inbox › Draft the release notes` — so the
+  merged list still says who made what. The name sits in the same grey as
+  the row's age until you hover or select the row, when it takes that
+  profile's colour (the colour of its rail square). Chats on the default
+  profile carry no mark, and the name steps aside when the list is grouped
+  by profile or narrowed to a single profile from the filter menu, where a
+  header already says so.
 - With several gateways the profile rail is a **fleet rail**: every registered
   gateway's profiles sit on the one strip, each group headed by that gateway's
   kind glyph (device, network, terminal, cloud) — the same glyph the gateway


### PR DESCRIPTION
## What does this PR do?

Follow-up to #95591 (fleet profile rail). With that in, the Sessions sidebar's layers pill shows **All profiles on this gateway**: every profile's chats on the active gateway, merged into one list. That list never said *whose* chat a row was. Only Pinned and search results carried the owner chip (#66003); the recents list — the one you actually read — had nothing, so seven chats from four profiles looked like seven chats from one.

This PR makes every row in the merged list name its owner, quietly:

- **One-line rows lead their title with the profile's name** — `inbox › Draft the release notes`. The name sits in the same grey as the row's age. Hover or select the row and it takes the profile's colour — the colour of that profile's square on the rail — so the mark points at the rail exactly when you engage with a row and stays out of the way while you scan. Selected also gets a little weight, so the colour survives the pointer leaving.
- **Text, not a swatch.** It reads without colour, and it lives in the title line right after the status dot, so every lead lines up whatever the ages on the right are doing. (The existing trailing chip can't line up — `8m` and `10h` are different widths — which is why it never went on the recents list.) Names elide past 14 characters so a long profile name can't take the title's room.
- **Default-profile rows carry no mark**, per the existing rule that a chip on every row saying "the normal one" is noise.
- **Cards keep the initial chip** in their header cluster — that column is straight on its own.
- **The lead steps aside where a header already says who**: Grouping → Profile, and a filter narrowed to exactly one profile.
- **User-picked profile colours carry over** (rail right-click → Color): same `resolveProfileColor` the rail and chip use.
- **Outside the All-profiles view nothing changes.** Single-profile scope renders byte-identically — the prop path is the existing `showProfile`, which the recents list now sets alongside Pinned and search.

## Related Issue

No issue filed. Builds on #95591 (All profiles on this gateway) and extends the #66003 decision (owner mark on flat cross-profile lists) to the recents list.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

- `apps/desktop/src/app/chat/sidebar/profile-lead.tsx` (new) — `ProfileLead`: the `name ›` lead, grey at rest, `--profile-lead-color` on hover / selected; `profileLeadLabel` elision.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — one-line rows in a mixed-profile list render the lead inside the title line instead of the trailing chip; cards unchanged; `showProfile` doc updated.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — the recents section passes `showProfileTags` in the All-profiles view, except when grouped by profile or narrowed to one profile.
- `website/docs/user-guide/multi-connection-desktop.md` — describes the mark under *Switching and scoping*.
- Tests: `profile-lead.test.tsx` (new), `session-row.test.tsx` (+5: lead vs chip, default unmarked, off outside mixed lists, card keeps chip, selected weight), `e2e/all-profiles-owner-lead.spec.ts` (new).

## How to Test

1. `cd apps/desktop && npm run test:ui` — full UI suite passes (6006 tests across 612 files), including the new unit tests.
2. `npm run typecheck && npm run lint` — clean (0 errors).
3. E2E: `npm run build && npx playwright test e2e/all-profiles-owner-lead.spec.ts --reporter=list`. Boots Desktop on the local backend with mock inference, seeds three named profiles beside default with real sessions, switches the sidebar to *Show all profiles*, and asserts: a lead on every named-profile row and none on default rows (`inbox › …` ahead of the title), the lead's colour changes on hover, and selecting the row keeps the colour after the pointer leaves. Needs the repo `.venv`. `OWNER_LEAD_SCREENSHOT_DIR=<dir>` saves the sidebar at each state (that's where the screenshots below come from — fictional profiles and chats in a sandbox).
4. Manually: with two or more profiles, click the layers pill at the sidebar foot; hover and click rows; `≡` → Grouping → Profile (leads step aside for the headers); `≡` → tick one profile (leads step aside again); switch back to one profile (nothing rendered).

Tested on Arch Linux (Hyprland), Electron 40, Node 26, Python 3.11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, desktop renderer only (`npm run test:ui` instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Hyprland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only CSS/markup, no platform code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

All-profiles view, before and after (e2e sandbox — the profiles and chats are made up):

![All-profiles sidebar: before, after at rest, hovering a row, row selected](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/all-profiles-owner-lead/owner-lead-before-after.png)

Left to right: before (no owner shown); after, at rest (grey `name ›` on every named-profile row, default rows bare); hovering the `ops` row (name takes the profile's colour — the same green as its rail square, alongside the row's usual hover chrome); the `ops` row selected (colour stays, with a little weight).
