### PR TITLE
fix(update): heal a TCC-anchored venv before the update stages run

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10778,6 +10778,20 @@ def cmd_update(args):
         )
         return
 
+    # Venvs the reverted TCC interpreter anchor already converted brick the
+    # update flow itself: updater subprocesses exec venv/bin/python3, whose
+    # symlink chain dies in the anchored copy ("No module named
+    # 'encodings'"), so every attempt exits 1 and the desktop handoff
+    # retries forever (#95759). The heal exists in doctor but the handoff
+    # never runs doctor — run it here, before any stage touches the venv.
+    # Best-effort: a failed heal must not block the update itself.
+    if sys.platform == "darwin":
+        try:
+            from hermes_cli.doctor import check_macos_tcc_anchor_removed
+            check_macos_tcc_anchor_removed()
+        except Exception as exc:  # noqa: BLE001 — never block the update
+            print(f"  ⚠ TCC anchor pre-heal skipped: {exc}")
+
     gateway_mode = getattr(args, "gateway", False)
 
     # Protect against mid-update terminal disconnects (SIGHUP) and tolerate

--- a/tests/hermes_cli/test_update_tcc_preheal.py
+++ b/tests/hermes_cli/test_update_tcc_preheal.py
@@ -1,0 +1,84 @@
+"""Regression tests for the update-path TCC anchor pre-heal (#95759).
+
+The revert of the TCC interpreter anchor (`2f9e187001`) kept a heal in
+``hermes doctor`` (``check_macos_tcc_anchor_removed``), but the desktop
+update handoff runs ``hermes update`` — never doctor — so pre-anchored
+venvs bricked every update attempt with "No module named 'encodings'" and
+the desktop retried forever. These pins keep the heal wired into
+``cmd_update``'s apply path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from unittest.mock import patch
+
+import hermes_cli.main as main_mod
+
+
+def test_cmd_update_apply_path_calls_the_heal_on_macos():
+    """The apply path invokes the doctor heal before any stage runs."""
+    source = inspect.getsource(main_mod.cmd_update)
+    assert "check_macos_tcc_anchor_removed" in source, (
+        "cmd_update must call the TCC anchor heal (#95759)"
+    )
+    # The call must precede the apply-path stages (gateway_mode marks the
+    # start of the stage machinery after the --check/--plan early returns).
+    heal_idx = source.index("check_macos_tcc_anchor_removed()")
+    gate_idx = source.index("gateway_mode = getattr(args")
+    assert heal_idx < gate_idx
+
+
+def test_heal_failure_never_blocks_the_update(monkeypatch):
+    """A crashing heal is swallowed — the update itself must still run."""
+    calls = {}
+
+    def boom():
+        calls["healed"] = True
+        raise RuntimeError("marker unreadable")
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(
+        "hermes_cli.doctor.check_macos_tcc_anchor_removed", boom
+    )
+    # Drive the wiring through the real cmd_update entry with stubbed
+    # downstream stages: an exception from the heal must not propagate.
+    class _Args:
+        plan = False
+        check = False
+        gateway = False
+        yes = True
+        branch = None
+
+    reached_impl = {"v": False}
+
+    class _Impl:
+        def _cmd_update_impl(self, args, gateway_mode=False):
+            reached_impl["v"] = True
+
+    monkeypatch.setattr(main_mod, "_self", lambda: _Impl())
+    import hermes_cli.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "detect_install_method", lambda root: "git")
+    monkeypatch.setattr(cfg_mod, "is_managed", lambda: False)
+    monkeypatch.setattr(cfg_mod, "is_nix_install_method", lambda m: False)
+    monkeypatch.setattr(main_mod, "_install_hangup_protection", lambda gateway_mode=None: None)
+    monkeypatch.setattr(main_mod, "_finalize_update_output", lambda state=None: None)
+
+    class _AlwaysAcquire:
+        def acquire(self):
+            return True
+
+        def release(self):
+            return None
+
+        holder = None
+
+    import hermes_cli.update_lock as ul
+    monkeypatch.setattr(ul, "UpdateLock", _AlwaysAcquire)
+    monkeypatch.setattr(ul, "describe_holder", lambda h: "")
+
+    main_mod.cmd_update(_Args())
+
+    assert calls["healed"] is True
+    assert reached_impl["v"] is True, "update must proceed past a failed heal"


### PR DESCRIPTION
## What does this PR do?

Fixes #95759: on a macOS install whose venv was already converted by the reverted TCC interpreter anchor, every desktop-driven update failed with `ModuleNotFoundError: No module named 'encodings'` and retried forever. The revert (`2f9e187001`) stopped NEW anchors and kept a heal in `hermes doctor` (`check_macos_tcc_anchor_removed`, restoring `venv/bin/python` to a symlink via the `.tcc-anchor-source` marker) — but the desktop update handoff runs `hermes update --yes --gateway --branch main`, which never calls doctor, so pre-anchored venvs stayed bricked and the update's own subprocesses (execing `venv/bin/python3`) died before any stage could run.

This PR wires the existing heal into `cmd_update`'s apply path: after the `--check`/`--plan`/docker/nix early returns and before `gateway_mode` marks the start of the stage machinery, on `darwin` only, via a lazy import, wrapped best-effort so a failed heal prints a one-line warning and never blocks the update itself. The heal is silent on venvs the anchor never touched (no marker) and on non-macOS.

## Related Issue

Fixes #95759

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `cmd_update` apply path invokes `hermes_cli.doctor.check_macos_tcc_anchor_removed()` on macOS before the update stages; comment documents the bricked-update loop (#95759) and the best-effort contract.
- `tests/hermes_cli/test_update_tcc_preheal.py` — two pins: the heal call site exists in `cmd_update` source and precedes the stage machinery; and a crashing heal is swallowed — driving `cmd_update` end-to-end with stubbed stages proves the update proceeds past a failed heal (monkeypatched `darwin` platform, stubbed install-method/lock/impl).

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_update_tcc_preheal.py -q` — should pass: 2 passed. Red/green: with the `main.py` change stashed, both fail (no heal call site; the wiring test raises), with the change, both pass.
2. Adjacent heal suite should pass: `pytest tests/hermes_cli/test_tcc_anchor_revert.py tests/hermes_cli/test_update_tcc_preheal.py -q` (5 passed). `ruff check` on both changed files should pass.
3. End-to-end shape (the report's repro): on a pre-anchored macOS install, the next desktop-driven `hermes update` first prints the heal's `✓ macOS TCC anchor removed` line, restores `venv/bin/python` to the recorded source symlink, and the update then completes instead of looping on exit 1.
4. Note: `tests/hermes_cli/test_cmd_update.py` has 8 failures in this sandbox that occur identically on unmodified `main` (same test names, 8 failed / 30 passed both sides — they drive real git operations and are environment-dependent); unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the two re-land PRs (#95605/#95754) build a NEW anchor; this PR only heals venvs the OLD reverted anchor converted, complementary to both
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file + adjacent heal suites green; the 8 sandbox-environment failures in test_cmd_update.py are documented above as pre-existing on main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — gated to `darwin` exactly like the heal itself
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
