### PR TITLE
fix(update): stop reporting success when SQLite remains vulnerable

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1456,8 +1456,48 @@ def _update_complete_message(pre_version: str | None) -> str:
     if post_version:
         return f"✓ Update complete! (v{post_version})"
     return "✓ Update complete!"
- 
- 
+
+
+def _post_update_sqlite_runtime_status():
+    """Return whether the interpreter used after update has safe SQLite."""
+    from hermes_constants import project_venv_dir
+    from hermes_cli.sqlite_runtime import probe_sqlite_runtime
+
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT)
+    python = (
+        venv_python_path(venv_dir, windows=_m()._is_windows())
+        if venv_dir is not None
+        else Path(sys.executable)
+    )
+    info = probe_sqlite_runtime(python)
+    return info is not None and not info.wal_reset_vulnerable, info
+
+
+def _print_verified_update_completion(message: str) -> bool:
+    """Print a success completion only after probing the next Hermes runtime."""
+    if not message.startswith("✓"):
+        _print_update_completion(message)
+        return False
+    sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
+    if sqlite_runtime_ok:
+        _print_update_completion(message)
+        return True
+    print()
+    if sqlite_info is None:
+        detail = "the post-update SQLite runtime could not be verified"
+    else:
+        detail = (
+            f"SQLite {sqlite_info.sqlite_version_string} still has the "
+            "WAL-reset corruption bug"
+        )
+    print(f"⚠ Update partially complete — {detail}.")
+    print(
+        "  Rebuild the Hermes venv with a uv-managed Python, restart Hermes, "
+        "then verify with `hermes doctor`."
+    )
+    return False
+
+
 def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
     """Delete the WAL / shared-memory / rollback-journal files next to *db_path*.
 
@@ -1484,11 +1524,12 @@ def _print_update_summary(
     node_failures: list,
     desktop_build_ok: bool,
     pre_update_version: str | None,
-) -> None:
+) -> bool:
     """Final update banner. A failed Desktop rebuild is non-fatal for the
     Python side, but must not print ``✓ Update complete!`` (#88251)."""
+    sqlite_runtime_ok, sqlite_info = _post_update_sqlite_runtime_status()
     print()
-    if node_failures or not desktop_build_ok:
+    if node_failures or not desktop_build_ok or not sqlite_runtime_ok:
         parts = []
         if node_failures:
             parts.append(
@@ -1498,14 +1539,30 @@ def _print_update_summary(
             parts.append(
                 "the desktop app was not rebuilt and is still on the previous build"
             )
+        if not sqlite_runtime_ok:
+            if sqlite_info is None:
+                parts.append("the post-update SQLite runtime could not be verified")
+            else:
+                parts.append(
+                    f"SQLite {sqlite_info.sqlite_version_string} still has the "
+                    "WAL-reset corruption bug"
+                )
         print("⚠ Update partially complete — " + "; ".join(parts) + ".")
         if node_failures:
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         if not desktop_build_ok:
             print("  Run `hermes desktop` to retry the desktop rebuild.")
+        if not sqlite_runtime_ok:
+            print(
+                "  The Python runtime remediation did not complete. Run `hermes "
+                "update` again; if SQLite is unchanged, rebuild the Hermes venv "
+                "with a uv-managed Python, restart Hermes, then verify with "
+                "`hermes doctor`."
+            )
     else:
         _print_update_completion(_update_complete_message(pre_update_version))
+    return desktop_build_ok and sqlite_runtime_ok
 
 
 def _write_gateway_update_exit_code(ok: bool) -> None:
@@ -1957,7 +2014,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             "Post-update state.db integrity check (zip path) failed: %s", exc
         )
 
-    _print_update_summary(
+    update_complete = _print_update_summary(
         node_failures=node_failures,
         desktop_build_ok=desktop_build_ok,
         pre_update_version=pre_update_version,
@@ -1977,11 +2034,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         from hermes_cli.update_receipt import finalize_update_receipt
 
         finalize_update_receipt(
-            "success" if (desktop_build_ok and not node_failures) else "partial"
+            "success" if update_complete and not node_failures else "partial"
         )
     except Exception as _receipt_exc:
         logger.debug("Update receipt finalize (zip path) failed: %s", _receipt_exc)
-    return desktop_build_ok
+    return update_complete
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
@@ -6799,7 +6856,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                _repair_node_deps_on_current_checkout(_print_update_completion)
+                _repair_node_deps_on_current_checkout(
+                    _print_verified_update_completion
+                )
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(
@@ -7669,7 +7728,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as exc:
             logger.debug("Sibling cron auto-restore check failed: %s", exc)
 
-        _print_update_summary(
+        update_complete = _print_update_summary(
             node_failures=node_failures,
             desktop_build_ok=desktop_build_ok,
             pre_update_version=pre_update_version,
@@ -7800,11 +7859,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         #
         # Writing the marker here — after git pull + pip install succeed but
         # before we attempt the restart — ensures the new gateway sees it
-        # regardless of how we die. Gated on desktop_build_ok (#88251): a
-        # Desktop rebuild failure must not be reported as "0" — the gateway's
-        # /update watcher (gateway/run.py) polls this file.
+        # regardless of how we die. The verified summary includes Desktop and
+        # SQLite-runtime health, so neither failure is reported as "0" to the
+        # gateway watcher (gateway/run.py).
         if gateway_mode:
-            _write_gateway_update_exit_code(desktop_build_ok)
+            _write_gateway_update_exit_code(update_complete)
 
         gateway_fleet_restart_incomplete = False
         # Snapshot of gateways running before we touch anything. Stays empty
@@ -8752,7 +8811,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             from hermes_cli.update_receipt import finalize_update_receipt
 
             _receipt_path = finalize_update_receipt(
-                "partial" if gateway_fleet_restart_incomplete else "success",
+                (
+                    "partial"
+                    if gateway_fleet_restart_incomplete or not update_complete
+                    else "success"
+                ),
                 fleet=_fleet_snapshot,
             )
             if _receipt_path is not None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6852,8 +6852,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
-                    _print_update_completion("✓ Update complete!")
+                    current_checkout_complete = _print_verified_update_completion(
+                        "✓ Update complete!"
+                    )
                 else:
+                    current_checkout_complete = False
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3190,7 +3190,7 @@ def _record_npm_lockfile_hash(hermes_root: Path) -> None:
     except OSError:
         logger.debug("Could not write npm lockfile hash cache")
 
-def _repair_node_deps_on_current_checkout(print_completion) -> None:
+def _repair_node_deps_on_current_checkout(print_completion) -> bool:
     """Repair Node deps on the ``commit_count == 0`` path (#77211).
 
     A current checkout does not imply healthy Node deps: a previous npm
@@ -3210,12 +3210,12 @@ def _repair_node_deps_on_current_checkout(print_completion) -> None:
         print_completion(
             "⚠ Checkout is current, but Node.js dependencies could not be repaired."
         )
-        return
+        return False
     # Pair the refresh with the web build like every other
     # _update_node_dependencies call site; it staleness-checks internally,
     # so this is a no-op when nothing changed.
     _m()._build_web_ui(_m().PROJECT_ROOT / "web")
-    print_completion("✓ Already up to date!")
+    return bool(print_completion("✓ Already up to date!"))
 
 
 def _update_node_dependencies() -> list[str]:
@@ -6786,6 +6786,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # "Already up to date!" and exits without doing the one job it
             # was spawned for.
             handed_off_sync = os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1"
+            current_checkout_complete = True
             if handed_off_sync:
                 print("→ Finishing the dependency install handed off by hermes.exe...")
             elif not healthy:
@@ -6856,7 +6857,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                _repair_node_deps_on_current_checkout(
+                current_checkout_complete = _repair_node_deps_on_current_checkout(
                     _print_verified_update_completion
                 )
             if runtime_repaired is not None and not _m()._is_windows():
@@ -6870,6 +6871,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 )
                 print("  Restart each of them to pick up the repaired runtime.")
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+            if not current_checkout_complete:
+                if gateway_mode:
+                    _write_gateway_update_exit_code(False)
+                try:
+                    from hermes_cli.update_receipt import finalize_update_receipt
+
+                    finalize_update_receipt("partial")
+                except Exception as _receipt_exc:
+                    logger.debug(
+                        "Update receipt finalize (current checkout) failed: %s",
+                        _receipt_exc,
+                    )
+                sys.exit(1)
             return
 
         if commit_count > 0:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -67,7 +67,11 @@ def _patch_managed_uv(request):
 
     with patch("hermes_cli.managed_uv.resolve_uv", side_effect=_fake_resolve_uv), \
          patch("hermes_cli.managed_uv.ensure_uv", side_effect=_fake_ensure_uv), \
-         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv):
+         patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv), \
+         patch(
+             "hermes_cli.update_cmd._post_update_sqlite_runtime_status",
+             return_value=(True, None),
+         ):
         yield
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -311,6 +311,42 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_current_checkout_verification_failure_is_durable(
+        self, mock_run, _mock_which, mock_args
+    ):
+        """A failed runtime check must fail receipts and gateway automation."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_args.gateway = True
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed"), patch.object(
+            update_cmd,
+            "_repair_node_deps_on_current_checkout",
+            return_value=False,
+        ), patch.object(
+            update_cmd, "_write_gateway_update_exit_code"
+        ) as write_gateway_exit, patch(
+            "hermes_cli.update_receipt.finalize_update_receipt"
+        ) as finalize_receipt, patch(
+            "hermes_cli.update_receipt.finalize_pending_update_receipt"
+        ):
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
+
+        assert exit_info.value.code == 1
+        write_gateway_exit.assert_called_once_with(False)
+        finalize_receipt.assert_called_once_with("partial")
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(
         self, mock_run, _mock_which, mock_args, capsys
     ):

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -309,12 +309,79 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @pytest.mark.parametrize(
+        ("health_after_repair", "runtime_status", "expected_runtime_checks"),
+        [
+            (True, (False, SimpleNamespace(sqlite_version_string="3.46.1")), 1),
+            (False, (True, None), 0),
+        ],
+    )
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_current_checkout_verification_failure_is_durable(
+    def test_current_checkout_python_repair_failure_is_durable(
+        self,
+        mock_run,
+        _mock_which,
+        mock_args,
+        health_after_repair,
+        runtime_status,
+        expected_runtime_checks,
+    ):
+        """Python repair must not bypass runtime and durable outcome checks."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_args.gateway = True
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed"), patch.object(
+            update_cmd,
+            "_venv_core_imports_healthy",
+            side_effect=[
+                (False, "broken before repair"),
+                (health_after_repair, "broken after repair"),
+            ],
+        ), patch.object(
+            hm, "_install_python_dependencies_with_optional_fallback"
+        ), patch.object(
+            hm, "_refresh_active_lazy_features"
+        ), patch.object(
+            hm, "_restore_active_tool_dependencies"
+        ), patch.object(
+            update_cmd, "_write_update_incomplete_marker"
+        ), patch.object(
+            hm, "_clear_update_incomplete_marker"
+        ), patch.object(
+            update_cmd,
+            "_post_update_sqlite_runtime_status",
+            return_value=runtime_status,
+        ) as runtime_check, patch.object(
+            update_cmd, "_write_gateway_update_exit_code"
+        ) as write_gateway_exit, patch(
+            "hermes_cli.update_receipt.finalize_update_receipt"
+        ) as finalize_receipt, patch(
+            "hermes_cli.update_receipt.finalize_pending_update_receipt"
+        ):
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
+
+        assert exit_info.value.code == 1
+        assert runtime_check.call_count == expected_runtime_checks
+        write_gateway_exit.assert_called_once_with(False)
+        finalize_receipt.assert_called_once_with("partial")
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_current_checkout_node_repair_verification_failure_is_durable(
         self, mock_run, _mock_which, mock_args
     ):
-        """A failed runtime check must fail receipts and gateway automation."""
+        """A failed Node-path runtime check must fail durable outcomes."""
         from hermes_cli import main as hm
         from hermes_cli import update_cmd
 

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -138,6 +138,9 @@ def test_summary_keeps_success_banner_when_desktop_ok(capsys, monkeypatch):
         update_cmd, "_update_complete_message", lambda _v: "✓ Update complete! (v0.20.2)"
     )
     monkeypatch.setattr(update_cmd, "_branch_head_suffix", lambda *a, **k: "")
+    monkeypatch.setattr(
+        update_cmd, "_post_update_sqlite_runtime_status", lambda: (True, None)
+    )
     _print_update_summary(
         node_failures=[],
         desktop_build_ok=True,

--- a/tests/hermes_cli/test_update_sqlite_remediation.py
+++ b/tests/hermes_cli/test_update_sqlite_remediation.py
@@ -1,0 +1,67 @@
+"""Post-update reporting for unresolved SQLite WAL-reset risk."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import update_cmd
+
+
+def test_runtime_status_probes_running_venv_outside_checkout(tmp_path, monkeypatch):
+    running_python = tmp_path / "venv312" / "bin" / "python"
+    observed = []
+    vulnerable = SimpleNamespace(wal_reset_vulnerable=True)
+    monkeypatch.setattr("hermes_constants.project_venv_dir", lambda _root: None)
+    monkeypatch.setattr(update_cmd.sys, "executable", str(running_python))
+    monkeypatch.setattr(
+        "hermes_cli.sqlite_runtime.probe_sqlite_runtime",
+        lambda python: observed.append(Path(python)) or vulnerable,
+    )
+
+    safe, info = update_cmd._post_update_sqlite_runtime_status()
+
+    assert observed == [running_python]
+    assert safe is False
+    assert info is vulnerable
+
+
+def test_summary_withholds_success_when_sqlite_remediation_failed(capsys, monkeypatch):
+    monkeypatch.setattr(
+        update_cmd,
+        "_post_update_sqlite_runtime_status",
+        lambda: (False, SimpleNamespace(sqlite_version_string="3.46.1")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_complete_message",
+        lambda _version: "✓ Update complete! (v0.20.5)",
+    )
+
+    complete = update_cmd._print_update_summary(
+        node_failures=[],
+        desktop_build_ok=True,
+        pre_update_version="0.20.4",
+    )
+
+    out = capsys.readouterr().out
+    assert complete is False
+    assert "Update complete" not in out
+    assert "SQLite 3.46.1" in out
+    assert "WAL-reset" in out
+    assert "uv-managed Python" in out
+    assert "hermes doctor" in out
+
+
+def test_current_checkout_completion_is_verified_before_success(capsys, monkeypatch):
+    monkeypatch.setattr(
+        update_cmd,
+        "_post_update_sqlite_runtime_status",
+        lambda: (False, SimpleNamespace(sqlite_version_string="3.46.1")),
+    )
+
+    complete = update_cmd._print_verified_update_completion("✓ Already up to date!")
+
+    out = capsys.readouterr().out
+    assert complete is False
+    assert "Already up to date" not in out
+    assert "SQLite 3.46.1" in out

--- a/tests/hermes_cli/test_update_sqlite_remediation.py
+++ b/tests/hermes_cli/test_update_sqlite_remediation.py
@@ -65,3 +65,14 @@ def test_current_checkout_completion_is_verified_before_success(capsys, monkeypa
     assert complete is False
     assert "Already up to date" not in out
     assert "SQLite 3.46.1" in out
+
+
+def test_current_checkout_repair_returns_verified_completion_result(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(update_cmd._m(), "_build_web_ui", lambda _path: None)
+
+    complete = update_cmd._repair_node_deps_on_current_checkout(
+        lambda _message: False
+    )
+
+    assert complete is False


### PR DESCRIPTION
## What does this PR do?

`hermes update` now probes the Python interpreter that Hermes will use after the update before printing a success banner. If that interpreter still links a SQLite build with the WAL-reset corruption bug, the update is reported as partial, gateway status and update receipts stay partial, and the user gets an explicit uv-managed Python recovery path instead of a false success.

### Symptom

A user can run `hermes update` in a Git install whose active venv links vulnerable SQLite, receive a successful completion message, restart Hermes, and still see the same WAL-reset warning and SQLite version.

### Impact

Operators can believe the runtime remediation succeeded while Hermes continues using the vulnerable SQLite build. The affected report experienced malformed FTS indexes and later write failures before rebuilding the venv on a uv-managed Python.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py` / `_cmd_update_impl` current-checkout completion and `_print_update_summary`

**Causal chain:**
1. A Git install runs under a venv outside the checkout and links a vulnerable SQLite build.
2. The managed-runtime repair targets checkout-local `venv` or `.venv`, while both the current-checkout path and the normal update summary print success without probing the interpreter that the next Hermes launch will use.
3. The command reports success even though the linked SQLite version is unchanged and the WAL-reset warning persists after restart.

**Why it is wrong:** Update completion was based on code, dependency, and Desktop outcomes, but it did not verify the specific runtime property that the remediation warning promised to repair.

**Working sibling / contrast:** Checkout-local managed venvs already have a transactional uv runtime replacement path that provisions and smoke-tests a SQLite-safe Python before cutover. The missing piece was outcome verification and truthful reporting when that path is not applicable or does not complete.

**Ruled out:** This is not caused by SQLite version parsing or the vulnerability predicate. Existing runtime tests correctly classify 3.46.1 as vulnerable and fixed/backported releases as safe; the missing check was at update completion.

### Fix

- Resolve the post-update interpreter from the checkout venv when present, otherwise use the running venv interpreter, and probe its linked SQLite in an isolated subprocess.
- Gate both normal and already-current success banners on that probe.
- Mark gateway update status and update receipts partial when runtime verification fails or still reports vulnerable SQLite.
- Print an actionable recovery path that names a uv-managed Python and `hermes doctor` verification.

## Related Issue

Fixes #95772

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - verify post-update SQLite runtime health before reporting success and propagate partial status to gateway/receipt outcomes.
- `tests/hermes_cli/test_update_sqlite_remediation.py` - cover external venv selection, vulnerable-runtime reporting, and current-checkout completion.
- `tests/hermes_cli/test_update_desktop_stale_warning.py` - keep Desktop summary tests explicit about unrelated SQLite health.
- `tests/hermes_cli/test_cmd_update.py` - isolate existing update-flow tests from host SQLite variability.

## How to Test

1. Run the focused SQLite remediation, summary, runtime, and receipt tests.
2. Run the current-checkout updater regression test.

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_sqlite_remediation.py tests/hermes_cli/test_update_desktop_stale_warning.py tests/hermes_cli/test_sqlite_runtime.py tests/hermes_cli/test_update_receipt.py -q
scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -k 'update_on_fork_checks_upstream_when_origin_up_to_date' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - user-facing remediation is emitted by the command
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no workflow changed
- [x] Cross-platform impact considered - interpreter resolution uses existing platform-aware venv helpers
- [x] Tool descriptions/schemas update: N/A - no model tool changed
