### PR TITLE
fix(desktop): forbid bare unaddressed commitments in group chat rooms

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6814,6 +6814,8 @@ function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
     '- Reply with ONE conversational message ONLY if you have something new worth adding: build on what was just said, claim or hand off work, answer a question aimed at you, or report a real result. Keep chatter short (1-3 sentences) — but when you are delivering a result, an answer the user asked for, or substantive work, give it at full quality and length; never thin out real content to fit the room.',
     '- If you have nothing new to add, reply with exactly "(pass)". Passing is good — it lets the conversation settle.',
     '- Mention a teammate as @name to pull them in; mention @user only for a judgment call or a result the user needs. Do not repeat points already made.',
+    '- Never commit to future work ("I will provide X", "I will follow up once Y") without an @mention that keeps the thread moving. Dispatch in this room happens ONLY via @mention — nothing else re-wakes anyone. A commitment with no @mention is a dead end: either @mention yourself so you get re-invoked once the condition is met, or @mention whoever should act next. Never leave a bare unaddressed promise as the last word in the room.',
+    '- If your commitment is real follow-up work (not a same-turn answer), also create a Kanban card for it via kanban_create (title = the commitment, assignee = whoever owns the follow-up, body citing this room + what unblocks it) before you rely on the @mention alone. A card on the board is visible and pollable outside the room transcript; a chat promise is not.',
     '- Never reveal content from your private 1:1 chats. Your reply text goes to the room verbatim — no preamble, no meta-commentary.'
   ].join('\n')
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1471,6 +1471,25 @@ test('mention routing: @hermes resolves to the default member', () => {
   assert.equal(parsed.mentioned.size, 1)
 })
 
+test('turn prompt forbids a bare unaddressed commitment and directs it to Kanban', () => {
+  // Regression for the Aug 2026 MSTACK-style stall: a member committed to
+  // future work ("I'll provide X") with no @mention, which is the room's
+  // ONLY dispatch trigger — nothing ever re-woke anyone and the thread died
+  // silently. The room rules must explicitly forbid that dead end and give
+  // members a durable place (a Kanban card) to park the commitment instead
+  // of relying on chat prose alone.
+  const gc = load(() => '(pass)')
+  const prompt = gc.buildGroupChatTurnPrompt({
+    groupName: 'Core',
+    members: [{ name: 'default', title: '' }, { name: 'builder', title: '' }],
+    viewer: { name: 'default', title: '' },
+    deltaLines: []
+  })
+  assert.match(prompt, /Never commit to future work/)
+  assert.match(prompt, /Dispatch in this room happens ONLY via @mention/)
+  assert.match(prompt, /kanban_create/)
+})
+
 test('source contract: workspace speaker labels use displayName with a click-to-reveal handle', () => {
   // Speaker labels come from the roster displayName (default → Hermes)…
   assert.match(pluginSource, /displayName\(member \|\| \{ name: entry\.from\.name \}, meta\)/)


### PR DESCRIPTION
## What

Group chat dispatch runs ONLY via `@mention` (`parseGroupChatMentions`) — nothing else re-wakes a member. A member that commits to future work ("I'll provide X once Y") without tagging anyone leaves the thread with no recovery path: the promise sits in the transcript, nothing polls it, and the room silently dies with every member gateway healthy and idle.

## Reproduced live

In a real multi-bot group chat, the final message was exactly this pattern — a bare commitment, zero `@mentions` — and the room stopped dead. Not a crash; a design gap in `buildGroupChatTurnPrompt`'s room rules text (the only place the mention-only contract is communicated to a model).

## Fix

Two additions to the room rules string:

- Forbid a bare unaddressed commitment; require either a self-mention (so the member gets re-invoked once its own stated condition is met) or an explicit handoff naming who acts next.
- For real follow-up work, direct members to also create a Kanban card via `kanban_create` so the commitment is visible/pollable on a board rather than living only in room prose that nothing scans for staleness.

## Testing

- Added a regression test in `group-chat.test.mjs` asserting the new rules text is present in the rendered prompt.
- Full existing suite still green: `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs` → 90/90 pass; `cross-connection-bots.test.mjs` → 10/10 pass.
- `node --check` on the modified file confirms no syntax regressions.

## Scope

Prose-only change to the per-turn prompt template + one new test. No changes to the mention-parsing/dispatch mechanism itself — this is a documentation-to-the-model fix for a documented-nowhere behavioral contract, plus a durable-tracking nudge toward Kanban for real commitments.
