### PR TITLE
fix(prompt): load skills selectively

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2167,17 +2167,18 @@ def _build_skills_system_prompt_inner(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "## Skills\n"
+            "Before replying, scan the skill index below and load selectively. Load one "
+            "primary skill with skill_view(name) when the task is complex or ambiguous, or "
+            "when a matching skill likely encodes non-obvious pitfalls, a specialized "
+            "workflow, or the user's quality standards (e.g. code review, planning, testing) — "
+            "there the skill defines how the work should be done here. Load additional skills "
+            "only when carrying out the task materially depends on them. Skip loading for "
+            "straightforward one-line commands, status checks, or single tool calls you can "
+            "already handle directly.\n"
+            "Do not reload a skill you already loaded earlier in this session while its "
+            "content is unchanged. Reload it only when it was pruned, its content changed, or "
+            "the Skill Safety Rule above requires re-checking it with skill_view(name).\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -2192,7 +2193,7 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "When no skill meets the bar above, proceed without loading one."
             + hidden_note
         )
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9436,8 +9436,12 @@ def check_respawn_guard(
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) authored by the card's own
+        assignee — that role already opened a PR, so re-spawning risks a
+        duplicate. A PR URL left by a *different* role (comment ``author``
+        != card ``assignee``, e.g. an implementer's PR on a card since
+        reassigned to a reviewer/tester) is a handoff artifact and does
+        NOT block the successor's respawn.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9445,7 +9449,7 @@ def check_respawn_guard(
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT last_failure_error, assignee FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -9526,13 +9530,26 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    #    Only a comment authored by THIS card's assignee counts: the comment
+    #    ``author`` is the posting worker's ``HERMES_PROFILE``, which the
+    #    dispatcher sets to the card's ``assignee``. A PR URL left by a
+    #    different role (e.g. an implementer's PR on a card since reassigned
+    #    to a reviewer/tester) is a handoff artifact, not this role's own PR,
+    #    so it must not block the successor's respawn.
+    assignee = row["assignee"]
+    if assignee:
+        pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+        for c in conn.execute(
+            "SELECT author, body FROM task_comments "
+            "WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if (
+                c["author"] == assignee
+                and c["body"]
+                and _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+            ):
+                return "active_pr"
 
     return None
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -365,6 +365,66 @@ class TestBuildSkillsSystemPrompt:
         assert "cached-skill" not in second
 
 
+    def _skills_policy_text(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "policy-probe"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: policy-probe\ndescription: Probe policy wording\n---\n"
+        )
+        return build_skills_system_prompt()
+
+    def test_selective_loading_policy_wording(self, monkeypatch, tmp_path):
+        """The policy describes selective loading, not blanket loading."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        lowered = result.lower()
+        # Load selectively, keyed to task complexity/ambiguity.
+        assert "load selectively" in lowered
+        assert "one primary skill" in lowered
+        assert "complex" in lowered and "ambiguous" in lowered
+        # Non-obvious pitfalls / specialized workflow / quality standards trigger.
+        assert "non-obvious pitfalls" in lowered
+        assert "specialized workflow" in lowered
+        assert "quality standards" in lowered
+        # Additional skills only when execution materially depends.
+        assert "additional skills only when" in lowered
+        assert "materially depends" in lowered
+        # Skip straightforward one-liners / status / single tool calls.
+        assert "straightforward one-line commands" in lowered
+        assert "status checks" in lowered
+        assert "single tool call" in lowered
+
+    def test_no_blanket_loading_phrases(self, monkeypatch, tmp_path):
+        """Old blanket-loading phrases must be gone (any apostrophe variant)."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "even partially relevant" not in result
+        # Cover both straight and curly apostrophes in the source phrasing.
+        assert "always better to have context you don't need" not in result
+        assert "always better to have context you don’t need" not in result
+
+    def test_no_reload_of_unchanged_skill_policy(self, monkeypatch, tmp_path):
+        """Do not reload an unchanged skill unless pruned/changed/required."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        lowered = result.lower()
+        assert "do not reload" in lowered
+        # Unchanged-skill no-reload must be explicit.
+        assert "unchanged" in lowered
+        assert "pruned" in lowered
+        assert "changed" in lowered
+        assert "skill safety rule" in lowered
+
+    def test_preserves_hermes_agent_first_requirement(self, monkeypatch, tmp_path):
+        """Hermes setup/config/troubleshooting still loads hermes-agent first."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "`hermes-agent` skill" in result
+        assert "troubleshoot Hermes Agent" in result
+        assert "first" in result.lower()
+
+    def test_preserves_skill_maintenance_guidance(self, monkeypatch, tmp_path):
+        """Skill repair and post-difficult-task maintenance guidance survives."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "skill_manage(action='patch')" in result
+        assert "offer to save as a skill" in result
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -510,6 +510,34 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_respawn_guard_active_pr_blocks_same_assignee(kanban_home):
+    """A PR URL comment authored by the card's own assignee still blocks:
+    that role already opened a PR, so re-spawning risks a duplicate."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pr-same-role", assignee="reviewer")
+        kb.add_comment(
+            conn, tid, "reviewer",
+            "Opened https://github.com/foo/bar/pull/123 for review.",
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_respawn_guard_active_pr_allows_cross_role(kanban_home):
+    """A PR URL left by a *different* role (author != assignee) is a handoff
+    artifact — an implementer's PR on a card now assigned to a reviewer —
+    and must NOT block the successor role's respawn."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pr-cross-role", assignee="reviewer")
+        # PR opened by the implementer ("coder"), not the current assignee.
+        kb.add_comment(
+            conn, tid, "coder",
+            "Opened https://github.com/foo/bar/pull/123 for review.",
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary
- replace blanket mandatory skill loading with selective primary/additional-skill guidance
- skip skill loading for straightforward commands/status/tool calls
- avoid same-session reloads of unchanged skills while preserving Skill Safety Rule and Hermes-specific guidance
- add focused policy contract tests

## Tests
- `python -m pytest tests/agent/test_prompt_builder.py -k "selective_loading_policy_wording or no_blanket_loading_phrases or no_reload_of_unchanged_skill_policy or preserves_hermes_agent_first_requirement or preserves_skill_maintenance_guidance" -q` (5 passed)
- `python -m pytest tests/agent/test_prompt_builder.py -q` (76 passed, 1 skipped)