### PR TITLE
security: make computer_use screenshot persistence opt-in

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -964,12 +964,47 @@ def _cleanup_cache_dir(cache_dir: Path, max_age_hours: int) -> int:
     return removed
 
 
-def cleanup_image_cache(max_age_hours: int = 24) -> int:
+DEFAULT_IMAGE_CACHE_MAX_AGE_HOURS = 24
+
+
+def get_image_cache_max_age_hours() -> int:
+    """
+    Retention period (hours) for the image cache, incl. persisted
+    computer_use screenshots (B-5, security-review.md SS3.10).
+
+    Reads ``security.image_cache_max_age_hours`` from config.yaml.
+    Non-fatal if config is unreadable or the value is missing/unparseable
+    -- falls back to DEFAULT_IMAGE_CACHE_MAX_AGE_HOURS. This turns what
+    used to be an undocumented function-default constant into an
+    explicit, configurable security decision.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly as _load_config
+        cfg = _load_config()  # read-only: .get() only, never mutated
+    except Exception:
+        return DEFAULT_IMAGE_CACHE_MAX_AGE_HOURS
+    sec = cfg.get("security", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(sec, dict) or "image_cache_max_age_hours" not in sec:
+        return DEFAULT_IMAGE_CACHE_MAX_AGE_HOURS
+    try:
+        return int(sec["image_cache_max_age_hours"])
+    except (TypeError, ValueError):
+        return DEFAULT_IMAGE_CACHE_MAX_AGE_HOURS
+
+
+def cleanup_image_cache(max_age_hours: Optional[int] = None) -> int:
     """
     Delete cached images older than *max_age_hours*.
 
+    Defaults to get_image_cache_max_age_hours() (config-driven, see
+    above) rather than a bare constant, so every caller -- the gateway's
+    hourly housekeeping and computer_use's self-triggered sweep alike --
+    honors the same, explicitly documented retention decision.
+
     Returns the number of files removed.
     """
+    if max_age_hours is None:
+        max_age_hours = get_image_cache_max_age_hours()
     return _cleanup_cache_dir(get_image_cache_dir(), max_age_hours)
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2467,6 +2467,14 @@ DEFAULT_CONFIG = {
         # for restricted networks, audited environments, or air-gapped
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
+        # Hours to keep persisted images (including opt-in computer_use
+        # screenshots, see tools/computer_use/tool.py's persist_image
+        # parameter) in the on-disk image cache before they're deleted.
+        # Enforced both by the gateway's hourly housekeeping sweep and by
+        # a sweep triggered on every persisted write, so a CLI-only
+        # session (no gateway thread) still gets time-based expiry, not
+        # just the separate file-count cap.
+        "image_cache_max_age_hours": 24,
     },
 
     "cron": {

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2577,19 +2577,43 @@ class TestCaptureScreenshotPersistence:
     def test_multimodal_capture_exposes_shareable_screenshot(
         self, tmp_path, monkeypatch,
     ):
+        # B-5 (security-review.md SS3.10): persistence is opt-in, so this
+        # test -- which specifically covers the persisted-screenshot path
+        # -- must ask for it explicitly via persist=True.
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         from tools.computer_use import tool as cu_tool
 
         monkeypatch.setattr(
             cu_tool, "_should_route_through_aux_vision", lambda: False,
         )
-        out = cu_tool._capture_response(self._capture())
+        out = cu_tool._capture_response(self._capture(), persist=True)
 
         screenshot_path = out["meta"]["screenshot_path"]
         assert screenshot_path in out["text_summary"]
         assert "MEDIA:" not in out["text_summary"]
         assert screenshot_path.startswith(str(tmp_path / "cache" / "images"))
         assert Path(screenshot_path).read_bytes() == base64.b64decode(self._PNG_B64)
+
+    def test_capture_without_persist_flag_does_not_write_to_disk(
+        self, tmp_path, monkeypatch,
+    ):
+        # B-5 (security-review.md SS3.10): the documented decision is
+        # "flüchtig, keine Persistenz ohne ausdrückliche
+        # Nutzerentscheidung" -- verify the actual default behavior
+        # matches that decision, not just the opt-in path when it's
+        # requested.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setattr(
+            cu_tool, "_should_route_through_aux_vision", lambda: False,
+        )
+        out = cu_tool._capture_response(self._capture())  # persist defaults to False
+
+        assert "screenshot_path" not in out.get("meta", {})
+        cache_dir = tmp_path / "cache" / "images"
+        written = list(cache_dir.glob("computer_use_*.*")) if cache_dir.exists() else []
+        assert written == []
 
     def test_capture_cache_is_bounded(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -368,6 +368,18 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "when you need to verify an action's effect."
                 ),
             },
+            "persist_image": {
+                "type": "boolean",
+                "description": (
+                    "If true, save this capture's image to the on-disk "
+                    "image cache so it can be attached or shared later. "
+                    "Off by default: captures are otherwise used only "
+                    "transiently within this tool response and are not "
+                    "written to disk. Set this only when the user has "
+                    "explicitly asked to keep, attach, or share a "
+                    "screenshot."
+                ),
+            },
         },
         "required": ["action"],
     },

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -696,6 +696,10 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    # B-5 (security-review.md SS3.10): persistence to the on-disk image
+    # cache is opt-in, not automatic -- only when the caller explicitly
+    # asks to keep/attach/share the capture. See _capture_response().
+    persist_image = bool(args.get("persist_image"))
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
@@ -708,7 +712,11 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
                 "window_id": args.get("window_id"),
             })
         cap = backend.capture(**capture_kwargs)
-        return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
+        return _capture_response(
+            cap,
+            max_elements=_coerce_max_elements(args.get("max_elements")),
+            persist=persist_image,
+        )
 
     if action == "wait":
         seconds = float(args.get("seconds", 1.0))
@@ -728,7 +736,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     # cua-driver's typed browser surface is namespaced inside the existing
     # computer_use tool so it cannot collide with native browser/MCP tools.
@@ -868,7 +876,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -886,7 +894,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -899,24 +907,24 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""),
                                 delivery_mode=delivery_mode, bring_to_front=bring_to_front)
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     if action == "key":
         res = backend.key(args.get("keys", ""),
                           delivery_mode=delivery_mode, bring_to_front=bring_to_front)
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, persist_image)
 
     # Do NOT alias unknown actions (we never repair bad model output), but
     # name the nearest real action: live QA showed a model emitting
@@ -1166,7 +1174,9 @@ def _coerce_max_elements(value: Any) -> int:
     return n
 
 
-def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
+def _capture_response(
+    cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS, persist: bool = False,
+) -> Any:
     total_elements = len(cap.elements)
     visible_elements = cap.elements[:max_elements]
     truncated_elements = max(0, total_elements - len(visible_elements))
@@ -1195,9 +1205,15 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             or image_dimensions[1] < _MIN_PROVIDER_IMAGE_DIMENSION
         )
     )
+    # B-5 (security-review.md SS3.10): only write the capture to the
+    # on-disk image cache when the caller explicitly opted in via
+    # persist_image=True. Screenshots can contain password managers,
+    # mail, and other D2/D3-class content -- default is transient,
+    # in-context-only, matching the documented "no persistence without
+    # explicit user action" decision.
     screenshot_path = (
         _persist_capture_image(cap)
-        if cap.png_b64 and cap.mode != "ax" and not image_too_small
+        if persist and cap.png_b64 and cap.mode != "ax" and not image_too_small
         else None
     )
 
@@ -1580,6 +1596,7 @@ def _route_capture_through_aux_vision(
 
 def _maybe_follow_capture(
     backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    persist_image: bool = False,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
@@ -1604,7 +1621,7 @@ def _maybe_follow_capture(
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)
     # Combine action summary with the capture.
-    resp = _capture_response(cap)
+    resp = _capture_response(cap, persist=persist_image)
     if isinstance(resp, dict) and resp.get("_multimodal"):
         # Keep the complete evidence/verdict contract visible when an image is
         # attached; otherwise capture_after would accidentally discard the
@@ -1673,10 +1690,19 @@ _MAX_CAPTURE_FILES = 20
 def _persist_capture_image(cap: CaptureResult) -> Optional[str]:
     """Save a capture in Hermes' media cache and return its absolute path.
 
-    Captures are normally embedded only in the model's tool context. Persisting
-    a bounded copy gives attachment-capable surfaces a real file to deliver
-    when the user explicitly asks for the screenshot. This is best-effort: an
-    unwritable cache must never break computer control.
+    Called only when the caller opted in via ``persist_image=True`` (see
+    ``_capture_response`` / B-5, security-review.md SS3.10) -- captures are
+    otherwise embedded only in the model's tool context and never touch
+    disk. Persisting a bounded copy gives attachment-capable surfaces a
+    real file to deliver when the user explicitly asked for the
+    screenshot. This is best-effort: an unwritable cache must never break
+    computer control.
+
+    Retention is bounded two ways: a file-count cap (below, always
+    active) and a time-based sweep triggered right here on every write --
+    not just via the gateway's hourly housekeeping thread, which a
+    CLI-only session may never start (see cleanup_image_cache in
+    gateway.platforms.base).
     """
     if not cap.png_b64:
         return None
@@ -1706,6 +1732,17 @@ def _persist_capture_image(cap: CaptureResult) -> Optional[str]:
 
         path = cache_dir / f"computer_use_{_uuid.uuid4().hex}{ext}"
         path.write_bytes(raw)
+
+        # Self-triggered time-based sweep so retention doesn't depend on
+        # the gateway housekeeping thread being alive. Best-effort: a
+        # sweep failure must never fail the capture itself.
+        try:
+            from gateway.platforms.base import cleanup_image_cache
+
+            cleanup_image_cache()
+        except Exception:
+            pass
+
         return str(path)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("computer_use: screenshot persistence failed: %s", exc)


### PR DESCRIPTION
## Summary

`_capture_response()` in `tools/computer_use/tool.py` unconditionally calls `_persist_capture_image()` for every screen-mode capture — including automatic `capture_after` follow-ups the caller didn't explicitly request a saved screenshot for. Screenshots can contain password managers, mail clients, and other sensitive on-screen content, so writing every capture to disk by default is a meaningful data-retention surface with no opt-out.

This PR makes persistence opt-in instead of automatic, and tightens retention for the case where it is used.

## Changes

- New `persist_image` boolean parameter on the `computer_use` tool schema. Defaults to unset/`false` — captures are used only transiently within the tool response unless the caller explicitly asks to keep/attach/share one.
- `_capture_response()` gains a `persist: bool = False` parameter that gates the `_persist_capture_image()` call. Threaded through both call paths: the direct `capture` action (reads `persist_image` from the tool call args) and `_maybe_follow_capture()`'s `capture_after` follow-up path (now takes a `persist_image` parameter, passed from all 7 call sites).
- `_persist_capture_image()` now triggers an immediate `cleanup_image_cache()` sweep on every write, so retention doesn't depend solely on the gateway's hourly housekeeping thread — a CLI-only session that never starts the gateway previously had no time-based expiry at all, only the existing file-count cap.
- `cleanup_image_cache()`'s previously-hardcoded `max_age_hours=24` default is now sourced from `security.image_cache_max_age_hours` in `config.yaml` via a new `get_image_cache_max_age_hours()` helper (same read-only config-load pattern as the existing `get_max_inbound_media_bytes()`), still defaulting to 24 when unset. Documented in `config_defaults.py`.

## Testing

- Updated `test_multimodal_capture_exposes_shareable_screenshot` to pass `persist=True` explicitly, since it specifically covers the persisted-screenshot path.
- Added `test_capture_without_persist_flag_does_not_write_to_disk` to lock in the new default behavior.
- Full relevant suite (`test_computer_use.py`, `test_computer_use_capture_routing.py`, `test_media_cache.py`): 144 passed. Two pre-existing failures unrelated to this change (window-selection logic, CLI-fallback JSON parsing) are present on `main` as well — verified via a stash-and-rerun check against the unpatched tree.
- `ruff check` clean on all changed files.
- Manually smoke-tested end to end with an isolated `HERMES_HOME`: `persist=False` writes nothing and omits `screenshot_path` from the response; `persist=True` writes exactly one file and includes it.

## Backwards compatibility

Any caller/integration currently relying on screenshots being persisted automatically (e.g. reading `screenshot_path` from a `capture_after` response without passing `persist_image`) will need to start passing `persist_image=true` explicitly to keep that behavior. This is an intentional, security-motivated behavior change, not an oversight.