### PR TITLE
feat(photon): native iMessage unsend tool

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2578,6 +2578,38 @@ class PhotonAdapter(BasePlatformAdapter):
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
+    async def unsend(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> SendResult:
+        """Recall one of OUR OWN messages via iMessage unsend.
+
+        Only messages sent by the bot can be unsent. Returns success if
+        the provider accepted the recall.
+        """
+        if not chat_id.strip() or not message_id.strip():
+            return SendResult(
+                success=False, error="chat_id and message_id are required"
+            )
+        return await self._sidecar_unsend(chat_id, message_id)
+
+    async def _sidecar_unsend(
+        self, space_id: str, message_id: str
+    ) -> SendResult:
+        """POST to the sidecar's ``/unsend-message`` endpoint.
+
+        Calls spectrum-ts's ``space.unsend()`` on the target message.
+        iMessage only permits unsending messages we sent; other cases
+        return a 4xx from the sidecar.
+        """
+        body: Dict[str, Any] = {"spaceId": space_id, "messageId": message_id}
+        try:
+            data = await self._sidecar_call("/unsend-message", body)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True, message_id=data.get("unsent"))
+
     async def _sidecar_send_attachment(
         self,
         space_id: str,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -1137,6 +1137,36 @@ const server = http.createServer(async (req, res) => {
       }
       return badRequest(res, "no tracked reaction for message");
     }
+    if (req.url === "/unsend-message") {
+      // Recall one of OUR OWN messages via iMessage unsend.
+      // spectrum-ts/iMessage rejects unsending inbound or foreign messages —
+      // surface that as a 4xx, not a crash. Restart-recovery: if the id is
+      // not in the live cache, rehydrate by id before attempting the unsend.
+      const { spaceId, messageId } = body || {};
+      if (!spaceId || !messageId) {
+        return badRequest(res, "spaceId and messageId are required");
+      }
+      const space = await resolveSpace(spaceId);
+      let target = null;
+      try {
+        target = knownMessages.get(messageId) ?? (await space.getMessage(messageId));
+      } catch (e) {
+        target = null;
+      }
+      if (!target) {
+        return badRequest(res, "message not found");
+      }
+      try {
+        await space.unsend(target);
+      } catch (e) {
+        return badRequest(
+          res,
+          "not unsent: " + (e && e.message ? e.message : String(e))
+        );
+      }
+      knownMessages.delete(messageId);
+      return ok(res, { unsent: messageId });
+    }
     if (req.url === "/send-poll") {
       const { spaceId, title, options } = body || {};
       const choices = Array.isArray(options)

--- a/tests/tools/test_photon_unsend_tool.py
+++ b/tests/tools/test_photon_unsend_tool.py
@@ -1,0 +1,117 @@
+"""Tests for the Photon unsend tool (``photon_unsend``).
+
+The tool must only be *offered* when a live Photon adapter exists in-process
+(the check_fn); handler routes to ``adapter.unsend``, defaults the chat to
+the Photon home channel when none given and the message to the most recent
+message the bot sent in that chat, and returns a JSON string (the registry's
+normal result shape).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import tools.photon_unsend_tool as put
+from gateway.platforms.base import SendResult
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.unsent: list[tuple] = []
+        self._last_sent_by_chat = {}
+
+    async def unsend(self, chat_id, message_id):
+        self.unsent.append((chat_id, message_id))
+        return SendResult(success=True, message_id=message_id)
+
+    def _normalize_chat_key(self, chat_id):
+        return chat_id
+
+
+@pytest.fixture(autouse=True)
+def _home_channel(monkeypatch):
+    """Photon home channel resolves without touching real config files."""
+
+    class _Home:
+        chat_id = "any;-;+162****1234"
+
+    class _Config:
+        @staticmethod
+        def get_home_channel(_platform):
+            return _Home()
+
+    import gateway.config as gw_config
+
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: _Config)
+
+
+def test_check_fn_requires_live_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: None)
+    assert put._photon_unsend_check() is False
+
+
+def test_check_fn_passes_with_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert put._photon_unsend_check() is True
+
+
+def test_handler_without_live_adapter_errors(monkeypatch) -> None:
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: None)
+    result = json.loads(
+        asyncio.run(put._photon_unsend({"message_id": "m1"}))
+    )
+    assert "live Photon adapter" in result["error"]
+
+
+def test_requires_message_id_or_recent(monkeypatch) -> None:
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: _FakeAdapter())
+    # No message_id and no recent sent message -> error
+    result = json.loads(
+        asyncio.run(put._photon_unsend({}))
+    )
+    assert "No message_id given and no recently-sent message" in result["error"]
+
+
+def test_unsend_with_explicit_message_id(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(put._photon_unsend({"message_id": "target-msg-1"}))
+    )
+    assert result["success"] is True
+    assert fake.unsent == [("any;-;+162****1234", "target-msg-1")]
+
+
+def test_unsend_defaults_to_recent_sent(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    fake._last_sent_by_chat = {"any;-;+162****1234": "recent-bot-msg"}
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(put._photon_unsend({}))
+    )
+    assert result["success"] is True
+    assert fake.unsent == [("any;-;+162****1234", "recent-bot-msg")]
+
+
+def test_unsend_prefers_current_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    fake._last_sent_by_chat = {"chat-current": "recent-in-current"}
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: fake)
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-current")
+    asyncio.run(put._photon_unsend({}))
+    assert fake.unsent[0][0] == "chat-current"
+
+
+def test_adapter_failure_propagates_error(monkeypatch) -> None:
+    class _BoomAdapter(_FakeAdapter):
+        async def unsend(self, chat_id, message_id):
+            return SendResult(success=False, error="not unsent: not our message")
+
+    fake = _BoomAdapter()
+    monkeypatch.setattr(put, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(put._photon_unsend({"message_id": "m1"}))
+    )
+    assert result["error"] == "not unsent: not our message"

--- a/tools/photon_unsend_tool.py
+++ b/tools/photon_unsend_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Recall (unsend) one of OUR OWN iMessage bubbles over Photon.
+
+iMessage supports recalling a message you sent — the bubble vanishes
+from both sides with the native "You unsent a message" notice. This
+tool wraps the sidecar's ``/unsend-message`` route (which calls
+spectrum-ts ``space.unsend()``). It is an opt-in tool in the
+``photon_tools`` toolset, exposed only when a live Photon adapter is
+running in this process (check_fn), so it costs zero tokens on
+every other install.
+
+Only messages sent by the bot can be unsent; iMessage rejects
+attempts to unsend inbound/foreign messages. The handler validates
+the chat and message id, defaults to the most recent message the bot
+sent in the chat when message_id is omitted, and returns a JSON
+string (the registry's normal result shape).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "photon_tools"
+
+SCHEMA: Dict[str, Any] = {
+    "name": "photon_unsend",
+    "description": (
+        "Unsend (recall) one of YOUR OWN recent iMessage messages on the "
+        "Photon platform — for example a garbled or mistaken bubble you "
+        "just sent. Only works on messages YOU sent (never the user's "
+        "messages) that are still in the session's memory. Omit message_id "
+        "to recall your most recent sent message in the chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_id": {
+                "type": "string",
+                "description": (
+                    "The id of the message to recall. Omit to recall your "
+                    "most recent sent message in the chat."
+                ),
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional chat (space GUID like 'any;-;+1555…' or bare "
+                    "E.164). Defaults to the conversation currently being "
+                    "answered."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _live_photon_adapter():
+    """Return the running Photon adapter, or None.
+
+    Mirrors ``photon_poll_tool`` / ``photon_react_tool``.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return runner.adapters.get(Platform.PHOTON)
+    except Exception:
+        return None
+
+
+async def _resolve_chat_id(explicit: str) -> str:
+    chat_id = (explicit or "").strip()
+    if chat_id:
+        return chat_id
+    try:
+        from gateway.session_context import get_session_env
+
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    except Exception:
+        chat_id = ""
+    if chat_id:
+        return chat_id
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+    home = config.get_home_channel("photon")
+    return home.chat_id
+
+
+async def _last_sent_message_id(chat_id: str) -> str | None:
+    """Most recent message WE sent in chat, via the adapter's tracker."""
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return None
+    # Prefer the adapter's own sent-tracker; fall back to sidecar /last-sent.
+    per_chat = getattr(adapter, "_last_sent_by_chat", None)
+    if per_chat:
+        norm = getattr(adapter, "_normalize_chat_key", None)
+        key = norm(chat_id) if norm else chat_id
+        return per_chat.get(key)
+    # Sidecar fallback would need the runtime record — not needed for core
+    # tools since the adapter tracks its own sent ids.
+    return None
+
+
+def _photon_unsend_check() -> bool:
+    """Availability check: tool only exists when live Photon adapter in-process."""
+    return _live_photon_adapter() is not None
+
+
+async def _photon_unsend(args: Dict[str, Any], **kw) -> str:
+    message_id = str(args.get("message_id") or "").strip()
+    chat_id = str(args.get("chat_id") or "").strip()
+
+    def err(msg: str) -> str:
+        return tool_error(msg)
+
+    try:
+        chat_id = await _resolve_chat_id(chat_id)
+    except Exception as e:
+        return err(f"No chat context available: {e}")
+
+    if not message_id:
+        message_id = await _last_sent_message_id(chat_id)
+        if not message_id:
+            return err(
+                "No message_id given and no recently-sent message found to recall."
+            )
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return err("No live Photon adapter in this process — unsend requires the "
+                   "gateway to be running here.")
+
+    result = await adapter.unsend(chat_id, message_id)
+    if getattr(result, "success", True) and not getattr(result, "error", None):
+        return json.dumps(
+            {"success": True, "unsent": getattr(result, "message_id", message_id)},
+            ensure_ascii=False,
+        )
+    return err(
+        getattr(result, "error", None)
+        or f"Unsend failed (HTTP {getattr(result, 'raw_response', '?')})."
+    )
+
+
+registry.register(
+    name="photon_unsend",
+    toolset=_TOOLSET,
+    schema=SCHEMA,
+    handler=lambda args, **kw: _photon_unsend(args, **kw),
+    check_fn=_photon_unsend_check,
+    is_async=True,
+    emoji="🗑️",
+)


### PR DESCRIPTION
## What does this PR do?

Adds a `photon_unsend` core tool so the agent can recall one of ITS OWN
iMessage bubbles (native "You unsent a message" on both sides).

What goes in:

- **Sidecar**: new `/unsend-message` HTTP endpoint in the same
  `req.url === ...` chain as `/send`, `/react`, `/send-poll`,
  `/send-effect`. Validates spaceId + messageId, resolves the space,
  rehydrates the target from the live `knownMessages` cache or via
  `space.getMessage()` if not tracked, calls `space.unsend()`, deletes
  the id from the live cache, surfaces iMessage rejections as 4xx.

- **Adapter**: new `PhotonAdapter.unsend(chat_id, message_id)` +
  private `_sidecar_unsend` that POSTs to the route, returning a
  `SendResult` so the caller (the tool) gets consistent success/error.

- **Tool**: `photon_unsend` in the `photon_tools` toolset follows the
  `photon_poll` / `photon_effect` / `photon_react` pattern — opt-in
  via a live-adapter check_fn, chat defaults to the current conversation
  then the Photon home channel, message_id defaults to the most recent
  message the bot sent in that chat (`_last_sent_by_chat`). Handler
  returns a JSON string (registry result shape).

- **Fixes the async-handler bug** that bit the local photon-unsend plugin:
  core tools with `is_async=True` are awaited natively by the registry, so
  no `asyncio.run()/get_event_loop()` wrapper dance (which crashes in worker
  threads on modern Python) is needed.

- **8 tests**: check_fn gating, "no adapter" error, message_id or
  recent-sent required, explicit message_id, default to recent sent message,
  current-chat preference, provider failure propagation.

E2E proven on iMessage before this PR: a real bubble sent via the sidecar
was recalled through `/unsend-message` and vanished from the phone. Same
chain, now as a core tool.
