### PR TITLE
fix(state): NULL-tolerant archived/hidden filters in session listing paths

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9969,11 +9969,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
         if archived_only:
-            where_clauses.append("s.archived = 1")
+            where_clauses.append("COALESCE(s.archived, 0) = 1")
         elif not include_archived:
-            where_clauses.append("s.archived = 0")
+            where_clauses.append("COALESCE(s.archived, 0) = 0")
         if not include_hidden:
-            where_clauses.append("s.hidden = 0")
+            where_clauses.append("COALESCE(s.hidden, 0) = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         # Snapshot the filter params before the query builders below extend
@@ -12705,9 +12705,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
         if archived_only:
-            where_clauses.append("s.archived = 1")
+            where_clauses.append("COALESCE(s.archived, 0) = 1")
         elif not include_archived:
-            where_clauses.append("s.archived = 0")
+            where_clauses.append("COALESCE(s.archived, 0) = 0")
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
@@ -12758,9 +12758,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(_LISTABLE_CHILD_SQL)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
         if archived_only:
-            where_clauses.append("s.archived = 1")
+            where_clauses.append("COALESCE(s.archived, 0) = 1")
         elif not include_archived:
-            where_clauses.append("s.archived = 0")
+            where_clauses.append("COALESCE(s.archived, 0) = 0")
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
@@ -13363,9 +13363,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("COALESCE(s.tool_call_count, 0) <= ?")
             params.append(max_tool_calls)
         if archived is True:
-            clauses.append("s.archived = 1")
+            clauses.append("COALESCE(s.archived, 0) = 1")
         elif archived is False:
-            clauses.append("s.archived = 0")
+            clauses.append("COALESCE(s.archived, 0) = 0")
         # Pinned sessions are a durable "keep" flag (exempt from the stale
         # auto-archive sweep). Bulk prune/delete/archive must honor that too:
         # exclude pinned rows unless the caller explicitly opts in. Without
@@ -13527,7 +13527,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             rows = self._conn.execute(
                 f"""
                 SELECT s.id FROM sessions s
-                WHERE s.archived = 0
+                WHERE COALESCE(s.archived, 0) = 0
                   AND COALESCE(s.end_reason, '') <> 'compression'
                   {pin_clause}
                   AND {_sql_session_last_active("s")} < ?

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5350,3 +5350,54 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+class TestNullFlagTolerance:
+    """Sessions whose archived/hidden columns are NULL behave as
+    not-archived / not-hidden in every listing and filter path.
+
+    Fresh schemas enforce NOT NULL DEFAULT 0 on these columns, but a
+    corruption-repair rebuild (state.db recovery) recreates tables from
+    captured DDL and can lose the constraints — observed Aug 2026, where
+    post-repair sessions had NULL flags and vanished from the sidebar.
+    Equality predicates (archived = 0) exclude NULL rows, so repaired
+    schemas must treat NULL exactly like 0.
+    """
+
+    def _mk_repaired_schema(self, db):
+        """Simulate the constraint-losing table rebuild of a repair.
+
+        Regex out the NOT NULL DEFAULT clauses on archived/hidden from
+        the live DDL, then swap the table (SQLite cannot drop constraints
+        in place). Keeps PK/UNIQUE so the normal insert paths still work.
+        """
+        import re
+        ddl = db._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
+        ).fetchone()[0]
+        ddl = re.sub(r"archived\s+INTEGER[^,]*", "archived INTEGER", ddl)
+        ddl = re.sub(r"hidden\s+INTEGER[^,]*", "hidden INTEGER", ddl)
+        db._conn.execute("ALTER TABLE sessions RENAME TO sessions_damaged")
+        db._conn.execute(ddl)
+        db._conn.execute("DROP TABLE sessions_damaged")
+        db._conn.commit()
+
+    def _mk_null_flags(self, db, sid="null-flags"):
+        self._mk_repaired_schema(db)
+        db.create_session(session_id=sid, source="cli")
+        db.end_session(sid, "completed")
+        db._conn.execute(
+            "UPDATE sessions SET archived = NULL, hidden = NULL WHERE id = ?",
+            (sid,),
+        )
+        db._conn.commit()
+
+    def test_null_archived_session_appears_in_default_listing(self, db):
+        self._mk_null_flags(db)
+        ids = [row["id"] for row in db.list_sessions_rich()]
+        assert "null-flags" in ids
+
+    def test_null_archived_session_is_not_treated_as_archived(self, db):
+        self._mk_null_flags(db)
+        assert "null-flags" not in [row["id"] for row in db.list_sessions_rich(archived_only=True)]
+        assert "null-flags" in [row["id"] for row in db.list_sessions_rich(archived_only=False)]


### PR DESCRIPTION
## Summary
Sessions whose `archived` / `hidden` columns are NULL (schema damage from a corruption-repair rebuild that lost the NOT NULL DEFAULT 0 constraints) silently vanish from listings, counts, and prune filters: equality predicates like `s.archived = 0` exclude NULL rows, so the sidebar looks empty and sessions become unreachable.

One site (`list_never_active_keyed_sessions`) already guards with `COALESCE(s.archived, 0)`; this extends the same tolerance to the whole bug class:
- `list_sessions_rich` (archived_only / include_archived / include_hidden)
- `session_count`, `session_count_by_source`
- `_prune_filter_where` (tri-state archived filter)
- `archive_stale_sessions`

## Test Plan
New `TestNullFlagTolerance` suite simulates the constraint-losing rebuild (regex out NOT NULL DEFAULT from live DDL, swap table), then asserts NULL-flag sessions appear in default listings and are excluded from archived-only listings.

`tests/test_hermes_state.py`: 246 passed. (One unrelated pre-existing failure: `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails identically on clean main under Windows, so it was not touched.)