### PR TITLE
fix(update): Windows fleet check no longer fails a healthy gateway resume (#95589, salvage #94580)

### DIFF
--- a/contributors/emails/alex.gazzillo@gmail.com
+++ b/contributors/emails/alex.gazzillo@gmail.com
@@ -1,0 +1,1 @@
+AlexGabbia

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8685,14 +8685,43 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # a moment to rewrite gateway_state.json with their new identity.
             # Skipped when the restart phase touched nothing (no gateways
             # were running) — nothing to settle.
+            #
+            # On Windows the resume path relaunches the gateway DETACHED, and
+            # that process must boot before it stamps gateway_state.json or
+            # answers the control socket (a Telegram gateway reconnects its
+            # polling loop — ~10s).  A single 2s sleep therefore races the
+            # gateway's own startup and reports "no rows" (exit 1) for a
+            # healthy resume, which then triggers a full retry that re-kills
+            # the gateway the first attempt just started.  Poll a bounded
+            # window for the resumed gateway to publish its identity instead.
+            _fleet_snapshot = []
             if _fleet_rows_expected:
-                _time.sleep(2.0)
-            # Pass the pre-restart PID snapshot so a gateway the restart
-            # phase stopped WITHOUT a verified replacement shows as a DOWN
-            # row (exit 1) instead of silently producing no row at all.
-            _fleet_snapshot = collect_fleet_versions(
-                pre_restart_pids=_pre_restart_gateway_pids
-            )
+                _fleet_deadline = _time.monotonic() + 30.0
+                while True:
+                    _time.sleep(2.0)
+                    # Pass the pre-restart PID snapshot so a gateway the
+                    # restart phase stopped WITHOUT a verified replacement
+                    # shows as a DOWN row (exit 1) instead of silently
+                    # producing no row at all.
+                    _fleet_snapshot = collect_fleet_versions(
+                        pre_restart_pids=_pre_restart_gateway_pids
+                    )
+                    # A "down" row here is the stale pre-restart record of a
+                    # gateway whose detached replacement is still booting —
+                    # not a confirmed failure.  Keep polling until every
+                    # resumed gateway has published (no "down" rows remain)
+                    # or the deadline passes, so a slow second gateway can't
+                    # be misread as down and re-trigger the retry loop.
+                    if _fleet_snapshot and not any(
+                        row.get("state") == "down" for row in _fleet_snapshot
+                    ):
+                        break
+                    if _time.monotonic() >= _fleet_deadline:
+                        break
+            else:
+                _fleet_snapshot = collect_fleet_versions(
+                    pre_restart_pids=_pre_restart_gateway_pids
+                )
             if print_fleet_version_matrix(_fleet_snapshot):
                 gateway_fleet_restart_incomplete = True
             elif not _fleet_snapshot and _fleet_rows_expected:


### PR DESCRIPTION
## Summary

`hermes update` on Windows no longer reports a healthy gateway resume as a fleet failure (#95589; salvage of #94580 by @AlexGabbia, his commit cherry-picked with authorship preserved). The post-update fleet check waited a flat 2 seconds before collecting gateway identities — but the Windows resume path relaunches gateways DETACHED, and the new process needs ~10s to boot and stamp `gateway_state.json` (Telegram polling reconnect). The check read that boot window as "no rows", exited 1, and the desktop hand-off treated the successful update as failed — sometimes re-killing the gateway the resume had just started. Fleet relevance (#91277): two independent same-night repros, both on post-#95313/#95069 main, confirmed this exact chain.

Root cause verified against both reporters' logs by triage: `_fleet_probe_expected_runtimes` correctly expects rows via the resume token, but `collect_fleet_versions` returns zero rows while the detached gateway is still booting, and the `not _fleet_snapshot and _fleet_rows_expected` branch forces exit 1.

## Changes

- `hermes_cli/update_cmd.py`: the single 2s settle becomes a bounded poll — 2s interval, 30s deadline — that keeps collecting until every resumed gateway has published its identity AND no stale "down" rows remain (a "down" row here is the pre-restart record of a gateway whose detached replacement is still booting — not a confirmed failure; incorporated from the PR's own review round). No-gateways path unchanged. Worst case is the old behavior at 30s instead of a false verdict at 2s.

## Validation

| | Result |
|---|---|
| Targeted fleet receipt tests | 6/6 passed |
| A/B (in-process, exact block semantics on the reported ~10s boot timeline) | merge-base single 2s poll → zero rows (the false exit-1); head → 5 polls, settles on `current` at 10s |
| Cherry-pick | clean onto current main (his branch base was stale; commit applies exactly) |

**Live repro:** the reported timeline replayed against both block variants in-process — the false failure fires on merge-base and clears at head. The changed logic is platform-neutral timing on an already-covered code path; a windows-latest lane run is available on request but adds no discrimination beyond the timeline replay.

Fixes the exit-1 half of #95589 (the separate silent-stall half is #95625's scope, under review next). Credit: @AlexGabbia.

## Infographic

![The 2-second verdict](https://files.catbox.moe/l0fvcm.png)
