### PR TITLE
fix(update): respawn hermes-webui service on update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5298,8 +5298,8 @@ def _for_each_systemd_gateway_unit(
     process_unit,
     on_unit_timeout,
 ) -> None:
-    """Process each ``hermes-gateway*.service``/``hermes-serve*.service`` unit
-    from ``systemctl list-units``.
+    """Process each ``hermes-gateway*.service``/``hermes-serve*.service``/
+    ``hermes-webui*.service`` unit from ``systemctl list-units``.
 
     ``subprocess.TimeoutExpired`` raised by ``process_unit`` is isolated to
     that unit via ``on_unit_timeout`` so one wedged systemctl call cannot
@@ -5313,15 +5313,18 @@ def _for_each_systemd_gateway_unit(
         if not unit.endswith(".service"):
             continue
         # list-units is already pattern-filtered, but keep the name gate so a
-        # stray non-gateway/serve line cannot enter the restart path.
+        # stray non-gateway/serve/webui line cannot enter the restart path.
         # ``unit.startswith("hermes-serve")`` alone would also accept the
         # unrelated ``hermes-server.service`` — require the exact base unit
-        # or the hyphenated profile family instead (review on #83595).
+        # or the hyphenated profile family instead (review on #83595). The
+        # same strict shape guards hermes-webui against ``hermes-webuid``.
         if not (
             unit == "hermes-gateway.service"
             or unit.startswith("hermes-gateway-")
             or unit == "hermes-serve.service"
             or unit.startswith("hermes-serve-")
+            or unit == "hermes-webui.service"
+            or unit.startswith("hermes-webui-")
         ):
             continue
         svc_name = unit.removesuffix(".service")
@@ -8024,7 +8027,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles) plus
-            # hermes-serve* units (the Desktop app's backend, #83438).
+            # hermes-serve* units (the Desktop app's backend, #83438) and
+            # hermes-webui* units (the WebUI/Hermex backend).
             if supports_systemd_services():
                 try:
                     _ensure_user_systemd_env()
@@ -8042,6 +8046,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 "list-units",
                                 "hermes-gateway*",
                                 "hermes-serve*",
+                                "hermes-webui*",
                                 "--plain",
                                 "--no-legend",
                                 "--no-pager",

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -140,6 +140,41 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == ["hermes-gateway-coder"]
 
+    def test_hermes_webui_units_are_included(self):
+        # hermes update restarted hermes-gateway*/hermes-serve* but left
+        # hermes-webui* (the WebUI/Hermex backend) on stale pre-update code.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            "\n".join(
+                [
+                    "ssh.service loaded active running",
+                    "hermes-webui.service loaded active running",
+                    "hermes-webui-work.service loaded active running",
+                    "hermes-gateway.service loaded active running",
+                    "",
+                ]
+            ),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-webui", "hermes-webui-work", "hermes-gateway"]
+
+    def test_hermes_webui_near_prefix_is_rejected(self):
+        # Same strict shape: a bare ``startswith("hermes-webui")`` gate would
+        # also accept ``hermes-webuid.service``. Only the exact base unit or
+        # the hyphenated profile family should pass.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            _list_units_stdout(["hermes-webuid"]),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == []
+
 
 class TestGracefulSigusr1Eligibility:
     def test_gateway_units_are_eligible(self):


### PR DESCRIPTION
## Summary

`hermes update` restarts `hermes-gateway*` and `hermes-dashboard` services but never restarts the Hermes WebUI backend (`hermes-webui.service`). After an update, the WebUI keeps serving the pre-update agent bundle and refuses all sends with:

```
Server returned HTTP 409: Hermes Agent was updated while Hermes WebUI was running.
Restart Hermes WebUI before retrying this action.
```

The only workaround is a manual `systemctl --user restart hermes-webui.service`. This has now happened 3 times on one deployment (2026-08-26, twice more before) — every `hermes update` reproduces it, since `hermes update` is how the agent is upgraded on that fleet.

## Root cause

`hermes_cli/update_cmd.py` only knows about gateway and dashboard units:
- `_for_each_systemd_gateway_unit`'s unit-name gate accepts `hermes-gateway*` / `hermes-dashboard*` (and `hermes-serve*`), but not `hermes-webui*`.
- The `systemctl list-units` discovery call in `_cmd_update_impl` globs `hermes-gateway*` / `hermes-dashboard*`, so the webui unit is never even discovered.

## Changes Made

- `hermes_cli/update_cmd.py`
  - Unit-name gate: accept `hermes-webui.service` exactly and `hermes-webui-*` hyphenated prefixes (same strict shape as the existing `hermes-serve` handling — bare `startswith` is not used, so near-prefixes like `hermes-webuid` are rejected).
  - Discovery globs: add `"hermes-webui*"` alongside the existing globs (both user and system scope).
  - SIGUSR1 eligibility deliberately NOT extended: the webui's SIGUSR1 handler is a faulthandler stack dump (`crash_visibility.py`, `chain=False`), not a graceful drain, so the blunt `systemctl restart` path is correct.
- `tests/hermes_cli/test_update_fleet_restart_timeout.py`
  - New: `hermes_webui_units_are_included`, `hermes_webui_near_prefix_rejected` (mirroring the existing `hermes_serve_units_are_included` / `hermes_server_near_prefix_is_rejected`).

## Tests

```
./scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_timeout.py
=== Summary: 1 files, 11 tests passed, 0 failed (100% complete) in 0.7s (8 workers) ===
```

11 = 9 pre-existing + 2 new. Both new tests fail before the change and pass after.

## Verification

- Dry-run on a live deployment: `hermes-webui.service` appears in `units entering restart path` (no TIMEOUT), alongside `hermes-gateway`, `hermes-gateway-komblabs`, `hermes-gateway-komblabs-public`; `hermes-dashboard` unaffected.
- The webui unit runs on the user bus (`systemctl --user`), which the existing discovery already covers (user scope first, then system).
- Real-update E2E on the affected fleet is deferred until this lands: local commits in the checkout are reset by `hermes update` itself, so the fix could not be tested end-to-end from a patched local checkout.

## Related Issue

Fixes #95882
