### PR TITLE
feat(providers): add chatgpt alias for openai-codex provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2242,6 +2242,7 @@ def resolve_provider(
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
         # Local server aliases — route through the generic custom provider
+        "chatgpt": "openai-codex", "chatgpt-codex": "openai-codex",
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
         "vllm": "custom", "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -282,6 +282,10 @@ ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
+    # openai-codex / chatgpt
+    "chatgpt": "openai-codex",
+    "chatgpt-codex": "openai-codex",
+
     # zai
     "glm": "zai",
     "z-ai": "zai",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -218,6 +218,10 @@ class TestResolveProvider:
         assert resolve_provider("Z-AI") == "zai"
         assert resolve_provider("Kimi") == "kimi-coding"
 
+    def test_alias_chatgpt(self):
+        assert resolve_provider("chatgpt") == "openai-codex"
+        assert resolve_provider("chatgpt-codex") == "openai-codex"
+
     def test_alias_github_copilot(self):
         assert resolve_provider("github-copilot") == "copilot"
 


### PR DESCRIPTION
Fixes #95794

### What does this PR do?
Adds `chatgpt` and `chatgpt-codex` as aliases resolving to the canonical `openai-codex` provider in `hermes_cli/providers.py` and `hermes_cli/auth.py`.

This allows users to pass `--provider chatgpt` or configure `model.provider: chatgpt` seamlessly without having to know the internal `openai-codex` identifier.

### Changes Made
- `hermes_cli/providers.py`: Added `chatgpt` and `chatgpt-codex` to `ALIASES`.
- `hermes_cli/auth.py`: Added `chatgpt` and `chatgpt-codex` to `_PROVIDER_ALIASES`.
- `tests/hermes_cli/test_api_key_providers.py`: Added unit test confirming alias resolution.

### Verification
- Ran `pytest tests/hermes_cli/test_api_key_providers.py` (106 passed).