### PR TITLE
fix(dashboard): let bare F11 reach the browser from the chat terminal

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -685,6 +685,22 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
+      // Bare F11 → browser fullscreen. xterm.js claims every function key
+      // for the PTY (F11 = CSI 23~), so once the chat terminal has focus
+      // Chrome never sees its own fullscreen shortcut — the fullscreen
+      // hardware key "stops working" after switching tabs and back (focus
+      // returns to the xterm textarea). Return false without
+      // preventDefault so xterm ignores the key and the browser acts.
+      if (
+        ev.key === "F11" &&
+        !ev.ctrlKey &&
+        !ev.metaKey &&
+        !ev.altKey &&
+        !ev.shiftKey
+      ) {
+        return false;
+      }
+
       // Copy: Cmd+C on macOS, Ctrl+C or Ctrl+Shift+C elsewhere. Copy only
       // when xterm has a selection; without one Ctrl+C still reaches the TUI
       // as SIGINT.


### PR DESCRIPTION
## Bug Description

On the web dashboard, Chrome's F11 fullscreen shortcut stops working after switching browser tabs and returning to the dashboard tab. It works on a freshly opened tab, but never again after the first tab switch. Hardware keys remapped to F11 (e.g. a fullscreen key via udev hwdb) are affected the same way.

## Root Cause

The dashboard chat embeds xterm.js, which claims every function key as PTY input (F11 → CSI 23~) and swallows it via preventDefault. The chat host is persistent across route changes and refocuses its xterm helper textarea on `pageshow`/`focus` (`ChatPage.tsx`, the resume path). After any tab switch, that textarea holds focus, so F11 is consumed as terminal input and Chrome never sees its own fullscreen shortcut.

## Fix

- In the `attachCustomKeyEventHandler` in `ChatPage.tsx`, return `false` for bare F11 (no Ctrl/Meta/Alt/Shift) so xterm ignores the key, without calling `preventDefault` — the browser then handles its native fullscreen toggle.
- Modifier combos (Ctrl/Meta/Alt/Shift+F11) still fall through to the terminal unchanged.

## How to Verify

1. Open the dashboard chat, click into the terminal so it has focus.
2. Switch to another browser tab and back.
3. Press F11 — the window now enters fullscreen. Before the fix, nothing happened.
4. Press F11 again to exit. Ctrl/Shift+F11 still reach the terminal as escape sequences.

## Test Plan

- [x] Manual verification on Linux/Chrome 152 (Pixelbook Go, Fedora 44, Wayland): F11 toggles fullscreen with terminal focus after tab switch; toggle back verified
- [x] Existing tests still pass: `npx tsc -p . --noEmit` clean; `npx vitest run src/pages/ChatPage.test.tsx` → 6/6 passed (node 26.7.0)

## Risk Assessment

Low — one early-return branch in the custom key handler; only bare F11 is affected, every other key path is unchanged.