### PR TITLE
fix(install): put managed Node behind shims, stop registering it on PATH

### DIFF
--- a/scripts/ci/test_install_ps1_path_migration.ps1
+++ b/scripts/ci/test_install_ps1_path_migration.ps1
@@ -1,61 +1,95 @@
-# Behavioral test for install.ps1's persisted-User-PATH migration.
+# Behavioral test for install.ps1's persisted-User-PATH handling of the
+# managed Node directory.
 #
 # Run:  pwsh -NoProfile -File scripts/ci/test_install_ps1_path_migration.ps1
 #
-# Not wired into the default CI lane — the Linux runners have no PowerShell
+# Not wired into the default CI lane -- the Linux runners have no PowerShell
 # host. It runs on any machine with pwsh (including via nixpkgs#powershell),
 # and on a Windows runner if one is ever added.
 #
-# This is NOT a source-regex test. It parses install.ps1, lifts the real
-# Set-ManagedNodeFirstOnUserPath body out of the AST, and rewrites *only* the
-# two registry calls into an in-memory store so the actual shipped logic —
-# split, dedupe, prepend, change-detection — executes for real. Rewriting from
-# the AST rather than hand-copying the body means the test cannot silently
-# drift away from the function it claims to cover.
+# This is NOT a source-regex test. Like its predecessor (which covered
+# Set-ManagedNodeFirstOnUserPath), it parses install.ps1, lifts real function
+# bodies out of the AST, and rewrites *only* the registry calls into an
+# in-memory store so the actual shipped logic -- split, filter, join,
+# change-detection -- executes for real. Rewriting from the AST rather than
+# hand-copying the bodies means the tests cannot silently drift away from the
+# functions they claim to cover.  Install-ManagedNodeShims defers registry
+# access to Add-DirToUserPathIfMissing, so it is lifted verbatim (0 direct
+# reads/writes) and exercises its real guards + real .cmd file writes.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $installPs1 = Join-Path $PSScriptRoot '..' 'install.ps1' | Resolve-Path
-$ast = [System.Management.Automation.Language.Parser]::ParseFile(
-    $installPs1, [ref]$null, [ref]$null)
 
-$fn = $ast.Find({
-    param($n)
-    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-    $n.Name -eq 'Set-ManagedNodeFirstOnUserPath'
-}, $true)
-
-if (-not $fn) {
-    throw "Set-ManagedNodeFirstOnUserPath not found in $installPs1"
+function Find-InstallFunction {
+    param([string]$Name)
+    $parsed = [System.Management.Automation.Language.Parser]::ParseFile(
+        $installPs1, [ref]$null, [ref]$null)
+    return $parsed.Find({
+        param($n)
+        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $n.Name -eq $Name
+    }, $true)
 }
 
-# Swap the two registry calls for the in-memory store. Both must match, or the
-# function has changed shape and this harness is no longer exercising it.
-# Rewrite the whole definition extent (which already carries `function <name>
-# { param(...) ... }`) so the shipped param block and body run verbatim.
-$definition = $fn.Extent.Text
-$reads = ([regex]'\[Environment\]::GetEnvironmentVariable\("Path", "User"\)').Matches($definition).Count
-$writes = ([regex]'\[Environment\]::SetEnvironmentVariable\("Path", ([^,]+), "User"\)').Matches($definition).Count
-if ($reads -ne 1 -or $writes -ne 1) {
-    throw "expected exactly one User PATH read and one write in the function body; found $reads read(s), $writes write(s). Update this harness."
+function Get-RewrittenDefinition {
+    # Lift the function definition and swap its User-PATH registry calls for
+    # the in-memory store. Both call shapes must match the expected counts, or
+    # the function has changed shape and this harness is no longer exercising
+    # it. Install-ManagedNodeShims has no direct registry access (it delegates
+    # to Add-DirToUserPathIfMissing), so it is lifted with 0/0 -- a future
+    # inline registry call then fails the count and forces a harness update.
+    param([string]$Name, [int]$ExpectedReads = 1, [int]$ExpectedWrites = 1)
+    $fn = Find-InstallFunction -Name $Name
+    if (-not $fn) {
+        throw "$Name not found in $installPs1"
+    }
+    $definition = $fn.Extent.Text
+    $reads  = ([regex]'\[Environment\]::GetEnvironmentVariable\("Path", "User"\)').Matches($definition).Count
+    $writes = ([regex]'\[Environment\]::SetEnvironmentVariable\("Path", ([^,]+), "User"\)').Matches($definition).Count
+    if ($reads -ne $ExpectedReads -or $writes -ne $ExpectedWrites) {
+        throw "expected $ExpectedReads read(s) and $ExpectedWrites write(s) in ${Name}; found $reads read(s), $writes write(s). Update this harness."
+    }
+    $definition = $definition -replace `
+        '\[Environment\]::GetEnvironmentVariable\("Path", "User"\)', '$script:FakeUserPath'
+    $definition = $definition -replace `
+        '\[Environment\]::SetEnvironmentVariable\("Path", ([^,]+), "User"\)', '$script:FakeUserPath = $1; $script:FakeWrites++'
+    return $definition
 }
 
-$definition = $definition -replace `
-    '\[Environment\]::GetEnvironmentVariable\("Path", "User"\)', '$script:FakeUserPath'
-$definition = $definition -replace `
-    '\[Environment\]::SetEnvironmentVariable\("Path", ([^,]+), "User"\)', '$script:FakeUserPath = $1; $script:FakeWrites++'
+Invoke-Expression (Get-RewrittenDefinition -Name 'Remove-ManagedNodeFromUserPath')
+Invoke-Expression (Get-RewrittenDefinition -Name 'Add-DirToUserPathIfMissing')
+Invoke-Expression (Get-RewrittenDefinition -Name 'Install-ManagedNodeShims' -ExpectedReads 0 -ExpectedWrites 0)
 
-Invoke-Expression $definition
+# Install-ManagedNodeShims calls install.ps1's write helpers on failure paths
+# and writes real .cmd files -- stub the helpers and point it at temp dirs so
+# the shipped logic (guards, shim content, delegation) runs for real.
+function Write-Info    { Write-Host "[info]  $args" }
+function Write-Success { Write-Host "[ok]    $args" }
+function Write-Warn    { Write-Host "[warn]  $args" }
+
+$script:FakeTree = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-node-shim-tree-" + [guid]::NewGuid().ToString("N"))
+$script:FakeBin  = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-node-shim-bin-"  + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $script:FakeTree | Out-Null
+New-Item -ItemType Directory -Force -Path $script:FakeBin  | Out-Null
 
 $NODE = 'C:\Users\me\AppData\Local\hermes\node'
+$BIN  = 'C:\Users\me\AppData\Local\hermes\bin'
 $script:Failures = 0
 
 function Invoke-Migration {
     param([string]$Start, [string]$NodeDir = $NODE)
     $script:FakeUserPath = $Start
     $script:FakeWrites = 0
-    Set-ManagedNodeFirstOnUserPath $NodeDir
+    Remove-ManagedNodeFromUserPath $NodeDir
+}
+
+function Invoke-AddIfMissing {
+    param([string]$Start, [string]$Dir)
+    $script:FakeUserPath = $Start
+    $script:FakeWrites = 0
+    Add-DirToUserPathIfMissing -Dir $Dir
 }
 
 function Assert-Equal {
@@ -70,50 +104,176 @@ function Assert-Equal {
     }
 }
 
-Write-Host "install.ps1 Set-ManagedNodeFirstOnUserPath"
+Write-Host "install.ps1 Remove-ManagedNodeFromUserPath"
 
-# The regression this function exists for: an install made by an older
-# install.ps1, which *appended*. A system Node leads and the managed dir is
-# stranded at the tail, so every new shell resolves the wrong node.exe. An
-# add-if-missing check would see the entry present and leave it there forever.
-Invoke-Migration "C:\Program Files\nodejs;C:\Users\me\bin;$NODE"
-Assert-Equal "$NODE;C:\Program Files\nodejs;C:\Users\me\bin" $script:FakeUserPath `
-    'upgrade from appending installer: managed dir becomes first entry'
-Assert-Equal 1 (@($script:FakeUserPath -split ';' | Where-Object { $_ -eq $NODE }).Count) `
-    'upgrade: managed dir is not duplicated'
-Assert-Equal "C:\Program Files\nodejs;C:\Users\me\bin" `
-    (($script:FakeUserPath -split ';' | Where-Object { $_ -ne $NODE }) -join ';') `
-    'upgrade: unrelated entries keep their relative order'
-Assert-Equal 1 $script:FakeWrites 'upgrade: persists exactly once'
+# The migration this function exists for: an install made by an installer
+# that registered the managed Node dir itself in User PATH (and moved it to
+# the front). Removing the entry restores the user's own node/npm selection;
+# unrelated entries must survive untouched.
+Invoke-Migration "$NODE;C:\Program Files\nodejs;C:\Users\me\bin"
+Assert-Equal "C:\Program Files\nodejs;C:\Users\me\bin" $script:FakeUserPath `
+    'upgrade from PATH-registration installer: managed dir removed'
 
-Invoke-Migration "$NODE;C:\Program Files\nodejs"
-Assert-Equal "$NODE;C:\Program Files\nodejs" $script:FakeUserPath 'already correct: unchanged'
-Assert-Equal 0 $script:FakeWrites 'already correct: no registry write'
+Invoke-Migration "C:\Program Files\nodejs;$NODE;C:\Users\me\bin"
+Assert-Equal "C:\Program Files\nodejs;C:\Users\me\bin" $script:FakeUserPath `
+    'entry at tail position is also removed'
 
 Invoke-Migration "C:\Program Files\nodejs"
-Assert-Equal "$NODE;C:\Program Files\nodejs" $script:FakeUserPath 'fresh install: prepended'
+Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath `
+    'clean User PATH: unchanged'
+Assert-Equal 0 $script:FakeWrites 'clean User PATH: no registry write'
 
 # Empty segments are legal in a real User PATH (a trailing ';' is common) and
 # the installer's other PATH code preserves them. Migration must not quietly
 # rewrite parts of PATH it was not asked to touch.
 Invoke-Migration "C:\Program Files\nodejs;;C:\Users\me\bin;"
-Assert-Equal "$NODE;C:\Program Files\nodejs;;C:\Users\me\bin;" $script:FakeUserPath `
-    'empty segments are preserved'
+Assert-Equal "C:\Program Files\nodejs;;C:\Users\me\bin;" $script:FakeUserPath `
+    'empty segments are preserved when the entry is absent'
+Invoke-Migration "$NODE;;C:\Users\me\bin;"
+Assert-Equal ";C:\Users\me\bin;" $script:FakeUserPath `
+    'removal drops only the entry itself, keeping empty segments around it'
 
 # Windows paths are case-insensitive, and -ne on strings is too.
-Invoke-Migration "C:\Program Files\nodejs;c:\users\me\appdata\local\HERMES\Node"
-Assert-Equal "$NODE;C:\Program Files\nodejs" $script:FakeUserPath `
-    'existing entry in different case is replaced, not duplicated'
+Invoke-Migration "c:\users\me\appdata\local\HERMES\Node;C:\Program Files\nodejs"
+Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath `
+    'existing entry in different case is removed, not partially matched'
 
+# Users edit User PATH in the GUI, where a trailing backslash is common; the
+# legacy writer never emitted one, but a hand-edited variant must still go.
+Invoke-Migration "$NODE\;C:\Program Files\nodejs"
+Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath `
+    'trailing-backslash variant of the managed dir is also removed'
+
+# Duplicate occurrences (older installers could accumulate them) all go.
 Invoke-Migration "$NODE;C:\Program Files\nodejs;$NODE"
-Assert-Equal "$NODE;C:\Program Files\nodejs" $script:FakeUserPath 'duplicates collapse'
+Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath 'duplicates collapse away'
 
-Invoke-Migration ""
-Assert-Equal $NODE $script:FakeUserPath 'empty User PATH'
+# Exactly one write on a run that changes anything.
+Invoke-Migration "$NODE"
+Assert-Equal "" $script:FakeUserPath 'sole entry removal empties PATH'
+Assert-Equal 1 $script:FakeWrites 'migration persists exactly once'
 
 Invoke-Migration "C:\Program Files\nodejs" ""
 Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath 'empty NodeDir is a no-op'
 Assert-Equal 0 $script:FakeWrites 'empty NodeDir does not write'
+
+Write-Host ""
+Write-Host "install.ps1 Add-DirToUserPathIfMissing (shim dir registration)"
+
+# Fresh install: bin dir not yet on PATH -> prepended, exactly one write.
+Invoke-AddIfMissing -Start "C:\Program Files\nodejs" -Dir $BIN
+Assert-Equal "$BIN;C:\Program Files\nodejs" $script:FakeUserPath `
+    'fresh: shim dir prepended'
+Assert-Equal 1 $script:FakeWrites 'fresh: persists exactly once'
+
+# Already present (the normal install/update case): no write at all.
+Invoke-AddIfMissing -Start "$BIN;C:\Program Files\nodejs" -Dir $BIN
+Assert-Equal "$BIN;C:\Program Files\nodejs" $script:FakeUserPath `
+    'already present: unchanged'
+Assert-Equal 0 $script:FakeWrites 'already present: no registry write'
+
+# Present with a trailing backslash or different case still counts as present.
+Invoke-AddIfMissing -Start "c:\users\me\appdata\local\hermes\bin\;C:\Program Files\nodejs" -Dir $BIN
+Assert-Equal "c:\users\me\appdata\local\hermes\bin\;C:\Program Files\nodejs" $script:FakeUserPath `
+    'trailing-backslash / case variant counts as present (no duplicate)'
+Assert-Equal 0 $script:FakeWrites 'variant match: no registry write'
+
+# Unrelated entries and empty segments are never touched.
+Invoke-AddIfMissing -Start "C:\Program Files\nodejs;;C:\Users\me\bin;" -Dir $BIN
+Assert-Equal "$BIN;C:\Program Files\nodejs;;C:\Users\me\bin;" $script:FakeUserPath `
+    'empty segments preserved when prepending'
+
+# Empty Dir is a guard-clause no-op.
+Invoke-AddIfMissing -Start "C:\Program Files\nodejs" -Dir ""
+Assert-Equal "C:\Program Files\nodejs" $script:FakeUserPath 'empty Dir is a no-op'
+Assert-Equal 0 $script:FakeWrites 'empty Dir does not write'
+
+# Empty/unset User PATH: prepend the dir with no trailing empty segment.
+Invoke-AddIfMissing -Start "" -Dir $BIN
+Assert-Equal "$BIN" $script:FakeUserPath 'empty User PATH: no trailing empty segment'
+Assert-Equal 1 $script:FakeWrites 'empty User PATH: persists exactly once'
+
+Write-Host ""
+Write-Host "install.ps1 Install-ManagedNodeShims (node/npm/npx delegators)"
+
+function Invoke-Shims {
+    param([string]$TreeDir, [string]$Destination = $script:FakeBin)
+    Install-ManagedNodeShims -NodeDir $TreeDir -Destination $Destination
+}
+
+function Reset-ShimEnv {
+    # Fresh User-PATH state, no skip-links flag, no stale shims.
+    $script:FakeUserPath = ""
+    $script:FakeWrites = 0
+    $script:NoVenv = $false
+    Remove-Item Env:HERMES_NODE_SKIP_LINKS -ErrorAction SilentlyContinue
+    Remove-Item (Join-Path $script:FakeBin "node.cmd"), `
+                (Join-Path $script:FakeBin "npm.cmd"), `
+                (Join-Path $script:FakeBin "npx.cmd") -ErrorAction SilentlyContinue
+}
+
+# --- managed tree present: three shims written, bin dir registered once ---
+Reset-ShimEnv
+New-Item -ItemType File -Force -Path (Join-Path $script:FakeTree "node.exe") | Out-Null
+Invoke-Shims -TreeDir $script:FakeTree
+Assert-Equal $true (Test-Path (Join-Path $script:FakeBin "node.cmd")) 'node.cmd written'
+Assert-Equal $true (Test-Path (Join-Path $script:FakeBin "npm.cmd"))  'npm.cmd written'
+Assert-Equal $true (Test-Path (Join-Path $script:FakeBin "npx.cmd"))  'npx.cmd written'
+$nodeRaw = [System.IO.File]::ReadAllText((Join-Path $script:FakeBin "node.cmd")).TrimEnd("`r`n")
+Assert-Equal "@echo off`r`n`"$script:FakeTree\node.exe`" %*" $nodeRaw `
+    'node shim delegates to the managed tree by absolute path'
+$npmRaw = [System.IO.File]::ReadAllText((Join-Path $script:FakeBin "npm.cmd")).TrimEnd("`r`n")
+Assert-Equal $true ($npmRaw.StartsWith("@echo off`r`ncall `"")) 'npm shim uses call to preserve exit codes'
+Assert-Equal $true ($npmRaw.Contains("$script:FakeTree\npm.cmd")) 'npm shim targets the managed npm.cmd'
+Assert-Equal $true ($script:FakeUserPath.StartsWith($script:FakeBin)) 'bin dir registered on User PATH'
+Assert-Equal 1 $script:FakeWrites 'bin dir registered exactly once'
+Remove-Item (Join-Path $script:FakeTree "node.exe") -Force
+
+# --- the regression this guard exists for: no managed tree -> no shims ---
+Reset-ShimEnv
+Invoke-Shims -TreeDir $script:FakeTree
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "node.cmd")) 'absent tree: no node.cmd'
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "npm.cmd"))  'absent tree: no npm.cmd'
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "npx.cmd"))  'absent tree: no npx.cmd'
+Assert-Equal 0 $script:FakeWrites 'absent tree: no registry write'
+Assert-Equal "" $script:FakeUserPath 'absent tree: User PATH untouched'
+
+# --- idempotent re-run refreshes the shims, no second PATH write ---
+New-Item -ItemType File -Force -Path (Join-Path $script:FakeTree "node.exe") | Out-Null
+Reset-ShimEnv
+Invoke-Shims -TreeDir $script:FakeTree
+Invoke-Shims -TreeDir $script:FakeTree
+Assert-Equal $true (Test-Path (Join-Path $script:FakeBin "node.cmd")) 're-run: shims still present'
+Assert-Equal 1 $script:FakeWrites 're-run: bin already registered, no second write'
+Remove-Item (Join-Path $script:FakeTree "node.exe") -Force
+
+# --- empty NodeDir is a guard-clause no-op ---
+Reset-ShimEnv
+Invoke-Shims -TreeDir ""
+Assert-Equal 0 $script:FakeWrites 'empty NodeDir: no registry write'
+
+# --- HERMES_NODE_SKIP_LINKS=1: private-only, and removes prior shims ---
+New-Item -ItemType File -Force -Path (Join-Path $script:FakeTree "node.exe") | Out-Null
+Reset-ShimEnv
+Invoke-Shims -TreeDir $script:FakeTree            # non-private install first
+$env:HERMES_NODE_SKIP_LINKS = "1"
+Invoke-Shims -TreeDir $script:FakeTree            # then the user opts out
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "node.cmd")) 'skip-links: stale node.cmd removed'
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "npm.cmd"))  'skip-links: stale npm.cmd removed'
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "npx.cmd"))  'skip-links: stale npx.cmd removed'
+Assert-Equal 1 $script:FakeWrites 'skip-links: no additional registry write'
+Remove-Item (Join-Path $script:FakeTree "node.exe") -Force
+
+# --- NoVenv: managed tree stays private, checkout stays clean ---
+New-Item -ItemType File -Force -Path (Join-Path $script:FakeTree "node.exe") | Out-Null
+Reset-ShimEnv
+$script:NoVenv = $true
+Invoke-Shims -TreeDir $script:FakeTree
+Assert-Equal $false (Test-Path (Join-Path $script:FakeBin "node.cmd")) 'NoVenv: no shims written'
+Assert-Equal 0 $script:FakeWrites 'NoVenv: no registry write'
+Remove-Item (Join-Path $script:FakeTree "node.exe") -Force
+
+Remove-Item -Recurse -Force $script:FakeTree, $script:FakeBin -ErrorAction SilentlyContinue
 
 if ($script:Failures -gt 0) {
     Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -883,39 +883,160 @@ function Ensure-NodeExeOnPath {
     return $true
 }
 
-# Put the Hermes-managed Node dir at the FRONT of the persisted User PATH.
+# Expose the Hermes-managed node/npm/npx to interactive shells WITHOUT
+# touching PATH.
 #
-# Appending is not enough: it leaves a pre-existing system Node ahead of the
-# bundled one in every new shell, so anything launched without a curated
-# environment (a standalone hermes-setup.exe run, a user typing `npm`) silently
-# resolves the wrong Node.  Bundled must win.
+# Shape parity with the POSIX installer: install.sh symlinks the managed
+# node/npm/npx into ~/.local/bin (a directory already on PATH for other
+# reasons); here the same three command names land as absolute-path .cmd
+# delegators in $HermesHome\bin -- the directory the hermes launcher already
+# lives in and that is already on the persisted User PATH.  One PATH entry,
+# shared by every Hermes-provided command, removable by deleting files --
+# the managed Node tree itself is never registered anywhere.
 #
-# Move-to-front rather than add-if-missing, because installs made by an older
-# install.ps1 already have this dir in User PATH -- at the tail.  An
-# add-if-missing check sees it present and leaves the broken ordering in place
-# forever, so the very users the ordering bug hurt would never be repaired.
+# Absolute paths (not %~dp0-relative): a shim in $HermesHome\bin must keep
+# working even if a future layout moves it, and npm.cmd's internal
+# self-location logic is bypassed entirely by calling the managed tree's
+# shims by full path.  `call` preserves npm/npx exit codes through the
+# batch delegation; plain invocation would not.
 #
-# Unrelated entries keep their relative order, including empty segments (a
-# trailing ';' is legal and common in a real User PATH; Install-Git's splitting
-# preserves them too, so this must not quietly rewrite them).  Duplicate
-# occurrences of the managed dir collapse into the single leading entry.
-# PowerShell's -ne is case-insensitive for strings, which is the right
-# comparison on Windows.  Persists only when the resulting string differs, so
-# an already-correct PATH costs one registry read and no write.
-function Set-ManagedNodeFirstOnUserPath {
+# .cmd rather than .ps1: batch files run regardless of execution policy
+# (see Install-NodeDeps for the same reasoning), and work identically from
+# cmd.exe and PowerShell.
+function Install-ManagedNodeShims {
+    param(
+        [string]$NodeDir,
+        [string]$Destination
+    )
+
+    if (-not $NodeDir) { return }
+
+    # -NoVenv installs keep the managed tree private.  The only PATH entry in
+    # that layout is the checkout root itself, and hosting shims there would
+    # (a) put untracked files inside the git working tree -- swept by `hermes
+    # update`'s autostash (git stash push --include-untracked), the exact bug
+    # class that moved the hermes launchers out of the checkout -- and (b)
+    # shadow the user's own node/npm/npx from a directory they never opted
+    # into.  Internals reach the tree by absolute path; Install-NodeDeps
+    # probes it directly (see its managed-tree fallback).
+    if ($NoVenv) { return }
+
+    if (-not $Destination) {
+        # Same destination rule as Set-PathVariable's $hermesBin.
+        $Destination = "$HermesHome\bin"
+    }
+
+    # HERMES_NODE_SKIP_LINKS=1: keep the Hermes-managed Node tree private.
+    # The user asked for a managed runtime usable by Hermes internals only --
+    # no node/npm/npx shims, no PATH changes -- so a toolchain of their own
+    # (nvm-windows, fnm, a normal Node install) keeps ownership of the
+    # `node`/`npm`/`npx` names in their shells. The tree remains reachable by
+    # absolute path for Hermes-internal use.  Also remove any shims a previous
+    # non-private install left behind, so the flag keeps working when it is
+    # set AFTER the fact -- the very users this escape hatch exists for.
+    if ($env:HERMES_NODE_SKIP_LINKS -eq "1") {
+        Remove-Item (Join-Path $Destination "node.cmd"), `
+                    (Join-Path $Destination "npm.cmd"), `
+                    (Join-Path $Destination "npx.cmd") -ErrorAction SilentlyContinue
+        return
+    }
+
+    # The shims must point at a real tree.  When the user already has a
+    # suitable node of their own, Test-Node never provisions a managed tree
+    # (and Set-PathVariable runs unconditionally) -- writing delegators to a
+    # nonexistent node.exe would shadow the user's toolchain with dead files
+    # in every new shell, which is exactly the class of interference this
+    # change exists to remove.
+    if (-not (Test-Path "$NodeDir\node.exe")) { return }
+
+    try {
+        New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    } catch {
+        Write-Warn "Could not create shim directory ${Destination}: $($_.Exception.Message)"
+        return
+    }
+
+    foreach ($pair in @(
+        @{ Name = "node.cmd"; Target = "$NodeDir\node.exe"; Call = $false },
+        @{ Name = "npm.cmd";  Target = "$NodeDir\npm.cmd";  Call = $true },
+        @{ Name = "npx.cmd";  Target = "$NodeDir\npx.cmd";  Call = $true }
+    )) {
+        $prefix = if ($pair.Call) { "call " } else { "" }
+        $body = "@echo off`r`n$prefix`"$($pair.Target)`" %*"
+        try {
+            Set-Content -Path (Join-Path $Destination $pair.Name) -Value $body -Encoding Ascii
+        } catch {
+            Write-Warn "Could not write $($pair.Name) shim: $($_.Exception.Message)"
+        }
+    }
+
+    # Make sure the shim directory is reachable in FRESH processes.  In the
+    # common case it already is: Set-PathVariable registered $HermesHome\bin
+    # (or a previous install did).  But Test-Node can also run BEFORE
+    # Set-PathVariable -- notably in cross-process stage-driver mode
+    # (Hermes-Setup.exe), where Stage-Node and Stage-Path are separate
+    # powershell.exe processes and a later stage re-reads User PATH from the
+    # registry to find npm (Install-NodeDeps' Get-Command probe).  Registering
+    # the shared bin dir here, if missing, keeps that contract intact without
+    # ever registering the Node tree itself.  Idempotent: no write when the
+    # directory is already present.
+    Add-DirToUserPathIfMissing -Dir $Destination
+}
+
+# Prepend one directory to the persisted User PATH unless already present
+# (case-insensitively, ignoring a trailing separator).  Single-entry helper
+# shared by the shim flow; unrelated entries are never reordered or rewritten,
+# and nothing is persisted when the directory is already there.
+function Add-DirToUserPathIfMissing {
+    param([string]$Dir)
+
+    if (-not $Dir) { return }
+
+    $persisted = [Environment]::GetEnvironmentVariable("Path", "User")
+    $present = @((($persisted -split ";") | Where-Object { $_ }) |
+        Where-Object { $_.TrimEnd('\') -ieq $Dir.TrimEnd('\') })
+    if ($present) { return }
+
+    # No trailing empty segment when the User PATH is empty/unset: "$Dir;"
+    # is legal but dirty, and the migration's split would leave a phantom
+    # entry for every future read.
+    $joined = if ($persisted) { "$Dir;$persisted" } else { "$Dir" }
+    [Environment]::SetEnvironmentVariable("Path", $joined, "User")
+}
+
+# Remove the managed Node dir from the persisted User PATH.
+#
+# Migration for installs made before the shims change: those registered
+# %LOCALAPPDATA%\hermes\node itself as a User PATH entry and moved it to the
+# front, silently overriding the user's own node/npm selection in every new
+# shell (and still losing to Machine-PATH system Nodes, so the override did
+# not even achieve its goal consistently).  With shims exposing the managed
+# toolchain, the raw directory entry is pure interference and comes off.
+#
+# Removal only -- unrelated entries keep their relative order, including
+# empty segments (a trailing ';' is legal and common; Install-Git's splitting
+# preserves them too).  PowerShell's -ne is case-insensitive for strings,
+# which is the right comparison on Windows.  Persists only when something was
+# actually removed, so an already-clean PATH costs one registry read and no
+# write.
+function Remove-ManagedNodeFromUserPath {
     param([string]$NodeDir)
 
     if (-not $NodeDir) { return }
 
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $items = if ($userPath) { @($userPath -split ";") } else { @() }
+    if (-not $userPath) { return }
 
-    $rest = @($items | Where-Object { $_ -ne $NodeDir })
-    $updated = (@($NodeDir) + $rest) -join ";"
+    $items = @($userPath -split ";")
+    # Trim a trailing separator before comparing (the legacy writer never
+    # wrote one, but users edit User PATH in the GUI and trailing backslashes
+    # are common there); -ne is already case-insensitive, which is the right
+    # comparison on Windows.  Non-matching entries are kept verbatim.
+    $nodeDirNorm = $NodeDir.TrimEnd('\')
+    $kept = @($items | Where-Object { $_.TrimEnd('\') -ne $nodeDirNorm })
+    if ($kept.Count -eq $items.Count) { return }
 
-    if ($updated -ne $userPath) {
-        [Environment]::SetEnvironmentVariable("Path", $updated, "User")
-    }
+    [Environment]::SetEnvironmentVariable("Path", ($kept -join ";"), "User")
 }
 
 # The npm range to install into the managed Node tree.  Prefers the checkout's
@@ -1714,7 +1835,7 @@ function Test-Node {
     if ((Test-Path $managedNode) -and (Test-NodeVersionOk (& $managedNode --version))) {
         $version = & $managedNode --version
         $env:Path = "$HermesHome\node;$env:Path"
-        Set-ManagedNodeFirstOnUserPath "$HermesHome\node"
+        Install-ManagedNodeShims -NodeDir "$HermesHome\node"
         Write-Success "Node.js $version found (Hermes-managed)"
         # A tree from an older install still has that Node major's bundled
         # npm, which is below the current engines.npm floor. No-ops when the
@@ -1828,12 +1949,12 @@ function Test-Node {
                 # Session PATH so the rest of this run sees node/npm.
                 $env:Path = "$HermesHome\node;$env:Path"
 
-                # Persist to User PATH so fresh shells (and future stages
-                # in cross-process driver mode) see it.  Matches the
-                # pattern Install-Git uses for PortableGit.  See
-                # Set-ManagedNodeFirstOnUserPath for why this is a
-                # move-to-front and not an add-if-missing.
-                Set-ManagedNodeFirstOnUserPath "$HermesHome\node"
+                # Expose node/npm/npx to fresh shells via shims in the
+                # already-registered $HermesHome\bin -- no new PATH entry,
+                # no registry write.  See Install-ManagedNodeShims for why
+                # this replaces the old move-the-directory-itself-to-front
+                # User PATH registration.
+                Install-ManagedNodeShims -NodeDir "$HermesHome\node"
 
                 $version = & "$HermesHome\node\node.exe" --version
                 Write-Success "Node.js $version installed to $HermesHome\node\ (portable, user-scoped)"
@@ -3193,6 +3314,30 @@ function Set-PathVariable {
     } else {
         Write-Info "PATH already configured"
     }
+
+    # The managed Node tree is exposed through shims in $hermesBin, not
+    # through its own PATH entry.  Migrate installs made by older installers,
+    # which registered %LOCALAPPDATA%\hermes\node itself in User PATH --
+    # removing it restores the user's own node/npm selection in new shells.
+    Remove-ManagedNodeFromUserPath "$HermesHome\node"
+
+    # Refresh/repair the shims every run (idempotent): a managed Node upgrade
+    # swaps the tree underneath them, so stale absolute paths must be
+    # rewritten.  Only when the managed tree actually exists -- when the user
+    # has a suitable node of their own, Test-Node never provisions one, and
+    # writing delegators to a nonexistent node.exe would shadow their
+    # toolchain with dead files in every new shell.  When the tree is gone
+    # (user switched to their own toolchain), drop any shims left behind.
+    if (-not $NoVenv) {
+        if (Test-Path "$HermesHome\node\node.exe") {
+            Install-ManagedNodeShims -NodeDir "$HermesHome\node" -Destination $hermesBin
+            Write-Success "node/npm/npx available via shims in $hermesBin"
+        } else {
+            Remove-Item (Join-Path $hermesBin "node.cmd"), `
+                        (Join-Path $hermesBin "npm.cmd"), `
+                        (Join-Path $hermesBin "npx.cmd") -ErrorAction SilentlyContinue
+        }
+    }
     
     # Set HERMES_HOME so the Python code finds config/data in the right place.
     # Only needed on Windows where we install to %LOCALAPPDATA%\hermes instead
@@ -3389,13 +3534,24 @@ You are Hermes Agent, an intelligent AI assistant created by Nous Research. You 
 }
 
 function Install-NodeDeps {
+    # In cross-process driver mode (Hermes-Setup.exe runs each -Stage NAME in
+    # a fresh powershell.exe), a private-only provision (HERMES_NODE_SKIP_LINKS=1
+    # or -NoVenv) leaves the managed tree off the persisted User PATH, so a
+    # registry-refreshed process cannot find npm via Get-Command.  Probe the
+    # managed tree by absolute path as a fallback -- the same programmatic
+    # resolution the Python side uses (find_node_executable /
+    # iter_hermes_node_dirs).
+    $managedNpm = "$HermesHome\node\npm.cmd"
+    $hasManagedNpm = (Test-Path $managedNpm)
+
     if (-not $HasNode) {
         # Cross-process driver mode (Hermes-Setup.exe runs each -Stage NAME
         # in a fresh powershell.exe) means $script:HasNode set by Stage-Node
         # in the previous process isn't visible here. Re-probe rather than
         # trust the stale global -- Stage-Node already ran successfully or
-        # the bootstrap would've aborted, so npm is reachable.
-        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        # the bootstrap would've aborted, so npm is reachable (managed tree
+        # by absolute path, or the user's own npm on PATH).
+        if (-not ($hasManagedNpm -or (Get-Command npm -ErrorAction SilentlyContinue))) {
             Write-Info "Skipping Node.js dependencies (Node not installed)"
             return
         }
@@ -3418,21 +3574,30 @@ function Install-NodeDeps {
     # it exists in the same directory.  Fall back to whatever Get-Command
     # returned if we can't find a .cmd sibling.
     $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
-    if (-not $npmCmd) {
+    if ($npmCmd) {
+        $npmExe = $npmCmd.Source
+        if ($npmExe -like "*.ps1") {
+            $npmCmdSibling = Join-Path (Split-Path $npmExe -Parent) "npm.cmd"
+            if (Test-Path $npmCmdSibling) {
+                Write-Info "Using npm.cmd (PowerShell execution policy blocks npm.ps1)"
+                $npmExe = $npmCmdSibling
+            } else {
+                Write-Warn "Only npm.ps1 available -- install may fail if script execution is disabled."
+                Write-Info "  If it fails, either enable PS script execution or install Node via winget."
+            }
+        }
+    } elseif ($hasManagedNpm) {
+        # Private-only provision (skip-links / NoVenv) in cross-process mode:
+        # the managed tree is off the persisted PATH, so resolve it directly
+        # and put its dir on the session PATH for npm lifecycle scripts
+        # (#48130).  Only reached when PATH offered no npm at all -- the
+        # user's own toolchain is preferred whenever it is present.
+        $npmExe = $managedNpm
+        $env:Path = "$HermesHome\node;$env:Path"
+    } else {
         Write-Warn "npm not found on PATH -- skipping Node.js dependencies."
         Write-Info "Open a new PowerShell window and re-run 'hermes setup tools' later."
         return
-    }
-    $npmExe = $npmCmd.Source
-    if ($npmExe -like "*.ps1") {
-        $npmCmdSibling = Join-Path (Split-Path $npmExe -Parent) "npm.cmd"
-        if (Test-Path $npmCmdSibling) {
-            Write-Info "Using npm.cmd (PowerShell execution policy blocks npm.ps1)"
-            $npmExe = $npmCmdSibling
-        } else {
-            Write-Warn "Only npm.ps1 available -- install may fail if script execution is disabled."
-            Write-Info "  If it fails, either enable PS script execution or install Node via winget."
-        }
     }
 
     # Wall-clock ceiling for each npm / Playwright invocation in this stage.


### PR DESCRIPTION
# fix(install): put managed Node behind shims, stop registering it on PATH

## What does this PR do?

On Windows, `install.ps1` registers the Hermes-managed Node directory
(`%LOCALAPPDATA%\hermes\node`) itself as an entry in the **persisted User
PATH**, force-moving it to the front on every install and update
(`Set-ManagedNodeFirstOnUserPath`, move-to-front per #76459). That silently
overrode a user's own node/npm selection in every new shell, re-applied the
override after any manual reorder, and still lost to a system Node.js MSI in
Machine PATH (Windows combines PATH Machine-first + User-appended, so the
front-of-User-PATH placement is beatable). Hermes internals no longer depend
on this ordering — since #76459/#58150 every Node/npm call site resolves the
managed tree programmatically via `find_node_executable()` /
`iter_hermes_node_dirs()` — so only interactive shells were affected.

This change exposes node/npm/npx through **absolute-path `.cmd` delegators**
in `$HermesHome\bin` (the directory the `hermes.exe` launcher already lives
in, already on the persisted User PATH), stops registering the `\node`
directory itself, migrates existing installs by stripping the legacy entry,
and honors `HERMES_NODE_SKIP_LINKS=1` so set-up can provision the managed
tree privately with no shims and no PATH change — the same guard the POSIX
installer and health path already use. Python is unaffected throughout
(`venv\Scripts` is never on the persisted User PATH).

The behavior model after this PR, for a machine without Hermes:

1. System already has a suitable node ecosystem (node ≥ 26 + working npm)
   → Hermes uses it directly; installs nothing; touches no PATH. (Unchanged —
   and now *guaranteed*: see the shim-writer guards below.)
2. System has no suitable node → Hermes provisions its own managed tree under
   `%LOCALAPPDATA%\hermes\node`, reachable by absolute path.
3. Auto-management doesn't take over command names →
   `HERMES_NODE_SKIP_LINKS=1` makes set-up private-only — including when the
   flag is set *after* a non-private install (stale shims are removed).

## Related Issue

Fixes #95747

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.ps1`:
  - Removed `Set-ManagedNodeFirstOnUserPath` (the whole-directory-in-User-PATH
    move-to-front writer).
  - Added `Install-ManagedNodeShims` — writes `node.cmd` / `npm.cmd` /
    `npx.cmd` absolute-path delegators into `$HermesHome\bin`; honors
    `HERMES_NODE_SKIP_LINKS=1` (private-only, no shims, no PATH write) and
    **removes any shims a previous non-private install left behind** when the
    flag is set, so opting out works retroactively.
  - **Guard: shims are only written when the managed tree actually exists**
    (`Test-Path "$NodeDir\node.exe"`). When the user already has a suitable
    node of their own, Test-Node never provisions a managed tree — writing
    delegators to a nonexistent `node.exe` would shadow their toolchain with
    dead files in every new shell (the exact class of interference this PR
    exists to remove). `Set-PathVariable` applies the same guard and drops
    stale shims when the tree is gone.
  - **Guard: `-NoVenv` installs never write shims.** The only PATH entry in
    that layout is the checkout root; hosting shims there would put untracked
    files inside the git working tree (swept by `hermes update`'s autostash —
    the bug class that moved the hermes launchers out of the checkout) and
    shadow the user's toolchain from a directory they never opted into.
  - `Install-NodeDeps` now **probes the managed tree by absolute path** as a
    fallback when PATH offers no npm. In cross-process stage-driver mode
    (Hermes-Setup.exe), a private-only provision (skip-links / NoVenv) leaves
    the tree off the persisted PATH, so a registry-refreshed stage could no
    longer find npm and silently skipped browser-tools/desktop deps. Mirrors
    the Python side's programmatic resolution
    (`find_node_executable` / `iter_hermes_node_dirs`).
  - Added `Remove-ManagedNodeFromUserPath` — one-time migration stripping the
    legacy `\node` User PATH entry (preserves unrelated entries and empty
    segments; zero writes once clean; also strips hand-edited
    trailing-backslash variants).
  - Added `Add-DirToUserPathIfMissing` — registers the shared `bin` dir only
    when genuinely missing (no trailing empty segment on an empty User PATH).
  - `Test-Node`: both former `Set-ManagedNodeFirstOnUserPath` call sites now
    call `Install-ManagedNodeShims`; the "system already has a suitable node"
    path is unchanged.
  - `Set-PathVariable`: refreshes the shims each run (only when the managed
    tree exists), removes stale shims otherwise, and invokes the migration.
- `scripts/ci/test_install_ps1_path_migration.ps1`:
  - Rewritten (AST-lift harness, same methodology as the file it replaces).
  - `Remove-ManagedNodeFromUserPath`: removal at head/tail, clean-PATH no-op
    with zero writes, empty-segment preservation, case-insensitive matching,
    trailing-backslash variant, duplicate collapse, single-entry-to-empty,
    empty-NodeDir guard.
  - `Add-DirToUserPathIfMissing`: fresh prepend, already-present no-op,
    trailing-backslash/case variant, empty-segment preservation, empty-Dir
    guard, empty-User-PATH no-trailing-segment.
  - **`Install-ManagedNodeShims` (new): 22 assertions** — three shims written
    with the exact delegator bodies (absolute-path target, `call` for
    npm/npx), bin dir registered exactly once, **no shims / no PATH write when
    the tree is absent** (the regression guard), idempotent re-run with no
    second registry write, empty-NodeDir no-op, skip-links removes stale shims
    with no additional write, NoVenv writes nothing. Total: **46 assertions**.

## How to Test

1. On a Windows box with no suitable node on PATH, run
   `iex (irm https://hermes-agent.nousresearch.com/install.ps1)` (or the
   updated `install.ps1` from this branch).
2. Open a new terminal; `where node` / `where npm` resolve via
   `%LOCALAPPDATA%\hermes\bin\{node,npm}.cmd`, and the `\hermes\node`
   directory is no longer a User PATH entry.
3. Re-run the install (update path): the shims are rewritten idempotently; no
   `\node` directory entry reappears.
4. **Regression check (the reason the guards exist):** on a box where the
   user already has node ≥ 26 of their own (fnm / unzip + User PATH), install
   Hermes, open a new terminal, run `where node` / `node --version` — the
   user's own node still resolves; no `node.cmd` was created in
   `%LOCALAPPDATA%\hermes\bin`.
5. With `HERMES_NODE_SKIP_LINKS=1` set: install again, confirm
   `$HermesHome\bin` gets no node/npm/npx shims and the User PATH is
   unchanged. Setting the flag after a non-private install removes the shims
   on the next run.
6. Behavioral unit check:
   `pwsh -NoProfile -File scripts/ci/test_install_ps1_path_migration.ps1`
   → all 46 assertions pass.

## Known Limitations

- Shims are written with `-Encoding Ascii` (the same pattern the existing
  `hermes.cmd` launcher writer in `Install-HermesCommandLaunchers` uses), so
  a Windows username containing non-ASCII characters (e.g. Chinese, Japanese,
  Cyrillic) produces mojibake delegators that point at a garbled path. This
  is a pre-existing limitation of the Windows installer's `.cmd` generation,
  not introduced by this change — the `hermes.cmd` launcher has the identical
  issue. A proper fix (codepage-aware `.cmd` via `chcp 65001` + UTF-8, or
  non-path-based resolution) needs Windows-side verification and should cover
  the hermes launchers too, so it is deliberately left out of this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test for this change:
  `pwsh -NoProfile -File scripts/ci/test_install_ps1_path_migration.ps1`
  → all 46 assertions pass; AST parse of modified `install.ps1` → clean.
  (No Python-side test references these symbols, so `pytest` is not exercised.)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (installer-branch behavior;
  no user-facing config key added beyond the existing env guard)
- [x] I've considered cross-platform impact (Windows, macOS) per the
  compatibility guide — the change aligns Windows with the existing POSIX
  `HERMES_NODE_SKIP_LINKS` behavior
- [ ] I've updated tool descriptions/schemas — N/A (no model tool changed)

### Screenshots / Logs

Shims generated into `%LOCALAPPDATA%\hermes\bin` (verified locally):

```
$HOME\AppData\Local\hermes\bin\node.cmd  →  @echo off
"<hermes>\node\node.exe" %*
$HOME\AppData\Local\hermes\bin\npm.cmd   →  @echo off
call "<hermes>\node\npm.cmd" %*
$HOME\AppData\Local\hermes\bin\npx.cmd   →  @echo off
call "<hermes>\node\npx.cmd" %*
```

`pwsh -NoProfile -File scripts/ci/test_install_ps1_path_migration.ps1`
→ `all assertions passed` (46 assertions).
