### PR TITLE
[PER2-HF-04-A] Fail-loud frontier check at frontier-required call sites (Layer A)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1831,6 +1831,7 @@ def run_conversation(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    frontier_required: bool = False,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -1855,6 +1856,13 @@ def run_conversation(
             the message unchanged.
         persist_user_display_metadata: Optional payload for that event
             (e.g. a delegation's task count).
+        frontier_required: Caller-supplied, per-call assertion that this turn
+            must be served by a frontier-class model (HF-04 Layer A, IGN-197).
+            When True *and* the shared HERMES_FRONTIER_DOWNGRADE_CHECK flag is
+            on, a turn that ends on a non-frontier model after fallback
+            activation appends a caller-visible ``frontier_downgrade`` entry to
+            ``result["warnings"]``. Never blocks the response. Defaults to
+            False, so no existing caller changes behaviour.
                 or queuing follow-up prefetch work.
 
     Returns:
@@ -8591,6 +8599,7 @@ def run_conversation(
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
+        frontier_required=frontier_required,
     )
 
 

--- a/agent/frontier_guard.py
+++ b/agent/frontier_guard.py
@@ -24,6 +24,17 @@ Design constraints this module encodes (from the approved IGN-192 design doc
   degrading into a no-op, because a no-op check is indistinguishable from a
   clean result.
 
+Scope of "caller-visible" (IGN-252 blocker #2, board decision recorded
+2026-08-26). Layer A's caller-visible surface is ``result["warnings"]`` plus the
+log line below — the shape approved in design rev 1. That is genuinely visible
+to in-process callers (CLI, cron, delegated) and, on the oneshot path where
+logging is disabled, via the ``--usage-file`` report and stderr. It is
+deliberately *not* serialised onto the HTTP response body: the API-server
+response builders emit only ``final_response``/``usage``/``runtime`` and
+``_sanitize_runtime_metadata`` whitelists keys, so carrying warnings there is a
+public response-schema change that gets its own ticket and its own back-compat
+review rather than riding along on this branch.
+
 Rollback: set ``HERMES_FRONTIER_DOWNGRADE_CHECK`` to a falsey value (or unset
 it). ``git revert`` of the implementing commit is the documented backstop if the
 flag mechanism itself misbehaves.

--- a/agent/frontier_guard.py
+++ b/agent/frontier_guard.py
@@ -199,13 +199,32 @@ def check_frontier_downgrade(
 
     # Also log it: on the cron path there is no human reading the result dict,
     # and the session log is the transcript.
-    logger.warning(
-        "Frontier guarantee not held: requested %r (%s) but %r (%s) served this turn",
-        warning.get("requested_model"),
-        warning.get("requested_class") or "unknown",
-        warning.get("served_model"),
-        warning.get("served_class") or "unknown",
-    )
+    #
+    # The two warning types are distinct findings and must not share a message.
+    # "Guarantee not held" is a claim that a frontier request was demonstrably
+    # served by a non-frontier model. On the frontier_check_unavailable path we
+    # know nothing of the kind — the check never ran, so the guarantee is
+    # *unverified*, not violated. Logging the stronger sentence for the weaker
+    # finding would send anyone reading the transcript hunting a downgrade that
+    # may not have happened, and it hides the thing that actually needs fixing:
+    # the check itself is broken.
+    if warning.get("type") == "frontier_downgrade":
+        logger.warning(
+            "Frontier guarantee not held: requested %r (%s) but %r (%s) served this turn",
+            warning.get("requested_model"),
+            warning.get("requested_class") or "unknown",
+            warning.get("served_model"),
+            warning.get("served_class") or "unknown",
+        )
+    else:
+        logger.warning(
+            "Frontier guarantee unverified for this turn (%s): requested %r, "
+            "served %r — the downgrade check could not run, so this is neither "
+            "a pass nor a detected downgrade",
+            warning.get("detail") or warning.get("type"),
+            warning.get("requested_model"),
+            warning.get("served_model"),
+        )
     return warning
 
 

--- a/agent/frontier_guard.py
+++ b/agent/frontier_guard.py
@@ -1,0 +1,218 @@
+"""Fail-loud requested-vs-served model check for frontier-required calls.
+
+Implements Layer A of the HF-04 remediation (silent frontier downgrade): when a
+caller explicitly marks a call ``frontier_required``, compare the model class it
+asked for against the model class that actually served the turn, and surface a
+caller-visible warning when a frontier request was served by a non-frontier
+model.
+
+Design constraints this module encodes (from the approved IGN-192 design doc
+``hf04-a-design`` rev 1):
+
+* **Caller-supplied, per-call.** ``frontier_required`` is an explicit flag on the
+  call, never inferred from task content. Inference would make correctness depend
+  on a second, separately-fallible classifier — the exact silent-failure surface
+  HF-04 already burned us on. Default is ``False``: opt-in, so no existing caller
+  changes behaviour.
+* **Non-blocking.** A downgrade produces a warning in the turn result, not an
+  exception. A hard-block mode is a separate, later decision.
+* **One shared feature flag**, read per-call so disabling takes effect on the very
+  next call with no restart. Both the API-server call path (IGN-196) and the
+  CLI/cron call path (IGN-197) read this same flag — do not add a second one.
+* **Fail loud, not silent.** If the check is switched on but the classifier from
+  IGN-195 cannot be imported, that is reported (once) rather than quietly
+  degrading into a no-op, because a no-op check is indistinguishable from a
+  clean result.
+
+Rollback: set ``HERMES_FRONTIER_DOWNGRADE_CHECK`` to a falsey value (or unset
+it). ``git revert`` of the implementing commit is the documented backstop if the
+flag mechanism itself misbehaves.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Shared feature-flag env var. Read per-call, never cached at process start.
+FRONTIER_DOWNGRADE_CHECK_ENV = "HERMES_FRONTIER_DOWNGRADE_CHECK"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+#: Candidate homes for the shared classifier delivered by IGN-195 (A1). A1 owns
+#: the final location; this list is tried in order so A3 keeps working wherever
+#: A1 lands it. Preferred/first entry is the one proposed to A1.
+_MODEL_CLASS_IMPORT_CANDIDATES = (
+    ("agent.model_classification", "model_class"),
+    ("agent.model_class", "model_class"),
+    ("hermes_cli.model_classification", "model_class"),
+    ("model_classification", "model_class"),
+)
+
+# Module-level latch so a missing classifier is reported once per process
+# instead of once per turn.
+_classifier_missing_reported = False
+
+
+def frontier_downgrade_check_enabled() -> bool:
+    """Return whether the shared frontier-downgrade check is switched on.
+
+    Reads the environment on every call (never cached) so that flipping the flag
+    off takes effect on the next call without a restart.
+    """
+    return (os.environ.get(FRONTIER_DOWNGRADE_CHECK_ENV) or "").strip().lower() in _TRUTHY
+
+
+def _resolve_model_class():
+    """Return IGN-195's ``model_class`` callable, or ``None`` if not present yet."""
+    for module_name, attr in _MODEL_CLASS_IMPORT_CANDIDATES:
+        try:
+            module = __import__(module_name, fromlist=[attr])
+        except Exception:
+            continue
+        fn = getattr(module, attr, None)
+        if callable(fn):
+            return fn
+    return None
+
+
+def classify_model(model: Any) -> Optional[str]:
+    """Classify ``model`` via the shared classifier. ``None`` when unavailable."""
+    if not isinstance(model, str) or not model.strip():
+        return None
+    fn = _resolve_model_class()
+    if fn is None:
+        return None
+    try:
+        result = fn(model.strip())
+    except Exception:
+        logger.warning(
+            "frontier downgrade check: model_class(%r) raised; treating class as unknown",
+            model,
+            exc_info=True,
+        )
+        return None
+    return result if isinstance(result, str) and result else None
+
+
+def build_frontier_downgrade_warning(
+    requested_model: Any,
+    served_model: Any,
+    *,
+    frontier_required: bool = False,
+) -> Optional[dict]:
+    """Return a caller-visible warning dict, or ``None`` when there is nothing to say.
+
+    Returns ``None`` — meaning "no warning" — when the call was not marked
+    ``frontier_required``, when the flag is off, or when a frontier request was
+    genuinely served by a frontier model.
+
+    Returns a ``frontier_check_unavailable`` warning when the check is switched
+    on for a frontier-required call but the shared classifier is missing. That is
+    deliberate: a silently skipped check looks exactly like a passing one.
+    """
+    global _classifier_missing_reported
+
+    if not frontier_required or not frontier_downgrade_check_enabled():
+        return None
+
+    fn = _resolve_model_class()
+    if fn is None:
+        if not _classifier_missing_reported:
+            _classifier_missing_reported = True
+            logger.warning(
+                "%s is enabled but the shared model classifier (IGN-195) is not "
+                "importable from any of %s — frontier-required calls cannot be "
+                "checked for downgrade",
+                FRONTIER_DOWNGRADE_CHECK_ENV,
+                [name for name, _ in _MODEL_CLASS_IMPORT_CANDIDATES],
+            )
+        return {
+            "type": "frontier_check_unavailable",
+            "requested_model": requested_model,
+            "served_model": served_model,
+            "detail": "shared model classifier is not importable",
+        }
+
+    requested_class = classify_model(requested_model)
+    served_class = classify_model(served_model)
+    if requested_class is None:
+        # The classifier exists but could not produce a verdict (it raised, or
+        # the requested model is not a usable string). Same reasoning as the
+        # missing-classifier branch: report it rather than let an unrun check
+        # look like a passing one.
+        return {
+            "type": "frontier_check_unavailable",
+            "requested_model": requested_model,
+            "served_model": served_model,
+            "detail": "requested model could not be classified",
+        }
+    if requested_class != "frontier":
+        # Nothing was promised. A non-frontier (or unclassifiable) request cannot
+        # be downgraded by definition.
+        return None
+    if served_class == "frontier":
+        return None
+
+    return {
+        "type": "frontier_downgrade",
+        "requested_model": requested_model,
+        "served_model": served_model,
+        "requested_class": requested_class,
+        "served_class": served_class,
+    }
+
+
+def check_frontier_downgrade(
+    result: dict,
+    *,
+    requested_model: Any,
+    served_model: Any,
+    frontier_required: bool = False,
+) -> Optional[dict]:
+    """Append a frontier-downgrade warning to ``result['warnings']`` if warranted.
+
+    Non-blocking by contract: this never raises for a downgrade, and any internal
+    failure is swallowed so the guard can never break a turn that would otherwise
+    have succeeded. Returns the warning that was appended, or ``None``.
+    """
+    try:
+        warning = build_frontier_downgrade_warning(
+            requested_model,
+            served_model,
+            frontier_required=frontier_required,
+        )
+    except Exception:
+        logger.warning("frontier downgrade check failed", exc_info=True)
+        return None
+    if warning is None:
+        return None
+
+    warnings = result.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+        result["warnings"] = warnings
+    warnings.append(warning)
+
+    # Also log it: on the cron path there is no human reading the result dict,
+    # and the session log is the transcript.
+    logger.warning(
+        "Frontier guarantee not held: requested %r (%s) but %r (%s) served this turn",
+        warning.get("requested_model"),
+        warning.get("requested_class") or "unknown",
+        warning.get("served_model"),
+        warning.get("served_class") or "unknown",
+    )
+    return warning
+
+
+__all__ = [
+    "FRONTIER_DOWNGRADE_CHECK_ENV",
+    "frontier_downgrade_check_enabled",
+    "classify_model",
+    "build_frontier_downgrade_warning",
+    "check_frontier_downgrade",
+]

--- a/agent/frontier_guard.py
+++ b/agent/frontier_guard.py
@@ -40,7 +40,14 @@ logger = logging.getLogger(__name__)
 #: Shared feature-flag env var. Read per-call, never cached at process start.
 FRONTIER_DOWNGRADE_CHECK_ENV = "HERMES_FRONTIER_DOWNGRADE_CHECK"
 
+#: Literal per-call override for the caller's frontier assertion (IGN-252
+#: blocker #3, board decision "both"). Truthy asserts the requirement even when
+#: the model name does not carry the intent; falsey suppresses it even for an
+#: explicitly-named frontier model. Unset means "derive it".
+FRONTIER_REQUIRED_ENV = "HERMES_FRONTIER_REQUIRED"
+
 _TRUTHY = {"1", "true", "yes", "on"}
+_FALSEY = {"0", "false", "no", "off"}
 
 #: Candidate homes for the shared classifier delivered by IGN-195 (A1). A1 owns
 #: the final location; this list is tried in order so A3 keeps working wherever
@@ -64,6 +71,65 @@ def frontier_downgrade_check_enabled() -> bool:
     off takes effect on the next call without a restart.
     """
     return (os.environ.get(FRONTIER_DOWNGRADE_CHECK_ENV) or "").strip().lower() in _TRUTHY
+
+
+def frontier_required_override() -> Optional[bool]:
+    """Return the caller's literal ``HERMES_FRONTIER_REQUIRED`` assertion.
+
+    ``True``/``False`` when the env var is set to a recognised value, ``None``
+    when unset/blank (meaning: no literal assertion, derive it). An
+    unrecognised value is logged and treated as unset rather than guessed —
+    guessing here would silently switch a fail-loud check on or off.
+    """
+    raw = (os.environ.get(FRONTIER_REQUIRED_ENV) or "").strip().lower()
+    if not raw:
+        return None
+    if raw in _TRUTHY:
+        return True
+    if raw in _FALSEY:
+        return False
+    logger.warning(
+        "%s=%r is not a recognised boolean (expected one of %s / %s); ignoring it "
+        "and deriving the frontier requirement instead",
+        FRONTIER_REQUIRED_ENV,
+        raw,
+        sorted(_TRUTHY),
+        sorted(_FALSEY),
+    )
+    return None
+
+
+def resolve_frontier_required(
+    requested_model: Any,
+    *,
+    explicitly_requested: bool,
+) -> bool:
+    """Decide whether a call asserts a frontier requirement.
+
+    Precedence, per the IGN-252 board decision (option "both"):
+
+    1. The literal ``HERMES_FRONTIER_REQUIRED`` override, in either direction.
+    2. Otherwise, derive it: the caller *explicitly named* a model (``--model``
+       / ``HERMES_INFERENCE_MODEL``, not the configured default) and that model
+       classifies as ``frontier``.
+
+    Deriving from the caller's own explicit model choice is not the inference
+    the design doc forbids — that was inferring the requirement from *task
+    content*. Here the caller has already named the model it wants; this only
+    reads that choice back.
+
+    Returns ``False`` when the classifier is unavailable on the derive path:
+    with no verdict there is no evidence the caller asked for frontier, and
+    asserting one would manufacture ``frontier_check_unavailable`` warnings on
+    every call. A caller that knows better sets the override, which does reach
+    the guard and does report unavailability.
+    """
+    override = frontier_required_override()
+    if override is not None:
+        return override
+    if not explicitly_requested:
+        return False
+    return classify_model(requested_model) == "frontier"
 
 
 def _resolve_model_class():
@@ -230,7 +296,10 @@ def check_frontier_downgrade(
 
 __all__ = [
     "FRONTIER_DOWNGRADE_CHECK_ENV",
+    "FRONTIER_REQUIRED_ENV",
     "frontier_downgrade_check_enabled",
+    "frontier_required_override",
+    "resolve_frontier_required",
     "classify_model",
     "build_frontier_downgrade_warning",
     "check_frontier_downgrade",

--- a/agent/model_classification.py
+++ b/agent/model_classification.py
@@ -1,0 +1,57 @@
+"""
+Shared frontier/cheap model classification (IGN-195, PER2-HF-04-A1).
+
+Single source of truth for ``model_class()`` inside the live hermes-agent tree.
+Both PER2-HF-04-A call-site children import from here:
+
+    from agent.model_classification import model_class
+
+Membership is mirrored verbatim from the PER2-MOD-01 offline evaluator
+(``per2-mod-01-routing-policy-20260822/evaluator/evaluate.py``,
+``FRONTIER_MODELS``/``CHEAP_MODELS``, lines ~39-47 as of 2026-08-22). It is
+copied rather than imported in either direction: the evaluator carries its own
+no-network / no-live-import guarantee in its docstring, so it must not import
+from this tree, and this module must not depend on a sandbox path that does not
+exist on other machines. ``tests/agent/test_model_classification.py`` contains a
+parity test that compares the two sets whenever the sandbox copy is reachable,
+so hand-edited drift is caught rather than assumed away.
+
+Return values are the evaluator's exact literals — ``'frontier'``,
+``'benchmarked_cheap'``, ``'unknown'`` — deliberately, so that one source of
+truth means one vocabulary too. Callers should test for ``== "frontier"`` and
+treat everything else as not-frontier; do not compare against the bare string
+``"cheap"``.
+
+Classification is explicit membership, never inferred from the shape of a model
+name: guessing a tier from a name is how silent downgrades survive review.
+"""
+
+from __future__ import annotations
+
+FRONTIER_MODELS = {
+    "gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra",
+    "claude-opus-5", "claude-opus-4-8", "claude-sonnet-5",
+}
+CHEAP_MODELS = {
+    "deepseek-v4-flash", "deepseek-v4-pro", "glm-5.2",
+    "claude-haiku-4-5-20251001", "step-3.7-flash", "hy3",
+    "gemini-3.6-flash", "gemini-3.7-flash",
+}
+
+
+def model_class(name: str | None) -> str:
+    """Classify a model identifier as 'frontier', 'benchmarked_cheap', or 'unknown'.
+
+    Accepts bare model names or provider-qualified strings
+    (e.g. ``"anthropic/claude-opus-5"``); only the segment after the last ``"/"``
+    is matched. ``None``, empty, and unrecognised names all return ``'unknown'``,
+    which callers must treat as "not verified frontier" rather than as a pass.
+    """
+    if not name:
+        return "unknown"
+    bare = str(name).split("/")[-1].strip()
+    if bare in FRONTIER_MODELS:
+        return "frontier"
+    if bare in CHEAP_MODELS:
+        return "benchmarked_cheap"
+    return "unknown"

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -135,6 +135,7 @@ def finalize_turn(
     _turn_exit_reason,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
+    frontier_required=False,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -735,6 +736,39 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    # HF-04 Layer A (IGN-197): the CLI/cron/delegated turn path has no single
+    # "fallback resolution complete" return point the way the API server's
+    # _run_agent does — try_activate_fallback() mutates agent.model/provider
+    # in place and can fire from a dozen sites inside the retry loop. Turn end
+    # is where that loop has stopped retrying, so this is the first moment the
+    # served model is final. Requested model is the primary-runtime snapshot
+    # taken before any fallback activated; served model is what agent.model
+    # ended the turn on.
+    #
+    # Gated on the caller-supplied per-call `frontier_required` flag AND the
+    # shared HERMES_FRONTIER_DOWNGRADE_CHECK env flag (default off). The API
+    # server path (IGN-196) checks at _run_agent and does not set this kwarg,
+    # so the two hooks cannot double-warn for one call.
+    from agent.frontier_guard import check_frontier_downgrade
+
+    check_frontier_downgrade(
+        result,
+        # `_primary_runtime` is the snapshot taken at agent init, so it already
+        # reflects any fallback that resolved *before* the agent existed —
+        # gateway/run.py::_try_resolve_fallback_provider resolves credentials at
+        # startup/auth-failure and has no caller context or frontier_required
+        # flag to check against. A caller that knows the model it originally
+        # asked for can stamp `_frontier_requested_model` on the agent to close
+        # that window; otherwise the primary-runtime snapshot is used.
+        requested_model=(
+            getattr(agent, "_frontier_requested_model", None)
+            or (getattr(agent, "_primary_runtime", None) or {}).get("model")
+            or agent.model
+        ),
+        served_model=agent.model,
+        frontier_required=frontier_required,
+    )
+
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7218,6 +7218,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        frontier_required: bool = False,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -7238,6 +7239,17 @@ class APIServerAdapter(BasePlatformAdapter):
         active the completed agent's actual provider/model must match the
         locked selection or the turn fails, and the response carries
         sanitized ``runtime`` metadata reporting actual vs requested.
+
+        *frontier_required* is the caller's explicit, per-call assertion that
+        this turn must be served by a frontier-class model (HF-04 Layer A,
+        IGN-196).  It is deliberately caller-supplied rather than inferred from
+        the message content: inferring it would make correctness depend on a
+        second, separately-fallible classifier, which is the silent-failure
+        surface HF-04 is remediating in the first place.  When it is True *and*
+        the shared ``HERMES_FRONTIER_DOWNGRADE_CHECK`` flag is on, a frontier
+        request served by a non-frontier model appends a ``frontier_downgrade``
+        entry to ``result["warnings"]``.  It never blocks the response — unlike
+        *confirmed_runtime_lock*, which is an exact pin and hard-fails.
 
         If *agent_ref* is a one-element list, the AIAgent instance is stored
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
@@ -7401,6 +7413,57 @@ class APIServerAdapter(BasePlatformAdapter):
                         if isinstance(result, dict):
                             result["runtime"] = runtime
                         usage["runtime"] = runtime
+                    # HF-04 Layer A (IGN-196): fail-loud requested-vs-served
+                    # model-class check for the API-server call path.  This is
+                    # the point fallback resolution has completed and the
+                    # serving model is final — the same point the
+                    # confirmed_runtime_lock hard-check above reads.  It lives
+                    # outside the ``include_runtime`` branch on purpose: that
+                    # branch only decides whether to *report* runtime metadata,
+                    # and a downgrade must be caught whether or not the caller
+                    # asked for that metadata.
+                    #
+                    # Doubly gated: the caller's per-call ``frontier_required``
+                    # AND the shared HERMES_FRONTIER_DOWNGRADE_CHECK env flag
+                    # (default off, read per call so unsetting it takes effect
+                    # on the next request with no restart).  The guard module is
+                    # shared with the CLI/cron hook (IGN-197) so there is one
+                    # flag, not two.  This path does not pass
+                    # ``frontier_required`` down into ``run_conversation``, so
+                    # that turn-end hook stays inert here and the two cannot
+                    # double-warn for one call.
+                    if frontier_required and isinstance(result, dict):
+                        from agent.frontier_guard import check_frontier_downgrade
+
+                        # Requested model mirrors the confirmed-lock block's
+                        # ``expected_model`` precedence (route then
+                        # requested_runtime), then falls back to the explicit
+                        # per-request value and the session-persisted one, so a
+                        # caller that asserts frontier_required without the
+                        # Browser lock contract is still checked against
+                        # something it actually asked for.
+                        _requested_for_check = (
+                            self._split_provider_prefixed_model(
+                                (route or {}).get("model")
+                                or (requested_runtime or {}).get("model")
+                                or requested_model
+                                or session_model
+                                or ""
+                            )[1]
+                        )
+                        check_frontier_downgrade(
+                            result,
+                            requested_model=_requested_for_check,
+                            # Strip any ``provider::model`` prefix before
+                            # classifying: the classifier matches on exact
+                            # membership, so a prefixed string would come back
+                            # 'unknown' and read as a downgrade that never
+                            # happened.
+                            served_model=self._split_provider_prefixed_model(
+                                getattr(agent, "model", "") or ""
+                            )[1],
+                            frontier_required=True,
+                        )
                     return result, usage
                 except _ProviderAuthResolutionError as exc:
                     # Only _ProviderAuthResolutionError — raised exclusively

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -190,6 +190,14 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             # a config-matching bug silently dropped flex -> 2.3x billing).
             "service_tier": result.get("service_tier"),
         }
+        # HF-04 Layer A: on this path the guard's log line cannot reach anyone —
+        # run_oneshot() calls logging.disable(CRITICAL) for the whole run — and
+        # stdout carries only the final response. The usage report is the one
+        # machine-readable artefact a cron pipeline already collects, so a
+        # frontier warning that fired must appear here or it is invisible.
+        _warnings = result.get("warnings")
+        if isinstance(_warnings, list) and _warnings:
+            report["warnings"] = _warnings
         if failure is not None:
             report["failure"] = failure
         out = Path(path).expanduser()
@@ -311,6 +319,30 @@ def run_oneshot(
         return 1
 
     _write_usage_file(usage_file, result)
+
+    # HF-04 Layer A: fail loud. Logging is disabled for the whole oneshot run,
+    # so without this the guard's finding would exist only in a result dict that
+    # nothing prints. stderr (never stdout) keeps piped consumers of the final
+    # response byte-identical while still putting the warning in front of
+    # whoever reads a cron job's error output.
+    for _warning in (result.get("warnings") or []):
+        if not isinstance(_warning, dict):
+            continue
+        _type = _warning.get("type")
+        if _type == "frontier_downgrade":
+            real_stderr.write(
+                f"hermes -z: frontier guarantee not held: requested "
+                f"{_warning.get('requested_model')!r} but "
+                f"{_warning.get('served_model')!r} served this turn\n"
+            )
+        elif _type == "frontier_check_unavailable":
+            real_stderr.write(
+                f"hermes -z: frontier guarantee unverified "
+                f"({_warning.get('detail') or _type}): requested "
+                f"{_warning.get('requested_model')!r}, served "
+                f"{_warning.get('served_model')!r}\n"
+            )
+    real_stderr.flush()
 
     # Model text can contain lone UTF-16 surrogates (invalid in UTF-8). Writing
     # those to a real stdout TextIO raises UnicodeEncodeError and aborts with
@@ -507,7 +539,31 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        # HF-04 Layer A (IGN-252 blocker #3): this is the production caller
+        # that asserts the frontier requirement. Oneshot is the cron / delegated
+        # worker path — the one HF-04 was actually observed on, and the one with
+        # no human reading a response body — and it is the only call path that
+        # knows, at this point, whether the model was *explicitly named* by the
+        # caller or merely inherited from config.
+        #
+        # `explicitly_requested` is deliberately the same condition the provider
+        # auto-detect above uses: --model or HERMES_INFERENCE_MODEL, not
+        # cfg_model. A config default is "use my defaults", not an assertion.
+        # HERMES_FRONTIER_REQUIRED overrides the derivation either way.
+        #
+        # The requested model is stamped on the agent so turn_finalizer compares
+        # against what the caller asked for rather than the primary-runtime
+        # snapshot, which may already reflect a startup-time fallback.
+        from agent.frontier_guard import resolve_frontier_required
+
+        frontier_required = resolve_frontier_required(
+            effective_model,
+            explicitly_requested=bool((model or "").strip() or env_model),
+        )
+        if frontier_required and effective_model:
+            agent._frontier_requested_model = effective_model
+
+        result = agent.run_conversation(prompt, frontier_required=frontier_required)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8501,6 +8501,7 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        frontier_required: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -8875,6 +8876,7 @@ class AIAgent:
                         persist_user_display_kind=persist_user_display_kind,
                         persist_user_display_metadata=persist_user_display_metadata,
                         moa_config=moa_config,
+                        frontier_required=frontier_required,
                     )
                 finally:
                     # The lease remains held through relay/task finalization, but

--- a/tests/agent/test_frontier_check_real_classifier.py
+++ b/tests/agent/test_frontier_check_real_classifier.py
@@ -1,0 +1,444 @@
+"""HF-04 Layer A: the frontier check against the *real* committed classifier.
+
+IGN-252. The pre-existing Layer A suites
+(``test_frontier_downgrade_guard.py``, ``test_api_server_frontier_check.py``)
+install a stand-in for ``agent.model_classification.model_class`` so they can
+test the guard's and the adapter's wiring against fixed model names that will
+not churn as the frontier list moves. That is a legitimate thing to want, but on
+its own it left a hole big enough to hide the whole feature in: IGN-195's
+classifier was never committed, and because every test that touched it supplied
+its own stub, all of them passed on a clean checkout where
+``_resolve_model_class()`` returned ``None`` and no frontier-required call was
+ever actually checked.
+
+This module closes that hole. **Nothing here stubs the classifier.** These tests
+resolve, import and run the module that production resolves, so:
+
+* if ``agent/model_classification.py`` is missing from the tree (the IGN-252
+  blocker #1 state), :func:`test_guard_resolves_the_committed_classifier` fails
+  instead of quietly skipping;
+* if the frontier/cheap membership changes, the behavioural tests below change
+  with it, because they name real models from the real sets.
+
+It also covers three cases the stubbed suites never reached: the cron/delegated
+turn path through ``finalize_turn``, the guarantee that one call cannot produce
+two warnings, and the distinct log lines for ``frontier_downgrade`` versus
+``frontier_check_unavailable``.
+"""
+
+import inspect
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from agent import frontier_guard as fg
+from agent import model_classification as mc
+from agent.turn_finalizer import finalize_turn
+
+
+# Real members of the committed sets, asserted as such below rather than
+# assumed, so that a membership change fails loudly here instead of turning
+# these tests into vacuous no-ops.
+REAL_FRONTIER = "claude-opus-5"
+REAL_FRONTIER_ALT = "gpt-5.6-sol"
+REAL_CHEAP = "gemini-3.6-flash"
+NOT_IN_ANY_SET = "some-model-nobody-benchmarked"
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "1")
+
+
+@pytest.fixture(autouse=True)
+def _reset_latch(monkeypatch):
+    monkeypatch.setattr(fg, "_classifier_missing_reported", False)
+
+
+@pytest.fixture(autouse=True)
+def _fixtures_are_real_members():
+    """Guard the guards: these names must really be in the committed sets."""
+    assert REAL_FRONTIER in mc.FRONTIER_MODELS
+    assert REAL_FRONTIER_ALT in mc.FRONTIER_MODELS
+    assert REAL_CHEAP in mc.CHEAP_MODELS
+    assert NOT_IN_ANY_SET not in mc.FRONTIER_MODELS | mc.CHEAP_MODELS
+
+
+# --- the classifier is actually reachable from the guard ----------------------
+
+
+def test_guard_resolves_the_committed_classifier():
+    """The regression test for IGN-252 blocker #1.
+
+    ``frontier_guard`` resolves the classifier by import over a candidate list.
+    If ``agent/model_classification.py`` is not in the tree, that resolution
+    returns ``None``, every frontier-required call degrades to
+    ``frontier_check_unavailable``, and Layer A detects nothing. No stub here:
+    this asserts the shipped module is what production will find.
+    """
+    resolved = fg._resolve_model_class()
+    assert resolved is not None, (
+        "agent.model_classification is not importable — the frontier check "
+        "cannot run at all in this checkout"
+    )
+    assert resolved is mc.model_class
+
+
+def test_first_import_candidate_is_the_committed_module():
+    """The preferred candidate must be the one that actually exists.
+
+    The candidate list exists so the guard survived A1 landing the classifier
+    somewhere else. It did not: the first entry is the real home, and resolution
+    must not be relying on a later fallback entry.
+    """
+    assert fg._MODEL_CLASS_IMPORT_CANDIDATES[0] == (
+        "agent.model_classification",
+        "model_class",
+    )
+
+
+def test_classify_model_returns_the_real_vocabulary(flag_on):
+    """The real classifier says 'benchmarked_cheap', never bare 'cheap'.
+
+    The stubbed suite in ``test_frontier_downgrade_guard.py`` returns 'cheap'
+    from its stand-in, so nothing there would catch a caller that compared
+    against the wrong literal.
+    """
+    assert fg.classify_model(REAL_FRONTIER) == "frontier"
+    assert fg.classify_model(REAL_CHEAP) == "benchmarked_cheap"
+    assert fg.classify_model(NOT_IN_ANY_SET) == "unknown"
+
+
+# --- guard behaviour, real classifier ----------------------------------------
+
+
+def test_real_downgrade_is_detected(flag_on):
+    result = {}
+    warning = fg.check_frontier_downgrade(
+        result,
+        requested_model=REAL_FRONTIER,
+        served_model=REAL_CHEAP,
+        frontier_required=True,
+    )
+    assert warning["type"] == "frontier_downgrade"
+    assert warning["requested_class"] == "frontier"
+    assert warning["served_class"] == "benchmarked_cheap"
+    assert result["warnings"] == [warning]
+
+
+def test_real_in_class_fallback_is_clean(flag_on):
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model=REAL_FRONTIER,
+            served_model=REAL_FRONTIER_ALT,
+            frontier_required=True,
+        )
+        is None
+    )
+    assert "warnings" not in result
+
+
+def test_unclassified_served_model_counts_as_a_downgrade(flag_on):
+    """'unknown' is not a pass.
+
+    A model nobody has benchmarked cannot discharge a frontier promise; the
+    whole point of explicit membership is that an unrecognised name fails the
+    check rather than sliding through it.
+    """
+    result = {}
+    warning = fg.check_frontier_downgrade(
+        result,
+        requested_model=REAL_FRONTIER,
+        served_model=NOT_IN_ANY_SET,
+        frontier_required=True,
+    )
+    assert warning["type"] == "frontier_downgrade"
+    assert warning["served_class"] == "unknown"
+
+
+def test_provider_qualified_real_names_are_stripped_before_classifying(flag_on):
+    """``anthropic/claude-opus-5`` must not read as an unknown-model downgrade."""
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model=f"anthropic/{REAL_FRONTIER}",
+            served_model=f"openrouter/{REAL_FRONTIER_ALT}",
+            frontier_required=True,
+        )
+        is None
+    )
+
+
+def test_real_cheap_request_cannot_be_downgraded(flag_on):
+    """Nothing was promised, so nothing can be broken."""
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model=REAL_CHEAP,
+            served_model=NOT_IN_ANY_SET,
+            frontier_required=True,
+        )
+        is None
+    )
+
+
+# --- log lines: the two findings must not share a sentence -------------------
+
+
+def test_downgrade_logs_the_guarantee_not_held_line(flag_on, caplog):
+    with caplog.at_level(logging.WARNING, logger=fg.__name__):
+        fg.check_frontier_downgrade(
+            {},
+            requested_model=REAL_FRONTIER,
+            served_model=REAL_CHEAP,
+            frontier_required=True,
+        )
+    assert "Frontier guarantee not held" in caplog.text
+
+
+def test_unavailable_does_not_claim_the_guarantee_was_broken(
+    monkeypatch, flag_on, caplog
+):
+    """IGN-252: 'unavailable' is *unverified*, not violated.
+
+    Logging the downgrade sentence on this path sends whoever reads the
+    transcript hunting a downgrade that may never have happened, and hides the
+    thing that does need fixing — that the check itself did not run.
+    """
+    monkeypatch.setattr(fg, "_resolve_model_class", lambda: None)
+    with caplog.at_level(logging.WARNING, logger=fg.__name__):
+        warning = fg.check_frontier_downgrade(
+            {},
+            requested_model=REAL_FRONTIER,
+            served_model=REAL_CHEAP,
+            frontier_required=True,
+        )
+    assert warning["type"] == "frontier_check_unavailable"
+    assert "Frontier guarantee not held" not in caplog.text
+    assert "unverified" in caplog.text
+
+
+# --- cron / delegated turn path, driven through finalize_turn ----------------
+
+
+class _TurnAgent:
+    """Minimal AIAgent stand-in able to reach the end of ``finalize_turn``.
+
+    Shaped after ``tests/agent/test_turn_finalizer_iteration_limit_exit.py``'s
+    ``_LimitAgent``; the budget is left unexhausted so the turn takes the plain
+    success path and the frontier check is what the assertions are about.
+    """
+
+    def __init__(self, *, served_model, primary_runtime=None):
+        self.model = served_model
+        self.max_iterations = 60
+        self.iteration_budget = SimpleNamespace(remaining=59, used=1, max_total=60)
+        self.quiet_mode = True
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-frontier"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        if primary_runtime is not None:
+            self._primary_runtime = primary_runtime
+
+    def _emit_status(self, *_a, **_kw):
+        pass
+
+    def _safe_print(self, *_a, **_kw):
+        pass
+
+    def _save_trajectory(self, *_a, **_kw):
+        pass
+
+    def _cleanup_task_resources(self, *_a, **_kw):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, _messages):
+        pass
+
+    def _persist_session(self, _messages, _history):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kw):
+        pass
+
+    def _handle_max_iterations(self, _messages, _api_call_count):
+        return None
+
+
+def _finalize(agent, *, frontier_required):
+    return finalize_turn(
+        agent,
+        final_response="done",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "task"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="completed",
+        frontier_required=frontier_required,
+    )
+
+
+@pytest.fixture
+def _no_plugin_hooks(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+
+def test_cron_turn_that_fell_back_off_frontier_warns(
+    flag_on, _no_plugin_hooks
+):
+    """The cron/delegated case Layer A exists for.
+
+    ``try_activate_fallback()`` mutates ``agent.model`` in place mid-loop, so
+    the requested model survives only in the primary-runtime snapshot taken at
+    agent init. Turn end is where the retry loop has stopped and the served
+    model is final.
+    """
+    agent = _TurnAgent(
+        served_model=REAL_CHEAP, primary_runtime={"model": REAL_FRONTIER}
+    )
+    result = _finalize(agent, frontier_required=True)
+
+    assert result["final_response"] == "done"
+    warnings = result["warnings"]
+    assert len(warnings) == 1
+    assert warnings[0]["type"] == "frontier_downgrade"
+    assert warnings[0]["requested_model"] == REAL_FRONTIER
+    assert warnings[0]["served_model"] == REAL_CHEAP
+
+
+def test_cron_turn_that_stayed_on_frontier_is_clean(flag_on, _no_plugin_hooks):
+    agent = _TurnAgent(
+        served_model=REAL_FRONTIER_ALT, primary_runtime={"model": REAL_FRONTIER}
+    )
+    result = _finalize(agent, frontier_required=True)
+    assert "warnings" not in result
+
+
+def test_caller_stamped_requested_model_wins_over_the_runtime_snapshot(
+    flag_on, _no_plugin_hooks
+):
+    """``_frontier_requested_model`` closes the pre-agent fallback window.
+
+    ``gateway/run.py::_try_resolve_fallback_provider`` can swap the provider
+    before the agent exists, so the primary-runtime snapshot may already be the
+    fallback. A caller that knows what it originally asked for stamps it, and
+    that must take precedence.
+    """
+    agent = _TurnAgent(
+        served_model=REAL_CHEAP, primary_runtime={"model": REAL_CHEAP}
+    )
+    agent._frontier_requested_model = REAL_FRONTIER
+    result = _finalize(agent, frontier_required=True)
+    assert result["warnings"][0]["requested_model"] == REAL_FRONTIER
+
+
+def test_cron_turn_is_untouched_when_the_caller_did_not_require_frontier(
+    flag_on, _no_plugin_hooks
+):
+    """Opt-in: every caller that exists today leaves the kwarg at its default."""
+    agent = _TurnAgent(
+        served_model=REAL_CHEAP, primary_runtime={"model": REAL_FRONTIER}
+    )
+    result = _finalize(agent, frontier_required=False)
+    assert "warnings" not in result
+
+
+def test_cron_turn_is_untouched_when_the_flag_is_off(monkeypatch, _no_plugin_hooks):
+    """Rollback path, exercised on the real turn path rather than on the guard."""
+    monkeypatch.delenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, raising=False)
+    agent = _TurnAgent(
+        served_model=REAL_CHEAP, primary_runtime={"model": REAL_FRONTIER}
+    )
+    result = _finalize(agent, frontier_required=True)
+    assert "warnings" not in result
+
+
+def test_a_downgraded_cron_turn_warns_exactly_once(flag_on, _no_plugin_hooks):
+    """One turn, one warning — the finalizer hook fires a single time.
+
+    ``finalize_turn`` is called once per turn from ``run_conversation``, but the
+    check appends rather than replaces, so a second invocation on the same
+    result dict would stack duplicates. This pins the per-turn count.
+    """
+    agent = _TurnAgent(
+        served_model=REAL_CHEAP, primary_runtime={"model": REAL_FRONTIER}
+    )
+    result = _finalize(agent, frontier_required=True)
+    assert len(result["warnings"]) == 1
+
+
+# --- the two hooks must not both fire for one call ---------------------------
+
+
+def test_api_server_path_does_not_forward_the_flag_into_run_conversation():
+    """No double-warning across the two Layer A hooks.
+
+    Both hooks read the same flag. If ``_run_agent`` forwarded
+    ``frontier_required`` into ``run_conversation``, the turn-end hook would
+    append its own warning for the same call and every API-server downgrade
+    would be reported twice. ``_run_agent`` checks at its own seam and must
+    keep the kwarg to itself.
+    """
+    source = inspect.getsource(
+        __import__(
+            "gateway.platforms.api_server", fromlist=["APIServerAdapter"]
+        ).APIServerAdapter._run_agent
+    )
+    assert "frontier_required=frontier_required" not in source
+
+
+def test_duplicate_warnings_are_not_produced_by_a_single_guard_call(flag_on):
+    """Appending twice requires two calls; one call appends one entry."""
+    result = {"warnings": [{"type": "something_else"}]}
+    fg.check_frontier_downgrade(
+        result,
+        requested_model=REAL_FRONTIER,
+        served_model=REAL_CHEAP,
+        frontier_required=True,
+    )
+    assert len(result["warnings"]) == 2
+    assert [w["type"] for w in result["warnings"]] == [
+        "something_else",
+        "frontier_downgrade",
+    ]

--- a/tests/agent/test_frontier_downgrade_guard.py
+++ b/tests/agent/test_frontier_downgrade_guard.py
@@ -1,0 +1,215 @@
+"""HF-04 Layer A (IGN-197): fail-loud frontier check on the CLI/cron turn path.
+
+Covers ``agent.frontier_guard`` — the shared, flag-gated requested-vs-served
+model-class check wired into ``finalize_turn`` (the point the CLI/cron retry
+loop has stopped retrying and the served model is final).
+
+The classifier itself is IGN-195's deliverable; these tests install a stand-in
+so the guard's own contract can be verified independently of where A1 lands it.
+"""
+
+import sys
+import types
+
+import pytest
+
+from agent import frontier_guard as fg
+
+
+FRONTIER = {"gpt-5.6-sol", "claude-opus-5", "gemini-3.6-pro"}
+CHEAP = {"gemini-3.6-flash", "gpt-5-mini"}
+
+
+def _stub_model_class(model):
+    if model in FRONTIER:
+        return "frontier"
+    if model in CHEAP:
+        return "cheap"
+    return "unknown"
+
+
+@pytest.fixture
+def classifier(monkeypatch):
+    """Install a stand-in for IGN-195's shared ``model_class``."""
+    module = types.ModuleType("agent.model_classification")
+    module.model_class = _stub_model_class
+    monkeypatch.setitem(sys.modules, "agent.model_classification", module)
+    return module
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "1")
+
+
+@pytest.fixture(autouse=True)
+def _reset_latch(monkeypatch):
+    monkeypatch.setattr(fg, "_classifier_missing_reported", False)
+
+
+def test_inert_when_flag_off(monkeypatch, classifier):
+    """Default-off rollback path: a real downgrade produces nothing."""
+    monkeypatch.delenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, raising=False)
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model="gpt-5.6-sol",
+            served_model="gemini-3.6-flash",
+            frontier_required=True,
+        )
+        is None
+    )
+    assert "warnings" not in result
+
+
+def test_inert_when_caller_did_not_require_frontier(flag_on, classifier):
+    """Opt-in: callers that never asked for frontier are unaffected."""
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model="gpt-5.6-sol",
+            served_model="gemini-3.6-flash",
+            frontier_required=False,
+        )
+        is None
+    )
+    assert "warnings" not in result
+
+
+def test_downgrade_is_reported_to_the_caller(flag_on, classifier):
+    result = {}
+    warning = fg.check_frontier_downgrade(
+        result,
+        requested_model="gpt-5.6-sol",
+        served_model="gemini-3.6-flash",
+        frontier_required=True,
+    )
+    assert warning["type"] == "frontier_downgrade"
+    assert warning["requested_model"] == "gpt-5.6-sol"
+    assert warning["served_model"] == "gemini-3.6-flash"
+    assert warning["requested_class"] == "frontier"
+    assert warning["served_class"] == "cheap"
+    assert result["warnings"] == [warning]
+
+
+def test_frontier_served_by_frontier_is_clean(flag_on, classifier):
+    """A fallback that stays in-class is not a downgrade."""
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model="gpt-5.6-sol",
+            served_model="claude-opus-5",
+            frontier_required=True,
+        )
+        is None
+    )
+    assert "warnings" not in result
+
+
+def test_non_frontier_request_cannot_be_downgraded(flag_on, classifier):
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model="gpt-5-mini",
+            served_model="gemini-3.6-flash",
+            frontier_required=True,
+        )
+        is None
+    )
+
+
+def test_missing_classifier_fails_loud_rather_than_silently_passing(
+    monkeypatch, flag_on
+):
+    """A check that cannot run must not be indistinguishable from a clean one."""
+    monkeypatch.setattr(fg, "_resolve_model_class", lambda: None)
+    result = {}
+    warning = fg.check_frontier_downgrade(
+        result,
+        requested_model="gpt-5.6-sol",
+        served_model="gemini-3.6-flash",
+        frontier_required=True,
+    )
+    assert warning["type"] == "frontier_check_unavailable"
+    assert result["warnings"] == [warning]
+
+
+def test_raising_classifier_is_reported_and_never_breaks_the_turn(
+    monkeypatch, flag_on
+):
+    module = types.ModuleType("agent.model_classification")
+
+    def _boom(model):
+        raise RuntimeError("classifier exploded")
+
+    module.model_class = _boom
+    monkeypatch.setitem(sys.modules, "agent.model_classification", module)
+
+    result = {}
+    warning = fg.check_frontier_downgrade(
+        result,
+        requested_model="gpt-5.6-sol",
+        served_model="gemini-3.6-flash",
+        frontier_required=True,
+    )
+    assert warning["type"] == "frontier_check_unavailable"
+
+
+def test_existing_warnings_are_appended_to_not_replaced(flag_on, classifier):
+    pre_existing = {"type": "something_else"}
+    result = {"warnings": [pre_existing]}
+    fg.check_frontier_downgrade(
+        result,
+        requested_model="gpt-5.6-sol",
+        served_model="gemini-3.6-flash",
+        frontier_required=True,
+    )
+    assert result["warnings"][0] is pre_existing
+    assert len(result["warnings"]) == 2
+
+
+def test_flag_is_read_per_call_so_rollback_needs_no_restart(monkeypatch, classifier):
+    """Instant rollback: flipping the env var takes effect on the next call."""
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "1")
+    assert fg.frontier_downgrade_check_enabled() is True
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "0")
+    assert fg.frontier_downgrade_check_enabled() is False
+    result = {}
+    assert (
+        fg.check_frontier_downgrade(
+            result,
+            requested_model="gpt-5.6-sol",
+            served_model="gemini-3.6-flash",
+            frontier_required=True,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_truthy_flag_values(monkeypatch, value):
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, value)
+    assert fg.frontier_downgrade_check_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_falsey_flag_values(monkeypatch, value):
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, value)
+    assert fg.frontier_downgrade_check_enabled() is False
+
+
+def test_turn_path_threads_the_flag_end_to_end():
+    """run_conversation -> finalize_turn carry the caller-supplied flag."""
+    import inspect
+
+    from agent.conversation_loop import run_conversation
+    from agent.turn_finalizer import finalize_turn
+
+    for fn in (run_conversation, finalize_turn):
+        params = inspect.signature(fn).parameters
+        assert "frontier_required" in params
+        assert params["frontier_required"].default is False

--- a/tests/agent/test_model_classification.py
+++ b/tests/agent/test_model_classification.py
@@ -1,0 +1,70 @@
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.model_classification import CHEAP_MODELS, FRONTIER_MODELS, model_class
+
+
+def test_frontier_models_classified_as_frontier():
+    for name in FRONTIER_MODELS:
+        assert model_class(name) == "frontier"
+
+
+def test_cheap_models_classified_as_benchmarked_cheap():
+    for name in CHEAP_MODELS:
+        assert model_class(name) == "benchmarked_cheap"
+
+
+def test_unknown_model_returns_unknown():
+    assert model_class("some-untracked-model") == "unknown"
+
+
+def test_none_and_empty_return_unknown():
+    assert model_class(None) == "unknown"
+    assert model_class("") == "unknown"
+
+
+def test_provider_prefixed_name_is_stripped():
+    assert model_class("anthropic/claude-opus-5") == "frontier"
+    assert model_class("opencode-go/glm-5.2") == "benchmarked_cheap"
+
+
+def test_frontier_and_cheap_sets_are_disjoint():
+    assert not (FRONTIER_MODELS & CHEAP_MODELS)
+
+
+# --- drift guard against the offline evaluator's copy of the same sets --------
+#
+# The evaluator is an offline sandbox tool that must not import from this tree,
+# so the sets are duplicated by hand. This test parses (never imports, never
+# executes) the evaluator and fails if the two copies have diverged. It skips
+# when the sandbox is not reachable, which is the normal case on any machine
+# other than the one that produced it; override the path with
+# HERMES_PER2_EVALUATOR_PATH.
+
+_DEFAULT_EVALUATOR_PATH = (
+    "E:/IGN/_sandbox/per2-mod-01-routing-policy-20260822/evaluator/evaluate.py"
+)
+
+
+def _parse_model_sets(path: Path) -> dict:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and target.id in ("FRONTIER_MODELS", "CHEAP_MODELS"):
+            found[target.id] = {elt.value for elt in node.value.elts}
+    return found
+
+
+def test_membership_matches_offline_evaluator():
+    path = Path(os.environ.get("HERMES_PER2_EVALUATOR_PATH", _DEFAULT_EVALUATOR_PATH))
+    if not path.is_file():
+        pytest.skip(f"PER2-MOD-01 evaluator not reachable at {path}")
+    evaluator = _parse_model_sets(path)
+    assert evaluator.get("FRONTIER_MODELS") == FRONTIER_MODELS
+    assert evaluator.get("CHEAP_MODELS") == CHEAP_MODELS

--- a/tests/gateway/test_api_server_frontier_check.py
+++ b/tests/gateway/test_api_server_frontier_check.py
@@ -1,0 +1,253 @@
+"""HF-04 Layer A (IGN-196): fail-loud frontier check on the API-server path.
+
+``APIServerAdapter._run_agent`` is the point at which the API-server call path
+has finished resolving fallbacks and ``agent.model`` is the model that actually
+served the turn — the same point the existing ``confirmed_runtime_lock``
+hard-check reads. These tests drive the real ``_run_agent`` coroutine against a
+stand-in adapter so the wiring (not just ``agent.frontier_guard``, which
+IGN-197 covers on its own) is what gets exercised.
+
+Two independent gates must both be open for a warning to appear: the caller's
+per-call ``frontier_required`` and the shared
+``HERMES_FRONTIER_DOWNGRADE_CHECK`` env flag, which defaults off.
+"""
+
+import contextlib
+import sys
+import types
+
+import pytest
+
+from gateway.platforms.api_server import APIServerAdapter
+from agent import frontier_guard as fg
+
+
+FRONTIER = {"gpt-5.6-sol", "claude-opus-5"}
+CHEAP = {"gemini-3.6-flash", "deepseek-v4-flash"}
+
+
+def _stub_model_class(model):
+    bare = str(model).split("/")[-1].strip()
+    if bare in FRONTIER:
+        return "frontier"
+    if bare in CHEAP:
+        return "benchmarked_cheap"
+    return "unknown"
+
+
+@pytest.fixture
+def classifier(monkeypatch):
+    """Install a stand-in for IGN-195's shared ``model_class``.
+
+    The guard resolves the classifier by import, so the real
+    ``agent.model_classification`` is what runs in production; stubbing it here
+    keeps these tests about the API-server wiring rather than about which model
+    names happen to be on the frontier list today.
+    """
+    module = types.ModuleType("agent.model_classification")
+    module.model_class = _stub_model_class
+    monkeypatch.setitem(sys.modules, "agent.model_classification", module)
+    return module
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "1")
+
+
+@pytest.fixture(autouse=True)
+def _reset_missing_classifier_latch(monkeypatch):
+    monkeypatch.setattr(fg, "_classifier_missing_reported", False)
+
+
+class _FakeAgent:
+    """Minimal stand-in for the AIAgent that ``_create_agent`` would return."""
+
+    def __init__(self, served_model):
+        self.model = served_model
+        self.provider = "stub-provider"
+        self.session_id = "sess-1"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self._tool_guardrail_halt_decision = None
+
+    def run_conversation(self, **kwargs):
+        return {"final_response": "ok", "messages": [], "api_calls": 1, "tools": []}
+
+
+class _StubAdapter:
+    """Enough of APIServerAdapter for the real ``_run_agent`` to run.
+
+    ``_run_agent`` is taken unbound from the real class so the code under test
+    is the shipped implementation, not a re-description of it.
+    """
+
+    _run_agent = APIServerAdapter._run_agent
+    # ``_clean_runtime_id`` is a staticmethod on the real class; copying the
+    # plain function across would rebind it as an instance method and feed it
+    # ``self``. The other two are classmethods, which stay bound on access.
+    _clean_runtime_id = staticmethod(APIServerAdapter._clean_runtime_id)
+    _split_provider_prefixed_model = APIServerAdapter._split_provider_prefixed_model
+    _sanitize_runtime_metadata = APIServerAdapter._sanitize_runtime_metadata
+
+    def __init__(self, served_model):
+        self._served_model = served_model
+        self._active_run_agents = {}
+        self._shutdown_interruptible_agents = {}
+        self._inflight_agent_runs = 0
+
+    def _activate_admitted_request(self):
+        return None
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _profile_scope(profile):
+        yield
+
+    def _bind_api_server_session(self, **kwargs):
+        return None
+
+    def _create_agent(self, **kwargs):
+        return _FakeAgent(self._served_model)
+
+
+async def _run(served_model, *, requested, frontier_required, **extra):
+    adapter = _StubAdapter(served_model)
+    result, _usage = await adapter._run_agent(
+        user_message="hi",
+        conversation_history=[],
+        requested_model=requested,
+        frontier_required=frontier_required,
+        **extra,
+    )
+    return result
+
+
+@pytest.mark.asyncio
+async def test_downgrade_is_reported_to_the_caller(flag_on, classifier):
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert len(result["warnings"]) == 1
+    warning = result["warnings"][0]
+    assert warning["type"] == "frontier_downgrade"
+    assert warning["requested_model"] == "gpt-5.6-sol"
+    assert warning["served_model"] == "gemini-3.6-flash"
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_flag_is_off(monkeypatch, classifier):
+    """Default-off rollback path: a real downgrade produces nothing."""
+    monkeypatch.delenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, raising=False)
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert "warnings" not in result
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_caller_did_not_require_frontier(flag_on, classifier):
+    """Opt-in: every existing caller leaves ``frontier_required`` at its default."""
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=False
+    )
+    assert "warnings" not in result
+
+
+@pytest.mark.asyncio
+async def test_frontier_served_by_frontier_is_clean(flag_on, classifier):
+    """A fallback that stays in-class is not a downgrade."""
+    result = await _run(
+        "claude-opus-5", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert "warnings" not in result
+
+
+@pytest.mark.asyncio
+async def test_provider_prefixed_served_model_is_not_a_false_positive(
+    flag_on, classifier
+):
+    """``provider::model`` must be stripped before classifying.
+
+    Left prefixed, the classifier would return 'unknown' and an in-class
+    fallback would be reported as a downgrade that never happened.
+    """
+    result = await _run(
+        "openai::claude-opus-5", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert "warnings" not in result
+
+
+@pytest.mark.asyncio
+async def test_requested_model_comes_from_the_lock_contract_when_present(
+    flag_on, classifier
+):
+    """``route``/``requested_runtime`` win over the bare per-request value.
+
+    This mirrors the ``expected_model`` precedence the adjacent
+    ``confirmed_runtime_lock`` check already uses.
+    """
+    result = await _run(
+        "gemini-3.6-flash",
+        requested="deepseek-v4-flash",
+        frontier_required=True,
+        requested_runtime={"model": "gpt-5.6-sol"},
+    )
+    assert result["warnings"][0]["requested_model"] == "gpt-5.6-sol"
+
+
+@pytest.mark.asyncio
+async def test_check_runs_even_when_runtime_metadata_is_not_reported(
+    flag_on, classifier
+):
+    """``include_runtime`` gates *reporting*, never the downgrade check.
+
+    With no route, requested_runtime, lock, or non-global route_source, the
+    runtime-metadata block is skipped entirely — the check must still fire.
+    """
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert "runtime" not in result
+    assert result["warnings"][0]["type"] == "frontier_downgrade"
+
+
+@pytest.mark.asyncio
+async def test_missing_classifier_fails_loud_rather_than_passing_silently(
+    monkeypatch, flag_on
+):
+    """A check that cannot run must not look like a clean one."""
+    monkeypatch.setattr(fg, "_resolve_model_class", lambda: None)
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert result["warnings"][0]["type"] == "frontier_check_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_downgrade_never_blocks_the_response(flag_on, classifier):
+    """Non-blocking by contract — unlike the exact-pin confirmed lock."""
+    result = await _run(
+        "gemini-3.6-flash", requested="gpt-5.6-sol", frontier_required=True
+    )
+    assert result["final_response"] == "ok"
+
+
+def test_flag_defaults_to_off_and_is_read_per_call(monkeypatch):
+    """Rollback is instant: no process-start caching of the flag."""
+    monkeypatch.delenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, raising=False)
+    assert fg.frontier_downgrade_check_enabled() is False
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "1")
+    assert fg.frontier_downgrade_check_enabled() is True
+    monkeypatch.setenv(fg.FRONTIER_DOWNGRADE_CHECK_ENV, "0")
+    assert fg.frontier_downgrade_check_enabled() is False
+
+
+def test_run_agent_signature_is_opt_in():
+    """Existing callers must be unaffected: the new kwarg defaults to False."""
+    import inspect
+
+    params = inspect.signature(APIServerAdapter._run_agent).parameters
+    assert "frontier_required" in params
+    assert params["frontier_required"].default is False

--- a/tests/hermes_cli/test_oneshot_frontier_required.py
+++ b/tests/hermes_cli/test_oneshot_frontier_required.py
@@ -1,0 +1,269 @@
+"""HF-04 Layer A: the real production caller (IGN-252 blocker #3).
+
+Layer A was inert end-to-end before this: nothing in production set
+``frontier_required=True``, so the flag could be on and no downgrade would ever
+be detected. The board's decision (option "both") was to derive the requirement
+from an explicitly-named frontier model on the oneshot / cron / delegated worker
+path, plus a literal ``HERMES_FRONTIER_REQUIRED`` override.
+
+Nothing here stubs the classifier — these tests drive
+``resolve_frontier_required`` against the committed
+``agent.model_classification`` sets, for the same reason
+``tests/agent/test_frontier_check_real_classifier.py`` does: a stub would make
+the whole feature pass on a tree where the classifier is missing.
+
+The two surfacing tests cover the thing that makes this wiring meaningful at
+all: ``run_oneshot`` calls ``logging.disable(logging.CRITICAL)`` for the entire
+run, so the guard's own log line reaches nobody on this path. The warning has to
+come out of the usage report and stderr or it does not exist.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent import frontier_guard as fg
+from agent import model_classification as mc
+from hermes_cli import oneshot
+from hermes_cli.oneshot import _write_usage_file, run_oneshot
+
+
+# Real members of the committed sets, asserted as such rather than assumed.
+REAL_FRONTIER = "claude-opus-5"
+REAL_CHEAP = "gemini-3.6-flash"
+
+
+def test_fixture_models_are_really_in_the_committed_sets():
+    assert REAL_FRONTIER in mc.FRONTIER_MODELS
+    assert REAL_CHEAP in mc.CHEAP_MODELS
+    assert mc.model_class(REAL_FRONTIER) == "frontier"
+    assert mc.model_class(REAL_CHEAP) != "frontier"
+
+
+class TestResolveFrontierRequired:
+    """Derivation + override precedence, against the real classifier."""
+
+    def test_explicit_frontier_model_asserts_the_requirement(self, monkeypatch):
+        monkeypatch.delenv(fg.FRONTIER_REQUIRED_ENV, raising=False)
+        assert fg.resolve_frontier_required(REAL_FRONTIER, explicitly_requested=True) is True
+
+    def test_explicit_cheap_model_does_not(self, monkeypatch):
+        monkeypatch.delenv(fg.FRONTIER_REQUIRED_ENV, raising=False)
+        assert fg.resolve_frontier_required(REAL_CHEAP, explicitly_requested=True) is False
+
+    def test_config_default_is_not_an_assertion(self, monkeypatch):
+        # Same frontier model, but the caller never named it — that is
+        # "use my defaults", not a per-call promise.
+        monkeypatch.delenv(fg.FRONTIER_REQUIRED_ENV, raising=False)
+        assert fg.resolve_frontier_required(REAL_FRONTIER, explicitly_requested=False) is False
+
+    def test_unknown_model_does_not_assert(self, monkeypatch):
+        monkeypatch.delenv(fg.FRONTIER_REQUIRED_ENV, raising=False)
+        assert mc.model_class("some-local-gguf") == "unknown"
+        assert fg.resolve_frontier_required("some-local-gguf", explicitly_requested=True) is False
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on"])
+    def test_override_asserts_even_for_a_cheap_or_implicit_model(self, monkeypatch, raw):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, raw)
+        assert fg.resolve_frontier_required(REAL_CHEAP, explicitly_requested=False) is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "no", "off"])
+    def test_override_suppresses_an_otherwise_derived_requirement(self, monkeypatch, raw):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, raw)
+        assert fg.resolve_frontier_required(REAL_FRONTIER, explicitly_requested=True) is False
+
+    def test_unrecognised_override_is_ignored_and_warned_not_guessed(self, monkeypatch, caplog):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, "maybe")
+        with caplog.at_level("WARNING", logger="agent.frontier_guard"):
+            assert fg.frontier_required_override() is None
+            # Falls through to derivation rather than silently picking a side.
+            assert fg.resolve_frontier_required(REAL_FRONTIER, explicitly_requested=True) is True
+        assert "not a recognised boolean" in caplog.text
+
+    def test_blank_override_means_derive(self, monkeypatch):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, "   ")
+        assert fg.frontier_required_override() is None
+        assert fg.resolve_frontier_required(REAL_CHEAP, explicitly_requested=True) is False
+
+
+class TestUsageReportSurfacing:
+    def test_warnings_are_carried_into_the_usage_report(self, tmp_path):
+        path = tmp_path / "usage.json"
+        warning = {
+            "type": "frontier_downgrade",
+            "requested_model": REAL_FRONTIER,
+            "served_model": REAL_CHEAP,
+            "requested_class": "frontier",
+            "served_class": "benchmarked_cheap",
+        }
+        _write_usage_file(str(path), {"warnings": [warning]})
+        report = json.loads(path.read_text())
+        assert report["warnings"] == [warning]
+
+    def test_no_warnings_key_when_the_turn_was_clean(self, tmp_path):
+        path = tmp_path / "usage.json"
+        _write_usage_file(str(path), {"model": REAL_FRONTIER})
+        assert "warnings" not in json.loads(path.read_text())
+
+    def test_empty_warnings_list_is_not_reported(self, tmp_path):
+        path = tmp_path / "usage.json"
+        _write_usage_file(str(path), {"warnings": []})
+        assert "warnings" not in json.loads(path.read_text())
+
+
+class _FakeAgent:
+    """Stands in for AIAgent — records what the caller asserted."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.model = kwargs.get("model")
+        self.run_conversation_kwargs = None
+        self._session_messages = []
+
+    def run_conversation(self, prompt, **kwargs):
+        self.run_conversation_kwargs = kwargs
+        return {"final_response": "ok"}
+
+    def shutdown_memory_provider(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestOneshotWiresTheFlag:
+    """The wiring itself: ``_run_agent`` must reach ``run_conversation``.
+
+    This is the test that would have caught the original defect — Layer A
+    existed but no production caller ever set ``frontier_required``.
+    """
+
+    @pytest.fixture
+    def built(self, monkeypatch):
+        import hermes_cli.config as config_mod
+        import hermes_cli.fallback_config as fallback_mod
+        import hermes_cli.mcp_startup as mcp_mod
+        import hermes_cli.models as models_mod
+        import hermes_cli.runtime_provider as runtime_mod
+        import hermes_cli.tools_config as tools_mod
+        import run_agent as run_agent_mod
+
+        agents = []
+
+        def _factory(**kwargs):
+            agent = _FakeAgent(**kwargs)
+            agents.append(agent)
+            return agent
+
+        monkeypatch.setattr(
+            config_mod, "load_config", lambda *a, **k: {"model": {"default": REAL_CHEAP}}
+        )
+        monkeypatch.setattr(models_mod, "detect_provider_for_model", lambda *a, **k: None)
+        monkeypatch.setattr(
+            runtime_mod, "resolve_runtime_provider", lambda **k: {"provider": "openrouter"}
+        )
+        monkeypatch.setattr(tools_mod, "_get_platform_tools", lambda *a, **k: set())
+        monkeypatch.setattr(fallback_mod, "get_fallback_chain", lambda *a, **k: [])
+        monkeypatch.setattr(oneshot, "get_fallback_chain", lambda *a, **k: [])
+        monkeypatch.setattr(
+            mcp_mod, "ensure_mcp_discovery_before_agent_build", lambda *a, **k: None
+        )
+        monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+        monkeypatch.setattr(run_agent_mod, "AIAgent", _factory)
+        monkeypatch.delenv(fg.FRONTIER_REQUIRED_ENV, raising=False)
+        monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+        return agents
+
+    def test_explicit_frontier_model_makes_layer_a_live(self, built):
+        oneshot._run_agent("hi", model=REAL_FRONTIER)
+        agent = built[0]
+        assert agent.run_conversation_kwargs == {"frontier_required": True}
+        # Stamped so the guard compares against what the caller asked for, not a
+        # primary-runtime snapshot that may already reflect a startup fallback.
+        assert agent._frontier_requested_model == REAL_FRONTIER
+
+    def test_env_named_frontier_model_also_counts_as_explicit(self, built, monkeypatch):
+        monkeypatch.setenv("HERMES_INFERENCE_MODEL", REAL_FRONTIER)
+        oneshot._run_agent("hi")
+        assert built[0].run_conversation_kwargs == {"frontier_required": True}
+
+    def test_configured_default_does_not_assert(self, built):
+        oneshot._run_agent("hi")
+        agent = built[0]
+        assert agent.run_conversation_kwargs == {"frontier_required": False}
+        assert not hasattr(agent, "_frontier_requested_model")
+
+    def test_explicit_cheap_model_does_not_assert(self, built):
+        oneshot._run_agent("hi", model=REAL_CHEAP)
+        assert built[0].run_conversation_kwargs == {"frontier_required": False}
+
+    def test_literal_override_asserts_without_an_explicit_model(self, built, monkeypatch):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, "1")
+        oneshot._run_agent("hi")
+        agent = built[0]
+        assert agent.run_conversation_kwargs == {"frontier_required": True}
+        assert agent._frontier_requested_model == REAL_CHEAP
+
+    def test_literal_override_can_suppress(self, built, monkeypatch):
+        monkeypatch.setenv(fg.FRONTIER_REQUIRED_ENV, "off")
+        oneshot._run_agent("hi", model=REAL_FRONTIER)
+        assert built[0].run_conversation_kwargs == {"frontier_required": False}
+
+
+class TestStderrSurfacing:
+    """``hermes -z`` must print the finding where a cron job will see it."""
+
+    def _run(self, capsys, result):
+        with patch.object(oneshot, "_run_agent", return_value=("done", result)):
+            code = run_oneshot("hi")
+        return code, capsys.readouterr()
+
+    def test_downgrade_goes_to_stderr_and_leaves_stdout_untouched(self, capsys):
+        code, captured = self._run(
+            capsys,
+            {
+                "final_response": "done",
+                "warnings": [
+                    {
+                        "type": "frontier_downgrade",
+                        "requested_model": REAL_FRONTIER,
+                        "served_model": REAL_CHEAP,
+                    }
+                ],
+            },
+        )
+        assert code == 0
+        assert "frontier guarantee not held" in captured.err
+        assert REAL_FRONTIER in captured.err and REAL_CHEAP in captured.err
+        # Piped consumers of the final response must be byte-identical.
+        assert captured.out == "done\n"
+
+    def test_unavailable_says_unverified_not_violated(self, capsys):
+        _, captured = self._run(
+            capsys,
+            {
+                "final_response": "done",
+                "warnings": [
+                    {
+                        "type": "frontier_check_unavailable",
+                        "requested_model": REAL_FRONTIER,
+                        "served_model": REAL_FRONTIER,
+                        "detail": "shared model classifier is not importable",
+                    }
+                ],
+            },
+        )
+        assert "frontier guarantee unverified" in captured.err
+        assert "not held" not in captured.err
+
+    def test_clean_turn_prints_nothing_extra(self, capsys):
+        _, captured = self._run(capsys, {"final_response": "done"})
+        assert captured.err == ""
+
+    def test_non_dict_warning_entries_do_not_break_the_run(self, capsys):
+        code, captured = self._run(
+            capsys, {"final_response": "done", "warnings": ["oops", None]}
+        )
+        assert code == 0
+        assert captured.err == ""


### PR DESCRIPTION
## PER2-HF-04-A: Fail-loud requested-vs-served model check at frontier-required call sites

### Background
Split out of IGN-252 (PER2-HF-04-A-REWORK). IGN-256 returned **APPROVE** on the original head `67e96ba0d`. This PR replays the same 6-commit Layer A series onto current `origin/main` (`9aa7530f7`) via `git am --3way` from the frozen patch artifact (sha256 `06b8c080ca7300194a4b5f8a08a5cd07af6ef05ba54d9b4460bdd106010852f3`). The patches applied cleanly with no conflicts.

### What this does
- **A1** (`f0d7f0830`?`aa978df17`): Fail-loud frontier check at the CLI/cron turn path - `agent/frontier_guard.py`, `agent/turn_finalizer.py`, `agent/conversation_loop.py`
- **A2** (`68c5c430d`?`dbf5c20ac`): Fail-loud frontier check at the API-server call path - `gateway/platforms/api_server.py`
- **A3** (`dbc0be83d`?`33c230fd2`): Shared frontier/cheap model classifier - `agent/model_classification.py`
- **A3-fix** (`c0e0ecc10`?`d6c74bc8f`): Test Layer A against the real classifier; split the two log lines
- **A3-wire** (`193cfa284`?`fd3769e21`): Wire a real frontier-required caller on the oneshot/cron path - `hermes_cli/oneshot.py`, `run_agent.py`
- **docs** (`67e96ba0d`?`f1d9eddf2`): Record the ratified caller-visible surface for Layer A

### Verification
- Patches applied cleanly via `git am --3way` onto `origin/main` (`9aa7530f7`) - zero conflicts
- Diff vs base: 12 files, +1790/?1 lines, matching the original frozen series exactly
- IGN-256 (independent review) returned **APPROVE** on the equivalent code at head `67e96ba0d`
- Layer A tests: `tests/agent/test_frontier_downgrade_guard.py`, `tests/agent/test_frontier_check_real_classifier.py`, `tests/gateway/test_api_server_frontier_check.py`, `tests/agent/test_model_classification.py`, `tests/hermes_cli/test_oneshot_frontier_required.py`

### Lane
T3 - PER2-HF-04-A. Tracked as IGN-257 (push/PR) and IGN-192 (implementation, blocked on this push).