### PR TITLE
fix(gateway): write loop heartbeat off the event loop

### DIFF
--- a/contributors/emails/rafael@amora.com.br
+++ b/contributors/emails/rafael@amora.com.br
@@ -1,0 +1,2 @@
+rtcopenclawgh
+# RTC-260 heartbeat off-loop

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2690,8 +2690,8 @@ from gateway.shutdown_watchdog import (
     DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
     _arm_loop_floor_timer,
     arm_shutdown_watchdog,
-    loop_heartbeat_forever,
     resolve_shutdown_watchdog_delay,
+    start_loop_heartbeat,
     start_loop_liveness_watchdog,
 )
 from gateway.restart import (
@@ -6843,7 +6843,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Loop-liveness heartbeat / watchdog handles (#66892, #69089). Class-level
     # defaults so partial construction in tests doesn't blow up on access; the
     # real values are set in __init__ / start() / stop().
-    _loop_heartbeat_task: Optional["asyncio.Task"] = None
+    _loop_heartbeat_task: Optional[Any] = None
     _loop_floor_timer_handle: Optional[Any] = None
     _loop_liveness_watchdog: Optional[Any] = None
     _gateway_started_at: float = 0.0
@@ -7256,11 +7256,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
 
-        # Event-loop liveness heartbeat (#66892): rewritten every 30s while
-        # the loop is dispatching. External supervisors use the file mtime /
-        # updated_at to distinguish "process alive" from "loop frozen".
+        # Event-loop liveness heartbeat (#66892 / RTC-260): rewritten off-loop
+        # every 30s, gated by a loop tick. External supervisors use the file
+        # mtime / updated_at to distinguish "process alive" from "loop frozen".
         self._gateway_started_at: float = time.time()
-        self._loop_heartbeat_task: Optional[asyncio.Task] = None
+        self._loop_heartbeat_task = None
         self._loop_floor_timer_handle = None
         self._loop_liveness_watchdog = None
 
@@ -12539,7 +12539,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 watchdog.stop()
             except Exception:
-                logger.debug("Failed to stop gateway loop liveness watchdog", exc_info=True)
+                logger.debug("Failed to stop loop liveness watchdog", exc_info=True)
+        heartbeat = getattr(self, "_loop_heartbeat_task", None)
+        self._loop_heartbeat_task = None
+        if heartbeat is not None:
+            stop = getattr(heartbeat, "stop", None)
+            if callable(stop):
+                try:
+                    stop()
+                except Exception:
+                    logger.debug("Failed to stop loop heartbeat writer", exc_info=True)
 
         floor_timer = getattr(self, "_loop_floor_timer_handle", None)
         self._loop_floor_timer_handle = None
@@ -12581,32 +12590,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return exact, fallback
 
     def _start_loop_heartbeat_task(self) -> None:
-        """Start the loop-liveness heartbeat task (#66892), idempotent.
+        """Arm the off-loop heartbeat writer, gated by a loop tick.
 
-        An asyncio task so a frozen loop stops refreshing
-        ``state/gateway.heartbeat``. Cancelled with the other background
-        tasks during stop(). Best-effort — a liveness probe must never be
-        able to abort startup.
+        The write never runs on the gateway loop (a slow fsync cannot stall
+        it and trip the watchdog). A frozen loop stops ticks, so the file
+        goes stale for CLI probes. The writer is a daemon thread, not an
+        asyncio task, so it cannot pin scale-to-zero idle.
         """
         try:
-            _existing_hb = getattr(self, "_loop_heartbeat_task", None)
-            if _existing_hb is not None and not _existing_hb.done():
+            existing = getattr(self, "_loop_heartbeat_task", None)
+            if existing is not None and getattr(existing, "is_alive", lambda: False)():
                 return
-            self._loop_heartbeat_task = asyncio.create_task(
-                loop_heartbeat_forever(
-                    interval_s=DEFAULT_HEARTBEAT_INTERVAL_S,
-                    start_time=getattr(self, "_gateway_started_at", 0.0),
-                )
+            loop = asyncio.get_running_loop()
+            self._loop_heartbeat_task = start_loop_heartbeat(
+                loop,
+                interval_s=DEFAULT_HEARTBEAT_INTERVAL_S,
+                start_time=getattr(self, "_gateway_started_at", 0.0) or None,
             )
-            # PERMANENT for the process lifetime, same as a
-            # _spawn_supervised watcher — tag it so
-            # _scale_to_zero_has_live_background_work() doesn't treat an
-            # armed, otherwise-idle gateway as busy forever.
-            self._loop_heartbeat_task._hermes_supervised_watcher = True  # type: ignore[attr-defined]
-            _bg = getattr(self, "_background_tasks", None)
-            if _bg is not None:
-                _bg.add(self._loop_heartbeat_task)
-                self._loop_heartbeat_task.add_done_callback(_bg.discard)
         except Exception:
             logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
 

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -55,6 +55,8 @@ DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
 # for genuine wedges. Deployments with legitimately slow loops can tune via
 # gateway.loop_watchdog_* in config.yaml.
 DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
+DEFAULT_HEARTBEAT_TICK_TIMEOUT_S = 2.0
+DEFAULT_HEARTBEAT_STALE_AFTER_S = 90.0
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 
@@ -175,6 +177,21 @@ def start_loop_liveness_watchdog(
 
             if stop_event.is_set():
                 return
+            # Second witness: a fresh off-loop heartbeat means the loop still
+            # ticked recently enough to schedule a write. Do not hard-exit 75
+            # on a lone probe miss.
+            if _heartbeat_is_fresh():
+                try:
+                    logger.error(
+                        "Gateway event loop missed %d consecutive liveness "
+                        "probes, but heartbeat is still fresh; holding exit %d",
+                        strikes,
+                        exit_code,
+                    )
+                except Exception:
+                    pass
+                strikes = max(strikes_limit - 1, 0)
+                continue
             try:
                 logger.critical(
                     "Gateway event loop missed %d consecutive liveness probes; "
@@ -227,6 +244,24 @@ def get_loop_heartbeat_path(home: Optional[Path] = None) -> Path:
     """Return ``<HERMES_HOME>/state/gateway.heartbeat``."""
     base = home if home is not None else _process_hermes_home()
     return base.joinpath(*_HEARTBEAT_RELATIVE)
+
+
+def _heartbeat_is_fresh(
+    *,
+    home: Optional[Path] = None,
+    stale_after: float = DEFAULT_HEARTBEAT_STALE_AFTER_S,
+) -> bool:
+    """True when the heartbeat file exists and is newer than ``stale_after``."""
+    path = get_loop_heartbeat_path(home)
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return False
+    try:
+        budget = max(float(stale_after), 0.0)
+    except (TypeError, ValueError):
+        budget = DEFAULT_HEARTBEAT_STALE_AFTER_S
+    return age <= budget
 
 
 def get_shutdown_watchdog_dump_path(home: Optional[Path] = None) -> Path:
@@ -441,18 +476,17 @@ async def loop_heartbeat_forever(
     home: Optional[Path] = None,
     should_continue: Optional[Callable[[], bool]] = None,
 ) -> None:
-    """Rewrite the loop heartbeat file on a cadence until cancelled / gated off.
+    """Legacy on-loop writer. Production uses :func:`start_loop_heartbeat`.
 
-    Runs as an asyncio task on the gateway loop — if the loop freezes, this
-    task stops and the file mtime/updated_at goes stale for external monitors.
+    Kept so older tests and out-of-tree callers still import a stable name.
+    Writing the heartbeat on the loop can stall the loop it monitors; do not
+    arm this from GatewayRunner.
     """
     try:
         interval = max(float(interval_s), 1.0)
     except (TypeError, ValueError):
         interval = DEFAULT_HEARTBEAT_INTERVAL_S
 
-    # Immediate first write so monitors see a fresh file as soon as the
-    # gateway is running, not after the first interval.
     write_loop_heartbeat(start_time=start_time, home=home)
     while True:
         if should_continue is not None and not should_continue():
@@ -461,3 +495,79 @@ async def loop_heartbeat_forever(
         if should_continue is not None and not should_continue():
             return
         write_loop_heartbeat(start_time=start_time, home=home)
+
+
+class LoopHeartbeatHandle:
+    """Stoppable owner for the off-loop heartbeat writer thread."""
+
+    def __init__(self, thread: threading.Thread, stop_event: threading.Event):
+        self._thread = thread
+        self._stop_event = stop_event
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self._thread.join(timeout)
+
+    def done(self) -> bool:
+        return not self.is_alive()
+
+    def cancel(self) -> None:
+        self.stop()
+
+
+def start_loop_heartbeat(
+    loop: asyncio.AbstractEventLoop,
+    *,
+    interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+    start_time: Optional[float] = None,
+    home: Optional[Path] = None,
+    tick_timeout_s: float = DEFAULT_HEARTBEAT_TICK_TIMEOUT_S,
+) -> LoopHeartbeatHandle:
+    """Write the heartbeat off-loop, gated by a loop tick.
+
+    A frozen loop stops ticks, so the file goes stale for CLI probes. The
+    write itself never runs on the loop, so a slow disk cannot stall the
+    loop and trip the watchdog.
+    """
+    try:
+        interval = max(float(interval_s), 0.01)
+    except (TypeError, ValueError):
+        interval = DEFAULT_HEARTBEAT_INTERVAL_S
+    try:
+        tick_timeout = max(float(tick_timeout_s), 0.01)
+    except (TypeError, ValueError):
+        tick_timeout = DEFAULT_HEARTBEAT_TICK_TIMEOUT_S
+    started = time.time() if start_time is None else start_time
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.is_set():
+            tick = threading.Event()
+            try:
+                loop.call_soon_threadsafe(tick.set)
+            except RuntimeError:
+                return
+            except Exception:
+                logger.debug("Failed to schedule loop heartbeat tick", exc_info=True)
+                if stop_event.wait(timeout=interval):
+                    return
+                continue
+            if not tick.wait(timeout=tick_timeout):
+                if stop_event.wait(timeout=interval):
+                    return
+                continue
+            try:
+                write_loop_heartbeat(start_time=started, home=home)
+            except Exception:
+                logger.debug("Failed to write loop heartbeat", exc_info=True)
+            if stop_event.wait(timeout=interval):
+                return
+
+    thread = threading.Thread(target=_run, name="hermes-loop-heartbeat", daemon=True)
+    thread.start()
+    return LoopHeartbeatHandle(thread, stop_event)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -388,21 +388,15 @@ GATEWAY_LOOP_UNKNOWN = "unknown"
 # Heartbeat cadence is 30s (gateway.shutdown_watchdog.DEFAULT_HEARTBEAT_INTERVAL_S).
 # Three missed beats is decisive without false-positiving on one slow write.
 DEFAULT_LOOP_LIVENESS_STALE_AFTER_S = 90.0
+DEFAULT_LOOP_LIVENESS_CONFIRM_S = 1.0
 
 
-def probe_gateway_loop_liveness(
+def _classify_loop_heartbeat(
     pid: int,
     *,
-    stale_after: float = DEFAULT_LOOP_LIVENESS_STALE_AFTER_S,
-    home: Path | None = None,
+    stale_after: float,
+    home: Path | None,
 ) -> str:
-    """Classify a gateway PID's event loop as alive / wedged / unknown.
-
-    Reads the loop-liveness heartbeat file the gateway rewrites every 30s
-    while its loop is dispatching.  Never raises; any ambiguity (missing
-    file, unreadable JSON, PID mismatch) returns ``GATEWAY_LOOP_UNKNOWN``
-    so callers default to the safe graceful-drain path.
-    """
     try:
         stale_budget = max(float(stale_after), 0.0)
     except (TypeError, ValueError):
@@ -417,13 +411,42 @@ def probe_gateway_loop_liveness(
     except Exception:
         return GATEWAY_LOOP_UNKNOWN
     if heartbeat_pid <= 0 or int(pid) <= 0 or heartbeat_pid != int(pid):
-        # No heartbeat for THIS process — old gateway version, still starting
-        # up, or a stale file from a previous PID.  Not evidence of a wedge.
         return GATEWAY_LOOP_UNKNOWN
     age = time.time() - mtime
     if age > stale_budget:
         return GATEWAY_LOOP_WEDGED
     return GATEWAY_LOOP_ALIVE
+
+
+def probe_gateway_loop_liveness(
+    pid: int,
+    *,
+    stale_after: float = DEFAULT_LOOP_LIVENESS_STALE_AFTER_S,
+    home: Path | None = None,
+    confirm_s: float = 0.0,
+) -> str:
+    """Classify a gateway PID's event loop as alive / wedged / unknown.
+
+    Reads the loop-liveness heartbeat file the gateway rewrites every 30s
+    while its loop is dispatching.  Never raises; any ambiguity (missing
+    file, unreadable JSON, PID mismatch) returns ``GATEWAY_LOOP_UNKNOWN``
+    so callers default to the safe graceful-drain path.
+
+    A single stale sample is not enough to escalate (exit 75 / SIGKILL).
+    Pass ``confirm_s > 0`` to re-read after a pause; only two consecutive
+    WEDGED samples confirm a dead loop.
+    """
+    status = _classify_loop_heartbeat(pid, stale_after=stale_after, home=home)
+    if status != GATEWAY_LOOP_WEDGED:
+        return status
+    try:
+        confirm = max(float(confirm_s), 0.0)
+    except (TypeError, ValueError):
+        confirm = 0.0
+    if confirm <= 0:
+        return GATEWAY_LOOP_WEDGED
+    time.sleep(confirm)
+    return _classify_loop_heartbeat(pid, stale_after=stale_after, home=home)
 
 
 def _escalate_wedged_gateway(
@@ -4146,7 +4169,7 @@ def systemd_restart(system: bool = False):
     from gateway.status import get_running_pid
 
     pid = get_running_pid() or _systemd_main_pid(system=system)
-    if pid is not None and probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+    if pid is not None and probe_gateway_loop_liveness(pid, confirm_s=DEFAULT_LOOP_LIVENESS_CONFIRM_S) == GATEWAY_LOOP_WEDGED:
         # Health probe says the event loop is provably dead (#81642): SIGUSR1
         # can never drain it, so the graceful wait below would burn the full
         # budget. Bounded escalation (SIGTERM grace → SIGKILL, ~10s) then let
@@ -5385,7 +5408,7 @@ def launchd_restart():
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
             return
-        if pid is not None and probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+        if pid is not None and probe_gateway_loop_liveness(pid, confirm_s=DEFAULT_LOOP_LIVENESS_CONFIRM_S) == GATEWAY_LOOP_WEDGED:
             # Health probe says the event loop is provably dead (#81642):
             # the gateway cannot process a graceful shutdown, so waiting the
             # full drain budget only stalls the restart (and `hermes update`

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7946,13 +7946,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         _graceful_ok = False
                         if _main_pid > 0:
                             from hermes_cli.gateway import (
+                                DEFAULT_LOOP_LIVENESS_CONFIRM_S,
                                 GATEWAY_LOOP_WEDGED,
                                 _escalate_wedged_gateway,
                                 probe_gateway_loop_liveness,
                             )
 
                             if (
-                                probe_gateway_loop_liveness(_main_pid)
+                                probe_gateway_loop_liveness(
+                                    _main_pid, confirm_s=DEFAULT_LOOP_LIVENESS_CONFIRM_S
+                                )
                                 == GATEWAY_LOOP_WEDGED
                             ):
                                 # Loop-liveness probe says the gateway's event
@@ -8248,12 +8251,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     f"(up to {int(_drain_budget)}s)..."
                 )
                 from hermes_cli.gateway import (
+                    DEFAULT_LOOP_LIVENESS_CONFIRM_S,
                     GATEWAY_LOOP_WEDGED,
                     _escalate_wedged_gateway,
                     probe_gateway_loop_liveness,
                 )
 
-                if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+                if probe_gateway_loop_liveness(
+                    pid, confirm_s=DEFAULT_LOOP_LIVENESS_CONFIRM_S
+                ) == GATEWAY_LOOP_WEDGED:
                     # Loop-liveness probe: this gateway's event loop is
                     # provably dead (#81642) — SIGUSR1/SIGTERM shutdown can
                     # never run, so the drain wait would burn the full budget

--- a/tests/gateway/test_loop_heartbeat_off_loop.py
+++ b/tests/gateway/test_loop_heartbeat_off_loop.py
@@ -1,0 +1,189 @@
+"""Off-loop heartbeat write + two-witness confirmation before exit 75.
+
+The on-loop asyncio heartbeat can stall the loop it is supposed to monitor
+(atomic JSON write / fsync). Production must write the file from a thread
+gated by a loop tick, and must not hard-exit until a second witness agrees
+the loop is dead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+from gateway.shutdown_watchdog import (
+    get_loop_heartbeat_path,
+    start_loop_heartbeat,
+    start_loop_liveness_watchdog,
+    write_loop_heartbeat,
+)
+
+
+def _write_heartbeat(home, pid, age_s=0.0):
+    path = get_loop_heartbeat_path(home)
+    write_loop_heartbeat(pid=pid, home=home)
+    if age_s:
+        stamp = time.time() - age_s
+        os.utime(path, (stamp, stamp))
+    return path
+
+
+def test_off_loop_heartbeat_refreshes_while_loop_runs(tmp_path):
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    handle = None
+    try:
+        handle = start_loop_heartbeat(
+            loop,
+            interval_s=0.05,
+            tick_timeout_s=0.5,
+            home=tmp_path,
+            start_time=time.time(),
+        )
+        path = get_loop_heartbeat_path(tmp_path)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not path.is_file():
+            time.sleep(0.02)
+        assert path.is_file(), "heartbeat was never written"
+        first = path.stat().st_mtime
+        deadline = time.time() + 2.0
+        while time.time() < deadline and path.stat().st_mtime <= first:
+            time.sleep(0.02)
+        assert path.stat().st_mtime > first
+        writer_names = {t.name for t in threading.enumerate()}
+        assert "hermes-loop-heartbeat" in writer_names
+    finally:
+        if handle is not None:
+            handle.stop()
+            handle.join(timeout=1.0)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_frozen_loop_does_not_refresh_heartbeat(tmp_path):
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+    def never_run(callback):
+        return None
+
+    loop.call_soon_threadsafe.side_effect = never_run
+    handle = start_loop_heartbeat(
+        loop,
+        interval_s=0.05,
+        tick_timeout_s=0.05,
+        home=tmp_path,
+        start_time=time.time(),
+    )
+    try:
+        time.sleep(0.2)
+        assert not get_loop_heartbeat_path(tmp_path).exists()
+    finally:
+        handle.stop()
+        handle.join(timeout=1.0)
+
+
+def test_slow_heartbeat_write_does_not_block_loop(tmp_path):
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    progressed = threading.Event()
+    handle = None
+
+    def slow_write(**kwargs):
+        time.sleep(0.3)
+        return write_loop_heartbeat(**kwargs)
+
+    try:
+        with patch("gateway.shutdown_watchdog.write_loop_heartbeat", side_effect=slow_write):
+            handle = start_loop_heartbeat(
+                loop,
+                interval_s=0.05,
+                tick_timeout_s=0.5,
+                home=tmp_path,
+                start_time=time.time(),
+            )
+            loop.call_soon_threadsafe(progressed.set)
+            assert progressed.wait(timeout=0.2), "loop blocked by heartbeat write"
+    finally:
+        if handle is not None:
+            handle.stop()
+            handle.join(timeout=1.0)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_probe_requires_two_stale_samples_before_wedged(tmp_path, monkeypatch):
+    _write_heartbeat(tmp_path, pid=4242, age_s=600.0)
+
+    def refresh(_seconds):
+        _write_heartbeat(tmp_path, pid=4242, age_s=0.0)
+
+    monkeypatch.setattr(gateway_cli.time, "sleep", refresh)
+    assert (
+        gateway_cli.probe_gateway_loop_liveness(4242, home=tmp_path, confirm_s=1.0)
+        == gateway_cli.GATEWAY_LOOP_ALIVE
+    )
+
+
+def test_probe_two_stale_samples_are_wedged(tmp_path, monkeypatch):
+    _write_heartbeat(tmp_path, pid=4242, age_s=600.0)
+    monkeypatch.setattr(gateway_cli.time, "sleep", lambda _seconds: None)
+    assert (
+        gateway_cli.probe_gateway_loop_liveness(4242, home=tmp_path, confirm_s=1.0)
+        == gateway_cli.GATEWAY_LOOP_WEDGED
+    )
+
+
+def test_watchdog_holds_exit_75_when_heartbeat_is_fresh(tmp_path):
+    write_loop_heartbeat(pid=os.getpid(), home=tmp_path)
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    loop.call_soon_threadsafe.side_effect = lambda _cb: None
+    with (
+        patch("gateway.shutdown_watchdog.get_loop_heartbeat_path", return_value=get_loop_heartbeat_path(tmp_path)),
+        patch("gateway.shutdown_watchdog.os._exit") as hard_exit,
+        patch("gateway.shutdown_watchdog.logger.critical"),
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback"),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        time.sleep(0.15)
+        handle.stop()
+        handle.join(timeout=1.0)
+    hard_exit.assert_not_called()
+
+
+def test_watchdog_exits_75_when_probe_and_heartbeat_agree_loop_is_dead(tmp_path):
+    path = _write_heartbeat(tmp_path, pid=os.getpid(), age_s=600.0)
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    loop.call_soon_threadsafe.side_effect = lambda _cb: None
+    exit_codes = []
+    fired = threading.Event()
+
+    def fake_exit(code):
+        if not fired.is_set():
+            exit_codes.append(code)
+            fired.set()
+
+    with (
+        patch("gateway.shutdown_watchdog.get_loop_heartbeat_path", return_value=path),
+        patch("gateway.shutdown_watchdog.os._exit", side_effect=fake_exit),
+        patch("gateway.shutdown_watchdog.logger.critical"),
+        patch("gateway.shutdown_watchdog.faulthandler.dump_traceback"),
+    ):
+        handle = start_loop_liveness_watchdog(
+            loop, probe_interval=0.01, probe_timeout=0.01, max_strikes=1
+        )
+        assert fired.wait(timeout=2.0), "watchdog did not hard-exit"
+        handle.stop()
+        handle.join(timeout=1.0)
+    assert exit_codes == [75]

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -374,12 +374,9 @@ async def test_done_supervised_watcher_is_ignored_either_way():
 
 # ── permanent tasks spawned OUTSIDE _spawn_supervised must also be tagged ──
 #
-# _loop_heartbeat_task and _heartbeat_poll_task are both infinite while-True
-# loops added to _background_tasks via plain asyncio.create_task() + manual
-# add(), NOT through _spawn_supervised — so they were untagged and defeated
-# the fix above: _loop_heartbeat_task starts unconditionally on every
-# gateway boot (start()), which would make the busy check return True
-# forever regardless of the _spawn_supervised fix, on every armed instance.
+# _loop_heartbeat_task is an off-loop daemon thread (RTC-260), not an
+# asyncio task, so it cannot pin scale-to-zero idle. Keep this test so a
+# regression that puts the writer back on `_background_tasks` is caught.
 
 
 @pytest.mark.asyncio
@@ -391,12 +388,13 @@ async def test_loop_heartbeat_task_does_not_block_idle():
     r._gateway_started_at = time.time()
 
     r._start_loop_heartbeat_task()
-    await asyncio.sleep(0)  # let the task start
     try:
         assert r._scale_to_zero_has_live_background_work() is False
     finally:
-        r._loop_heartbeat_task.cancel()
-        await asyncio.gather(r._loop_heartbeat_task, return_exceptions=True)
+        handle = r._loop_heartbeat_task
+        if handle is not None:
+            handle.stop()
+            handle.join(timeout=1.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The watchdog's heartbeat write used call_soon_threadsafe on the loop it was monitoring, so a wedged loop could look alive — and a single missed probe could SIGKILL a healthy gateway (exit 75).

Move the writer to a daemon thread gated by a loop tick, require a second stale sample plus a dead heartbeat before exit 75, and give hermes gateway status a 1s confirmation window.

Related: #66892 #92315

Agent: roger
Task: RTC-260
Runner: Mac mini

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

