### PR TITLE
fix(tui_gateway): scope config.get/set RPC to params.profile

### DIFF
--- a/tests/tui_gateway/test_config_profile_scope.py
+++ b/tests/tui_gateway/test_config_profile_scope.py
@@ -1,0 +1,113 @@
+"""config.get / config.set must honor params.profile (issue #95760).
+
+A single dashboard backend in desktop app-global remote mode serves every
+profile. projects.* RPCs already bind params.profile via @_profile_scoped;
+config.get / config.set did not, so reads and persistent writes used the
+launch profile's config.yaml for every focused profile.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import tui_gateway.server as server
+
+
+LAUNCH_CWD = "/workspace/default"
+WORKER_CWD = "/workspace/code"
+LAUNCH_ROOTS = ["/workspace/default"]
+WORKER_ROOTS = ["/workspace/code"]
+
+
+def _write_cfg(home: Path, cwd: str, roots: list[str]) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "terminal": {"cwd": cwd},
+                "desktop": {"repo_scan_roots": list(roots)},
+                "display": {"busy_input_mode": "queue"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _homes(tmp_path: Path) -> tuple[Path, Path]:
+    launch = tmp_path / "launch"
+    worker = tmp_path / "profiles" / "code"
+    _write_cfg(launch, LAUNCH_CWD, LAUNCH_ROOTS)
+    _write_cfg(worker, WORKER_CWD, WORKER_ROOTS)
+    return launch, worker
+
+
+def _reset_cfg_cache() -> None:
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+
+def _bind_homes(monkeypatch, launch: Path, worker: Path) -> None:
+    monkeypatch.setattr(server, "_hermes_home", launch)
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda name: worker if (name or "").strip() == "code" else None,
+    )
+    _reset_cfg_cache()
+
+
+def _get(params: dict) -> dict:
+    return server._methods["config.get"]("rid-get", params)
+
+
+def _set(params: dict) -> dict:
+    return server._methods["config.set"]("rid-set", params)
+
+
+def _read_yaml(home: Path) -> dict:
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
+def test_config_get_full_reads_params_profile_yaml_not_launch(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    launch_resp = _get({"key": "full"})
+    assert launch_resp["result"]["config"]["terminal"]["cwd"] == LAUNCH_CWD
+    assert launch_resp["result"]["config"]["desktop"]["repo_scan_roots"] == LAUNCH_ROOTS
+
+    _reset_cfg_cache()
+    worker_resp = _get({"key": "full", "profile": "code"})
+    assert worker_resp["result"]["config"]["terminal"]["cwd"] == WORKER_CWD
+    assert worker_resp["result"]["config"]["desktop"]["repo_scan_roots"] == WORKER_ROOTS
+
+    # Launch file must be untouched by the focused-profile read.
+    assert _read_yaml(launch)["terminal"]["cwd"] == LAUNCH_CWD
+
+
+def test_config_set_persistent_write_lands_on_params_profile_yaml(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    resp = _set({"key": "busy", "value": "steer", "profile": "code"})
+    assert resp["result"]["value"] == "steer"
+
+    worker_cfg = _read_yaml(worker)
+    launch_cfg = _read_yaml(launch)
+    assert worker_cfg["display"]["busy_input_mode"] == "steer"
+    assert launch_cfg["display"]["busy_input_mode"] == "queue"
+    assert launch_cfg["terminal"]["cwd"] == LAUNCH_CWD
+    assert worker_cfg["terminal"]["cwd"] == WORKER_CWD
+
+
+def test_config_set_without_profile_still_writes_launch_home(tmp_path, monkeypatch):
+    launch, worker = _homes(tmp_path)
+    _bind_homes(monkeypatch, launch, worker)
+
+    resp = _set({"key": "busy", "value": "interrupt"})
+    assert resp["result"]["value"] == "interrupt"
+    assert _read_yaml(launch)["display"]["busy_input_mode"] == "interrupt"
+    assert _read_yaml(worker)["display"]["busy_input_mode"] == "queue"

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -179,6 +179,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("config.get")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     key = params.get("key", "")
     if key == "provider":

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3929,7 +3929,9 @@ def _save_cfg(cfg: dict):
 
     from utils import atomic_roundtrip_yaml_save
 
-    path = _hermes_home / "config.yaml"
+    override = get_hermes_home_override()
+    home = Path(override) if isinstance(override, str) and override else _hermes_home
+    path = Path(home) / "config.yaml"
     # Comment-, ordering-, and Unicode-preserving full-state write.
     # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
     # `atomic_config_write`, which is not comment-preserving) which clobbered
@@ -12706,6 +12708,7 @@ def _respond(rid, params, key, *, allow_expired=False):
 # opt/model-resolution-core PR touches its body; move it to methods_config.py
 # in a follow-up once that PR lands.
 @method("config.set")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
     session = _sessions.get(params.get("session_id", ""))


### PR DESCRIPTION
## What does this PR do?

In app-global remote mode a single TUI gateway serves every profile. `projects.*` already bound `params.profile` via `@_profile_scoped`; `config.get` / `config.set` did not, so RPC reads used the launch profile's `config.yaml`, and `_save_cfg` always wrote that launch file even if a home override was set.

This PR applies the existing `@_profile_scoped` decorator to `config.get` and `config.set`, and makes `_save_cfg` write to the override home when one is active. Callers that omit `profile` (or name the launch profile) keep the previous launch-home behavior.

`Fixes #95760` is the RPC gap named in the issue title and source-level findings (`config.get` / `config.set` not `@_profile_scoped`). It does **not** change the Desktop Settings → Workspace page: that surface already loads `GET /api/config?profile=` (REST, scoped since earlier work). If Settings still shows launch values after this, that is a client follow-active / `_apiProfile` path, not this RPC. Shared-remote callers that already inject `params.profile` on `config.get` / `config.set` now read and persist the focused profile's yaml.

Residual (not in this PR):
- Desktop **Settings** pages load `GET /api/config` (already profile-scoped in REST), not `config.get`.
- `config.set` with only `session_id` / `profile_home` and no `params.profile` still writes the launch yaml (#85669).
- `config.get` keys `mtime` and `profile`/`home` still report the process `_hermes_home`.

## Related Issue

Fixes #95760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_config.py` — `@_profile_scoped` on `config.get`
- `tui_gateway/server.py` — `@_profile_scoped` on `config.set`; `_save_cfg` uses `get_hermes_home_override()` when set
- `tests/tui_gateway/test_config_profile_scope.py` — `config.get full` / persistent `config.set busy` with `profile=code` vs launch; omit-profile still writes launch

## How to Test

```bash
scripts/run_tests.sh tests/tui_gateway/test_config_profile_scope.py tests/tui_gateway/test_fast_session_scope.py tests/tui_gateway/test_reasoning_session_scope.py tests/tui_gateway/test_projects_rpc.py -q --tb=line
```

4 files, 48 passed, 0 failed.

Class repro: two temp Hermes homes with distinct `terminal.cwd` / `desktop.repo_scan_roots`; `config.get {key: full, profile: code}` must return the worker yaml; `config.set {key: busy, value: steer, profile: code}` must not mutate the launch yaml.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux), Python 3.12.3, `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
