### PR TITLE
feat(tools): retain head and tail in persisted previews

### DIFF
--- a/docs/deepseek-harness-adoption-roadmap.md
+++ b/docs/deepseek-harness-adoption-roadmap.md
@@ -1,0 +1,46 @@
+# DeepSeek Harness adoption roadmap
+
+This roadmap tracks narrowly scoped DeepSeek Harness (DSH) mechanisms evaluated for independent adoption in Hermes. Each candidate requires an Issue, an isolated worktree, strict RED→GREEN tests, measurable before/after evidence, Hermes gates, an exact staged digest, and two independent reviews. Architectural similarity alone is not a reason to port code.
+
+## Source baseline
+
+- Repository: <https://github.com/deepseek-ai/deepseek-harness>
+- Pinned analysis commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+- License: MIT
+- Adoption policy: independently implement behavior through existing Hermes seams; do not port Cordis, plugin registries, or storage abstractions unless a separate measured Issue proves they are necessary.
+
+## Ranked candidates
+
+| Rank | Candidate | Hermes seam | Status | Decision evidence | Next boundary |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Bounded head/tail previews for persisted tool results | `tools/tool_result_storage.py::generate_preview` | Locally verified in Issue [#95717](https://github.com/NousResearch/hermes-agent/issues/95717); exact-digest review in progress | Synthetic benchmark retained the tail sentinel in 8,000/8,000 oversized samples versus 0/8,000 for the prefix baseline, respected the 1,500-character cap, and measured a 0.819214 median runtime ratio | Require a detached post-stage digest attestation and 2/2 PASS; no publication without explicit authorization |
+| 2 | Defer additional low-frequency, high-schema-cost tools | Existing `tool_search` / `tool_describe` / `tool_call` progressive-disclosure seam | Prototype next | Prior source-first inventory found 30 visible tools, roughly 16,861 schema tokens, including six specialized BFL tools; Hermes already has the required registry/disclosure mechanism, so only catalog tuning is justified | Separate Issue; measure schema tokens, discovery success, task success, and latency before changing defaults |
+| 3 | Post-middleware request snapshot and deterministic provider replay | Existing transport and middleware abstractions | Deferred until candidate 2 completes | DSH has a scriptable mock adapter and replay testkit; Hermes lacks one general artifact for the effective post-middleware request and normalized response replay through the loop | Separate Issue; define a redacted deterministic format and prove a real regression it catches |
+| 4 | Cordis/plugin architecture port | Core runtime | Rejected | No measured gap requires a framework port; Hermes already has narrower extension seams | Reconsider only if two independent adopted candidates demonstrate a shared missing contract |
+
+## Issue #95717 — head/tail preview slice
+
+- Hermes base: `9aa7530f7b53699e2c6d648ded8f6300503b3dc7`
+- Worktree: `C:/ha-dsh-head-tail-latest`
+- DSH source mechanism: `packages/spill/spill-policy/src/index.ts:94-101`, which uses a head/tail `TextRetainer`
+- Hermes implementation: independent character-budget split in the existing pure preview function; full spill storage, paths, cleanup, and recovery guidance remain unchanged
+- RED→GREEN coverage:
+  - decisive tail sentinel retention;
+  - one-character budget;
+  - zero and negative budgets;
+  - honest persisted-output head/tail label.
+- Local verification:
+  - focused storage suite: 39 passed;
+  - adjacent canonical batch: 122 passed across five files after excluding one Windows symlink-privilege test that fails identically on clean `upstream/main`;
+  - Ruff, production `ty`, compile, real-path smoke, and `git diff --check`: passed;
+  - synthetic benchmark: passed all predeclared thresholds.
+- Known baseline limitations, not hidden:
+  - `TestPathCanonicalization::test_symlink_aliases_are_not_parallelized` fails on this host and clean base with `WinError 1314`;
+  - `ty` reports two unresolved-import diagnostics in the pre-existing test module on clean base, while production-only `ty` passes.
+- Evidence: `docs/evidence/dsh-head-tail-preview.json`
+- Review state: the first exact-digest round returned 0/2 PASS because this roadmap and the staged evidence still described staging as pending. That round is preserved in evidence and invalidated by the evidence-only correction. The immutable payload cannot contain its own SHA-256 without changing that SHA-256, so each final digest and Auto Research run are detached post-stage attestations supplied to both reviewers.
+- Publication state: payload staged for review; not committed, not pushed, no PR, and no CI result.
+
+## Rollback
+
+Revert the Issue-specific preview function, message label, tests, roadmap entry, and evidence. The on-disk spill format and full persisted content are unchanged, so rollback requires no data migration.

--- a/docs/evidence/dsh-head-tail-preview.json
+++ b/docs/evidence/dsh-head-tail-preview.json
@@ -1,0 +1,272 @@
+{
+  "schema_version": "hermes.dsh-adoption-evidence.v1",
+  "generated_at_utc": "2026-08-26T17:37:07Z",
+  "issue": {
+    "number": 95717,
+    "url": "https://github.com/NousResearch/hermes-agent/issues/95717",
+    "objective": "Retain bounded decision signal from both the head and tail of oversized persisted tool results."
+  },
+  "hermes": {
+    "base_sha": "9aa7530f7b53699e2c6d648ded8f6300503b3dc7",
+    "branch": "deepseek-harness/95717-head-tail-preview",
+    "upstream": "upstream/main",
+    "worktree": "C:/ha-dsh-head-tail-latest"
+  },
+  "deepseek_harness": {
+    "repository": "https://github.com/deepseek-ai/deepseek-harness",
+    "source_sha": "b150a551b8d465e31e418e1b2eaf5e79bbb7d28e",
+    "license": "MIT",
+    "source_files": [
+      "packages/spill/spill-policy/src/index.ts",
+      "packages/spill/spill-policy/tests/spill-policy.spec.ts"
+    ],
+    "source_symbol": "preview(text, budget) using TextRetainer(kind=headTail)",
+    "disposition": "Independent implementation of the bounded head/tail invariant through Hermes' existing pure preview seam; no DSH code, Cordis framework, plugin registry, or storage abstraction copied."
+  },
+  "scope": {
+    "production": [
+      "tools/tool_result_storage.py::generate_preview",
+      "tools/tool_result_storage.py::_build_persisted_message"
+    ],
+    "tests": [
+      "tests/tools/test_tool_result_storage.py"
+    ],
+    "docs": [
+      "docs/deepseek-harness-adoption-roadmap.md",
+      "docs/evidence/dsh-head-tail-preview.json"
+    ],
+    "non_goals": [
+      "Cordis or plugin architecture port",
+      "new spill storage or lifecycle abstraction",
+      "code-mode dispatch changes",
+      "tool schema/catalog changes",
+      "context compression or prompt-history mutation",
+      "publication without explicit user authorization"
+    ]
+  },
+  "tdd": [
+    {
+      "behavior": "oversized content retains a decisive tail sentinel",
+      "red_command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/tools/test_tool_result_storage.py::TestGeneratePreview::test_oversized_content_retains_tail_signal -q",
+      "red_exit_code": 1,
+      "red_observation": "preview ended with middle content instead of TAIL-SIGNAL",
+      "green_exit_code": 0,
+      "green_observation": "1 passed in 1.04s"
+    },
+    {
+      "behavior": "one-character budget remains bounded",
+      "red_command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/tools/test_tool_result_storage.py::TestGeneratePreview::test_one_character_budget_stays_bounded -q",
+      "red_exit_code": 1,
+      "red_observation": "preview was ooversized because content[-0:] returns the full string",
+      "green_exit_code": 0,
+      "green_observation": "included in 2 passed in 1.04s"
+    },
+    {
+      "behavior": "non-positive budgets return an empty preview",
+      "red_command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/tools/test_tool_result_storage.py::TestGeneratePreview::test_non_positive_budget_returns_empty_preview -q",
+      "red_exit_code": 1,
+      "red_observation": "negative budget returned versized; zero budget already passed",
+      "green_exit_code": 0,
+      "green_observation": "TestGeneratePreview class: 6 passed in 1.15s"
+    },
+    {
+      "behavior": "persisted-output copy labels a head/tail preview honestly",
+      "red_command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/tools/test_tool_result_storage.py::TestBuildPersistedMessage::test_structure -q",
+      "red_exit_code": 1,
+      "red_observation": "message said Preview (first 18 chars)",
+      "green_exit_code": 0,
+      "green_observation": "1 passed in 1.08s"
+    }
+  ],
+  "benchmark": {
+    "artifact": "C:/Users/fjmn2/AppData/Local/Temp/dsh95717-benchmark.json",
+    "script": "C:/Users/fjmn2/AppData/Local/Temp/dsh95717_benchmark.py",
+    "kind": "synthetic_microbenchmark",
+    "environment": {
+      "platform": "Windows-10-10.0.26200-SP0",
+      "processor": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+      "python": "3.11.15 MSC v.1944 64 bit AMD64"
+    },
+    "method": {
+      "iterations_per_sample": 10000,
+      "warmups": 2,
+      "samples": 9,
+      "budget_chars": 1500,
+      "input_distribution": {
+        "short": 2000,
+        "oversized_with_tail_sentinel": 8000
+      },
+      "baseline": "upstream/main generate_preview prefix plus newline boundary"
+    },
+    "thresholds": {
+      "tail_retention_percent_min": 100.0,
+      "max_preview_chars": 1500,
+      "median_runtime_ratio_max": 2.5,
+      "current_median_ms_per_10000_max": 100.0
+    },
+    "actual": {
+      "oversized_sentinel_samples": 8000,
+      "baseline_tail_retained": 0,
+      "current_tail_retained": 8000,
+      "current_tail_retention_percent": 100.0,
+      "max_preview_length": 1500,
+      "baseline_median_ms_per_10000": 7.8485,
+      "current_median_ms_per_10000": 6.4296,
+      "median_runtime_ratio": 0.819214,
+      "baseline_elapsed_ms_samples": [8.1192, 7.3122, 6.4112, 8.7483, 7.8485, 6.8479, 6.9029, 9.2501, 8.1152],
+      "current_elapsed_ms_samples": [6.3865, 6.3178, 7.752, 6.4296, 6.2983, 7.4451, 6.1884, 7.0482, 7.7682]
+    },
+    "passed": true
+  },
+  "verification": [
+    {
+      "gate": "focused storage suite",
+      "command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/tools/test_tool_result_storage.py -q",
+      "exit_code": 0,
+      "status": "passed",
+      "duration_seconds": 1.95,
+      "result": "39 passed"
+    },
+    {
+      "gate": "canonical adjacent batch, unfiltered",
+      "command": "HERMES_PYTHON=C:/ha-dsh/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/run_agent/test_tool_batch_segmentation.py tests/run_agent/test_tool_call_incremental_persistence.py tests/agent/test_stall_guards.py tests/run_agent/test_compression_boundary.py -j 4 -q",
+      "exit_code": 1,
+      "status": "baseline_environment_failure",
+      "duration_seconds": 22,
+      "result": "122 passed, 1 failed: Windows symlink creation WinError 1314"
+    },
+    {
+      "gate": "clean-base symlink classification",
+      "command": "C:/ha-dsh/.venv/Scripts/python.exe -m pytest tests/run_agent/test_tool_batch_segmentation.py::TestPathCanonicalization::test_symlink_aliases_are_not_parallelized -q",
+      "exit_code": 1,
+      "status": "reproduced_on_clean_base",
+      "duration_seconds": 7.3,
+      "result": "WinError 1314 at upstream/main base SHA"
+    },
+    {
+      "gate": "canonical adjacent batch excluding classified baseline test",
+      "command": "HERMES_PYTHON=C:/ha-dsh/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/run_agent/test_tool_batch_segmentation.py tests/run_agent/test_tool_call_incremental_persistence.py tests/agent/test_stall_guards.py tests/run_agent/test_compression_boundary.py -j 4 -q -k 'not symlink_aliases_are_not_parallelized'",
+      "exit_code": 0,
+      "status": "passed",
+      "duration_seconds": 12,
+      "result": "122 passed, 0 failed across 5 files"
+    },
+    {
+      "gate": "Ruff touched Python files",
+      "command": "C:/ha-dsh/.venv/Scripts/ruff.exe check tools/tool_result_storage.py tests/tools/test_tool_result_storage.py",
+      "exit_code": 0,
+      "status": "passed",
+      "duration_seconds": 1,
+      "result": "All checks passed"
+    },
+    {
+      "gate": "ty production module",
+      "command": "C:/ha-dsh/.venv/Scripts/python.exe -m ty check tools/tool_result_storage.py",
+      "exit_code": 0,
+      "status": "passed",
+      "duration_seconds": null,
+      "result": "All checks passed"
+    },
+    {
+      "gate": "ty production plus touched test",
+      "command": "C:/ha-dsh/.venv/Scripts/python.exe -m ty check tools/tool_result_storage.py tests/tools/test_tool_result_storage.py",
+      "exit_code": 1,
+      "status": "baseline_static_analysis_failure",
+      "duration_seconds": 0,
+      "result": "Two unresolved-import diagnostics for pre-existing module functions; reproduced identically on clean upstream/main"
+    },
+    {
+      "gate": "compile, real-path smoke, and diff check",
+      "command": "python -m py_compile touched modules; invoke generate_preview with oversized head/tail input; git diff --check",
+      "exit_code": 0,
+      "status": "passed",
+      "duration_seconds": 0,
+      "result": "SMOKE head_tail=true chars=100"
+    }
+  ],
+  "auto_research": {
+    "intermediate_runs": [
+      "20260826T165620Z",
+      "20260826T172229Z",
+      "20260826T172458Z",
+      "20260826T172741Z",
+      "20260826T173326Z",
+      "20260826T174113Z",
+      "20260826T182759Z"
+    ],
+    "intermediate_status": "ready_for_review",
+    "intermediate_model_references_verified": true,
+    "intermediate_no_failed_evidence_commands": true,
+    "final_staged_run": {
+      "recording": "detached_post_stage_attestation",
+      "reason": "Embedding a payload digest or post-stage run identifier in this staged file would change the payload digest itself.",
+      "superseded_run_id": "20260826T174454Z",
+      "superseded_digest": "a39a53bba698321cab1408900a37fdb210f9f4954f83aa91ed513427b83f4f7b",
+      "superseded_report_integrity": {
+        "raw_file_sha256": "979fd4e5ce4e17cdd89a09e1f9a98f2b0b42ebee931117a4c5dcc820a455bdbf",
+        "stable_json_sha256": "a04b69f4a319467db592d8c62b5eaef0c93084f2103f834f830f03235bcc7e50",
+        "manifest_hash_algorithm": "SHA-256 of recursively key-sorted compact JSON",
+        "manifest_match": true
+      },
+      "verification_contract": "Reviewers must independently hash the immutable staged patch and compare it with the detached Auto Research report and action manifest created after staging."
+    },
+    "final_can_use_for_product_change": {
+      "value": false,
+      "reason": "Auto Research recognizes only a root smoke_check.py; Hermes uses scripts/run_tests.sh.",
+      "workflow_equivalence": "hermes-dsh-adoption-workflow v1.2.0 permits review only because canonical deterministic gates and clean-base classifications are preserved above."
+    }
+  },
+  "workspace_artifacts": {
+    "classified_untracked": [
+      {
+        "path": "%SystemDrive%/ProgramData/Microsoft/Windows/Caches/",
+        "classification": "runner-created Windows cache artifact from literal environment expansion; unrelated and excluded from payload",
+        "deleted": false
+      }
+    ]
+  },
+  "staged_payload": {
+    "status": "ready_for_detached_exact_digest_attestation",
+    "files": [
+      "docs/deepseek-harness-adoption-roadmap.md",
+      "docs/evidence/dsh-head-tail-preview.json",
+      "tests/tools/test_tool_result_storage.py",
+      "tools/tool_result_storage.py"
+    ],
+    "sha256": null,
+    "sha256_recording": "detached_post_stage_attestation",
+    "reason": "The exact SHA-256 is computed only after this self-describing evidence file is staged; embedding it here would invalidate it."
+  },
+  "reviews": {
+    "required": 2,
+    "current_round_completed": 0,
+    "current_round_verdicts": [],
+    "superseded_rounds": [
+      {
+        "digest": "a39a53bba698321cab1408900a37fdb210f9f4954f83aa91ed513427b83f4f7b",
+        "completed": 2,
+        "pass_count": 0,
+        "verdicts": [
+          {
+            "reviewer": "independent reviewer A",
+            "verdict": "FAIL",
+            "blocking_reason": "Staged roadmap/evidence described final staging and digest readiness as pending; reviewer also compared raw report bytes to the manifest's documented stable-JSON hash."
+          },
+          {
+            "reviewer": "independent reviewer B",
+            "verdict": "FAIL",
+            "blocking_reason": "Staged roadmap/evidence described final staging and digest readiness as pending."
+          }
+        ],
+        "invalidated_by": "Evidence-only correction addressing both reviewers' shared blocking finding."
+      }
+    ]
+  },
+  "publication": {
+    "authorized": false,
+    "commit": null,
+    "push": null,
+    "pull_request": null,
+    "ci": null
+  }
+}

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -42,6 +42,29 @@ class TestGeneratePreview:
         assert preview == text
         assert has_more is False
 
+    def test_oversized_content_retains_tail_signal(self):
+        text = "HEAD-SIGNAL\n" + ("middle\n" * 100) + "TAIL-SIGNAL"
+
+        preview, has_more = generate_preview(text, max_chars=80)
+
+        assert preview.startswith("HEAD-SIGNAL")
+        assert preview.endswith("TAIL-SIGNAL")
+        assert len(preview) <= 80
+        assert has_more is True
+
+    def test_one_character_budget_stays_bounded(self):
+        preview, has_more = generate_preview("oversized", max_chars=1)
+
+        assert preview == "o"
+        assert has_more is True
+
+    @pytest.mark.parametrize("max_chars", [0, -1])
+    def test_non_positive_budget_returns_empty_preview(self, max_chars):
+        preview, has_more = generate_preview("oversized", max_chars=max_chars)
+
+        assert preview == ""
+        assert has_more is True
+
 
 # ── _heredoc_marker ───────────────────────────────────────────────────
 
@@ -155,6 +178,7 @@ class TestBuildPersistedMessage:
         assert "/tmp/hermes-results/test123.txt" in msg
         assert "read_file" in msg
         assert "first 100 chars..." in msg
+        assert "Preview (head/tail, 18 chars):" in msg
         assert "..." in msg  # has_more indicator
 
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -229,14 +229,15 @@ def _safe_result_filename(tool_use_id: str) -> str:
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
-    """Truncate at last newline within max_chars. Returns (preview, has_more)."""
+    """Return a bounded head/tail preview and whether content was omitted."""
+    if max_chars <= 0:
+        return "", bool(content)
     if len(content) <= max_chars:
         return content, False
-    truncated = content[:max_chars]
-    last_nl = truncated.rfind("\n")
-    if last_nl > max_chars // 2:
-        truncated = truncated[:last_nl + 1]
-    return truncated, True
+    head_chars = (max_chars + 1) // 2
+    tail_chars = max_chars // 2
+    tail = content[-tail_chars:] if tail_chars else ""
+    return content[:head_chars] + tail, True
 
 
 def _heredoc_marker(content: str) -> str:
@@ -287,7 +288,7 @@ def _build_persisted_message(
         "process it with execute_code — do NOT re-request the same data from the "
         "remote API; the full result is already on disk.\n\n"
     )
-    msg += f"Preview (first {len(preview)} chars):\n"
+    msg += f"Preview (head/tail, {len(preview)} chars):\n"
     msg += preview
     if has_more:
         msg += "\n..."


### PR DESCRIPTION
## Summary

- retain bounded preview signal from both the head and tail of oversized persisted tool results
- preserve exact behavior for content that fits the budget and preserve full on-disk content/recovery semantics
- handle one-character, zero, and negative budgets without Python's `[-0:]` edge case
- label persisted messages honestly as `Preview (head/tail, N chars)`
- add an auditable DeepSeek Harness adoption roadmap and machine-readable evidence

Closes #95717

## Provenance and scope

- independently implements the bounded head/tail invariant through Hermes' existing `generate_preview` seam
- source mechanism inspected at DeepSeek Harness commit `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`, `packages/spill/spill-policy/src/index.ts:94-101`
- DeepSeek Harness source license: MIT
- no DSH framework, registry, storage abstraction, or source code was copied
- full spill writes, paths, cleanup, recovery guidance, dispatch, schemas, and compression remain unchanged

## Verification

- focused storage suite: **39 passed**
- adjacent persistence/compression batch: **122 passed**
- Ruff on touched Python files: **PASS**
- production `ty`: **PASS**
- `py_compile`: **PASS**
- real-path 100-character head/tail smoke: **PASS**
- `git diff --check`: **PASS**
- static added-line security scan: **PASS**

Known host/baseline limitations are preserved rather than hidden:

- `TestPathCanonicalization::test_symlink_aliases_are_not_parallelized` fails with Windows `WinError 1314` on both this branch and a clean `upstream/main` worktree; the adjacent 122-test batch excludes that single baseline failure explicitly
- `ty` on the touched test module reports the same two pre-existing unresolved-import diagnostics on clean `upstream/main`; production-only `ty` passes

## Benchmark

Synthetic microbenchmark, 10,000 mixed previews per sample, two warmups, nine measured samples, 1,500-character budget:

- oversized tail sentinel retention: **0/8,000 → 8,000/8,000**
- maximum preview length: **1,500**
- baseline median: **7.8485 ms**
- candidate median: **6.4296 ms**
- candidate/baseline median ratio: **0.819214**

This is a microbenchmark, not an end-to-end latency claim.

## Evidence and review

- evidence: `docs/evidence/dsh-head-tail-preview.json`
- roadmap: `docs/deepseek-harness-adoption-roadmap.md`
- Auto Research final staged payload: `ready_for_review`, references verified, parsed report, no failed evidence commands, exact staged payload present
- functional exact-digest review: **2/2 PASS**, no blocking findings
- publication full-index digest attestation: **2/2 PASS**, no blocking findings

Digests:

- DSH workflow diff SHA-256: `0d93bc92bb4b28973906c764c23a2b3e7c11e28494f66058f5986b1a7c1c6b2e`
- publication `--full-index` diff SHA-256: `7ec49348f93dbce53caa5e53eded23fe15dfd4fdb9d6d96895d268a4431c4ea2`

The artifacts differ only in abbreviated versus full Git object IDs on four `index` metadata lines; two independent attestators verified every other byte and the live staged payload were identical.

## Rollback

Revert this commit. The persisted full-content format is unchanged, so no migration is required.
