### PR TITLE
feat(desktop): per-profile breathing indicator for finished-but-unseen sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -70,6 +70,7 @@ import {
   setShowAllProfiles,
   sortByProfileOrder
 } from '@/store/profile'
+import { $profilesBreathing } from '@/store/profile-breath'
 import {
   $profileRemoteOverrides,
   openRemoteOverrideDialog,
@@ -132,6 +133,7 @@ export function ProfileRail() {
   const colors = useStore($profileColors)
   const remoteOverrides = useStore($profileRemoteOverrides)
   const multipleConnections = useStore($hasMultipleConnections)
+  const breathing = useStore($profilesBreathing)
   const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
@@ -319,6 +321,7 @@ export function ProfileRail() {
                   {named.map(profile => (
                     <ProfileSquare
                       active={!isAll && normalizeProfileKey(profile.name) === activeKey}
+                      breathing={Boolean(breathing[normalizeProfileKey(profile.name)])}
                       color={resolveProfileColor(profile.name, colors)}
                       key={profile.name}
                       label={profileLabel(profile)}
@@ -633,6 +636,9 @@ function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
 
 interface ProfileSquareProps {
   active: boolean
+  // A finished-but-unseen turn exists in this profile's sessions (#95502):
+  // paints the breathing pulse until any of them is opened.
+  breathing: boolean
   color: null | string
   label: string
   onSelect: () => void
@@ -659,6 +665,7 @@ const LONG_PRESS_MS = 450
 // dnd listeners, hover tip, and right-click menu.
 function ProfileSquare({
   active,
+  breathing,
   color,
   label,
   onConnectRemote,
@@ -774,7 +781,20 @@ function ProfileSquare({
                     }}
                     onPointerUp={clearPress}
                   >
-                    {label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
+                    {/* The breathing initial (#95502): a finished-but-unseen turn
+                        in this profile's sessions. Only the LETTER breathes its
+                        luminance (brightness) between dim and bright — the square's
+                        own background color stays at its resting unselected state,
+                        so no glow, no ring, no extra visual noise. The dim trough
+                        keeps the letter visible (still on-screen, just darker). */}
+                    <span
+                      aria-hidden="true"
+                      className="relative"
+                      data-profile-breathing={breathing || undefined}
+                      data-slot="profile-breath-badge"
+                    >
+                      {label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
+                    </span>
                     {/* The "remote" badge: a tiny globe pinned to the corner of an
                         overridden profile's square, so which profiles leave this
                         machine is visible at a glance (#91349). */}

--- a/apps/desktop/src/store/profile-breath.test.ts
+++ b/apps/desktop/src/store/profile-breath.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { profilesWithBreathing } from './profile-breath'
+
+describe('profilesWithBreathing', () => {
+  it('marks a profile whose listed row resolved to unread', () => {
+    const byId = { s1: 'unread', s2: 'idle' }
+
+    const rows = [
+      { archived: false, id: 's1', profile: 'coder' },
+      { id: 's2', profile: 'design' }
+    ]
+
+    expect(profilesWithBreathing(byId, rows)).toEqual({ coder: true })
+  })
+
+  it('falls back to default when the row carries no profile', () => {
+    const byId = { s1: 'unread' }
+
+    expect(profilesWithBreathing(byId, [{ id: 's1' }])).toEqual({ default: true })
+  })
+
+  it('ignores archived rows and non-unread states', () => {
+    const byId = { s1: 'unread', s2: 'unread', s3: 'working' }
+
+    const rows = [
+      { archived: true, id: 's1', profile: 'coder' },
+      { id: 's2', profile: 'coder' },
+      { id: 's3', profile: 'design' }
+    ]
+
+    expect(profilesWithBreathing(byId, rows)).toEqual({ coder: true })
+  })
+
+  it('aggregates across multiple lists (sessions + messaging)', () => {
+    const byId = { s1: 'unread', m1: 'unread' }
+
+    expect(
+      profilesWithBreathing(
+        byId,
+        [{ id: 's1', profile: 'quant' }],
+        [{ id: 'm1', profile: 'media' }]
+      )
+    ).toEqual({ media: true, quant: true })
+  })
+
+  it('returns empty when nothing is unread', () => {
+    expect(profilesWithBreathing({}, [{ id: 's1', profile: 'coder' }])).toEqual({})
+    expect(profilesWithBreathing({ s1: 'working' }, [{ id: 's1', profile: 'coder' }])).toEqual({})
+  })
+})

--- a/apps/desktop/src/store/profile-breath.ts
+++ b/apps/desktop/src/store/profile-breath.ts
@@ -1,0 +1,39 @@
+/**
+ * PROFILE BREATH — which profiles have finished-but-unseen work, aggregated
+ * from the shared session dot states. Feeds the breathing badge on the
+ * sidebar's profile rail (#95502): when any listed session of a profile
+ * resolved to `unread` (a turn finished in the background, or the persisted
+ * read-watermark says unseen), that profile's square pulses until the session
+ * is opened. Derives live from $sessionDotStateById, so it clears the moment
+ * the underlying sessions are read — no extra ack state of its own.
+ */
+
+import { computed } from 'nanostores'
+
+import { $messagingSessions, $sessions } from './session'
+import { $sessionDotStateById } from './session-dot-state'
+
+/** Profiles (default fallback included) whose listed rows hold an unread
+ *  state. Pure so the aggregation stays unit-testable, mirroring
+ *  `unreadSessionCount`. */
+export function profilesWithBreathing(
+  byId: Readonly<Record<string, string>>,
+  ...lists: Array<readonly { archived?: boolean; id: string; profile?: string }[]>
+): Record<string, boolean> {
+  const next: Record<string, boolean> = {}
+
+  for (const rows of lists) {
+    for (const row of rows) {
+      if (!row.archived && byId[row.id] === 'unread') {
+        next[row.profile || 'default'] = true
+      }
+    }
+  }
+
+  return next
+}
+
+export const $profilesBreathing = computed(
+  [$sessionDotStateById, $sessions, $messagingSessions],
+  (byId, sessions, messaging) => profilesWithBreathing(byId, sessions, messaging)
+)

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3459,3 +3459,37 @@ html:has([data-hud-shell]) [data-slot='popover-content'] {
 [data-hud-shell] [data-slot='composer-bounds'] *::-webkit-scrollbar {
   display: none;
 }
+
+/* Profile-rail breathing badge (#95502): a finished-but-unseen turn in any of
+   a profile's sessions pulses that profile's square. Opacity-only travel on a
+   compositor layer — no layout, no paint — mirroring the arc-border budget. */
+/* The breathing initial (#95502): finished-but-unseen work in this profile's
+   sessions. Reuses the desktop's OWN resting states — the letter breathes
+   between the unselected dim (opacity .35) and the selected bright
+   (opacity 1.0), inherited from the official profile square styling. Only the
+   LETTER's opacity animates; the square's background stays at its resting
+   unselected fill (22% color-mix), so there is zero glow, zero box-shadow,
+   zero extra visual noise — a quiet dim→bright pulse of the glyph itself, in
+   the profile color, matching the official look-and-feel exactly. */
+[data-profile-breathing='true'] {
+  animation: profile-breath 1.6s ease-in-out infinite;
+}
+
+@keyframes profile-breath {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Reduced motion: hold a static resting opacity instead of pulsing
+   (mirrors the app-wide reduce policy). */
+@media (prefers-reduced-motion: reduce) {
+  [data-profile-breathing='true'] {
+    animation: none;
+    opacity: 0.85;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a quiet **breathing indicator** to the sidebar profile rail: when any listed session of a profile has finished running but is still unseen (unread), that profile's initial gently pulses to draw attention until the session is opened.

This addresses the feature request in #95502.

## Design decisions (after several rounds of tuning)

The intent was to make the cue *calm and unobtrusive* — a subtle signal that does not add visual noise to the already-colorful profile rail.

- **Reuses the desktop's own resting states.** The letter breathes between the existing *unselected* dim state (`opacity: .35`) and the *selected* bright state (`opacity: 1.0`). No new colors, no new tokens.
- **Only the letter's opacity animates.** The square's background stays at its resting unselected fill (the existing `profileColorSoft(hue, 22)` mix). There is **no glow, no box-shadow, no ring, no extra element** — so we avoid light pollution and visual noise in a rail that already carries per-profile color.
- **Prefers-reduced-motion honored.** A static resting opacity is held instead of pulsing for users who request reduced motion.
- **Pure, testable aggregation.** Unread-finished state is derived live from the existing `$sessionDotStateById`, so the badge clears the moment sessions are read — no extra acknowledgement state to keep in sync.

## Implementation

- `store/profile-breath.ts` (new): `profilesWithBreathing()` aggregates unread-finished session ids per profile; `$profilesBreathing` is a `nanostores` `computed` over the shared session stores.
- `store/profile-breath.test.ts` (new): 5 unit cases covering the aggregation.
- `app/chat/sidebar/profile-switcher.tsx`: wraps the profile initial in a span that drives `data-profile-breathing`; the `breathing` prop is threaded from the store.
- `styles.css`: `@keyframes profile-breath` (`opacity: .35 ↔ 1.0`, 1.6s ease-in-out) with a reduced-motion fallback.

## Verification

- `tsc --build` clean (0 errors)
- `vitest run store/profile-breath.test.ts`: 5/5 pass
- Manual visual check in a sandboxed dev instance confirmed the unread-finished state renders on the letter with the background staying fixed.

## Notes

- Pure type/renderer change; no backend, gateway, or model-tool surface touched.
- Contribution priority: small, focused, single-logical-change PR per the contributing guide.
