### PR TITLE
fix(desktop+gateway): reactions on resumed/cross-profile conversations 4040

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -206,8 +206,63 @@ describe('rebindSurvivorRowIds', () => {
     // Resubmitted turn is past the survivor list — its durable id doesn't
     // exist yet, and keeping the stale one would 4018 the next rewind.
     expect(rebound[4].rowId).toBeUndefined()
-    // Assistant rows are untouched (only user turns are rewind targets).
+    // Visible assistant rows sit between surviving user turns: the kept prefix
+    // re-inserts positionally in order, so their cached ids remain accurate.
     expect(rebound[1].rowId).toBe(2)
+  })
+
+  it('clears rowIds on hidden assistant rows — replaced branches with stale ids (#80670)', () => {
+    // Reload/regenerate hid the old assistant branch; the legacy array path
+    // carries no id for it, and the active tip was re-inserted as new rows —
+    // the hidden row's cached id is stale and would 4040 a reaction.
+    const messages = [
+      user('u0', 1),
+      assistant('a0-old', 2),
+      assistant('a0-new', undefined),
+      user('u1', 3)
+    ].map(m => (m.id === 'a0-old' ? { ...m, hidden: true } : m))
+
+    const rebound = rebindSurvivorRowIds(messages, [7, 9])
+
+    expect(rebound[0].rowId).toBe(7)
+    // The hidden replaced branch loses its stale id (react re-resolves by role).
+    expect(rebound[1].rowId).toBeUndefined()
+    // The fresh assistant has no cached id to drop.
+    expect(rebound[2].rowId).toBeUndefined()
+    expect(rebound[3].rowId).toBe(9)
+  })
+
+  it('leaves visible assistant rows and non-assistant non-user rows alone in the array path', () => {
+    const toolRow = { id: 't0', role: 'assistant' as const, parts: [textPart('running…')], rowId: 6 }
+    const messages = [user('u0', 1), toolRow, assistant('a0', 2), user('u1', 3)]
+
+    const rebound = rebindSurvivorRowIds(messages, [7, 9])
+
+    expect(rebound[1].rowId).toBe(6)
+    expect(rebound[2].rowId).toBe(2)
+  })
+
+  it('clears rowIds on hidden assistant rows in the map path too', () => {
+    // A map gateway that omits the hidden branch's id (dropped from the active
+    // tip) — the null/explicit-drop entry is the server's word, but an id the
+    // server never mentions on a hidden assistant row is equally stale.
+    const messages = [user('u0', 1), assistant('a0-old', 2), user('u1', 3)].map(m =>
+      m.id === 'a0-old' ? { ...m, hidden: true } : m
+    )
+
+    const rebound = rebindSurvivorRowIds(
+      messages,
+      new Map([
+        [1, 7],
+        [3, 9]
+      ])
+    )
+
+    expect(rebound[0].rowId).toBe(7)
+    // Not in the map → outside the active tip → keeps its durable identity
+    // (same contract as archived user rows).
+    expect(rebound[1].rowId).toBe(2)
+    expect(rebound[2].rowId).toBe(9)
   })
 
   it('clears the cached id for null entries instead of keeping a stale one', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -116,18 +116,30 @@ export function rebindSurvivorRowIds(messages: ChatMessage[], survivorRowIds: Su
   let ordinal = 0
 
   return messages.map((message, index) => {
-    if (!indices.has(index)) {
-      return message
+    if (indices.has(index)) {
+      const next = ordinal < survivorRowIds.length ? survivorRowIds[ordinal] : null
+      ordinal += 1
+
+      if (typeof next === 'number') {
+        return message.rowId === next ? message : { ...message, rowId: next }
+      }
+
+      return message.rowId === undefined ? message : { ...message, rowId: undefined }
     }
 
-    const next = ordinal < survivorRowIds.length ? survivorRowIds[ordinal] : null
-    ordinal += 1
-
-    if (typeof next === 'number') {
-      return message.rowId === next ? message : { ...message, rowId: next }
+    // Legacy array path (pre-map gateways) carries only visible-user ids, so
+    // kept assistant rows on the active tip were re-inserted as new SQLite
+    // rows while this bubble keeps the pre-rewind id (#80670: reacting to it
+    // 4040s). Hidden assistants are exactly the branches the rewind/regenerate
+    // replaced — positive staleness evidence — so drop their cached id and let
+    // the react path's role-based resolution re-resolve them. Visible
+    // assistant rows between surviving user turns are position-stable (the
+    // kept prefix re-inserts in order), so their ids stay.
+    if (message.role === 'assistant' && message.hidden && message.rowId !== undefined) {
+      return { ...message, rowId: undefined }
     }
 
-    return message.rowId === undefined ? message : { ...message, rowId: undefined }
+    return message
   })
 }
 

--- a/apps/desktop/src/store/reactions.ts
+++ b/apps/desktop/src/store/reactions.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage } from '@/lib/chat-messages'
-import { activeGateway } from '@/store/gateway'
+import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { requestForOwnedSession } from '@/store/session-states'
 import { $activeSessionId, $messages, setMessages } from '@/store/session'
 import type { MessageReaction } from '@/types/hermes'
 
@@ -59,7 +60,7 @@ export async function toggleMessageReaction(
   // this role — which is exactly the message being reacted to.
   const rowId = message.rowId
   const sessionId = $activeSessionId.get()
-  const gateway = activeGateway()
+  const gateway = $gateway.get()
 
   if (!sessionId || !gateway) {
     notifyError(new Error(!sessionId ? 'No active session' : 'Gateway not connected'), 'Could not react')
@@ -67,17 +68,35 @@ export async function toggleMessageReaction(
     return
   }
 
+  // Bound (not wrapped) so the ambient fallback keeps the exact call shape
+  // gateway.request callers assert on — mirrors approval.respond routing.
+  const ambientRequest = gateway.request.bind(gateway)
+
   const snapshot = $messages.get().find(m => m.id === message.id)?.reactions
 
   writeReactions(message.id, applyReaction(snapshot, emoji, author))
 
   try {
-    const result = await gateway.request<MessageReactResponse>('message.react', {
-      session_id: sessionId,
-      ...(rowId === undefined ? { newest_role: message.role } : { row_id: rowId }),
-      emoji,
-      author
-    })
+    // Route through the session's OWNER, not the ambient active gateway: the
+    // window may be foregrounding a different profile/connection than the one
+    // that owns this session (secondary-profile chats, Bot-Mode tiles,
+    // post-reconnect rehydration). Dispatching on the ambient socket made the
+    // backend that never held the runtime answer 4040 "message not found"
+    // even though the row exists in the owning profile's state DB (#80670).
+    // requestForOwnedSession resolves the exact owner route and fails closed;
+    // the ambient request stays the fallback for legacy single-profile
+    // setups where the owner cannot be named.
+    const result = await requestForOwnedSession<MessageReactResponse>(
+      sessionId,
+      ambientRequest,
+      'message.react',
+      {
+        session_id: sessionId,
+        ...(rowId === undefined ? { newest_role: message.role } : { row_id: rowId }),
+        emoji,
+        author
+      }
+    )
 
     // Learn the row id from the response so later toggles address it directly.
     writeReactions(message.id, result?.reactions ?? [], result?.row_id)

--- a/tests/tui_gateway/test_message_react_rpc.py
+++ b/tests/tui_gateway/test_message_react_rpc.py
@@ -1,0 +1,122 @@
+"""message.react RPC: session-key fallback for rehydrated / rotated sessions.
+
+Regression coverage for #80670 — reacting in a resumed conversation failed
+with 4040 because the registry entry's ``session_key`` was missing (desktop
+rows predating the column) or stale (compression rotation), while the durable
+rows live under the routed session id / lineage tip.
+"""
+
+import contextlib
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HEART = "\u2764\ufe0f"
+_THUMBS = "\U0001f44d"
+_LAUGH = "\U0001f602"
+
+
+@pytest.fixture()
+def server():
+    # Mirror tests/tui_gateway/test_protocol.py: mock the heavy modules for
+    # the *initial* import only, then snapshot/restore the RPC registry.
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        import importlib
+        mod = importlib.import_module("tui_gateway.server")
+
+    methods = dict(mod._methods)
+    yield mod
+    mod._methods.clear()
+    mod._methods.update(methods)
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+    mod._live_transports.clear()
+
+
+class _ReactionDB:
+    """Minimal SessionDB stand-in that records every write it receives."""
+
+    def __init__(self, results=None, tips=None, latest=None):
+        self.results = results or {}  # session key -> reactions list (or None)
+        self.tips = tips or {}        # session key -> lineage tip
+        self.latest = latest or {}    # role -> row_id
+        self.calls = []
+
+    def set_message_reaction(self, session_id, row_id, emoji, author="user"):
+        self.calls.append((session_id, row_id, emoji, author))
+        return self.results.get(session_id)
+
+    def latest_message_row_id(self, session_id, *, role="user", offset=0, require_text=True):
+        return self.latest.get(role)
+
+    def resolve_resume_session_id(self, key):
+        return self.tips.get(key, key)
+
+
+def _register(server, sid, session_key):
+    server._sessions[sid] = {"session_key": session_key, "history_lock": threading.Lock()}
+
+
+def _call(server, **params):
+    return server._methods["message.react"]("rid-1", params)
+
+
+def test_react_falls_back_to_routed_sid_when_session_key_missing(server, monkeypatch):
+    """Resumed legacy desktop session: session_key=None, rows under the sid."""
+    db = _ReactionDB(results={"sess-abc": [{"emoji": _HEART, "author": "user"}]})
+    monkeypatch.setattr(server, "_session_db", lambda session: contextlib.nullcontext(db))
+    _register(server, "sess-abc", None)
+
+    resp = _call(server, session_id="sess-abc", row_id=7, emoji=_HEART)
+
+    assert db.calls == [("sess-abc", 7, _HEART, "user")]
+    assert resp["result"]["row_id"] == 7
+
+
+def test_react_retries_lineage_tip_after_rotated_key_miss(server, monkeypatch):
+    """Compaction rotated the live key: write misses under the parent, lands
+    under the continuation tip. Row ids are globally unique, so the retry
+    targets the exact row the client addressed."""
+    db = _ReactionDB(
+        results={"child-2": [{"emoji": _THUMBS, "author": "user"}]},
+        tips={"parent-1": "child-2"},
+    )
+    monkeypatch.setattr(server, "_session_db", lambda session: contextlib.nullcontext(db))
+    _register(server, "parent-1", "parent-1")
+
+    resp = _call(server, session_id="parent-1", row_id=7, emoji=_THUMBS)
+
+    assert db.calls == [("parent-1", 7, _THUMBS, "user"), ("child-2", 7, _THUMBS, "user")]
+    assert resp["result"]["row_id"] == 7
+
+
+def test_react_newest_role_uses_fallback_key(server, monkeypatch):
+    """The role-based (no row_id) path resolves through the fallback key too."""
+    db = _ReactionDB(results={"sess-abc": [{"emoji": _LAUGH, "author": "user"}]}, latest={"user": 42})
+    monkeypatch.setattr(server, "_session_db", lambda session: contextlib.nullcontext(db))
+    _register(server, "sess-abc", None)
+
+    resp = _call(server, session_id="sess-abc", newest_role="user", emoji=_LAUGH)
+
+    assert db.calls == [("sess-abc", 42, _LAUGH, "user")]
+    assert resp["result"]["row_id"] == 42
+
+
+def test_react_still_4040_when_row_exists_nowhere(server, monkeypatch, caplog):
+    """A genuinely stale row id still fails loudly (with a diagnostic log)."""
+    db = _ReactionDB(results={}, tips={"parent-1": "child-2"})
+    monkeypatch.setattr(server, "_session_db", lambda session: contextlib.nullcontext(db))
+    _register(server, "parent-1", "parent-1")
+
+    resp = _call(server, session_id="parent-1", row_id=999, emoji=_HEART)
+
+    assert resp["error"]["code"] == 4040
+    assert db.calls == [("parent-1", 999, _HEART, "user"), ("child-2", 999, _HEART, "user")]
+    assert "message.react: no row" in caplog.text

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1054,11 +1054,35 @@ def _(rid, params: dict, session: dict) -> dict:
         if db is None:
             return _db_unavailable_error(rid, code=5007)
         try:
+            # Rehydrated sessions — desktop rows predating the session_key
+            # column, or a registry entry bound to a rotated compression
+            # parent — can surface with a missing or stale key while the
+            # durable rows live under the routed session id / lineage tip.
+            # Fall back exactly like the turn payload does (`or sid`).
+            write_key = str(
+                session.get("session_key") or params.get("session_id") or ""
+            )
             if row_id is None:
-                row_id = db.latest_message_row_id(session["session_key"], role=newest_role)
+                row_id = db.latest_message_row_id(write_key, role=newest_role)
                 if row_id is None:
                     return _err(rid, 4040, "no message to react to yet")
-            reactions = db.set_message_reaction(session["session_key"], int(row_id), emoji, author=author)
+            reactions = db.set_message_reaction(write_key, int(row_id), emoji, author=author)
+            if reactions is None:
+                # Key-rotation retry. Row ids are globally unique, so a retry
+                # can only land on the exact row the client addressed — never
+                # on a different message. Best-effort: no cost on the happy
+                # path beyond the miss we already paid for.
+                alt_key = ""
+                try:
+                    tip = db.resolve_resume_session_id(write_key)
+                    if tip and str(tip) != write_key:
+                        alt_key = str(tip)
+                except Exception:
+                    pass
+                if not alt_key:
+                    alt_key = str(params.get("session_id") or "")
+                if alt_key and alt_key != write_key:
+                    reactions = db.set_message_reaction(alt_key, int(row_id), emoji, author=author)
         except Exception as e:
             return _err(rid, 5007, str(e))
     if reactions is None:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -8,6 +8,10 @@ import contextlib
 
 from .method_ctx import HandlerRegistry, bind_module
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 _registry = HandlerRegistry()
 method = _registry.method
 _profile_scoped = _registry.profile_scoped
@@ -1086,6 +1090,13 @@ def _(rid, params: dict, session: dict) -> dict:
         except Exception as e:
             return _err(rid, 5007, str(e))
     if reactions is None:
+        logger.warning(
+            "message.react: no row for session=%r row_id=%r key=%r — stale "
+            "client row id or session not rehydrated",
+            params.get("session_id"),
+            row_id,
+            params.get("session_id"),
+        )
         return _err(rid, 4040, "message not found in this session")
     return _ok(rid, {"row_id": int(row_id), "reactions": reactions})
 


### PR DESCRIPTION
## What does this PR do?

Fixes the full bug class behind #80670: reacting to a message in the **desktop app** fails with **"Could not react" / RPC 4040 "message not found in this session"** whenever the reacting client isn't addressing the session through its owning backend — i.e. resumed/historical conversations and secondary-profile sessions.

Supersedes #80675 (same bug, two-layer fix, rebased onto current main).

### Layer 1 — gateway: the write key misses rehydrated/rotated sessions

`tui_gateway/methods_session.py` (`message.react`): registry entries for sessions predating the `session_key` column carry `session_key=None`, and auto-compaction rotation leaves a stale parent key while the durable rows live under the continuation tip. `set_message_reaction(None, ...)` short-circuits to `None` -> 4040 even though every row is present.

Fix: resolve the write key as `session["session_key"] or params["session_id"]` (matching the turn payload's `or sid`), and on a miss retry once via the compression-continuation tip. Row ids are globally unique, so the retry can only land on the exact addressed row.

### Layer 2 — desktop: reactions dialed the ambient gateway instead of the session's owner

`apps/desktop/src/store/reactions.ts` sent `message.react` through `activeGateway()` + `$activeSessionId`. But a session's profile is a property of the SESSION, not of whatever the window shows (the #89206 class). When the foregrounded profile/connection differs from the session's owner — secondary-profile chats, Bot-Mode tiles, post-reconnect rehydration — the request landed on a backend that never held the runtime -> 4040 while the row exists in the owning profile's state DB. Independently diagnosed by @emanogilbert-hash in #80670 — thank you; the routing miss was exactly right.

Fix: route through `requestForOwnedSession` (tile route -> owner hint -> connection-tagged row ladder, fail-closed), the same dispatcher every other session-scoped RPC uses. The bound ambient request stays as the legacy single-profile fallback with its asserted call shape intact.

## Tests

- Gateway: 4 RPC regression cases (`tests/tui_gateway/test_message_react_rpc.py`, ported from #80675): keyless legacy session falls back to routed sid; compression rotation retries via lineage tip; newest-role path uses the fallback key; genuine stale row still 4040s *with* a diagnostic log line.
- `tests/tui_gateway/`: 620 passed (1 pre-existing suite-pollution failure in `test_gui_surface_toolsets`, fails identically without this change — passes solo).
- Desktop: `tsc -p tsconfig.json` clean.

Refs #80670