### PR TITLE
fix(desktop): don't gate hover-reveal on the hover media query

### DIFF
--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -236,15 +236,12 @@ describe('AttachmentList', () => {
     )
   })
 
-  it('shows the remove control at rest and does not hide it behind hover', async () => {
+  it('removes an attachment from the composer chip', async () => {
     const onRemove = vi.fn()
 
     await renderWithI18n(<AttachmentList attachments={[makeAttachment('a', 'doc.pdf')]} onRemove={onRemove} />)
 
-    const remove = screen.getByRole('button', { name: 'Remove doc.pdf' })
-
-    expect(remove.className.split(/\s+/)).not.toContain('opacity-0')
-    fireEvent.click(remove)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove doc.pdf' }))
     expect(onRemove).toHaveBeenCalledWith('a')
   })
 

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -149,7 +149,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
   return (
     <>
       <Tip label={attachment.path || attachment.detail || attachment.label}>
-        <div className="relative min-w-0 shrink-0">
+        <div className="group/attachment relative min-w-0 shrink-0">
           <button
             aria-busy={isUploading || undefined}
             aria-label={canPreview ? c.previewLabel(attachment.label) : attachment.label}
@@ -204,11 +204,11 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
           {onRemove && (
             <button
               aria-label={c.removeAttachment(attachment.label)}
-              className="absolute -right-1 -top-1 z-10 grid size-4 place-items-center rounded-full border border-border/70 bg-background text-muted-foreground shadow-xs transition hover:bg-accent hover:text-foreground"
+              className="absolute -right-1 -top-1 grid size-3.5 place-items-center rounded-full border border-border/70 bg-background text-muted-foreground opacity-0 shadow-xs transition hover:bg-accent hover:text-foreground group-hover/attachment:opacity-100 focus-visible:opacity-100"
               onClick={() => onRemove(attachment.id)}
               type="button"
             >
-              <Codicon name="close" size="0.7rem" />
+              <Codicon name="close" size="0.625rem" />
             </button>
           )}
         </div>

--- a/apps/desktop/src/components/assistant-ui/markdown-text.artifacts.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.artifacts.test.tsx
@@ -65,12 +65,10 @@ describe('MarkdownTextContent artifacts', () => {
     expect(artifactsForSession('session-artifacts')).toHaveLength(0)
   })
 
-  it('keeps the code-block copy control visible without hover', async () => {
+  it('renders a copy control on a fenced code block', async () => {
     render(<MarkdownTextContent isRunning={false} text={fenced('js', SMALL_SNIPPET)} />)
 
-    const copy = await screen.findByRole('button', { name: 'Copy code' })
-
-    expect(copy.className.split(/\s+/)).not.toContain('opacity-0')
+    expect(await screen.findByRole('button', { name: 'Copy code' })).toBeTruthy()
   })
 
   it('does not register while the message is still streaming', async () => {

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -15,8 +15,7 @@ import { isLikelyProseCodeBlock } from '@/lib/markdown-code'
  * own the wrapping `<CodeCard>` here and neutralize the upstream
  * `data-streamdown="code-block"` chrome from styles.css. The card is
  * background-only — no header row, no language label — so a fence reads as a
- * tinted slab of the reply. Copy stays visible in the corner (not hover-only)
- * so Windows / touch / no-hover surfaces can still find it.
+ * tinted slab of the reply; copy is a hover-reveal control in the corner.
  *
  * `react-shiki` full bundle so all `bundledLanguages` work; theme switches
  * follow the document `color-scheme` via `defaultColor="light-dark()"`.
@@ -149,7 +148,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
     <CodeCard data-streaming={defer ? 'true' : undefined}>
       <CopyButton
         appearance="inline"
-        className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md bg-(--ui-bg-editor)/90 px-1"
+        className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-0 transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}

--- a/apps/desktop/src/hover-variant.test.ts
+++ b/apps/desktop/src/hover-variant.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { compile } from '@tailwindcss/node'
+import { describe, expect, it } from 'vitest'
+
+const SRC = dirname(fileURLToPath(import.meta.url))
+
+const CANDIDATES = ['hover:opacity-100', 'group-hover/attachment:opacity-100', 'group-hover/code:opacity-100']
+
+async function utilitiesFor(css: string): Promise<string> {
+  const { build } = await compile(css, { base: SRC, onDependency() {} })
+  const out = build(CANDIDATES)
+  const start = out.indexOf('@layer utilities {')
+  expect(start).toBeGreaterThanOrEqual(0)
+  return out.slice(start)
+}
+
+function gatesHoverOnCapabilityQuery(css: string): boolean {
+  return /@media\s*\(\s*hover\s*:\s*hover\s*\)/.test(css)
+}
+
+describe('hover variant (Windows hover-reveal)', () => {
+  it('still wraps hover utilities in the capability query without an override', async () => {
+    const utilities = await utilitiesFor('@import "tailwindcss";\n')
+
+    expect(utilities).toContain('group-hover')
+    expect(gatesHoverOnCapabilityQuery(utilities)).toBe(true)
+  })
+
+  it('does not wrap the app stylesheet hover utilities in the capability query', async () => {
+    const utilities = await utilitiesFor('@import "./styles.css";\n')
+
+    expect(utilities).toContain('.group-hover\\/attachment\\:opacity-100')
+    expect(utilities).toContain('.group-hover\\/code\\:opacity-100')
+    expect(utilities).toContain('.hover\\:opacity-100')
+    expect(gatesHoverOnCapabilityQuery(utilities)).toBe(false)
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -10,6 +10,10 @@
   font-size: var(--titlebar-icon-size);
 }
 
+/* v4 gates hover: on @media (hover: hover). Some Windows hosts with a
+   digitizer answer false even with a mouse, so hover-reveal controls stay
+   opacity-0 (clickable, invisible). Trust :hover itself. */
+@custom-variant hover (&:hover);
 @custom-variant dark (&:is(.dark *));
 
 /* Blanket reduced-motion override: kill ALL CSS animations and transitions


### PR DESCRIPTION
## Summary

[\#95611](https://github.com/NousResearch/hermes-agent/pull/95611) made the composer X and code-block copy always visible. The real bug is Tailwind v4 wrapping every `hover:` / `group-hover:` in `@media (hover: hover)`. Some Windows hosts (touchscreen laptops, tablet mode) answer that query false even with a mouse, so hover-reveal controls stay `opacity-0`: clickable, but invisible. Same class as the assistant action bar, image download, and sidebar row actions.

This overrides the hover variant so `:hover` is enough, then puts those two icons back on hover-reveal.

Credit: @xxxigm (diagnosis on [\#95611](https://github.com/NousResearch/hermes-agent/pull/95611)).

## Test plan
- [x] `cd apps/desktop && npm run test:ui -- src/hover-variant.test.ts src/app/chat/composer/attachments.test.tsx src/components/assistant-ui/markdown-text.artifacts.test.tsx`
- [ ] Desktop: emulate `hover: none` in DevTools, hover an attachment and a code block. X and copy should appear.
- [ ] Windows 2-in-1 if available: same, plus the assistant message action bar.