### PR TITLE
feat(cron): add deterministic capability routing

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -63,7 +63,15 @@ describe('cronEditorUpdates', () => {
   it('omits prompt when saving a script-only job with an empty prompt', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'local', model: '', name: 'Weekly', prompt: '', provider: '', schedule: '0 9 * * 1' },
+        {
+          deliver: 'local',
+          model: '',
+          name: 'Weekly',
+          prompt: '',
+          provider: '',
+          routingSlot: '',
+          schedule: '0 9 * * 1'
+        },
         { scriptOnlyJob: true }
       )
     ).toEqual({
@@ -76,7 +84,15 @@ describe('cronEditorUpdates', () => {
   it('includes prompt when the user typed one on a script-only job', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'email', model: '', name: 'Weekly', prompt: 'note', provider: '', schedule: '0 9 * * 1' },
+        {
+          deliver: 'email',
+          model: '',
+          name: 'Weekly',
+          prompt: 'note',
+          provider: '',
+          routingSlot: '',
+          schedule: '0 9 * * 1'
+        },
         { scriptOnlyJob: true }
       ).prompt
     ).toBe('note')
@@ -90,6 +106,7 @@ describe('cronEditorUpdates', () => {
         name: 'Daily',
         prompt: 'go',
         provider: 'anthropic',
+        routingSlot: 'synthesis',
         schedule: '0 9 * * *'
       },
       { scriptOnlyJob: false }
@@ -97,25 +114,44 @@ describe('cronEditorUpdates', () => {
 
     expect(updates.model).toBe('claude-sonnet-4')
     expect(updates.provider).toBe('anthropic')
+    expect(updates.routing_slot).toBe('synthesis')
   })
 
   it('clears a previous pin when the override is reset to default', () => {
     const updates = cronEditorUpdates(
-      { deliver: 'local', model: '', name: 'Daily', prompt: 'go', provider: '', schedule: '0 9 * * *' },
+      {
+        deliver: 'local',
+        model: '',
+        name: 'Daily',
+        prompt: 'go',
+        provider: '',
+        routingSlot: '',
+        schedule: '0 9 * * *'
+      },
       { scriptOnlyJob: false }
     )
 
     expect(updates.model).toBe(null)
     expect(updates.provider).toBe(null)
+    expect(updates.routing_slot).toBe(null)
   })
 
   it('never touches model fields on script-only jobs', () => {
     const updates = cronEditorUpdates(
-      { deliver: 'local', model: 'x', name: 'Weekly', prompt: '', provider: 'y', schedule: '0 9 * * 1' },
+      {
+        deliver: 'local',
+        model: 'x',
+        name: 'Weekly',
+        prompt: '',
+        provider: 'y',
+        routingSlot: 'critical',
+        schedule: '0 9 * * 1'
+      },
       { scriptOnlyJob: true }
     )
 
     expect('model' in updates).toBe(false)
     expect('provider' in updates).toBe(false)
+    expect('routing_slot' in updates).toBe(false)
   })
 })

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -42,6 +42,8 @@ export interface CronEditorSaveValues {
   prompt: string
   /** Provider for the model override ('' = none). Always paired with model. */
   provider: string
+  /** Optional capability slot override ('' = deterministic classifier). */
+  routingSlot: string
   schedule: string
 }
 
@@ -89,6 +91,7 @@ export function cronEditorUpdates(values: CronEditorSaveValues, options: { scrip
   if (!options.scriptOnlyJob) {
     updates.model = values.model.trim() || null
     updates.provider = values.provider.trim() || null
+    updates.routing_slot = values.routingSlot.trim() || null
   }
 
   return updates

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -90,6 +90,11 @@ const DEFAULT_DELIVER = 'local'
 // the model picker carries this sentinel and is mapped back to '' on save.
 const MODEL_DEFAULT_VALUE = '__default__'
 
+// Radix <SelectItem> rejects empty-string values. This sentinel represents
+// the backend's deterministic classifier; the empty string is sent on save so
+// the server, not the desktop, remains the routing authority.
+const ROUTING_SLOT_DEFAULT_VALUE = '__routing_default__'
+
 // "Start from" default: the manual editor (blank cron). Any other value is a
 // blueprint key. Blueprint keys never collide with this sentinel.
 const CUSTOM_TEMPLATE = 'custom'
@@ -146,6 +151,42 @@ function jobModel(job: CronJob): string {
 
 function jobProvider(job: CronJob): string {
   return asText(job.provider).trim()
+}
+
+function jobRouting(job: CronJob): Record<string, unknown> {
+  return job.routing && typeof job.routing === 'object' ? job.routing : {}
+}
+
+function jobRoutingSlot(job: CronJob): string {
+  const routing = jobRouting(job)
+  if (job.no_agent || asText(routing.mode) === 'no_agent') {
+    return ''
+  }
+  return asText(job.routing_slot).trim() || asText(routing.slot).trim()
+}
+
+function jobRoutingReasoning(job: CronJob): string {
+  const routing = jobRouting(job)
+  if (job.no_agent || asText(routing.mode) === 'no_agent') {
+    return ''
+  }
+  return asText(job.reasoning_effort).trim() || asText(routing.reasoning_effort).trim()
+}
+
+function jobRoutingModel(job: CronJob): string {
+  const routing = jobRouting(job)
+  if (job.no_agent || asText(routing.mode) === 'no_agent') {
+    return ''
+  }
+  return asText(routing.effective_model).trim() || asText(routing.requested_model).trim() || jobModel(job)
+}
+
+function jobRoutingProvider(job: CronJob): string {
+  const routing = jobRouting(job)
+  if (job.no_agent || asText(routing.mode) === 'no_agent') {
+    return ''
+  }
+  return asText(routing.effective_provider).trim() || asText(routing.requested_provider).trim() || jobProvider(job)
 }
 
 function cronParts(expr: string): null | string[] {
@@ -796,7 +837,10 @@ function CronJobDetail({
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
-  const modelOverride = jobModel(job)
+  const routeSlot = jobRoutingSlot(job)
+  const routeReasoning = jobRoutingReasoning(job)
+  const routeModel = jobRoutingModel(job)
+  const routeProvider = jobRoutingProvider(job)
 
   return (
     <PanelDetail>
@@ -822,7 +866,15 @@ function CronJobDetail({
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
             { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
-            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : [])
+            ...(routeModel ? [{ label: c.modelLabel, value: routeModel }] : []),
+            ...(routeSlot
+              ? [
+                  {
+                    label: c.routingLabel,
+                    value: `${c.routingSlots[routeSlot] ?? routeSlot}${routeProvider ? ` · ${routeProvider}` : ''}${routeReasoning ? ` · ${routeReasoning}` : ''}`
+                  }
+                ]
+              : [])
           ]}
         />
 
@@ -1040,6 +1092,9 @@ function CronEditorDialog({
   // Per-job model override, encoded as `${providerSlug}:${model}` (split on the
   // first ':' when saving). MODEL_DEFAULT_VALUE = follow the global default.
   const [modelChoice, setModelChoice] = useState(MODEL_DEFAULT_VALUE)
+  // Empty means the backend's deterministic classifier. The UI only sends an
+  // explicit override when the user picks one; it never resolves models here.
+  const [routingSlot, setRoutingSlot] = useState('')
   // Blueprint fills typed slots (time/enum/weekdays/text) instead of the raw
   // cron fields; the backend renders the prompt + schedule from them.
   const [slotValues, setSlotValues] = useState<Record<string, string>>({})
@@ -1094,6 +1149,7 @@ function CronEditorDialog({
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
     setModelChoice(initial && jobModel(initial) ? `${jobProvider(initial)}:${jobModel(initial)}` : MODEL_DEFAULT_VALUE)
+    setRoutingSlot(initial ? asText(initial.routing_slot).trim() : '')
     setSlotValues({})
     setTemplateChoice(editor.mode === 'create' ? (editor.blueprintKey ?? CUSTOM_TEMPLATE) : CUSTOM_TEMPLATE)
     setError(null)
@@ -1175,6 +1231,7 @@ function CronEditorDialog({
         name: name.trim(),
         prompt: prompt.trim(),
         provider: overrideProvider,
+        ...(routingSlot ? { routing_slot: routingSlot } : {}),
         schedule: schedule.trim()
       })
     } catch (err) {
@@ -1366,6 +1423,27 @@ function CronEditorDialog({
               </Field>
             )}
 
+            {!scriptOnlyJob && (
+              <Field htmlFor="cron-routing-slot" label={c.routingSlotLabel} optional optionalLabel={c.optional}>
+                <Select
+                  onValueChange={value => setRoutingSlot(value === ROUTING_SLOT_DEFAULT_VALUE ? '' : value)}
+                  value={routingSlot || ROUTING_SLOT_DEFAULT_VALUE}
+                >
+                  <SelectTrigger className="h-9 rounded-md" id="cron-routing-slot">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ROUTING_SLOT_DEFAULT_VALUE}>{c.routingSlotDefault}</SelectItem>
+                    {(['deterministic', 'interpretation', 'synthesis', 'critical'] as const).map(slot => (
+                      <SelectItem key={slot} value={slot}>
+                        {c.routingSlots[slot] ?? slot}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+
             {schedulePreset === 'custom' ? (
               <Field htmlFor="cron-schedule" label={c.customScheduleLabel}>
                 <Input
@@ -1423,6 +1501,7 @@ interface EditorValues {
   prompt: string
   /** Provider slug for the model override ('' = none). */
   provider: string
+  routingSlot: string
   schedule: string
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2047,6 +2047,15 @@ export const en: Translations = {
     deliverNeedsHomeChannel: 'set a home channel first',
     modelLabel: 'Model',
     modelDefault: 'Default (global model)',
+    routingLabel: 'Capability route',
+    routingSlotLabel: 'Capability slot',
+    routingSlotDefault: 'Automatic (recommended)',
+    routingSlots: {
+      deterministic: 'Deterministic',
+      interpretation: 'Interpretation',
+      synthesis: 'Synthesis',
+      critical: 'Critical'
+    },
     customScheduleLabel: 'Custom schedule',
     customPlaceholder: '0 9 * * * or weekdays at 9am',
     customHint: 'Cron expression, or phrases like "every hour" or "weekdays at 9am".',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1719,6 +1719,10 @@ export interface Translations {
     deliverNeedsHomeChannel: string
     modelLabel: string
     modelDefault: string
+    routingLabel: string
+    routingSlotLabel: string
+    routingSlotDefault: string
+    routingSlots: Record<string, string>
     customScheduleLabel: string
     customPlaceholder: string
     customHint: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2229,6 +2229,15 @@ export const zh: Translations = {
     deliverNeedsHomeChannel: '请先设置主频道',
     modelLabel: '模型',
     modelDefault: '默认（全局模型）',
+    routingLabel: '能力路由',
+    routingSlotLabel: '能力槽位',
+    routingSlotDefault: '自动（推荐）',
+    routingSlots: {
+      deterministic: '确定性',
+      interpretation: '解读',
+      synthesis: '综合',
+      critical: '关键'
+    },
     customScheduleLabel: '自定义排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表达式，或类似"每小时""工作日上午 9 点"的短语。',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -856,6 +856,9 @@ export interface CronJob {
   no_agent?: boolean
   prompt?: null | string
   provider?: null | string
+  reasoning_effort?: null | string
+  routing?: Record<string, unknown>
+  routing_slot?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
@@ -868,6 +871,8 @@ export interface CronJobCreatePayload {
   name?: string
   prompt: string
   provider?: string
+  reasoning_effort?: string
+  routing_slot?: string
   schedule: string
 }
 
@@ -884,6 +889,8 @@ export interface CronJobUpdates {
   name?: string
   prompt?: string
   provider?: null | string
+  reasoning_effort?: null | string
+  routing_slot?: null | string
   schedule?: string
 }
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1830,6 +1830,26 @@ def _normalize_reasoning_effort(value: Any) -> Optional[str]:
     return text
 
 
+def _normalize_routing_slot(value: Any) -> Optional[str]:
+    """Validate and normalize a user-owned capability-slot override."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid routing_slot {value!r}. Valid slots: "
+            "deterministic, interpretation, synthesis, critical "
+            "(empty string clears the override)."
+        )
+    text = value.strip().lower()
+    if not text:
+        return None
+    from cron.routing import ROUTING_SLOTS
+
+    if text not in ROUTING_SLOTS:
+        raise ValueError(f"Unknown cron routing slot: {value!r}")
+    return text
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -1933,6 +1953,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    routing_slot: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2000,6 +2021,11 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        routing_slot: Optional explicit capability slot override. When omitted,
+                the shared deterministic cron classifier selects one of
+                ``deterministic``, ``interpretation``, ``synthesis``, or
+                ``critical``. The selected policy is persisted in ``routing``
+                and resolved fail-closed at fire time.
 
     Returns:
         The created job dict
@@ -2033,6 +2059,7 @@ def create_job(
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_routing_slot = _normalize_routing_slot(routing_slot)
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
@@ -2074,12 +2101,47 @@ def create_job(
 
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
 
+    # One shared deterministic routing contract for every creation surface.
+    # ``create_job`` is the storage choke point used by the model tool, CLI,
+    # dashboard/API, blueprints, and suggestions; keeping the policy record
+    # here prevents adapter-specific routing drift. Pure script jobs are
+    # explicitly marked no_agent and skip classification/model selection.
+    from cron.routing import build_cron_routing_record
+
     provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
         provider=normalized_provider,
         model=normalized_model,
         base_url=normalized_base_url,
         no_agent=normalized_no_agent,
     )
+
+    routing_input = {
+        "prompt": prompt_text,
+        "skills": normalized_skills,
+        "enabled_toolsets": normalized_toolsets,
+        "schedule": parsed_schedule,
+        "context_from": context_from,
+        "monitor_script": normalized_monitor_script,
+        "monitor_url": normalized_monitor_url,
+        "script": normalized_script,
+        "no_agent": normalized_no_agent,
+        "model": normalized_model,
+        "provider": normalized_provider,
+        "base_url": normalized_base_url,
+        "reasoning_effort": normalized_reasoning_effort,
+        "routing_slot": normalized_routing_slot,
+        # If the global config stores no provider/model axis but the
+        # runtime resolver can identify one, use the creation snapshot as
+        # the durable routing assignment. This keeps every new agent job
+        # executable/auditable without making creation itself a paid call.
+        "provider_snapshot": provider_snapshot,
+        "model_snapshot": model_snapshot,
+    }
+    # The creation snapshots are intentionally calculated before the policy
+    # record so an unpinned job receives a concrete, auditable route without a
+    # second provider-resolution call. The shared builder still owns all slot
+    # and override validation.
+    routing_record = build_cron_routing_record(routing_input)
 
     next_run_at = compute_next_run(parsed_schedule)
     if parsed_schedule.get("kind") == "once" and next_run_at is None:
@@ -2103,6 +2165,8 @@ def create_job(
         "skill": normalized_skills[0] if normalized_skills else None,
         "model": normalized_model,
         "provider": normalized_provider,
+        "routing_slot": normalized_routing_slot,
+        "routing": routing_record,
         # Provider/model resolution captured at creation for unpinned jobs
         # (#44585). None for pinned axes, no_agent jobs, resolution failures, and
         # any pre-existing job written before these fields existed (back-compat).
@@ -2264,6 +2328,22 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["reasoning_effort"]
                 )
 
+            if "routing_slot" in updates:
+                updates["routing_slot"] = _normalize_routing_slot(updates["routing_slot"])
+
+            # Keep the storage contract for inference axes identical on create
+            # and update. Dashboard/API callers often send empty strings to
+            # clear an override; store ``None`` rather than a false pin.
+            for _inference_field in ("model", "provider"):
+                if _inference_field in updates:
+                    updates[_inference_field] = _normalize_job_optional_text(
+                        updates[_inference_field]
+                    )
+            if "base_url" in updates:
+                updates["base_url"] = _normalize_job_optional_text(
+                    updates["base_url"], strip_trailing_slash=True
+                )
+
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
@@ -2301,6 +2381,26 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
             ) and _normalized_inference_axes(updated) != previous_inference_axes
+
+            routing_fields_changed = bool(
+                {
+                    "prompt",
+                    "schedule",
+                    "skills",
+                    "skill",
+                    "script",
+                    "monitor_script",
+                    "monitor_url",
+                    "context_from",
+                    "enabled_toolsets",
+                    "no_agent",
+                    "model",
+                    "provider",
+                    "base_url",
+                    "reasoning_effort",
+                    "routing_slot",
+                }.intersection(updates)
+            )
 
             if "skills" in updates or "skill" in updates:
                 normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
@@ -2353,6 +2453,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 )
                 updated["provider_snapshot"] = provider_snapshot
                 updated["model_snapshot"] = model_snapshot
+
+            # New jobs carry the shared routing record. Reclassify/rebuild it
+            # whenever routing inputs change so all mutation surfaces retain
+            # one auditable policy. Legacy records without ``routing`` remain
+            # on the pre-feature execution path until explicitly opted into a
+            # slot, preserving backwards compatibility.
+            if routing_fields_changed and (
+                "routing" in job or bool(updated.get("routing_slot"))
+            ):
+                from cron.routing import build_cron_routing_record
+
+                updated["routing"] = build_cron_routing_record(updated)
 
             if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
                 next_run = compute_next_run(updated["schedule"])

--- a/cron/routing.py
+++ b/cron/routing.py
@@ -1,0 +1,577 @@
+"""Deterministic model/reasoning routing for durable cron jobs.
+
+This module is deliberately independent from the UI and transport layers.  Job
+creation records the deterministic policy decision; execution resolves that
+record against the active profile's configured credentials and fails closed when
+the selected route is not eligible.  No LLM is used for classification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import logging
+import os
+import re
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+ROUTING_VERSION = 1
+ROUTING_SLOTS = ("deterministic", "interpretation", "synthesis", "critical")
+_DEFAULT_REASONING = {
+    "deterministic": "none",
+    "interpretation": "low",
+    "synthesis": "medium",
+    "critical": "high",
+}
+
+
+class CronRoutingError(RuntimeError):
+    """A selected cron route cannot be executed safely."""
+
+    def __init__(self, message: str, *, audit: Mapping[str, Any] | None = None) -> None:
+        self.audit = dict(audit or {})
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class CronRoutingClassification:
+    """Stable, JSON-friendly result of the cron complexity classifier."""
+
+    slot: str
+    score: int
+    scores: dict[str, int]
+    signals: dict[str, Any]
+    reason: str
+
+
+@dataclass(frozen=True)
+class CronRoute:
+    """Effective route selected for one cron fire."""
+
+    slot: str
+    model: str
+    provider: str
+    reasoning_effort: str | None
+    base_url: str | None
+    runtime: dict[str, Any]
+    audit: dict[str, Any]
+
+
+_RISK_RE = re.compile(
+    r"\b(?:prod(?:uction)?|deploy|release|publish|payment|billing|credential|"
+    r"secret|password|token|permission|access|rotate|delete|remove|refund|"
+    r"financial|invoice|legal|external\s+send)\b",
+    re.IGNORECASE,
+)
+_MULTI_STEP_RE = re.compile(
+    r"\b(?:then|after(?:wards)?|before|first|next|finally|compare|pipeline|"
+    r"step\s*\d|one\s+by\s+one|in\s+order|plan)\b",
+    re.IGNORECASE,
+)
+_SEMANTIC_OUTPUTS = frozenset(
+    {"plan", "report", "digest", "summary", "synthesis", "recommendation", "draft"}
+)
+_INTERPRETATION_OUTPUTS = frozenset({"alert", "status", "classification", "decision"})
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    result: list[str] = []
+    for item in value:
+        item_text = _text(item)
+        if item_text and item_text not in result:
+            result.append(item_text)
+    return result
+
+
+def _schedule_kind(schedule: Any) -> str:
+    if isinstance(schedule, Mapping):
+        return _text(schedule.get("kind")).lower()
+    return ""
+
+
+def _schedule_minutes(schedule: Any) -> int | None:
+    if not isinstance(schedule, Mapping):
+        return None
+    try:
+        value = int(schedule.get("minutes"))
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def classify_cron_job(
+    *,
+    prompt: str | None = None,
+    skills: Any = None,
+    enabled_toolsets: Any = None,
+    schedule: Any = None,
+    frequency: Any = None,
+    risk: Any = None,
+    output_type: str | None = None,
+    context_from: Any = None,
+    monitor_script: str | None = None,
+    monitor_url: str | None = None,
+    script: str | None = None,
+    no_agent: bool = False,
+    multiple_steps: Any = None,
+) -> CronRoutingClassification:
+    """Classify a job using only normalized, deterministic input features.
+
+    The classifier is intentionally conservative: risk wins over all other
+    signals, and context/multi-step semantic work wins over simple monitoring.
+    ``no_agent`` is represented as a skipped classification by
+    :func:`build_cron_routing_record`, so callers never spend routing work on a
+    script-only job.
+    """
+    prompt_text = _text(prompt)
+    skill_list = _string_list(skills)
+    toolset_list = _string_list(enabled_toolsets)
+    output = _text(output_type).lower()
+    context_list = _string_list(context_from)
+    schedule_kind = _schedule_kind(schedule)
+    interval_minutes = _schedule_minutes(schedule)
+    if interval_minutes is None:
+        try:
+            interval_minutes = int(frequency) if frequency is not None else None
+        except (TypeError, ValueError):
+            interval_minutes = None
+
+    inferred_risk = bool(risk) if isinstance(risk, bool) else bool(_RISK_RE.search(prompt_text))
+    inferred_multi_step = (
+        bool(multiple_steps)
+        if isinstance(multiple_steps, bool)
+        else bool(_MULTI_STEP_RE.search(prompt_text) or ";" in prompt_text or "\n" in prompt_text)
+    )
+    monitor = bool(_text(monitor_script) or _text(monitor_url))
+    high_frequency = bool(interval_minutes is not None and interval_minutes <= 15)
+    multiple_skills = len(skill_list) > 1
+    multiple_toolsets = len(toolset_list) > 2
+    semantic_output = output in _SEMANTIC_OUTPUTS
+    interpretation_output = output in _INTERPRETATION_OUTPUTS
+
+    scores = {slot: 0 for slot in ROUTING_SLOTS}
+    scores["deterministic"] += 1 if _text(script) and not prompt_text else 0
+    scores["deterministic"] += 1 if output in {"fixed", "verbatim"} else 0
+    scores["interpretation"] += 3 if monitor else 0
+    scores["interpretation"] += 2 if interpretation_output else 0
+    scores["interpretation"] += 1 if high_frequency else 0
+    scores["synthesis"] += 4 if context_list else 0
+    scores["synthesis"] += 3 if multiple_skills else 0
+    scores["synthesis"] += 2 if multiple_toolsets else 0
+    scores["synthesis"] += 3 if semantic_output else 0
+    scores["synthesis"] += 2 if inferred_multi_step else 0
+    scores["critical"] += 10 if inferred_risk else 0
+    scores["critical"] += 2 if output == "action" else 0
+    scores["critical"] += 1 if inferred_multi_step and inferred_risk else 0
+
+    # Risk is an explicit safety override, not merely another weighted signal:
+    # a production/credential/payment action must remain critical even when a
+    # semantic prompt accumulates more synthesis signals. For non-risk jobs,
+    # stable precedence is part of the audit contract; a tie cannot depend on
+    # dict insertion order or a provider/model list returned by the network.
+    precedence = {"critical": 4, "synthesis": 3, "interpretation": 2, "deterministic": 1}
+    slot = (
+        "critical"
+        if inferred_risk
+        else max(ROUTING_SLOTS, key=lambda candidate: (scores[candidate], precedence[candidate]))
+    )
+    if scores[slot] == 0:
+        slot = "interpretation"
+        scores[slot] = 1
+
+    signals = {
+        "risk": inferred_risk,
+        "multiple_steps": inferred_multi_step,
+        "multiple_skills": multiple_skills,
+        "multiple_toolsets": multiple_toolsets,
+        "context_from": bool(context_list),
+        "monitor": monitor,
+        "high_frequency": high_frequency,
+        "schedule_kind": schedule_kind,
+        "output_type": output or None,
+        "script": bool(_text(script)),
+    }
+    reason_parts = [key for key, enabled in signals.items() if enabled is True]
+    reason = ", ".join(reason_parts) if reason_parts else "baseline semantic task"
+    return CronRoutingClassification(
+        slot=slot,
+        score=scores[slot],
+        scores=scores,
+        signals=signals,
+        reason=reason,
+    )
+
+
+def _cron_config(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    cron = config.get("cron") if isinstance(config, Mapping) else None
+    return cron if isinstance(cron, Mapping) else {}
+
+
+def _model_config(config: Mapping[str, Any]) -> tuple[str, str, str | None]:
+    model_cfg = config.get("model") if isinstance(config, Mapping) else None
+    if isinstance(model_cfg, str):
+        return _text(model_cfg), "", None
+    if isinstance(model_cfg, Mapping):
+        default = model_cfg.get("default") or model_cfg.get("model") or model_cfg.get("name")
+        if isinstance(default, Mapping):
+            default_model = default.get("model") or default.get("default") or default.get("name")
+            default_provider = default.get("provider")
+        else:
+            default_model = default
+            default_provider = None
+        return (
+            _text(default_model),
+            _text(model_cfg.get("provider") or default_provider),
+            _text(model_cfg.get("base_url")) or None,
+        )
+    return "", "", None
+
+
+def _slot_policy(config: Mapping[str, Any], slot: str) -> Mapping[str, Any]:
+    cron = _cron_config(config)
+    routing = cron.get("routing") if isinstance(cron, Mapping) else None
+    slots = routing.get("slots") if isinstance(routing, Mapping) else None
+    if isinstance(slots, Mapping) and isinstance(slots.get(slot), Mapping):
+        return slots[slot]
+    return {}
+
+
+def _load_active_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
+def _canonical_effort(value: Any, *, default: str | None = None) -> str | None:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return default
+    from hermes_constants import parse_reasoning_effort
+
+    parsed = parse_reasoning_effort(value)
+    if parsed is None:
+        raise ValueError(f"Invalid cron routing reasoning_effort: {value!r}")
+    if parsed.get("enabled") is False:
+        return "none"
+    return _text(parsed.get("effort")) or default
+
+
+def _assignment_for_job(job: Mapping[str, Any], config: Mapping[str, Any], slot: str) -> dict[str, Any]:
+    cron = _cron_config(config)
+    policy = _slot_policy(config, slot)
+    global_model, global_provider, global_base_url = _model_config(config)
+
+    def _specific_provider(value: Any) -> str:
+        provider = _text(value)
+        return "" if provider.lower() in {"", "auto"} else provider
+
+    requested_model = _text(job.get("model")) or _text(policy.get("model"))
+    if not requested_model:
+        requested_model = _text(job.get("model_snapshot"))
+    if not requested_model:
+        requested_model = _text(cron.get("model")) or global_model
+    if not requested_model:
+        requested_model = _text(os.getenv("HERMES_MODEL"))
+
+    requested_provider = _specific_provider(job.get("provider")) or _specific_provider(policy.get("provider"))
+    if not requested_provider:
+        requested_provider = _specific_provider(cron.get("model_provider")) or _specific_provider(global_provider)
+    if not requested_provider:
+        requested_provider = _text(job.get("provider_snapshot"))
+
+    base_url = _text(job.get("base_url")) or _text(policy.get("base_url"))
+    if not base_url:
+        base_url = _text(global_base_url)
+
+    explicit_effort = job.get("reasoning_effort")
+    effort = _canonical_effort(
+        explicit_effort,
+        default=_canonical_effort(
+            policy.get("reasoning_effort"),
+            default=_DEFAULT_REASONING[slot],
+        ),
+    )
+    return {
+        "model": requested_model,
+        "provider": requested_provider,
+        "base_url": base_url or None,
+        "reasoning_effort": effort,
+    }
+
+
+def build_cron_routing_record(
+    job: Mapping[str, Any],
+    config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the persisted routing policy for a newly-created/updated job."""
+    raw_slot = _text(job.get("routing_slot") or job.get("cron_slot"))
+    if raw_slot and raw_slot.lower() not in ROUTING_SLOTS:
+        raise ValueError(f"Unknown cron routing slot: {raw_slot!r}")
+    if bool(job.get("no_agent")):
+        return {
+            "version": ROUTING_VERSION,
+            "mode": "no_agent",
+            "slot": None,
+            "classification": {"skipped": True, "reason": "no_agent script job"},
+            "overrides": {},
+        }
+
+    cfg = config if isinstance(config, Mapping) else _load_active_config()
+    if raw_slot:
+        slot = raw_slot.lower()
+        classification = classify_cron_job(
+            prompt=_text(job.get("prompt")),
+            skills=job.get("skills") or job.get("skill"),
+            enabled_toolsets=job.get("enabled_toolsets"),
+            schedule=job.get("schedule"),
+            context_from=job.get("context_from"),
+            monitor_script=job.get("monitor_script"),
+            monitor_url=job.get("monitor_url"),
+            script=job.get("script"),
+            no_agent=False,
+        )
+        classification_reason = f"explicit slot override ({slot}); classifier={classification.slot}"
+    else:
+        classification = classify_cron_job(
+            prompt=_text(job.get("prompt")),
+            skills=job.get("skills") or job.get("skill"),
+            enabled_toolsets=job.get("enabled_toolsets"),
+            schedule=job.get("schedule"),
+            context_from=job.get("context_from"),
+            monitor_script=job.get("monitor_script"),
+            monitor_url=job.get("monitor_url"),
+            script=job.get("script"),
+            no_agent=False,
+        )
+        slot = classification.slot
+        classification_reason = classification.reason
+
+    assignment = _assignment_for_job(job, cfg, slot)
+    explicit_overrides = {
+        key: _text(job.get(key))
+        for key in ("model", "provider", "base_url", "routing_slot", "cron_slot")
+        if _text(job.get(key))
+    }
+    return {
+        "version": ROUTING_VERSION,
+        "mode": "agent",
+        "slot": slot,
+        "classification": {
+            "skipped": False,
+            **asdict(classification),
+            "reason": classification_reason,
+        },
+        # These are the creation-time policy inputs. They keep a later global
+        # chat-model switch from silently changing a durable job.
+        "requested_model": assignment["model"] or None,
+        "requested_provider": assignment["provider"] or None,
+        "requested_base_url": assignment["base_url"],
+        "reasoning_effort": assignment["reasoning_effort"],
+        "overrides": explicit_overrides,
+        "fallback_policy": "fail_closed",
+    }
+
+
+def _runtime_is_eligible(runtime: Mapping[str, Any]) -> tuple[bool, str]:
+    if runtime.get("healthy") is False or runtime.get("available") is False:
+        return False, "provider runtime reported unhealthy/unavailable"
+    provider = _text(runtime.get("provider")).lower()
+    if not provider:
+        return False, "runtime did not identify a provider"
+    # A normal provider must expose a resolved credential or a concrete local
+    # endpoint. This rejects catalog-only entries and empty auth resolution.
+    if not _text(runtime.get("api_key")) and not _text(runtime.get("base_url")):
+        return False, "provider has neither a resolved credential nor an endpoint"
+
+    # ``resolve_runtime_provider`` is the canonical credential/endpoint
+    # resolver. A pool object returned in the runtime is already selected by
+    # that resolver; probing a freshly-loaded pool here would mutate/prune
+    # shared auth state and can disagree with the entry actually selected for
+    # the call. Only inspect an explicitly supplied runtime pool.
+    pool = runtime.get("credential_pool")
+    if pool is not None:
+        try:
+            if pool.has_credentials() and not pool.has_available():
+                return False, f"all credentials for provider {provider!r} are exhausted or unavailable"
+        except Exception as exc:
+            return False, f"credential availability could not be verified: {exc}"
+    return True, "eligible"
+
+
+def resolve_cron_route(
+    job: Mapping[str, Any],
+    config: Mapping[str, Any] | None = None,
+) -> CronRoute:
+    """Resolve one persisted policy against the active profile runtime.
+
+    There is deliberately no fallback loop here.  The selected provider/model
+    pair is atomic; an unavailable route raises :class:`CronRoutingError` and
+    the scheduler must not construct an agent or spend tokens.
+    """
+    assert not bool(job.get("no_agent")), "no_agent jobs do not have an inference route"
+    cfg = config if isinstance(config, Mapping) else _load_active_config()
+    policy = job.get("routing")
+    if not isinstance(policy, Mapping):
+        policy = build_cron_routing_record(job, cfg)
+    if _text(policy.get("mode")).lower() == "no_agent":
+        raise AssertionError("no_agent jobs do not have an inference route")
+
+    slot = _text(policy.get("slot")).lower()
+    if slot not in ROUTING_SLOTS:
+        raise CronRoutingError(
+            f"Cron routing fail-closed: invalid persisted slot {slot!r}",
+            audit={"status": "blocked", "slot": slot, "reason": "invalid_slot"},
+        )
+    assignment = {
+        "model": _text(policy.get("requested_model")),
+        "provider": _text(policy.get("requested_provider")),
+        "base_url": _text(policy.get("requested_base_url")) or None,
+        "reasoning_effort": policy.get("reasoning_effort"),
+    }
+    if not assignment["model"] or not assignment["provider"]:
+        fallback_assignment = _assignment_for_job(job, cfg, slot)
+        assignment = {
+            key: assignment[key] or fallback_assignment[key]
+            for key in assignment
+        }
+
+    requested_model = _text(assignment["model"])
+    requested_provider = _text(assignment["provider"])
+    audit = {
+        "version": ROUTING_VERSION,
+        "status": "blocked",
+        "slot": slot,
+        "requested_model": requested_model or None,
+        "requested_provider": requested_provider or None,
+        "reasoning_effort": assignment["reasoning_effort"],
+        "fallback_policy": "fail_closed",
+        "family_switch": False,
+    }
+    if not requested_model:
+        raise CronRoutingError(
+            "Cron routing fail-closed: no eligible model is configured "
+            f"for slot {slot!r}; the job was not executed.",
+            audit=audit | {"reason": "missing_model_assignment"},
+        )
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        provider_is_dynamic = not requested_provider or requested_provider.lower() == "auto"
+        runtime_kwargs: dict[str, Any] = {
+            # A missing provider means the profile has no explicit provider
+            # assignment (for example a bare model config). Let the canonical
+            # runtime resolver choose its configured/eligible default once,
+            # without opening the legacy fallback chain. A concrete provider
+            # remains an exact family pin.
+            "requested": None if provider_is_dynamic else requested_provider,
+            "target_model": requested_model,
+        }
+        if assignment["base_url"]:
+            runtime_kwargs["explicit_base_url"] = assignment["base_url"]
+        runtime = resolve_runtime_provider(**runtime_kwargs)
+    except Exception as exc:
+        raise CronRoutingError(
+            "Cron routing fail-closed: selected model/provider is not eligible "
+            f"for slot {slot!r}; no fallback or family switch was attempted: {exc}",
+            audit=audit | {"reason": "runtime_resolution_failed"},
+        ) from exc
+
+    effective_provider = _text(runtime.get("provider")).lower()
+    try:
+        from hermes_cli.models import normalize_provider
+
+        requested_provider_family = normalize_provider(requested_provider)
+    except Exception:
+        requested_provider_family = requested_provider.lower()
+    # Named custom providers are addressed as ``custom:<name>`` but the
+    # transport intentionally reports the generic ``custom`` provider. Keep
+    # that canonical family equivalence while still pinning the actual
+    # endpoint/credential selected by the resolver.
+    if requested_provider_family.lower().startswith("custom:"):
+        requested_provider_family = "custom"
+    if requested_provider_family.lower() != "custom":
+        try:
+            from hermes_cli.auth import resolve_provider
+
+            if resolve_provider(requested_provider) == "custom":
+                requested_provider_family = "custom"
+        except Exception:
+            pass
+    if not provider_is_dynamic and effective_provider != requested_provider_family.lower():
+        raise CronRoutingError(
+            "Cron routing fail-closed: runtime provider changed the selected "
+            f"family from {requested_provider!r} to {effective_provider!r}; "
+            "no silent family switch is allowed.",
+            audit=audit | {
+                "reason": "family_switch",
+                "effective_provider": effective_provider or None,
+            },
+        )
+    eligible, eligibility_reason = _runtime_is_eligible(runtime)
+    if not eligible:
+        raise CronRoutingError(
+            "Cron routing fail-closed: selected model/provider is unavailable "
+            f"for slot {slot!r} ({eligibility_reason}); no inference call was made.",
+            audit=audit | {"reason": eligibility_reason},
+        )
+
+    runtime_model = _text(runtime.get("model"))
+    if runtime_model and runtime_model != requested_model:
+        raise CronRoutingError(
+            "Cron routing fail-closed: runtime changed the selected model "
+            f"from {requested_model!r} to {runtime_model!r}; "
+            "no silent model switch is allowed.",
+            audit=audit | {
+                "reason": "model_switch",
+                "effective_model": runtime_model,
+                "effective_provider": effective_provider,
+            },
+        )
+
+    effective_runtime = dict(runtime)
+    effective_runtime["model"] = requested_model
+    resolved_audit = audit | {
+        "status": "resolved",
+        "effective_model": requested_model,
+        "effective_provider": effective_provider,
+        "eligibility": eligibility_reason,
+    }
+    return CronRoute(
+        slot=slot,
+        model=requested_model,
+        provider=effective_provider,
+        reasoning_effort=_canonical_effort(
+            assignment["reasoning_effort"],
+            default=_DEFAULT_REASONING[slot],
+        ),
+        base_url=_text(runtime.get("base_url")) or assignment["base_url"],
+        runtime=effective_runtime,
+        audit=resolved_audit,
+    )
+
+
+__all__ = [
+    "CronRoute",
+    "CronRoutingClassification",
+    "CronRoutingError",
+    "ROUTING_SLOTS",
+    "ROUTING_VERSION",
+    "build_cron_routing_record",
+    "classify_cron_job",
+    "resolve_cron_route",
+]

--- a/cron/routing.py
+++ b/cron/routing.py
@@ -60,8 +60,18 @@ class CronRoute:
 
 _RISK_RE = re.compile(
     r"\b(?:prod(?:uction)?|deploy|release|publish|payment|billing|credential|"
-    r"secret|password|token|permission|access|rotate|delete|remove|refund|"
-    r"financial|invoice|legal|external\s+send)\b",
+    r"secret|password|permission|access|rotate|delete|remove|refund|"
+    r"financial|invoice|legal|external\s+send|"
+    r"(?:api|access|auth(?:entication)?|bearer|oauth|refresh|service)\s+tokens?)\b",
+    re.IGNORECASE,
+)
+# A risk word in an explicit prohibition is not an instruction to perform the
+# risky action. Keep the check clause-local so a later positive action in the
+# same prompt still wins (e.g. "do not deploy; deploy after approval").
+_RISK_NEGATION_RE = re.compile(
+    r"\b(?:no|not|never|without|don['’]?t|do\s+not|does\s+not|did\s+not|"
+    r"cannot|can['’]?t|avoid|prevent|read[- ]only|sem|não|nao|nunca|"
+    r"jamais|evite|evitar|somente\s+leitura|apenas\s+leitura)\b",
     re.IGNORECASE,
 )
 _MULTI_STEP_RE = re.compile(
@@ -110,6 +120,22 @@ def _schedule_minutes(schedule: Any) -> int | None:
     return value if value > 0 else None
 
 
+def _has_risk_signal(text: str) -> bool:
+    """Return whether a prompt contains a positive, actionable risk signal."""
+    for match in _RISK_RE.finditer(text):
+        # Stop at sentence/line boundaries. A negation in an earlier clause
+        # must not suppress a later independent risky instruction.
+        clause_start = max(
+            text.rfind(delimiter, 0, match.start())
+            for delimiter in (".", "!", "?", "\n", ";")
+        ) + 1
+        prefix = text[clause_start : match.start()]
+        if _RISK_NEGATION_RE.search(prefix):
+            continue
+        return True
+    return False
+
+
 def classify_cron_job(
     *,
     prompt: str | None = None,
@@ -147,7 +173,7 @@ def classify_cron_job(
         except (TypeError, ValueError):
             interval_minutes = None
 
-    inferred_risk = bool(risk) if isinstance(risk, bool) else bool(_RISK_RE.search(prompt_text))
+    inferred_risk = bool(risk) if isinstance(risk, bool) else _has_risk_signal(prompt_text)
     inferred_multi_step = (
         bool(multiple_steps)
         if isinstance(multiple_steps, bool)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -601,6 +601,113 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
     return resolve_reasoning_config(cfg if isinstance(cfg, dict) else {}, str(model))
 
 
+def _resolve_cron_routing(job: dict, cfg: dict):
+    """Resolve the shared deterministic cron route before agent construction.
+
+    Jobs written before the routing contract existed deliberately return None;
+    the scheduler keeps their legacy model/provider/fallback semantics. New
+    jobs created through ``cron.jobs.create_job`` always carry ``routing`` and
+    therefore use the fail-closed contract.
+    """
+    if not isinstance(job.get("routing"), dict):
+        return None
+    from cron.routing import resolve_cron_route
+
+    return resolve_cron_route(job, cfg)
+
+
+def _cron_routing_audit_fields(
+    *,
+    route=None,
+    audit: Optional[dict] = None,
+    status: Optional[str] = None,
+    failure_reason: Optional[str] = None,
+) -> dict:
+    """Return non-secret, flat + nested routing fields for run audit logs."""
+    payload = dict(audit or {})
+    if route is not None:
+        payload = dict(route.audit)
+        payload.setdefault("slot", route.slot)
+        payload.setdefault("effective_model", route.model)
+        payload.setdefault("effective_provider", route.provider)
+        payload.setdefault("reasoning_effort", route.reasoning_effort)
+    if status is not None:
+        payload["status"] = status
+    if failure_reason is not None:
+        payload["failure_reason"] = failure_reason
+    return {
+        "routing_slot": payload.get("slot"),
+        "routing_requested_model": payload.get("requested_model"),
+        "routing_requested_provider": payload.get("requested_provider"),
+        "routing_effective_model": payload.get("effective_model"),
+        "routing_effective_provider": payload.get("effective_provider"),
+        "routing_reasoning_effort": payload.get("reasoning_effort"),
+        "routing_status": payload.get("status"),
+        "routing_failure_reason": payload.get("failure_reason"),
+        "routing_audit": payload,
+    }
+
+
+def _block_cron_routing_job(
+    job_id: str,
+    job_name: str,
+    reason: str,
+    *,
+    audit: Optional[dict] = None,
+    deliver_target: Optional[str] = None,
+) -> tuple[bool, str, str, Optional[str]]:
+    """Return a loud routing failure without silently executing or downgrading.
+
+    Unlike malformed-job auto-pause, route unavailability can be transient
+    (credential cooldown, provider outage, or a capacity window). Leave the
+    job scheduled so the next tick can retry the same selected route, while
+    exposing the failure through the normal cron error delivery path.
+    """
+    logger.error("Job '%s': cron routing blocked: %s audit=%s", job_id, reason, audit or {})
+    now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+    route_fields = _cron_routing_audit_fields(
+        audit=audit,
+        status="blocked",
+        failure_reason=reason,
+    )
+    route_audit = route_fields["routing_audit"]
+    doc = (
+        f"# Cron Job: {job_name}\n\n"
+        f"**Job ID:** {job_id}\n"
+        f"**Run Time:** {now_iso}\n"
+        "**Status:** BLOCKED (cron routing)\n\n"
+        "The selected capability route was not executed and no model call was "
+        "made. Automatic fallback or family switching is disabled for cron "
+        "routing.\n\n"
+        f"**Reason:** {reason}\n\n"
+        "## Routing audit\n\n"
+        f"- Slot: `{route_audit.get('slot') or 'unknown'}`\n"
+        f"- Requested model: `{route_audit.get('requested_model') or 'unknown'}`\n"
+        f"- Requested provider: `{route_audit.get('requested_provider') or 'unknown'}`\n"
+        f"- Effective model: `{route_audit.get('effective_model') or 'not resolved'}`\n"
+        f"- Effective provider: `{route_audit.get('effective_provider') or 'not resolved'}`\n"
+        f"- Reasoning: `{route_audit.get('reasoning_effort') or 'unknown'}`\n"
+        f"- Failure reason: `{route_audit.get('failure_reason') or reason}`\n"
+    )
+    alert = f"⚠ Cron job '{job_name}' blocked by routing\n\n{reason}"
+    _write_usage_audit({
+        "ts": _utcnow_iso_ms(),
+        "job_id": job_id,
+        "fire_id": uuid.uuid4().hex,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+        "response_silent": False,
+        "deliver_target": deliver_target,
+        "model": route_fields["routing_effective_model"]
+        or route_fields["routing_requested_model"],
+        "duration_ms": 0,
+        "error": reason,
+        **route_fields,
+    })
+    return False, doc, alert, reason
+
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -4997,6 +5104,12 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     blocking here would break that contract (and burning zero LLM calls is
     already guaranteed by the fallback resolution being config-local).
     """
+    # Routed jobs have already passed the canonical provider/credential
+    # resolver and eligibility check immediately before preflight. Re-running
+    # it here would select another pooled credential and break route atomicity;
+    # the remaining preflight checks (skills and delivery) still run.
+    if isinstance(job.get("routing"), dict) and job["routing"].get("mode") != "no_agent":
+        return None
     try:
         if get_fallback_chain(cfg):
             return None
@@ -5336,6 +5449,20 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    cron_route = None
+    route_policy_audit = {}
+    if isinstance(job.get("routing"), dict):
+        _policy = job["routing"]
+        route_policy_audit = {
+            "version": _policy.get("version", 1),
+            "status": "blocked",
+            "slot": _policy.get("slot"),
+            "requested_model": _policy.get("requested_model"),
+            "requested_provider": _policy.get("requested_provider"),
+            "reasoning_effort": _policy.get("reasoning_effort"),
+            "fallback_policy": _policy.get("fallback_policy", "fail_closed"),
+            "family_switch": False,
+        }
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -5865,12 +5992,10 @@ def run_job(
                 else str(delivery_target["thread_id"])
             )
 
-        # Model resolution precedence: per-job override > cron.model (the
-        # cron-fleet default) > HERMES_MODEL env > config.yaml ``model:``
-        # (string or ``{default: ...}``). The per-job value is intentionally
-        # re-read from storage every tick so a ``hermes cron edit --model``
-        # after a failed run takes effect on the next tick — there is no
-        # in-memory cache.
+        # Model resolution is completed by the shared deterministic cron
+        # router immediately before dispatch. Keep this initial value only for
+        # compatibility with the config-loading block below; the route record
+        # is authoritative once loaded.
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # cron.model / cron.model_provider: a deliberate cron-fleet default
@@ -5923,9 +6048,64 @@ def run_job(
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
-        # Fail fast if no model resolved from job / env / config.yaml: an empty
-        # model otherwise reaches the provider as an opaque 400 (#23979).
-        if not (isinstance(model, str) and model.strip()):
+        # The route record may carry a base_url/provider pair that differs from
+        # the legacy top-level fields. Vet that effective pair BEFORE the route
+        # resolver can attach a credential to it; otherwise a hand-edited route
+        # could bypass the F8 credential-exfiltration backstop.
+        _route_guard_job = job
+        if isinstance(job.get("routing"), dict):
+            _route_policy = job["routing"]
+            _route_guard_job = {
+                **job,
+                "provider": _route_policy.get("requested_provider")
+                or job.get("provider"),
+                "base_url": _route_policy.get("requested_base_url")
+                or job.get("base_url"),
+            }
+        try:
+            _guard_job_credential_exfil(_route_guard_job)
+        except Exception as guard_exc:
+            if route_policy_audit:
+                return _block_cron_routing_job(
+                    job_id,
+                    job_name,
+                    f"Cron routing safety gate blocked the selected route: {guard_exc}",
+                    audit=route_policy_audit,
+                    deliver_target=job.get("deliver"),
+                )
+            raise
+
+        # Shared deterministic routing gate. It runs after the existing cheap
+        # monitor/script gates and before provider/agent construction. The
+        # route is atomic: no provider fallback or family switch is attempted
+        # here when the selected slot is unavailable.
+        if route_policy_audit:
+            _audit_fire_id = uuid.uuid4().hex
+            _audit_t_start = time.monotonic()
+        try:
+            cron_route = _resolve_cron_routing(job, _cfg if isinstance(_cfg, dict) else {})
+        except Exception as route_exc:
+            route_audit = getattr(route_exc, "audit", {}) or {}
+            logger.warning(
+                "Job '%s': cron routing blocked before agent construction: %s audit=%s",
+                job_id,
+                route_exc,
+                route_audit,
+            )
+            return _block_cron_routing_job(
+                job_id,
+                job_name,
+                str(route_exc),
+                audit=route_audit,
+                deliver_target=job.get("deliver"),
+            )
+
+        if cron_route is not None:
+            model = cron_route.model
+        elif not (isinstance(model, str) and model.strip()):
+            # Preserve the legacy diagnostic for pre-routing records. New
+            # records fail through the shared route gate above; old jobs must
+            # keep their established missing-model behavior.
             raise RuntimeError(
                 f"Cron job '{job_name}' has no model configured "
                 f"(job.model={job.get('model')!r}, "
@@ -5983,7 +6163,10 @@ def run_job(
             _mt = _cfg.get("max_turns")
         max_iterations = _resolve_turn_limit(_mt)
 
-        # Provider routing
+        # Provider routing. The shared cron route has already resolved and
+        # eligibility-checked the selected primary route. Reuse its exact
+        # transport metadata below; legacy jobs continue through the existing
+        # resolver/fallback path.
         pr = _cfg.get("provider_routing") or {}
 
         from hermes_cli.runtime_provider import (
@@ -5991,14 +6174,6 @@ def run_job(
             format_runtime_provider_error,
         )
         from hermes_cli.auth import AuthError
-
-        # F8 runtime backstop: never resolve a stored provider/base_url pair that
-        # would ship a named provider's stored credential to an off-host endpoint
-        # (CWE-200/CWE-522). The cron tool validates this on create/update, but a
-        # job persisted before that guard — or written directly to the jobs store
-        # — reaches this sink unchecked. Fail closed before resolution so no
-        # off-host call is ever made with a stored key.
-        _guard_job_credential_exfil(job)
 
         # ---------------------------------------------------------------
         # Pre-dispatch configuration validation (T1-26).
@@ -6090,7 +6265,10 @@ def run_job(
                 # Per-job user pin wins; otherwise the cron-fleet default
                 # provider (cron.model_provider); otherwise resolve from
                 # persisted global config.
-                "requested": job.get("provider") or _cron_default_provider or None,
+                "requested": (
+                    cron_route.provider if cron_route is not None
+                    else job.get("provider") or _cron_default_provider or None
+                ),
                 # Derive provider-specific api_mode from the model this job
                 # will actually run (per-job pin > env > config default), not
                 # the stale persisted default — mirrors the fallback path
@@ -6099,12 +6277,31 @@ def run_job(
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
-            runtime = resolve_runtime_provider(**runtime_kwargs)
+            # Reuse the route's already-authenticated runtime for new jobs. A
+            # second resolution can select another pooled credential and, more
+            # importantly, can reintroduce implicit fallback semantics after
+            # the fail-closed routing decision. Legacy jobs retain the old
+            # resolver/fallback path below.
+            if cron_route is not None:
+                runtime = dict(cron_route.runtime)
+                runtime.setdefault("provider", cron_route.provider)
+                runtime.setdefault("requested_provider", cron_route.provider)
+                runtime["model"] = cron_route.model
+            else:
+                runtime = resolve_runtime_provider(**runtime_kwargs)
             primary_provider_for_drift = (
                 str(runtime.get("provider") or "").strip().lower()
                 or primary_provider_for_drift
             )
         except Exception as resolve_exc:
+            if cron_route is not None:
+                # The route was already resolved atomically. An unexpected
+                # failure while transferring its transport metadata must not
+                # reopen the legacy fallback chain or switch model families.
+                raise RuntimeError(
+                    "Cron routed runtime handoff failed after atomic route "
+                    f"resolution: {resolve_exc}"
+                ) from resolve_exc
             # Primary provider resolution failed. Walk fallback_providers for:
             #   1) AuthError (missing/expired credential)
             #   2) Transient network/DNS failures during OAuth refresh or
@@ -6169,6 +6366,10 @@ def run_job(
         reasoning_config = _resolve_job_reasoning_config(
             job, _cfg if isinstance(_cfg, dict) else {}, str(model)
         )
+        if cron_route is not None:
+            from hermes_constants import parse_reasoning_effort
+
+            reasoning_config = parse_reasoning_effort(cron_route.reasoning_effort)
 
         # Provider/model-drift fail-closed guard (#44585).
         #
@@ -6193,7 +6394,7 @@ def run_job(
         # cron.model / cron.model_provider: an axis resolved from the explicit
         # cron-fleet default is NOT drift — the user deliberately routed
         # unpinned cron jobs there, so the guard is skipped for that axis.
-        if cron_model_drift_guard_enabled(_cfg):
+        if cron_route is None and cron_model_drift_guard_enabled(_cfg):
             _drift: list[str] = []
             _current_provider = str(
                 primary_provider_for_drift or runtime.get("provider") or ""
@@ -6266,23 +6467,33 @@ def run_job(
                     f"config is pinned or restored. See #44585."
                 )
 
-        fallback_model = get_fallback_chain(_cfg) or None
+        # Legacy jobs retain the pre-routing fallback chain. New routed jobs
+        # have an atomic family decision and must not silently switch family.
+        fallback_model = None if cron_route is not None else (get_fallback_chain(_cfg) or None)
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
+        if cron_route is not None and runtime.get("credential_pool") is not None:
+            # The route resolver may have selected a pooled credential. Reuse
+            # that exact pool object instead of loading/selecting a second pool
+            # after the atomic route decision.
+            credential_pool = runtime.get("credential_pool")
         if runtime_provider:
-            try:
-                from agent.credential_pool import load_pool
-                pool = load_pool(runtime_provider)
-                if pool.has_credentials():
-                    credential_pool = pool
-                    logger.info(
-                        "Job '%s': loaded credential pool for provider %s with %d entries",
-                        job_id,
-                        runtime_provider,
-                        len(pool.entries()),
-                    )
-            except Exception as e:
-                logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
+            if credential_pool is not None:
+                runtime_provider = str(runtime.get("provider") or "").strip().lower()
+            else:
+                try:
+                    from agent.credential_pool import load_pool
+                    pool = load_pool(runtime_provider)
+                    if pool.has_credentials():
+                        credential_pool = pool
+                        logger.info(
+                            "Job '%s': loaded credential pool for provider %s with %d entries",
+                            job_id,
+                            runtime_provider,
+                            len(pool.entries()),
+                        )
+                except Exception as e:
+                    logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 
         # Initialize MCP servers so configured mcp_servers are available to
         # the agent's tool registry before AIAgent is constructed. Without
@@ -6600,7 +6811,7 @@ def run_job(
         # Emit one JSONL line per fire for usage audit.
         _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
         _audit_response_silent = _is_cron_silence_response(final_response or "")
-        _write_usage_audit({
+        _audit_record = {
             "ts": _utcnow_iso_ms(),
             "job_id": job_id,
             "fire_id": _audit_fire_id,
@@ -6612,7 +6823,15 @@ def run_job(
             "model": model or None,
             "duration_ms": _audit_duration_ms,
             "error": None,
-        })
+        }
+        if cron_route is not None:
+            _audit_record.update(
+                _cron_routing_audit_fields(
+                    route=cron_route,
+                    status="completed",
+                )
+            )
+        _write_usage_audit(_audit_record)
         return True, output, final_response, None
 
     except Exception as e:
@@ -6623,7 +6842,7 @@ def run_job(
         # with a None check so the audit write itself never raises.
         if "_audit_fire_id" in locals():
             _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
-            _write_usage_audit({
+            _audit_record = {
                 "ts": _utcnow_iso_ms(),
                 "job_id": job_id,
                 "fire_id": _audit_fire_id,
@@ -6635,7 +6854,24 @@ def run_job(
                 "model": model or None,
                 "duration_ms": _audit_duration_ms,
                 "error": error_msg,
-            })
+            }
+            if cron_route is not None:
+                _audit_record.update(
+                    _cron_routing_audit_fields(
+                        route=cron_route,
+                        status="failed",
+                        failure_reason=error_msg,
+                    )
+                )
+            elif route_policy_audit:
+                _audit_record.update(
+                    _cron_routing_audit_fields(
+                        audit=route_policy_audit,
+                        status="blocked",
+                        failure_reason=error_msg,
+                    )
+                )
+            _write_usage_audit(_audit_record)
         
         output = f"""# Cron Job: {job_name} (FAILED)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6561,7 +6561,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled",
+        "model", "provider", "base_url", "reasoning_effort", "routing_slot",
+        "script", "context_from", "enabled_toolsets", "workdir", "no_agent",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -6639,6 +6643,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
 
+            # The core storage choke point owns canonical reasoning/slot
+            # validation. API accepts the same fields as dashboard/CLI and
+            # never performs model selection locally.
+
             kwargs = {
                 "prompt": prompt,
                 "schedule": schedule,
@@ -6650,11 +6658,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            for key in (
+                "model", "provider", "base_url", "reasoning_effort", "routing_slot",
+                "script", "context_from", "enabled_toolsets", "workdir", "no_agent",
+            ):
+                if key in body:
+                    kwargs[key] = body[key]
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
         except _CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
+        except ValueError as e:
+            # Validation owned by cron.jobs (including the shared routing slot
+            # and reasoning grammar) is a client error, not a server failure.
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6712,6 +6730,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -510,6 +510,7 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        routing_slot=getattr(args, "routing_slot", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -585,6 +586,7 @@ def cron_edit(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        routing_slot=getattr(args, "routing_slot", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
+from cron.routing import ROUTING_SLOTS
 
 
 def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
@@ -118,6 +119,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "and agent.reasoning_overrides for this job; unsupported levels are "
             "clamped by the provider at request time. Omit to follow config."
         ),
+    )
+    cron_create.add_argument(
+        "--routing-slot",
+        choices=ROUTING_SLOTS,
+        help="Override the deterministic CRON capability slot for this job.",
     )
     cron_create.add_argument(
         "--continuity",
@@ -253,6 +259,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "medium, high, xhigh, max, or ultra. Pass empty string to clear "
             "the pin and follow config resolution."
         ),
+    )
+    cron_edit.add_argument(
+        "--routing-slot",
+        choices=ROUTING_SLOTS,
+        help="Override the CRON capability slot. Omit to keep the current slot.",
     )
 
     # lifecycle actions

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -391,6 +391,8 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    reasoning_effort: Optional[str] = None
+    routing_slot: Optional[str] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12902,9 +12902,11 @@ def _normalize_dashboard_cron_updates(
     """
     normalized = dict(updates or {})
 
-    for key in ("model", "provider", "workdir"):
+    for key in ("model", "provider", "workdir", "routing_slot"):
         if key in normalized:
             normalized[key] = _cron_optional_text(normalized[key])
+    if "reasoning_effort" in normalized:
+        normalized["reasoning_effort"] = _cron_optional_text(normalized["reasoning_effort"])
     if "script" in normalized:
         normalized["script"] = _normalize_dashboard_cron_script(
             normalized["script"],
@@ -13272,6 +13274,8 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            reasoning_effort=_cron_optional_text(body.reasoning_effort),
+            routing_slot=_cron_optional_text(body.routing_slot),
         )
     except HTTPException:
         raise

--- a/tests/cron/test_cron_reasoning_effort.py
+++ b/tests/cron/test_cron_reasoning_effort.py
@@ -208,10 +208,12 @@ class TestCronjobToolReasoningEffort:
         import tools.cronjob_tools as mod
 
         assert "reasoning_effort" not in mod.CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "routing_slot" not in mod.CRONJOB_SCHEMA["parameters"]["properties"]
         # The registry handler lambda must not forward the agent's args to
         # the parameter (mirrors the intentional model/provider omission).
         source = inspect.getsource(self._tool_handler())
         assert 'args.get("reasoning_effort")' not in source
+        assert 'args.get("routing_slot")' not in source
 
     def test_tool_dispatch_drops_reasoning_effort_arg(self, tmp_cron_dir):
         """Even if a model hallucinates the argument, dispatch ignores it:
@@ -222,7 +224,7 @@ class TestCronjobToolReasoningEffort:
             self._tool_handler()(
                 {
                     "action": "create",
-                    "prompt": "daily digest",
+                    "prompt": "Compare the daily inputs, then draft a digest.",
                     "schedule": "every 1h",
                     "reasoning_effort": "max",
                 }
@@ -230,3 +232,22 @@ class TestCronjobToolReasoningEffort:
         )
         assert out["success"] is True
         assert load_jobs()[0].get("reasoning_effort") is None
+
+    def test_tool_dispatch_drops_routing_slot_arg(self, tmp_cron_dir):
+        """A model cannot override the shared capability classifier."""
+        import json
+
+        out = json.loads(
+            self._tool_handler()(
+                {
+                    "action": "create",
+                    "prompt": "Compare the daily inputs, then draft a digest.",
+                    "schedule": "every 1h",
+                    "routing_slot": "critical",
+                }
+            )
+        )
+        assert out["success"] is True
+        stored = load_jobs()[0]
+        assert stored.get("routing_slot") is None
+        assert stored["routing"]["slot"] == "synthesis"

--- a/tests/cron/test_cron_routing.py
+++ b/tests/cron/test_cron_routing.py
@@ -1,0 +1,612 @@
+"""Contract tests for deterministic cron capability routing."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+
+def test_classify_multi_step_context_job_as_synthesis():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt=(
+            "Review the completed week and next two weeks, compare the inputs, "
+            "then produce a concise plan with recommendations."
+        ),
+        skills=["weekly-review-planning", "google-workspace"],
+        enabled_toolsets=["calendar", "file", "web"],
+        schedule={"kind": "interval", "minutes": 10080},
+        context_from=["upstream-job"],
+        output_type="plan",
+    )
+
+    assert result.slot == "synthesis"
+    assert result.signals["context_from"] is True
+    assert result.signals["multiple_skills"] is True
+    assert result.signals["output_type"] == "plan"
+
+
+def test_classify_script_backed_job_as_deterministic():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt="",
+        script="collect_metrics.py",
+        schedule={"kind": "interval", "minutes": 60},
+    )
+
+    assert result.slot == "deterministic"
+    assert result.signals["script"] is True
+
+
+
+def test_classify_high_risk_job_as_critical():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt="Deploy the production release and rotate the payment credentials.",
+        skills=["deployment"],
+        enabled_toolsets=["terminal", "file"],
+        schedule={"kind": "once"},
+        output_type="action",
+    )
+
+    assert result.slot == "critical"
+    assert result.signals["risk"] is True
+
+
+def test_risk_override_beats_many_synthesis_signals():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt="Compare the reports, then draft a production release plan.",
+        skills=["research", "planning", "release"],
+        enabled_toolsets=["web", "file", "terminal"],
+        context_from=["upstream-a", "upstream-b"],
+        output_type="plan",
+    )
+
+    assert result.slot == "critical"
+    assert result.scores["synthesis"] > result.scores["critical"]
+
+
+
+def test_no_agent_route_does_not_resolve_a_provider():
+    from cron.routing import build_cron_routing_record, resolve_cron_route
+
+    job = {
+        "id": "script-only",
+        "prompt": "",
+        "script": "watchdog.py",
+        "no_agent": True,
+        "skills": [],
+        "enabled_toolsets": None,
+        "context_from": None,
+        "routing_slot": None,
+    }
+    record = build_cron_routing_record(job, config={})
+    assert record["mode"] == "no_agent"
+    assert record["classification"]["skipped"] is True
+
+    with pytest.raises(AssertionError):
+        # The no-agent record is intentionally not an inference route.
+        resolve_cron_route({**job, "routing": record}, {})
+
+
+
+def test_resolve_route_uses_configured_slot_and_audits_runtime(monkeypatch):
+    from cron.routing import resolve_cron_route
+
+    calls = []
+
+    def fake_resolve(**kwargs):
+        calls.append(kwargs)
+        return {
+            "provider": "nous",
+            "requested_provider": "nous",
+            "model": "openai/gpt-5.6-luna",
+            "api_key": "test-key",
+            "base_url": "https://inference.example/v1",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve,
+    )
+    cfg = {
+        "cron": {
+            "routing": {
+                "enabled": True,
+                "slots": {
+                    "synthesis": {
+                        "provider": "nous",
+                        "model": "openai/gpt-5.6-luna",
+                        "reasoning_effort": "medium",
+                    }
+                },
+            }
+        }
+    }
+    job = {
+        "id": "synthesis-job",
+        "prompt": "Summarize the source material and draft a report.",
+        "skills": ["research"],
+        "enabled_toolsets": ["web"],
+        "context_from": None,
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "synthesis",
+            "reasoning_effort": "medium",
+            "requested_model": "openai/gpt-5.6-luna",
+            "requested_provider": "nous",
+        },
+    }
+
+    route = resolve_cron_route(job, cfg)
+
+    assert route.slot == "synthesis"
+    assert route.model == "openai/gpt-5.6-luna"
+    assert route.provider == "nous"
+    assert route.reasoning_effort == "medium"
+    assert route.audit["status"] == "resolved"
+    assert route.audit["family_switch"] is False
+    assert calls == [
+        {
+            "requested": "nous",
+            "target_model": "openai/gpt-5.6-luna",
+        }
+    ]
+
+
+
+def test_resolve_route_fails_closed_without_eligible_runtime(monkeypatch):
+    from cron.routing import CronRoutingError, resolve_cron_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("no credential")),
+    )
+    job = {
+        "id": "blocked-job",
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "critical",
+            "reasoning_effort": "high",
+            "requested_model": "m",
+            "requested_provider": "p",
+        },
+    }
+
+    with pytest.raises(CronRoutingError, match="fail-closed"):
+        resolve_cron_route(job, {"cron": {"routing": {"enabled": True}}})
+
+
+def test_resolve_route_rejects_provider_family_switch(monkeypatch):
+    from cron.routing import CronRoutingError, resolve_cron_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "anthropic",
+            "api_key": "test-key",
+            "base_url": "https://api.anthropic.com",
+        },
+    )
+    job = {
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "critical",
+            "requested_model": "m",
+            "requested_provider": "nous",
+            "reasoning_effort": "high",
+        }
+    }
+
+    with pytest.raises(CronRoutingError, match="family") as exc_info:
+        resolve_cron_route(job, {})
+
+    assert exc_info.value.audit["reason"] == "family_switch"
+    assert exc_info.value.audit["effective_provider"] == "anthropic"
+
+
+def test_resolve_route_rejects_runtime_model_switch(monkeypatch):
+    from cron.routing import CronRoutingError, resolve_cron_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "nous",
+            "model": "different-model",
+            "api_key": "test-key",
+            "base_url": "https://inference.example/v1",
+        },
+    )
+    job = {
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "synthesis",
+            "requested_model": "selected-model",
+            "requested_provider": "nous",
+            "reasoning_effort": "medium",
+        }
+    }
+
+    with pytest.raises(CronRoutingError, match="selected model") as exc_info:
+        resolve_cron_route(job, {})
+
+    assert exc_info.value.audit["reason"] == "model_switch"
+
+
+def test_resolve_route_allows_profile_default_provider_resolution(monkeypatch):
+    from cron.routing import resolve_cron_route
+
+    calls = []
+
+    def fake_resolve(**kwargs):
+        calls.append(kwargs)
+        return {
+            "provider": "test",
+            "api_key": "test-key",
+            "base_url": "http://test.local",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve,
+    )
+    route = resolve_cron_route(
+        {
+            "routing": {
+                "version": 1,
+                "mode": "agent",
+                "slot": "interpretation",
+                "requested_model": "profile-model",
+                "requested_provider": "auto",
+            }
+        },
+        {},
+    )
+
+    assert route.provider == "test"
+    assert calls == [{"requested": None, "target_model": "profile-model"}]
+
+
+def test_routed_preflight_does_not_resolve_provider_again(monkeypatch):
+    from cron.scheduler import _preflight_check_provider_key
+
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    assert _preflight_check_provider_key(
+        {
+            "routing": {"mode": "agent", "slot": "synthesis"},
+            "provider": None,
+            "model": None,
+        },
+        {},
+    ) is None
+    assert calls == []
+
+
+def test_routed_scheduler_run_reuses_atomic_runtime_and_audits_route(tmp_path):
+    from cron.scheduler import run_job
+
+    runtime_calls = []
+    runtime = {
+        "provider": "nous",
+        "requested_provider": "nous",
+        "api_key": "test-key",
+        "base_url": "https://inference.example/v1",
+        "api_mode": "chat_completions",
+    }
+
+    def fake_resolve(**kwargs):
+        runtime_calls.append(kwargs)
+        return dict(runtime)
+
+    fake_db = MagicMock()
+    job = {
+        "id": "routed-run",
+        "name": "routed run",
+        "prompt": "Produce a synthesis.",
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "skills": [],
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "synthesis",
+            "requested_model": "selected-model",
+            "requested_provider": "nous",
+            "reasoning_effort": "high",
+        },
+    }
+
+    with patch("cron.scheduler.load_config", return_value={}), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("cron.scheduler._cron_preflight_enabled", return_value=False), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=fake_resolve), \
+         patch("cron.scheduler._usage_audit_path", return_value=tmp_path / "usage_audit.jsonl"), \
+         patch("run_agent.AIAgent") as agent_cls:
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "ok"}
+        agent_cls.return_value = agent
+
+        success, _output, final_response, error = run_job(job)
+
+    assert success is True
+    assert final_response == "ok"
+    assert error is None
+    assert runtime_calls == [{"requested": "nous", "target_model": "selected-model"}]
+    kwargs = agent_cls.call_args.kwargs
+    assert kwargs["model"] == "selected-model"
+    assert kwargs["provider"] == "nous"
+    assert kwargs["fallback_model"] is None
+    assert kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+    audit = __import__("json").loads((tmp_path / "usage_audit.jsonl").read_text().splitlines()[0])
+    assert audit["routing_slot"] == "synthesis"
+    assert audit["routing_effective_model"] == "selected-model"
+    assert audit["routing_effective_provider"] == "nous"
+    assert audit["routing_reasoning_effort"] == "high"
+    assert audit["routing_status"] == "completed"
+
+
+def test_routed_scheduler_blocks_without_agent_or_fallback_and_audits_failure(tmp_path):
+    from cron.scheduler import run_job
+
+    job = {
+        "id": "blocked-routed-run",
+        "name": "blocked routed run",
+        "prompt": "Produce a report.",
+        "deliver": "local",
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "synthesis",
+            "requested_model": "selected-model",
+            "requested_provider": "nous",
+            "reasoning_effort": "medium",
+        },
+    }
+
+    with patch("cron.scheduler.load_config", return_value={}), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=RuntimeError("credential unavailable")), \
+         patch("cron.scheduler._usage_audit_path", return_value=tmp_path / "usage_audit.jsonl"), \
+         patch("run_agent.AIAgent") as agent_cls, \
+         patch("cron.scheduler.get_fallback_chain") as fallback_chain:
+        success, doc, _final_response, error = run_job(job)
+
+    assert success is False
+    assert agent_cls.called is False
+    assert fallback_chain.called is False
+    assert error is not None and "fail-closed" in error
+    assert "no model call was made" in doc
+
+    audit = __import__("json").loads((tmp_path / "usage_audit.jsonl").read_text().splitlines()[0])
+    assert audit["routing_slot"] == "synthesis"
+    assert audit["routing_effective_model"] is None
+    assert audit["routing_effective_provider"] is None
+    assert audit["routing_reasoning_effort"] == "medium"
+    assert audit["routing_status"] == "blocked"
+    assert "credential unavailable" in audit["routing_failure_reason"]
+
+
+def test_routed_safety_guard_runs_before_runtime_resolution(tmp_path):
+    from cron.scheduler import run_job
+
+    resolver_calls = []
+    job = {
+        "id": "unsafe-routed-run",
+        "name": "unsafe routed run",
+        "prompt": "Deploy the release.",
+        "deliver": "local",
+        "routing": {
+            "version": 1,
+            "mode": "agent",
+            "slot": "critical",
+            "requested_model": "selected-model",
+            "requested_provider": "anthropic",
+            "requested_base_url": "https://evil.example/v1",
+            "reasoning_effort": "high",
+        },
+    }
+
+    with patch("cron.scheduler.load_config", return_value={}), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             side_effect=lambda **kwargs: resolver_calls.append(kwargs),
+         ), \
+         patch("cron.scheduler._usage_audit_path", return_value=tmp_path / "usage_audit.jsonl"), \
+         patch("run_agent.AIAgent") as agent_cls:
+        success, doc, _final_response, error = run_job(job)
+
+    assert success is False
+    assert agent_cls.called is False
+    assert resolver_calls == []
+    assert error is not None and "safety gate" in error
+    assert "critical" in doc
+    audit = __import__("json").loads((tmp_path / "usage_audit.jsonl").read_text().splitlines()[0])
+    assert audit["routing_slot"] == "critical"
+    assert audit["routing_effective_model"] is None
+    assert audit["routing_failure_reason"]
+
+
+
+def test_invalid_slot_override_is_rejected_at_shared_creation_contract():
+    from cron.routing import build_cron_routing_record
+
+    with pytest.raises(ValueError, match="Unknown cron routing slot"):
+        build_cron_routing_record(
+            {
+                "prompt": "Do something semantic",
+                "skills": [],
+                "routing_slot": "cheap-but-secret",
+                "no_agent": False,
+            },
+            config={},
+        )
+
+
+def test_non_string_slot_override_is_rejected_at_storage_boundary(tmp_path, monkeypatch):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    with pytest.raises(ValueError, match="Invalid routing_slot"):
+        jobs.create_job(
+            prompt="hello",
+            schedule="every 1h",
+            routing_slot=3,
+        )
+
+    assert jobs.load_jobs() == []
+
+
+
+def test_slot_classification_is_deterministic_for_same_inputs():
+    from cron.routing import classify_cron_job
+
+    kwargs = {
+        "prompt": "Check the status and report only if it changed.",
+        "skills": ["status-check"],
+        "enabled_toolsets": ["web"],
+        "schedule": {"kind": "interval", "minutes": 15},
+        "monitor_script": "status.py",
+        "output_type": "alert",
+    }
+    first = classify_cron_job(**kwargs)
+    second = classify_cron_job(**kwargs)
+
+    assert first == second
+    assert first.slot == "interpretation"
+    assert first.score == second.score
+
+
+
+def test_no_agent_does_not_call_classification(monkeypatch):
+    from cron import routing
+
+    monkeypatch.setattr(
+        routing,
+        "classify_cron_job",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("classified")),
+    )
+    record = routing.build_cron_routing_record(
+        {
+            "prompt": "",
+            "script": "watchdog.py",
+            "no_agent": True,
+            "skills": [],
+        },
+        config={},
+    )
+    assert record["mode"] == "no_agent"
+    assert record["classification"]["skipped"] is True
+
+
+def test_create_job_persists_shared_route_and_audit_fields(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {"provider": "nous"},
+    )
+    monkeypatch.setattr(jobs, "_resolve_default_model_snapshot", lambda: "model-a")
+
+    created = jobs.create_job(
+        prompt="Summarize the collected reports and draft a plan.",
+        schedule="every 1h",
+        skills=["research", "weekly-review-planning"],
+    )
+
+    assert created["routing"]["slot"] == "synthesis"
+    assert created["routing"]["requested_model"] == "model-a"
+    assert created["routing"]["requested_provider"] == "nous"
+    assert created["routing"]["fallback_policy"] == "fail_closed"
+
+
+def test_update_rebuilds_route_when_existing_routed_job_changes(tmp_path, monkeypatch):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr(jobs, "_resolve_default_model_snapshot", lambda: "model-a")
+    created = jobs.create_job(
+        prompt="Check status",
+        schedule="every 1h",
+        routing_slot="interpretation",
+    )
+
+    updated = jobs.update_job(created["id"], {"routing_slot": "critical"})
+
+    assert updated["routing_slot"] == "critical"
+    assert updated["routing"]["slot"] == "critical"
+    assert "explicit slot override" in updated["routing"]["classification"]["reason"]
+
+
+def test_legacy_update_without_explicit_slot_keeps_legacy_execution_path(tmp_path, monkeypatch):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    jobs.save_jobs(
+        [
+            {
+                "id": "legacy-route-job",
+                "name": "legacy route job",
+                "prompt": "hello",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "schedule_display": "every 60m",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+            }
+        ]
+    )
+
+    updated = jobs.update_job("legacy-route-job", {"name": "renamed", "routing_slot": None})
+
+    assert updated["name"] == "renamed"
+    assert "routing" not in updated
+
+
+def test_routed_update_reclassifies_when_schedule_changes(tmp_path, monkeypatch):
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    created = jobs.create_job(
+        prompt="Check status",
+        schedule="every 1h",
+        routing_slot="interpretation",
+    )
+    assert created["routing"]["classification"]["signals"]["high_frequency"] is False
+
+    updated = jobs.update_job(created["id"], {"schedule": "every 5m"})
+
+    assert updated["routing"]["classification"]["signals"]["high_frequency"] is True

--- a/tests/cron/test_cron_routing.py
+++ b/tests/cron/test_cron_routing.py
@@ -42,6 +42,46 @@ def test_classify_script_backed_job_as_deterministic():
 
 
 
+def test_negated_risk_language_does_not_make_a_job_critical():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt=(
+            "Somente leitura. NUNCA autoaplique nada: apenas sugira. "
+            "Sem merge/deploy/gasto."
+        ),
+        schedule={"kind": "interval", "minutes": 1440},
+    )
+
+    assert result.signals["risk"] is False
+    assert result.slot != "critical"
+
+
+def test_cost_tokens_are_not_treated_as_secret_credentials():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt="Analise eficiência de tokens e custo do relatório.",
+        schedule={"kind": "interval", "minutes": 1440},
+    )
+
+    assert result.signals["risk"] is False
+    assert result.slot != "critical"
+
+
+def test_positive_token_credential_instruction_remains_critical():
+    from cron.routing import classify_cron_job
+
+    result = classify_cron_job(
+        prompt="Revogue o access token de produção após a falha de autenticação.",
+        schedule={"kind": "once"},
+    )
+
+    assert result.signals["risk"] is True
+    assert result.slot == "critical"
+
+
+
 def test_classify_high_risk_job_as_critical():
     from cron.routing import classify_cron_job
 

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,14 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_keeps_model_routing_decisions_user_owned():
+    """The model-facing tool may classify jobs, but cannot pin the route."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    properties = CRONJOB_SCHEMA["parameters"]["properties"]
+    assert "model" not in properties
+    assert "provider" not in properties
+    assert "reasoning_effort" not in properties
+    assert "routing_slot" not in properties
+
+

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -122,6 +122,8 @@ class TestCreateJob:
                     "name": "test-job",
                     "schedule": "*/5 * * * *",
                     "prompt": "do something",
+                    "reasoning_effort": "high",
+                    "routing_slot": "critical",
                 }, headers={
                     "X-Forwarded-For": "203.0.113.11",
                     "User-Agent": "cron-client",
@@ -138,6 +140,8 @@ class TestCreateJob:
                 assert call_kwargs["origin"]["chat_id"] == "api"
                 assert call_kwargs["origin"]["forwarded_for"] == "203.0.113.11"
                 assert call_kwargs["origin"]["user_agent"] == "cron-client"
+                assert call_kwargs["reasoning_effort"] == "high"
+                assert call_kwargs["routing_slot"] == "critical"
 
 
     @pytest.mark.asyncio
@@ -230,6 +234,8 @@ class TestUpdateJob:
                     f"/api/jobs/{VALID_JOB_ID}",
                     json={
                         "name": "new-name",
+                        "reasoning_effort": "xhigh",
+                        "routing_slot": "synthesis",
                         "evil_field": "malicious",
                         "__proto__": "hack",
                     },
@@ -238,6 +244,8 @@ class TestUpdateJob:
                 call_args = mock_update.call_args
                 sanitized = call_args[0][1]
                 assert "name" in sanitized
+                assert sanitized["reasoning_effort"] == "xhigh"
+                assert sanitized["routing_slot"] == "synthesis"
                 assert "evil_field" not in sanitized
                 assert "__proto__" not in sanitized
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -22,6 +22,21 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 class TestCronCommandLifecycle:
 
+    def test_parser_accepts_user_owned_routing_slot(self):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        create_args = parser.parse_args(
+            ["cron", "create", "every 1h", "report", "--routing-slot", "synthesis"]
+        )
+        edit_args = parser.parse_args(
+            ["cron", "edit", "job-id", "--routing-slot", "critical"]
+        )
+
+        assert create_args.routing_slot == "synthesis"
+        assert edit_args.routing_slot == "critical"
+
     def test_edit_persists_user_owned_inference_pins(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Daily report", schedule="every 1h")
         parser = argparse.ArgumentParser(prog="hermes")

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1022,6 +1022,40 @@ async def test_dashboard_cron_noop_inference_fields_keep_existing_snapshots(
     assert updated["model_snapshot"] == "test-model"
 
 
+def test_dashboard_cron_persists_shared_routing_contract(isolated_profiles):
+    from hermes_cli import web_server
+
+    created = web_server._create_cron_job_sync(
+        web_server.CronJobCreate(
+            prompt="produce a release report",
+            schedule="every 1h",
+            name="routed-dashboard-job",
+            model="selected-model",
+            provider="nous",
+            reasoning_effort="ultra",
+            routing_slot="synthesis",
+        ),
+        profile="worker_alpha",
+    )
+
+    assert created["routing"]["slot"] == "synthesis"
+    assert created["routing"]["requested_model"] == "selected-model"
+    assert created["routing"]["requested_provider"] == "nous"
+    assert created["routing"]["reasoning_effort"] == "ultra"
+
+    updated = web_server._update_cron_job_sync(
+        created["id"],
+        web_server.CronJobUpdate(
+            updates={"routing_slot": "critical", "reasoning_effort": "high"}
+        ),
+        profile="worker_alpha",
+    )
+
+    assert updated["routing_slot"] == "critical"
+    assert updated["routing"]["slot"] == "critical"
+    assert updated["routing"]["reasoning_effort"] == "high"
+
+
 @pytest.mark.asyncio
 async def test_update_cron_job_clears_snapshots_for_no_agent(
     isolated_profiles,

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -763,6 +763,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "routing": job.get("routing"),
+        "routing_slot": job.get("routing_slot"),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -1371,6 +1373,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    routing_slot: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1481,12 +1484,13 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
-                    # reasoning_effort reaches here from the CLI
-                    # (hermes cron create --reasoning-effort) ONLY — it is
-                    # deliberately absent from CRONJOB_SCHEMA and the model
-                    # dispatch below: models do not make model-config
-                    # decisions (standing policy).
+                    # reasoning_effort and routing_slot reach here from the
+                    # user-owned CLI/API paths. They are deliberately absent
+                    # from the model-facing CRONJOB_SCHEMA and registry
+                    # dispatch below: models do not make model-config or
+                    # capability-route decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    routing_slot=routing_slot,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1697,6 +1701,8 @@ def cronjob(
                 # CLI-only lane (see create above): update_job validates
                 # against the canonical grammar; empty string clears the pin.
                 updates["reasoning_effort"] = reasoning_effort
+            if routing_slot is not None:
+                updates["routing_slot"] = routing_slot
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may


### PR DESCRIPTION
## Summary

- Add one deterministic CRON capability router shared by storage, scheduler, CLI, REST API, dashboard, desktop, blueprints, suggestions, and the cronjob tool.
- Classify jobs into `deterministic`, `interpretation`, `synthesis`, or `critical` with explicit reasoning policy.
- Resolve provider/model/credentials at fire time with fail-closed behavior: no silent provider-family/model switching and no fallback chain for routed jobs.
- Preserve legacy behavior for jobs without routing metadata and keep `no_agent` jobs free of routing/LLM work.
- Add routing audit fields and user-owned CLI/API/desktop slot overrides.

## Design notes

- `cron/routing.py` is the single source of truth for classification, persisted policy, and runtime route resolution.
- Risk signals force the `critical` slot.
- Reasoning is resolved against the actual selected route and transport capability remains provider-owned.
- The model-facing `cronjob` schema does not let a model choose provider, model, reasoning, or routing slot.

## Validation

- `tests/cron` excluding three pre-existing Windows-specific tests: **944 passed, 32 skipped**.
- Cross-surface CRON/API/tool/dashboard tests: **310 passed**.
- Additional cronjob tool/schema regression: **73 passed**.
- Desktop cron model tests: **15 passed**.
- TypeScript/TSX parse via esbuild: passed.
- Prettier: passed.
- Python compileall: passed.
- `git diff --check`: passed.

The full desktop typecheck could not start in the isolated worktree because its local `node_modules/.bin/tsc` is not installed. No lockfile change was made to mask that environment issue.

## Scope

- `package-lock.json` and unrelated Kanban changes are intentionally excluded.
- No production deploy or merge is included in this PR.
