### PR TITLE
fix(config): preserve lossy decimal values as strings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -15,6 +15,7 @@ This module provides:
 """
 
 import copy
+from decimal import Decimal, InvalidOperation
 from hermes_cli.cli_output import line_input
 import json
 import logging
@@ -5434,7 +5435,12 @@ def _coerce_int(value: str):
 
 
 def _coerce_float(value: str):
-    """Return float(value) for a clean float literal, else None."""
+    """Return ``float(value)`` when conversion preserves its decimal value.
+
+    Decimal-looking identifiers can be much more precise than a binary float.
+    Silently rounding one here corrupts it before it reaches ``config.yaml``,
+    so values that do not round-trip through ``float`` remain strings.
+    """
     try:
         f = float(value)
     except (TypeError, ValueError):
@@ -5442,6 +5448,11 @@ def _coerce_float(value: str):
     # Reject NaN/inf spellings — they are almost never intended config values
     # and round-trip confusingly through YAML.
     if f != f or f in (float("inf"), float("-inf")):
+        return None
+    try:
+        if Decimal(value) != Decimal(str(f)):
+            return None
+    except InvalidOperation:
         return None
     return f
 

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -42,6 +42,18 @@ class TestNumericCoercion:
         v = _read(tmp_path, "agent", "max_turns")
         assert v == -2.5 and isinstance(v, float)
 
+    def test_lossy_decimal_identifier_stays_string(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        client_id = "123456789012.98765432109876"
+
+        cfg.set_config_value("mcp_servers.example.oauth.client_id", client_id)
+
+        saved = _read(
+            tmp_path, "mcp_servers", "example", "oauth", "client_id"
+        )
+        assert saved == client_id
+        assert isinstance(saved, str)
+
 
 class TestNullCoercion:
     @pytest.mark.parametrize("token", ["null", "none", "None", "~"])


### PR DESCRIPTION
## What does this PR do?

`hermes config set` auto-coerces decimal-looking values with `float()`. For values with more decimal precision than a binary float can preserve, that silently changes the value before it is written to `config.yaml`.

This keeps the existing automatic coercion for ordinary decimal settings, but preserves the original string whenever the parsed float would not round-trip to the same decimal value. That fixes precision-sensitive identifiers without maintaining a list of string-typed dynamic keys.

## Related Issue

No GitHub issue. Related coercion work: #90628. A closed alternative that added an explicit `--string` flag was proposed in #92950.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Make `_coerce_float()` compare the source decimal value with the float's round-tripped decimal value.
- Leave lossy decimal-looking values as strings instead of silently rounding them.
- Add a behavioral regression covering a precision-sensitive MCP OAuth client ID written through `set_config_value()`.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_config_set_coercion.py -q -j 4`.
2. Verify an ordinary value such as `-2.5` is still stored as a float.
3. Run `hermes config set mcp_servers.example.oauth.client_id '123456789012.98765432109876'` and verify the exact value is stored as a string.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`git diff --check` passes. Focused Python tests were not run locally; GitHub CI will exercise the added regression.
