### PR TITLE
fix(ollama): omit reasoning_effort for local models without thinking

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -4,6 +4,8 @@ Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
 Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
+  - local Ollama without the ``thinking`` capability → omit reasoning_effort
+    entirely (sending it 400s: '"model" does not support thinking')
   - reasoning_config disabled → top-level reasoning_effort="none"
     (Ollama /v1/chat/completions ignores think=False — ollama#14820)
     + extra_body.think = False for /api/chat and proxies
@@ -18,6 +20,32 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 
+def _endpoint_is_ollama(
+    *,
+    ollama_num_ctx: int | None = None,
+    base_url: str | None = None,
+) -> bool:
+    """True when this custom endpoint is an Ollama server, not vLLM/ARK/etc.
+
+    Local Ollama rejects ``reasoning_effort`` on instruct models with HTTP 400
+    ('does not support thinking'). GLM-5.2 on ARK still needs that field, so
+    we only gate it when we already know the backend is Ollama.
+    """
+    if ollama_num_ctx:
+        return True
+    url = (base_url or "").strip().lower()
+    if ":11434" in url:
+        return True
+    try:
+        from utils import base_url_host_matches
+
+        if base_url_host_matches(url, "ollama.com"):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
@@ -26,6 +54,8 @@ class CustomProfile(ProviderProfile):
         *,
         reasoning_config: dict | None = None,
         ollama_num_ctx: int | None = None,
+        supports_reasoning: bool = False,
+        base_url: str | None = None,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
@@ -36,6 +66,15 @@ class CustomProfile(ProviderProfile):
             options = extra_body.get("options", {})
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
+
+        # Local Ollama instruct models (qwen3-coder, gemma, …) 400 if we send
+        # reasoning_effort at all — including "none". Omit the field unless
+        # /api/show advertised the thinking capability. Non-Ollama custom
+        # endpoints (GLM-5.2/ARK, vLLM) keep the un-gated path below.
+        if _endpoint_is_ollama(
+            ollama_num_ctx=ollama_num_ctx, base_url=base_url
+        ) and not supports_reasoning:
+            return extra_body, top_level
 
         # Reasoning / thinking control for custom OpenAI-compatible endpoints
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).

--- a/run_agent.py
+++ b/run_agent.py
@@ -7651,11 +7651,13 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
-        # Ollama Cloud (and any Ollama-compatible server): the native
-        # /api/show capabilities list is authoritative — emit reasoning_effort
-        # only for models that declare the "thinking" capability. deepseek-v4
-        # has it; gemma3 / qwen3-coder don't. Cached per (model, base_url).
-        if base_url_host_matches(self._base_url_lower, "ollama.com"):
+        # Ollama Cloud AND local/self-hosted Ollama: the native /api/show
+        # capabilities list is authoritative — emit reasoning_effort only for
+        # models that declare the "thinking" capability. deepseek-v4 has it;
+        # gemma3 / qwen3-coder don't. Local Ollama 400s with
+        # '"model" does not support thinking' if we send the field anyway.
+        # Cached per (model, base_url).
+        if self._is_ollama_compatible_endpoint():
             return self._ollama_supports_thinking_cached()
         if not self._is_openrouter_url():
             return False
@@ -7734,6 +7736,25 @@ class AIAgent:
             opts = []
         cache[key] = (opts, _time.monotonic())
         return opts
+
+    def _is_ollama_compatible_endpoint(self) -> bool:
+        """True for Ollama Cloud and local/self-hosted Ollama servers.
+
+        Used to decide whether to probe ``/api/show`` for the ``thinking``
+        capability before emitting ``reasoning_effort``. Must NOT match
+        arbitrary custom endpoints (vLLM, ARK, llama.cpp) — those still
+        rely on CustomProfile's un-gated reasoning_effort for GLM-5.2 etc.
+        """
+        if base_url_host_matches(self._base_url_lower, "ollama.com"):
+            return True
+        if getattr(self, "_ollama_num_ctx", None):
+            # query_ollama_num_ctx already succeeded against /api/show.
+            return True
+        url = self._base_url_lower or ""
+        if ":11434" in url:
+            return True
+        provider = (self.provider or "").strip().lower()
+        return provider == "ollama"
 
     def _ollama_supports_thinking_cached(self) -> bool:
         """Probe Ollama's ``/api/show`` capabilities once per (model, base_url).

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -300,6 +300,23 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["think"] is False
 
+    def test_local_ollama_non_thinking_omits_reasoning_effort(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:UD-Q4_K_XL",
+            messages=msgs,
+            provider_profile=profile,
+            ollama_num_ctx=262144,
+            supports_reasoning=False,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="http://127.0.0.1:11434/v1",
+        )
+        assert "reasoning_effort" not in kw
+        assert "think" not in kw.get("extra_body", {})
+        assert kw["extra_body"]["options"]["num_ctx"] == 262144
+
 
 
     def test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config(self, transport):

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -13,6 +13,8 @@ These tests pin the wire-shape contract:
                           including ``max``/``xhigh``
   - enabled + no effort → nothing emitted (endpoint's server default applies)
   - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
+  - local Ollama without thinking capability → omit reasoning_effort
+    (instruct models 400: '"model" does not support thinking')
 """
 
 from __future__ import annotations
@@ -106,4 +108,67 @@ class TestCustomReasoningWithNumCtx:
         )
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
+
+    def test_glm_still_emits_effort_when_supports_reasoning_false(self, custom_profile):
+        """Non-Ollama custom endpoints (ARK/vLLM) ignore supports_reasoning.
+
+        CustomProfile always emits reasoning_effort there so GLM-5.2 keeps
+        working. The Ollama-only gate must not leak onto this path.
+        """
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=False,
+            model="glm-5.2",
+        )
+        assert tl == {"reasoning_effort": "high"}
+        assert "think" not in eb
+
+    def test_local_ollama_non_thinking_omits_reasoning_effort(self, custom_profile):
+        """Instruct Ollama models 400 if reasoning_effort is sent at all."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            ollama_num_ctx=262144,
+            supports_reasoning=False,
+            base_url="http://127.0.0.1:11434/v1",
+            model="hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:UD-Q4_K_XL",
+        )
+        assert tl == {}
+        assert "think" not in eb
+        assert eb == {"options": {"num_ctx": 262144}}
+
+    def test_local_ollama_non_thinking_omits_even_disabled_effort(self, custom_profile):
+        """reasoning_effort='none' also 400s on non-thinking Ollama models."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            ollama_num_ctx=8192,
+            supports_reasoning=False,
+            base_url="http://127.0.0.1:11434/v1",
+            model="qwen3-coder",
+        )
+        assert tl == {}
+        assert "think" not in eb
+        assert eb == {"options": {"num_ctx": 8192}}
+
+    def test_local_ollama_thinking_model_still_emits_effort(self, custom_profile):
+        """Thinking-capable Ollama models keep top-level reasoning_effort."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            ollama_num_ctx=8192,
+            supports_reasoning=True,
+            base_url="http://127.0.0.1:11434/v1",
+            model="deepseek-r1",
+        )
+        assert tl == {"reasoning_effort": "medium"}
+        assert eb == {"options": {"num_ctx": 8192}}
+
+    def test_local_ollama_detected_by_default_port(self, custom_profile):
+        """Port 11434 is enough to identify Ollama even without num_ctx."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            supports_reasoning=False,
+            base_url="http://127.0.0.1:11434/v1",
+            model="qwen3-coder",
+        )
+        assert tl == {}
+        assert eb == {}
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7032,6 +7032,44 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    def _make_local_ollama_agent(self, *, thinking: bool):
+        agent = object.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.base_url = "http://127.0.0.1:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:UD-Q4_K_XL"
+        agent._ollama_num_ctx = 262144
+        agent._ollama_thinking_cache = {
+            (agent.model, agent.base_url): (thinking, 0.0),
+        }
+        return agent
+
+    def test_local_ollama_port_is_treated_as_ollama(self):
+        agent = object.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.base_url = "http://127.0.0.1:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "qwen3-coder"
+        agent._ollama_num_ctx = None
+        assert agent._is_ollama_compatible_endpoint() is True
+
+    def test_custom_ark_endpoint_is_not_treated_as_ollama(self):
+        agent = object.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.base_url = "https://ark.cn-beijing.volces.com/api/v3"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.2"
+        agent._ollama_num_ctx = None
+        assert agent._is_ollama_compatible_endpoint() is False
+
+    def test_local_ollama_non_thinking_model_is_not_reasoning_capable(self):
+        agent = self._make_local_ollama_agent(thinking=False)
+        assert agent._supports_reasoning_extra_body() is False
+
+    def test_local_ollama_thinking_model_is_reasoning_capable(self):
+        agent = self._make_local_ollama_agent(thinking=True)
+        assert agent._supports_reasoning_extra_body() is True
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## What does this PR do?

Local Ollama instruct models (e.g. Unsloth `Qwen3-Coder` GGUFs) reject any request that *enables* thinking:

```
HTTP 400: "<model>" does not support thinking
```

Hermes was sending top-level `reasoning_effort` (from `agent.reasoning_effort: medium`) because:

1. `_supports_reasoning_extra_body()` only probed `/api/show` when the host was `ollama.com`. Local `127.0.0.1:11434` never got the capability check.
2. `CustomProfile` (used for `provider: custom` / user-defined Ollama endpoints) always forwarded `reasoning_effort`, ignoring `supports_reasoning`.

This probes local/self-hosted Ollama the same way we already do for Ollama Cloud, and omits `reasoning_effort` unless `/api/show` lists the `thinking` capability. Non-Ollama custom endpoints (GLM-5.2/ARK, vLLM) are unchanged.

## Related Issue

Fixes #59660

Related (open, overlapping): #86197, #63315, #81574

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — `_is_ollama_compatible_endpoint()` covers localhost `:11434`, detected `num_ctx`, and `provider: ollama`, then probes `/api/show` for `thinking`.
- `plugins/model-providers/custom/__init__.py` — if the backend is Ollama and `supports_reasoning` is false, omit `reasoning_effort` / `think` entirely (still emit `num_ctx`).
- Tests for the 400 path, a thinking-capable local model still receiving the field, and GLM-on-ARK not being gated by mistake.

## How to Test

1. Point Hermes at local Ollama with a non-thinking model (`qwen3-coder`, Unsloth Qwen3-Coder Instruct GGUF, `llama3.1`, …) and `agent.reasoning_effort: medium`.
2. Send a message. Before: HTTP 400 `does not support thinking`. After: the request goes through with no `reasoning_effort` field.
3. Repeat with a thinking-capable local model (`deepseek-r1`, etc.) and confirm `reasoning_effort` is still sent.
4. Confirm a non-Ollama custom endpoint (GLM-5.2/ARK) still receives `reasoning_effort`.

Targeted tests:

```
pytest tests/plugins/model_providers/test_custom_profile.py \
  tests/agent/transports/test_chat_completions.py::TestChatCompletionsBuildKwargs::test_local_ollama_non_thinking_omits_reasoning_effort \
  tests/run_agent/test_run_agent.py::TestSupportsReasoningExtraBody -q
```

24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suite above; not the full tree)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.6.0) against local Ollama

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Ollama default port 11434 is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live `/api/show` for the Unsloth Qwen3-Coder Instruct GGUF:

```
capabilities: ['completion', 'tools']
```

No `thinking` cap. Hermes was still sending `"reasoning_effort": "medium"` in `/v1/chat/completions`.

Made with [Cursor](https://cursor.com)