### PR TITLE
fix(kanban): resume blocked worker sessions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Durable session owned by the profile that last blocked the task. Stored
+    # separately from session_id (the task's origin conversation) so an
+    # unblocked worker can resume its own execution context.
+    worker_session_id: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1238,9 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            worker_session_id=(
+                row["worker_session_id"] if "worker_session_id" in keys else None
             ),
         )
 
@@ -1410,6 +1417,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT,
+    -- Durable profile-local worker session used to resume an execution after
+    -- a human-input block. NULL until a dispatcher-owned worker blocks.
+    worker_session_id    TEXT,
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
@@ -2663,6 +2673,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "session_id", "session_id TEXT"
         )
 
+    if "worker_session_id" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "worker_session_id", "worker_session_id TEXT"
+        )
+
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
         # blocks. Existing blocked rows get NULL, which is treated as a
@@ -3708,7 +3723,8 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     profile = _canonical_assignee(profile)
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
+            "SELECT status, claim_lock, assignee, worker_session_id FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if not row:
             return False
@@ -3716,6 +3732,12 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             raise RuntimeError(
                 f"cannot reassign {task_id}: currently running (claimed). "
                 "Wait for completion or reclaim the stale lock first."
+            )
+        if row["worker_session_id"] and row["assignee"] != profile:
+            raise RuntimeError(
+                f"cannot reassign session-bound task {task_id} from "
+                f"{row['assignee'] or 'none'} to {profile or 'none'}: "
+                "the durable worker session belongs to the current profile"
             )
         if row["assignee"] != profile:
             # The retry guard is scoped to the task/profile combination. A
@@ -5201,6 +5223,18 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    profile = _canonical_assignee(profile)
+    row = conn.execute(
+        "SELECT assignee, worker_session_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    if row["worker_session_id"] and row["assignee"] != profile:
+        # Authorization must happen before reclaim_task(), which can terminate
+        # the current worker and close its run. A profile-local session cannot
+        # be transferred implicitly to another profile's HERMES_HOME.
+        return False
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
@@ -6250,6 +6284,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    worker_session_id: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -6290,6 +6325,12 @@ def block_task(
         ).fetchone()
         if cur_row is None:
             return False
+        def persist_worker_session() -> None:
+            if worker_session_id:
+                conn.execute(
+                    "UPDATE tasks SET worker_session_id = COALESCE(worker_session_id, ?) WHERE id = ?",
+                    (worker_session_id, task_id),
+                )
         source_status = (
             _retry_status_for_run(conn, task_id)
             if cur_row["status"] == "running"
@@ -6324,6 +6365,7 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            persist_worker_session()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6382,6 +6424,7 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            persist_worker_session()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6436,6 +6479,7 @@ def block_task(
                 )
             if cur.rowcount != 1:
                 return False
+            persist_worker_session()
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -10870,6 +10914,8 @@ def _default_spawn(
     # branch, not a nested one.
     if task.reasoning_effort:
         cmd.extend(["--reasoning", task.reasoning_effort])
+    if task.worker_session_id:
+        cmd.extend(["--resume", task.worker_session_id])
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -49,6 +49,77 @@ def _init_git_repo(repo: Path) -> None:
 
 
 
+def test_session_bound_task_cannot_be_reassigned_across_profiles(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="session-bound", assignee="alice")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="awaiting human",
+            worker_session_id="alice-worker-session",
+        ) is True
+
+        assert kb.assign_task(conn, task_id, "alice") is True
+        with pytest.raises(RuntimeError, match="session-bound.*alice"):
+            kb.assign_task(conn, task_id, "bob")
+        assert kb.reassign_task(conn, task_id, "bob") is False
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "alice"
+        assert task.worker_session_id == "alice-worker-session"
+    finally:
+        conn.close()
+
+
+def test_reassign_preflights_session_binding_before_reclaiming(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="claimed session-bound", assignee="alice")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="awaiting human",
+            worker_session_id="alice-worker-session",
+        ) is True
+        assert kb.unblock_task(conn, task_id) is True
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+
+        before_task = dict(conn.execute(
+            "SELECT status, assignee, worker_session_id, claim_lock, claim_expires, "
+            "worker_pid, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone())
+        before_run = dict(conn.execute(
+            "SELECT status, outcome, ended_at, claim_lock FROM task_runs WHERE id = ?",
+            (before_task["current_run_id"],),
+        ).fetchone())
+
+        assert kb.reassign_task(
+            conn,
+            task_id,
+            "bob",
+            reclaim_first=True,
+            reason="cross-profile recovery",
+        ) is False
+
+        after_task = dict(conn.execute(
+            "SELECT status, assignee, worker_session_id, claim_lock, claim_expires, "
+            "worker_pid, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone())
+        after_run = dict(conn.execute(
+            "SELECT status, outcome, ended_at, claim_lock FROM task_runs WHERE id = ?",
+            (before_task["current_run_id"],),
+        ).fetchone())
+        assert after_task == before_task
+        assert after_run == before_run
+    finally:
+        conn.close()
+
+
 @pytest.mark.windows_only
 def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypatch):
     """Windows must use a real (non-blocking) process lock, not a no-op open.
@@ -101,7 +172,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     """
     db_path = tmp_path / "legacy-kanban.db"
     conn = sqlite3.connect(str(db_path))
-    # Pre-#16081 ``tasks`` shape: missing tenant, idempotency_key, session_id.
+    # Legacy ``tasks`` shape: missing additive metadata and session columns.
     conn.execute("""
         CREATE TABLE tasks (
             id TEXT PRIMARY KEY,
@@ -153,9 +224,14 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        legacy_worker_session = migrated.execute(
+            "SELECT worker_session_id FROM tasks WHERE id = 'legacy'"
+        ).fetchone()[0]
 
     # Additive columns added by migration:
     assert "session_id" in task_columns
+    assert "worker_session_id" in task_columns
+    assert legacy_worker_session is None
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
     assert "run_id" in event_columns
@@ -164,6 +240,13 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "idx_tasks_tenant" in indexes
     assert "idx_tasks_idempotency" in indexes
     assert "idx_events_run" in indexes
+
+    # Repeated initialization is idempotent and preserves the legacy row.
+    with kb.connect(db_path) as migrated_again:
+        row = migrated_again.execute(
+            "SELECT title, worker_session_id FROM tasks WHERE id = 'legacy'"
+        ).fetchone()
+        assert tuple(row) == ("old board task", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -134,6 +134,41 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     assert args.query == "work kanban task t_spawn_tools"
 
 
+def test_default_spawn_resumes_persisted_worker_session(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli._parser import build_top_level_parser
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4245
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _make_task(kb, assignee="elias")
+    task.worker_session_id = "20260826_201545_6ded45"
+    kb._default_spawn(task, str(workspace))
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    assert captured["cmd"][1:3] == ["-p", "elias"]
+    args = parser.parse_args(captured["cmd"][3:])
+    assert args.command == "chat"
+    assert args.resume == "20260826_201545_6ded45"
+    assert args.query == "work kanban task t_spawn_tools"
+
+
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -228,6 +228,89 @@ def test_block_happy_path(worker_env):
         conn.close()
 
 
+def test_block_records_worker_session_id_from_session_context(monkeypatch, worker_env):
+    from gateway.session_context import scoped_current_session_id
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    with scoped_current_session_id("kanban-context-session"):
+        out = kt._handle_block({"reason": "awaiting human"})
+    assert json.loads(out)["ok"] is True
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).worker_session_id == "kanban-context-session"
+    finally:
+        conn.close()
+
+
+def test_non_dispatcher_context_cannot_stamp_worker_session(monkeypatch, worker_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+    from gateway.session_context import scoped_current_session_id
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "inherited-worker-session")
+    with non_dispatcher_owned_context(), scoped_current_session_id("cron-session"):
+        assert kt._worker_session_id(worker_env) is None
+
+
+def test_worker_session_id_fails_closed_when_ownership_check_errors(
+    monkeypatch, worker_env
+):
+    from agent import delegation_context
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-process-session")
+
+    def raise_ownership_error():
+        raise RuntimeError("ownership context unavailable")
+
+    monkeypatch.setattr(
+        delegation_context,
+        "is_dispatcher_owned_worker_context",
+        raise_ownership_error,
+    )
+    assert kt._worker_session_id(worker_env) is None
+
+
+def test_worker_session_id_fails_closed_when_session_context_errors(
+    monkeypatch, worker_env
+):
+    from gateway import session_context
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-process-session")
+
+    def raise_session_error(_key):
+        raise RuntimeError("session context unavailable")
+
+    monkeypatch.setattr(session_context, "get_session_env", raise_session_error)
+    assert kt._worker_session_id(worker_env) is None
+
+
+def test_block_never_overwrites_the_first_worker_session(monkeypatch, worker_env):
+    from gateway.session_context import scoped_current_session_id
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    with scoped_current_session_id("first-worker-session"):
+        assert json.loads(kt._handle_block({"reason": "awaiting human"}))["ok"] is True
+
+    conn = kb.connect()
+    try:
+        assert kb.block_task(
+            conn,
+            worker_env,
+            reason="duplicate block",
+            worker_session_id="different-worker-session",
+        ) is False
+        assert kb.get_task(conn, worker_env).worker_session_id == "first-worker-session"
+    finally:
+        conn.close()
+
+
 def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     """Set up an isolated HERMES_HOME with one claimed goal_mode task,
     matching the pattern used by the kanban_complete judge gate tests."""

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -79,7 +79,7 @@ def _is_dispatcher_owned_worker() -> bool:
 
         return is_dispatcher_owned_worker_context()
     except Exception:
-        return True
+        return False
 
 
 def _reject_delegated_child_mutation(tool_name: str) -> Optional[str]:
@@ -163,6 +163,21 @@ def _worker_run_id(task_id: str) -> Optional[int]:
     try:
         return int(raw)
     except ValueError:
+        return None
+
+
+def _worker_session_id(task_id: str) -> Optional[str]:
+    """Return the durable session only for this dispatcher-owned worker."""
+    if (
+        not _is_dispatcher_owned_worker()
+        or os.environ.get("HERMES_KANBAN_TASK") != task_id
+    ):
+        return None
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env("HERMES_SESSION_ID") or None
+    except Exception:
         return None
 
 
@@ -870,6 +885,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                worker_session_id=_worker_session_id(tid),
             )
             if not ok:
                 return tool_error(


### PR DESCRIPTION
## Summary
- persist the dispatcher-owned worker session only after a successful block transition
- resume the same profile-local session when an unblocked task is dispatched again
- fail closed for stale run IDs, context-resolution errors, and cross-profile reassignment/reclaim
- add additive/idempotent SQLite migration and regression coverage

## Verification
- 145 focused Kanban/cron tests passed
- 2 platform-only tests skipped on macOS
- 0 failures
- `py_compile` passed
- `git diff --check` passed
- static security scan found no matches
- independent review: 0 security concerns, 0 logic errors
- runtime canary preserved worker session `20260826_201545_6ded45` across block/unblock and produced proof `ALFA`

## Safety
- session persistence is post-CAS and write-once via `COALESCE`
- dispatcher ownership and session-context failures return no durable session
- session-bound tasks cannot transfer to another profile
- cross-profile reclaim is rejected before terminating the legitimate worker