### PR TITLE
feat(skins): add DigitalOcean dark and light built-in skins

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -104,6 +104,8 @@ BUILT-IN SKINS
 - ``slate``   — Cool blue developer-focused theme
 - ``daylight`` — Light background theme with dark text and blue accents
 - ``warm-lightmode`` — Warm brown/gold text for light terminal backgrounds
+- ``digitalocean-dark`` — DigitalOcean Blue on deep navy/teal cloud surfaces
+- ``digitalocean-light`` — DigitalOcean Blue on bright cloud surfaces
 
 USER SKINS
 ==========
@@ -564,6 +566,154 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 [#4A4A4A]⠀⠀⠀⠀⠀⣀⣴⣿⣿⣿⣿⣿⣿⣦⣀⠀⠀⠀⠀⠀⠀[/]
 [#656565]⠀⠀⠀━━━━━━━━━━━━━━━━━━━━━━━⠀⠀⠀[/]
 [dim #4A4A4A]⠀⠀⠀⠀⠀⠀⠀⠀⠀the boulder⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
+    },
+    "digitalocean-dark": {
+        "name": "digitalocean-dark",
+        "description": "DigitalOcean Blue on deep navy and teal cloud surfaces",
+        "colors": {
+            "banner_border": "#325553",
+            "banner_title": "#E5ECEB",
+            "banner_accent": "#0069FF",
+            "banner_dim": "#6F908C",
+            "banner_text": "#C9D6D4",
+            "ui_accent": "#0069FF",
+            "ui_label": "#9FDDFF",
+            "ui_ok": "#68D391",
+            "ui_error": "#FF7B8A",
+            "ui_warn": "#FFE175",
+            "prompt": "#0069FF",
+            "input_rule": "#325553",
+            "response_border": "#0069FF",
+            "status_bar_bg": "#000C2A",
+            "status_bar_text": "#E5ECEB",
+            "status_bar_strong": "#0069FF",
+            "status_bar_dim": "#8A96B5",
+            "status_bar_good": "#68D391",
+            "status_bar_warn": "#FFE175",
+            "status_bar_bad": "#FFAF8C",
+            "status_bar_critical": "#FF7B8A",
+            "session_label": "#0069FF",
+            "session_border": "#4D5B7C",
+            "voice_status_bg": "#000C2A",
+            "selection_bg": "#13302E",
+            "completion_menu_bg": "#000C2A",
+            "completion_menu_current_bg": "#13302E",
+            "completion_menu_meta_bg": "#000A0A",
+            "completion_menu_meta_current_bg": "#1F403E",
+        },
+        "spinner": {
+            "waiting_faces": ["(do)", "(· )", "( ·)", "(··)"],
+            "thinking_faces": ["(do)", "(//)", "(-- )", "( --)"],
+            "thinking_verbs": [
+                "provisioning droplets", "routing the request", "scaling the control plane",
+                "checking the region", "keeping it simple",
+            ],
+            "wings": [["⟪#", "#⟫"], ["⟪·", "·⟫"], ["⟪/", "/⟫"]],
+        },
+        "branding": {
+            "agent_name": "DigitalOcean Sammy",
+            "welcome": "Welcome to DigitalOcean Sammy. Type your message or /help for commands.",
+            "goodbye": "Goodbye from the cloud. ▌",
+            "response_label": " ▌ DigitalOcean Sammy ",
+            "prompt_symbol": "▌",
+            "help_header": "▌ Available Commands",
+        },
+        "tool_prefix": "│",
+        "banner_logo": """[bold #F5F5F5]██████╗ ██╗ ██████╗ ██╗████████╗ █████╗ ██╗      ██████╗  ██████╗███████╗ █████╗ ███╗   ██╗[/]
+[bold #E7E7E7]██╔══██╗██║██╔════╝ ██║╚══██╔══╝██╔══██╗██║     ██╔═══██╗██╔════╝██╔════╝██╔══██╗████╗  ██║[/]
+[#D7D7D7]██║  ██║██║██║  ███╗██║   ██║   ███████║██║     ██║   ██║██║     █████╗  ███████║██╔██╗ ██║[/]
+[#C7C7C7]██║  ██║██║██║   ██║██║   ██║   ██╔══██║██║     ██║   ██║██║     ██╔══╝  ██╔══██║██║╚██╗██║[/]
+[#B7B7B7]██████╔╝██║╚██████╔╝██║   ██║   ██║  ██║███████╗╚██████╔╝╚██████╗███████╗██║  ██║██║ ╚████║[/]
+[#8A96B5]╚═════╝ ╚═╝ ╚═════╝ ╚═╝   ╚═╝   ╚═╝  ╚═╝╚══════╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝[/]""",
+        "banner_hero": """[#0069FF]        ▄▄██████████▄▄▄[/]
+[#0069FF]     ▄██████████████████▄[/]
+[#0069FF]   ▄██████████████████████▄[/]
+[#0069FF]  ███████▀▀        ▀▀███████▄[/]
+[#0069FF] ██████▀              ▀██████[/]
+[#0069FF]██████▀                ▀██████[/]
+[#0069FF]██████                  ██████[/]
+[#0069FF]▀▀▀▀▀▀                  ██████[/]
+[#0069FF]                        ██████[/]
+[#0069FF]         ██████        ▄██████[/]
+[#0069FF] ████    ██████       ███████[/]
+[#0069FF] ████    ██████    ▄████████[/]
+[#0069FF]     ████      ███████████▀[/]
+[#0069FF]     ████      █████████▀[/]
+[#0069FF]     ▀▀▀▀      █████▀▀[/]""",
+    },
+    "digitalocean-light": {
+        "name": "digitalocean-light",
+        "description": "DigitalOcean Blue on bright cloud surfaces",
+        "colors": {
+            "banner_border": "#D6DCEA",
+            "banner_title": "#000C2A",
+            "banner_accent": "#0069FF",
+            "banner_dim": "#4D5B7C",
+            "banner_text": "#11192E",
+            "ui_accent": "#0069FF",
+            "ui_label": "#1433D6",
+            "ui_ok": "#006650",
+            "ui_error": "#A2001D",
+            "ui_warn": "#7A4A00",
+            "prompt": "#0069FF",
+            "input_rule": "#D6DCEA",
+            "response_border": "#0069FF",
+            "status_bar_bg": "#E3E8F4",
+            "status_bar_text": "#000C2A",
+            "status_bar_strong": "#0069FF",
+            "status_bar_dim": "#4D5B7C",
+            "status_bar_good": "#006650",
+            "status_bar_warn": "#7A4A00",
+            "status_bar_bad": "#A2001D",
+            "status_bar_critical": "#A2001D",
+            "session_label": "#0069FF",
+            "session_border": "#8A96B5",
+            "voice_status_bg": "#E3E8F4",
+            "selection_bg": "#C6E3FF",
+            "completion_menu_bg": "#FFFFFF",
+            "completion_menu_current_bg": "#E3E8F4",
+            "completion_menu_meta_bg": "#F7F8FB",
+            "completion_menu_meta_current_bg": "#D6DCEA",
+        },
+        "spinner": {
+            "waiting_faces": ["(do)", "(· )", "( ·)", "(··)"],
+            "thinking_faces": ["(do)", "(//)", "(-- )", "( --)"],
+            "thinking_verbs": [
+                "provisioning droplets", "routing the request", "scaling the control plane",
+                "checking the region", "keeping it simple",
+            ],
+            "wings": [["⟪#", "#⟫"], ["⟪·", "·⟫"], ["⟪/", "/⟫"]],
+        },
+        "branding": {
+            "agent_name": "DigitalOcean Sammy",
+            "welcome": "Welcome to DigitalOcean Sammy. Type your message or /help for commands.",
+            "goodbye": "Goodbye from the cloud. ▌",
+            "response_label": " ▌ DigitalOcean Sammy ",
+            "prompt_symbol": "▌",
+            "help_header": "▌ Available Commands",
+        },
+        "tool_prefix": "│",
+        "banner_logo": """[bold #000C2A]██████╗ ██╗ ██████╗ ██╗████████╗ █████╗ ██╗      ██████╗  ██████╗███████╗ █████╗ ███╗   ██╗[/]
+[bold #1433D6]██╔══██╗██║██╔════╝ ██║╚══██╔══╝██╔══██╗██║     ██╔═══██╗██╔════╝██╔════╝██╔══██╗████╗  ██║[/]
+[#0069FF]██║  ██║██║██║  ███╗██║   ██║   ███████║██║     ██║   ██║██║     █████╗  ███████║██╔██╗ ██║[/]
+[#1450D6]██║  ██║██║██║   ██║██║   ██║   ██╔══██║██║     ██║   ██║██║     ██╔══╝  ██╔══██║██║╚██╗██║[/]
+[#2870E6]██████╔╝██║╚██████╔╝██║   ██║   ██║  ██║███████╗╚██████╔╝╚██████╗███████╗██║  ██║██║ ╚████║[/]
+[#4D5B7C]╚═════╝ ╚═╝ ╚═════╝ ╚═╝   ╚═╝   ╚═╝  ╚═╝╚══════╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝[/]""",
+        "banner_hero": """[#0069FF]        ▄▄██████████▄▄▄[/]
+[#0069FF]     ▄██████████████████▄[/]
+[#0069FF]   ▄██████████████████████▄[/]
+[#0069FF]  ███████▀▀        ▀▀███████▄[/]
+[#0069FF] ██████▀              ▀██████[/]
+[#0069FF]██████▀                ▀██████[/]
+[#0069FF]██████                  ██████[/]
+[#0069FF]▀▀▀▀▀▀                  ██████[/]
+[#0069FF]                        ██████[/]
+[#0069FF]         ██████        ▄██████[/]
+[#0069FF] ████    ██████       ███████[/]
+[#0069FF] ████    ██████    ▄████████[/]
+[#0069FF]     ████      ███████████▀[/]
+[#0069FF]     ████      █████████▀[/]
+[#0069FF]     ▀▀▀▀      █████▀▀[/]""",
     },
     "charizard": {
         "name": "charizard",

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -2,9 +2,139 @@
 
 import json
 import os
+import re
 import pytest
 from pathlib import Path
 from unittest.mock import patch
+
+# ANSI Shadow glyphs used by builtin banner_logo word-art. Longest-first
+# matching is required because I (`██╗`) is a prefix of H (`██╗  ██╗`).
+_ANSI_SHADOW = {
+    "G": (
+        " ██████╗ ",
+        "██╔════╝ ",
+        "██║  ███╗",
+        "██║   ██║",
+        "╚██████╔╝",
+        " ╚═════╝ ",
+    ),
+    "O": (
+        " ██████╗ ",
+        "██╔═══██╗",
+        "██║   ██║",
+        "██║   ██║",
+        "╚██████╔╝",
+        " ╚═════╝ ",
+    ),
+    "N": (
+        "███╗   ██╗",
+        "████╗  ██║",
+        "██╔██╗ ██║",
+        "██║╚██╗██║",
+        "██║ ╚████║",
+        "╚═╝  ╚═══╝",
+    ),
+    "T": (
+        "████████╗",
+        "╚══██╔══╝",
+        "   ██║   ",
+        "   ██║   ",
+        "   ██║   ",
+        "   ╚═╝   ",
+    ),
+    "A": (
+        " █████╗ ",
+        "██╔══██╗",
+        "███████║",
+        "██╔══██║",
+        "██║  ██║",
+        "╚═╝  ╚═╝",
+    ),
+    "C": (
+        " ██████╗",
+        "██╔════╝",
+        "██║     ",
+        "██║     ",
+        "╚██████╗",
+        " ╚═════╝",
+    ),
+    "D": (
+        "██████╗ ",
+        "██╔══██╗",
+        "██║  ██║",
+        "██║  ██║",
+        "██████╔╝",
+        "╚═════╝ ",
+    ),
+    "E": (
+        "███████╗",
+        "██╔════╝",
+        "█████╗  ",
+        "██╔══╝  ",
+        "███████╗",
+        "╚══════╝",
+    ),
+    "H": (
+        "██╗  ██╗",
+        "██║  ██║",
+        "███████║",
+        "██╔══██║",
+        "██║  ██║",
+        "╚═╝  ╚═╝",
+    ),
+    "L": (
+        "██╗     ",
+        "██║     ",
+        "██║     ",
+        "██║     ",
+        "███████╗",
+        "╚══════╝",
+    ),
+    "I": (
+        "██╗",
+        "██║",
+        "██║",
+        "██║",
+        "██║",
+        "╚═╝",
+    ),
+}
+
+
+def _decode_ansi_shadow_logo(banner_logo: str) -> str:
+    """Read the letters spelled by a Rich-markup ANSI Shadow banner_logo."""
+    rows = [
+        line for line in (
+            re.sub(r"\[/?[^\]]*\]", "", line) for line in banner_logo.splitlines()
+        )
+        if line.strip()
+    ]
+    assert len(rows) == 6, f"expected 6 art rows, got {len(rows)}"
+    width = max(len(row) for row in rows)
+    rows = [row.ljust(width) for row in rows]
+    letters = []
+    pos = 0
+    glyphs = sorted(_ANSI_SHADOW.items(), key=lambda item: -len(item[1][0]))
+    while pos < width:
+        if all(row[pos] == " " for row in rows):
+            pos += 1
+            continue
+        match = None
+        for name, glyph in glyphs:
+            glen = len(glyph[0])
+            if pos + glen <= width and all(
+                rows[i][pos:pos + glen] == glyph[i] for i in range(6)
+            ):
+                match = name
+                pos += glen
+                break
+        if match is None:
+            window = [row[pos:pos + 12] for row in rows]
+            raise AssertionError(
+                f"unrecognized ANSI Shadow glyph at column {pos}: {window!r}"
+            )
+        letters.append(match)
+    return "".join(letters)
 
 
 @pytest.fixture(autouse=True)
@@ -99,6 +229,38 @@ class TestBuiltinSkins:
         assert skin.name == "warm-lightmode"
         assert skin.get_color("banner_text") == "#2C1810"
         assert skin.get_color("completion_menu_bg") == "#F5EFE0"
+
+    @pytest.mark.parametrize(
+        ("name", "status_bar_bg"),
+        [("digitalocean-dark", "#000C2A"), ("digitalocean-light", "#E3E8F4")],
+    )
+    def test_digitalocean_skins_load(self, name, status_bar_bg):
+        from hermes_cli.skin_engine import load_skin
+
+        skin = load_skin(name)
+        assert skin.name == name
+        assert skin.get_color("ui_accent") == "#0069FF"
+        assert skin.get_color("status_bar_bg") == status_bar_bg
+        assert skin.get_branding("agent_name") == "DigitalOcean Sammy"
+        assert "████" in skin.banner_logo
+        assert _decode_ansi_shadow_logo(skin.banner_logo) == "DIGITALOCEAN"
+        hero = re.sub(r"\[/?[^\]]*\]", "", skin.banner_hero)
+        assert "#0069FF" in skin.banner_hero
+        assert "⣿" not in hero  # old droplet used braille; logomark is block cells
+        # Official mark: thick C-ring open on the left, three detached squares
+        # (inner / left / bottom) in a down-left stair.
+        assert "████    ██████" in hero  # left pixel separated from inner square
+        assert "    ████      ████" in hero  # bottom pixel offset under the gap
+        assert skin.banner_hero.count("█") >= 40
+
+    def test_digitalocean_skins_share_the_same_logomark(self):
+        from hermes_cli.skin_engine import load_skin
+
+        strip = lambda s: re.sub(r"\[/?[^\]]*\]", "", s)
+        dark = load_skin("digitalocean-dark")
+        light = load_skin("digitalocean-light")
+        assert strip(dark.banner_hero) == strip(light.banner_hero)
+        assert strip(dark.banner_logo).splitlines()[0].startswith("██████╗ ██╗ ██████╗")
 
     def test_unknown_skin_falls_back_to_default(self):
         from hermes_cli.skin_engine import load_skin

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -41,6 +41,8 @@ display:
 | `poseidon` | Ocean-god theme — deep blue and seafoam | `Poseidon Agent` | Deep blue to seafoam gradient. Ocean-themed spinners ("charting currents", "sounding the depth"). Trident ASCII art banner. |
 | `sisyphus` | Sisyphean theme — austere grayscale with persistence | `Sisyphus Agent` | Light grays with stark contrast. Boulder-themed spinners ("pushing uphill", "resetting the boulder", "enduring the loop"). Boulder-and-hill ASCII art banner. |
 | `charizard` | Volcanic theme — burnt orange and ember | `Charizard Agent` | Warm burnt orange to ember gradient. Fire-themed spinners ("banking into the draft", "measuring burn"). Dragon-silhouette ASCII art banner. |
+| `digitalocean-dark` | DigitalOcean Blue on deep navy and teal cloud surfaces | `DigitalOcean Sammy` | DigitalOcean Blue (`#0069FF`) focus states over deep navy and teal cloud surfaces, with a geometric DigitalOcean logo banner and cloud-infrastructure spinner verbs. |
+| `digitalocean-light` | DigitalOcean Blue on bright cloud surfaces | `DigitalOcean Sammy` | Bright cloud surfaces with DigitalOcean Blue (`#0069FF`) focus states, cool slate text, and the same geometric logo banner. |
 
 ## Complete list of configurable keys
 


### PR DESCRIPTION
## Summary
- Add `digitalocean-dark` and `digitalocean-light` built-in CLI skins using DigitalOcean brand colors, typography, and spinner/branding defaults.
- Fix `banner_logo` ANSI Shadow word art so it spells **DIGITALOCEAN** correctly (both themes).
- Replace `banner_hero` braille art with official DigitalOcean logomark ASCII art for a recognizable banner mark.
- Extend skin engine tests with ANSI Shadow glyph decoding helpers, wordmark validation, and logomark shape checks; document the skins in the user guide.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_skin_engine.py -q` — **35 passed**
- [ ] Manual: `/skin digitalocean-dark` and `/skin digitalocean-light` in the CLI; confirm banner wordmark and logomark render as expected

Replaces #95642 (squashed to a single commit on the fork branch after history rewrite).


Made with [Cursor](https://cursor.com)