### PR TITLE
optional-mcps: add Cliphi (remote MCP, OAuth 2.1 + DCR)

### DIFF
--- a/optional-mcps/cliphi/manifest.yaml
+++ b/optional-mcps/cliphi/manifest.yaml
@@ -1,0 +1,46 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: cliphi
+description: >-
+  Turn your long videos into ready-to-post vertical clips with captions
+  via https://www.cliphi.com/api/mcp (OAuth).
+source: https://www.cliphi.com/docs
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Native OAuth 2.1 + Dynamic Client Registration
+# (verified live: RFC 9728 protected-resource metadata -> AS metadata with
+# registration_endpoint and code_challenge_methods_supported: S256);
+# Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE, token
+# exchange, and refresh. Registration is open — no client_name allowlist —
+# so no provider-specific defaults are needed.
+transport:
+  type: http
+  url: https://www.cliphi.com/api/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - cliphi
+    - clips
+    - shorts
+  hosts:
+    - cliphi.com
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with Cliphi
+  (or run `hermes mcp login cliphi`). Approve access, then restart the
+  session so tools load.
+
+  Try it before connecting anything — the free get_demo tool returns a
+  real finished job with live preview pages.
+
+  Prompt with a link to your own video:
+    make clips from my talk: https://www.youtube.com/watch?v=<id>
+
+  Previews are free. Only the moments you pick get rendered, and each
+  render reports its exact credit cost before you keep it.


### PR DESCRIPTION
Adds `optional-mcps/cliphi/manifest.yaml` — Cliphi's official vendor-hosted remote MCP.

Cliphi turns a long video into ready-to-post vertical clips with captions: it finds the strongest moments, scores them, and renders vertical cuts with captions and the user's saved branding. Previews are free; only the moments the user picks get rendered, and every render reports its exact credit cost before it is kept.

**Shape matches the existing `canva` / `figma` entries:** URL-only remote MCP, so Hermes never spawns a local process.

**OAuth 2.1 + DCR, verified live** — the same chain cited in the `canva` entry:

```
GET /api/mcp/.well-known/oauth-protected-resource/api/mcp
  -> {"resource":"https://www.cliphi.com/api/mcp",
      "authorization_servers":["https://www.cliphi.com/api/mcp"],
      "scopes_supported":["clips"]}

GET /.well-known/oauth-authorization-server/api/mcp
  -> registration_endpoint: https://www.cliphi.com/api/mcp/register
     code_challenge_methods_supported: ["S256"]
     grant_types_supported: ["authorization_code","refresh_token"]
     revocation_endpoint: https://www.cliphi.com/api/mcp/revoke
```

Registration is open — no `client_name` allowlist — so unlike the Figma entry this needs no provider-specific defaults in `apply_oauth_provider_defaults`. `mcp_oauth_manager` handles discovery, PKCE, token exchange, and refresh unmodified.

**Validation:** parsed with this repo's own `hermes_cli.mcp_catalog._parse_manifest` before submitting — accepted, with `transport.type=http`, `auth.type=oauth`, and the `suggest`/`post_install` blocks resolving as expected.

**Try it without connecting anything:** the free `get_demo` tool returns a real finished job with live preview pages, so the entry can be reviewed end to end without an account.

Docs: https://www.cliphi.com/docs
