### PR TITLE
feat(video_gen): route FLUX 3 keyframes and drafts through managed FAL

### DIFF
--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -150,6 +150,10 @@ class VideoGenProvider(abc.ABC):
                 "supports_negative_prompt": True,
                 "supports_seed": True,
                 "supports_upscale": True,
+                "supports_keyframes": True,
+                "supports_first_last": True,
+                "supports_draft": True,
+                "supports_draft_enhance": True,
                 "max_reference_images": 7,
             }
 
@@ -170,6 +174,10 @@ class VideoGenProvider(abc.ABC):
             "supports_negative_prompt": False,
             "supports_seed": False,
             "supports_upscale": False,
+            "supports_keyframes": False,
+            "supports_first_last": False,
+            "supports_draft": False,
+            "supports_draft_enhance": False,
             "max_reference_images": 0,
         }
 

--- a/plugins/video_gen/deepinfra/__init__.py
+++ b/plugins/video_gen/deepinfra/__init__.py
@@ -69,6 +69,10 @@ class DeepInfraVideoGenProvider(OpenAICompatibleVideoGenProvider):
             "supports_negative_prompt": True,
             "supports_seed": True,
             "supports_upscale": False,
+            "supports_keyframes": False,
+            "supports_first_last": False,
+            "supports_draft": False,
+            "supports_draft_enhance": False,
             "max_reference_images": 0,
         }
 

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -21,6 +21,7 @@ Model families (most expose both t2v + i2v; gemini-omni-flash is image-to-video 
     minimax-h3         minimax/h3/text-to-video                   /  minimax/h3/image-to-video
     minimax-h3-max     minimax/h3-max/text-to-video               /  minimax/h3-max/image-to-video
     flux-3             blackforestlabs/flux-3/text-to-video       /  blackforestlabs/flux-3/image-to-video
+                       + keyframes-to-video, first-last-frame-to-video, /draft, draft-enhance
     grok-imagine-1.5   xai/grok-imagine-video/v1.5/text-to-video  /  xai/grok-imagine-video/v1.5/image-to-video
     kling-v3-4k        fal-ai/kling-video/v3/4k/text-to-video     /  fal-ai/kling-video/v3/4k/image-to-video
     happy-horse        alibaba/happy-horse/text-to-video          /  alibaba/happy-horse/image-to-video
@@ -245,10 +246,18 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "display": "FLUX 3 (via FAL)",
         "speed": "~60-120s",
         "price": "premium",
-        "strengths": "Black Forest Labs frontier video. Native audio, 5-20s, 8 aspect ratios.",
+        "strengths": "Black Forest Labs frontier video. Native audio, 5-20s, keyframes, first/last frame, draft+enhance.",
         "tier": "premium",
         "text_endpoint": "blackforestlabs/flux-3/text-to-video",
         "image_endpoint": "blackforestlabs/flux-3/image-to-video",
+        "keyframes_endpoint": "blackforestlabs/flux-3/keyframes-to-video",
+        "first_last_endpoint": "blackforestlabs/flux-3/first-last-frame-to-video",
+        "draft_enhance_endpoint": "blackforestlabs/flux-3/draft-enhance",
+        "draft": True,
+        "max_keyframes": 10,
+        "keyframe_fps": 24,
+        # Draft endpoints omit resolution; full-quality keeps hd/fhd via 720p/1080p.
+        "draft_drop_keys": ("resolution",),
         # FLUX 3 duration enum is "auto" | 5..20 as JSON integers.
         "duration_int": True,
         "aspect_ratios": ("21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"),
@@ -381,7 +390,75 @@ def _load_video_gen_section() -> Dict[str, Any]:
         return {}
 
 
-_ENDPOINT_MODALITY_LEAVES = frozenset({"text-to-video", "image-to-video"})
+def _family_endpoints(meta: Dict[str, Any]) -> Tuple[str, ...]:
+    """Declared FAL app ids for a family, including draft variants."""
+    bases: List[str] = []
+    for key in (
+        "text_endpoint",
+        "image_endpoint",
+        "keyframes_endpoint",
+        "first_last_endpoint",
+        "draft_enhance_endpoint",
+    ):
+        value = meta.get(key)
+        if isinstance(value, str) and value.strip():
+            bases.append(value.strip())
+    out: List[str] = []
+    for base in bases:
+        out.append(base)
+        if not base.endswith("/draft") and not base.endswith("draft-enhance"):
+            out.append(f"{base}/draft")
+    return tuple(out)
+
+
+def _with_draft_suffix(endpoint: str, draft: bool) -> str:
+    if not draft or endpoint.endswith("/draft") or endpoint.endswith("draft-enhance"):
+        return endpoint
+    return f"{endpoint}/draft"
+
+
+def _file_url(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        url = value.get("url")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    return None
+
+
+def _normalize_keyframes(raw: Any) -> Optional[List[Dict[str, Any]]]:
+    """Parse ``[{frame_index, image_url}, ...]`` into FAL's keyframe objects."""
+    if not isinstance(raw, list) or not raw:
+        return None
+    out: List[Dict[str, Any]] = []
+    seen: set[int] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("each keyframe must be an object with frame_index and image_url")
+        url = _file_url(item.get("image_url") or item.get("url"))
+        if not url:
+            raise ValueError("each keyframe needs image_url")
+        try:
+            index = int(item.get("frame_index"))
+        except (TypeError, ValueError):
+            raise ValueError("each keyframe needs an integer frame_index") from None
+        if index < 0:
+            raise ValueError("frame_index must be >= 0")
+        if index in seen:
+            raise ValueError(f"duplicate keyframe frame_index {index}")
+        seen.add(index)
+        out.append({"frame_index": index, "image_url": url})
+    return out
+
+
+_ENDPOINT_MODALITY_LEAVES = frozenset({
+    "text-to-video",
+    "image-to-video",
+    "keyframes-to-video",
+    "first-last-frame-to-video",
+    "draft-enhance",
+})
 
 
 def _normalize_family_key(c: str) -> Optional[str]:
@@ -401,7 +478,7 @@ def _normalize_family_key(c: str) -> Optional[str]:
     # Exact declared endpoint — unambiguous, and beats any segment scan
     # that would otherwise see "seedance-2.0" inside ".../seedance-2.0/mini/...".
     for fid, meta in FAL_FAMILIES.items():
-        if c in (meta.get("text_endpoint"), meta.get("image_endpoint")):
+        if c in _family_endpoints(meta):
             return fid
 
     # Truncated stem of a declared endpoint: "minimax/h3" or
@@ -410,9 +487,7 @@ def _normalize_family_key(c: str) -> Optional[str]:
     # Mini family's deeper ".../seedance-2.0/mini/text-to-video" path.
     stem_hits: List[Tuple[int, str]] = []
     for fid, meta in FAL_FAMILIES.items():
-        for endpoint in (meta.get("text_endpoint"), meta.get("image_endpoint")):
-            if not isinstance(endpoint, str):
-                continue
+        for endpoint in _family_endpoints(meta):
             if not endpoint.startswith(c + "/"):
                 continue
             first = endpoint[len(c) + 1:].split("/", 1)[0]
@@ -475,13 +550,26 @@ def _build_payload(
     negative_prompt: Optional[str],
     audio: Optional[bool],
     seed: Optional[int],
+    keyframes: Optional[List[Dict[str, Any]]] = None,
+    end_image_url: Optional[str] = None,
+    draft: bool = False,
+    draft_cache_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a family-specific payload, dropping keys the family doesn't declare."""
     payload: Dict[str, Any] = {}
 
+    if draft_cache_url:
+        payload["draft_cache_url"] = draft_cache_url
+        return payload
+
     if prompt:
         payload["prompt"] = prompt
-    if image_url:
+    if keyframes:
+        payload["keyframes"] = keyframes
+    elif end_image_url:
+        payload["start_image_url"] = image_url
+        payload["end_image_url"] = end_image_url
+    elif image_url:
         # Some endpoints (e.g. Kling v3 4K image-to-video) expect
         # `start_image_url` instead of `image_url`. The family entry can
         # declare an override.
@@ -527,8 +615,11 @@ def _build_payload(
 
     # Keys the family's image-to-video endpoint rejects outright (e.g.
     # Seedance 2.5 / MiniMax H3 derive aspect_ratio from the input image).
-    if image_url:
+    if image_url and not keyframes and not end_image_url:
         for key in family.get("image_drop_keys", ()):  # type: ignore[assignment]
+            payload.pop(key, None)
+    if draft:
+        for key in family.get("draft_drop_keys", ()):  # type: ignore[assignment]
             payload.pop(key, None)
 
     # Constant keys the endpoint requires on every request (e.g. MiniMax
@@ -780,6 +871,8 @@ class FALVideoGenProvider(VideoGenProvider):
                 modalities.append("text")
             if meta.get("image_endpoint"):
                 modalities.append("image")
+            if meta.get("keyframes_endpoint") or meta.get("first_last_endpoint"):
+                modalities.append("keyframes")
             entry: Dict[str, Any] = {
                 "id": fid,
                 "display": meta["display"],
@@ -855,6 +948,10 @@ class FALVideoGenProvider(VideoGenProvider):
                 "supports_seed": bool(family.get("seed", False)),
                 # SeedVR upscaler chains for any FAL video family.
                 "supports_upscale": True,
+                "supports_keyframes": bool(family.get("keyframes_endpoint")),
+                "supports_first_last": bool(family.get("first_last_endpoint")),
+                "supports_draft": bool(family.get("draft")),
+                "supports_draft_enhance": bool(family.get("draft_enhance_endpoint")),
                 "max_reference_images": 0,
             }
         # Fallback: union across families (legacy shape).
@@ -880,6 +977,10 @@ class FALVideoGenProvider(VideoGenProvider):
             "supports_negative_prompt": True,
             "supports_seed": True,
             "supports_upscale": True,
+            "supports_keyframes": False,
+            "supports_first_last": False,
+            "supports_draft": False,
+            "supports_draft_enhance": False,
             "max_reference_images": 0,
         }
 
@@ -937,10 +1038,91 @@ class FALVideoGenProvider(VideoGenProvider):
 
         prompt = (prompt or "").strip()
         family_id, family = _resolve_family(model)
-
-        # Route: image_url → image-to-video endpoint; else → text-to-video.
+        model_id = (model or "").strip()
+        draft = bool(kwargs.get("draft")) or model_id.rstrip("/").endswith("/draft")
+        draft_cache_url = _file_url(kwargs.get("draft_cache_url"))
+        end_image_url = _file_url(kwargs.get("end_image_url"))
         image_url_norm = (image_url or "").strip() or None
-        if image_url_norm:
+        try:
+            keyframes = _normalize_keyframes(kwargs.get("keyframes"))
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_request",
+                provider="fal", model=family_id, prompt=prompt,
+            )
+
+        if draft_cache_url:
+            endpoint = family.get("draft_enhance_endpoint")
+            modality_used = "draft_enhance"
+            draft = False
+            if not endpoint:
+                return error_response(
+                    error=(
+                        f"FAL family {family_id} has no draft-enhance endpoint. "
+                        f"FLUX 3 is the family that supports draft_cache_url."
+                    ),
+                    error_type="modality_unsupported",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+        elif keyframes:
+            endpoint = family.get("keyframes_endpoint")
+            modality_used = "keyframes"
+            max_kf = int(family.get("max_keyframes") or 10)
+            if len(keyframes) > max_kf:
+                return error_response(
+                    error=f"at most {max_kf} keyframes are supported",
+                    error_type="invalid_request",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+            if not endpoint:
+                return error_response(
+                    error=(
+                        f"FAL family {family_id} has no keyframes-to-video "
+                        f"endpoint. Use model=flux-3."
+                    ),
+                    error_type="modality_unsupported",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+            fps = int(family.get("keyframe_fps") or 24)
+            clamped = _clamp_duration(family, duration)
+            if clamped is None:
+                return error_response(
+                    error="keyframes-to-video needs an explicit duration so frame_index can be validated (duration×24fps).",
+                    error_type="invalid_request",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+            duration = clamped
+            limit = duration * fps
+            for frame in keyframes:
+                if frame["frame_index"] > limit:
+                    return error_response(
+                        error=(
+                            f"frame_index {frame['frame_index']} is past duration {duration}s "
+                            f"({limit} frames at {fps}fps)"
+                        ),
+                        error_type="invalid_request",
+                        provider="fal", model=family_id, prompt=prompt,
+                    )
+        elif end_image_url:
+            endpoint = family.get("first_last_endpoint")
+            modality_used = "first_last"
+            if not image_url_norm:
+                return error_response(
+                    error="first/last-frame video needs image_url (start) and end_image_url",
+                    error_type="invalid_request",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+            if not endpoint:
+                return error_response(
+                    error=(
+                        f"FAL family {family_id} has no first-last-frame endpoint. "
+                        f"Use model=flux-3."
+                    ),
+                    error_type="modality_unsupported",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+        elif image_url_norm:
             endpoint = family.get("image_endpoint")
             modality_used = "image"
             if not endpoint:
@@ -967,12 +1149,23 @@ class FALVideoGenProvider(VideoGenProvider):
                     provider="fal", model=family_id, prompt=prompt,
                 )
 
-        if not prompt:
+        if modality_used != "draft_enhance" and not prompt:
             return error_response(
                 error="prompt is required.",
                 error_type="missing_prompt",
                 provider="fal", model=family_id, prompt=prompt,
             )
+        if draft:
+            if modality_used == "draft_enhance" or not endpoint:
+                draft = False
+            elif not family.get("keyframes_endpoint") and not family.get("draft_enhance_endpoint"):
+                return error_response(
+                    error=f"FAL family {family_id} does not support Flux 3 /draft endpoints.",
+                    error_type="modality_unsupported",
+                    provider="fal", model=family_id, prompt=prompt,
+                )
+            else:
+                endpoint = _with_draft_suffix(str(endpoint), True)
 
         payload = _build_payload(
             family,
@@ -984,6 +1177,10 @@ class FALVideoGenProvider(VideoGenProvider):
             negative_prompt=negative_prompt,
             audio=audio,
             seed=seed,
+            keyframes=keyframes,
+            end_image_url=end_image_url,
+            draft=draft,
+            draft_cache_url=draft_cache_url,
         )
 
         try:
@@ -1033,6 +1230,11 @@ class FALVideoGenProvider(VideoGenProvider):
         extra: Dict[str, Any] = {"endpoint": endpoint, "upscaled": upscaled}
         if upscaled:
             extra["upscale_factor"] = UPSCALER_FACTOR
+        if draft:
+            extra["draft"] = True
+            cache_url = _file_url((result or {}).get("draft_cache") if isinstance(result, dict) else None)
+            if cache_url:
+                extra["draft_cache_url"] = cache_url
         if isinstance(video, dict):
             if video.get("file_size") and not upscaled:
                 extra["file_size"] = video["file_size"]

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -616,10 +616,10 @@ def _build_payload(
     # Keys the family's image-to-video endpoint rejects outright (e.g.
     # Seedance 2.5 / MiniMax H3 derive aspect_ratio from the input image).
     if image_url and not keyframes and not end_image_url:
-        for key in family.get("image_drop_keys", ()):  # type: ignore[assignment]
+        for key in family.get("image_drop_keys", ()):
             payload.pop(key, None)
     if draft:
-        for key in family.get("draft_drop_keys", ()):  # type: ignore[assignment]
+        for key in family.get("draft_drop_keys", ()):
             payload.pop(key, None)
 
     # Constant keys the endpoint requires on every request (e.g. MiniMax
@@ -881,6 +881,10 @@ class FALVideoGenProvider(VideoGenProvider):
                 "price": meta["price"],
                 "tier": meta.get("tier", "premium"),
                 "modalities": modalities,
+                # Config may store a full FAL endpoint rather than the family
+                # id. The generic dynamic schema uses these aliases to recover
+                # the active family's exact capabilities and guidance.
+                "aliases": list(_family_endpoints(meta)),
             }
             durs = meta.get("durations")
             if durs:

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -425,6 +425,10 @@ class XAIVideoGenProvider(VideoGenProvider):
             "supports_negative_prompt": False,
             "supports_seed": True,
             "supports_upscale": False,
+            "supports_keyframes": False,
+            "supports_first_last": False,
+            "supports_draft": False,
+            "supports_draft_enhance": False,
             "max_reference_images": MAX_REFERENCE_IMAGES,
         }
 
@@ -568,8 +572,9 @@ async def _generate_xai_video_async(
 
     prompt = (prompt or "").strip()
     image_input = None
-    if (image_url or "").strip():
-        image_input = _image_ref_to_xai_input(image_url)
+    image_url_norm = (image_url or "").strip()
+    if image_url_norm:
+        image_input = _image_ref_to_xai_input(image_url_norm)
         if not image_input:
             return error_response(
                 error=(
@@ -636,7 +641,7 @@ async def _generate_xai_video_async(
         resolved_model = DEFAULT_TEXT_TO_VIDEO_MODEL
 
     clamped_duration = _clamp_duration(duration, has_reference_images=bool(refs))
-    payload = {
+    payload: Dict[str, Any] = {
         "model": resolved_model,
         "prompt": prompt,
         "duration": clamped_duration,

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -355,6 +355,87 @@ class TestFamilyRouting:
         assert result["error_type"] == "modality_unsupported"
 
 
+def test_flux3_keyframe_draft_and_enhance_use_managed_gateway(monkeypatch):
+    """The Hermes-credit workflow must stay on managed fal-queue end to end."""
+    from plugins.video_gen import fal as fal_plugin
+
+    calls = []
+
+    class FakeHandle:
+        request_id = "managed-request-1"
+
+        def __init__(self, result):
+            self._result = result
+
+        def get(self):
+            return self._result
+
+    class ManagedClient:
+        def submit(self, endpoint, arguments=None, headers=None):
+            calls.append({
+                "endpoint": endpoint,
+                "arguments": arguments,
+                "headers": headers,
+            })
+            result = {"video": {"url": "https://managed.example/out.mp4"}}
+            if endpoint.endswith("/draft"):
+                result["draft_cache"] = {
+                    "url": "https://managed.example/draft-cache.bin",
+                }
+            return FakeHandle(result)
+
+    direct_client = Mock()
+    direct_client.submit.side_effect = AssertionError(
+        "Nous selection must not fall back to direct FAL billing"
+    )
+    managed_gateway = object()
+    managed_client = ManagedClient()
+
+    monkeypatch.setattr(fal_plugin, "_check_fal_video_available", lambda: True)
+    monkeypatch.setattr(fal_plugin, "_load_fal_client", lambda: None)
+    monkeypatch.setattr(
+        fal_plugin,
+        "_resolve_managed_fal_video_gateway",
+        lambda: managed_gateway,
+    )
+    monkeypatch.setattr(
+        fal_plugin,
+        "_get_managed_fal_video_client",
+        lambda gateway: managed_client if gateway is managed_gateway else None,
+    )
+    monkeypatch.setattr(fal_plugin, "_fal_client", direct_client)
+
+    provider = fal_plugin.FALVideoGenProvider()
+    draft = provider.generate(
+        "move between frames",
+        model="flux-3",
+        duration=10,
+        draft=True,
+        keyframes=[
+            {"frame_index": 0, "image_url": "https://example.com/a.png"},
+            {"frame_index": 240, "image_url": "https://example.com/b.png"},
+        ],
+    )
+    enhanced = provider.generate(
+        "",
+        model="flux-3",
+        draft_cache_url=draft["draft_cache_url"],
+    )
+
+    assert draft["success"] is True
+    assert enhanced["success"] is True
+    assert [call["endpoint"] for call in calls] == [
+        "blackforestlabs/flux-3/keyframes-to-video/draft",
+        "blackforestlabs/flux-3/draft-enhance",
+    ]
+    assert calls[0]["arguments"]["keyframes"][1]["frame_index"] == 240
+    assert "resolution" not in calls[0]["arguments"]
+    assert calls[1]["arguments"] == {
+        "draft_cache_url": "https://managed.example/draft-cache.bin",
+    }
+    direct_client.submit.assert_not_called()
+
+
 class TestFamilyKeyNormalization:
     def test_full_endpoint_paths_resolve_to_their_own_family(self):
         """A configured endpoint path must resolve to the family that declares

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -234,19 +234,137 @@ class TestFamilyRouting:
         # Seedance uses regular image_url (not start_image_url)
         assert with_fake_fal["arguments"]["image_url"] == "https://example.com/dog.png"
 
+    def test_flux3_image_to_video_unchanged(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "animate this",
+            model="flux-3",
+            image_url="https://example.com/start.png",
+            duration=20,
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/image-to-video"
+        assert with_fake_fal["arguments"]["image_url"] == "https://example.com/start.png"
+        assert "keyframes" not in with_fake_fal["arguments"]
+
+    def test_flux3_draft_image_to_video(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "animate this",
+            model="flux-3",
+            image_url="https://example.com/start.png",
+            duration=20,
+            draft=True,
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/image-to-video/draft"
+        assert result.get("draft") is True
+        assert "resolution" not in with_fake_fal["arguments"]
+
+    def test_flux3_keyframes_to_video(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "walk from the tray to the bite",
+            model="flux-3",
+            duration=20,
+            keyframes=[
+                {"frame_index": 0, "image_url": "https://example.com/a.png"},
+                {"frame_index": 480, "image_url": "https://example.com/b.png"},
+            ],
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/keyframes-to-video"
+        assert result["modality"] == "keyframes"
+        assert with_fake_fal["arguments"]["keyframes"] == [
+            {"frame_index": 0, "image_url": "https://example.com/a.png"},
+            {"frame_index": 480, "image_url": "https://example.com/b.png"},
+        ]
+        assert "image_url" not in with_fake_fal["arguments"]
+
+    def test_flux3_keyframes_draft(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "walk from the tray to the bite",
+            model="flux-3",
+            duration=10,
+            draft=True,
+            keyframes=[
+                {"frame_index": 0, "image_url": "https://example.com/a.png"},
+                {"frame_index": 120, "image_url": "https://example.com/b.png"},
+            ],
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/keyframes-to-video/draft"
+
+    def test_flux3_first_last_frame(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "bite the sandwich",
+            model="flux-3",
+            image_url="https://example.com/start.png",
+            end_image_url="https://example.com/end.png",
+            duration=8,
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/first-last-frame-to-video"
+        args = with_fake_fal["arguments"]
+        assert args["start_image_url"] == "https://example.com/start.png"
+        assert args["end_image_url"] == "https://example.com/end.png"
+        assert "image_url" not in args
+
+    def test_flux3_draft_enhance(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "",
+            model="flux-3",
+            draft_cache_url="https://example.com/cache.bin",
+        )
+        assert result["success"] is True
+        assert with_fake_fal["endpoint"] == "blackforestlabs/flux-3/draft-enhance"
+        assert with_fake_fal["arguments"] == {
+            "draft_cache_url": "https://example.com/cache.bin",
+        }
+
+    def test_flux3_keyframes_need_duration(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "x",
+            model="flux-3",
+            keyframes=[{"frame_index": 0, "image_url": "https://example.com/a.png"}],
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_request"
+
+    def test_other_family_rejects_keyframes(self, with_fake_fal):
+        from plugins.video_gen.fal import FALVideoGenProvider
+
+        result = FALVideoGenProvider().generate(
+            "x",
+            model="pixverse-v6",
+            duration=5,
+            keyframes=[{"frame_index": 0, "image_url": "https://example.com/a.png"}],
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "modality_unsupported"
+
 
 class TestFamilyKeyNormalization:
     def test_full_endpoint_paths_resolve_to_their_own_family(self):
         """A configured endpoint path must resolve to the family that declares
         it. The segment scan alone reads the "seedance-2.0" in
         ".../seedance-2.0/mini/..." and bills the full-price family."""
-        from plugins.video_gen.fal import FAL_FAMILIES, _normalize_family_key
+        from plugins.video_gen.fal import FAL_FAMILIES, _family_endpoints, _normalize_family_key
 
         for fid, meta in FAL_FAMILIES.items():
-            for key in ("text_endpoint", "image_endpoint"):
-                endpoint = meta.get(key)
-                if endpoint:
-                    assert _normalize_family_key(endpoint) == fid, endpoint
+            for endpoint in _family_endpoints(meta):
+                assert _normalize_family_key(endpoint) == fid, endpoint
 
     def test_bare_and_prefixed_ids_still_resolve(self):
         from plugins.video_gen.fal import _normalize_family_key

--- a/tests/tools/test_video_generate_schema.py
+++ b/tests/tools/test_video_generate_schema.py
@@ -34,6 +34,10 @@ CAPABILITY_AXES = (
     "supports_negative_prompt",
     "supports_seed",
     "supports_upscale",
+    "supports_keyframes",
+    "supports_first_last",
+    "supports_draft",
+    "supports_draft_enhance",
     "max_reference_images",
 )
 
@@ -97,7 +101,9 @@ class TestFleetCapabilityCoverage(unittest.TestCase):
         caps = _P().capabilities()
         self.assertEqual(caps.get("modalities"), ["text"])
         for axis in ("supports_audio", "supports_negative_prompt",
-                     "supports_seed", "supports_upscale"):
+                     "supports_seed", "supports_upscale",
+                     "supports_keyframes", "supports_first_last",
+                     "supports_draft", "supports_draft_enhance"):
             self.assertFalse(caps.get(axis), axis)
         for axis in CAPABILITY_AXES:
             self.assertIn(axis, caps, f"ABC default missing {axis}")
@@ -207,16 +213,33 @@ class TestDynamicParamGating(unittest.TestCase):
         self.assertEqual(props["duration"]["maximum"], 12)
         self.assertEqual(props["aspect_ratio"]["enum"], ["16:9"])
 
+    def test_flux_extras_are_capability_gated(self):
+        schema = self._schema_with({
+            "modalities": ["text", "image"],
+            "supports_audio": False, "supports_negative_prompt": False,
+            "supports_seed": False, "supports_upscale": False,
+            "supports_keyframes": True, "supports_first_last": True,
+            "supports_draft": True, "supports_draft_enhance": True,
+            "max_reference_images": 0,
+        })
+        props = schema["parameters"]["properties"]
+        for p in ("keyframes", "end_image_url", "draft", "draft_cache_url"):
+            self.assertIn(p, props, p)
+        self.assertEqual(schema["parameters"]["required"], [])
+
     def test_minimal_backend_gets_bare_params(self):
         schema = self._schema_with({
             "modalities": ["text"],
             "supports_audio": False, "supports_negative_prompt": False,
             "supports_seed": False, "supports_upscale": False,
+            "supports_keyframes": False, "supports_first_last": False,
+            "supports_draft": False, "supports_draft_enhance": False,
             "max_reference_images": 0,
         })
         props = schema["parameters"]["properties"]
         for p in ("image_url", "reference_image_urls", "negative_prompt",
-                  "audio", "seed", "upscale"):
+                  "audio", "seed", "upscale", "keyframes", "end_image_url",
+                  "draft", "draft_cache_url"):
             self.assertNotIn(p, props, p)
         self.assertIn("text-to-video only", schema["description"])
 

--- a/tests/tools/test_video_generation_dispatch.py
+++ b/tests/tools/test_video_generation_dispatch.py
@@ -116,3 +116,42 @@ class TestUnifiedDispatch:
 
         self._run({"prompt": "a dog"}, configured="fake")
         assert "upscale" not in provider.last_kwargs
+
+    def test_draft_enhance_schema_and_handler_allow_cache_without_prompt(self):
+        from jsonschema import validate
+        from tools.video_generation_tool import VIDEO_GENERATE_SCHEMA
+
+        args = {"draft_cache_url": "https://example.com/cache.bin"}
+        validate(args, VIDEO_GENERATE_SCHEMA["parameters"])
+
+        provider = _RecordingProvider()
+        video_gen_registry.register_provider(provider)
+        result = self._run(args, configured="fake")
+
+        assert result["success"] is True
+        assert provider.last_kwargs["prompt"] == ""
+        assert provider.last_kwargs["draft_cache_url"] == args["draft_cache_url"]
+
+    @pytest.mark.parametrize(
+        "keyframes",
+        [
+            [],
+            [{"frame_index": 0, "image_url": ""}],
+            [{"frame_index": "nope", "image_url": "https://example.com/a.png"}],
+            [
+                {"frame_index": 0, "image_url": "https://example.com/a.png"},
+                {"frame_index": 0, "image_url": "https://example.com/b.png"},
+            ],
+        ],
+    )
+    def test_malformed_keyframes_fail_before_paid_provider_dispatch(self, keyframes):
+        provider = _RecordingProvider()
+        video_gen_registry.register_provider(provider)
+
+        result = self._run(
+            {"prompt": "animate", "keyframes": keyframes},
+            configured="fake",
+        )
+
+        assert "error" in result
+        assert provider.last_kwargs == {}

--- a/tests/tools/test_video_generation_dynamic_schema.py
+++ b/tests/tools/test_video_generation_dynamic_schema.py
@@ -118,6 +118,30 @@ class TestDynamicSchemaBuilder:
         assert props["duration"]["minimum"] == 1
         assert props["duration"]["maximum"] == 15
 
+    def test_full_fal_endpoint_uses_family_guidance(self, cfg_home, monkeypatch):
+        from plugins.video_gen.fal import FALVideoGenProvider
+        from tools.video_generation_tool import _build_dynamic_video_schema
+
+        monkeypatch.setenv("FAL_KEY", "test")
+        video_gen_registry.register_provider(FALVideoGenProvider())
+        _write_cfg(
+            cfg_home,
+            {
+                "video_gen": {
+                    "provider": "fal",
+                    "model": "blackforestlabs/flux-3/keyframes-to-video/draft",
+                }
+            },
+        )
+
+        schema = _build_dynamic_video_schema()
+        props = schema["parameters"]["properties"]
+        assert "FLUX 3 extras" in schema["description"]
+        assert props["duration"]["minimum"] == 5
+        assert props["duration"]["maximum"] == 20
+        assert {"keyframes", "end_image_url", "draft", "draft_cache_url"} <= set(props)
+        assert schema["parameters"]["required"] == []
+
     def test_i2v_only_model_does_not_claim_text_to_video(self, cfg_home):
         """A dual-modality backend with an i2v-only active model must not
         contradict the model caveat with a 'supports both' line."""

--- a/tests/tools/test_video_generation_tool_surface_matrix.py
+++ b/tests/tools/test_video_generation_tool_surface_matrix.py
@@ -55,7 +55,10 @@ def matrix_env(tmp_path, monkeypatch):
 
     def _submit(endpoint, arguments=None, headers=None):
         fal_calls.append({"endpoint": endpoint, "arguments": arguments})
-        return _FalHandle({"video": {"url": f"https://fake-fal/{endpoint.replace('/','_')}.mp4"}})
+        result = {"video": {"url": f"https://fake-fal/{endpoint.replace('/','_')}.mp4"}}
+        if endpoint.endswith("/draft"):
+            result["draft_cache"] = {"url": "https://fake-fal/draft-cache.bin"}
+        return _FalHandle(result)
     fake_fal.submit = _submit  # type: ignore
 
     monkeypatch.setitem(__import__("sys").modules, "fal_client", fake_fal)
@@ -229,6 +232,84 @@ def test_fal_image_to_video_routes_to_image_endpoint(matrix_env, family_id):
     assert payload.get(image_key) == "https://example.com/i.png"
     other_keys = [k for k in payload if "image" in k and "url" in k and k != image_key]
     assert not other_keys, f"{family_id} sent extra image keys: {other_keys}"
+
+
+def test_flux3_keyframes_routes_through_tool_surface(matrix_env):
+    home, fal_calls, _ = matrix_env
+    keyframes = [
+        {"frame_index": 0, "image_url": "https://example.com/a.png"},
+        {"frame_index": 240, "image_url": "https://example.com/b.png"},
+    ]
+
+    result = _invoke_tool(
+        home,
+        {"video_gen": {"provider": "fal", "model": "flux-3"}},
+        {"prompt": "move between frames", "duration": 10, "keyframes": keyframes},
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "keyframes"
+    assert fal_calls == [{
+        "endpoint": "blackforestlabs/flux-3/keyframes-to-video",
+        "arguments": {
+            "prompt": "move between frames",
+            "keyframes": keyframes,
+            "aspect_ratio": "16:9",
+            "resolution": "720p",
+            "duration": 10,
+        },
+    }]
+
+
+def test_flux3_first_last_routes_through_tool_surface(matrix_env):
+    home, fal_calls, _ = matrix_env
+
+    result = _invoke_tool(
+        home,
+        {"video_gen": {"provider": "fal", "model": "flux-3"}},
+        {
+            "prompt": "move between frames",
+            "image_url": "https://example.com/start.png",
+            "end_image_url": "https://example.com/end.png",
+            "duration": 8,
+        },
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "first_last"
+    assert fal_calls[0]["endpoint"] == "blackforestlabs/flux-3/first-last-frame-to-video"
+    assert fal_calls[0]["arguments"]["start_image_url"] == "https://example.com/start.png"
+    assert fal_calls[0]["arguments"]["end_image_url"] == "https://example.com/end.png"
+
+
+def test_flux3_draft_and_enhance_round_trip_through_tool_surface(matrix_env):
+    home, fal_calls, _ = matrix_env
+    cfg = {"video_gen": {"provider": "fal", "model": "flux-3"}}
+
+    draft = _invoke_tool(
+        home,
+        cfg,
+        {"prompt": "preview this shot", "draft": True},
+    )
+
+    assert draft["success"] is True
+    assert draft["draft"] is True
+    assert draft["draft_cache_url"] == "https://fake-fal/draft-cache.bin"
+    assert fal_calls[0]["endpoint"] == "blackforestlabs/flux-3/text-to-video/draft"
+    assert "resolution" not in fal_calls[0]["arguments"]
+
+    enhanced = _invoke_tool(
+        home,
+        cfg,
+        {"draft_cache_url": draft["draft_cache_url"]},
+    )
+
+    assert enhanced["success"] is True
+    assert enhanced["modality"] == "draft_enhance"
+    assert fal_calls[1] == {
+        "endpoint": "blackforestlabs/flux-3/draft-enhance",
+        "arguments": {"draft_cache_url": "https://fake-fal/draft-cache.bin"},
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -21,10 +21,14 @@ Unified surface
 One tool covers the common cases - text-to-video, image-to-video, and
 reference-to-video - with a compact schema:
 
-    prompt                   text instruction (required)
-    image_url                drives image-to-video
+    prompt                   text instruction (required unless draft_cache_url)
+    image_url                drives image-to-video / first frame
+    end_image_url            optional last-frame still (FLUX 3 first/last)
+    keyframes                optional [{frame_index, image_url}, ...] (FLUX 3)
+    draft                    optional; FLUX 3 cheap preview (/draft)
+    draft_cache_url          optional; FLUX 3 draft-enhance of a prior draft
     reference_image_urls     list, up to provider-declared cap
-    duration                 seconds (provider clamps)
+    duration                 seconds (provider clamps; required for keyframes)
     aspect_ratio             "16:9" | "9:16" | "1:1" | ...
     resolution               "480p" | "540p" | "720p" | "1080p"
     negative_prompt          optional (Pixverse/Kling style)
@@ -262,9 +266,32 @@ def _normalize_reference_images(value: Any) -> Optional[List[str]]:
     return out or None
 
 
+def _normalize_keyframes_arg(value: Any) -> Optional[List[Dict[str, Any]]]:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        return None
+    out: List[Dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("image_url") or item.get("url")
+        if not isinstance(url, str) or not url.strip():
+            continue
+        try:
+            index = int(item.get("frame_index"))
+        except (TypeError, ValueError):
+            continue
+        out.append({"frame_index": index, "image_url": url.strip()})
+    return out or None
+
+
 def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     prompt = (args.get("prompt") or "").strip()
     image_url = (args.get("image_url") or "").strip() or None
+    end_image_url = (args.get("end_image_url") or "").strip() or None
+    draft_cache_url = (args.get("draft_cache_url") or "").strip() or None
+    keyframes = _normalize_keyframes_arg(args.get("keyframes"))
     reference_image_urls = _normalize_reference_images(args.get("reference_image_urls"))
     task_id = _kw.get("task_id")
 
@@ -277,6 +304,23 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
         image_url, reference_image_urls, task_id)
     if confine_error is not None:
         return confine_error
+    if end_image_url:
+        _, confined_end, confine_error = _confine_source_images(
+            None, [end_image_url], task_id)
+        if confine_error is not None:
+            return confine_error
+        if confined_end:
+            end_image_url = confined_end[0]
+    if keyframes:
+        _, confined_kf, confine_error = _confine_source_images(
+            None, [frame["image_url"] for frame in keyframes], task_id)
+        if confine_error is not None:
+            return confine_error
+        if confined_kf and len(confined_kf) == len(keyframes):
+            keyframes = [
+                {"frame_index": frame["frame_index"], "image_url": url}
+                for frame, url in zip(keyframes, confined_kf)
+            ]
     duration = _coerce_int(args.get("duration"))
     aspect_ratio = (args.get("aspect_ratio") or DEFAULT_ASPECT_RATIO).strip() or DEFAULT_ASPECT_RATIO
     resolution = (args.get("resolution") or DEFAULT_RESOLUTION).strip() or DEFAULT_RESOLUTION
@@ -286,10 +330,9 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     upscale = _coerce_bool(args.get("upscale"))
     model_override = (args.get("model") or "").strip() or None
 
-    # Soft validation — providers do their own. Prompt is required by the
-    # schema; the backend may still accept image-only on its image-to-video
-    # endpoint but our surface always needs a prompt.
-    if not prompt:
+    # Soft validation — providers do their own. Prompt is required except
+    # for FLUX 3 draft-enhance, which only needs the prior draft_cache_url.
+    if not prompt and not draft_cache_url:
         return tool_error("prompt is required for video generation")
     if "operation" in args or "video_url" in args:
         return tool_error(
@@ -310,6 +353,10 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
         "model": model,
         "_model_override_explicit": bool(model_override),
         "image_url": image_url,
+        "end_image_url": end_image_url,
+        "keyframes": keyframes,
+        "draft": _coerce_bool(args.get("draft")),
+        "draft_cache_url": draft_cache_url,
         "reference_image_urls": reference_image_urls,
         "duration": duration,
         "aspect_ratio": aspect_ratio,
@@ -490,6 +537,17 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
     elif not can_i2v:
         parts.append("- text-to-video only (no image input)")
 
+    supports_keyframes = bool(caps.get("supports_keyframes"))
+    supports_first_last = bool(caps.get("supports_first_last"))
+    supports_draft = bool(caps.get("supports_draft"))
+    supports_draft_enhance = bool(caps.get("supports_draft_enhance"))
+    if any((supports_keyframes, supports_first_last, supports_draft, supports_draft_enhance)):
+        parts.append(
+            "- FLUX 3 extras: keyframes pin images at 24fps; image_url + "
+            "end_image_url pins the boundaries; draft=true creates a cheap "
+            "preview; draft_cache_url enhances that exact draft"
+        )
+
     if provider.name == "xai":
         parts.append(
             "- chaining: for edit/extend pass the public HTTPS MP4 in `video` "
@@ -528,6 +586,54 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
                     "(style or character refs)."
                 ),
             }
+
+    if supports_first_last:
+        properties["end_image_url"] = {
+            "type": "string",
+            "description": (
+                "Public HTTPS URL of the last-frame still. Pass image_url "
+                "for the first frame."
+            ),
+        }
+    if supports_keyframes:
+        properties["keyframes"] = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "frame_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Frame position at 24fps.",
+                    },
+                    "image_url": {
+                        "type": "string",
+                        "description": "Public HTTPS or data URL of the keyframe image.",
+                    },
+                },
+                "required": ["frame_index", "image_url"],
+                "additionalProperties": False,
+            },
+            "minItems": 1,
+            "maxItems": 10,
+            "description": (
+                "FLUX 3 storyboard keyframes. Requires explicit duration; "
+                "frame_index values must be unique and <= duration*24."
+            ),
+        }
+    if supports_draft:
+        properties["draft"] = {
+            "type": "boolean",
+            "description": "Generate a cheap FLUX 3 draft preview.",
+        }
+    if supports_draft_enhance:
+        properties["draft_cache_url"] = {
+            "type": "string",
+            "description": (
+                "FLUX 3 draft cache URL returned by a prior draft. Enhances "
+                "that exact shot at full quality; prompt is not needed."
+            ),
+        }
 
     min_duration = model_meta.get("min_duration", caps.get("min_duration"))
     max_duration = model_meta.get("max_duration", caps.get("max_duration"))
@@ -591,7 +697,9 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
         "parameters": {
             "type": "object",
             "properties": properties,
-            "required": ["prompt"],
+            # draft-enhance only needs the opaque cache from the draft call;
+            # the handler enforces prompt-or-cache for this capability.
+            "required": [] if supports_draft_enhance else ["prompt"],
         },
     }
 

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -68,9 +68,10 @@ VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
     # Placeholder — description AND params are rebuilt dynamically at
     # get_tool_definitions() time from the active provider's declared
     # capabilities() and the active model's catalog entry. Optional args
-    # (image_url, reference_image_urls, negative_prompt, audio, seed,
-    # upscale) are advertised ONLY when the active backend/model honors
-    # them; the handler accepts them regardless (replay compat — providers
+    # (image_url, references, negative_prompt, audio, seed, upscale,
+    # keyframes, first/last frames, and draft/enhance) are advertised ONLY
+    # when the active backend/model honors them; the handler accepts them
+    # regardless (replay compat — providers
     # clamp/ignore). See _build_dynamic_video_schema().
     "description": "(rebuilt at get_definitions() time — see _build_dynamic_video_schema)",
     "parameters": {
@@ -114,7 +115,6 @@ VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
             # per-capability by _build_dynamic_video_schema. Do not re-add
             # them statically.
         },
-        "required": ["prompt"],
     },
 }
 
@@ -267,23 +267,33 @@ def _normalize_reference_images(value: Any) -> Optional[List[str]]:
 
 
 def _normalize_keyframes_arg(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Normalize keyframes without silently changing the requested modality."""
     if value is None:
         return None
-    if not isinstance(value, list):
-        return None
+    if not isinstance(value, list) or not value:
+        raise ValueError("keyframes must be a non-empty list")
+    if len(value) > 10:
+        raise ValueError("at most 10 keyframes are supported")
+
     out: List[Dict[str, Any]] = []
+    seen: set[int] = set()
     for item in value:
         if not isinstance(item, dict):
-            continue
+            raise ValueError("each keyframe must be an object with frame_index and image_url")
         url = item.get("image_url") or item.get("url")
         if not isinstance(url, str) or not url.strip():
-            continue
+            raise ValueError("each keyframe needs image_url")
         try:
             index = int(item.get("frame_index"))
         except (TypeError, ValueError):
-            continue
+            raise ValueError("each keyframe needs an integer frame_index") from None
+        if index < 0:
+            raise ValueError("frame_index must be >= 0")
+        if index in seen:
+            raise ValueError(f"duplicate keyframe frame_index {index}")
+        seen.add(index)
         out.append({"frame_index": index, "image_url": url.strip()})
-    return out or None
+    return out
 
 
 def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
@@ -291,7 +301,10 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     image_url = (args.get("image_url") or "").strip() or None
     end_image_url = (args.get("end_image_url") or "").strip() or None
     draft_cache_url = (args.get("draft_cache_url") or "").strip() or None
-    keyframes = _normalize_keyframes_arg(args.get("keyframes"))
+    try:
+        keyframes = _normalize_keyframes_arg(args.get("keyframes"))
+    except ValueError as exc:
+        return tool_error(str(exc))
     reference_image_urls = _normalize_reference_images(args.get("reference_image_urls"))
     task_id = _kw.get("task_id")
 
@@ -516,10 +529,19 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
         models = []
 
     active_model = configured_model or provider.default_model()
-    model_meta = next(
-        (m for m in models if isinstance(m, dict) and m.get("id") == active_model),
-        {},
-    )
+
+    def _matches_active_model(entry: Any) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        if entry.get("id") == active_model:
+            return True
+        aliases = entry.get("aliases")
+        return (
+            isinstance(aliases, (list, tuple, set))
+            and active_model in aliases
+        )
+
+    model_meta = next((m for m in models if _matches_active_model(m)), {})
 
     # ---- description -------------------------------------------------
     for c in _format_model_caveats(model_meta, caps):


### PR DESCRIPTION
## What does this PR do?

FAL already hosts the extra FLUX 3 endpoints. Hermes `video_generate` only routed `text-to-video` and `image-to-video`. This wires the rest of that family into the existing FAL plugin instead of bringing back `bfl_flux3_*`.

The primary use case is the paid Nous Subscription path: when Video Generation is set to **Nous Subscription**, these requests use the existing managed `fal-queue` gateway and therefore bill against the user's Hermes Portal credits rather than requiring a separate FAL account. The same client routing also works with a direct `FAL_KEY`.

- `keyframes=[{frame_index, image_url}]` → `blackforestlabs/flux-3/keyframes-to-video`
- `image_url` + `end_image_url` → `first-last-frame-to-video`
- `draft=true` → the matching `/draft` endpoint
- `draft_cache_url` → `draft-enhance` (returns `draft_cache_url` on draft results so enhance can reuse the shot)

`extend-video` is intentionally not included. `video_generate` still rejects `video_url`; that belongs on a later extend/edit surface.

This PR supplies the Hermes client routing. It does not change the hosted Portal gateway.

## Managed Portal requirement

For the Hermes-credit workflow to operate in production, the managed `fal-queue` deployment must:

1. Entitle/allow `blackforestlabs/flux-3/keyframes-to-video/draft`.
2. Entitle/allow `blackforestlabs/flux-3/draft-enhance`.
3. Configure credit pricing for those endpoint IDs.
4. Preserve FAL's `draft_cache` response object so Hermes can return `draft_cache_url` and submit it to `draft-enhance`.

Once those server-side entries are enabled, this PR is the client support needed to call them through the existing Nous token and managed gateway. Until then, Hermes returns the existing clear managed-gateway 4xx guidance and does not silently fall back to a different billing path. Direct `FAL_KEY` remains independently usable.

## Related Issue

Fixes #95829

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/video_gen/fal/__init__.py` — FLUX 3 family endpoints, managed/direct routing, draft suffix, payload shape, and active-model capability declarations
- `agent/video_gen_provider.py` + other in-tree video providers — fail-closed declarations for the new capability axes
- `tools/video_generation_tool.py` — capability-gated schema + handler for keyframes / end_image_url / draft / draft_cache_url; these fields appear only for a model that supports them
- `tests/plugins/video_gen/test_fal_plugin.py` — provider routing plus a managed-billing contract test proving keyframe draft → enhance stays on `fal-queue` and never calls direct FAL
- `tests/tools/test_video_generation_dispatch.py` — fail-closed keyframe and promptless enhance coverage
- `tests/tools/test_video_generation_dynamic_schema.py` — full-endpoint capability alias coverage
- `tests/tools/test_video_generation_tool_surface_matrix.py` — end-to-end keyframes, first/last, draft, and enhance routing

## How to Test

1. `scripts/run_tests.sh tests/plugins/video_gen/test_fal_plugin.py tests/tools/test_video_generation_tool_surface_matrix.py tests/tools/test_video_generation_dispatch.py tests/tools/test_video_generation_dynamic_schema.py tests/tools/test_video_generate_schema.py -q`
2. In `hermes tools`, select **Nous Subscription** for Video Generation and select `flux-3`.
3. Call `video_generate` with `draft=true`, an explicit duration, and `keyframes=[{frame_index,image_url}, ...]`; verify it submits `blackforestlabs/flux-3/keyframes-to-video/draft` through managed `fal-queue` and returns `draft_cache_url` when FAL supplies one.
4. Call `video_generate` again with that `draft_cache_url` and no prompt; verify it submits `blackforestlabs/flux-3/draft-enhance`.
5. Optional BYOK check: select direct FAL and repeat with `FAL_KEY`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated tool descriptions/schemas if I changed tool behavior
- [x] N/A — no config key changes
- [x] N/A — no CONTRIBUTING/AGENTS architecture change beyond the existing FAL family router




