### PR TITLE
fix(desktop): bound runGit with a hard timeout so a stalled fetch can't hang the update UI

### DIFF
--- a/apps/desktop/electron/bundle-skew.ts
+++ b/apps/desktop/electron/bundle-skew.ts
@@ -44,7 +44,7 @@ export interface BundleSkewResult {
 export type RunGit = (
   args: string[],
   options: { cwd: string }
-) => Promise<{ code: number; stderr: string; stdout: string }>
+) => Promise<{ code: number | null; stderr: string; stdout: string }>
 
 const NOT_STALE: BundleSkewResult = { desktopCommitsBehind: null, outOfSync: false }
 

--- a/apps/desktop/electron/fixtures/fake-git-bin/git
+++ b/apps/desktop/electron/fixtures/fake-git-bin/git
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Fake `git` binary for run-git.test.ts (see README in this dir).
+#
+# Args:
+#   ok    -> exit 0, print a line on stdout  (normal fast success)
+#   fail  -> exit 7, print a line on stderr  (normal fast failure)
+#   block -> sleep forever (simulates a blackholed git fetch: never exits)
+case "$1" in
+  ok)
+    printf 'ok-stdout\n'
+    exit 0
+    ;;
+  fail)
+    printf 'fail-stderr\n' >&2
+    exit 7
+    ;;
+  block)
+    # Never return: the runGit timeout must kill this and settle the promise.
+    # `exec` replaces the shell so SIGTERM lands on the blocking child directly.
+    exec sleep 100000
+    ;;
+  *)
+    printf 'unknown command: %s\n' "$1" >&2
+    exit 2
+    ;;
+esac

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -307,6 +307,7 @@ import {
 } from './remote-ws-headers'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { createRunGit } from './run-git'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -2772,34 +2773,13 @@ function resolveUpdateRoot() {
   return candidates.find(c => directoryExists(path.join(c, '.git'))) || candidates[0] || ACTIVE_HERMES_ROOT
 }
 
-function runGit(args, options: any = {}): Promise<{ code: number; stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      resolveGitBinary(),
-      IS_WINDOWS ? ['-c', 'windows.appendAtomically=false', ...args] : args,
-      hiddenWindowsChildOptions({
-        cwd: options.cwd,
-        env: { ...process.env, ...((options.env || {}) as any), GIT_TERMINAL_PROMPT: '0' },
-        stdio: ['ignore', 'pipe', 'pipe']
-      })
-    )
-
-    let stdout = ''
-    let stderr = ''
-    child.stdout.on('data', chunk => {
-      const text = chunk.toString()
-      stdout += text
-      options.onLine?.('stdout', text)
-    })
-    child.stderr.on('data', chunk => {
-      const text = chunk.toString()
-      stderr += text
-      options.onLine?.('stderr', text)
-    })
-    child.once('error', reject)
-    child.once('exit', code => resolve({ code, stdout, stderr }))
-  })
-}
+// runGit is the bounded git subprocess runner (extracted for testability).
+// It resolves with `{ code, stdout, stderr }` on exit, and on a stalled/
+// blackholed git call it hard-timeouts (SIGTERM then SIGKILL) and resolves
+// with `{ code: null, timedOut: true, stderr: ... }` so the update check
+// surfaces a fetch-failed error instead of hanging on "Looking for updates…"
+// forever. See run-git.ts.
+const runGit = createRunGit(resolveGitBinary)
 
 const firstLine = text => (text || '').split('\n').find(Boolean) || ''
 

--- a/apps/desktop/electron/run-git.test.ts
+++ b/apps/desktop/electron/run-git.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { createRunGit, type RunGitOptions } from './run-git'
+
+/**
+ * Regression tests for the bounded git runner (issue #95788).
+ *
+ * The bug: runGit resolved only on the child's `exit` event with no timeout,
+ * so a blackholed git call (TCP up, HTTP never answered) hung the update
+ * check on "Looking for updates…" forever. These tests prove the hard
+ * timeout settles the promise with a `timedOut` result well before a wedged
+ * child would finish, and that fast commands still resolve normally.
+ */
+
+/** Path to a tiny executable "git" used by every test. */
+const GIT_BIN = __dirname + '/fixtures/fake-git-bin/git'
+
+/** Timeout the run and measure how long the promise actually took. */
+async function timed<T>(timeoutMs: number | undefined, args: string[], options: Omit<RunGitOptions, 'timeoutMs'> = {}) {
+  const runGit = createRunGit(() => GIT_BIN)
+  const started = Date.now()
+  const result = await runGit(args, { ...options, timeoutMs })
+
+  return { result, elapsed: Date.now() - started }
+}
+
+describe('runGit timeout bound (regression #95788)', () => {
+  it('resolves with timedOut when the child would block forever', async () => {
+    const { result, elapsed } = await timed(400, ['block'])
+
+    // The promise must settle on the timeout, not hang forever.
+    expect(result.timedOut).toBe(true)
+    expect(result.code).toBeNull()
+    // Fast completion of the bound, not the child (which would never finish).
+    expect(elapsed).toBeLessThan(5000)
+    // A clear message flows to the fetch-failed path via stderr.
+    expect(result.stderr).toContain('timed out after 400ms')
+  })
+
+  it('still resolves normally with its exit code for a fast command', async () => {
+    const { result } = await timed(2000, ['ok'])
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain('ok-stdout')
+    expect(result.stderr).toBe('')
+  })
+
+  it('propagates a non-zero exit code for a fast failing command', async () => {
+    const { result } = await timed(2000, ['fail'])
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(7)
+    expect(result.stderr).toContain('fail-stderr')
+  })
+})

--- a/apps/desktop/electron/run-git.ts
+++ b/apps/desktop/electron/run-git.ts
@@ -1,0 +1,130 @@
+/**
+ * run-git.ts
+ *
+ * Dependency-free wrapper around spawning `git` for the desktop update flow,
+ * extracted from main.ts so it can be unit-tested in isolation.
+ *
+ * The bound (hard timeout) is the whole point: `runGit` used to resolve only
+ * on the child's `exit` event with no timeout, so a blackholed git call —
+ * TCP connect and TLS complete, but HTTP never answers — left the fetch
+ * never exiting, the promise never settling, and the update check pinned on
+ * "Looking for updates…" forever.
+ *
+ * On timeout the child is SIGTERM'd then SIGKILL'd after a short grace, the
+ * timer is cleared, and the promise RESOLVES (never rejects) with a
+ * `timedOut` result so the caller's existing fetch-failed path surfaces a
+ * clear error instead of spinning forever.
+ */
+
+import { spawn } from 'node:child_process'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export interface RunGitOptions {
+  cwd?: string
+  env?: Record<string, string>
+  onLine?: (stream: 'stdout' | 'stderr', text: string) => void
+  /** Hard wall-clock bound for the whole git run, in ms. Default 15_000. */
+  timeoutMs?: number
+}
+
+export interface RunGitResult {
+  /** Process exit code. `null` when the run did not finish (timed out). */
+  code: number | null
+  stdout: string
+  stderr: string
+  /** True when the hard timeout fired and the child was terminated. */
+  timedOut?: boolean
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000
+/** Grace between SIGTERM and SIGKILL so a child that ignores TERM still dies. */
+const SIGKILL_GRACE_MS = 500
+
+/**
+ * Build a `runGit(args, options)` bound to a git-binary resolver. The
+ * resolver is injected so the update flow keeps its Windows-specific git
+ * discovery while tests can substitute a scriptable fake binary.
+ */
+export function createRunGit(resolveGitBinary: () => string) {
+  return function runGit(
+    args: string[],
+    options: RunGitOptions = {}
+  ): Promise<RunGitResult> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(
+        resolveGitBinary(),
+        process.platform === 'win32' ? ['-c', 'windows.appendAtomically=false', ...args] : args,
+        hiddenWindowsChildOptions({
+          cwd: options.cwd,
+          env: { ...process.env, ...(options.env || {}), GIT_TERMINAL_PROMPT: '0' },
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      )
+
+      let stdout = ''
+      let stderr = ''
+      let settled = false
+
+      child.stdout.on('data', chunk => {
+        const text = chunk.toString()
+        stdout += text
+        options.onLine?.('stdout', text)
+      })
+      child.stderr.on('data', chunk => {
+        const text = chunk.toString()
+        stderr += text
+        options.onLine?.('stderr', text)
+      })
+
+      const timer = setTimeout(() => {
+        if (settled) {return}
+        settled = true
+
+        // Terminate the wedged child: SIGTERM first, then SIGKILL after a
+        // short grace for anything that ignores TERM.
+        try {
+          child.kill('SIGTERM')
+        } catch {
+          /* already gone */
+        }
+
+        setTimeout(() => {
+          try {
+            if (child.exitCode === null) {child.kill('SIGKILL')}
+          } catch {
+            /* already gone */
+          }
+        }, SIGKILL_GRACE_MS).unref()
+        resolve({
+          code: null,
+          stdout,
+          stderr: (stderr ? stderr + '\n' : '') + `git operation timed out after ${timeoutMs}ms`,
+          timedOut: true
+        })
+      }, timeoutMs)
+
+      // Never let the pending timer hold the process open after the child exits.
+      timer.unref()
+
+      child.once('error', err => {
+        if (settled) {return}
+        settled = true
+        clearTimeout(timer)
+        reject(err)
+      })
+      // Resolve on 'close' (not 'exit'): 'exit' can fire before the final
+      // stdout/stderr 'data' events are delivered, losing the tail of the
+      // output. 'close' fires only once the child has exited AND its stdio
+      // streams have fully drained, so captured output is complete.
+      child.once('close', code => {
+        if (settled) {return}
+        settled = true
+        clearTimeout(timer)
+        resolve({ code, stdout, stderr, timedOut: false })
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Summary

The desktop Electron app's update check can hang the "Looking for updates…" UI forever. `runGit()` in `apps/desktop/electron/main.ts` resolved its promise **only** on the git child's `exit` event and had **no timeout**. On a network where a GitHub connection blackholes (TCP connects and TLS completes but the HTTP request never answers), the `git fetch` never exits, the promise never settles, and the renderer pins on an endless spinner with no recovery affordance.

This is the desktop-side half of the same network condition behind #95777, and the exact fix proposed in #39096 — which was closed on 2026-06-13 without ever merging.

## Changes

- **`apps/desktop/electron/run-git.ts` (new)** — extracts `runGit` out of `main.ts` so it can be unit-tested, and adds a hard 15s wall-clock timeout (injectable via `options.timeoutMs`). On timeout the wedged child is `SIGTERM`'d then `SIGKILL`'d after a 500ms grace, the timer is cleared, and the promise **resolves** (never rejects) with `{ code: null, timedOut: true, stderr: ... }` so the caller's existing fetch-failed path surfaces a clear error instead of hanging.
- **`apps/desktop/electron/main.ts`** — replaces the inline `runGit` with `createRunGit(resolveGitBinary)`. A timed-out fetch returns `code: null`, which hits the existing `if (fetched.code !== 0)` check and reports `fetch-failed` with the timeout message.
- **`apps/desktop/electron/run-git.test.ts` + `fixtures/fake-git-bin/git`** — regression tests proving the timeout. A `block` fixture `exec sleep 100000` simulates a blackholed git call; the test asserts the promise settles with `timedOut=true` well within the bound. Reverting to the old no-timeout implementation makes this test hang and fail — the regression genuinely catches the bug.
- **`apps/desktop/electron/bundle-skew.ts`** — widens the shared `RunGit` result type `code` from `number` to `number | null` to match the timeout result.

## Tests

```
$ npx vitest run --project electron electron/run-git.test.ts
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Revert-to-buggy proof: with the old no-timeout `runGit`, the blocking test hangs and fails with `Test timed out in 5000ms`; with the fix it passes. Full electron project suite: `132 passed | 2 skipped`.

Closes #95788
