### PR TITLE
fix(google-chat): cron deliveries must not consume interactive typing card

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2091,7 +2091,17 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error="empty message")
 
             last_result: Optional[SendResult] = None
-            typing_msg_name = self._typing_messages.pop(chat_id, None)
+            # Cron deliveries (metadata.job_id) must NOT consume the chat's
+            # typing card: that card belongs to whatever interactive turn is
+            # processing in this DM. Consuming it would land cron content in
+            # the interactive turn's thread AND leave that turn with no card
+            # to patch, stranding its reply at top-level. Observed Aug 21,
+            # 2026: the Morning Briefing patched an active turn's card and
+            # its output landed inside the user's conversation thread.
+            if metadata and metadata.get("job_id"):
+                typing_msg_name = None
+            else:
+                typing_msg_name = self._typing_messages.pop(chat_id, None)
             # Treat any earlier sentinel as "no real card to patch" — defensive.
             if typing_msg_name == _TYPING_CONSUMED_SENTINEL:
                 typing_msg_name = None

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -743,6 +743,36 @@ class TestSend:
 
 
     @pytest.mark.asyncio
+    async def test_cron_delivery_does_not_consume_interactive_typing_card(self, adapter):
+        """Cron deliveries (metadata.job_id) must not steal the typing card
+        that belongs to the interactive turn processing in this DM.
+
+        Consuming it would patch cron content into the interactive turn's
+        thread and leave that turn with no card to patch, stranding its
+        reply at top-level. _resolve_thread_id already routes cron output
+        to a fresh top-level thread; this closes the remaining hole in
+        send(). Regression for Aug 21, 2026: the Morning Briefing patched
+        an active turn's card and its output landed inside the user's
+        conversation thread.
+        """
+        adapter._typing_messages["spaces/S"] = "spaces/S/messages/THINK"
+        adapter._patch_message = AsyncMock()
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True, "message_id": "m/cron",
+                                        "error": None})()
+        )
+        result = await adapter.send(
+            "spaces/S", "cron output",
+            metadata={"job_id": "cron_daily_briefing"},
+        )
+        # The interactive typing card is untouched: no patch, slot intact.
+        adapter._patch_message.assert_not_awaited()
+        adapter._create_message.assert_awaited_once()
+        assert adapter._typing_messages["spaces/S"] == "spaces/S/messages/THINK"
+        assert result.success is True
+
+
+    @pytest.mark.asyncio
     async def test_send_clarify_posts_choice_card(self, adapter):
         adapter._create_message = AsyncMock(
             return_value=type(


### PR DESCRIPTION
## Summary
When a cron delivery and an interactive turn race in the same DM, the cron send consumed the typing card owned by the interactive turn. Two consequences:
1. cron content was patched into the interactive turn thread
2. the interactive turn was left with no card to patch, stranding its reply at top-level

`_resolve_thread_id` already routes cron output (metadata.job_id) to a fresh top-level thread; this closes the remaining hole by skipping the typing-card pop in `send()` for cron deliveries.

Observed Aug 21, 2026: the Morning Briefing patched an active turn card and its output landed inside the user conversation.

## Test Plan
New `test_cron_delivery_does_not_consume_interactive_typing_card`: a cron send (metadata.job_id) must not patch the typing card, and the card slot must stay intact for the interactive turn.

`tests/gateway/test_google_chat.py`: 68 passed.