### PR TITLE
fix(desktop): re-arm gateway reconnect after a failed soft switch

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1262,6 +1262,51 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($awaitingResponse.get()).toBe(false)
   })
 
+  it('FIX: a soft switch whose re-dial fails still auto-retries — no permanently dead socket (missing-messages repro)', async () => {
+    // The missing-message defect. A soft switch (connection/mode apply) calls
+    // gateway.close() FIRST, which sets state 'closed'. If the subsequent
+    // re-dial then fails, connect() sets 'error' and softSwitch's catch runs
+    // failDesktopBoot — which only paints, it schedules NOTHING. The boot-retry
+    // timer belongs to boot(), not softSwitch.
+    //
+    // Worse, HermesGateway.setState() de-dupes identical states, so once the
+    // socket is parked on 'closed'/'error' no FURTHER transition is emitted —
+    // the onState listener never fires again and scheduleReconnect() is never
+    // reached. The socket stays dead until the user hits Cmd+R.
+    //
+    // That matches the incident exactly: a deliberate client close (code 1005)
+    // followed by 668s with ZERO ws-ticket mints in the NPM access log, while
+    // the agent turn completed server-side and was persisted but never painted.
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    // The re-dial after the deliberate close cannot reach the backend.
+    FakeWebSocket.mode = 'fail'
+    const socketsBeforeSwitch = FakeWebSocket.instances.length
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    // The switch failed, so we are not open.
+    expect($gatewayState.get()).not.toBe('open')
+
+    // Now let real time pass — far beyond the 15s backoff cap. A healthy
+    // client must keep re-dialing; the incident showed it never did.
+    for (let i = 0; i < 8; i += 1) {
+      await advanceBackoff()
+    }
+
+    // Before the fix this stays flat: the socket is parked dead forever and
+    // any assistant output produced meanwhile never reaches the UI.
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(socketsBeforeSwitch + 1)
+
+    // And when the backend comes back, the client must recover ON ITS OWN.
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+    expect($gatewayState.get()).toBe('open')
+  })
+
   it('manual reconnect revalidates, re-resolves, re-mints, and re-dials the dropped socket', async () => {
     const desktop = fakeDesktop()
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -630,6 +630,17 @@ export function useGatewayBoot({
         if (switchToken !== null) {
           endGatewaySwitch(switchToken)
         }
+
+        // The switch suppressed reconnect scheduling for its whole duration
+        // (the onState guard skips while switching), and HermesGateway
+        // de-dupes identical states — so a socket left closed/errored by a
+        // failed re-dial emits NO further transition and would sit dead until
+        // a manual reload. Re-arm here, after the flag clears: an assistant
+        // turn completing server-side while this socket is dead is exactly the
+        // missing-message defect (persisted but never painted).
+        if (!cancelled && !gatewayOpen() && !$gatewaySwitching.get()) {
+          scheduleReconnect()
+        }
       }
     }
 


### PR DESCRIPTION
## Symptom

A connection/mode apply (local ↔ remote ↔ cloud) whose re-dial fails leaves the WebSocket closed with nothing scheduled to reopen it. The window still looks connected; the socket is dead until the user hits Cmd+R.

The user-visible form is worse than an obvious disconnect: server-side assistant turns keep completing against a client that will never hear them, so **replies silently go missing**.

## Root cause

`useGatewayBoot` suppresses reconnect scheduling while `$gatewaySwitching` is true — correct, because the switch owns the dial. On the success path the flag clears and normal transitions resume.

When the re-dial itself **fails**, the teardown clears the flag and returns without scheduling anything. And because `HermesGateway` dedupes repeated closed/error states, no later transition arrives to schedule recovery either. Nothing is left to re-arm the socket.

This is the ladder rule in `apps/desktop/AGENTS.md` — *"retries are bounded and end in a real recovery affordance — never an infinite spinner"* — failing in the other direction: the retry chain terminates early and silently, with no affordance at all.

## Fix

Re-arm reconnect after the switch teardown when the socket is not open:

```ts
if (!cancelled && !gatewayOpen() && !$gatewaySwitching.get()) {
  scheduleReconnect()
}
```

The `$gatewaySwitching` re-check is load-bearing, not belt-and-braces. `endGatewaySwitch(token)` deliberately declines to clear the flag when its token is stale and a newer switch already owns it. In that case this (older) switch must not schedule a dial that would race the live one. Re-reading the flag *after* teardown is what distinguishes "my switch finished and failed" from "someone else is switching now."

## Tests

A regression test that boots successfully, forces the soft-switch re-dial to fail, advances the retry intervals, asserts further connection attempts are made, then restores an open socket and requires automatic recovery.

It is a behavior test, not a change-detector: reverting the production hunk fails **exactly** that test (1 failed / 39 passed) and nothing else.

## Verification against 68518c1f9b

- `use-gateway-boot.test.tsx` — 40/40 pass
- `src/app/gateway/` — 59/59 pass
- `eslint` — clean on both changed files
- `tsc -p .` reports one error in `src/app/contrib/hooks/use-background-sync.test.ts:660`. It **reproduces on pristine main** with this change stashed, and is unrelated (missing `updateSessionState` in a mock's params).
