### PR TITLE
fix(cli): scope external secret hydration

### DIFF
--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -41,6 +41,7 @@ __all__ = [
     "read_install_method",
     "print_fast_version_info",
     "try_fast_version",
+    "should_load_external_secrets",
 ]
 
 
@@ -78,6 +79,32 @@ def is_termux_fast_version_argv(argv: list[str]) -> bool:
 
 def is_global_fast_version_argv(argv: list[str]) -> bool:
     return argv in (["--version"], ["-V"])
+
+
+def should_load_external_secrets(argv: list[str]) -> bool:
+    """Return whether this CLI invocation needs startup secret hydration.
+
+    External secret sources are intentionally broad: a mapped 1Password
+    source executes one ``op read`` per configured reference.  Purely local
+    administration, help rendering, and public-client OAuth login do not use
+    those values, so hydrating them is both wasteful and capable of exhausting
+    a secret manager's request quota before the requested command starts.
+
+    Keep the allow-to-skip list deliberately narrow.  Runtime commands and MCP
+    discovery/tests still hydrate credentials exactly as before.
+    """
+    args = [arg for arg in argv if isinstance(arg, str)]
+    if any(arg in {"-h", "--help"} for arg in args):
+        return False
+    if not args:
+        return True
+    if args[0] == "update":
+        return False
+    if args[0] == "config" and len(args) >= 2:
+        return args[1] not in {"set", "unset", "path", "env-path", "edit"}
+    if len(args) >= 2 and args[0] == "mcp" and args[1] in {"login", "reauth"}:
+        return False
+    return True
 
 
 def is_container_startup_environment() -> bool:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -716,16 +716,16 @@ if sys.platform == "win32":
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
-# Updating dependencies must not import optional secret-manager libraries into
-# the updater process before ``uv`` replaces the environment.  On Windows,
-# Bitwarden's cryptography import maps ``_rust.pyd`` and the parent updater then
-# prevents its own child installer from replacing that file (#73381).  Profile
-# flags have already been stripped above, so the first remaining argument is
-# the authoritative argparse subcommand.  Dotenv/managed config still loads;
-# only external secret fetches are unnecessary for installation maintenance.
+# Some CLI paths must not import or query optional secret managers. Updating
+# dependencies can self-lock Bitwarden's mapped cryptography DLL on Windows,
+# while local config/help and public-client MCP OAuth login need no provider
+# credentials and can otherwise exhaust mapped-source request quotas before
+# dispatch. Profile flags have already been stripped above, so the remaining
+# argv is authoritative. Dotenv and managed config still load in every case;
+# only external secret-source hydration is command-scoped.
 load_hermes_dotenv(
     project_env=PROJECT_ROOT / ".env",
-    load_external_secrets=sys.argv[1:2] != ["update"],
+    load_external_secrets=_startup_fast.should_load_external_secrets(sys.argv[1:]),
 )
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -251,7 +251,20 @@ def _apply_mcp_preset(
 
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
 
-def _resolve_mcp_server_config(config: dict) -> dict:
+def _has_unresolved_env_ref(value: Any) -> bool:
+    """Return True when an interpolated MCP config still contains an env ref."""
+    if isinstance(value, str):
+        return bool(re.search(r"\$\{(?:env:)?[A-Za-z_][A-Za-z0-9_]*\}", value))
+    if isinstance(value, dict):
+        return any(_has_unresolved_env_ref(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_has_unresolved_env_ref(v) for v in value)
+    return False
+
+
+def _resolve_mcp_server_config(
+    config: dict, *, load_external_secrets: bool = True
+) -> dict:
     """Resolve ``${ENV}`` placeholders in a server config before connecting.
 
     Mirrors ``_load_mcp_config()`` in ``tools/mcp_tool.py``: load
@@ -269,14 +282,32 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     if current_secret_scope() is None:
         try:
             from hermes_cli.env_loader import load_hermes_dotenv
-            load_hermes_dotenv()
+            load_hermes_dotenv(load_external_secrets=load_external_secrets)
         except Exception:  # pragma: no cover — defensive
             pass
-    return _interpolate_env_vars(config)
+    resolved = _interpolate_env_vars(config)
+    # OAuth login normally needs only public server metadata and should not
+    # hydrate a whole company secret inventory. Preserve compatibility for a
+    # pre-registered confidential client, though: if its explicit ${VAR}
+    # remains unresolved after dotenv/scoped-env loading, fall back to the
+    # configured external sources and interpolate once more.
+    if not load_external_secrets and _has_unresolved_env_ref(resolved):
+        try:
+            from hermes_cli.env_loader import load_hermes_dotenv
+            load_hermes_dotenv(load_external_secrets=True)
+        except Exception:  # pragma: no cover — defensive
+            pass
+        resolved = _interpolate_env_vars(config)
+    return resolved
 
 
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: Optional[float] = None, *, details: Optional[dict] = None
+    name: str,
+    config: dict,
+    connect_timeout: Optional[float] = None,
+    *,
+    details: Optional[dict] = None,
+    load_external_secrets: bool = True,
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
@@ -299,7 +330,9 @@ def _probe_single_server(
         _parse_boolish,
     )
 
-    config = _resolve_mcp_server_config(config)
+    config = _resolve_mcp_server_config(
+        config, load_external_secrets=load_external_secrets
+    )
     if connect_timeout is None:
         raw_timeout = config.get("connect_timeout", 30)
         try:
@@ -857,7 +890,10 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         _login_connect_timeout = max(_login_connect_timeout, 315.0)
         with force_interactive_oauth():
             tools = _probe_single_server(
-                name, server_config, connect_timeout=_login_connect_timeout
+                name,
+                server_config,
+                connect_timeout=_login_connect_timeout,
+                load_external_secrets=False,
             )
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -76,6 +76,56 @@ class FakeTool:
         self.description = description
 
 
+class TestMcpSecretResolution:
+    def test_oauth_probe_skips_external_sources_without_placeholders(self, monkeypatch):
+        from hermes_cli.mcp_config import _resolve_mcp_server_config
+
+        calls = []
+        monkeypatch.setattr("agent.secret_scope.current_secret_scope", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.load_hermes_dotenv",
+            lambda **kwargs: calls.append(kwargs["load_external_secrets"]),
+        )
+
+        resolved = _resolve_mcp_server_config(
+            {"url": "https://mcp.example.com", "auth": "oauth"},
+            load_external_secrets=False,
+        )
+
+        assert resolved["url"] == "https://mcp.example.com"
+        assert calls == [False]
+
+    def test_oauth_probe_falls_back_for_unresolved_explicit_secret_ref(self, monkeypatch):
+        from hermes_cli.mcp_config import _resolve_mcp_server_config
+
+        calls = []
+        monkeypatch.delenv("MCP_CLIENT_SECRET", raising=False)
+        monkeypatch.setattr("agent.secret_scope.current_secret_scope", lambda: None)
+
+        def fake_load(**kwargs):
+            load_external = kwargs["load_external_secrets"]
+            calls.append(load_external)
+            if load_external:
+                monkeypatch.setenv("MCP_CLIENT_SECRET", "resolved-secret")
+
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.load_hermes_dotenv",
+            fake_load,
+        )
+
+        resolved = _resolve_mcp_server_config(
+            {
+                "url": "https://mcp.example.com",
+                "auth": "oauth",
+                "oauth": {"client_secret": "${MCP_CLIENT_SECRET}"},
+            },
+            load_external_secrets=False,
+        )
+
+        assert resolved["oauth"]["client_secret"] == "resolved-secret"
+        assert calls == [False, True]
+
+
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_list
 # ---------------------------------------------------------------------------
@@ -737,7 +787,7 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg, connect_timeout=30: [
+            lambda name, cfg, connect_timeout=30, **kwargs: [
                 ("search_files", "d"), ("read_file_content", "d"),
             ],
         )
@@ -763,8 +813,9 @@ class TestMcpLogin:
         # probe drops a token file, mirroring a successful authorization.
         seen = {}
 
-        def mock_probe(name, cfg, connect_timeout=30):
+        def mock_probe(name, cfg, connect_timeout=30, **kwargs):
             seen["connect_timeout"] = connect_timeout
+            seen["load_external_secrets"] = kwargs.get("load_external_secrets")
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]
@@ -782,7 +833,8 @@ class TestMcpLogin:
         assert "no OAuth token" not in out
         # The login path must grant a human enough time to finish the browser
         # OAuth round-trip — far longer than the 30s probe default.
-        assert seen["connect_timeout"] >= 180
+        assert seen["connect_timeout"] >= 315
+        assert seen["load_external_secrets"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_startup_fast_guards.py
+++ b/tests/hermes_cli/test_startup_fast_guards.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_cli._startup_fast import should_load_external_secrets
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Modules that must NEVER be imported by the fast path. Each one either
@@ -104,3 +106,24 @@ def test_fast_version_reports_install_method_stamp(tmp_path):
     result = _run_version({"HERMES_HOME": str(home), "TERMUX_VERSION": ""})
     assert result.returncode == 0, result.stderr
     assert "Install method: git" in result.stdout
+
+
+def test_offline_cli_commands_skip_external_secret_hydration():
+    """Offline config/help paths must never query external secret managers."""
+    assert not should_load_external_secrets(["config", "set", "x", "y"])
+    assert should_load_external_secrets(["config", "show"])
+    assert should_load_external_secrets(["config", "get", "OPENAI_API_KEY"])
+    assert should_load_external_secrets(["config", "check"])
+    assert should_load_external_secrets(["config", "migrate"])
+    assert not should_load_external_secrets(["mcp", "login", "hubspot"])
+    assert not should_load_external_secrets(["mcp", "reauth", "hubspot"])
+    assert not should_load_external_secrets(["mcp", "list", "--help"])
+    assert not should_load_external_secrets(["doctor", "--help"])
+
+
+def test_runtime_cli_commands_still_load_external_secrets():
+    """Chat, gateways, and MCP probes retain normal credential hydration."""
+    assert should_load_external_secrets([])
+    assert should_load_external_secrets(["chat"])
+    assert should_load_external_secrets(["gateway", "run"])
+    assert should_load_external_secrets(["mcp", "test", "github"])


### PR DESCRIPTION
## Summary

- skip external secret-manager hydration for CLI help and local config file operations that do not consume credentials
- prevent `hermes mcp login` / `reauth` from resolving every mapped secret before public OAuth begins
- preserve confidential-client compatibility by hydrating external sources only when an explicit `${VAR}` / `${env:VAR}` remains unresolved
- keep runtime commands, MCP probes, and credential-reporting config commands unchanged

## Reproduction

With multiple mapped 1Password references configured, `hermes mcp login <server>` previously executed one `op read` for every reference before starting OAuth. Repeated CLI invocations could exhaust the secret manager's request quota even when the OAuth server entry required no credential.

## Verification

- `uv run --extra dev --frozen pytest -q tests/hermes_cli/test_startup_fast_guards.py tests/hermes_cli/test_mcp_config.py`
- `uv run --extra dev --frozen ruff check hermes_cli/_startup_fast.py hermes_cli/main.py hermes_cli/mcp_config.py tests/hermes_cli/test_startup_fast_guards.py tests/hermes_cli/test_mcp_config.py`
- subprocess probes with a synthetic `op` executable verify zero external reads for help and public-client OAuth login
- explicit unresolved confidential-client reference still invokes the configured external source and resolves successfully

No credentials, private configuration, customer data, logs, screenshots, or machine-specific paths are included.
