### PR TITLE
fix: keep loopback OpenAI endpoints on chat completions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -827,6 +827,8 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
+        and agent._base_url_hostname
+        not in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
         and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
@@ -841,6 +843,19 @@ def init_agent(
         agent.api_mode = "codex_responses"
         # Invalidate the eager-warmed transport cache — api_mode changed
         # from chat_completions to codex_responses after the warm at __init__.
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
+
+    # A persisted/provider-derived codex_responses mode can reach this layer
+    # without passing through the fallback resolver.  Loopback endpoints are
+    # OpenAI-compatible local daemons and must stay on chat completions.
+    if agent.api_mode == "codex_responses" and agent._base_url_hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+    }:
+        agent.api_mode = "chat_completions"
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -736,6 +736,13 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     if mandated is not None:
         return mandated
 
+    # Local OpenAI-compatible daemons commonly identify as ``openai-api``
+    # while only implementing /v1/chat/completions.  Do not let the provider
+    # overlay force those loopback endpoints onto /v1/responses.
+    hostname = base_url_hostname(base_url)
+    if hostname in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
+        return "chat_completions"
+
     # Nous is dual-wire: anthropic/* → Messages, everything else →
     # chat_completions. The Hermes overlay still advertises openai_chat
     # (the majority of the Portal catalog), so the transport lookup below

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -175,6 +175,10 @@ def _fallback_api_mode(provider: str, base_url: str, model: str = "") -> str:
     detected = _detect_api_mode_for_url(base_url)
     if detected:
         return detected
+    # Provider overlays such as ``openai-api`` prefer the Responses API, but
+    # local OpenAI-compatible servers generally expose chat completions only.
+    if _loopback_hostname(base_url_hostname(base_url)):
+        return "chat_completions"
     from hermes_cli.providers import determine_api_mode
 
     return determine_api_mode(provider, base_url, model) or "chat_completions"

--- a/tests/hermes_cli/test_meta_prompt_cache.py
+++ b/tests/hermes_cli/test_meta_prompt_cache.py
@@ -75,6 +75,20 @@ class TestHostMandatedMetaResponses:
         # generic still chat
         assert rp._fallback_api_mode("custom", "https://generic.example.com/v1", "muse-spark-1.2") == "chat_completions"
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8000/v1",
+            "http://127.0.0.1:8003/v1",
+            "http://[::1]:8000/v1",
+            "http://0.0.0.0:8000/v1",
+        ],
+    )
+    def test_loopback_openai_api_stays_on_chat_completions(self, url):
+        model = "local-tool-model"
+        assert rp._fallback_api_mode("openai-api", url, model) == "chat_completions"
+        assert determine_api_mode("openai-api", url, model) == "chat_completions"
+
 
 class TestMetaConfigRoundtrip:
     def test_providers_meta_api_mode_roundtrip(self):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7782,7 +7782,19 @@ def _make_agent(
             if override_api_key:
                 runtime["api_key"] = override_api_key
             if override_api_mode:
-                runtime["api_mode"] = override_api_mode
+                from hermes_cli.runtime_provider import (
+                    _loopback_hostname,
+                    base_url_hostname,
+                )
+
+                effective_url = runtime.get("base_url") or override_base_url or ""
+                if (
+                    str(override_api_mode).strip().lower() == "codex_responses"
+                    and _loopback_hostname(base_url_hostname(effective_url))
+                ):
+                    runtime["api_mode"] = "chat_completions"
+                else:
+                    runtime["api_mode"] = override_api_mode
     else:
         model, requested_provider = _resolve_startup_runtime()
         if isinstance(model_override, str) and model_override:


### PR DESCRIPTION
## Summary

- keep localhost, IPv4 loopback, IPv6 loopback, and `0.0.0.0` OpenAI-compatible endpoints on `chat_completions`
- prevent the `openai-api` provider overlay, GPT-5.x auto-upgrade, and persisted desktop/TUI overrides from forcing local daemons onto `/v1/responses`
- add regression coverage for all supported loopback host forms

Local OpenAI-compatible servers such as Ollama, vLLM, and MTPLX commonly implement `/v1/chat/completions` but not `/v1/responses`. When configured with `provider: openai-api`, the provider overlay could select `codex_responses`, causing a 404 before the first useful turn.

## Test plan

- `tests/hermes_cli/test_meta_prompt_cache.py`
- `tests/agent/test_stall_guards.py`
- `tests/agent/test_run_budget.py`

Result: **91 passed** using the repository source plus its existing dependency environment.