### PR TITLE
fix(tools): BSD find must not print pruned macOS protected dirs

### DIFF
--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -192,6 +192,35 @@ def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):
         assert "-prune" in command
 
 
+def test_bsd_find_fallback_prints_only_the_keep_branch(tmp_path, monkeypatch):
+    """BSD find default-prints prune matches unless the keep side has -print.
+
+    The GNU command uses -printf (an action). When that fails, the fallback
+    had no action, so macOS find printed ~/Downloads as a search hit.
+    """
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+    result = ops.search("*.txt", path=str(home), target="files")
+
+    bsd = [
+        command
+        for command in env.commands
+        if command.startswith("find ") and "-printf" not in command
+    ]
+    assert bsd
+    for command in bsd:
+        assert "-print" in command
+        assert "-prune" in command
+    assert result.warning is not None
+    assert "Downloads" in result.warning
+
+
 def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypatch):
     home = tmp_path / "Users" / "alice"
     safe = home / "safe"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3095,8 +3095,16 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+            # -print on the keep side is required: BSD find (macOS) has no
+            # -printf, so without an action it default-prints every path for
+            # which the whole expression is true. The prune clause is true
+            # for the protected dir itself, so ~/Downloads would land in
+            # results while the warning claimed it was skipped.
+            cmd_simple = (
+                f"find {self._escape_shell_arg(path)}{prune_expr}"
+                f"{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} "
+                f"-print 2>/dev/null | sort -rn{pagination_expr}"
+            )
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
 


### PR DESCRIPTION
## What does this PR do?

#95535 said broad macOS searches skip protected home folders and warn about what was skipped. The GNU find command uses `-printf`, so prune matches stay off the list. The BSD fallback (macOS, no `-printf`) had no action, so find default-printed `~/Downloads` as a hit.

This puts `-print` on the keep side of that fallback command.

## Related Issue

Fixes #95765

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/file_operations.py`: BSD find fallback uses `-print` on the keep side.
- `tests/tools/test_macos_protected_search.py`: asserts the fallback command has `-print`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/tools/test_macos_protected_search.py -q`
2. With only `find` available, `search_files` against `$HOME` must send a find command that has both `-prune` and `-print`.
3. The GNU `-printf` command is unchanged.

Ran on Windows 11 with Python 3.11: 10 passed. Two older path-string asserts fail on Windows (`C:\` vs `/c/...`) and are unchanged here.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
10 passed (new BSD -print test included)
```
