### PR TITLE
fix(prompt): load skills selectively

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2083,17 +2083,18 @@ def _build_skills_system_prompt_inner(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            f"even if you think you could handle the task with basic tools like {_basic_tools}. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "## Skills\n"
+            "Before replying, scan the skill index below and load selectively. Load one "
+            "primary skill with skill_view(name) when the task is complex or ambiguous, or "
+            "when a matching skill likely encodes non-obvious pitfalls, a specialized "
+            "workflow, or the user's quality standards (e.g. code review, planning, testing) — "
+            "there the skill defines how the work should be done here. Load additional skills "
+            "only when carrying out the task materially depends on them. Skip loading for "
+            "straightforward one-line commands, status checks, or single tool calls you can "
+            "already handle directly.\n"
+            "Do not reload a skill you already loaded earlier in this session while its "
+            "content is unchanged. Reload it only when it was pruned, its content changed, or "
+            "the Skill Safety Rule above requires re-checking it with skill_view(name).\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -2108,7 +2109,7 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "When no skill meets the bar above, proceed without loading one."
             + hidden_note
         )
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -380,6 +380,68 @@ class TestBuildSkillsSystemPrompt:
         assert "cached-skill" not in second
 
 
+    def _skills_policy_text(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "policy-probe"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: policy-probe\ndescription: Probe policy wording\n---\n"
+        )
+        return build_skills_system_prompt()
+
+    def test_selective_loading_policy_wording(self, monkeypatch, tmp_path):
+        """The policy describes selective loading, not blanket loading."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        lowered = result.lower()
+        # Load selectively, keyed to task complexity/ambiguity.
+        assert "load selectively" in lowered
+        assert "one primary skill" in lowered
+        assert "complex" in lowered and "ambiguous" in lowered
+        # Non-obvious pitfalls / specialized workflow / quality standards trigger.
+        assert "non-obvious pitfalls" in lowered
+        assert "specialized workflow" in lowered
+        assert "quality standards" in lowered
+        # Additional skills only when execution materially depends.
+        assert "additional skills only when" in lowered
+        assert "materially depends" in lowered
+        # Skip straightforward one-liners / status / single tool calls.
+        assert "straightforward one-line commands" in lowered
+        assert "status checks" in lowered
+        assert "single tool call" in lowered
+
+    def test_no_blanket_loading_phrases(self, monkeypatch, tmp_path):
+        """Old blanket-loading phrases must be gone (any apostrophe variant)."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "even partially relevant" not in result
+        # Cover both straight and curly apostrophes in the source phrasing.
+        assert "always better to have context you don't need" not in result
+        assert "always better to have context you don’t need" not in result
+
+    def test_no_reload_of_unchanged_skill_policy(self, monkeypatch, tmp_path):
+        """Do not reload an unchanged skill unless pruned/changed/required."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        lowered = result.lower()
+        assert "do not reload" in lowered
+        # Unchanged-skill no-reload must be explicit.
+        assert "unchanged" in lowered
+        assert "pruned" in lowered
+        assert "changed" in lowered
+        assert "skill safety rule" in lowered
+
+    def test_preserves_hermes_agent_first_requirement(self, monkeypatch, tmp_path):
+        """Hermes setup/config/troubleshooting still loads hermes-agent first."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "`hermes-agent` skill" in result
+        assert "troubleshoot Hermes Agent" in result
+        assert "first" in result.lower()
+
+    def test_preserves_skill_maintenance_guidance(self, monkeypatch, tmp_path):
+        """Skill repair and post-difficult-task maintenance guidance survives."""
+        result = self._skills_policy_text(monkeypatch, tmp_path)
+        assert "skill_manage(action='patch')" in result
+        assert "offer to save as a skill" in result
+
+
 # =========================================================================
 # Context files prompt builder
 # =========================================================================


### PR DESCRIPTION
## Summary
Make the Skills system-prompt policy load skills **selectively** instead of blanket-loading. The agent now loads one primary skill only when the task is complex/ambiguous or a matching skill encodes non-obvious pitfalls, a specialized workflow, or the user's quality standards; loads additional skills only when execution materially depends on them; skips loading for straightforward one-line commands, status checks, or single tool calls; and does not reload an unchanged skill already loaded this session (unless pruned, changed, or the Skill Safety Rule requires re-checking).

Dedicated `hermes-agent`-first guidance and skill-maintenance guidance (`skill_manage(action='patch')`, offer-to-save-as-a-skill) are preserved.

## Changes
- `agent/prompt_builder.py`: replace the blanket "## Skills (mandatory)" policy with the selective policy; update the trailing fallthrough sentence.
- `tests/agent/test_prompt_builder.py`: add coverage asserting selective wording, absence of old blanket phrases, no-reload policy, and preservation of hermes-agent/skill-maintenance guidance.

## Testing
- `pytest tests/agent/test_prompt_builder.py` — 73 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
