### PR TITLE
fix(honcho): a transient read failure is not an empty credential store

### DIFF
--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -412,6 +412,15 @@ def _rotate_and_persist(
     endpoint until a new login rotates the refresh token.
     """
     try:
+        # Read the store BEFORE spending the refresh token: rotation is
+        # single-use, so an exchange whose result cannot be persisted loses
+        # the grant. An unreadable store is a refresh failure (fail open,
+        # cooldown), not a reason to write a single-host file.
+        raw = _read_config_strict(path)
+    except OSError:
+        _refresh_failure_at[key] = time.monotonic()
+        return None
+    try:
         rotated = _exchange_with_retry(cred, now=now)
     except OAuthRefreshError as exc:
         if exc.permanent:
@@ -431,14 +440,62 @@ def _rotate_and_persist(
             op_label, host, _redact_tokens(str(exc)),
         )
         return None
-    _persist_credential(path, host, rotated)
+    _persist_credential(path, host, rotated, raw=raw)
     return rotated
 
 
 def _read_config(path: Path) -> dict[str, Any]:
+    """Tolerant reader for the fail-open READ paths only.
+
+    An unreadable or unparseable store reads as "no credential" and callers
+    fall back per this module's contract. Never feed this into a full-file
+    write — that is what turned one bad read into a store wipe; writers go
+    through :func:`_read_config_strict`.
+    """
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _read_config_strict(path: Path) -> dict[str, Any]:
+    """Reader for the WRITE paths: never lets a failed read become an empty store.
+
+    A missing file is the bootstrap case and reads as ``{}``. A file that
+    EXISTS but cannot be read (EACCES after a root-owned write, EIO, a stalled
+    mount) raises instead — ``_atomic_write_config`` replaces the whole file
+    and ``os.replace`` needs only a writable parent, so degrading here would
+    let the next persist erase every other host's credentials. Genuine
+    corruption still degrades, but only after preserving a ``.corrupt`` copy:
+    a truncated store usually holds the other hosts' tokens verbatim, and the
+    next full-file write would otherwise destroy the only recoverable version.
+    """
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        logger.warning(
+            "Honcho config at %s could not be read; refusing to treat it as "
+            "empty (a persist would erase every other host's credentials)",
+            path, exc_info=True,
+        )
+        raise
+    except json.JSONDecodeError as exc:
+        corrupt = path.with_name(path.name + ".corrupt")
+        preserved = False
+        try:
+            import shutil
+            shutil.copy2(path, corrupt)
+            preserved = True
+        except Exception:
+            logger.debug("could not preserve a copy at %s", corrupt, exc_info=True)
+        logger.warning(
+            "Honcho config at %s is corrupt (%s); starting from an empty store. "
+            "%s", path, exc,
+            f"Original preserved at {corrupt}" if preserved
+            else f"A copy could NOT be preserved at {corrupt}",
+        )
         return {}
 
 
@@ -467,9 +524,19 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
     return base
 
 
-def _persist_credential(path: Path, host: str, cred: OAuthCredential) -> None:
-    """Persist ``cred`` into ``host``'s block (apiKey + oauth), leaving all else intact."""
-    raw = _read_config(path)
+def _persist_credential(
+    path: Path, host: str, cred: OAuthCredential,
+    raw: dict[str, Any] | None = None,
+) -> None:
+    """Persist ``cred`` into ``host``'s block (apiKey + oauth), leaving all else intact.
+
+    "Leaving all else intact" is only true if the existing store was actually
+    READ: raises on an unreadable file rather than replacing the whole store
+    with a single-host block. Callers that already hold a strict read pass it
+    as ``raw`` (also closes the re-read race between lock and persist).
+    """
+    if raw is None:
+        raw = _read_config_strict(path)
     hosts = raw.setdefault("hosts", {})
     block = hosts.setdefault(host, {})
     block["apiKey"] = cred.access_token
@@ -608,7 +675,10 @@ def install_grant(
         token_type=str(grant.get("token_type", "Bearer")),
     )
 
-    raw = _read_config(path)
+    # Strict: a fresh login must not seed its write from a store that exists
+    # but could not be read — the root-merge below would erase every other
+    # host. Raising here surfaces in the interactive setup flow.
+    raw = _read_config_strict(path)
     granted_config = grant.get("config")
     if isinstance(granted_config, dict):
         cred.consent_peer_name = granted_config.get("peerName")

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -199,3 +199,119 @@ class TestApplyTokenToClient:
 
     def test_returns_false_when_shape_unknown(self):
         assert oauth.apply_token_to_client(object(), "hch-at-new") is False
+
+
+class TestPersistReadFailure:
+    """One unreadable honcho.json must never become a single-host store.
+
+    ``_persist_credential`` promises "leaving all else intact", but it seeded
+    the write from a reader that returned ``{}`` on ANY read failure, and
+    ``_atomic_write_config`` replaces the whole file via ``os.replace`` —
+    which needs only a writable parent, so a present-but-unreadable store did
+    not stop the overwrite. Same class as the auth-store fix in #75206.
+    """
+
+    @staticmethod
+    def _seed_two_hosts(path: Path) -> bytes:
+        _write(path, {
+            "hosts": {
+                "keep.example": _host_block(refresh="hch-rt-keep"),
+                "rotate.example": _host_block(refresh="hch-rt-rot"),
+            },
+            "defaults": {"workspace": "w1"},
+        })
+        return path.read_bytes()
+
+    def _unreadable(self, monkeypatch, target: Path):
+        real = Path.read_text
+
+        def boom(self, *a, **kw):
+            if self.name == target.name:
+                raise PermissionError(13, "Permission denied")
+            return real(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", boom)
+
+    def test_persist_raises_and_preserves_store_when_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-new"))
+
+        with monkeypatch.context() as m:
+            self._unreadable(m, path)
+            with pytest.raises(OSError):
+                oauth._persist_credential(path, "rotate.example", cred)
+
+        assert path.read_bytes() == before
+
+    def test_rotate_refuses_before_spending_the_refresh_token(
+        self, tmp_path, monkeypatch
+    ):
+        # Rotation is single-use: an exchange whose result cannot be persisted
+        # loses the grant, so an unreadable store must fail the refresh BEFORE
+        # the exchange, not after.
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+        cred = OAuthCredential.from_host_block(_host_block(refresh="hch-rt-rot"))
+        key = (str(path), "rotate.example")
+        oauth._refresh_failure_at.pop(key, None)
+
+        def no_exchange(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("exchange ran against an unreadable store")
+
+        with monkeypatch.context() as m:
+            m.setattr(oauth, "_exchange_with_retry", no_exchange)
+            self._unreadable(m, path)
+            assert oauth._rotate_and_persist(
+                path, "rotate.example", key, cred, now=1.0
+            ) is None
+
+        assert key in oauth._refresh_failure_at
+        oauth._refresh_failure_at.pop(key, None)
+        assert path.read_bytes() == before
+
+    def test_corrupt_store_degrades_but_preserves_a_copy(self, tmp_path):
+        path = tmp_path / "honcho.json"
+        truncated = json.dumps(
+            {"hosts": {"keep.example": _host_block(refresh="hch-rt-keep")}}
+        )[:-5]
+        path.write_text(truncated, encoding="utf-8")
+
+        assert oauth._read_config_strict(path) == {}
+        corrupt = path.with_name(path.name + ".corrupt")
+        assert corrupt.exists()
+        assert corrupt.read_text(encoding="utf-8") == truncated
+
+    def test_missing_store_still_bootstraps_empty(self, tmp_path):
+        assert oauth._read_config_strict(tmp_path / "honcho.json") == {}
+
+    def test_bom_prefixed_store_is_not_corruption(self, tmp_path):
+        path = tmp_path / "honcho.json"
+        path.write_text(
+            json.dumps({"hosts": {"keep.example": _host_block()}}),
+            encoding="utf-8-sig",
+        )
+        assert "keep.example" in oauth._read_config(path).get("hosts", {})
+        assert "keep.example" in oauth._read_config_strict(path).get("hosts", {})
+        assert not path.with_name(path.name + ".corrupt").exists()
+
+    def test_install_grant_raises_and_preserves_store_when_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "honcho.json"
+        before = self._seed_two_hosts(path)
+
+        with monkeypatch.context() as m:
+            self._unreadable(m, path)
+            with pytest.raises(OSError):
+                oauth.install_grant(
+                    path, "new.example",
+                    {"access_token": "hch-at-new", "refresh_token": "hch-rt-new",
+                     "expires_in": 3600},
+                    client_id="hermes-desktop",
+                    token_endpoint="http://localhost:8000/oauth/token",
+                )
+
+        assert path.read_bytes() == before


### PR DESCRIPTION
## What does this PR do?

`plugins/memory/honcho/oauth.py::_persist_credential` docstring promises **"leaving all else intact"** — but it seeds its write from `_read_config()`, which returns `{}` on **any** read failure, and `_atomic_write_config()` replaces the whole file via `os.replace`, which needs only a writable parent. So a present-but-unreadable `honcho.json` does not stop the overwrite: the next persist replaces the store with a single-host block, destroying every other host's credentials and the root config.

Two paths reach it:

1. **Automatic token refresh** (`_rotate_and_persist`, called from `ensure_fresh_token` near expiry) — no user action required. The store can be readable when the token is cached and unreadable by the time the refresh fires (EACCES after a root-owned write, EIO, a stalled mount).
2. **Fresh login** (`install_grant`) — the root-merge is seeded from the same tolerant reader.

This is the defect class of #75206 (P1, fixed for the core auth store in #75258, and the same shape as my open #88822 for the photon plugin): *a failed read must never become an empty store that then gets written back.*

## Related Issue

No issue filed — #75206 is the accepted precedent for the class; #88822 is the photon sibling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

One file, `plugins/memory/honcho/oauth.py`:

- **`_read_config_strict()`** (new) for the write paths: missing file still bootstraps as `{}`; an unreadable file **raises** with the store untouched; genuine corruption still degrades but **preserves a `.corrupt` copy first** — a truncated store usually holds the other hosts' tokens verbatim, and the next full-file write destroys the only recoverable version. Mirrors `hermes_cli.auth._load_auth_store`.
- **`_rotate_and_persist`** takes the strict read **before** the exchange — rotation is single-use, so an exchange whose result cannot be persisted loses the grant. An unreadable store is now a refresh failure (cooldown set, callers fail open per this module's documented contract), not a reason to write a single-host file. The dict threads through to `_persist_credential`, which also closes the re-read race between the locked read and the persist.
- **`install_grant`** seeds its root-merge from the strict reader; a raise surfaces in the interactive setup flow.
- **Read paths unchanged**: `_read_config` keeps its fail-open contract (unreadable = no credential) and now documents why it must never feed a full-file write. Both readers use `utf-8-sig`, so a BOM'd (perfectly healthy) store is no longer classified as corruption — that variant needed no filesystem fault at all.

## How to Test

```
pytest tests/honcho_plugin/test_oauth.py -q
```

New `TestPersistReadFailure` class, six tests:

- persist over an unreadable store raises and leaves the file byte-identical
- rotation refuses **before** spending the refresh token (a monkeypatched exchange fails the test if called), sets the failure cooldown, file untouched
- `install_grant` over an unreadable store raises, file byte-identical
- corrupt store degrades but `honcho.json.corrupt` holds the original bytes
- missing store still bootstraps `{}`
- BOM'd store loads and is never treated as corrupt

**4 of the 6 fail against the previous source** (the rotate test passed vacuously before — the broad exchange-except masked it — and now pins the ordering; the missing-store test pins unchanged bootstrap behaviour).

Local run (Python 3.13, macOS arm64), in a copy of the tree outside the git checkout:

```
tests/honcho_plugin/  →  310 passed, 16 skipped, 1 failed
```

The 1 failure (`test_memory_oauth_router_dispatches_by_provider_convention`) fails identically on pristine `main` in this environment — pre-existing, unrelated. `ruff check` clean on both touched files. Full `pytest tests/ -q` deferred to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted dir green (310 passed, 1 pre-existing env failure documented above), full suite deferred to CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.13.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A *(rationale lives in the docstrings this PR adds)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A *(N/A)*
- [x] I've considered cross-platform impact — or N/A *(exception handling + encoding only; EACCES/EIO/BOM are if anything more common on network mounts and Windows)*
- [x] I've updated tool descriptions/schemas — or N/A *(N/A)*
