### PR TITLE
fix(desktop): keep tsc --build --clean away from tracked plugin sources

### DIFF
--- a/apps/desktop/scripts/clean-renderer-safety.test.mjs
+++ b/apps/desktop/scripts/clean-renderer-safety.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'vitest'
+
+// `npm run clean` (the `prebuild` step) runs `tsc --build <tsconfig> --clean` for every
+// tsconfig in this package. tsc deletes whatever it *would* have emitted, so a config
+// whose outputs land next to its sources makes the clean step delete tracked files —
+// src/plugins/*/plugin.js are the plain-ESM twins of plugin.tsx and were wiped on every
+// desktop rebuild (#95671). Every config must therefore emit into build/ (gitignored).
+
+const require = createRequire(import.meta.url)
+const desktopRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const tsc = require.resolve('typescript/bin/tsc')
+
+function wouldDelete(tsconfig) {
+  const out = execFileSync(process.execPath, [tsc, '--build', tsconfig, '--clean', '--dry'], {
+    cwd: desktopRoot,
+    encoding: 'utf8',
+  })
+  return out
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('* '))
+    .map(line => path.relative(desktopRoot, line.slice(2).trim()))
+}
+
+for (const tsconfig of ['tsconfig.json', 'tsconfig.electron.json', 'tsconfig.e2e.json']) {
+  test(`${tsconfig}: tsc --build --clean only targets build outputs, never sources`, () => {
+    const targets = wouldDelete(tsconfig)
+    const outsideBuild = targets.filter(
+      file => !file.startsWith(`build${path.sep}`) && !file.endsWith('.tsbuildinfo'),
+    )
+    assert.deepEqual(outsideBuild, [], `clean would delete tracked sources: ${outsideBuild.join(', ')}`)
+  })
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -5,6 +5,8 @@
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": ["node"],
     "allowJs": false,
+    "outDir": "build/renderer-types",
+    "rootDir": "..",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## What does this PR do?

`npm run clean` (the desktop `prebuild` step) runs `tsc --build tsconfig.json --clean`. The renderer tsconfig had no `outDir`, so tsc computed `src/plugins/accent/plugin.js` and `src/plugins/kanban/plugin.js` as the emit targets of the sibling `plugin.tsx` files and deleted those tracked plain-ESM plugin sources on every desktop rebuild — leaving `git status` dirty and blocking `hermes update` in its autostash loop.

The fix points the renderer config at `build/renderer-types` (already gitignored, mirroring the electron config's `build/electron-types`) with `rootDir: ".."` so the `../shared/src` includes stay inside the root — tsc's clean step can now only ever touch `build/`. `noEmit` was tried first and is not enough: TypeScript 6's `--build --clean` still deletes the computed outputs.

## Related Issue

Fixes #95671

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/tsconfig.json`: add `"outDir": "build/renderer-types"` and `"rootDir": ".."`.
- `apps/desktop/scripts/clean-renderer-safety.test.mjs` (vitest, `electron` project): runs `tsc --build <cfg> --clean --dry` for `tsconfig.json`, `tsconfig.electron.json` and `tsconfig.e2e.json` and fails if any listed file is outside `build/` (or not a `.tsbuildinfo`). On `main` it fails with exactly the two `plugin.js` paths from the issue.

## How to Test

1. On `main`: `cd apps/desktop && npx tsc --build tsconfig.json --clean --dry` lists `src/plugins/accent/plugin.js` and `src/plugins/kanban/plugin.js`; `npm run clean:renderer && git status` shows both as deleted.
2. On this branch: the same dry run lists nothing for all three configs, and `npm run clean && git status` leaves the tree untouched.
3. `npx vitest run --project electron scripts/clean-renderer-safety.test.mjs` — 3 passed (1 failed on `main`).
4. `npm run typecheck` — unchanged: the single pre-existing error in `src/app/contrib/hooks/use-background-sync.test.ts:660` is present on `main` too; no new errors (the `rootDir` TS6059 that appears without `rootDir: ".."` is gone).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, the change is confined to `apps/desktop` (desktop vitest project and `npm run typecheck` run instead, see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Darwin 25.5), Node 24, TypeScript 6.0.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the test uses `path.sep`/`path.relative`, no shell

---
Prepared with AI assistance (Claude Code); reviewed and tested locally by @apetcu.
