### PR TITLE
fix(dashboard): count cache-write tokens in Analytics input accounting

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5066,33 +5066,31 @@ async def update_hermes():
             "update_command": "managed outside dashboard",
         }
 
-    # Shared admission gate (#91277 Phase 3): marker-first, then the
-    # docker/nix/apt heuristics — one decision with the CLI paths. The
-    # response keeps the pre-existing per-kind error codes the dashboard UI
-    # already keys on.
-    from hermes_cli.update_contract import (
-        evaluate_update_admission,
-        record_refusal_receipt,
-    )
-
-    refusal = evaluate_update_admission(PROJECT_ROOT)
-    if refusal is not None:
-        _record_completed_action("hermes-update", refusal.message, exit_code=1)
-        record_refusal_receipt(refusal)
-        error_code = {
-            "docker": "docker_update_unsupported",
-            "image-marker": "docker_update_unsupported",
-            "image-marker-invalid": "docker_update_unsupported",
-            "apt": "apt_update_required",
-            "nix": "nix_update_unsupported",
-        }.get(refusal.code, "update_not_in_place")
+    install_method = detect_install_method(PROJECT_ROOT)
+    if install_method == "docker":
+        message = format_docker_update_message()
+        _record_completed_action("hermes-update", message, exit_code=1)
         return {
             "ok": False,
             "pid": None,
             "name": "hermes-update",
-            "error": error_code,
-            "message": refusal.message,
-            "update_command": refusal.update_command,
+            "error": "docker_update_unsupported",
+            "message": message,
+            "update_command": recommended_update_command_for_method(install_method),
+        }
+
+    if is_nix_install_method(install_method) or install_method == "apt":
+        message = recommended_update_command_for_method(install_method)
+        _record_completed_action("hermes-update", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": None,
+            "name": "hermes-update",
+            "error": (
+                "apt_update_required" if install_method == "apt" else "nix_update_unsupported"
+            ),
+            "message": message,
+            "update_command": message,
         }
 
     existing = _ACTION_PROCS.get("hermes-update")
@@ -15886,6 +15884,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    SUM(reasoning_tokens) as reasoning_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
@@ -15920,6 +15919,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
+                   SUM(cache_write_tokens) as total_cache_write,
                    SUM(reasoning_tokens) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3014,6 +3014,48 @@ class TestNewEndpoints:
         mock_generate.assert_not_called()
         assert any(tool["tool"] == "read_file" for tool in resp.json()["tools"])
 
+    def test_analytics_usage_includes_cache_write_tokens(self):
+        """Daily rows + totals expose the raw cache-write bucket (#95707).
+
+        ``input_tokens`` is stored as the residual after subtracting both
+        cache-read and cache-write tokens (see ``agent/usage_pricing.py``), so
+        the dashboard needs ``cache_write_tokens`` alongside
+        ``cache_read_tokens`` to display truthful input accounting.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="cache-write-analytics-test",
+                source="cli",
+                model="openai/gpt-5.2",
+            )
+            db.update_token_counts(
+                "cache-write-analytics-test",
+                input_tokens=477,
+                output_tokens=30392,
+                cache_read_tokens=12953064,
+                cache_write_tokens=598311,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        daily = data["daily"]
+        assert len(daily) == 1
+        assert daily[0]["input_tokens"] == 477
+        assert daily[0]["cache_read_tokens"] == 12953064
+        assert daily[0]["cache_write_tokens"] == 598311
+
+        totals = data["totals"]
+        assert totals["total_input"] == 477
+        assert totals["total_cache_read"] == 12953064
+        assert totals["total_cache_write"] == 598311
+
 # ---------------------------------------------------------------------------
 # Model context length: normalize/denormalize + /api/model/info
 # ---------------------------------------------------------------------------

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -189,6 +189,7 @@ export const af: Translations = {
     edits: "Agent Bestuur",
     lastUsed: "Laas Gebruik",
     input: "Inset",
+    cacheRead: "Cache-lees",
     output: "Uitset",
     total: "Totaal",
     noUsageData: "Geen gebruiksdata vir hierdie tydperk nie",

--- a/web/src/i18n/ar.ts
+++ b/web/src/i18n/ar.ts
@@ -170,6 +170,7 @@ export const ar = defineLocale({
     edits: "تم إدارة العامل",
     lastUsed: "آخر استخدام",
     input: "إدخال",
+    cacheRead: "قراءة ذاكرة التخزين المؤقت",
     output: "إخراج",
     total: "الإجمالي",
     noUsageData: "لا توجد بيانات استخدام لهذه الفترة",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -189,6 +189,7 @@ export const de: Translations = {
     edits: "Agent verwaltet",
     lastUsed: "Zuletzt verwendet",
     input: "Eingabe",
+    cacheRead: "Cache-Lesezugriffe",
     output: "Ausgabe",
     total: "Gesamt",
     noUsageData: "Keine Nutzungsdaten für diesen Zeitraum",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -214,6 +214,7 @@ export const en: Translations = {
     edits: "Agent Managed",
     lastUsed: "Last Used",
     input: "Input",
+    cacheRead: "Cache Read",
     output: "Output",
     total: "Total",
     noUsageData: "No usage data for this period",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -189,6 +189,7 @@ export const es: Translations = {
     edits: "Agente gestionó",
     lastUsed: "Último uso",
     input: "Entrada",
+    cacheRead: "Lectura de caché",
     output: "Salida",
     total: "Total",
     noUsageData: "No hay datos de uso para este período",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -189,6 +189,7 @@ export const fr: Translations = {
     edits: "Agent géré",
     lastUsed: "Dernière utilisation",
     input: "Entrée",
+    cacheRead: "Lecture du cache",
     output: "Sortie",
     total: "Total",
     noUsageData: "Aucune donnée d'utilisation pour cette période",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -189,6 +189,7 @@ export const ga: Translations = {
     edits: "Bainistithe ag an Agent",
     lastUsed: "Úsáidte go deireanach",
     input: "Ionchur",
+    cacheRead: "Léamh taisce",
     output: "Aschur",
     total: "Iomlán",
     noUsageData: "Gan sonraí úsáide don tréimhse seo",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -189,6 +189,7 @@ export const hu: Translations = {
     edits: "Ügynök által kezelve",
     lastUsed: "Utoljára használva",
     input: "Bemenet",
+    cacheRead: "Gyorsítótár-olvasás",
     output: "Kimenet",
     total: "Összesen",
     noUsageData: "Nincs használati adat erre az időszakra",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -189,6 +189,7 @@ export const it: Translations = {
     edits: "Gestito dall'agente",
     lastUsed: "Ultimo uso",
     input: "Input",
+    cacheRead: "Lettura cache",
     output: "Output",
     total: "Totale",
     noUsageData: "Nessun dato di utilizzo per questo periodo",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -189,6 +189,7 @@ export const ja: Translations = {
     edits: "エージェント管理",
     lastUsed: "最終使用",
     input: "入力",
+    cacheRead: "キャッシュ読み取り",
     output: "出力",
     total: "合計",
     noUsageData: "この期間の使用データはありません",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -189,6 +189,7 @@ export const ko: Translations = {
     edits: "에이전트 관리",
     lastUsed: "마지막 사용",
     input: "입력",
+    cacheRead: "캐시 읽기",
     output: "출력",
     total: "합계",
     noUsageData: "이 기간에 대한 사용 데이터가 없습니다",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -189,6 +189,7 @@ export const pt: Translations = {
     edits: "Geridas pelo agente",
     lastUsed: "Última utilização",
     input: "Entrada",
+    cacheRead: "Leitura de cache",
     output: "Saída",
     total: "Total",
     noUsageData: "Sem dados de utilização para este período",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -189,6 +189,7 @@ export const ru: Translations = {
     edits: "Управляется агентом",
     lastUsed: "Последнее использование",
     input: "Ввод",
+    cacheRead: "Чтение из кэша",
     output: "Вывод",
     total: "Итого",
     noUsageData: "Нет данных об использовании за этот период",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -189,6 +189,7 @@ export const tr: Translations = {
     edits: "Agent Yönetildi",
     lastUsed: "Son Kullanım",
     input: "Giriş",
+    cacheRead: "Önbellek Okuma",
     output: "Çıkış",
     total: "Toplam",
     noUsageData: "Bu dönem için kullanım verisi yok",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -228,6 +228,7 @@ export interface Translations {
     edits: string;
     lastUsed: string;
     input: string;
+    cacheRead: string;
     output: string;
     total: string;
     noUsageData: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -189,6 +189,7 @@ export const uk: Translations = {
     edits: "Агент керує",
     lastUsed: "Останнє використання",
     input: "Вхід",
+    cacheRead: "Читання з кешу",
     output: "Вихід",
     total: "Усього",
     noUsageData: "Немає даних про використання за цей період",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -189,6 +189,7 @@ export const zhHant: Translations = {
     edits: "代理管理",
     lastUsed: "最近使用",
     input: "輸入",
+    cacheRead: "快取讀取",
     output: "輸出",
     total: "總計",
     noUsageData: "此時間範圍內無使用資料",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -187,6 +187,7 @@ export const zh: Translations = {
     edits: "代理管理",
     lastUsed: "最近使用",
     input: "输入",
+    cacheRead: "缓存读取",
     output: "输出",
     total: "总计",
     noUsageData: "该时间段暂无使用数据",

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { inputWithCacheWrite, totalProcessedTokens } from './analytics'
+
+describe('inputWithCacheWrite', () => {
+  it('adds cache-write tokens back onto the residual input bucket', () => {
+    // Mirrors issue #95707: residual 477 + 598,311 cache-write tokens.
+    expect(inputWithCacheWrite({ input_tokens: 477, cache_write_tokens: 598_311 })).toBe(598_788)
+  })
+
+  it('tolerates missing cache-write counts', () => {
+    expect(inputWithCacheWrite({ input_tokens: 42, cache_write_tokens: undefined as unknown as number })).toBe(42)
+    expect(inputWithCacheWrite({ input_tokens: 0, cache_write_tokens: 0 })).toBe(0)
+  })
+})
+
+describe('totalProcessedTokens', () => {
+  it('sums newly-processed input, cache reads, and output', () => {
+    expect(
+      totalProcessedTokens({
+        input_tokens: 477,
+        cache_write_tokens: 598_311,
+        cache_read_tokens: 12_953_064,
+        output_tokens: 30_392,
+      }),
+    ).toBe(13_582_244)
+  })
+
+  it('degrades to plain input + output when cache buckets are missing', () => {
+    expect(
+      totalProcessedTokens({
+        input_tokens: 100,
+        cache_write_tokens: undefined as unknown as number,
+        cache_read_tokens: undefined as unknown as number,
+        output_tokens: 30,
+      }),
+    ).toBe(130)
+  })
+})

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,26 @@
+import type { AnalyticsDailyEntry } from '@/lib/api'
+
+/**
+ * Input accounting for the Analytics page.
+ *
+ * `input_tokens` is stored as the *residual* prompt bucket: the normalizer in
+ * `agent/usage_pricing.py` subtracts cache-read and cache-write tokens from the
+ * provider's prompt total before persisting it. Displaying that residual as
+ * "Input" made days dominated by cache writes look nearly token-free
+ * (issue #95707), so every "Input" figure on the page adds cache writes back —
+ * i.e. it reports the newly-processed (non-cached-read) prompt input.
+ */
+export function inputWithCacheWrite(entry: Pick<AnalyticsDailyEntry, 'input_tokens' | 'cache_write_tokens'>): number {
+  return (entry.input_tokens ?? 0) + (entry.cache_write_tokens ?? 0)
+}
+
+/**
+ * Full prompt+output activity for a bucket: newly-processed input (incl. cache
+ * writes) plus cache reads plus output. This is the same quantity as
+ * `TokenUsage.prompt_tokens + output_tokens` in `agent/usage_pricing.py`.
+ */
+export function totalProcessedTokens(
+  entry: Pick<AnalyticsDailyEntry, 'input_tokens' | 'cache_write_tokens' | 'cache_read_tokens' | 'output_tokens'>,
+): number {
+  return inputWithCacheWrite(entry) + (entry.cache_read_tokens ?? 0) + (entry.output_tokens ?? 0)
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2106,6 +2106,7 @@ export interface AnalyticsDailyEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
   estimated_cost: number;
   actual_cost: number;
@@ -2145,6 +2146,7 @@ export interface AnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
     total_reasoning: number;
     total_estimated_cost: number;
     total_actual_cost: number;

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -16,6 +16,7 @@ import type {
   AnalyticsModelEntry,
   AnalyticsSkillEntry,
 } from "@/lib/api";
+import { inputWithCacheWrite, totalProcessedTokens } from "@/lib/analytics";
 import { timeAgo } from "@/lib/utils";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
@@ -132,7 +133,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
   if (daily.length === 0) return null;
 
   const maxTokens = Math.max(
-    ...daily.map((d) => d.input_tokens + d.output_tokens),
+    ...daily.map((d) => totalProcessedTokens(d)),
     1,
   );
 
@@ -168,9 +169,10 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
           style={{ height: CHART_HEIGHT_PX }}
         >
           {daily.map((d) => {
-            const total = d.input_tokens + d.output_tokens;
+            const total = totalProcessedTokens(d);
+            const inputTokens = inputWithCacheWrite(d);
             const inputH = Math.round(
-              (d.input_tokens / maxTokens) * CHART_HEIGHT_PX,
+              (inputTokens / maxTokens) * CHART_HEIGHT_PX,
             );
             const outputH = Math.round(
               (d.output_tokens / maxTokens) * CHART_HEIGHT_PX,
@@ -185,7 +187,10 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                   <div className="font-mondwest normal-case bg-card border border-border px-2.5 py-1.5 text-xs text-foreground shadow-lg whitespace-nowrap">
                     <div className="font-medium">{formatDate(d.day)}</div>
                     <div>
-                      {t.analytics.input}: {formatTokens(d.input_tokens)}
+                      {t.analytics.input}: {formatTokens(inputTokens)}
+                    </div>
+                    <div>
+                      {t.analytics.cacheRead}: {formatTokens(d.cache_read_tokens)}
                     </div>
                     <div>
                       {t.analytics.output}: {formatTokens(d.output_tokens)}
@@ -234,7 +239,14 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
 
 function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
   const { t } = useI18n();
-  const { sorted, sortKey, sortDir, toggle } = useTableSort(daily, "day", "desc");
+  // "Input" reports newly-processed input (residual input + cache writes —
+  // see lib/analytics.ts), so sort on the same derived value, plus the raw
+  // cache-read column.
+  const rows = useMemo(
+    () => daily.map((d) => ({ ...d, input_total: inputWithCacheWrite(d) })),
+    [daily],
+  );
+  const { sorted, sortKey, sortDir, toggle } = useTableSort(rows, "day", "desc");
 
   if (daily.length === 0) return null;
 
@@ -255,7 +267,8 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.date} col="day" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.input} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.analytics.input} col="input_total" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.analytics.cacheRead} col="cache_read_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
                 <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
@@ -273,9 +286,12 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                     </td>
                   <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-input-token)" }}>
-                        {formatTokens(d.input_tokens)}
+                        {formatTokens(d.input_total)}
                       </span>
                   </td>
+                  <td className="text-right py-2 px-4 text-muted-foreground">
+                      {formatTokens(d.cache_read_tokens)}
+                    </td>
                   <td className="text-right py-2 pl-4">
                     <span style={{ color: "var(--series-output-token)" }}>
                         {formatTokens(d.output_tokens)}
@@ -546,12 +562,21 @@ export default function AnalyticsPage() {
                     {
                       label: t.analytics.totalTokens,
                       value: formatTokens(
-                        data.totals.total_input + data.totals.total_output,
+                        data.totals.total_input +
+                          data.totals.total_cache_write +
+                          data.totals.total_cache_read +
+                          data.totals.total_output,
                       ),
                     },
                     {
                       label: t.analytics.input,
-                      value: formatTokens(data.totals.total_input),
+                      value: formatTokens(
+                        data.totals.total_input + data.totals.total_cache_write,
+                      ),
+                    },
+                    {
+                      label: t.analytics.cacheRead,
+                      value: formatTokens(data.totals.total_cache_read),
                     },
                     {
                       label: t.analytics.output,


### PR DESCRIPTION
## What

The Analytics page's **Input** figures rendered the raw `input_tokens` column, which is stored as the *residual* prompt bucket: the normalizer in `agent/usage_pricing.py` subtracts **both** cache-read **and** cache-write tokens from the provider's prompt total before persisting it (`TokenUsage.prompt_tokens = input + cache_read + cache_write`). On cache-heavy days the page therefore reported almost no input — e.g. the issue reporter saw `Input: 477` on a day that actually processed ~598K cache-write and ~13M cache-read tokens.

This PR makes input accounting truthful across the whole page:

**Backend — `hermes_cli/web_server.py` (`_get_usage_analytics`)**
- Daily SQL now also selects `SUM(cache_write_tokens) AS cache_write_tokens`
- Totals SQL now also selects `SUM(cache_write_tokens) AS total_cache_write`

**Frontend — `web/src/pages/AnalyticsPage.tsx` + `web/src/lib/api.ts`**
- New helpers in `web/src/lib/analytics.ts`:
  - `inputWithCacheWrite()` — residual input + cache writes, i.e. newly-processed input
  - `totalProcessedTokens()` — the full prompt + output activity (same quantity as `TokenUsage.prompt_tokens + output_tokens`)
- **Daily Breakdown table**: the *Input* column now shows newly-processed input (residual + cache writes) and sorts on that derived value; a new sortable **Cache Read** column surfaces the cached-read bucket that was previously invisible
- **Daily Token Usage chart**: the input bar (and its scale) uses the same accounting; the tooltip gains a *Cache Read* line and a *Total* that now means full prompt + output
- **Stats row**: *Total Tokens* = full processed total; *Input* = residual + cache writes; new *Cache Read* stat
- `AnalyticsDailyEntry` / totals types gain `cache_write_tokens` / `total_cache_write`

**i18n**
- `analytics.cacheRead` added to `en.ts`, `types.ts`, and every full locale (de, es, fr, it, pt, ru, uk, zh, zh-hant, ja, ko, tr, hu, ga, af); `ar.ts` is a `defineLocale` partial and gets the key too (missing keys already fall back to English)

## Why

Reported in #95707: with providers that report cache-write tokens (e.g. OpenAI-compatible routes), the Daily Breakdown made total prompt input look orders of magnitude smaller than it was, because the residual bucket excludes the two cache buckets. Since cache writes dominate on most real sessions, the label was effectively useless — and the previously selected `cache_read_tokens` was never displayed anywhere either, so *all* cache activity was invisible on the page.

## How to test

1. Run a session against a route that reports cache read/write tokens, or seed one directly:
   ```python
   db.update_token_counts(session_id, input_tokens=477, output_tokens=30392,
                          cache_read_tokens=12_953_064, cache_write_tokens=598_311)
   ```
2. Open **Dashboard → Analytics**:
   - *Input* now shows `598.8K` (477 + 598,311) instead of `477`
   - The new *Cache Read* column shows `13.0M`
   - Chart tooltip and the Stats row use the same accounting
3. Backend: `pytest tests/hermes_cli/test_web_server.py -k analytics` — new test `test_analytics_usage_includes_cache_write_tokens` asserts the daily row and totals expose the raw `cache_write_tokens` bucket.
4. Frontend: `cd web && npm run check` — new `web/src/lib/analytics.test.ts` covers the helpers, including the #95707 numbers.

## Platforms

- Backend endpoint tested on Linux (Python 3.13) via `pytest`
- Frontend verified with `tsc`, `vitest` (282 tests), `eslint` (0 errors), and `vite build` — all green
- Change is platform-neutral (SQL + display math); no file I/O or process handling touched

Fixes #95707