### PR TITLE
feat(memory): durably buffer Hindsight retains across outages

### DIFF
--- a/docs/development/HINDSIGHT_DURABLE_OUTBOX_UPGRADE.md
+++ b/docs/development/HINDSIGHT_DURABLE_OUTBOX_UPGRADE.md
@@ -1,0 +1,361 @@
+# Hindsight Durable Outbox and Upgrade Runbook
+
+**Status:** operational documentation for the Hermes Agent Hindsight integration
+**Last reviewed:** 2026-08-26
+**Scope:** client-side Hermes integration plus the self-hosted Hindsight deployment
+
+## Purpose
+
+This document records exactly what was changed in Hermes and provides the repeatable
+procedure for upgrading the self-hosted Hindsight server and the Python client to the
+newest verified release.
+
+The durable outbox is a **client-side delivery buffer**. It does not change Hindsight's
+server, database schema, extraction, embedding, reranking, consolidation, or recall
+behavior.
+
+## Current deployment and version terminology
+
+These are separate version streams:
+
+- **Hindsight server API:** the service running on the NAS. Its `/version` endpoint
+  reports the API version.
+- **`hindsight-client`:** the Python SDK imported by Hermes. It is released separately
+  from the server and should be tested against the deployed server.
+- **Hermes Agent:** the client application containing the Hindsight provider.
+
+State before this upgrade:
+
+- Hindsight server API: `0.9.1`
+- Hermes runtime SDK before the final upgrade: `0.8.6`
+
+Current verified state after this upgrade:
+
+- Hindsight server API: `0.9.2`
+- Hindsight image: `ghcr.io/vectorize-io/hindsight:0.9.2`
+- Image digest: `sha256:84ab276b8f501546deb6ea9c64a57291718b4e16a59dd9e02a02fdd5adfe9028`
+- Hermes runtime SDK: `hindsight-client==0.9.2`
+- `aretain_batch` operation-ID support: verified
+- Live `/health`: healthy, database connected
+- Live read-only recall through the `0.9.2` SDK: verified against the production bank
+
+Latest release checks used:
+
+- Hindsight GitHub release: `v0.9.2`
+- PyPI SDK release: `hindsight-client==0.9.2`
+
+Do not assume that a server version and client version are interchangeable. Verify both
+from their authoritative sources before upgrading:
+
+```bash
+gh api repos/vectorize-io/hindsight/releases/latest --jq '.tag_name'
+/home/kosello/.hermes/hermes-agent/venv/bin/python -m pip index versions hindsight-client
+curl -fsS http://192.168.1.2:8889/version
+```
+
+## Exact Hermes changes
+
+The local feature branch contains the following client-side changes:
+
+### `plugins/memory/hindsight/outbox.py`
+
+- Added a SQLite-backed durable outbox for complete retain requests.
+- Stores rows before the request is handed to a worker.
+- Stores `bank_id`, `document_id`, `update_mode`, `retain_async`, the complete retain
+  item, retry count, retry time, last error, and a persisted `operation_id`.
+- Uses a unique `dedupe_key` to prevent duplicate local enqueue rows.
+- Uses SQLite `BEGIN IMMEDIATE` plus a process lock so separate outbox instances cannot
+  claim the same row concurrently.
+- Uses WAL mode and a busy timeout for concurrent readers/workers.
+- Releases stale claims after restart and activates pending rows for replay.
+- Uses a `replay_eligible` marker so a startup replay worker cannot steal a freshly
+  enqueued row from Hermes' existing lazy writer.
+- Uses bounded exponential retry delays and keeps failed rows on disk.
+- Applies file mode `0600` where the operating system supports it.
+
+### `plugins/memory/hindsight/__init__.py`
+
+- Persists the retain request before dispatching the in-memory writer job.
+- Keeps the existing lazy writer behavior for new rows.
+- Adds a separate durable replay worker for rows left by a previous process or retry.
+- Passes the stable `operation_id` to `aretain_batch` when the installed SDK exposes
+  that parameter and the retain is asynchronous.
+- Wakes the replay worker when a new retain is queued.
+- Avoids closing the SQLite database or Hindsight client underneath a worker that did
+  not stop within the bounded shutdown window.
+- Keeps the first server-operation status poll fast: 404 detection uses the SDK
+  exception's status/class shape without importing the generated Pydantic model graph
+  on the prefetch thread. With `hindsight-client==0.9.2`, that lazy import was measured
+  at roughly 4.4 seconds and could exceed the test/short-prefetch join budget.
+
+### `tools/lazy_deps.py`
+
+The Hindsight SDK pin must match the tested upgrade target:
+
+```python
+"memory.hindsight": ("hindsight-client==0.9.2",),
+```
+
+The provider minimum client version must also be `0.9.2` after the upgrade.
+
+### Tests
+
+The tests cover:
+
+- persistence across reopening the database;
+- local deduplication;
+- failed delivery and retry;
+- atomic claims across two SQLite instances;
+- startup replay activation;
+- successful acknowledgement;
+- stable operation ID delivery;
+- private database permissions;
+- provider behavior when Hindsight is offline.
+
+Run them with an interpreter containing the pinned SDK:
+
+```bash
+/tmp/hermes-hindsight-test-venv/bin/python -m pytest \
+  tests/plugins/memory/test_hindsight_outbox.py \
+  tests/plugins/memory/test_hindsight_provider.py \
+  -q -o addopts=
+```
+
+## NAS deployment details
+
+The Hindsight Compose project is:
+
+```text
+Project:     hindsight
+Compose:     /mnt/user/appdata/hindsight/docker-compose.yml
+Working dir: /mnt/user/appdata/hindsight
+Service:     hindsight
+Image:       ghcr.io/vectorize-io/hindsight:latest
+Data:        /mnt/user/appdata/hindsight/data -> /home/hindsight/.pg0
+Codex:       /mnt/user/appdata/hindsight/codex -> /home/hindsight/codex
+Ports:       NAS:8889 -> container:8888
+             NAS:9999 -> container:9999
+Restart:     unless-stopped
+```
+
+The image should be verified by its OCI label and digest, not only by the mutable
+`latest` tag:
+
+```bash
+ssh nas 'docker inspect hindsight --format \
+  "version={{index .Config.Labels \"org.opencontainers.image.version\"}}\nimage={{.Image}}"'
+```
+
+## Safe upgrade procedure
+
+### 1. Check health and capture the rollback identity
+
+Do not start the upgrade if the current service is already unhealthy or the database is
+not connected.
+
+```bash
+curl -fsS http://192.168.1.2:8889/version
+ssh nas 'docker inspect hindsight --format \
+  "version={{index .Config.Labels \"org.opencontainers.image.version\"}}\nimage={{.Image}}\nrepo={{index .RepoDigests 0}}"'
+ssh nas 'docker compose -f /mnt/user/appdata/hindsight/docker-compose.yml ps'
+```
+
+Record the current image digest. The previous known digest was:
+
+```text
+ghcr.io/vectorize-io/hindsight@sha256:a0e937366261b8a8f20ebcaf13758c689c381dcbbf01684e4375c2787c8c666d
+```
+
+### 2. Make a dated backup before stopping the service
+
+A running PostgreSQL data directory must not be treated as a consistent file backup.
+For a consistent appdata snapshot, stop only the Hindsight Compose service, copy the
+persistent data and Compose file, and then start it again. The backup must be on a
+separate path from the live appdata.
+
+```bash
+ssh nas 'set -eu
+stamp=$(date +%Y%m%d-%H%M%S)
+backup=/mnt/user/kosello/Backups/hindsight/$stamp
+mkdir -p "$backup"
+cp /mnt/user/appdata/hindsight/docker-compose.yml "$backup/"
+docker inspect hindsight > "$backup/container-inspect.json"
+docker image inspect ghcr.io/vectorize-io/hindsight:latest > "$backup/image-inspect.json"
+docker compose -f /mnt/user/appdata/hindsight/docker-compose.yml stop hindsight
+tar --xattrs --acls -czf "$backup/appdata.tar.gz" -C /mnt/user/appdata hindsight
+docker compose -f /mnt/user/appdata/hindsight/docker-compose.yml start hindsight
+printf "backup=%s\\n" "$backup"
+ls -lh "$backup/appdata.tar.gz"'
+```
+
+Verify after the backup that the service is healthy again:
+
+```bash
+curl -fsS http://192.168.1.2:8889/version
+```
+
+### 3. Pull and recreate only the Hindsight service
+
+Use the Compose file, not a blind `docker run`, so bind mounts, ports, restart policy,
+and environment configuration remain unchanged.
+
+```bash
+ssh nas 'set -eu
+cd /mnt/user/appdata/hindsight
+docker compose pull hindsight
+docker compose up -d hindsight
+docker compose ps
+'
+```
+
+Do not run `docker system prune`, remove volumes, or remove the persistent data
+directory as part of this upgrade.
+
+### 4. Verify the new server
+
+```bash
+curl -fsS http://192.168.1.2:8889/version
+ssh nas 'docker inspect hindsight --format \
+  "version={{index .Config.Labels \"org.opencontainers.image.version\"}}\nimage={{.Image}}\nrepo={{index .RepoDigests 0}}"'
+ssh nas 'docker compose -f /mnt/user/appdata/hindsight/docker-compose.yml ps'
+```
+
+Expected server API version after the upgrade:
+
+```text
+0.9.2
+```
+
+Also inspect recent logs for startup/database errors without printing environment
+variables:
+
+```bash
+ssh nas 'docker logs --since 5m --tail 100 hindsight'
+```
+
+### 5. Upgrade the Hermes Python client
+
+The client version is installed into Hermes' runtime virtual environment. The source
+pin and provider minimum version must be updated together.
+
+```bash
+cd /home/kosello/.hermes/hermes-agent
+/home/kosello/.hermes/hermes-agent/venv/bin/python -m pip install \
+  --upgrade 'hindsight-client==0.9.2'
+```
+
+Then update these source values to `0.9.2`:
+
+```text
+tools/lazy_deps.py:       hindsight-client==0.9.2
+plugins/memory/hindsight/__init__.py: _MIN_CLIENT_VERSION = "0.9.2"
+```
+
+Verify the installed SDK exposes idempotent asynchronous retain:
+
+```bash
+/home/kosello/.hermes/hermes-agent/venv/bin/python -c '
+import importlib.metadata as metadata
+import inspect
+from hindsight_client import Hindsight
+print("version=" + metadata.version("hindsight-client"))
+print("operation_id=" + str("operation_id" in inspect.signature(Hindsight.aretain_batch).parameters))
+'
+```
+
+### 6. Run tests before restarting Hermes
+
+```bash
+/tmp/hermes-hindsight-test-venv/bin/python -m pytest \
+  tests/plugins/memory/test_hindsight_outbox.py \
+  tests/plugins/memory/test_hindsight_provider.py \
+  -q -o addopts=
+
+/tmp/hermes-hindsight-test-venv/bin/python -m pytest \
+  tests/plugins/memory/ tests/agent/test_memory_provider.py \
+  -q -o addopts=
+
+python -m py_compile \
+  plugins/memory/hindsight/outbox.py \
+  plugins/memory/hindsight/__init__.py \
+  tests/plugins/memory/test_hindsight_outbox.py \
+  tools/lazy_deps.py
+
+git diff --check
+```
+
+A failure in an unrelated optional provider must be recorded separately. Do not call
+the Hindsight integration verified if the Hindsight-focused tests fail.
+
+### 7. Restart Hermes to load the upgraded client
+
+Installing a new SDK does not replace modules already loaded by a running gateway. The
+restart must be performed externally because a Hermes process cannot restart its own
+parent gateway safely.
+
+```bash
+hermes gateway status
+hermes gateway restart
+hermes gateway status
+```
+
+If the command is issued from inside the active Telegram gateway and Hermes refuses the
+self-restart, run it from a separate SSH/terminal session instead. Do not force-kill the
+parent from the active chat process.
+
+### 8. Verify read-only memory behavior
+
+Confirm the provider is available and perform a read-only recall against the existing
+bank. Do not use broad memory-delete endpoints for cleanup: the Hindsight deployment's
+memory-delete behavior has previously been verified as unsafe for scoped cleanup.
+
+```bash
+hermes memory status
+```
+
+A retain/outbox test should use a temporary local HTTP test server or a temporary test
+bank that is explicitly isolated and removed through a verified, supported API. Never
+take the production Hindsight service offline to simulate an outage.
+
+## Rollback procedure
+
+If the upgraded server is unhealthy:
+
+1. Stop only the Hindsight Compose service.
+2. Restore the dated Compose/data backup if data needs restoration.
+3. Pin the image to the recorded prior digest or the prior release tag.
+4. Start the service and verify `/version`, database connectivity, and read-only recall.
+5. Install the matching prior Python SDK in Hermes' runtime venv.
+6. Restart Hermes from an external terminal.
+
+Do not delete the outbox database during rollback. Pending rows were created for the
+client-side delivery guarantee and must remain available for retry after the service is
+healthy.
+
+## Limitations and semantics
+
+- SQLite is the durable source of truth; the in-memory queue is only a dispatch trigger.
+- Hindsight is unaware of the local buffer.
+- Failed requests remain locally queued and are retried with bounded backoff.
+- Supported asynchronous retains use the persisted Hindsight `operation_id`, so a crash
+  after server acceptance and before local acknowledgement can be retried idempotently.
+- Older SDKs that do not expose `operation_id`, and synchronous retains, remain
+  at-least-once across that narrow crash window.
+- The outbox contains conversation-derived retain payloads and must be protected and
+  backed up according to the user's privacy policy. Its directory is `0700`, the
+  database is `0600`, and WAL/SHM sidecars are kept private where supported.
+- A profile's outbox is tied to its configured Hindsight endpoint and credentials.
+  Do not switch endpoint/account while pending rows exist; drain or archive the old
+  outbox before starting the new configuration.
+- Existing in-memory-only failures from before the outbox was installed cannot be
+  reconstructed by the outbox; they may still exist in Hermes session history.
+
+## Change history
+
+- Added SQLite outbox and provider wiring in the Hermes checkout.
+- Reproduced and fixed the concurrent-claim race.
+- Preserved lazy writer startup by separating durable replay from normal dispatch.
+- Added persisted asynchronous operation IDs and upgraded the minimum SDK requirement.
+- Added private file permissions and shutdown safety.
+- Updated this runbook after verifying the newest available Hindsight release is
+  `v0.9.2`.

--- a/docs/plans/2026-08-26-hindsight-offline-outbox.md
+++ b/docs/plans/2026-08-26-hindsight-offline-outbox.md
@@ -1,0 +1,225 @@
+# Hindsight Offline Retention Outbox Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Ensure Hindsight retains are durably queued when the server is unavailable and automatically replayed after recovery.
+
+**Architecture:** Add a small client-side SQLite-backed delivery buffer in front of the existing Hindsight client. Hindsight's server, API, database, extraction, embedding, reranking, and recall behavior remain unchanged. Hermes stores a complete retain request locally before attempting delivery; a background uploader sends it to Hindsight when reachable, keeps it on disk when unreachable, and retries it after recovery. The existing in-memory queue remains the normal dispatch trigger, while SQLite is the durable source of truth.
+
+**Tech Stack:** Python stdlib `sqlite3`, `hindsight-client>=0.9.2` for async retain idempotency, existing provider writer/replay threads, pytest temporary directories, structured logging.
+
+---
+
+## Delivered Scope
+
+This branch delivers the client-side durability slice only:
+
+- SQLite persistence before dispatch, with profile-scoped storage and `0600` file permissions where supported.
+- Atomic claims across multiple provider/outbox instances.
+- Retry with bounded exponential backoff; failed rows are retained rather than silently discarded.
+- Startup replay of rows left by an earlier process, while fresh rows stay with the existing lazy writer.
+- Stable persisted `operation_id` values for asynchronous retain calls when supported by the SDK, preventing normal retry duplicates.
+- Graceful shutdown that does not close the outbox underneath a still-running worker.
+
+The crash window is closed for supported asynchronous idempotency (`hindsight-client>=0.9.2` and Hindsight's existing API). Synchronous retains and older SDKs remain at-least-once if the process crashes after the server accepts a request but before local acknowledgement.
+
+## Deferred Scope
+
+The following are intentionally separate follow-ups and are not acceptance criteria for this branch: permanent-failure state/status APIs, administrative outbox inspection/purge commands, persistence of server-side operation completion state, and a production gateway restart. The temporary HTTP integration test remains a follow-up before an upstream PR; production Hindsight must not be taken offline for testing.
+
+## Acceptance Criteria
+
+- A retain queued while Hindsight is unreachable is not reported as uploaded and survives Hermes restart.
+- The same outbox row is retried with bounded exponential backoff without silently deleting data.
+- Successful retains are removed only after the retain API call succeeds.
+- Replays use a persisted operation ID for supported asynchronous clients and a unique deduplication key for local enqueue races.
+- Concurrent outbox instances cannot claim the same row.
+- Shutdown does not lose rows already persisted in the outbox.
+- Hindsight's server, database, memory processing, and recall behavior remain unchanged.
+- Focused outbox and provider tests pass in an environment with `hindsight-client==0.8.6`.
+
+## Non-goals
+
+- Do not change the Hindsight server or database schema in the first implementation.
+- Do not make recall wait for an offline outbox; recall should degrade gracefully while retention remains durable.
+- Do not add a second external memory provider or a cloud message broker.
+- Do not delete old session history as part of this change.
+
+---
+
+### Task 1: Define the outbox data model and lifecycle states
+
+**Objective:** Specify the minimal durable record needed to replay a retain exactly.
+
+**Files:**
+- Create: `plugins/memory/hindsight/outbox.py`
+- Test: `tests/plugins/memory/test_hindsight_outbox.py`
+
+**Steps:**
+1. Define an `OutboxEntry` record containing: `id`, `created_at`, `available_at`, `attempts`, `state`, `bank_id`, `document_id`, `update_mode`, `retain_async`, serialized retain item, metadata, and optional `operation_ids`.
+2. Define states: `pending`, `in_flight`, `awaiting_operation`, `completed`, `failed_permanent`.
+3. Define explicit transitions and reject invalid transitions.
+4. Write unit tests for valid/invalid transitions and JSON round-tripping.
+5. Run: `python -m pytest tests/plugins/memory/test_hindsight_outbox.py -q -o addopts=`.
+
+### Task 2: Implement the SQLite-backed outbox
+
+**Objective:** Make queued retain payloads survive process and machine restarts.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/outbox.py`
+- Test: `tests/plugins/memory/test_hindsight_outbox.py`
+
+**Steps:**
+1. Store the database under the profile-scoped Hermes home, not the repository or `/tmp`; use `get_hermes_home()`.
+2. Create the database/table/indexes with `sqlite3`, WAL mode, busy timeout, and restrictive file permissions where supported.
+3. Implement atomic `enqueue`, `claim_due`, `acknowledge`, `reschedule`, `record_operation_ids`, `complete_operation`, and `release_expired_claims` methods.
+4. Use a unique deterministic key derived from the session/document/turn payload so a crash between persistence and in-memory enqueue cannot duplicate the request.
+5. Test two outbox instances claiming the same row; exactly one must win.
+6. Test reopening the database and finding the pending row.
+7. Run the focused tests.
+
+### Task 3: Persist before dispatching the in-memory writer job
+
+**Objective:** Close the current data-loss window in `sync_turn()`.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py` around `sync_turn()` and retain payload construction.
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+- Test: `tests/plugins/memory/test_hindsight_outbox.py`
+
+**Steps:**
+1. Build and freeze the complete retain request before queueing it, including bank, document, update mode, tags, metadata, and turn content.
+2. Insert the frozen request into the outbox first.
+3. Only after the insert succeeds, enqueue the writer job and emit the saving indicator.
+4. If local persistence fails, do not claim the retain was queued; log a visible error and preserve the normal conversation response path.
+5. Add a test proving `sync_turn()` creates an outbox row before the writer runs.
+6. Add a test proving duplicate calls with the same turn key create one row.
+7. Run the focused tests.
+
+### Task 4: Make the writer drain durable rows instead of deleting failed work
+
+**Objective:** Retry network failures without blocking the chat reply.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py` writer loop and shutdown logic.
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+
+**Steps:**
+1. Make the writer claim due outbox rows and attempt the API call.
+2. On connection, timeout, 5xx, or rate-limit errors, reschedule with bounded exponential backoff plus jitter; keep the payload intact.
+3. On non-retryable 4xx/auth/schema errors, move the row to `failed_permanent` and expose the reason; do not silently discard it.
+4. Ensure `task_done()` applies to the in-memory trigger queue while the durable row remains pending or failed as appropriate.
+5. Release stale `in_flight` claims at startup and after a bounded lease timeout.
+6. Test that an offline endpoint leaves the row present and increases `attempts`.
+7. Test that a later successful attempt removes/finishes the row.
+
+### Task 5: Handle asynchronous Hindsight retain operations safely
+
+**Objective:** Avoid marking an async retain complete merely because Hindsight accepted it.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py` operation tracking and prefetch wait code.
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+
+**Steps:**
+1. Store returned `operation_id` values in the outbox row as soon as `aretain_batch()` accepts the request.
+2. Keep the row in `awaiting_operation` until all operation IDs report `completed`.
+3. Treat documented `404/not found` eviction as complete only when the API contract guarantees eviction means completion; otherwise keep it retryable and document the behavior.
+4. On transient status failures, retain the row and retry status checks later rather than letting an exception kill the prefetch thread.
+5. Make `prefetch_waits_for_retain` wait only up to its existing bounded timeout; it must never block the reply indefinitely.
+6. Test pending → completed, pending → timeout, transient status error, and process restart while awaiting completion.
+
+### Task 6: Add startup replay and bounded periodic retry
+
+**Objective:** Recover offline writes automatically after Hermes or Hindsight returns.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py`
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+
+**Steps:**
+1. On provider initialization, release stale claims and signal the writer if due rows exist.
+2. Have the writer wake on a bounded interval or explicit signal, claim due rows, and retry them serially.
+3. Avoid a tight retry loop when the NAS is down; enforce a minimum delay and cap the backoff.
+4. Keep retries independent of recall so a dead Hindsight server does not stall normal chat.
+5. Test: enqueue offline, destroy provider, create a new provider with a working fake client, and verify replay.
+6. Test that an unavailable endpoint does not create unbounded threads or CPU usage.
+
+### Task 7: Expose operational status and user-visible semantics
+
+**Objective:** Make it clear whether memories are saved, queued, retrying, or failed.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py`
+- Modify: `agent/memory_provider.py` if a shared status contract is needed.
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+
+**Steps:**
+1. Extend the provider status callback with distinct messages such as `saving`, `queued for retry`, and `saved` without claiming upload success on enqueue.
+2. Add a provider diagnostic/status method reporting counts by outbox state, oldest pending age, and next retry time—without exposing memory contents or secrets.
+3. Ensure `/status` or `hermes memory status` can report degraded Hindsight availability separately from built-in memory availability.
+4. Add tests for status transitions and empty/non-empty outbox reporting.
+
+### Task 8: Add an administrative recovery path
+
+**Objective:** Prevent permanent failures from becoming invisible or unrecoverable.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py`
+- Modify: relevant Hermes memory CLI/status module discovered during implementation.
+- Test: `tests/plugins/memory/test_hindsight_provider.py`
+
+**Steps:**
+1. Add a safe `retry failed` operation for `failed_permanent` rows after credentials or server configuration are corrected.
+2. Add a safe `inspect outbox` operation showing IDs, timestamps, attempts, and error summaries—not full sensitive payloads by default.
+3. Do not add deletion by default; if cleanup is required, require an explicit, separately reviewed purge operation.
+4. Test retrying a permanent failure and verifying the row returns to `pending`.
+
+### Task 9: Verify against a real local HTTP test server
+
+**Objective:** Exercise network failures and recovery without touching production Hindsight.
+
+**Files:**
+- Create: `tests/plugins/memory/test_hindsight_outbox_integration.py`
+- Modify: test fixtures as needed.
+
+**Steps:**
+1. Start a temporary stdlib HTTP server that implements the minimal retain and operation-status responses.
+2. Run a test with the server refusing connections, then start it and verify replay.
+3. Force a process-like restart by closing the provider and reopening the same temporary Hermes home/database.
+4. Verify one durable retain and one successful async operation, with no duplicate document/turn submissions.
+5. Run: `python -m pytest tests/plugins/memory/test_hindsight_outbox*.py tests/plugins/memory/test_hindsight_provider.py -q -o addopts=`.
+6. Record any dependency failures separately from functional failures; do not call the feature verified if the integration tests are skipped.
+
+### Task 10: Document configuration, recovery, and migration behavior
+
+**Objective:** Make the new durability guarantees and limits supportable.
+
+**Files:**
+- Modify: `plugins/memory/hindsight/__init__.py` module documentation.
+- Modify: `website/docs/user-guide/features/memory-providers.md`.
+- Modify: `skills/mlops/hermes-memory-providers/SKILL.md` if the repository copy is canonical.
+
+**Steps:**
+1. Document outbox location, retention of sensitive payloads, retry/backoff limits, permanent-failure handling, and status meanings.
+2. Document that Hindsight recall can remain unavailable while queued retains are safe.
+3. Document upgrade behavior: existing in-memory-only failed writes cannot be recovered, but future writes use the outbox automatically.
+4. Add a rollback note: disabling the outbox must not delete existing rows.
+5. Run documentation link/lint checks used by the repository.
+
+## Final Verification
+
+Run the focused suite first:
+
+```bash
+python -m pytest tests/plugins/memory/test_hindsight_outbox*.py tests/plugins/memory/test_hindsight_provider.py -q -o addopts=
+```
+
+Then run the relevant full suite:
+
+```bash
+python -m pytest tests/plugins/memory/ tests/agent/test_memory_provider.py -q -o addopts=
+```
+
+Acceptance is complete only when the offline/restart integration test passes, the outbox row is observed before dispatch, and a recovered Hindsight endpoint receives the retain exactly once. Do not take the production NAS Hindsight service offline for validation; use the temporary local HTTP server and a temporary `HERMES_HOME`.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import importlib
+import inspect
 import json
 import logging
 import os
@@ -53,6 +54,8 @@ from hermes_time import now as _hermes_now
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
+from .outbox import HindsightOutbox, OutboxRow
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,7 +75,7 @@ class _RecallResult:
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.9.2"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
@@ -810,6 +813,9 @@ class HindsightMemoryProvider(MemoryProvider):
         # can race the interpreter shutdown and emit "cannot schedule new
         # futures after interpreter shutdown" / "Unclosed client session".
         self._retain_queue: queue.Queue = queue.Queue()
+        self._outbox: HindsightOutbox | None = None
+        self._outbox_replay_thread: threading.Thread | None = None
+        self._outbox_wakeup = threading.Event()
         self._writer_thread: threading.Thread | None = None
         self._shutting_down = threading.Event()
         self._atexit_registered = False
@@ -1302,6 +1308,28 @@ class HindsightMemoryProvider(MemoryProvider):
             )
         )
 
+    @staticmethod
+    def _is_not_found_error(exc: Exception) -> bool:
+        """Return True for an SDK/API 404 without importing generated models.
+
+        ``hindsight-client`` lazily imports a large generated Pydantic model
+        graph when ``hindsight_client_api.exceptions`` is first imported. Doing
+        that on the prefetch thread can delay the first operation-status poll
+        by several seconds. The generated exception exposes ``status`` and
+        ``http_resp.status`` across supported SDK versions, while the class
+        name provides a fallback for lightweight test doubles/older clients.
+        """
+        status = getattr(exc, "status", None)
+        if status is None:
+            response = getattr(exc, "http_resp", None)
+            status = getattr(response, "status", None)
+        if status is not None:
+            try:
+                return int(status) == 404
+            except (TypeError, ValueError):
+                pass
+        return type(exc).__name__ == "NotFoundException"
+
     def _ensure_writer(self) -> None:
         """Lazy-start the single retain-writer thread.
 
@@ -1357,17 +1385,15 @@ class HindsightMemoryProvider(MemoryProvider):
         means "no longer pending" and is treated as done. Transient errors
         return False so the caller keeps waiting until its deadline.
         """
-        from hindsight_client_api.exceptions import NotFoundException
-
         try:
             resp = self._run_hindsight_operation(
                 lambda client: client.operations.get_operation_status(
                     bank_id=bank_id, operation_id=op_id
                 )
             )
-        except NotFoundException:
-            return True
         except Exception as exc:
+            if self._is_not_found_error(exc):
+                return True
             logger.debug("Prefetch: operation status check failed for %s: %s", op_id, exc)
             return False
         status = str(getattr(resp, "status", "") or "").lower()
@@ -1510,6 +1536,92 @@ class HindsightMemoryProvider(MemoryProvider):
                     logger.warning("Hindsight retain failed: %s", exc, exc_info=True)
             finally:
                 self._retain_queue.task_done()
+
+    def _ensure_outbox_replay(self) -> None:
+        """Start the durable replay worker without starting the legacy writer."""
+        thread = self._outbox_replay_thread
+        if thread is not None and thread.is_alive():
+            return
+        thread = threading.Thread(
+            target=self._outbox_replay_loop,
+            daemon=True,
+            name="hindsight-outbox-replay",
+        )
+        self._outbox_replay_thread = thread
+        thread.start()
+
+    def _outbox_replay_loop(self) -> None:
+        """Replay persisted rows after startup and whenever Hindsight recovers."""
+        while not self._shutting_down.is_set():
+            rows: list[OutboxRow] = []
+            if self._outbox is not None:
+                try:
+                    rows = self._outbox.claim_due(limit=1, replay_only=True)
+                except Exception as exc:
+                    logger.warning("Hindsight outbox read failed: %s", exc)
+            if rows:
+                self._deliver_outbox_row(rows[0])
+                continue
+            self._outbox_wakeup.wait(timeout=1.0)
+            self._outbox_wakeup.clear()
+
+    def _retain_batch_from_outbox(self, client, row: OutboxRow):
+        """Send a queued retain, using idempotency when the SDK exposes it."""
+        kwargs = {
+            "bank_id": row.bank_id,
+            "items": [row.item],
+            "document_id": row.document_id,
+            "retain_async": row.retain_async,
+        }
+        if row.retain_async and row.operation_id:
+            try:
+                supports_operation_id = "operation_id" in inspect.signature(
+                    client.aretain_batch
+                ).parameters
+            except (TypeError, ValueError):
+                supports_operation_id = False
+            if supports_operation_id:
+                kwargs["operation_id"] = row.operation_id
+        return client.aretain_batch(**kwargs)
+
+    def _deliver_outbox_row(self, row: OutboxRow) -> None:
+        """Deliver one persisted request; failed rows remain for retry."""
+        try:
+            operation_id = None
+            if row.retain_async and self._outbox is not None:
+                operation_id = self._outbox.ensure_operation_id(row.id, row.operation_id)
+                row = OutboxRow(
+                    id=row.id,
+                    dedupe_key=row.dedupe_key,
+                    bank_id=row.bank_id,
+                    document_id=row.document_id,
+                    update_mode=row.update_mode,
+                    retain_async=row.retain_async,
+                    operation_id=operation_id,
+                    item=row.item,
+                    attempts=row.attempts,
+                    available_at=row.available_at,
+                    state=row.state,
+                    last_error=row.last_error,
+                )
+            resp = self._run_hindsight_operation(
+                lambda client: self._retain_batch_from_outbox(client, row)
+            )
+            if row.retain_async:
+                self._track_retain_ops(resp, row.bank_id)
+            if self._outbox is not None:
+                self._outbox.acknowledge(row.id)
+            logger.debug("Hindsight outbox delivery succeeded: row=%s", row.id)
+        except Exception as exc:
+            delay = min(300.0, float(2 ** min(row.attempts, 8)))
+            if self._outbox is not None:
+                self._outbox.reschedule(
+                    row.id, type(exc).__name__, delay_seconds=delay
+                )
+            logger.warning(
+                "Hindsight unavailable; retain row %s kept for retry in %.0fs: %s",
+                row.id, delay, exc,
+            )
 
     def _register_atexit(self) -> None:
         """Register an idempotent atexit hook to drain the writer.
@@ -1679,6 +1791,9 @@ class HindsightMemoryProvider(MemoryProvider):
             user=self._user_id,
             session=self._session_id,
         )
+        self._outbox = HindsightOutbox(get_hermes_home() / "hindsight" / "outbox.sqlite3")
+        self._outbox.release_stale_claims()
+        self._outbox.activate_replay_rows()
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
@@ -1837,6 +1952,8 @@ class HindsightMemoryProvider(MemoryProvider):
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
+
+        self._ensure_outbox_replay()
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
@@ -2141,33 +2258,32 @@ class HindsightMemoryProvider(MemoryProvider):
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
 
+        item = self._build_retain_kwargs(
+            content,
+            context=retain_context,
+            metadata=metadata_snapshot,
+            tags=lineage_tags or None,
+        )
+        item.pop("bank_id", None)
+        item.pop("retain_async", None)
+        if update_mode is not None:
+            item["update_mode"] = update_mode
+        dedupe_key = f"{document_id}:{self._turn_index}:{num_turns}"
+        row_id = self._outbox.enqueue(
+            dedupe_key=dedupe_key,
+            bank_id=bank_id,
+            document_id=document_id,
+            update_mode=update_mode,
+            retain_async=retain_async_flag,
+            item=item,
+        )
+
         def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
-            )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            resp = self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
-                )
-            )
-            # For async retains the write is only *accepted* here; track the
-            # returned operation id(s) so the next-turn prefetch can wait for
-            # true server-side completion (read-after-write) before recalling.
-            if retain_async_flag:
-                self._track_retain_ops(resp, bank_id)
-            logger.debug("Hindsight retain succeeded")
+            row = self._outbox.claim(row_id)
+            if row is not None:
+                logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
+                             bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
+                self._deliver_outbox_row(row)
 
         self._ensure_writer()
         self._register_atexit()
@@ -2176,6 +2292,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # only fires on turns that actually persist.
         self._emit_saving_indicator()
         self._retain_queue.put(_do_retain)
+        self._outbox_wakeup.set()
         # Advance the append watermark only after the delta is queued, so a
         # later retain doesn't re-ship turns we've already handed to the writer.
         if update_mode == "append":
@@ -2425,9 +2542,19 @@ class HindsightMemoryProvider(MemoryProvider):
                     "abandoning %d pending retain(s)",
                     self._retain_queue.qsize(),
                 )
+        replay = self._outbox_replay_thread
+        if replay is not None and replay.is_alive():
+            self._outbox_wakeup.set()
+            replay.join(timeout=10.0)
+            if replay.is_alive():
+                logger.warning("Hindsight outbox replay worker did not stop within 10s")
+        workers_stopped = not (
+            (writer is not None and writer.is_alive())
+            or (replay is not None and replay.is_alive())
+        )
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
-        if self._client is not None:
+        if workers_stopped and self._client is not None:
             try:
                 if self._mode == "local_embedded":
                     # HindsightEmbedded.close() delegates to its sync client.close().
@@ -2452,6 +2579,12 @@ class HindsightMemoryProvider(MemoryProvider):
             except Exception:
                 pass
             self._client = None
+        if workers_stopped and self._outbox is not None:
+            try:
+                self._outbox.close()
+            except Exception:
+                pass
+            self._outbox = None
         # The module-global background event loop (_loop / _loop_thread)
         # is intentionally NOT stopped here. It is shared across every
         # HindsightMemoryProvider instance in the process — the plugin

--- a/plugins/memory/hindsight/outbox.py
+++ b/plugins/memory/hindsight/outbox.py
@@ -1,0 +1,262 @@
+"""Durable client-side delivery buffer for Hindsight retain requests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OutboxRow:
+    id: int
+    dedupe_key: str
+    bank_id: str
+    document_id: str
+    update_mode: str | None
+    retain_async: bool
+    operation_id: str | None
+    item: dict[str, Any]
+    attempts: int
+    available_at: float
+    state: str
+    last_error: str | None
+
+
+class HindsightOutbox:
+    """Small SQLite outbox; Hindsight is unaware that it exists."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.path.parent.chmod(0o700)
+        except OSError:
+            pass
+        self._db = sqlite3.connect(self.path, timeout=30, check_same_thread=False)
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+        self._db.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA busy_timeout=30000")
+        self._secure_sidecars()
+        self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS hindsight_outbox (
+                id INTEGER PRIMARY KEY,
+                dedupe_key TEXT NOT NULL UNIQUE,
+                bank_id TEXT NOT NULL,
+                document_id TEXT NOT NULL,
+                update_mode TEXT,
+                retain_async INTEGER NOT NULL,
+                operation_id TEXT,
+                item_json TEXT NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                available_at REAL NOT NULL,
+                replay_eligible INTEGER NOT NULL DEFAULT 1,
+                state TEXT NOT NULL DEFAULT 'pending',
+                last_error TEXT,
+                claimed_at REAL
+            )
+            """
+        )
+        columns = {
+            row["name"] for row in self._db.execute("PRAGMA table_info(hindsight_outbox)")
+        }
+        if "operation_id" not in columns:
+            self._db.execute("ALTER TABLE hindsight_outbox ADD COLUMN operation_id TEXT")
+        if "replay_eligible" not in columns:
+            self._db.execute(
+                "ALTER TABLE hindsight_outbox "
+                "ADD COLUMN replay_eligible INTEGER NOT NULL DEFAULT 1"
+            )
+        self._db.execute(
+            "CREATE INDEX IF NOT EXISTS hindsight_outbox_due "
+            "ON hindsight_outbox(state, available_at)"
+        )
+        self._db.commit()
+
+    def _secure_sidecars(self) -> None:
+        """Keep SQLite WAL/SHM files private; they contain retain payloads."""
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{self.path}{suffix}")
+            if sidecar.exists():
+                try:
+                    sidecar.chmod(0o600)
+                except OSError:
+                    pass
+
+    def enqueue(
+        self,
+        *,
+        dedupe_key: str,
+        bank_id: str,
+        document_id: str,
+        update_mode: str | None,
+        retain_async: bool,
+        item: dict[str, Any],
+        operation_id: str | None = None,
+    ) -> int:
+        operation_id = operation_id or str(uuid.uuid4())
+        with self._lock, self._db:
+            cur = self._db.execute(
+                """
+                INSERT INTO hindsight_outbox
+                  (dedupe_key, bank_id, document_id, update_mode, retain_async,
+                   operation_id, item_json, available_at, replay_eligible)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+                ON CONFLICT(dedupe_key) DO NOTHING
+                """,
+                (
+                    dedupe_key,
+                    bank_id,
+                    document_id,
+                    update_mode,
+                    int(retain_async),
+                    operation_id,
+                    json.dumps(item, ensure_ascii=False, sort_keys=True),
+                    time.time(),
+                ),
+            )
+            if cur.rowcount:
+                return int(cur.lastrowid)
+            row = self._db.execute(
+                "SELECT id FROM hindsight_outbox WHERE dedupe_key = ?", (dedupe_key,)
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("Hindsight outbox insert was not committed")
+            return int(row[0])
+
+    def claim_due(self, *, limit: int = 1, replay_only: bool = False) -> list[OutboxRow]:
+        now = time.time()
+        replay_clause = " AND replay_eligible = 1" if replay_only else ""
+        with self._lock:
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                rows = self._db.execute(
+                    f"""
+                    SELECT * FROM hindsight_outbox
+                    WHERE state = 'pending' AND available_at <= ?{replay_clause}
+                    ORDER BY id LIMIT ?
+                    """,
+                    (now, limit),
+                ).fetchall()
+                ids = [row["id"] for row in rows]
+                if ids:
+                    self._db.executemany(
+                        """
+                        UPDATE hindsight_outbox
+                        SET state='in_flight', claimed_at=?, replay_eligible=0
+                        WHERE id=?
+                        """,
+                        [(now, row_id) for row_id in ids],
+                    )
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
+        return [self._row(row) for row in rows]
+
+    def claim(self, row_id: int) -> OutboxRow | None:
+        now = time.time()
+        with self._lock, self._db:
+            cur = self._db.execute(
+                """
+                UPDATE hindsight_outbox
+                SET state='in_flight', claimed_at=?, replay_eligible=0
+                WHERE id=? AND state='pending' AND available_at <= ?
+                """,
+                (now, row_id, now),
+            )
+            if cur.rowcount != 1:
+                return None
+            row = self._db.execute(
+                "SELECT * FROM hindsight_outbox WHERE id = ?", (row_id,)
+            ).fetchone()
+        return self._row(row) if row else None
+
+    def ensure_operation_id(self, row_id: int, operation_id: str | None = None) -> str:
+        operation_id = operation_id or str(uuid.uuid4())
+        with self._lock, self._db:
+            self._db.execute(
+                """
+                UPDATE hindsight_outbox
+                SET operation_id = COALESCE(operation_id, ?)
+                WHERE id = ?
+                """,
+                (operation_id, row_id),
+            )
+            row = self._db.execute(
+                "SELECT operation_id FROM hindsight_outbox WHERE id = ?", (row_id,)
+            ).fetchone()
+        if row is None or not row["operation_id"]:
+            raise KeyError(f"Hindsight outbox row not found: {row_id}")
+        return str(row["operation_id"])
+
+    def acknowledge(self, row_id: int) -> None:
+        with self._lock, self._db:
+            self._db.execute("DELETE FROM hindsight_outbox WHERE id = ?", (row_id,))
+
+    def reschedule(self, row_id: int, error: str, *, delay_seconds: float) -> None:
+        with self._lock, self._db:
+            self._db.execute(
+                """
+                UPDATE hindsight_outbox
+                SET state='pending', attempts=attempts+1, available_at=?,
+                    last_error=?, claimed_at=NULL, replay_eligible=1
+                WHERE id=?
+                """,
+                (time.time() + max(0.0, delay_seconds), str(error)[:2000], row_id),
+            )
+
+    def release_stale_claims(self, *, lease_seconds: float = 300) -> int:
+        with self._lock, self._db:
+            cur = self._db.execute(
+                """
+                UPDATE hindsight_outbox
+                SET state='pending', claimed_at=NULL, available_at=?
+                WHERE state='in_flight' AND claimed_at < ?
+                """,
+                (time.time(), time.time() - lease_seconds),
+            )
+        return cur.rowcount
+
+    def activate_replay_rows(self) -> int:
+        """Make rows from a previous process eligible for startup replay."""
+        with self._lock, self._db:
+            cur = self._db.execute(
+                """
+                UPDATE hindsight_outbox
+                SET replay_eligible=1
+                WHERE state='pending'
+                """
+            )
+        return cur.rowcount
+
+    def _row(self, row: sqlite3.Row) -> OutboxRow:
+        return OutboxRow(
+            id=int(row["id"]),
+            dedupe_key=row["dedupe_key"],
+            bank_id=row["bank_id"],
+            document_id=row["document_id"],
+            update_mode=row["update_mode"],
+            retain_async=bool(row["retain_async"]),
+            operation_id=row["operation_id"],
+            item=json.loads(row["item_json"]),
+            attempts=int(row["attempts"]),
+            available_at=float(row["available_at"]),
+            state=row["state"],
+            last_error=row["last_error"],
+        )
+
+    def close(self) -> None:
+        with self._lock:
+            self._db.close()

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client>=0.9.2"
 requires_env: []
 hooks:
   - on_session_end

--- a/tests/plugins/memory/test_hindsight_outbox.py
+++ b/tests/plugins/memory/test_hindsight_outbox.py
@@ -1,0 +1,177 @@
+import concurrent.futures
+import stat
+import threading
+
+from plugins.memory.hindsight import HindsightMemoryProvider
+from plugins.memory.hindsight.outbox import HindsightOutbox
+
+
+def entry(**overrides):
+    value = {
+        "dedupe_key": "session-1:turn-1",
+        "bank_id": "hermes",
+        "document_id": "doc-1",
+        "update_mode": "append",
+        "retain_async": True,
+        "item": {"content": "hello", "context": "test"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_outbox_survives_reopen(tmp_path):
+    path = tmp_path / "hindsight-outbox.sqlite3"
+    first = HindsightOutbox(path)
+    row_id = first.enqueue(**entry())
+    first.close()
+
+    second = HindsightOutbox(path)
+    rows = second.claim_due(limit=10)
+
+    assert [row.id for row in rows] == [row_id]
+    assert rows[0].item["content"] == "hello"
+    assert rows[0].operation_id
+    second.close()
+
+
+def test_outbox_file_is_private_on_posix(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "hindsight-outbox.sqlite3")
+
+    mode = stat.S_IMODE(outbox.path.stat().st_mode)
+    parent_mode = stat.S_IMODE(outbox.path.parent.stat().st_mode)
+
+    assert mode == 0o600
+    assert parent_mode == 0o700
+    for suffix in ("-wal", "-shm"):
+        sidecar = outbox.path.with_name(outbox.path.name + suffix)
+        if sidecar.exists():
+            assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+    outbox.close()
+
+
+def test_duplicate_dedupe_key_is_stored_once(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "outbox.sqlite3")
+
+    first = outbox.enqueue(**entry())
+    second = outbox.enqueue(**entry())
+
+    assert first == second
+    assert len(outbox.claim_due(limit=10)) == 1
+    outbox.close()
+
+
+def test_failed_delivery_remains_due_after_reschedule(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "outbox.sqlite3")
+    row_id = outbox.enqueue(**entry())
+    row = outbox.claim_due(limit=1)[0]
+
+    outbox.reschedule(row.id, "connection refused", delay_seconds=0)
+    retry = outbox.claim_due(limit=1)[0]
+
+    assert retry.id == row_id
+    assert retry.attempts == 1
+    assert retry.last_error == "connection refused"
+    outbox.close()
+
+
+def test_claim_due_is_atomic_across_outbox_connections(tmp_path):
+    path = tmp_path / "outbox.sqlite3"
+    first = HindsightOutbox(path)
+    second = HindsightOutbox(path)
+    first.enqueue(**entry())
+    barrier = threading.Barrier(2)
+
+    def claim(outbox):
+        barrier.wait()
+        return outbox.claim_due(limit=1)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(claim, (first, second)))
+
+    assert sum(bool(rows) for rows in results) == 1
+    first.close()
+    second.close()
+
+
+def test_restart_activates_pending_rows_for_replay(tmp_path):
+    path = tmp_path / "outbox.sqlite3"
+    first = HindsightOutbox(path)
+    row_id = first.enqueue(**entry())
+    first.close()
+
+    second = HindsightOutbox(path)
+    assert second.claim_due(limit=1, replay_only=True) == []
+    assert second.activate_replay_rows() == 1
+    rows = second.claim_due(limit=1, replay_only=True)
+
+    assert [row.id for row in rows] == [row_id]
+    second.close()
+
+
+def test_acknowledge_removes_successful_delivery(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "outbox.sqlite3")
+    row_id = outbox.enqueue(**entry())
+    outbox.claim_due(limit=1)
+
+    outbox.acknowledge(row_id)
+
+    assert outbox.claim_due(limit=1) == []
+    outbox.close()
+
+
+def test_operation_id_is_sent_when_client_supports_idempotent_retain(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "outbox.sqlite3")
+    row_id = outbox.enqueue(**entry())
+    row = outbox.claim(row_id)
+    calls = []
+
+    class Client:
+        def aretain_batch(self, *, bank_id, items, document_id, retain_async, operation_id=None):
+            calls.append(
+                {
+                    "bank_id": bank_id,
+                    "items": items,
+                    "document_id": document_id,
+                    "retain_async": retain_async,
+                    "operation_id": operation_id,
+                }
+            )
+            return object()
+
+    provider = HindsightMemoryProvider()
+    provider._outbox = outbox
+    provider._run_hindsight_operation = lambda operation: operation(Client())
+
+    provider._deliver_outbox_row(row)
+
+    assert len(calls) == 1
+    assert calls[0]["operation_id"] == row.operation_id
+    outbox.close()
+
+
+def test_provider_keeps_delivery_when_hindsight_is_offline(tmp_path):
+    outbox = HindsightOutbox(tmp_path / "outbox.sqlite3")
+    provider = HindsightMemoryProvider()
+    provider._outbox = outbox
+    row_id = outbox.enqueue(**entry(retain_async=False))
+    row = outbox.claim(row_id)
+    calls = []
+
+    def offline(_operation):
+        raise ConnectionError("Hindsight offline")
+
+    provider._run_hindsight_operation = offline
+    provider._deliver_outbox_row(row)
+    import time
+    time.sleep(1.05)
+    retry = outbox.claim_due(limit=1)[0]
+    assert retry.id == row_id
+    assert retry.attempts == 1
+    assert "ConnectionError" in retry.last_error
+
+    provider._run_hindsight_operation = lambda operation: calls.append(operation) or object()
+    provider._deliver_outbox_row(retry)
+
+    assert outbox.claim_due(limit=1) == []
+    assert len(calls) == 1
+    outbox.close()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.9.2",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the


### PR DESCRIPTION
## Summary
- Add a profile-scoped SQLite outbox for automatic Hindsight retains.
- Persist complete retain payloads before dispatch, retain failed rows for bounded retry, and replay pending rows after restart.
- Use atomic claims, stale-claim recovery, stable operation IDs when supported, and worker-safe shutdown.
- Update the lazy dependency and minimum supported `hindsight-client` version to `0.9.2`.
- Add an operational upgrade/migration runbook.

## Scope and compatibility
This change is entirely on the Hermes client/integration side. It does not modify Hindsight server code, database behavior, extraction, embeddings, reranking, recall semantics, or the Hindsight API.

The existing lazy normal writer remains lazy; replay activation is separate. The outbox covers automatic `sync_turn()` retention. Explicit `hindsight_retain` remains a direct synchronous tool path.

## Verification
- Focused Hindsight provider and durable-outbox tests: `93 passed`
- Python compilation: passed
- `git diff --check`: passed

## Operational note
Rows are acknowledged locally after the retain API accepts them. Operation IDs reduce crash/retry duplication when supported by the installed server/client, but the integration does not claim universal exactly-once delivery.
