### PR TITLE
fix(tui): scope async image attachments to the active draft

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -837,6 +837,35 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('carries the originating attachment scope through an async command alias', async () => {
+    const scope = { draftVersion: 1, sid: 'sid-a' }
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.reject(new Error('use command.dispatch'))
+            }
+
+            if (method === 'command.dispatch') {
+              return Promise.resolve({ type: 'alias', target: 'image' })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/img /tmp/screenshot.png', scope)).toBe(true)
+    await vi.waitFor(() => {
+      expect(ctx.composer.attachImagePath).toHaveBeenCalledWith('/tmp/screenshot.png', scope)
+    })
+  })
+
   it('resolves unique local aliases through the catalog', () => {
     const ctx = buildCtx({
       local: {
@@ -851,6 +880,21 @@ describe('createSlashHandler', () => {
 
     expect(createSlashHandler(ctx)('/h')).toBe(true)
     expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
+  })
+
+  it('routes an unambiguous image prefix through the canonical attachment command', () => {
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/image': '/image'
+          }
+        }
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/imag /tmp/screenshot.png')).toBe(true)
+    expect(ctx.composer.attachImagePath).toHaveBeenCalledWith('/tmp/screenshot.png', undefined)
   })
 
   it('lets exact catalog commands win over longer prefix matches', async () => {
@@ -1113,6 +1157,8 @@ const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 })
 
 const buildComposer = () => ({
+  attachClipboardImage: vi.fn(),
+  attachImagePath: vi.fn(),
   enqueue: vi.fn(),
   hasSelection: false,
   openEditor: vi.fn(async () => {}),

--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -1,6 +1,62 @@
 import { describe, expect, it } from 'vitest'
 
-import { looksLikeDroppedPath } from '../app/useComposerState.js'
+import {
+  advanceDraftVersion,
+  createSlashClearTracker,
+  isAttachmentScopeCurrent,
+  looksLikeDroppedPath,
+  resolveSlashAttachment
+} from '../app/useComposerState.js'
+
+describe('advanceDraftVersion', () => {
+  it('keeps attachment-command clears in the active draft', () => {
+    expect(advanceDraftVersion(4, true)).toBe(4)
+  })
+
+  it('advances ordinary submit and cancel clears', () => {
+    expect(advanceDraftVersion(4, false)).toBe(5)
+  })
+})
+
+describe('createSlashClearTracker', () => {
+  it('preserves the draft when a synchronous canonical attachment marks the pending clear', () => {
+    const tracker = createSlashClearTracker()
+    const scope = tracker.begin(4, 'sid-a')
+
+    tracker.markAttachment(scope)
+
+    expect(tracker.clear(4)).toBe(4)
+    expect(scope).toEqual({ draftVersion: 4, sid: 'sid-a' })
+  })
+
+  it('does not leak preservation from an async alias into the next clear', () => {
+    const tracker = createSlashClearTracker()
+    const scope = tracker.begin(4, 'sid-a')
+
+    expect(tracker.clear(4)).toBe(5)
+    expect(scope).toEqual({ draftVersion: 5, sid: 'sid-a' })
+
+    // command.dispatch may resolve an alias to /image after the originating
+    // slash was already cleared. That late action has no paired clear to mark.
+    tracker.markAttachment(scope)
+
+    expect(tracker.clear(5)).toBe(6)
+  })
+})
+
+describe('isAttachmentScopeCurrent', () => {
+  const scope = { draftVersion: 5, sid: 'sid-a' }
+
+  it('accepts a carried alias scope only in its originating draft and session', () => {
+    expect(isAttachmentScopeCurrent(scope, 5, 'sid-a')).toBe(true)
+    expect(isAttachmentScopeCurrent(scope, 6, 'sid-a')).toBe(false)
+    expect(isAttachmentScopeCurrent(scope, 5, 'sid-b')).toBe(false)
+  })
+
+  it('accepts direct attachment actions without a slash scope', () => {
+    expect(isAttachmentScopeCurrent(undefined, 5, 'sid-a')).toBe(true)
+  })
+})
 
 describe('looksLikeDroppedPath', () => {
   it('recognizes macOS screenshot temp paths and file URIs', () => {
@@ -55,5 +111,189 @@ describe('looksLikeDroppedPath', () => {
     expect(looksLikeDroppedPath('/usr/bin/test')).toBe(true)
     expect(looksLikeDroppedPath('/tmp/file.txt')).toBe(true)
     expect(looksLikeDroppedPath('/etc/hosts')).toBe(true) // has second /
+  })
+})
+
+describe('resolveSlashAttachment', () => {
+  it('does not resurrect the consumed slash command after the RPC resolves', async () => {
+    let resolveRequest!: (value: { name: string; path: string }) => void
+    let composer = { draftVersion: 0, sid: 'sid-a', value: '/image /tmp/dashboard.png' }
+    let discarded = false
+
+    const request = new Promise<{ name: string; path: string }>(resolve => {
+      resolveRequest = resolve
+    })
+
+    const pending = resolveSlashAttachment(
+      () => request,
+      () => composer,
+      0,
+      'sid-a',
+      (_attached, value, cursor) => ({
+        cursor: cursor + 13,
+        value: `${value}[[ Image 1 ]]`
+      }),
+      () => {
+        discarded = true
+      },
+      value => {
+        composer.value = value
+      }
+    )
+
+    composer = { draftVersion: 0, sid: 'sid-a', value: '' }
+    resolveRequest({ name: 'dashboard.png', path: '/tmp/dashboard.png' })
+
+    await expect(pending).resolves.toMatchObject({ value: '[[ Image 1 ]]' })
+    expect(composer.value).toBe('[[ Image 1 ]]')
+    expect(discarded).toBe(false)
+  })
+
+  it('preserves prompt text typed while the attachment is in flight', async () => {
+    let composer = { draftVersion: 0, sid: 'sid-a', value: '/image /tmp/dashboard.png' }
+    let resolveRequest!: (value: { name: string; path: string }) => void
+
+    const request = new Promise<{ name: string; path: string }>(resolve => {
+      resolveRequest = resolve
+    })
+
+    const pending = resolveSlashAttachment(
+      () => request,
+      () => composer,
+      0,
+      'sid-a',
+      (_attached, value, cursor) => ({ cursor: cursor + 13, value: `${value} [[ Image 1 ]]` }),
+      () => {
+        throw new Error('current attachment should not be discarded')
+      },
+      value => {
+        composer.value = value
+      }
+    )
+
+    composer = { draftVersion: 0, sid: 'sid-a', value: 'explain this' }
+    resolveRequest({ name: 'dashboard.png', path: '/tmp/dashboard.png' })
+
+    await expect(pending).resolves.toMatchObject({ value: 'explain this [[ Image 1 ]]' })
+    expect(composer.value).toBe('explain this [[ Image 1 ]]')
+  })
+
+  it('discards an attachment after a later submission clears the composer again', async () => {
+    const attached = { name: 'dashboard.png', path: '/tmp/dashboard.png' }
+    let applied = false
+    let discarded: typeof attached | undefined
+
+    const result = await resolveSlashAttachment(
+      async () => attached,
+      () => ({ draftVersion: 1, sid: 'sid-a', value: 'next draft' }),
+      0,
+      'sid-a',
+      () => {
+        applied = true
+
+        return { cursor: 0, value: 'wrong' }
+      },
+      value => {
+        discarded = value
+      },
+      () => {
+        throw new Error('discarded attachment should not update the composer')
+      }
+    )
+
+    expect(result).toBeNull()
+    expect(applied).toBe(false)
+    expect(discarded).toEqual(attached)
+  })
+
+  it('keeps earlier attachments when a batch issues another image slash command', async () => {
+    const attached = { name: 'second.png', path: '/tmp/second.png' }
+    const composer = { draftVersion: 0, sid: 'sid-a', value: '[[ Image 1 ]]' }
+
+    const result = await resolveSlashAttachment(
+      async () => attached,
+      () => composer,
+      0,
+      'sid-a',
+      (_attachment, value) => ({ cursor: value.length + 14, value: `${value} [[ Image 2 ]]` }),
+      () => {
+        throw new Error('same-draft attachment should not be discarded')
+      },
+      value => {
+        composer.value = value
+      }
+    )
+
+    expect(result).toEqual({ cursor: 27, value: '[[ Image 1 ]] [[ Image 2 ]]' })
+    expect(composer.value).toBe('[[ Image 1 ]] [[ Image 2 ]]')
+  })
+
+  it('discards an attachment after its originating session changes', async () => {
+    const attached = { name: 'dashboard.png', path: '/tmp/dashboard.png' }
+    let discarded: typeof attached | undefined
+
+    const result = await resolveSlashAttachment(
+      async () => attached,
+      () => ({ draftVersion: 0, sid: 'sid-b', value: '' }),
+      0,
+      'sid-a',
+      () => {
+        throw new Error('stale-session attachment should not update the composer')
+      },
+      value => {
+        discarded = value
+      },
+      () => {
+        throw new Error('stale-session attachment should not update the composer')
+      }
+    )
+
+    expect(result).toBeNull()
+    expect(discarded).toEqual(attached)
+  })
+
+  it('commits concurrent attachment resolutions without hiding either token', async () => {
+    const composer = { draftVersion: 0, sid: 'sid-a', value: '' }
+    const tokens: string[] = []
+
+    const attach = (_attachment: { name: string; path: string }, value: string) => {
+      const token = `[[ Image ${tokens.length + 1} ]]`
+
+      tokens.push(token)
+
+      return { cursor: value.length + token.length, value: `${value}${token}` }
+    }
+
+    const apply = (value: string) => {
+      composer.value = value
+    }
+
+    const discard = () => {
+      throw new Error('same-draft attachment should not be discarded')
+    }
+
+    await Promise.all([
+      resolveSlashAttachment(
+        async () => ({ name: 'first.png', path: '/tmp/first.png' }),
+        () => composer,
+        0,
+        'sid-a',
+        attach,
+        discard,
+        apply
+      ),
+      resolveSlashAttachment(
+        async () => ({ name: 'second.png', path: '/tmp/second.png' }),
+        () => composer,
+        0,
+        'sid-a',
+        attach,
+        discard,
+        apply
+      )
+    ])
+
+    expect(composer.value).toBe('[[ Image 1 ]][[ Image 2 ]]')
+    expect(tokens).toEqual(['[[ Image 1 ]]', '[[ Image 2 ]]'])
   })
 })

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -4,18 +4,20 @@ import { asCommandDispatch, rpcErrorMessage } from '../lib/rpc.js'
 import { launchWidget } from '../sdk/host.js'
 import { getWidgetApp } from '../sdk/registry.js'
 
-import type { SlashHandlerContext } from './interfaces.js'
+import type { AttachmentDraftScope, SlashHandlerContext } from './interfaces.js'
 import { scoreSlashMenuItem } from './slash/fuzzyScore.js'
 import { findSlashCommand } from './slash/registry.js'
 import type { SlashRunCtx } from './slash/types.js'
 import { getUiState } from './uiStore.js'
 
-export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => boolean {
+export function createSlashHandler(
+  ctx: SlashHandlerContext
+): (cmd: string, attachmentScope?: AttachmentDraftScope) => boolean {
   const { gw } = ctx.gateway
   const { catalog } = ctx.local
   const { page, send, sys } = ctx.transcript
 
-  const handler = (cmd: string): boolean => {
+  const handler = (cmd: string, attachmentScope?: AttachmentDraftScope): boolean => {
     const flight = ++ctx.slashFlightRef.current
     const ui = getUiState()
     const sid = ui.sid
@@ -38,7 +40,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
     }
 
-    const runCtx: SlashRunCtx = { ...ctx, flight, guarded, guardedErr, sid, stale, ui }
+    const runCtx: SlashRunCtx = { ...ctx, attachmentScope, flight, guarded, guardedErr, sid, stale, ui }
 
     const found = findSlashCommand(parsed.name)
 
@@ -67,7 +69,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
 
       if (exact) {
         if (exact.toLowerCase() !== needle) {
-          return handler(`${exact}${argTail}`)
+          return handler(`${exact}${argTail}`, attachmentScope)
         }
       } else {
         // Tiered name scoring (ported from grok-cli's slash menu): prefix
@@ -85,7 +87,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
         const matches = [...new Set(scored.filter(entry => entry.score === best).map(entry => entry.canon))]
 
         if (matches.length === 1 && matches[0]!.toLowerCase() !== needle) {
-          return handler(`${matches[0]}${argTail}`)
+          return handler(`${matches[0]}${argTail}`, attachmentScope)
         }
 
         if (matches.length > 1) {
@@ -108,7 +110,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
 
       if (d.type === 'alias') {
-        return void handler(`/${d.target}${argTail}`)
+        return void handler(`/${d.target}${argTail}`, attachmentScope)
       }
 
       // A skill/bundle dispatch's `message` is the expanded skill body —

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -367,11 +367,18 @@ export interface ComposerPasteResult {
 
 export type MaybePromise<T> = Promise<T> | T
 
+export interface AttachmentDraftScope {
+  draftVersion: number
+  sid: string
+}
+
 export interface ComposerActions {
   /** Pull an image off the system clipboard in as a token. */
-  attachClipboardImage: () => void
+  attachClipboardImage: (scope?: AttachmentDraftScope) => void
   /** Attach an image by path in as a token. */
-  attachImagePath: (path: string) => void
+  attachImagePath: (path: string, scope?: AttachmentDraftScope) => void
+  /** Open the synchronous slash-dispatch window paired with the next clear. */
+  beginSlashClear: () => AttachmentDraftScope | null
   clearIn: () => void
   dequeue: () => string | undefined
   enqueue: (text: string, display?: string) => void
@@ -505,8 +512,8 @@ export interface GatewayEventHandlerContext {
 
 export interface SlashHandlerContext {
   composer: {
-    attachClipboardImage: () => void
-    attachImagePath: (path: string) => void
+    attachClipboardImage: (scope?: AttachmentDraftScope) => void
+    attachImagePath: (path: string, scope?: AttachmentDraftScope) => void
     enqueue: (text: string, display?: string) => void
     hasSelection: boolean
     openEditor: () => Promise<void>

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -440,7 +440,8 @@ export const coreCommands: SlashCommand[] = [
   {
     help: 'attach clipboard image',
     name: 'paste',
-    run: (arg, ctx) => (arg ? ctx.transcript.sys('usage: /paste') : ctx.composer.attachClipboardImage())
+    run: (arg, ctx) =>
+      arg ? ctx.transcript.sys('usage: /paste') : ctx.composer.attachClipboardImage(ctx.attachmentScope)
   },
 
   {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -191,7 +191,7 @@ export const sessionCommands: SlashCommand[] = [
   {
     help: 'attach an image',
     name: 'image',
-    run: (arg, ctx) => ctx.composer.attachImagePath(arg)
+    run: (arg, ctx) => ctx.composer.attachImagePath(arg, ctx.attachmentScope)
   },
 
   {

--- a/ui-tui/src/app/slash/types.ts
+++ b/ui-tui/src/app/slash/types.ts
@@ -1,8 +1,9 @@
 import type { MutableRefObject } from 'react'
 
-import type { SlashHandlerContext, UiState } from '../interfaces.js'
+import type { AttachmentDraftScope, SlashHandlerContext, UiState } from '../interfaces.js'
 
 export interface SlashRunCtx extends SlashHandlerContext {
+  attachmentScope?: AttachmentDraftScope
   flight: number
   guarded: <T>(fn: (r: T) => void) => (r: null | T) => void
   guardedErr: (e: unknown) => void

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -20,6 +20,7 @@ import { isRemoteShellSession } from '../lib/terminalSetup.js'
 import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
 
 import type {
+  AttachmentDraftScope,
   ComposerPasteResult,
   ComposerToken,
   MaybePromise,
@@ -32,6 +33,54 @@ import { getUiState } from './uiStore.js'
 
 const TOKEN_MAX_COUNT = 32
 const TOKEN_MAX_TOTAL_BYTES = 4 * 1024 * 1024
+
+type ResolvedImageAttachment = (ClipboardPasteResponse | ImageAttachResponse) & { path: string }
+
+interface ComposerSnapshot {
+  draftVersion: number
+  sid: null | string
+  value: string
+}
+
+export const advanceDraftVersion = (current: number, preserveCurrentDraft: boolean): number =>
+  preserveCurrentDraft ? current : current + 1
+
+export const isAttachmentScopeCurrent = (
+  scope: AttachmentDraftScope | undefined,
+  draftVersion: number,
+  sid: string
+): boolean => !scope || (scope.draftVersion === draftVersion && scope.sid === sid)
+
+export const createSlashClearTracker = () => {
+  let pendingScope: AttachmentDraftScope | null = null
+  let preserve = false
+
+  return {
+    begin: (draftVersion: number, sid: string): AttachmentDraftScope => {
+      pendingScope = { draftVersion, sid }
+      preserve = false
+
+      return pendingScope
+    },
+    clear: (draftVersion: number) => {
+      const next = advanceDraftVersion(draftVersion, pendingScope !== null && preserve)
+
+      if (pendingScope) {
+        pendingScope.draftVersion = next
+      }
+
+      pendingScope = null
+      preserve = false
+
+      return next
+    },
+    markAttachment: (scope: AttachmentDraftScope) => {
+      if (pendingScope === scope) {
+        preserve = true
+      }
+    }
+  }
+}
 
 const trimTokens = (tokens: ComposerToken[]): ComposerToken[] => {
   let total = 0
@@ -105,6 +154,44 @@ export function looksLikeDroppedPath(text: string): boolean {
   return false
 }
 
+/** Resolve a slash-command attachment only while its originating draft remains active. */
+export async function resolveSlashAttachment<T extends ResolvedImageAttachment>(
+  request: () => Promise<T | null>,
+  readCurrentComposer: () => ComposerSnapshot,
+  expectedDraftVersion: number,
+  expectedSid: string,
+  attach: (
+    attached: T,
+    value: string,
+    cursor: number
+  ) => ComposerPasteResult,
+  discard: (attached: T) => void,
+  apply: (value: string) => void
+): Promise<ComposerPasteResult | null> {
+  const attached = await request()
+
+  if (!attached) {
+    return null
+  }
+
+  const current = readCurrentComposer()
+
+  if (current.draftVersion !== expectedDraftVersion || current.sid !== expectedSid) {
+    discard(attached)
+
+    return null
+  }
+
+  const next = attach(attached, current.value, current.value.length)
+
+  // Keep this write in the same request-resolution continuation as the live
+  // composer read above. A later microtask may resolve another attachment and
+  // must observe this value instead of computing from the same stale draft.
+  apply(next.value)
+
+  return next
+}
+
 export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions): UseComposerStateResult {
   const [input, setInputState] = useState('')
   const [inputBuf, setInputBuf] = useState<string[]>([])
@@ -114,6 +201,12 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   // of truth for "what is in the composer right now".
   const inputRef = useRef('')
   const tokensRef = useRef<ComposerToken[]>([])
+  const draftVersionRef = useRef(0)
+  const slashClearTrackerRef = useRef<ReturnType<typeof createSlashClearTracker> | null>(null)
+
+  if (!slashClearTrackerRef.current) {
+    slashClearTrackerRef.current = createSlashClearTracker()
+  }
 
   const setInput = useCallback<StateSetter<string>>(next => {
     inputRef.current = typeof next === 'function' ? next(inputRef.current) : next
@@ -144,7 +237,15 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
   const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
 
+  const beginSlashClear = useCallback(() => {
+    const sid = getUiState().sid
+
+    return sid ? slashClearTrackerRef.current!.begin(draftVersionRef.current, sid) : null
+  }, [])
+
   const clearIn = useCallback(() => {
+    draftVersionRef.current = slashClearTrackerRef.current!.clear(draftVersionRef.current)
+
     setInput('')
     setInputBuf([])
     setComposerTokens([])
@@ -345,47 +446,93 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   )
 
   /**
-   * `/paste` and `/image` attach without a cursor of their own — the token
-   * lands at the end of whatever is currently typed.
+   * `/paste` and `/image` clear their slash text without advancing the draft
+   * generation, so a multi-image batch and text typed while RPCs are in flight
+   * stay together. A later submit/cancel does advance the generation; detach
+   * any result that resolves after that boundary instead of silently moving it
+   * into an unrelated draft.
    */
-  const appendAttachment = useCallback(
-    (attach: (value: string, cursor: number) => Promise<ComposerPasteResult | null>) => {
-      const current = inputRef.current
+  const appendSlashAttachment = useCallback(
+    (
+      sid: string,
+      request: () => Promise<ResolvedImageAttachment | null>,
+      scope?: AttachmentDraftScope
+    ) => {
+      const expectedDraftVersion = scope?.draftVersion ?? draftVersionRef.current
+      const expectedSid = scope?.sid ?? sid
 
-      void attach(current, current.length).then(next => {
-        if (next) {
-          setInput(next.value)
-        }
-      })
+      void resolveSlashAttachment(
+        request,
+        () => ({ draftVersion: draftVersionRef.current, sid: getUiState().sid, value: inputRef.current }),
+        expectedDraftVersion,
+        expectedSid,
+        attachImageToken,
+        attached => {
+          void gw.request('image.detach', { path: attached.path, session_id: sid }).catch(() => {})
+        },
+        value => setInput(value)
+      )
+        .catch((e: Error) => sys(`error: ${e.message}`))
     },
-    [setInput]
+    [attachImageToken, gw, setInput, sys]
   )
 
-  const attachClipboardImage = useCallback(
-    () => appendAttachment((value, cursor) => pasteClipboardImage(value, cursor, false)),
-    [appendAttachment, pasteClipboardImage]
-  )
+  const attachClipboardImage = useCallback((scope?: AttachmentDraftScope) => {
+    const sid = getUiState().sid
+
+    if (!sid) {
+      return
+    }
+
+    if (!isAttachmentScopeCurrent(scope, draftVersionRef.current, sid)) {
+      return
+    }
+
+    if (scope) {
+      slashClearTrackerRef.current!.markAttachment(scope)
+    }
+
+    appendSlashAttachment(sid, async () => {
+      const attached = await gw
+        .request<ClipboardPasteResponse & { path?: string }>('clipboard.paste', { session_id: sid })
+        .catch(() => null)
+
+      if (!attached?.attached || !attached.path) {
+        sys(attached?.message || 'No image found in clipboard')
+
+        return null
+      }
+
+      return { ...attached, path: attached.path }
+    }, scope)
+  }, [appendSlashAttachment, gw, sys])
 
   const attachImagePath = useCallback(
-    (path: string) =>
-      appendAttachment(async (value, cursor) => {
-        const sid = getUiState().sid
+    (path: string, scope?: AttachmentDraftScope) => {
+      const sid = getUiState().sid
 
-        if (!sid || !path.trim()) {
-          return null
-        }
+      if (!sid || !path.trim()) {
+        return
+      }
 
-        const attached = await gw
-          .request<ImageAttachResponse & { path?: string }>('image.attach', { path, session_id: sid })
-          .catch((e: Error) => {
-            sys(`error: ${e.message}`)
+      if (!isAttachmentScopeCurrent(scope, draftVersionRef.current, sid)) {
+        return
+      }
 
-            return null
-          })
+      if (scope) {
+        slashClearTrackerRef.current!.markAttachment(scope)
+      }
 
-        return attached?.name ? attachImageToken(attached, value, cursor) : null
-      }),
-    [appendAttachment, attachImageToken, gw, sys]
+      appendSlashAttachment(sid, async () => {
+        const attached = await gw.request<ImageAttachResponse & { path?: string }>('image.attach', {
+          path,
+          session_id: sid
+        })
+
+        return attached?.name && attached.path ? { ...attached, path: attached.path } : null
+      }, scope)
+    },
+    [appendSlashAttachment, gw]
   )
 
   const openEditor = useCallback(async () => {
@@ -424,6 +571,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     () => ({
       attachClipboardImage,
       attachImagePath,
+      beginSlashClear,
       clearIn,
       dequeue,
       enqueue,
@@ -444,6 +592,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     [
       attachClipboardImage,
       attachImagePath,
+      beginSlashClear,
       clearIn,
       dequeue,
       enqueue,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -50,7 +50,12 @@ import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
-import { type GatewayRpc, type StateSetter, type TranscriptRow } from './interfaces.js'
+import {
+  type AttachmentDraftScope,
+  type GatewayRpc,
+  type StateSetter,
+  type TranscriptRow
+} from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
@@ -225,7 +230,7 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const slashFlightRef = useRef(0)
-  const slashRef = useRef<(cmd: string) => boolean>(() => false)
+  const slashRef = useRef<(cmd: string, attachmentScope?: AttachmentDraftScope) => boolean>(() => false)
   const colsRef = useRef(cols)
   const scrollRef = useRef<null | ScrollBoxHandle>(null)
   const onEventRef = useRef<(ev: GatewayEvent) => void>(() => {})

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -10,7 +10,7 @@ import { asRpcResult } from '../lib/rpc.js'
 import { hasInterpolation, INTERPOLATION_RE } from '../protocol/interpolation.js'
 import type { Msg } from '../types.js'
 
-import type { ComposerActions, ComposerRefs, ComposerState, ComposerToken } from './interfaces.js'
+import type { AttachmentDraftScope, ComposerActions, ComposerRefs, ComposerState, ComposerToken } from './interfaces.js'
 import { submitPrompt } from './submissionCore.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -253,7 +253,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
           composerActions.enqueue(queued.text, queued.display)
           sys(`queued: "${queued.display.slice(0, 50)}${queued.display.length > 50 ? '…' : ''}"`)
         } else {
-          slashRef.current(full)
+          const attachmentScope = composerActions.beginSlashClear()
+
+          slashRef.current(full, attachmentScope ?? undefined)
         }
 
         composerActions.clearIn()
@@ -394,7 +396,7 @@ export interface UseSubmissionOptions {
   composerState: ComposerState
   gw: GatewayClient
   setLastUserMsg: (value: string) => void
-  slashRef: MutableRefObject<(cmd: string) => boolean>
+  slashRef: MutableRefObject<(cmd: string, attachmentScope?: AttachmentDraftScope) => boolean>
   submitRef: MutableRefObject<(value: string) => void>
   sys: (text: string) => void
 }


### PR DESCRIPTION
## Summary

Follow-up for NousResearch/hermes-agent#86008: slash-driven image attachments now stay tied to the draft and session that launched them, so late `/image` or `/paste` completions cannot attach invisible media to a later prompt. Alias and fuzzy-dispatch paths carry the same attachment scope as the canonical command, stale completions detach their uploaded image, and concurrent image completions update the composer atomically so tokens and gateway state stay in sync.

The branch has been cleaned up onto current `main` as a single upstream-ready remediation commit. The original dashboard PTY helper diff is not included because current `main` already sends the command and Return as separate frames; the remaining change is the TUI draft/session scoping needed to make first-submit image attachment safe.

## Verification

- `ui-tui`: `npm test -- --maxWorkers=2` — 159 files / 1727 tests passed
- `ui-tui`: `npm run typecheck` — passed
- `ui-tui`: `npm run lint` — 0 errors, 2 existing warnings
- `ui-tui`: `npm run build` — passed
- `ui-tui`: focused attachment/slash regressions — 104 tests passed
- `git diff --check origin/main...HEAD` — passed

Note: an initial unconstrained local `npm run check` run hit unrelated timing-sensitive UI tests under load; rerunning the failing tests alone and the full suite with `--maxWorkers=2` passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenAI_Codex_gpt--5.5](https://img.shields.io/badge/OpenAI_Codex_gpt--5.5-000000)