### PR TITLE
fix(desktop): restore scroll on the capped thinking preview (supersedes #73757)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -237,10 +237,12 @@ const ThinkingDisclosure: FC<{
           className={cn(
             // Body sits flush with the "Thinking" header — no left indent —
             // and inherits the disclosure-level opacity fade defined in
-            // styles.css (~0.67 at rest, 1 on hover/focus).
-            'mt-0.5 w-full min-w-0 max-w-full overflow-hidden wrap-anywhere pb-1',
+            // styles.css (~0.67 at rest, 1 on hover/focus). overflow-auto so
+            // the max-h-40 preview is a real scroller, not a clip.
+            'mt-0.5 w-full min-w-0 max-w-full overflow-auto overscroll-contain wrap-anywhere pb-1',
             isPreview && 'max-h-40'
           )}
+          data-slot="aui_thinking-body"
           ref={scrollRef}
         >
           <div ref={contentRef}>{children}</div>

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -621,6 +621,28 @@ describe('assistant-ui streaming renderer', () => {
     expect(container.textContent).not.toContain('```ts')
   })
 
+  it('keeps the height-capped thinking preview scrollable after the turn settles', async () => {
+    const { container, settle } = renderSettlingReasoning()
+
+    const live = container.querySelector('[data-slot="aui_thinking-body"]')?.className ?? ''
+
+    expect(live).toContain('max-h-40')
+    expect(live).toMatch(/\boverflow-auto\b/)
+    expect(live).not.toMatch(/\boverflow-hidden\b/)
+
+    settle()
+
+    await waitFor(() => {
+      expect(within(container).getByRole('button', { name: /thought/i })).toBeTruthy()
+    })
+
+    const settled = container.querySelector('[data-slot="aui_thinking-body"]')?.className ?? ''
+
+    expect(settled).toContain('max-h-40')
+    expect(settled).toMatch(/\boverflow-auto\b/)
+    expect(settled).not.toMatch(/\boverflow-hidden\b/)
+  })
+
   it('does not collapse a live thinking preview when the turn settles', async () => {
     const { container, settle } = renderSettlingReasoning()
     const toggle = within(container).getByRole('button', { name: /thinking/i })


### PR DESCRIPTION
## Summary

Supersedes [#73757](https://github.com/NousResearch/hermes-agent/pull/73757).

The thinking preview is height-capped (`max-h-40`) so a long thought doesn't shove the reply off-screen, and that cap stays after the turn settles so the transcript doesn't jump. `overflow-hidden` made the cap a clip: the JS pin-to-bottom still worked, but you couldn't scroll the rest of the thought.

This keeps the cap and makes it a scroller (`overflow-auto` + `overscroll-contain`).

### What this PR does

- Thinking body uses `overflow-auto` so the existing max-height window scrolls
- `overscroll-contain` so the wheel doesn't chain into the transcript
- Regression: the cap stays a scroller after the turn settles

### What was dropped from #73757

- Extra `max-h-[40dvh]` cap on a completed thought you expand from collapsed
- Class-name snapshot tests for that 40dvh bound

## Test plan

- [x] `npx vitest run src/components/assistant-ui/thread/streaming.test.tsx -t "height-capped"` (from `apps/desktop`)
- [ ] Expand a long thinking block in Desktop and scroll it; the wheel should not drag the transcript

Credit: @danspicytaco