### PR TITLE
fix(cron): report background dispatch instead of false failure

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -472,7 +472,10 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         print(f"  Next run: {result['job']['next_run_at']}")
     if action == "run":
         job = result.get("job", {})
-        if job.get("executed"):
+        if job.get("execution_mode") == "background":
+            print("  Dispatched to background — outcome will arrive as a new")
+            print("  message when the job finishes. Do not wait or poll.")
+        elif job.get("executed"):
             outcome = "succeeded" if job.get("execution_success") else "failed"
             print(f"  Ran now: {outcome}.")
         elif job.get("execution_skipped"):

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -213,6 +213,81 @@ def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):
     assert calls == [True]
 
 
+def test_cron_run_background_dispatch_does_not_report_failed(monkeypatch, capsys):
+    """`hermes cron run` on a background-dispatched job should report
+    'Dispatched to background', not 'Ran now: failed'.
+
+    The cronjob tool returns ``execution_mode: "background"`` when the job
+    is dispatched via async delegation. The CLI must not interpret the
+    missing ``execution_success`` (which is only set for synchronous runs)
+    as a failure.
+    """
+    monkeypatch.setattr(
+        cron_cli,
+        "_cron_api",
+        lambda **kwargs: {
+            "success": True,
+            "job": {
+                "id": "test-job-123",
+                "name": "test-job",
+                "next_run_at": "2026-08-27T10:00:00-04:00",
+                "executed": True,
+                "execution_mode": "background",
+                "delegation_id": "deleg_abc123",
+            },
+        },
+    )
+    rc = cron_command(Namespace(cron_command="run", job_id="test-job-123", accept_hooks=False))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dispatched to background" in out
+    assert "failed" not in out.lower()
+
+
+def test_cron_run_sync_failure_still_reports_failed(monkeypatch, capsys):
+    """Synchronous runs that genuinely fail should still report 'failed'."""
+    monkeypatch.setattr(
+        cron_cli,
+        "_cron_api",
+        lambda **kwargs: {
+            "success": True,
+            "job": {
+                "id": "test-job-456",
+                "name": "test-job",
+                "next_run_at": "2026-08-27T10:00:00-04:00",
+                "executed": True,
+                "execution_success": False,
+            },
+        },
+    )
+    rc = cron_command(Namespace(cron_command="run", job_id="test-job-456", accept_hooks=False))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Ran now: failed" in out
+
+
+def test_cron_run_sync_success_reports_succeeded(monkeypatch, capsys):
+    """Synchronous runs that succeed should report 'succeeded'."""
+    monkeypatch.setattr(
+        cron_cli,
+        "_cron_api",
+        lambda **kwargs: {
+            "success": True,
+            "job": {
+                "id": "test-job-789",
+                "name": "test-job",
+                "next_run_at": "2026-08-27T10:00:00-04:00",
+                "executed": True,
+                "execution_success": True,
+            },
+        },
+    )
+    rc = cron_command(Namespace(cron_command="run", job_id="test-job-789", accept_hooks=False))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Ran now: succeeded" in out
+
+
 def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     monkeypatch.setattr(cron_cli, "_cron_api", lambda **kwargs: {"success": False, "error": "boom"})
 


### PR DESCRIPTION
## Summary

When `hermes cron run` dispatches a job via async delegation (background mode), the cronjob tool returns `execution_mode: "background"` without setting `execution_success` (which is only populated for synchronous runs). The CLI handler in `_job_action` checked `execution_success` and, finding it falsy, printed `"Ran now: failed."` — even though the job was still running in the background and had not actually failed.

This caused user confusion: manual cron runs appeared to fail instantly while the job was actually executing fine in the background. The stale `fire_claim` left by the still-running delegation also blocked subsequent manual triggers with "already being fired by the scheduler."

## Fix

Check `execution_mode` before falling through to the `execution_success` check:
- If `"background"`: report that the job was dispatched to the background and its outcome will arrive as a new message when it finishes
- Only report `succeeded`/`failed` for synchronous runs where `execution_success` is meaningful

## Test Plan

- [x] `test_cron_run_background_dispatch_does_not_report_failed` — verifies background dispatch prints "Dispatched to background", not "failed"
- [x] `test_cron_run_sync_failure_still_reports_failed` — verifies synchronous failures still report "failed"
- [x] `test_cron_run_sync_success_reports_succeeded` — verifies synchronous successes still report "succeeded"
- [x] All 11 existing tests in `test_cron.py` pass with no regressions