### PR TITLE
feat: bound automatic fallback tool execution

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1411,7 +1411,15 @@ def init_agent(
                     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
                         _fb_entries = [fallback_model]
                     _fb_resolved = False
-                    for _fb in _fb_entries:
+                    for _fb_index, _fb in enumerate(_fb_entries):
+                        from agent.fallback_safety import fallback_runtime_block_reason
+
+                        _runtime_block = fallback_runtime_block_reason(
+                            _fb, _fb.get("api_mode") or "chat_completions"
+                        )
+                        if _runtime_block is not None:
+                            logger.warning("Init-time fallback rejected: %s", _runtime_block)
+                            continue
                         try:
                             from hermes_cli.fallback_config import resolve_entry_api_key
                             _fb_explicit_key = resolve_entry_api_key(_fb)
@@ -1430,6 +1438,8 @@ def init_agent(
                             agent.provider = _fb["provider"]
                             agent.model = _fb_model or _fb["model"]
                             agent._fallback_activated = True
+                            agent._active_fallback_entry = dict(_fb)
+                            agent._fallback_index = _fb_index + 1
                             client_kwargs = {
                                 "api_key": _fb_client.api_key,
                                 "base_url": str(_fb_client.base_url),
@@ -1575,8 +1585,13 @@ def init_agent(
         agent._fallback_chain = [fallback_model]
     else:
         agent._fallback_chain = []
-    agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
+    if not agent._fallback_activated:
+        agent._fallback_index = 0
+        agent._active_fallback_entry = None
+    else:
+        # Init-time activation happens before the chain is materialized.
+        agent._fallback_index = int(getattr(agent, "_fallback_index", 0) or 0)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1787,6 +1787,7 @@ def restore_primary_runtime(agent) -> bool:
 
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
+        agent._active_fallback_entry = None
         agent._fallback_index = 0
         agent._rate_limit_backoff_count = 0  # reset exponential backoff counter
 
@@ -3214,9 +3215,19 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
 
+    # Fallback safety is a mandatory runtime boundary independent of plugin
+    # hooks and human approvals. Keep it here so direct invoke_tool callers
+    # cannot bypass the managed sequential/concurrent dispatcher.
+    from agent.fallback_safety import fallback_tool_block_reason
+
+    block_message: Optional[str] = fallback_tool_block_reason(
+        agent, function_name, function_args
+    )
+    block_error_type = "fallback_safety_block"
+
     # Check plugin hooks for a block or approval directive before executing.
-    block_message: Optional[str] = None
-    if not pre_tool_block_checked:
+    if block_message is None and not pre_tool_block_checked:
+        block_error_type = "plugin_block"
         try:
             from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
             block_message, modified_args = _dispatch_pre_tool_call_hooks(
@@ -3245,7 +3256,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 status="blocked",
-                error_type="plugin_block",
+                error_type=block_error_type,
                 error_message=block_message,
                 middleware_trace=list(_tool_middleware_trace),
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2675,6 +2675,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             ):
                 fb_api_mode = "bedrock_converse"
 
+        from agent.fallback_safety import fallback_runtime_block_reason
+
+        runtime_block = fallback_runtime_block_reason(fb, fb_api_mode)
+        if runtime_block is not None:
+            unavailable.add(fb_key)
+            logger.warning("Fallback rejected: %s", runtime_block)
+            return agent._try_activate_fallback(reason)
+
         old_model = agent.model
         old_provider = agent.provider
 
@@ -2694,6 +2702,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+        agent._active_fallback_entry = dict(fb)
 
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream

--- a/agent/fallback_safety.py
+++ b/agent/fallback_safety.py
@@ -1,0 +1,162 @@
+"""Deterministic tool restrictions for bounded automatic fallbacks.
+
+Fallback entries may opt into ``safety_mode: read_only``. While that entry is
+active, only a small allowlist of inspection-only tools/actions may execute.
+Unknown tools fail closed. Fallback entries without ``safety_mode`` retain the
+legacy unrestricted behavior for compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_READ_ONLY_TOOLS = frozenset(
+    {
+        "clarify",
+        "page_info",
+        "read_file",
+        "read_preview",
+        "read_terminal",
+        "read_window_below",
+        "search_files",
+        "session_search",
+        "skill_view",
+        "skills_list",
+        "vision_analyze",
+        "web_extract",
+        "web_search",
+    }
+)
+
+_READ_ONLY_ACTIONS = {
+    "computer_use": frozenset(
+        {"capture", "list_apps", "list_windows", "cua_browser_state"}
+    ),
+    "cronjob": frozenset({"list"}),
+    "process": frozenset({"list", "poll", "log", "wait"}),
+}
+
+_READ_ONLY_MODES = frozenset({"bounded", "read-only", "read_only", "readonly"})
+_UNRESTRICTED_MODES = frozenset({"full", "none", "off", "unrestricted"})
+# Runtimes that execute tools inside a model-driven subprocess that never
+# passes through Hermes tool dispatch. ``codex_app_server`` is the embedded
+# Codex app-server runtime (detected via api_mode). The copilot-acp provider
+# resolves the same way through its *provider name*: CopilotACPClient keeps
+# api_mode=chat_completions but services ACP fs/write_text_file requests
+# directly, so a read_only fallback on that provider could still mutate files.
+_EMBEDDED_EXECUTION_RUNTIMES = frozenset({"codex_app_server"})
+_EMBEDDED_EXECUTION_PROVIDERS = frozenset({"copilot-acp"})
+# Mirrors the copilot-acp entries in auxiliary_client._PROVIDER_ALIASES.
+_EMBEDDED_PROVIDER_ALIASES = {
+    "github-copilot-acp": "copilot-acp",
+    "copilot-acp-agent": "copilot-acp",
+}
+
+
+def _embedded_runtime_name(api_mode: str, provider: str | None) -> str | None:
+    """Return the embedded-execution runtime name when the entry resolves to one.
+
+    A bounded fallback entry is rejected when either its api_mode names an
+    embedded runtime or its provider resolves (after alias normalization) to
+    a provider whose client executes outside Hermes tool dispatch.
+    """
+    mode = str(api_mode or "").strip().lower()
+    if mode in _EMBEDDED_EXECUTION_RUNTIMES:
+        return mode
+    name = str(provider or "").strip().lower()
+    if not name:
+        return None
+    name = _EMBEDDED_PROVIDER_ALIASES.get(name, name)
+    if name in _EMBEDDED_EXECUTION_PROVIDERS:
+        return name
+    return None
+
+
+def fallback_runtime_block_reason(
+    entry: dict[str, Any], api_mode: str
+) -> str | None:
+    """Reject embedded-execution runtimes for bounded fallback entries."""
+    raw_mode = entry.get("safety_mode") if isinstance(entry, dict) else None
+    if raw_mode is None or not str(raw_mode).strip():
+        return None
+    mode = str(raw_mode).strip().lower()
+    if mode in _UNRESTRICTED_MODES:
+        return None
+    runtime = _embedded_runtime_name(
+        api_mode, entry.get("provider") if isinstance(entry, dict) else None
+    )
+    if runtime is None:
+        return None
+    if mode not in _READ_ONLY_MODES:
+        mode = "read_only"
+    return (
+        f"Fallback safety policy ({mode}) rejected runtime '{runtime}' "
+        "because it executes tools outside Hermes tool dispatch."
+    )
+
+
+def _active_fallback_entry(agent: Any) -> dict[str, Any] | None:
+    snapshot = getattr(agent, "_active_fallback_entry", None)
+    if isinstance(snapshot, dict):
+        return snapshot
+    chain = getattr(agent, "_fallback_chain", None)
+    index = getattr(agent, "_fallback_index", None)
+    if not isinstance(chain, list) or not isinstance(index, int):
+        return None
+    active_index = index - 1
+    if active_index < 0 or active_index >= len(chain):
+        return None
+    entry = chain[active_index]
+    return entry if isinstance(entry, dict) else None
+
+
+def _is_bounded_read(agent: Any, tool_name: str, args: dict[str, Any]) -> bool:
+    if tool_name in _READ_ONLY_TOOLS:
+        return True
+    allowed_actions = _READ_ONLY_ACTIONS.get(tool_name)
+    if allowed_actions is None:
+        return False
+    action = str(args.get("action") or "").strip().lower()
+    return action in allowed_actions
+
+
+def fallback_tool_block_reason(
+    agent: Any,
+    tool_name: str,
+    args: dict[str, Any] | None,
+) -> str | None:
+    """Return a deterministic denial reason, or ``None`` when execution is allowed."""
+    if getattr(agent, "_fallback_activated", False) is not True:
+        return None
+
+    entry = _active_fallback_entry(agent)
+    if entry is None:
+        mode = "read_only"
+        provider = str(getattr(agent, "provider", "") or "unknown fallback")
+        model = str(getattr(agent, "model", "") or "unknown model")
+        identity = f"{provider}:{model} (unknown fallback entry)"
+    else:
+        raw_mode = entry.get("safety_mode")
+        if raw_mode is None or not str(raw_mode).strip():
+            return None
+        mode = str(raw_mode).strip().lower()
+        if mode in _UNRESTRICTED_MODES:
+            return None
+        # Unknown modes fail closed to the bounded read-only policy.
+        if mode not in _READ_ONLY_MODES:
+            mode = "read_only"
+        provider = str(entry.get("provider") or getattr(agent, "provider", "") or "unknown fallback")
+        model = str(entry.get("model") or getattr(agent, "model", "") or "unknown model")
+        identity = f"{provider}:{model}"
+
+    normalized_args = args if isinstance(args, dict) else {}
+    if _is_bounded_read(agent, tool_name, normalized_args):
+        return None
+
+    return (
+        f"Fallback safety policy ({mode}) blocked tool '{tool_name}' while "
+        f"automatic fallback {identity} is active. Only bounded read-only "
+        "inspection is permitted; retry after the primary provider recovers "
+        "or explicitly switch to a trusted model."
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -633,6 +633,15 @@ def _run_agent_tool_execution_middleware(
         block_message = scope_block
         block_error_type = "tool_scope_block"
         if block_message is None:
+            from agent.fallback_safety import fallback_tool_block_reason
+
+            block_message = fallback_tool_block_reason(
+                agent, function_name, final_args
+            )
+            if block_message is not None:
+                block_error_type = "fallback_safety_block"
+
+        if block_message is None:
             block_error_type = "plugin_block"
 
             def _resolve_pre_tool_block():

--- a/tests/agent/test_fallback_safety.py
+++ b/tests/agent/test_fallback_safety.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+from agent.fallback_safety import (
+    fallback_runtime_block_reason,
+    fallback_tool_block_reason,
+)
+
+
+def _agent(entry=None, *, activated=True):
+    chain = [entry] if entry is not None else []
+    return SimpleNamespace(
+        _fallback_activated=activated,
+        _active_fallback_entry=entry,
+        _fallback_chain=chain,
+        _fallback_index=1 if chain else 0,
+        provider="openai-api",
+        model="local-fallback",
+    )
+
+
+def test_inactive_fallback_does_not_restrict_tools():
+    agent = _agent({"safety_mode": "read_only"}, activated=False)
+    assert fallback_tool_block_reason(agent, "terminal", {"command": "rm -rf /tmp/x"}) is None
+
+
+def test_legacy_entry_without_safety_mode_is_unrestricted():
+    agent = _agent({"provider": "openai-api", "model": "fallback"})
+    assert fallback_tool_block_reason(agent, "terminal", {"command": "touch /tmp/x"}) is None
+
+
+def test_read_only_entry_allows_inspection_and_blocks_mutation():
+    entry = {
+        "provider": "openai-api",
+        "model": "fallback",
+        "safety_mode": "read_only",
+    }
+    agent = _agent(entry)
+    assert fallback_tool_block_reason(agent, "read_file", {"path": "/tmp/x"}) is None
+    assert fallback_tool_block_reason(agent, "process", {"action": "poll"}) is None
+    assert fallback_tool_block_reason(agent, "process", {"action": "kill"}) is not None
+    assert fallback_tool_block_reason(agent, "terminal", {"command": "true"}) is not None
+
+
+def test_unknown_safety_mode_fails_closed():
+    agent = _agent({"provider": "custom", "model": "x", "safety_mode": "mystery"})
+    assert fallback_tool_block_reason(agent, "write_file", {"path": "/tmp/x"}) is not None
+
+
+def test_explicit_unrestricted_mode_preserves_legacy_behavior():
+    agent = _agent({"provider": "custom", "model": "x", "safety_mode": "full"})
+    assert fallback_tool_block_reason(agent, "write_file", {"path": "/tmp/x"}) is None
+
+
+def test_bounded_entry_rejects_embedded_execution_runtime():
+    entry = {"provider": "custom", "model": "x", "safety_mode": "read_only"}
+    reason = fallback_runtime_block_reason(entry, "codex_app_server")
+    assert reason is not None
+    assert "outside Hermes tool dispatch" in reason
+
+
+def test_bounded_entry_rejects_embedded_execution_provider_alias():
+    entry = {
+        "provider": "github-copilot-acp",
+        "model": "x",
+        "safety_mode": "read_only",
+    }
+    assert fallback_runtime_block_reason(entry, "chat_completions") is not None
+
+
+def test_unrestricted_entry_allows_embedded_runtime():
+    entry = {"provider": "custom", "model": "x", "safety_mode": "full"}
+    assert fallback_runtime_block_reason(entry, "codex_app_server") is None


### PR DESCRIPTION
## Summary

- add opt-in `safety_mode: read_only` enforcement for automatic fallback entries
- allow inspection-only tools/actions while failing closed for unknown tools and unknown bounded modes
- reject bounded fallbacks that execute tools outside Hermes dispatch (`codex_app_server` and Copilot ACP aliases)
- enforce the policy in both sequential/direct and managed concurrent tool paths
- preserve legacy behavior when `safety_mode` is absent or explicitly unrestricted

## Why

An automatic provider fallback can switch execution to a model/runtime with different tool-safety characteristics. Without a runtime boundary, a fallback advertised as read-only can still invoke mutating tools, and embedded runtimes may bypass Hermes tool dispatch entirely. This makes the bounded policy deterministic and fail-closed while remaining opt-in for compatibility.

## Test plan

- new `tests/agent/test_fallback_safety.py` coverage for inactive, legacy, read-only, unknown, unrestricted, action-scoped, and embedded-runtime cases
- focused regression run including stall guards, run budget, and config coercion

Result: **83 passed**.