### PR TITLE
feat(acp): add verified closed-book sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1131,6 +1131,8 @@ class HermesACPAgent(acp.Agent):
         """Register ACP-provided MCP servers and refresh the agent tool surface."""
         if not mcp_servers:
             return
+        if state.closed_book:
+            raise ValueError("closed-book session cannot register MCP servers")
 
         try:
             from tools.mcp_tool import register_mcp_servers
@@ -1221,6 +1223,8 @@ class HermesACPAgent(acp.Agent):
         No-op when discovery already finished, when the join times out, when the
         registry was unchanged, or when the session was closed while waiting.
         """
+        if state.closed_book:
+            return
         try:
             from hermes_cli.mcp_startup import mcp_discovery_in_flight
         except Exception:
@@ -1594,19 +1598,31 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        command_adviser = kwargs.get("commandAdviser")
+        closed_book = (
+            isinstance(command_adviser, dict)
+            and command_adviser.get("mode") == "closed-book"
+        )
+        state = self.session_manager.create_session(cwd=cwd, closed_book=closed_book)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
+        response_meta = self._provenance_meta(
+            state.session_id, getattr(state.agent, "session_id", state.session_id)
+        )
+        if state.closed_book:
+            response_meta["commandAdviser"] = {
+                "mode": "closed-book",
+                "enabledToolsets": list(getattr(state.agent, "enabled_toolsets", [])),
+                "toolNames": sorted(getattr(state.agent, "valid_tool_names", set())),
+            }
         return NewSessionResponse(
             session_id=state.session_id,
             models=self._build_model_state(state),
             modes=self._session_modes(state),
-            field_meta=self._provenance_meta(
-                state.session_id, getattr(state.agent, "session_id", state.session_id)
-            ),
+            field_meta=response_meta,
         )
 
     async def load_session(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -166,6 +166,28 @@ def _clear_task_cwd(task_id: str) -> None:
         logger.debug("Failed to clear ACP task cwd override", exc_info=True)
 
 
+_CLOSED_BOOK_TOOL_NAMES = frozenset({"terminal", "process"})
+
+
+def _enforce_closed_book_agent(agent: Any) -> Any:
+    """Pin an ACP agent to the local terminal surface with no learned context helpers."""
+    agent.enabled_toolsets = ["terminal"]
+    agent.disabled_toolsets = ["memory"]
+    agent.skip_context_files = True
+    agent.skip_memory = True
+    tools = getattr(agent, "tools", None)
+    if isinstance(tools, list):
+        agent.tools = [
+            tool
+            for tool in tools
+            if (tool.get("function") or {}).get("name") in _CLOSED_BOOK_TOOL_NAMES
+        ]
+        agent.valid_tool_names = {
+            (tool.get("function") or {}).get("name") for tool in agent.tools
+        }
+    return agent
+
+
 @dataclass
 class SessionState:
     """Tracks per-session state for an ACP-managed Hermes agent."""
@@ -181,6 +203,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    closed_book: bool = False
 
 
 class SessionManager:
@@ -207,19 +230,22 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
+    def create_session(self, cwd: str = ".", *, closed_book: bool = False) -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(session_id=session_id, cwd=cwd, closed_book=closed_book)
+        if closed_book:
+            agent = _enforce_closed_book_agent(agent)
         state = SessionState(
             session_id=session_id,
             agent=agent,
             cwd=cwd,
             model=getattr(agent, "model", "") or "",
             cancel_event=threading.Event(),
+            closed_book=closed_book,
         )
         with self._lock:
             self._sessions[session_id] = state
@@ -608,6 +634,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        closed_book: bool = False,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -626,7 +653,7 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
+        configured_mcp_servers = [] if closed_book else [
             name
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
@@ -635,9 +662,12 @@ class SessionManager:
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                ["terminal"] if closed_book else ["hermes-acp"],
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": ["memory"] if closed_book else None,
+            "skip_context_files": closed_book,
+            "skip_memory": closed_book,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
@@ -674,15 +704,16 @@ class SessionManager:
         # ``mcp_discovery_timeout`` (config.yaml, default ~1.5s) so a dead
         # server can't block — servers that miss the bound are picked up by
         # the automatic late-refresh (see HermesACPAgent._schedule_mcp_late_refresh).
-        try:
-            from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+        if not closed_book:
+            try:
+                from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
 
-            ensure_mcp_discovery_before_agent_build(
-                logger=logger,
-                thread_name="acp-mcp-discovery",
-            )
-        except Exception:
-            logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
+                ensure_mcp_discovery_before_agent_build(
+                    logger=logger,
+                    thread_name="acp-mcp-discovery",
+                )
+            except Exception:
+                logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
@@ -692,4 +723,4 @@ class SessionManager:
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print
-        return agent
+        return _enforce_closed_book_agent(agent) if closed_book else agent

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -178,6 +178,52 @@ class TestAuthenticate:
 class TestSessionOps:
 
     @pytest.mark.asyncio
+    async def test_closed_book_session_exposes_only_terminal_tools_and_rejects_mcp(self):
+        agent = SimpleNamespace(
+            model="local-model",
+            provider="lmstudio",
+            base_url="http://127.0.0.1:8000/v1",
+            enabled_toolsets=["hermes-acp"],
+            disabled_toolsets=[],
+            tools=[
+                {"function": {"name": "terminal"}},
+                {"function": {"name": "process"}},
+                {"function": {"name": "memory"}},
+                {"function": {"name": "web_search"}},
+            ],
+            valid_tool_names={"terminal", "process", "memory", "web_search"},
+        )
+        manager = SessionManager(agent_factory=lambda: agent)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        router = build_agent_router(acp_agent)
+
+        response = await router(
+            "session/new",
+            {
+                "cwd": "/tmp",
+                "mcpServers": [],
+                "_meta": {"commandAdviser": {"mode": "closed-book"}},
+            },
+            False,
+        )
+        state = manager.get_session(response.session_id)
+
+        assert state is not None
+        assert state.closed_book is True
+        assert state.agent.enabled_toolsets == ["terminal"]
+        assert state.agent.skip_context_files is True
+        assert state.agent.skip_memory is True
+        assert state.agent.valid_tool_names == {"terminal", "process"}
+        assert response.field_meta["commandAdviser"] == {
+            "mode": "closed-book",
+            "enabledToolsets": ["terminal"],
+            "toolNames": ["process", "terminal"],
+        }
+
+        with pytest.raises(ValueError, match="closed-book session cannot register MCP servers"):
+            await acp_agent._register_session_mcp_servers(state, [SimpleNamespace(name="rag")])
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(


### PR DESCRIPTION
## Summary
- add an opt-in ACP closed-book session profile requested through `_meta.commandAdviser`
- restrict the model tool surface to terminal/process and skip context files, memory, configured MCP discovery, ACP MCP registration, and late MCP refresh
- return the effective toolset and tool names in session metadata so evaluation clients can fail closed

## Verification
- `scripts/run_tests.sh tests/acp/test_server.py tests/acp_adapter/test_acp_mcp_discovery.py -q` (35 passed)
- Ruff checks passed on changed Python files
- real stdio ACP initialize/session-new probe advertised only `terminal` and `process`, even with a configured MCP server in the isolated Hermes home