### PR TITLE
fix(tools): prevent computer use from enabling Orca

### DIFF
--- a/tests/computer_use/test_cua_telemetry.py
+++ b/tests/computer_use/test_cua_telemetry.py
@@ -1,9 +1,12 @@
-"""Tests for the cua-driver telemetry opt-in policy.
+"""Tests for cua-driver child-environment policy.
 
 cua-driver ships anonymous PostHog telemetry ENABLED by default upstream.
 Hermes disables it unless the user opts in via
 ``computer_use.cua_telemetry: true``. The policy is applied by injecting
 ``CUA_DRIVER_RS_TELEMETRY_ENABLED=0`` into every cua-driver child env.
+
+Linux children also retain cua-driver's desktop-aware accessibility policy
+when a system gateway lacks graphical-session environment variables.
 
 These assert the behavior contract (default disables, opt-in leaves the var
 untouched, config failure fails safe toward disabled), not specific config
@@ -16,6 +19,7 @@ from tools.computer_use import cua_backend
 
 
 _VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
+_A11Y_VAR = "CUA_DRIVER_RS_A11Y_ADVERTISE_MODE"
 
 
 class TestTelemetryDisabledFlag:
@@ -49,4 +53,160 @@ class TestChildEnv:
         with patch.object(cua_backend, "_cua_telemetry_disabled", return_value=True):
             env = cua_backend.cua_driver_child_env({_VAR: "1"})
             assert env[_VAR] == "0"
+
+    def test_gnome_and_cosmic_force_non_activating_a11y_advertisement(self):
+        # GNOME treats ScreenReaderEnabled=true as a request to persist the
+        # setting and launch Orca. Hermes must retain AT-SPI support without
+        # changing that user preference, even if the parent inherited an
+        # unsafe advertisement mode.
+        for desktop in ("ubuntu:GNOME", "COSMIC", "pop:COSMIC"):
+            with patch.object(cua_backend.sys, "platform", "linux"):
+                env = cua_backend.cua_driver_child_env({
+                    "XDG_CURRENT_DESKTOP": desktop,
+                    _A11Y_VAR: "all",
+                })
+            assert env[_A11Y_VAR] == "is_enabled_only", desktop
+
+    def test_gnome_preserves_stricter_inherited_none_mode(self):
+        with patch.object(cua_backend.sys, "platform", "linux"):
+            env = cua_backend.cua_driver_child_env({
+                "XDG_CURRENT_DESKTOP": "GNOME",
+                _A11Y_VAR: "none",
+            })
+        assert env[_A11Y_VAR] == "none"
+
+    def test_cinnamon_disables_a11y_advertisement(self):
+        for desktop in ("Cinnamon", "X-Cinnamon", "GNOME:X-Cinnamon"):
+            with patch.object(cua_backend.sys, "platform", "linux"):
+                env = cua_backend.cua_driver_child_env({
+                    "XDG_CURRENT_DESKTOP": desktop,
+                    _A11Y_VAR: "all",
+                })
+            assert env[_A11Y_VAR] == "none", desktop
+
+    def test_kde_and_unknown_linux_preserve_driver_policy(self):
+        for desktop in ("KDE", "sway", "unknown"):
+            with patch.object(cua_backend.sys, "platform", "linux"):
+                inherited = cua_backend.cua_driver_child_env({
+                    "XDG_CURRENT_DESKTOP": desktop, _A11Y_VAR: "all"
+                })
+                absent = cua_backend.cua_driver_child_env({
+                    "XDG_CURRENT_DESKTOP": desktop
+                })
+            assert inherited[_A11Y_VAR] == "all", desktop
+            assert _A11Y_VAR not in absent, desktop
+
+    def test_desktop_identity_uses_order_and_skips_empty_values(self):
+        assert cua_backend._desktop_identity_from({
+            "XDG_CURRENT_DESKTOP": "",
+            "XDG_SESSION_DESKTOP": "GNOME",
+            "DESKTOP_SESSION": "fallback",
+        }) == "GNOME"
+        assert cua_backend._desktop_identity_from({
+            "XDG_SESSION_DESKTOP": "",
+            "DESKTOP_SESSION": "cinnamon",
+        }) == "cinnamon"
+
+    def test_missing_desktop_recovers_user_manager_identity(self):
+        service_env = {"SYSTEMD_EXEC_PID": str(cua_backend.os.getpid())}
+        with patch.dict(cua_backend.os.environ, service_env, clear=True), \
+             patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.object(cua_backend, "_cua_telemetry_disabled", return_value=True), \
+             patch.object(
+                 cua_backend,
+                 "_linux_desktop_from_user_manager",
+                 return_value="ubuntu:GNOME",
+             ):
+            env = cua_backend.cua_driver_child_env()
+        assert env["XDG_CURRENT_DESKTOP"] == "ubuntu:GNOME"
+        assert env[_A11Y_VAR] == "is_enabled_only"
+
+    def test_user_manager_probe_uses_minimal_fixed_bus_environment(self):
+        result = cua_backend.subprocess.CompletedProcess(
+            args=["systemctl"],
+            returncode=0,
+            stdout="PATH=/usr/bin\nXDG_CURRENT_DESKTOP=ubuntu:GNOME\n",
+            stderr="",
+        )
+        inherited = {
+            "XDG_RUNTIME_DIR": "/run/user/999",
+            "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/999/bus",
+            "OPENAI_API_KEY": "must-not-leak",
+        }
+        with patch.dict(cua_backend.os.environ, inherited, clear=True), \
+             patch.object(cua_backend.os, "getuid", return_value=1000, create=True), \
+             patch.object(
+                 cua_backend,
+                 "_trusted_systemctl_path",
+                 return_value="/usr/bin/systemctl",
+             ), \
+             patch.object(cua_backend.subprocess, "run", return_value=result) as run:
+            desktop = cua_backend._probe_linux_desktop_from_user_manager()
+
+        assert desktop == "ubuntu:GNOME"
+        assert run.call_args.args[0] == [
+            "/usr/bin/systemctl", "--user", "show-environment"
+        ]
+        probe_env = run.call_args.kwargs["env"]
+        assert set(probe_env) == {
+            "PATH", "LC_ALL", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS"
+        }
+        assert probe_env["XDG_RUNTIME_DIR"] == "/run/user/1000"
+        assert probe_env["DBUS_SESSION_BUS_ADDRESS"] == (
+            "unix:path=/run/user/1000/bus"
+        )
+        assert "OPENAI_API_KEY" not in probe_env
+
+    def test_user_manager_probe_failures_return_none(self):
+        for error in (
+            OSError("missing"),
+            cua_backend.subprocess.TimeoutExpired("systemctl", 2),
+        ):
+            with patch.object(
+                cua_backend, "_trusted_systemctl_path", return_value="/usr/bin/systemctl"
+            ), patch.object(cua_backend.subprocess, "run", side_effect=error):
+                assert cua_backend._probe_linux_desktop_from_user_manager() is None
+
+        for result in (
+            cua_backend.subprocess.CompletedProcess(
+                args=["systemctl"], returncode=1, stdout="", stderr="failed"
+            ),
+            cua_backend.subprocess.CompletedProcess(
+                args=["systemctl"], returncode=0, stdout="PATH=/usr/bin\n", stderr=""
+            ),
+        ):
+            with patch.object(
+                cua_backend, "_trusted_systemctl_path", return_value="/usr/bin/systemctl"
+            ), patch.object(cua_backend.subprocess, "run", return_value=result):
+                assert cua_backend._probe_linux_desktop_from_user_manager() is None
+
+    def test_user_manager_desktop_probe_is_briefly_cached(self):
+        original = cua_backend._cua_linux_desktop_cache
+        cua_backend._cua_linux_desktop_cache = (0.0, None)
+        try:
+            with patch.object(
+                cua_backend,
+                "_probe_linux_desktop_from_user_manager",
+                return_value="ubuntu:GNOME",
+            ) as probe:
+                assert cua_backend._linux_desktop_from_user_manager() == "ubuntu:GNOME"
+                assert cua_backend._linux_desktop_from_user_manager() == "ubuntu:GNOME"
+            probe.assert_called_once()
+        finally:
+            cua_backend._cua_linux_desktop_cache = original
+
+    def test_child_of_systemd_service_does_not_probe_user_manager(self):
+        inherited = {"SYSTEMD_EXEC_PID": str(cua_backend.os.getpid() - 1)}
+        with patch.dict(cua_backend.os.environ, inherited, clear=True), \
+             patch.object(cua_backend.sys, "platform", "linux"), \
+             patch.object(cua_backend, "_cua_telemetry_disabled", return_value=True), \
+             patch.object(cua_backend, "_linux_desktop_from_user_manager") as probe:
+            env = cua_backend.cua_driver_child_env()
+        probe.assert_not_called()
+        assert _A11Y_VAR not in env
+
+    def test_non_linux_preserves_inherited_a11y_advertisement(self):
+        with patch.object(cua_backend.sys, "platform", "darwin"):
+            env = cua_backend.cua_driver_child_env({_A11Y_VAR: "all"})
+        assert env[_A11Y_VAR] == "all"
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -220,6 +220,26 @@ _NON_APP_WINDOW_TITLE_PREFIXES = (
 # (telemetry ON upstream).
 _CUA_TELEMETRY_ENV_VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
 
+# On GNOME, advertising ScreenReaderEnabled=true is not a passive AT-SPI
+# capability hint: GNOME persists screen-reader-enabled=true and starts Orca.
+# Cinnamon must not receive even the reduced IsEnabled-only advertisement.
+# Keep cua-driver's desktop-specific policy intact even when a system gateway
+# lacks the graphical session's XDG desktop variables.
+_CUA_LINUX_A11Y_ADVERTISE_ENV_VAR = "CUA_DRIVER_RS_A11Y_ADVERTISE_MODE"
+_CUA_LINUX_A11Y_ADVERTISE_SAFE_MODE = "is_enabled_only"
+_CUA_LINUX_A11Y_ADVERTISE_NONE_MODE = "none"
+_CUA_LINUX_DESKTOP_ENV_VARS = (
+    "XDG_CURRENT_DESKTOP",
+    "XDG_SESSION_DESKTOP",
+    "DESKTOP_SESSION",
+)
+_CUA_SYSTEMCTL_SEARCH_PATH = os.pathsep.join(
+    ("/usr/bin", "/bin", "/usr/local/bin", "/run/current-system/sw/bin")
+)
+_CUA_LINUX_DESKTOP_CACHE_SECONDS = 5.0
+_cua_linux_desktop_cache: Tuple[float, Optional[str]] = (0.0, None)
+_cua_linux_desktop_cache_lock = threading.Lock()
+
 
 def _computer_use_cfg() -> Dict[str, Any]:
     """The ``computer_use`` config block, or ``{}`` when config is unreadable."""
@@ -404,18 +424,147 @@ def _computer_use_max_image_dimension() -> Optional[int]:
     return dim if dim > 0 else None
 
 
+def _desktop_identity_from(env: Dict[str, str]) -> Optional[str]:
+    """Return the first non-empty identity in cua-driver's variable order."""
+    for key in _CUA_LINUX_DESKTOP_ENV_VARS:
+        value = env.get(key)
+        if value:
+            return value
+    return None
+
+
+def _trusted_systemctl_path() -> Optional[str]:
+    """Resolve a root-owned, non-writable systemctl outside the inherited PATH."""
+    candidate = shutil.which("systemctl", path=_CUA_SYSTEMCTL_SEARCH_PATH)
+    if not candidate:
+        return None
+    resolved = os.path.realpath(candidate)
+    try:
+        metadata = os.stat(resolved)
+    except OSError:
+        return None
+    if metadata.st_uid != 0 or metadata.st_mode & 0o022:
+        return None
+    return resolved
+
+
+def _probe_linux_desktop_from_user_manager() -> Optional[str]:
+    """Recover the graphical desktop identity for a system-service gateway.
+
+    A system-level Hermes gateway does not normally inherit the user's XDG
+    desktop variables. The per-user systemd manager does, and its D-Bus socket
+    has a stable runtime path. Query only the desktop identity; do not merge the
+    manager's full environment into a third-party child process.
+    """
+    try:
+        getuid = getattr(os, "getuid", None)
+        if not callable(getuid):
+            return None
+        systemctl = _trusted_systemctl_path()
+        if not systemctl:
+            return None
+        runtime_dir = f"/run/user/{getuid()}"
+        probe_env = {
+            "PATH": os.pathsep.join(
+                dict.fromkeys((os.path.dirname(systemctl), "/usr/bin", "/bin"))
+            ),
+            "LC_ALL": "C",
+            "XDG_RUNTIME_DIR": runtime_dir,
+            "DBUS_SESSION_BUS_ADDRESS": f"unix:path={runtime_dir}/bus",
+        }
+        proc = subprocess.run(
+            [systemctl, "--user", "show-environment"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=2.0,
+            check=False,
+            env=probe_env,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
+        return None
+    if proc.returncode != 0:
+        return None
+    manager_env: Dict[str, str] = {}
+    for line in getattr(proc, "stdout", "").splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key in _CUA_LINUX_DESKTOP_ENV_VARS:
+            manager_env[key] = value
+    return _desktop_identity_from(manager_env)
+
+
+def _linux_desktop_from_user_manager() -> Optional[str]:
+    """Return the briefly cached user-manager desktop identity."""
+    global _cua_linux_desktop_cache
+    with _cua_linux_desktop_cache_lock:
+        now = time.monotonic()
+        expires_at, cached = _cua_linux_desktop_cache
+        if now < expires_at:
+            return cached
+        desktop = _probe_linux_desktop_from_user_manager()
+        _cua_linux_desktop_cache = (
+            now + _CUA_LINUX_DESKTOP_CACHE_SECONDS,
+            desktop,
+        )
+        return desktop
+
+
+def _is_systemd_service_process(env: Dict[str, str]) -> bool:
+    """Return true only in the exact process systemd launched for the service."""
+    return env.get("SYSTEMD_EXEC_PID") == str(os.getpid())
+
+
+def _linux_a11y_advertise_mode(
+    desktop: Optional[str], configured: Optional[str]
+) -> Optional[str]:
+    """Return a safety override, or None to preserve cua-driver's default."""
+    tokens = {
+        part.strip().lower()
+        for part in re.split(r"[:;]", desktop or "")
+        if part.strip()
+    }
+    if tokens.intersection({"cinnamon", "x-cinnamon"}):
+        return _CUA_LINUX_A11Y_ADVERTISE_NONE_MODE
+    if tokens.intersection({"gnome", "cosmic"}):
+        if (configured or "").strip().lower() == _CUA_LINUX_A11Y_ADVERTISE_NONE_MODE:
+            return _CUA_LINUX_A11Y_ADVERTISE_NONE_MODE
+        return _CUA_LINUX_A11Y_ADVERTISE_SAFE_MODE
+    return None
+
+
 def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Return the environment dict for spawning cua-driver.
 
     Starts from ``base_env`` (defaults to ``os.environ``) and, when telemetry
     is disabled (the default), injects ``CUA_DRIVER_RS_TELEMETRY_ENABLED=0``.
-    When the user has opted in, the var is left untouched so cua-driver uses
-    its own default. Used by every cua-driver spawn site (MCP backend, status,
-    doctor, install) so the policy is applied consistently.
+    On Linux, recover a missing graphical desktop identity from the user
+    manager, then enforce cua-driver's safe GNOME/COSMIC/Cinnamon policies.
+    KDE and unknown desktops retain cua-driver's Chromium-compatible default.
+    When the user opts into cua telemetry, the telemetry variable is left
+    untouched so cua-driver uses its own default. Used by every cua-driver
+    spawn site (MCP backend, status, doctor, install) so the policy is applied
+    consistently.
     """
+    use_process_env = base_env is None
     env = dict(base_env if base_env is not None else os.environ)
     if _cua_telemetry_disabled():
         env[_CUA_TELEMETRY_ENV_VAR] = "0"
+    if sys.platform.startswith("linux"):
+        desktop = _desktop_identity_from(env)
+        if (
+            desktop is None
+            and use_process_env
+            and _is_systemd_service_process(env)
+        ):
+            desktop = _linux_desktop_from_user_manager()
+            if desktop:
+                env["XDG_CURRENT_DESKTOP"] = desktop
+        mode = _linux_a11y_advertise_mode(
+            desktop, env.get(_CUA_LINUX_A11Y_ADVERTISE_ENV_VAR)
+        )
+        if mode is not None:
+            env[_CUA_LINUX_A11Y_ADVERTISE_ENV_VAR] = mode
     return env
 
 


### PR DESCRIPTION
## Summary

- preserve `cua-driver`'s desktop-aware Linux accessibility policy when Hermes runs as a system service without graphical-session environment variables
- recover only the missing desktop identity from the user's systemd manager
- enforce non-activating advertisement on GNOME/COSMIC and disable advertisement on Cinnamon, while preserving KDE/other-desktop behavior
- add regression coverage for the desktop matrix, system-service recovery, non-service isolation, and non-Linux behavior

## Problem

On GNOME, advertising `ScreenReaderEnabled=true` is interpreted as a user request rather than a passive accessibility capability hint. GNOME persists `screen-reader-enabled=true`, starts Orca, creates its graphical-session startup link, and begins reading the focused screen aloud.

`cua-driver 0.20+` already avoids this when it can identify GNOME from `XDG_CURRENT_DESKTOP`, `XDG_SESSION_DESKTOP`, or `DESKTOP_SESSION`. A system-level Hermes gateway does not normally inherit those graphical-session variables. The driver therefore sees an unknown desktop, uses its Chromium-compatible `all` default, and can unexpectedly enable Orca.

## Implementation

The shared `cua_driver_child_env()` helper still covers every driver spawn site. On Linux it now:

1. Uses the existing desktop variables when present.
2. If the current process is the exact process launched by systemd and the variables are missing, queries `systemctl --user show-environment` through the fixed `/run/user/<uid>/bus` path.
3. Resolves `systemctl` only from trusted root-owned, non-writable system locations and passes it a minimal environment with no provider credentials.
4. Copies only the recovered desktop identity—not the full user-manager environment—into the child environment.
5. Briefly caches successful and failed probes to avoid repeated launch delays without masking a later graphical login.
6. Forces `none` for Cinnamon/X-Cinnamon and `is_enabled_only` for GNOME/COSMIC, while preserving an inherited stricter `none` policy.
7. Leaves KDE, unknown desktops, non-service child processes, and non-Linux platforms unchanged.

The systemd PID check prevents test runners and other descendants that merely inherit `SYSTEMD_EXEC_PID` from adding an unexpected subprocess.

## Verification

- Initial blanket-Linux implementation was independently reviewed and rejected before merge because it could freeze Cinnamon and degrade KDE accessibility trees
- Revised focused child-environment suite: **21 passed**
- All discovered Computer Use-related tests, isolated per file: **397 passed, 1 skipped across 28 files**
- `python3 -m py_compile` on changed Python files: passed
- `git diff --check`: passed
- Staged/worktree blob hashes matched exactly; no unstaged changes
- Live system-service simulation with all desktop variables removed recovered `ubuntu:GNOME` and selected `is_enabled_only`
- Live Ubuntu 26.04 / GNOME 50.1 test with `cua-driver 0.21.0`: guarded driver launch left Screen Reader off, Orca inactive, and the generic accessibility bridge enabled
- Verified against upstream `cua-driver-rs-v0.20.0`: the required Hermes runtime contract includes the desktop-aware advertisement variable and Cinnamon/GNOME/COSMIC/KDE policy

## Risk

Linux-only and fail-preserving outside the affected desktops. The change does not disable AT-SPI globally, uninstall Orca, alter speech-to-text tools, or merge arbitrary user-manager environment variables into `cua-driver`.
