### PR TITLE
fix(mcp): don't report live stdio children as dead in fast-fail check

### DIFF
--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -1,0 +1,49 @@
+"""Tests for MCPServerTask._stdio_children_dead (#81995 fast-fail regression).
+
+The fast-fail guard treats a ``True`` return as "all stdio children have
+exited" and rejects the tool call before sending it. A regression
+(``786f37071``, the psutil.pid_exists conversion) inverted the liveness
+branch: a *live* child returned ``True``, so every tool call to a healthy
+stdio MCP server failed instantly with "MCP stdio subprocess ... has exited".
+"""
+
+import psutil
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+@pytest.fixture
+def task():
+    t = MCPServerTask("test-server")
+    t._config = {}  # no "url" → stdio transport
+    return t
+
+
+def test_empty_pids_returns_false(task):
+    task._stdio_child_pids = set()
+    assert task._stdio_children_dead() is False
+
+
+def test_http_transport_returns_false(task):
+    task._config = {"url": "https://example.com/mcp"}
+    task._stdio_child_pids = {999999}
+    assert task._stdio_children_dead() is False
+
+
+def test_live_child_returns_false(task, monkeypatch):
+    monkeypatch.setattr(psutil, "pid_exists", lambda pid: pid == 12345)
+    task._stdio_child_pids = {12345}
+    assert task._stdio_children_dead() is False
+
+
+def test_all_children_dead_returns_true(task, monkeypatch):
+    monkeypatch.setattr(psutil, "pid_exists", lambda pid: False)
+    task._stdio_child_pids = {12345, 67890}
+    assert task._stdio_children_dead() is True
+
+
+def test_mixed_alive_and_dead_returns_false(task, monkeypatch):
+    monkeypatch.setattr(psutil, "pid_exists", lambda pid: pid == 12345)
+    task._stdio_child_pids = {12345, 67890}
+    assert task._stdio_children_dead() is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2999,11 +2999,9 @@ class MCPServerTask:
             # os.kill probe below only runs when psutil is unavailable.
             import psutil
 
-            if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            if psutil.pid_exists(pid):
+                return False  # at least one child alive → not all dead
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
## What does this PR do?

Fixes an inverted return in `MCPServerTask._stdio_children_dead()` that made Hermes believe a stdio MCP server had died the moment it was actually alive, causing every tool call to be rejected with `MCP stdio subprocess for '<name>' has exited; failing the call fast`.

## Related Issue

Fixes # (none filed — see root cause below)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — `MCPServerTask._stdio_children_dead()`: a live child now returns `False` (at least one child alive), and only an all-dead set returns `True`; removed the unreachable `return False` dead code.
- `tests/tools/test_mcp_stdio_children_dead.py` — 5 regression tests (empty set, http transport, live child, all dead, mixed alive+dead).

## How to Test

1. Register a stdio MCP server whose process stays alive after spawn (e.g. `maestro mcp --no-viewer`).
2. Call any of its tools → before the fix it fails instantly with the fast-fail error; after the fix it returns the server's result.
3. Run the regression suite: `pytest tests/tools/test_mcp_stdio_children_dead.py -q` → 5 passed.

## Root Cause

`tools/mcp_tool.py`, method `MCPServerTask._stdio_children_dead()`. Docstring: *"True when every stdio child we spawned has exited."* The fast-fail caller treats a `True` return as "all children dead" and raises `TimeoutError`.

Regression introduced by commit `786f37071` ("fix(mcp): psutil.pid_exists for stdio children liveness — Windows footgun (#85125 CI)"). Before it (introduced in `2f33833de`), the `os.kill(pid, 0)` implementation returned `False` for a live child — correct. The `psutil.pid_exists` conversion inverted the branch:

```python
for pid in pids:
    import psutil
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True  # alive ← WRONG: inverted
    return False  # unreachable
return True
```

When a child is **alive**, `psutil.pid_exists(pid)` is `True`, so `if not ...` is `False`, control falls to `return True` → "all children dead" while the process is alive → fast-fail fires on every call.

Why not universally triggered: the fast-fail path only runs when `_stdio_child_pids` is non-empty (stdio transport, PID snapshot captured) and `_is_http()` is `False`. HTTP MCP servers and servers with an empty PID snapshot are unaffected.

Observed with the `maestro` MCP server (`maestro mcp --no-viewer`): every tool call failed instantly while the server subprocess was confirmed alive via `ps` and a manual stdio probe (`initialize` → `tools/list` → `tools/call` all returned valid results).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and all pass (`pytest tests/tools/test_mcp_stdio_children_dead.py tests/tools/test_mcp_stdio_watchdog.py -q` → 10 passed)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] N/A — no docs/config/architecture change
