### PR TITLE
fix(update): retry a stalled or anonymously-rejected fetch over HTTP/1.1

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -173,6 +173,60 @@ def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
         return result
 
 
+def _is_anonymous_auth_rejection(stderr: str) -> bool:
+    """git's fast signature for an anonymous fetch GitHub answered with 401.
+
+    With terminal prompts disabled the 401 never blocks on a ``Username:``
+    prompt — git exits immediately with ``could not read Username`` /
+    ``terminal prompts disabled``. GitHub does this during outages, and
+    persistently from IPs it throttles (datacenter VPSes): the anonymous
+    protocol-v2 ``POST /git-upload-pack`` is answered with a fast 401 over
+    HTTP/2 while the anonymous ``GET /info/refs`` still succeeds and HTTP/1.1
+    still works (#101584).
+    """
+    stderr = stderr or ""
+    return "could not read Username" in stderr or "terminal prompts disabled" in stderr
+
+
+def _fetch_with_http1_fallback(git_cmd, fetch_args):
+    """One bounded fetch with a one-shot HTTP/1.1 retry (#95777, #101584).
+
+    Two failure signatures are HTTP/2-specific degradations of GitHub's
+    anonymous protocol-v2 channel and get exactly one retry over HTTP/1.1:
+
+    * a dead-stall — the transport received zero bytes until the per-attempt
+      bound expired (``_git_run`` reports it as returncode 124);
+    * a fast 401 — GitHub answered the anonymous upload-pack POST with 401
+      and git exited immediately with the no-prompt signature
+      (``_is_anonymous_auth_rejection``).
+
+    Every other failure is returned as-is so ``_classify_fetch_failure``
+    keeps diagnosing it untouched.
+    """
+    result = _git_run(git_cmd, ["fetch"] + list(fetch_args), network=True)
+    if result.returncode == 0:
+        return result
+    stalled = result.returncode == 124
+    if not stalled and not _is_anonymous_auth_rejection(result.stderr):
+        return result
+
+    if stalled:
+        print("  ⚠ fetch stalled; retrying over HTTP/1.1")
+    else:
+        print("  ⚠ GitHub rejected the anonymous fetch; retrying over HTTP/1.1")
+    retry = _git_run(git_cmd, ["-c", "http.version=HTTP/1.1", "fetch"] + list(fetch_args), network=True)
+    if retry.returncode == 124:
+        # Both transports dead-stalled within the bound: name it for the user
+        # instead of the per-attempt line (which would read "git -c timed out").
+        retry = subprocess.CompletedProcess(
+            retry.args, 124, stdout=retry.stdout,
+            stderr=(
+                "git fetch timed out twice — once over HTTP/2 and once over HTTP/1.1 —"
+                " after a bounded wait each. A proxy, VPN, or middlebox is likely"
+                " breaking the connection to the remote."))
+    return retry
+
+
 def _capture_head_sha(git_cmd, cwd) -> str | None:
     """Return the current HEAD SHA, or None if it can't be resolved."""
     try:
@@ -519,12 +573,12 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     fetch_result = None
     if branch == "main" and _git_run(git_cmd, ["remote", "get-url", "upstream"]).returncode == 0:
         print("→ Fetching from upstream...")
-        fetch_result = _git_run(git_cmd, ["fetch"] + depth_args + ["upstream", branch], network=True)
+        fetch_result = _fetch_with_http1_fallback(git_cmd, depth_args + ["upstream", branch])
     if fetch_result is not None and fetch_result.returncode == 0:
         compare_branch = f"upstream/{branch}"
     else:
         print("→ Fetching from origin...")
-        fetch_result = _git_run(git_cmd, ["fetch"] + depth_args + ["origin", branch], network=True)
+        fetch_result = _fetch_with_http1_fallback(git_cmd, depth_args + ["origin", branch])
         compare_branch = f"origin/{branch}"
 
     if fetch_result.returncode != 0:
@@ -1351,7 +1405,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _m()._warn_orphaned_update_autostashes(git_cmd, _m().PROJECT_ROOT)
 
         print("→ Fetching updates...")
-        fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        fetch_result = _fetch_with_http1_fallback(git_cmd, ["origin", branch])
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
             sys.exit(1)

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -331,10 +331,17 @@ _FETCH_FAILURE_RULES = (
      "✗ GitHub appears to be having an outage — try again in a few minutes (https://www.githubstatus.com)."),
     (lambda s: "Could not resolve host" in s or "unable to access" in s,
      "✗ Network error — cannot reach the remote repository."),
+    # Signature synthesized by update_cmd._fetch_with_http1_fallback when both the HTTP/2
+    # attempt and its HTTP/1.1 retry dead-stalled within the bounded wait.
+    (lambda s: "timed out twice" in s,
+     "✗ The remote never answered — the fetch stalled on both HTTP/2 and HTTP/1.1 within the"
+     " bounded wait. A proxy, VPN, or middlebox is likely breaking the connection."),
     (lambda s: "could not read Username" in s or "terminal prompts disabled" in s,
-     "✗ GitHub rejected the anonymous fetch (asked for a login) — this usually means a GitHub outage;"
-     " try again in a few minutes (https://www.githubstatus.com). If it persists, check"
-     " `git remote -v` points at a public repo."),
+     "✗ GitHub rejected the anonymous fetch (asked for a login) — this happens during GitHub"
+     " outages (https://www.githubstatus.com) and, persistently, from IPs GitHub throttles such"
+     " as datacenter VPSes. Both HTTP/2 and HTTP/1.1 were just tried. Workarounds: `git config"
+     " --global http.https://github.com.version HTTP/1.1`, an authenticated remote, or waiting"
+     " out the outage; also check `git remote -v` points at a public repo."),
     (lambda s: "Authentication failed" in s,
      "✗ Authentication failed — check your git credentials or SSH key."),
 )

--- a/tests/hermes_cli/test_update_fetch_http_fallback.py
+++ b/tests/hermes_cli/test_update_fetch_http_fallback.py
@@ -1,0 +1,179 @@
+"""Regression tests for the update-path HTTP/1.1 fetch fallback (#95777).
+
+git negotiates HTTP/2 by default; on networks where HTTP/2 to the git host
+dead-stalls after the TLS handshake the fetch receives zero bytes until the
+bounded per-attempt timeout expires (``_git_run`` reports returncode 124).
+The fetch must then retry once over HTTP/1.1 instead of failing — the same
+retry covers the fast anonymous-401 signature GitHub answers throttled
+datacenter IPs with (#101584).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.update_cmd as uc
+
+
+def _ok(returncode=0, stderr="", stdout=""):
+    return SimpleNamespace(returncode=returncode, stderr=stderr, stdout=stdout)
+
+
+def _is_fetch(argv):
+    return len(argv) > 1 and argv[1] == "fetch"
+
+
+def _is_http11_fetch(argv):
+    return len(argv) > 3 and argv[1:3] == ["-c", "http.version=HTTP/1.1"]
+
+
+def _patch_check_github(monkeypatch, tmp_path):
+    from pathlib import Path
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir(exist_ok=True)
+    (repo / ".git").mkdir(exist_ok=True)
+    m = uc._m()
+    monkeypatch.setattr(m, "PROJECT_ROOT", repo, raising=False)
+    import hermes_cli.update_contract as contract
+    monkeypatch.setattr(contract, "evaluate_update_admission", lambda root: None)
+    monkeypatch.setattr(contract, "record_refusal_receipt", lambda refusal: None)
+
+
+def _git_mock(fetch_behavior):
+    """subprocess.run double: ``fetch_behavior(argv)`` decides fetch results, every
+    other git query answers benignly (not shallow, no upstream remote, 0 behind)."""
+    def mock_run(argv, **kwargs):
+        if _is_http11_fetch(argv) or _is_fetch(argv):
+            return fetch_behavior(argv)
+        if argv[1:3] == ["rev-parse", "--is-shallow-repository"]:
+            return _ok(stdout="false")
+        if argv[1:2] == ["remote"]:
+            return _ok(returncode=1)
+        if argv[1:2] == ["rev-list"]:
+            return _ok(stdout="0")
+        return _ok(stdout="")
+
+    return mock_run
+
+
+def test_check_path_fetch_stall_retries_over_http11(monkeypatch, capsys, tmp_path):
+    """A stalled HTTP/2 fetch in --check retries over HTTP/1.1 and completes."""
+    fetch_calls = []
+
+    def behavior(argv):
+        if _is_http11_fetch(argv):
+            fetch_calls.append("http11")
+            return _ok()
+        fetch_calls.append("http2")
+        # _git_run turns TimeoutExpired into returncode 124 with a synthesized
+        # stderr; raising here exercises the real conversion path.
+        raise uc.subprocess.TimeoutExpired(cmd=argv, timeout=300)
+
+    monkeypatch.setattr(uc.subprocess, "run", _git_mock(behavior))
+    _patch_check_github(monkeypatch, tmp_path)
+
+    uc._cmd_update_check("main", branch_explicit=False)
+
+    assert fetch_calls == ["http2", "http11"], "stall must retry once over HTTP/1.1"
+    assert "HTTP/1.1" in capsys.readouterr().out
+
+
+def test_check_path_double_stall_exits_with_transport_diagnosis(monkeypatch, capsys, tmp_path):
+    """Both attempts stalling exits bounded with a both-transports diagnosis."""
+
+    def behavior(argv):
+        raise uc.subprocess.TimeoutExpired(cmd=argv, timeout=300)
+
+    monkeypatch.setattr(uc.subprocess, "run", _git_mock(behavior))
+    _patch_check_github(monkeypatch, tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        uc._cmd_update_check("main", branch_explicit=False)
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "HTTP/1.1" in out
+    assert "stalled on both HTTP/2 and HTTP/1.1" in out
+
+
+def test_check_path_plain_fetch_failure_has_no_retry(monkeypatch, capsys, tmp_path):
+    """A normal non-zero exit (auth, DNS) fails directly — the retry is for
+    stalls and anonymous-401s, not every failure."""
+    fetch_calls = []
+
+    def behavior(argv):
+        fetch_calls.append(list(argv))
+        return _ok(returncode=128, stderr="fatal: Authentication failed")
+
+    monkeypatch.setattr(uc.subprocess, "run", _git_mock(behavior))
+    _patch_check_github(monkeypatch, tmp_path)
+
+    with pytest.raises(SystemExit):
+        uc._cmd_update_check("main", branch_explicit=False)
+
+    assert len(fetch_calls) == 1, "non-stall failure must not trigger the retry"
+
+
+def test_check_path_fast_401_retries_over_http11(monkeypatch, capsys, tmp_path):
+    """A fast anonymous-401 rejection (throttled datacenter IPs) retries
+    over HTTP/1.1 and completes when HTTP/1.1 answers (#101584)."""
+    fast_401 = (
+        "fatal: could not read Username for 'https://github.com': terminal "
+        "prompts disabled\nfatal: expected flush after ref listing"
+    )
+    fetch_calls = []
+
+    def behavior(argv):
+        if _is_http11_fetch(argv):
+            fetch_calls.append("http11")
+            return _ok()
+        fetch_calls.append("http2")
+        return _ok(returncode=128, stderr=fast_401)
+
+    monkeypatch.setattr(uc.subprocess, "run", _git_mock(behavior))
+    _patch_check_github(monkeypatch, tmp_path)
+
+    uc._cmd_update_check("main", branch_explicit=False)
+
+    assert fetch_calls == ["http2", "http11"], "fast 401 must retry once over HTTP/1.1"
+    assert "HTTP/1.1" in capsys.readouterr().out
+
+
+def test_check_path_fast_401_after_retry_names_both_transports(monkeypatch, capsys, tmp_path):
+    """When the HTTP/1.1 retry is also rejected with 401, the diagnosis names
+    both transports and the config workaround."""
+    fast_401 = "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+
+    def behavior(argv):
+        return _ok(returncode=128, stderr=fast_401)
+
+    monkeypatch.setattr(uc.subprocess, "run", _git_mock(behavior))
+    _patch_check_github(monkeypatch, tmp_path)
+
+    with pytest.raises(SystemExit):
+        uc._cmd_update_check("main", branch_explicit=False)
+
+    out = capsys.readouterr().out
+    assert "Both HTTP/2 and HTTP/1.1 were just tried" in out
+    assert "http.https://github.com.version HTTP/1.1" in out
+
+
+def test_fetch_helper_returns_other_failures_untouched():
+    """Non-stall, non-401 failures pass through without a retry."""
+    calls = []
+
+    def fake_git_run(git_cmd, args, **kwargs):
+        calls.append(list(args))
+        return SimpleNamespace(returncode=128, stdout="", stderr="fatal: Authentication failed")
+
+    original = uc._git_run
+    try:
+        uc._git_run = fake_git_run
+        result = uc._fetch_with_http1_fallback(["git"], ["origin", "main"])
+    finally:
+        uc._git_run = original
+
+    assert result.returncode == 128
+    assert len(calls) == 1, "unrelated failures must not consume the retry"


### PR DESCRIPTION
## What does this PR do?

`hermes update` (and `hermes update --check`) still fails on networks where HTTP/2 to the git host dead-stalls after the TLS handshake while HTTP/1.1 works: the fetch receives zero bytes forever, and the only workaround is `git config --global http.version HTTP/1.1` (#95777).

The merged bounded fetch (#108053) turns that infinite hang into a bounded error after 300s — but the update still fails. This PR builds directly on that work: when the bounded HTTP/2 fetch dead-stalls (returncode 124) or GitHub answers the anonymous protocol-v2 POST with a fast 401 (the `terminal prompts disabled` signature GitHub gives throttled datacenter IPs, #101584), the fetch is retried **once** with `-c http.version=HTTP/1.1`, so the update actually succeeds on those networks.

Every other failure passes through untouched so `_classify_fetch_failure` keeps diagnosing it exactly as before.

## Related Issue

Fixes #95777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py`: added `_fetch_with_http1_fallback()` — wraps the three bounded fetch call sites (`--check` upstream/origin paths and the apply path); one-shot HTTP/1.1 retry on stall (returncode 124) or anonymous-401, and synthesizes a both-transports-stalled stderr when both attempts time out.
- `hermes_cli/update_cmd.py`: added `_is_anonymous_auth_rejection()` — the fast-401 stderr signature.
- `hermes_cli/update_cmd_git.py`: `_FETCH_FAILURE_RULES` gained a both-transports-stalled rule, and the anonymous-401 diagnosis now names both transports plus the config workaround (the old text suggested a transient outage only).
- `tests/hermes_cli/test_update_fetch_http_fallback.py`: regression tests for stall-retry, double-stall bounded exit, plain-failure no-retry, fast-401 retry, and the post-retry diagnosis.

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_fetch_http_fallback.py -q` → Observed result: **6 passed**.
2. `python -m pytest tests/hermes_cli/test_update_fetch_timeout.py tests/hermes_cli/test_shallow_graft_prune.py tests/hermes_cli/test_cmd_update.py -q` → Observed result: **52 passed** — the bounded-fetch tests from #108053 still pass; this PR layers on top of them with no behavior overlap.
3. `ruff check hermes_cli/update_cmd.py hermes_cli/update_cmd_git.py tests/hermes_cli/test_update_fetch_http_fallback.py` → All checks passed.
4. Manual: on a network that black-holes HTTP/2 to github.com, `hermes update --check` should print `⚠ fetch stalled; retrying over HTTP/1.1` and complete instead of failing after the 300s bound.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: the new file plus every update-path suite touching the changed call sites — see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings on the new helpers)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the retry uses git's `-c` flag, which is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
