### PR TITLE
fix(desktop): restore the typecheck by completing the typing-sync harness

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -653,7 +653,19 @@ describe('typing-aware sessions.changed deferral', () => {
       refreshCurrentModel: vi.fn(),
       refreshHermesConfig: vi.fn(),
       refreshMessagingSessions: vi.fn(),
-      requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+      requestGateway: vi.fn(async () => ({ sessions: [] })) as never,
+      // Required by the hook's params. This harness never drives the
+      // transcript path, so the updater just runs against a throwaway state —
+      // but it must live in `stable` like every other prop, since a fresh
+      // identity per render would re-run the connect-reseed effect.
+      updateSessionState: vi.fn(
+        (
+          _sessionId: string,
+          updater: (state: ReturnType<typeof createClientSessionState>) => ReturnType<
+            typeof createClientSessionState
+          >
+        ) => updater(createClientSessionState(ACTIVE_STORED_ID))
+      )
     }
 
     return renderHook(() => {


### PR DESCRIPTION
## main is red

`68518c1f9b` added a dedicated `renderTypingSync` harness for the typing-aware deferral tests, but its params object omits `updateSessionState`, which `BackgroundSyncParams` requires:

```
src/app/contrib/hooks/use-background-sync.test.ts(660,25): error TS2345:
Argument of type '{ refreshSessions: ...; gatewayState: string; }' is not
assignable to parameter of type 'BackgroundSyncParams'.
  Property 'updateSessionState' is missing in type '{ ... }' but required
  in type 'BackgroundSyncParams'.
```

`npm run typecheck` exits 2 → `apps/desktop :: check:lint` fails → **JS & TS checks goes red on every open PR regardless of its contents.** I hit this on an unrelated Desktop PR and traced it back to main HEAD rather than my own change.

## Why it got through

Vitest transpiles without typechecking, so the new suite passes green while `tsc -p .` fails. The tests are fine; only the harness's type contract is incomplete.

## Fix

Supply the missing prop. The updater runs against a throwaway state, since this harness never exercises the transcript path.

It is added to the existing `stable` object rather than inline deliberately — the harness's own comment requires every param to keep a stable identity across the tick-driven re-renders:

> EVERY param must keep a stable identity across the tick-driven re-renders — an unstable prop would re-run the connect-reseed effect and re-subscribe the throttle each render, polluting the counts under observation.

A fresh `vi.fn()` per render would do exactly that and quietly corrupt the counts these tests assert on.

## Verification

- `tsc -p .`, `tsc -p tsconfig.electron.json`, `tsc -p tsconfig.e2e.json` — all clean (the full `npm run typecheck` chain)
- `use-background-sync` suites — 26/26 pass
- `eslint` — clean

Worth merging ahead of other Desktop PRs; they can't go green until this lands.
