### PR TITLE
feat: add safe Slack elapsed progress

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -663,6 +663,31 @@ _TOOL_VERBS: dict[str, str] = {
     "todo": "Updating tasks",
 }
 
+# Argument-free categories for status surfaces in shared or sensitive lanes.
+# The mapping is intentionally closed: unknown plugin/MCP names become the
+# generic "Working" category rather than leaking an implementation name.
+_SAFE_STATUS_CATEGORIES: dict[str, str] = {
+    "web_search": "Searching references",
+    "web_extract": "Searching references",
+    "search_files": "Inspecting project",
+    "session_search": "Searching references",
+    "skill_view": "Searching references",
+    "skills_list": "Searching references",
+    "browser_navigate": "Inspecting project",
+    "browser_click": "Inspecting project",
+    "read_file": "Inspecting project",
+    "vision_analyze": "Inspecting project",
+    "write_file": "Editing",
+    "patch": "Editing",
+    "browser_type": "Editing",
+    "terminal": "Running checks",
+    "execute_code": "Running checks",
+    "image_generate": "Building",
+    "video_generate": "Building",
+    "text_to_speech": "Building",
+    "delegate_task": "Waiting on delegated work",
+}
+
 # Verbs that read better without the raw argument preview appended.
 _TOOL_VERBS_NO_PREVIEW: frozenset[str] = frozenset({
     "skills_list",
@@ -713,7 +738,13 @@ def verb_drops_preview(tool_name: str) -> bool:
     return tool_name in _TOOL_VERBS_NO_PREVIEW
 
 
-def build_status_phrase(tool_name: str, args: dict | None, max_len: int = 49) -> str | None:
+def build_status_phrase(
+    tool_name: str,
+    args: dict | None,
+    max_len: int = 49,
+    *,
+    safe: bool = False,
+) -> str | None:
     """Build a short present-tense status phrase for platform status surfaces.
 
     Used by text-rendering "typing" indicators (Slack's
@@ -735,6 +766,13 @@ def build_status_phrase(tool_name: str, args: dict | None, max_len: int = 49) ->
         return None
     if not _friendly_tool_labels:
         return None
+
+    if safe:
+        category = _SAFE_STATUS_CATEGORIES.get(tool_name, "Working")
+        phrase = f"is {category[0].lower()}{category[1:]}"
+        if len(phrase) > max_len - 1:
+            return phrase[: max_len - 2].rstrip() + "…"
+        return phrase + "…"
 
     verb = _TOOL_VERBS.get(tool_name)
     if verb:

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -63,6 +63,8 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     #   "full" / true  -> verb + argument preview ("is running pytest…")
     #   "verb"         -> verb only ("is running…") — keeps file paths and
     #                     commands out of shared channels
+    #   "safe"         -> fixed argument-free activity categories; unknown
+    #                     plugin/MCP names become "is working…"
     #   "off" / false  -> static text (typing_status_text or "is thinking...")
     # Independent of tool_progress: works even when progress bubbles are off
     # (Slack's default), and costs no extra API calls — the existing typing
@@ -286,7 +288,8 @@ def _normalise(setting: str, value: Any) -> Any:
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
     if setting == "live_status":
-        # Tri-state: "full" (verb + preview), "verb" (verb only), "off".
+        # "full" (verb + preview), "verb" (verb only), "safe" (closed,
+        # argument-free categories), or "off".
         if value is True:
             return "full"
         if value is False:
@@ -296,7 +299,7 @@ def _normalise(setting: str, value: Any) -> Any:
             return "full"
         if val in {"false", "0", "no"}:
             return "off"
-        return val if val in {"full", "verb", "off"} else "full"
+        return val if val in {"full", "verb", "safe", "off"} else "full"
     if setting == "tool_progress_grouping":
         val = str(value).lower()
         return val if val in ("accumulate", "separate") else "accumulate"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4324,6 +4324,7 @@ class TurnRunner:
                     _phrase = build_status_phrase(
                         tool_name,
                         args if ctx._live_status_mode == "full" else None,
+                        safe=ctx._live_status_mode == "safe",
                     )
                     ctx._live_status_adapter.set_status_text(ctx.source.chat_id, _phrase)
                 elif event_type == "tool.completed":

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3604,22 +3604,31 @@ class SlackAdapter(BasePlatformAdapter):
                 getattr(self, "_status_text", {}).get(str(chat_id))
                 or getattr(self.config, "typing_status_text", None)
             )
+            _elapsed = (
+                int(time.monotonic() - _status_started)
+                if _status_started is not None
+                else 0
+            )
             if not _status:
                 # Heartbeat (#45702): once a turn has run for 30s+, replace
-                # the static default with visible elapsed progress. Only the
-                # fallback label changes — explicit live-status phrases and
-                # configured typing_status_text always win.
-                _elapsed = (
-                    int(time.monotonic() - _status_started)
-                    if _status_started is not None
-                    else 0
-                )
+                # the static default with visible elapsed progress.
                 if _elapsed >= 30:
                     _mins, _secs = divmod(_elapsed, 60)
                     _human = f"{_mins}m{_secs:02d}s" if _mins else f"{_secs}s"
                     _status = f"still working… ({_human})"
                 else:
                     _status = "is thinking..."
+            elif _elapsed >= 30:
+                # Preserve the sanitized live stage while making elapsed work
+                # visible. Keep the complete status within Slack's 50-character
+                # status surface so the elapsed suffix cannot be truncated.
+                _mins, _secs = divmod(_elapsed, 60)
+                _human = f"{_mins}m{_secs:02d}s" if _mins else f"{_secs}s"
+                _suffix = f" ({_human})"
+                _base_limit = 50 - len(_suffix)
+                if len(_status) > _base_limit:
+                    _status = _status[: max(1, _base_limit - 1)].rstrip(" …") + "…"
+                _status = f"{_status}{_suffix}"
             await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -296,6 +296,15 @@ class TestBuildStatusPhrase:
         assert build_status_phrase("terminal", None) == "is running…"
         assert build_status_phrase("read_file", None) == "is reading…"
 
+    def test_safe_mode_uses_bounded_categories_without_args_or_tool_names(self):
+        from agent.display import build_status_phrase
+
+        secret = "/private/path --token=secret-value"
+        assert build_status_phrase("read_file", {"path": secret}, safe=True) == "is inspecting project…"
+        assert build_status_phrase("terminal", {"command": secret}, safe=True) == "is running checks…"
+        assert build_status_phrase("delegate_task", {"goal": secret}, safe=True) == "is waiting on delegated work…"
+        assert build_status_phrase("custom_private_mcp", {"token": secret}, safe=True) == "is working…"
+
 
 
     def test_caps_length_for_slack_status_line(self):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -301,4 +301,10 @@ class TestLiveStatusSetting:
 
         assert resolve_display_setting({}, "slack", "live_status") == "full"
 
+    def test_safe_mode_is_preserved_for_platform_override(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"slack": {"live_status": "safe"}}}}
+        assert resolve_display_setting(config, "slack", "live_status") == "safe"
+
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2339,6 +2339,42 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_live_status_keeps_sanitized_stage_and_adds_elapsed_time(self, adapter, monkeypatch):
+        import time as _time
+
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        clock = [3000.0]
+        monkeypatch.setattr(_time, "monotonic", lambda: clock[0])
+
+        adapter.set_status_text("C123", "is running checks…")
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        clock[0] += 95
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        assert (
+            adapter._app.client.assistant_threads_setStatus.call_args.kwargs["status"]
+            == "is running checks… (1m35s)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_elapsed_suffix_stays_visible_with_maximum_length_stage(self, adapter, monkeypatch):
+        import time as _time
+
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        clock = [4000.0]
+        monkeypatch.setattr(_time, "monotonic", lambda: clock[0])
+
+        adapter.set_status_text("C123", "is running " + "x" * 36 + "…")
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        clock[0] += 95
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        status = adapter._app.client.assistant_threads_setStatus.call_args.kwargs["status"]
+        assert len(status) <= 50
+        assert status.endswith(" (1m35s)")
+        assert status.startswith("is running ")
+
+    @pytest.mark.asyncio
     async def test_heartbeat_resets_after_stop_typing(self, adapter, monkeypatch):
         """stop_typing ends the turn — the next turn starts a fresh clock."""
         import time as _time

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -515,7 +515,8 @@ display:
   platforms:
     slack:
       # full = verb + argument ("is running pytest…")   [default]
-      # verb = verb only ("is running…") — hides commands/paths,
+      # verb = verb only ("is running…") — hides commands/paths
+      # safe = fixed activity categories; hides arguments and unknown tool names,
       #        useful in shared or customer-facing channels
       # off  = static text (typing_status_text or "is thinking...")
       live_status: full
@@ -523,7 +524,7 @@ display:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `display.live_status` | `"full"` | Live per-tool status line. `full` shows verb + argument preview; `verb` shows the verb only (keeps file paths and commands out of shared channels); `off` restores the static text. Requires the `assistant:write` scope, same as the static status line. |
+| `display.live_status` | `"full"` | Live per-tool status line. `full` shows verb + argument preview; `verb` shows the verb only; `safe` uses a closed set of argument-free activity categories and hides unknown plugin/MCP names; `off` restores the static text. Elapsed time is appended after 30 seconds. Requires the `assistant:write` scope, same as the static status line. |
 
 ### Native Streaming (live-typing replies)
 


### PR DESCRIPTION
## Summary
- add `display.platforms.slack.live_status: safe` with a closed, argument-free status category allowlist
- append elapsed time after 30 seconds while preserving sanitized stage context
- keep the full Slack status, including elapsed suffix, within 50 characters
- document the safe mode and retain the existing default behavior

## Verification
- 275 affected tests passed across display, display config, and Slack adapter suites
- Python compilation passed
- `git diff --cached --check` passed before commit
- one independent pre-commit review completed; its status-length blocker was fixed with a regression test

No tool arguments, command text, private paths, prompts, credentials, or arbitrary plugin/MCP names are exposed in safe mode.