### PR TITLE
feat(desktop): make the browser pane hotkey a true toggle

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -70,7 +70,7 @@ import {
 import { $bindings, bindingsFor } from '@/store/keybinds'
 import { $dismissedAutoProjectIds, filterVisibleProjects } from '@/store/layout'
 import { openPetGenerate } from '@/store/pet-generate'
-import { openBrowserTab } from '@/store/preview'
+import { toggleBrowserTab } from '@/store/preview'
 import { $projectTree, goToProject, openFolderAsProject, requestStartWorkSession } from '@/store/projects'
 import { $connection } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
@@ -941,9 +941,9 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
             action: 'view.showBrowser',
             icon: codiconIcon('globe'),
             id: 'cc-open-browser',
-            keywords: ['browser', 'web', 'url', 'address', 'open', 'navigate', 'internet', 'site'],
+            keywords: ['browser', 'web', 'url', 'address', 'open', 'toggle', 'close', 'navigate', 'internet', 'site'],
             label: cc.openBrowser,
-            run: () => openBrowserTab()
+            run: () => toggleBrowserTab()
           }
         ]
       },

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -37,7 +37,7 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
-import { openBrowserTab } from '@/store/preview'
+import { toggleBrowserTab } from '@/store/preview'
 import {
   $newChatProfile,
   cycleProfile,
@@ -251,7 +251,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.toggleStatusbar': toggleStatusbarVisible,
     'view.toggleTabStrip': () => void toggleTargetZoneTabStrip(),
     'view.showFiles': showFiles,
-    'view.showBrowser': openBrowserTab,
+    'view.showBrowser': toggleBrowserTab,
     'view.toggleHud': () => toggleHud(hudTargetSessionId()),
     'view.showTerminal': () => togglePaneVisible('terminal'),
     // Create first so the pane's open-effect ensure sees a non-empty set and

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -275,7 +275,7 @@ export const ar = defineLocale({
       'view.toggleRightSidebar': 'تبديل متصفح الملفات',
       'view.toggleReview': 'تبديل لوحة المراجعة',
       'view.showFiles': 'إظهار متصفح الملفات',
-      'view.showBrowser': 'فتح المتصفح',
+      'view.showBrowser': 'تبديل المتصفح',
       'view.showTerminal': 'إظهار الطرفية',
       'view.closeTab': 'إغلاق علامة التبويب',
       'view.reopenTab': 'إعادة فتح علامة التبويب المغلقة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -312,7 +312,7 @@ export const en: Translations = {
       'view.toggleStatusbar': 'Toggle status bar',
       'view.toggleTabStrip': 'Toggle tabs',
       'view.showFiles': 'Show file browser',
-      'view.showBrowser': 'Open browser',
+      'view.showBrowser': 'Toggle browser',
       'view.toggleHud': 'Toggle HUD mode',
       'hud.snapToPointer': 'Move HUD to pointer (global, while HUD is open)',
       'view.showTerminal': 'Toggle terminal',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -305,7 +305,7 @@ export const zh: Translations = {
       'view.toggleStatusbar': '切换状态栏',
       'view.toggleTabStrip': '切换标签',
       'view.showFiles': '显示文件浏览器',
-      'view.showBrowser': '打开浏览器',
+      'view.showBrowser': '切换浏览器',
       'view.showTerminal': '显示终端',
       'view.selectionToComposer': '将选区发送到输入框',
       'view.terminalCopy': '复制终端选区',

--- a/apps/desktop/src/store/preview-toggle-browser.test.ts
+++ b/apps/desktop/src/store/preview-toggle-browser.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { group } from '@/components/pane-shell/tree/model'
+import { $dismissedPanes, $layoutTree, isPaneVisible } from '@/components/pane-shell/tree/store'
+
+import { $previewTabs, closeRightRail, openBrowserTab, openPreview, toggleBrowserTab } from './preview'
+
+beforeEach(() => {
+  closeRightRail()
+  $dismissedPanes.set(new Set())
+  $layoutTree.set(null)
+})
+
+describe('toggleBrowserTab', () => {
+  it('opens a blank browser when there is no browser tab yet', () => {
+    toggleBrowserTab()
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0]?.target.url).toBe('about:blank')
+  })
+
+  // Close must not cost the page: the TAB survives so the next toggle re-fronts
+  // what was showing instead of landing on about:blank.
+  it('dismisses the visible browser pane but keeps its tab', () => {
+    openBrowserTab()
+
+    const paneId = `preview-tile:${$previewTabs.get()[0]?.id}`
+
+    // The shape watchPreviewTiles maintains: the mirrored pane in the tree,
+    // fronted in its zone.
+    $layoutTree.set(group([paneId, 'workspace'], { active: paneId, id: 'g-main' }))
+    expect(isPaneVisible(paneId)).toBe(true)
+
+    toggleBrowserTab()
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect(isPaneVisible(paneId)).toBe(false)
+  })
+
+  it('re-fronts the existing page instead of blanking it', () => {
+    openPreview({ kind: 'url', label: 'Example', source: 'https://example.com', url: 'https://example.com' })
+
+    // Browser away (no tree, pane not on screen): the toggle brings it back.
+    toggleBrowserTab()
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0]?.target.url).toBe('https://example.com')
+  })
+
+  it('leaves other preview tabs alone', () => {
+    openPreview({ kind: 'file', label: 'notes.md', source: '/work/notes.md', url: 'file:///work/notes.md' })
+    toggleBrowserTab()
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(2)
+    expect(tabs.map(tab => tab.target.url)).toContain('file:///work/notes.md')
+  })
+})

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -1,5 +1,6 @@
 import { atom, computed } from 'nanostores'
 
+import { dismissTreePane, isPaneVisible } from '@/components/pane-shell/tree/store'
 import { persistentAtom } from '@/lib/persisted'
 import { readKey } from '@/lib/storage'
 import { normalize } from '@/lib/text'
@@ -404,6 +405,25 @@ export function openBrowserTab() {
   const current = tabs.find(tab => tab.id === browserTabId(tabs))
 
   openPreview(current?.target ?? blankPage())
+}
+
+/** ⌘⇧L is a TOGGLE: show the Browser when it's away, fold it away when it's
+ *  the thing on screen. "Away" includes dismissed (Close/⌘W), hidden, or
+ *  parked behind a sibling tab — each re-opens through openBrowserTab's
+ *  reveal path with the page it was last showing. "On screen" means the
+ *  preview tile pane the mirror keeps in the layout tree is visible, i.e.
+ *  not dismissed/hidden/minimized AND the zone's active tab. */
+export function toggleBrowserTab() {
+  const tabs = $previewTabs.get()
+  const id = browserTabId(tabs)
+
+  if (isPaneVisible(`preview-tile:${id}`)) {
+    dismissTreePane(`preview-tile:${id}`)
+
+    return
+  }
+
+  openBrowserTab()
 }
 
 /** Another Browser, always — the strip's "+". */


### PR DESCRIPTION
## What does this PR do?

`view.showBrowser` (⌘⇧L / Ctrl+Shift+L) only ever OPENED the Browser pane. There was no keyboard way to close it again — once the pane was on screen the hotkey read as half-dead and you reached for the mouse (or ⌘W, which throws the page away).

This makes it a real toggle:

- **Open path unchanged.** With the Browser away (closed, hidden, minimized, or parked behind a sibling tab in its zone), the key opens / re-fronts it with the page it was last showing — exactly the existing `openBrowserTab()` behavior.
- **New close path.** When the mirrored `preview-tile:<id>` pane is actually on screen, the key dismisses just that pane through the layout tree's own close path (`dismissTreePane`). The TAB survives, so the next toggle re-fronts the same page instead of landing on `about:blank` — the existing reveal path already handles un-dismissing (`revealTreePane`'s "Reveal beats a Close").

Visibility is asked of the TREE (`isPaneVisible`), not a store boolean — same lesson as `toggleFileBrowserOpen`'s comment: a store flag can say "open" while the pane sits behind a sibling tab, and then the hotkey spends its press re-asserting a value it already held and reads as a dead key.

## Related Issue

None found — searched open PRs for browser-pane/toggle duplicates before opening.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/store/preview.ts` — new `toggleBrowserTab()`: `isPaneVisible('preview-tile:<browserTabId>') ? dismissTreePane(...) : openBrowserTab()`
- `apps/desktop/src/app/hooks/use-keybinds.ts` — `view.showBrowser` handler now calls `toggleBrowserTab`
- `apps/desktop/src/app/command-palette/index.tsx` — `cc-open-browser` runs the toggle; added `toggle`/`close` keywords
- `apps/desktop/src/i18n/{en,zh,ar}.ts` — label "Open browser" → "Toggle browser"
- `apps/desktop/src/store/preview-toggle-browser.test.ts` — behavior tests mirroring `preview-open-browser.test.ts`

## How to Test

1. Press ⌘⇧L — Browser pane opens (blank state invites an address)
2. Navigate somewhere (e.g. example.com)
3. Press ⌘⇧L again — pane folds away
4. Press ⌘⇧L again — pane returns showing example.com, not about:blank
5. Same from ⌘K → "Toggle browser"
6. File preview tabs in the same zone are untouched by the close

```
cd apps/desktop
npx vitest run src/store/preview-toggle-browser.test.ts src/store/preview-open-browser.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(desktop change — ran the full desktop suite instead: 739 files / 7803 tests green, plus `npm run typecheck` clean)*
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (Apple silicon, packaged app)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, tool schemas, or cross-platform surface touched

## For New Skills

N/A

## Screenshots / Logs

Packaged-app verification on macOS: hotkey opens the pane, second press dismisses it, third press restores the previously shown page. Full desktop vitest suite before/after: 7803 passed / 6 skipped, no regressions.