### PR TITLE
fix(gateway): fall back to legacy launchctl load when bootstrap is EIO-broken (macOS 26.x)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4487,8 +4487,11 @@ _LAUNCHD_JOB_UNLOADED_EXIT_CODES = frozenset({3, 113, 125})
 #      cannot supervise the gateway at all and we degrade to a detached
 #      background process (the `nohup hermes gateway run` workaround). See #23387.
 # `_launchctl_bootstrap()` disambiguates by trying the bootout+retry (case 1)
-# first; only when that retry ALSO returns 5/125 do callers treat the domain as
-# unsupported (case 2) via `_launchctl_domain_unsupported`.
+# first; only when that retry ALSO returns 5/125 does it make one more attempt
+# through the legacy ``launchctl load -w`` (which still works on hosts where
+# the modern bootstrap is EIO-broken even with nothing loaded — measured on
+# macOS 26.5.2). Only when the legacy loader ALSO fails do callers treat the
+# domain as unsupported (case 2) via `_launchctl_domain_unsupported`.
 _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES = frozenset({5, 125})
 
 
@@ -4515,6 +4518,22 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
 _LAUNCHCTL_BOOTSTRAP_EIO = 5
 
 
+def _launchctl_load_legacy(plist_path, *, timeout: int = 30) -> None:
+    """Load a LaunchAgent via the legacy ``launchctl load -w`` command.
+
+    On some macOS 26.x hosts the modern ``launchctl bootstrap`` fails with
+    ``5: Input/output error`` (EIO) even when the label is registered in no
+    domain — the legacy loader, however, still works and registers the job in
+    ``gui/<uid>`` (measured 2026-08-27 on macOS 26.5.2, follow-up to #23387).
+    ``-w`` persists the enabled state so the job auto-starts at login.
+    """
+    subprocess.run(
+        ["launchctl", "load", "-w", str(plist_path)],
+        check=True,
+        timeout=timeout,
+    )
+
+
 def _launchctl_bootstrap(
     domain: str, plist_path, label: str, *, timeout: int = 30
 ) -> None:
@@ -4530,8 +4549,11 @@ def _launchctl_bootstrap(
     to a detached process, silently losing auto-start and crash-restart.
 
     Recover by booting the stale label out and bootstrapping once more. If the
-    retry still fails, the ``CalledProcessError`` propagates so callers apply
-    their domain-unsupported fallback for a genuinely broken domain.
+    retry still fails with 5/125, fall back to the legacy ``launchctl load -w``
+    (which works on hosts where the modern bootstrap is EIO-broken, see
+    :func:`_launchctl_load_legacy`). Only when the legacy loader also fails does
+    the ``CalledProcessError`` propagate so callers apply their
+    domain-unsupported fallback for a genuinely broken domain.
     """
     try:
         subprocess.run(
@@ -4549,11 +4571,22 @@ def _launchctl_bootstrap(
             check=False,
             timeout=timeout,
         )
-        subprocess.run(
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            check=True,
-            timeout=timeout,
-        )
+        try:
+            subprocess.run(
+                ["launchctl", "bootstrap", domain, str(plist_path)],
+                check=True,
+                timeout=timeout,
+            )
+        except subprocess.CalledProcessError as retry_exc:
+            if not _launchctl_domain_unsupported(retry_exc.returncode):
+                raise
+            # Persistent EIO with nothing loaded: the modern bootstrap is
+            # broken on this host but the domain is fine — try the legacy
+            # loader before declaring the domain unmanageable.
+            try:
+                _launchctl_load_legacy(plist_path, timeout=timeout)
+            except subprocess.CalledProcessError:
+                raise retry_exc from None
 
 
 def _launchd_reload_log_path() -> Path:
@@ -4632,7 +4665,15 @@ def _retry_launchctl_bootstrap_until_registered(
         attempt += 1
         try:
             _launchctl_bootstrap(domain, plist_path, label, timeout=30)
-            if _launchctl_label_supervising_process(label):
+            # Judge success by a live supervised PID after a short settle
+            # window, not a one-shot check: the job registers instantly but the
+            # gateway takes a few seconds to start, and on hosts where the
+            # bootstrap only succeeds via the legacy `load -w` rung an
+            # immediate miss would retry and boot the still-starting instance
+            # out again, churning it until the deadline.
+            if _wait_for_launchd_service_pid(
+                label, None, timeout=10.0, domain=domain
+            ):
                 return True
             _append_launchd_reload_log(
                 f"bootstrap attempt {attempt} exited 0 but {domain}/{label} "
@@ -5030,7 +5071,10 @@ def refresh_launchd_plist_if_needed() -> bool:
             f"sleep 1; "
             f"_deadline=$(($(date +%s) + {_reload_budget})); "
             f"while :; do "
-            f"  launchctl bootstrap {shlex.quote(domain)} {shlex.quote(str(plist_path))} 2>/dev/null; "
+            # Legacy `load -w` rung: on macOS 26.x hosts where the modern
+            # bootstrap is EIO-broken (exit 5 even with nothing loaded), the
+            # legacy loader still registers the job — mirrors _launchctl_bootstrap.
+            f"  launchctl bootstrap {shlex.quote(domain)} {shlex.quote(str(plist_path))} 2>/dev/null || launchctl load -w {shlex.quote(str(plist_path))} 2>/dev/null; "
             # Require a POSITIVE PID, not just exit 0: a bare `launchctl list`
             # also succeeds for a registered-but-not-running definition, and a
             # recently-crashed job reports `"PID" = -1` — both must keep the
@@ -5439,18 +5483,16 @@ def launchd_restart():
             # Restart is the one path where the job is almost always still
             # registered (we just drained it), so a plain bootstrap would hit
             # EIO on the common case. Boot the stale label out first — cheaper
-            # and clearer here than routing through _launchctl_bootstrap's
-            # bootstrap-first/retry-on-EIO flow. See #23387, #42914.
+            # and clearer here than a bootstrap-first flow. The reload itself
+            # still routes through _launchctl_bootstrap so hosts with an
+            # EIO-broken modern bootstrap get its EIO-recovery + legacy
+            # `load -w` rungs. See #23387, #42914.
             subprocess.run(
                 ["launchctl", "bootout", target],
                 check=False,
                 timeout=90,
             )
-            subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
+            _launchctl_bootstrap(_launchd_domain(), plist_path, label, timeout=30)
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2187,10 +2187,11 @@ class TestLaunchctlBootstrapEioRetry:
         ]
 
     def test_persistent_eio_reraises_for_domain_fallback(self, monkeypatch):
-        # When the retry also fails, the error must propagate so callers apply
-        # their _launchctl_domain_unsupported fallback (degrade to detached).
+        # When the retry AND the legacy `load -w` rung both fail, the error
+        # must propagate so callers apply their _launchctl_domain_unsupported
+        # fallback (degrade to detached).
         def fake_run(cmd, check=True, **kwargs):
-            if cmd[1] == "bootstrap":
+            if cmd[1] in ("bootstrap", "load"):
                 raise subprocess.CalledProcessError(5, cmd)
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -2200,38 +2201,63 @@ class TestLaunchctlBootstrapEioRetry:
             gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
         assert excinfo.value.returncode == 5
 
+    def test_persistent_eio_recovers_via_legacy_load(self, monkeypatch):
+        # On macOS 26.x hosts where the modern bootstrap is EIO-broken even
+        # with nothing loaded, the legacy `launchctl load -w` still registers
+        # the job — the helper must use it instead of propagating to the
+        # detached fallback (measured 2026-08-27 on macOS 26.5.2).
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            if cmd[1] == "bootstrap":
+                raise subprocess.CalledProcessError(5, cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
+
+        assert calls[-1] == ["launchctl", "load", "-w", self.PLIST]
+
 
 class TestRetryLaunchctlBootstrapUntilRegistered:
     """`_retry_launchctl_bootstrap_until_registered` — salvage of #53277.
 
     Covers the three review findings the salvage hardens: retry until the
-    label is actually LISTED (not just a zero bootstrap exit), TimeoutExpired
-    is retried (not escaped leaving the service unloaded), and the retry is
-    bounded by a wall-clock deadline rather than a fixed short window.
+    label is actually supervised (a live PID via `launchctl print`, not just a
+    zero bootstrap exit), TimeoutExpired is retried (not escaped leaving the
+    service unloaded), and the retry is bounded by a wall-clock deadline
+    rather than a fixed short window.
     """
 
     DOMAIN = "gui/501"
     PLIST = "/tmp/ai.hermes.gateway.plist"
     LABEL = "ai.hermes.gateway"
 
-    # `launchctl list <label>` output for a job launchd is actively running.
-    # Success requires a PID here, not just exit 0 — exit 0 alone also covers a
-    # registered-but-not-running definition (macOS 26+ `state = not running`).
-    RUNNING_LIST_OUTPUT = '{\n\t"PID" = 4242;\n\t"Label" = "ai.hermes.gateway";\n};'
+    # `launchctl print <domain>/<label>` output for a job launchd is actively
+    # running. Success requires a `pid =` line, not just exit 0 — exit 0 alone
+    # also covers a registered-but-not-running definition.
+    NOT_RUNNING_PRINT_OUTPUT = "gui/501/ai.hermes.gateway = {\n\tstate = running\n}\n"
+    RUNNING_PRINT_OUTPUT = (
+        "gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 4242\n}\n"
+    )
 
     def test_returns_true_once_label_is_registered(self, monkeypatch):
-        """Success requires launchctl list to confirm a supervised process, not
-        just a zero bootstrap exit."""
-        list_results = iter([1, 0])  # first check: not registered, second: registered
+        """Success requires a live supervised PID, not just a zero bootstrap
+        exit."""
+        # First print: registered but no pid yet; second: launchd is running
+        # it. The settle wait re-checks its deadline on every poll, so a short
+        # no-pid window does not burn the full settle budget.
+        print_results = iter([
+            (0, self.NOT_RUNNING_PRINT_OUTPUT),
+            (0, self.RUNNING_PRINT_OUTPUT),
+        ])
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "list"]:
-                rc = next(list_results)
-                return SimpleNamespace(
-                    returncode=rc,
-                    stdout=self.RUNNING_LIST_OUTPUT if rc == 0 else "",
-                    stderr="",
-                )
+            if cmd[:2] == ["launchctl", "print"]:
+                rc, out = next(print_results, (0, self.RUNNING_PRINT_OUTPUT))
+                return SimpleNamespace(returncode=rc, stdout=out, stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -2254,12 +2280,12 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
                 if attempts["bootstrap"] == 1:
                     raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 30))
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
-            if cmd[:2] == ["launchctl", "list"]:
-                # registered only after the second (successful) bootstrap
+            if cmd[:2] == ["launchctl", "print"]:
+                # supervised only after the second (successful) bootstrap
                 ok = attempts["bootstrap"] >= 2
                 return SimpleNamespace(
-                    returncode=0 if ok else 1,
-                    stdout=self.RUNNING_LIST_OUTPUT if ok else "",
+                    returncode=0,
+                    stdout=self.RUNNING_PRINT_OUTPUT if ok else "",
                     stderr="",
                 )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -2274,32 +2300,40 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
     def test_registered_but_not_running_is_not_success(self, monkeypatch):
-        """A definition with no PID must not end the loop.
+        """A definition with no live PID must not end the loop.
 
-        `launchctl list` exits 0 for a registered-but-not-running job (macOS
-        26+ `state = not running`), so exit-0 alone would report success for a
-        gateway launchd is not actually running. Verified against live launchd
-        on 2026-08-05.
+        `launchctl print` exits 0 for a registered-but-not-running job, so
+        exit-0 alone would report success for a gateway launchd is not
+        actually running.
         """
-        list_calls = {"n": 0}
+        print_calls = {"n": 0}
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "list"]:
-                list_calls["n"] += 1
-                # Registered (exit 0) but no PID line — never running.
+            if cmd[:2] == ["launchctl", "print"]:
+                print_calls["n"] += 1
+                # Registered (exit 0) but no `pid =` line — never running.
                 return SimpleNamespace(
                     returncode=0,
-                    stdout='{\n\t"Label" = "ai.hermes.gateway";\n};',
+                    stdout=self.NOT_RUNNING_PRINT_OUTPUT,
                     stderr="",
                 )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
+        # Jump the clock past the settle budget on every read so the
+        # no-pid wait loop exits immediately instead of spinning in real time.
+        clock = {"t": 1000.0}
+
+        def fake_monotonic():
+            clock["t"] += 11.0
+            return clock["t"]
+
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
         monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
+        monkeypatch.setattr(gateway_cli.time, "monotonic", fake_monotonic)
 
         ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
             self.DOMAIN, self.PLIST, self.LABEL,
             deadline=gateway_cli.time.monotonic() - 1,  # already expired
         )
         assert ok is False
-        assert list_calls["n"] >= 1
+        assert print_calls["n"] >= 1


### PR DESCRIPTION
## What does this PR do?

On some macOS 26.x hosts (measured on macOS 26.5.2), the modern `launchctl bootstrap` command fails with `exit 5` (EIO) **even when the label is registered in no launchd domain** — while the legacy `launchctl load -w` works fine and registers the job in `gui/<uid>`. The gateway CLI misclassified that persistent EIO as "launchd cannot manage this macOS version" (the #23387 case) and degraded to a detached background process, silently losing auto-start at login and auto-restart on crash.

This PR adds a legacy `launchctl load -w` rung to the bootstrap path: the CLI now tries it before declaring the domain unmanageable, so the gateway stays under launchd supervision (RunAtLoad + KeepAlive) on these hosts.

Repro details, manual launchd confirmation, and root-cause walkthrough: #95758.

## Related Issue

Fixes #95758

Related: #91549 (EIO from an already-loaded label — same symptom, different trigger), #23387, #42914, #40831

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`:
  - New `_launchctl_load_legacy()` — runs the legacy `launchctl load -w <plist>` (persists the enabled state so the job auto-starts at login).
  - `_launchctl_bootstrap()` — when EIO → `bootout` → retry still fails with 5/125, try the legacy loader; only propagate the domain-unsupported error when the legacy loader also fails. (Previously the retry error propagated straight to the detached-process fallback.)
  - `launchd_restart()` — the reload path now routes through `_launchctl_bootstrap` instead of a raw `bootstrap` call, so it gets the same EIO-recovery + legacy rungs.
  - Deferred `launchctl submit` reload script — adds the same `bootstrap ... || load -w ...` rung so plist refreshes during `hermes update` recover on these hosts too.
  - `_retry_launchctl_bootstrap_until_registered()` — success is now judged by a live supervised PID after a short (10s) settle window instead of a one-shot check, so a still-starting instance is not booted out and reloaded in a churn loop on hosts that only succeed via the legacy loader.
- `tests/hermes_cli/test_gateway_service.py`:
  - `test_persistent_eio_reraises_for_domain_fallback` updated — the legacy `load -w` rung must also fail for the error to propagate.
  - New `test_persistent_eio_recovers_via_legacy_load` — persistent EIO with nothing loaded recovers via the legacy loader.
  - `TestRetryLaunchctlBootstrapUntilRegistered` updated to the print-based success check (`launchctl print <domain>/<label>` with a live `pid =` line) instead of `launchctl list`.

Cross-platform note: every changed code path is launchd/macOS-only (call sites are `is_macos()`-gated; no function signatures changed), so Linux (systemd) and Windows (scheduled task) behaviour is untouched. `scripts/check-windows-footguns.py` reports no footguns in the added lines; `ruff` is clean.

## How to Test

1. **Unit tests (any platform):** `pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_proc_fallback.py -q` → 97 passed (3 skipped, platform-gated) on macOS 26.5.2.
2. **On a macOS 26.x host with an EIO-broken modern bootstrap** (the affected class of hosts):
   - `hermes gateway stop` → `hermes gateway start`
     → expect `↻ launchd job was unloaded; reloading service definition` then `✓ Service started` — no "launchd cannot manage" warning, no background-process fallback.
   - `hermes gateway restart` → `✓ Service restarted`.
   - `hermes gateway status` → `✓ Gateway is supervised by launchd (PID ...)` / `Auto-start at login and auto-restart on crash are available.`
   - Reboot / re-login → the LaunchAgent starts the gateway automatically.
3. **On healthy hosts (macOS 15.x, Linux, Windows):** no behavior change — the legacy rung only fires after the modern bootstrap has failed twice, and the Linux/Windows service paths never enter the launchd code.
4. Note: 3 pre-existing failures in `tests/hermes_cli/test_update_launchd_fleet_restart.py` exist on the unmodified base commit as well (fleet-restart warning text / PID scoping, unrelated to launchd loading); this PR does not touch those code paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before (macOS 26.5.2, `hermes gateway restart` with the job unloaded):**

```
Could not find service "ai.hermes.gateway" in domain for user gui: 501
↻ launchd job was unloaded; reloading
Boot-out failed: 3: No such process
Bootstrap failed: 5: Input/output error
⚠ launchd cannot manage the gateway on this macOS version (launchctl exit 5).
✓ Started gateway as a background process instead
  It will NOT auto-start at login or auto-restart on crash.
```

**After (same host, same command):**

```
→ Stopping gateway (PID 51977) — draining in-flight runs (up to 0s)...
⚠ Gateway PID 51977 still running after 0.0s — restart may fail
⚠ Gateway drain timed out after 0s — forcing launchd restart
✓ Service restarted
```

(The two ⚠ lines are the default `agent.restart_drain_timeout: 0` forced-restart notice, identical on healthy platforms.)

```
$ hermes gateway status
Launchd plist: /Users/<user>/Library/LaunchAgents/ai.hermes.gateway.plist
✓ Service definition matches the current Hermes install
✓ Gateway is supervised by launchd (PID 52111)
  Auto-start at login and auto-restart on crash are available.
```
