### PR TITLE
test(update): isolate the launchd fleet-restart tests from live service state

### DIFF
--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -196,7 +196,7 @@ class TestProbeLaunchdDomainForLabel:
 
 
 class TestGetServicePidsScoping:
-    def _wire(self, monkeypatch):
+    def _wire(self, monkeypatch, *, bare_list_stdout=""):
         monkeypatch.setattr(gw, "is_macos", lambda: True)
         monkeypatch.setattr(gw, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(gw, "get_launchd_label", lambda: "ai.hermes.gateway")
@@ -213,6 +213,21 @@ class TestGetServicePidsScoping:
         monkeypatch.setattr(
             gw, "_locate_launchd_gateway_service", lambda label: located[label]
         )
+        # The all-profiles belt-and-suspenders branch runs a REAL bare
+        # ``launchctl list`` prefix scan (unmocked subprocess.run) that picks
+        # up ai.hermes.gateway* agents this fixture never declared — on a
+        # host with a live gateway the real service PID leaked into the
+        # assertion and made the test host-dependent (#95827). Serve a
+        # canned listing instead so only fixture state is visible.
+        def _fake_bare_list_run(argv, *args, **kwargs):
+            assert argv[:2] == ["launchctl", "list"], (
+                f"unexpected subprocess call under test: {argv}"
+            )
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=bare_list_stdout, stderr=""
+            )
+
+        monkeypatch.setattr(gw.subprocess, "run", _fake_bare_list_run)
 
     def test_all_profiles_returns_every_gateway_service_pid(self, monkeypatch):
         """The update sweep's exclude-set must protect ALL freshly-restarted
@@ -220,6 +235,18 @@ class TestGetServicePidsScoping:
         gateways launchd just respawned)."""
         self._wire(monkeypatch)
         assert gw._get_service_pids(all_profiles=True) == {100, 200}
+
+    def test_all_profiles_scan_merges_unmapped_agent_pids(self, monkeypatch):
+        """The bare ``launchctl list`` prefix scan (#74075) must still add
+        PIDs for agents the label derivation can't map — pinned here with a
+        canned listing so the merge stays deterministic on any host."""
+        listing = (
+            "PID\tStatus\tLabel\n"
+            "300\t0\tai.hermes.gateway-renamed\n"
+            "999\t0\tcom.apple.somethingelse\n"
+        )
+        self._wire(monkeypatch, bare_list_stdout=listing)
+        assert gw._get_service_pids(all_profiles=True) == {100, 200, 300}
 
     def test_default_stays_scoped_to_current_profile(self, monkeypatch):
         """Regression guard: default-scope callers (gateway status, cron,
@@ -642,13 +669,25 @@ class TestWaitForLaunchdServicePid:
 
 
 class TestIncompleteWarningMentionsLaunchctl:
-    def test_launchd_labels_get_launchctl_hint(self, capsys):
+    def test_launchd_labels_get_launchctl_hint(self, monkeypatch, capsys):
+        # The warning reads is_macos() via a call-time ``from hermes_cli
+        # .gateway import is_macos``, so patching the gateway attribute pins
+        # the branch on every host — without this the macOS early-return
+        # branch (bootstrap contract, #88848) ran on macOS while Linux CI
+        # exercised the legacy kickstart line, i.e. the test asserted
+        # different contracts per host (#95827).
+        monkeypatch.setattr(gw, "is_macos", lambda: True)
         _warn_incomplete_gateway_fleet_restart(["ai.hermes.gateway-merit-ops"])
         out = capsys.readouterr().out
         assert "Update incomplete" in out
-        assert "launchctl kickstart -k" in out
+        # #88848: a launchd label in this list means the job is likely
+        # deregistered, and kickstart cannot revive a job launchd no longer
+        # knows about — the recovery contract is bootstrap.
+        assert "launchctl bootstrap" in out
+        assert "launchctl kickstart" not in out
 
-    def test_systemd_units_keep_systemctl_hint(self, capsys):
+    def test_systemd_units_keep_systemctl_hint(self, monkeypatch, capsys):
+        monkeypatch.setattr(gw, "is_macos", lambda: False)
         _warn_incomplete_gateway_fleet_restart(["hermes-gateway-coder"])
         out = capsys.readouterr().out
         assert "systemctl" in out


### PR DESCRIPTION
## What does this PR do?

Fixes #95827: three tests in `tests/hermes_cli/test_update_launchd_fleet_restart.py` failed on any macOS host with a real Hermes launchd gateway loaded (`scripts/run_tests.sh` reported 24 passed / 3 failed at `68518c1f9`). All three are test-isolation gaps, fixed here without touching implementation:

1. **`test_all_profiles_returns_every_gateway_service_pid`** — the all-profiles belt-and-suspenders branch runs a REAL bare `launchctl list` prefix scan (`subprocess.run` directly, unmocked), so the host's live `ai.hermes.gateway` service PID leaked into the `{100, 200}` assertion. The `_wire` fixture now serves a canned `launchctl list` listing (asserting the subprocess call is the bare scan), making the test host-independent. A new sibling pin (`test_all_profiles_scan_merges_unmapped_agent_pids`) covers the merge behavior the live scan was accidentally exercising — the #74075 prefix scan must still add PIDs for agents the label derivation can't map, pinned with a deterministic listing (`{100, 200, 300}`).
2. **`test_launchd_labels_get_launchctl_hint`** — asserted the prior `launchctl kickstart -k` recovery contract, but the implementation deliberately emits `launchctl bootstrap` since #88848 (a deregistered job cannot be kickstarted), and the macOS branch returns early — so the test passed on Linux CI while asserting a dead contract on macOS. It now pins `gw.is_macos → True` (the warning re-imports the predicate at call time, so patching the gateway attribute works on every host) and asserts the current contract: `launchctl bootstrap` present, `launchctl kickstart` absent.
3. **`test_systemd_units_keep_systemctl_hint`** — never patched the platform predicate, so a macOS host emitted launchd recovery lines even for the systemd fixture and the `launchctl not in out` assertion failed. Now pins `gw.is_macos → False`.

## Related Issue

Fixes #95827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/hermes_cli/test_update_launchd_fleet_restart.py` — `_wire` fixture mocks the bare `launchctl list` subprocess scan (host-independence for the all-profiles tests); new `test_all_profiles_scan_merges_unmapped_agent_pids` pins the #74075 merge behavior the live scan used to exercise; both warning tests monkeypatch `gw.is_macos` (call-time re-import documented) and the launchd test asserts the current bootstrap recovery contract instead of the pre-#88848 kickstart contract.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_update_launchd_fleet_restart.py -q` — should pass: 28 passed.
2. Red/green verified on a macOS host WITH a live `ai.hermes.gateway` launchd service (the report's trigger condition): with the test change stashed, exactly the three reported tests fail (3 failed, 24 passed — the real service PID leaks into the scoping assertion, the launchd hint test asserts the dead kickstart contract, the systemd test sees launchd lines); with the change, 28 passed.
3. On a host with no live Hermes gateway the suite passes both before and after (the failures are strictly host-state-dependent — this PR removes that dependence). `ruff check` on the changed file should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches this test file's isolation
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file suite green on a live-gateway host)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — the #74075 merge pin replaces the accidental live coverage
- [x] I've tested on my platform: macOS 15.5 (arm64) with a live launchd gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the tests were host-state-dependent; now deterministic on every host
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
