### PR TITLE
fix(kanban): gate KANBAN_GUIDANCE on HERMES_KANBAN_TASK env var

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4900,11 +4900,11 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
-        # Kanban worker/orchestrator lifecycle — only present when the
-        # dispatcher spawned this process (kanban_show check_fn gates on
-        # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-        # this block.
-        if "kanban_show" in self.valid_tool_names:
+        # Kanban worker lifecycle — only for dispatcher-spawned workers.
+        # Do not key off kanban_show in valid_tool_names: orchestrator
+        # profiles and gateway platforms may expose kanban_* interactively
+        # without HERMES_KANBAN_TASK, and must not get worker protocol.
+        if os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in self.valid_tool_names:
             tool_guidance.append(KANBAN_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -448,6 +448,35 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
     assert "kanban_show()" not in prompt
 
 
+def test_kanban_guidance_not_inferred_from_tool_presence(monkeypatch, tmp_path):
+    """Orchestrator/interactive sessions may expose kanban_show without worker env.
+
+    KANBAN_GUIDANCE is worker protocol (assigned task, workspace, lifecycle).
+    It must not leak into api_server chat just because kanban_* tools are loaded.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    # Simulate a non-worker session that still has kanban lifecycle tools
+    # (e.g. orchestrator profile or platform_toolsets pinning kanban).
+    a.valid_tool_names.add("kanban_show")
+    prompt = a._build_system_prompt()
+    assert "You are a Kanban worker" not in prompt
+    assert "kanban_show()" not in prompt
+
+
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     """A worker session (HERMES_KANBAN_TASK set) MUST have the full
     lifecycle guidance in its system prompt."""


### PR DESCRIPTION
## Summary

- Gate `KANBAN_GUIDANCE` system-prompt injection on `HERMES_KANBAN_TASK` being set, not merely on `kanban_show` appearing in `valid_tool_names`.
- Add regression test for interactive/orchestrator sessions that expose `kanban_show` without worker env — they must not receive worker lifecycle protocol.

## Problem

`run_agent.py` injects the full Kanban worker protocol whenever `kanban_show` is in the active tool schema. That was a reasonable proxy when kanban tools were **only** available to dispatcher-spawned workers (`HERMES_KANBAN_TASK` set).

Orchestrator profiles and gateway platforms can now expose `kanban_*` interactively (via `toolsets: [kanban]` / `platform_toolsets`) without a dispatched task. Those sessions incorrectly receive worker copy ("You have been assigned ONE task…", `kanban_show()` first, `$HERMES_KANBAN_WORKSPACE`, etc.).

This matches the intent already documented in comments and existing tests (`test_kanban_guidance_not_in_normal_prompt`, `test_kanban_guidance_in_worker_prompt`).

## Test plan

- [x] `pytest tests/tools/test_kanban_tools.py -k kanban_guidance`
- [ ] Confirm kanban dispatcher workers still receive full lifecycle guidance when `HERMES_KANBAN_TASK` is set


Made with [Cursor](https://cursor.com)