### PR TITLE
feat(photon): native iMessage edit tool

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2578,6 +2578,45 @@ class PhotonAdapter(BasePlatformAdapter):
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Edit a previously sent iMessage via the sidecar /edit route.
+
+        Apple allows edits within a 15-minute window (max 5 edits per
+        message). ``finalize`` is a no-op for iMessage (an edit is an edit).
+        """
+        if not chat_id.strip() or not message_id.strip() or not content.strip():
+            return SendResult(
+                success=False, error="chat_id, message_id, and content are required"
+            )
+        return await self._sidecar_edit_message(chat_id, message_id, content)
+
+    async def _sidecar_edit_message(
+        self, space_id: str, message_id: str, content: str
+    ) -> SendResult:
+        """POST to the sidecar's ``/edit`` endpoint.
+
+        Calls spectrum-ts ``space.send(spectrumEdit(...))`` on the target
+        message. iMessage only permits editing a message we sent within
+        the 15-minute window; other cases return a 4xx from the sidecar.
+        """
+        body: Dict[str, Any] = {
+            "spaceId": space_id,
+            "messageId": message_id,
+            "text": content,
+        }
+        try:
+            data = await self._sidecar_call("/edit", body)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True, message_id=data.get("messageId") or message_id)
+
     async def _sidecar_send_attachment(
         self,
         space_id: str,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -306,6 +306,7 @@ let Spectrum,
   spectrumRichlink,
   spectrumTyping,
   spectrumPoll,
+  spectrumEdit,
   imessageEffect;
 try {
   ({
@@ -317,6 +318,7 @@ try {
     markdown: spectrumMarkdown,
     richlink: spectrumRichlink,
     typing: spectrumTyping,
+    edit: spectrumEdit,
   } = await import("spectrum-ts"));
   ({ imessage, effect: imessageEffect } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
@@ -1136,6 +1138,38 @@ const server = http.createServer(async (req, res) => {
         return badRequest(res, "reaction not removable");
       }
       return badRequest(res, "no tracked reaction for message");
+    }
+    if (req.url === "/edit") {
+      // Edit a previously sent iMessage via spectrum-ts `edit(content, target)`.
+      // Apple allows edits within a 15-minute window (max 5 edits per message);
+      // `target` must be an outbound message record ({id, direction: "outbound"})
+      // so we try the live cache first, then rehydrate via space.getMessage(), and
+      // fall back to a minimal record for ids the sidecar never cached.
+      const { spaceId, messageId, text } = body || {};
+      if (!spaceId || !messageId || typeof text !== "string" || !text) {
+        return badRequest(res, "spaceId, messageId, and text are required");
+      }
+      const space = await resolveSpace(spaceId);
+      let target = null;
+      try {
+        target = knownMessages.get(messageId) ?? (await space.getMessage(messageId));
+      } catch (e) {
+        target = null;
+      }
+      if (!target) {
+        // Fall back to a minimal outbound message record so edits still work
+        // for ids the sidecar never cached (e.g. pre-cache sends).
+        target = { id: messageId, direction: "outbound" };
+      }
+      try {
+        await space.send(spectrumEdit(spectrumText(text), target));
+        return ok(res, { messageId });
+      } catch (e) {
+        console.error(
+          "photon-sidecar: edit failed: " + (e && e.stack ? e.stack : String(e))
+        );
+        return badRequest(res, "edit failed: " + (e && e.message ? e.message : String(e)));
+      }
     }
     if (req.url === "/send-poll") {
       const { spaceId, title, options } = body || {};

--- a/tests/tools/test_photon_edit_tool.py
+++ b/tests/tools/test_photon_edit_tool.py
@@ -1,0 +1,115 @@
+"""Tests for the Photon edit tool (``photon_edit``).
+
+The tool must only be *offered* when a live Photon adapter exists in-process
+(the check_fn); handler routes to ``adapter.edit_message``, defaults the chat
+to the Photon home channel when none given, and returns a JSON string (the
+registry's normal result shape).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import tools.photon_edit_tool as pet
+from gateway.platforms.base import SendResult
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.edited: list[tuple] = []
+
+    async def edit_message(self, chat_id, message_id, content, *, finalize=False):
+        self.edited.append((chat_id, message_id, content))
+        return SendResult(success=True, message_id=message_id)
+
+
+@pytest.fixture(autouse=True)
+def _home_channel(monkeypatch):
+    """Photon home channel resolves without touching real config files."""
+
+    class _Home:
+        chat_id = "any;-;+162****1234"
+
+    class _Config:
+        @staticmethod
+        def get_home_channel(_platform):
+            return _Home()
+
+    import gateway.config as gw_config
+
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: _Config)
+
+
+def test_check_fn_requires_live_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: None)
+    assert pet._photon_edit_check() is False
+
+
+def test_check_fn_passes_with_adapter(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert pet._photon_edit_check() is True
+
+
+def test_handler_without_live_adapter_errors(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: None)
+    result = json.loads(
+        asyncio.run(pet._photon_edit({"message_id": "m1", "text": "hi"}))
+    )
+    assert "live Photon adapter" in result["error"]
+
+
+def test_requires_message_id_and_text(monkeypatch) -> None:
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert json.loads(
+        asyncio.run(pet._photon_edit({"text": "hi"}))
+    )["error"] == "Both 'message_id' and 'text' are required."
+    assert json.loads(
+        asyncio.run(pet._photon_edit({"message_id": "m1"}))
+    )["error"] == "Both 'message_id' and 'text' are required."
+
+
+def test_edit_with_explicit_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(
+            pet._photon_edit(
+                {"message_id": "m1", "text": "corrected", "chat_id": "my-chat"}
+            )
+        )
+    )
+    assert result["success"] is True
+    assert fake.edited == [("my-chat", "m1", "corrected")]
+
+
+def test_edit_defaults_to_home_channel(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(pet._photon_edit({"message_id": "m1", "text": "hi"}))
+    )
+    assert result["success"] is True
+    assert fake.edited[0][0] == "any;-;+162****1234"
+
+
+def test_edit_prefers_current_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-current")
+    asyncio.run(pet._photon_edit({"message_id": "m1", "text": "hi"}))
+    assert fake.edited[0][0] == "chat-current"
+
+
+def test_adapter_failure_propagates_error(monkeypatch) -> None:
+    class _BoomAdapter(_FakeAdapter):
+        async def edit_message(self, chat_id, message_id, content, *, finalize=False):
+            return SendResult(success=False, error="edit failed: window closed")
+
+    fake = _BoomAdapter()
+    monkeypatch.setattr(pet, "_live_photon_adapter", lambda: fake)
+    result = json.loads(
+        asyncio.run(pet._photon_edit({"message_id": "m1", "text": "hi"}))
+    )
+    assert result["error"] == "edit failed: window closed"

--- a/tools/photon_edit_tool.py
+++ b/tools/photon_edit_tool.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Edit one of OUR OWN iMessage bubbles over Photon.
+
+iMessage supports editing a message you sent within a 15-minute window
+(max 5 edits): the bubble's text is replaced in place, with a subtle
+"Edited" label. This tool wraps the sidecar's ``/edit`` route (which
+calls spectrum-ts ``space.send(spectrumEdit(...))``). It is an opt-in
+tool in the ``photon_tools`` toolset, exposed only when a live Photon
+adapter is running in this process (check_fn), so it costs zero tokens
+on every other install.
+
+Only messages sent by the bot can be edited, and only within Apple's
+15-minute / 5-edit window; iMessage rejects other cases. Handlers
+return JSON strings (the registry's normal result shape).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "photon_tools"
+
+SCHEMA: Dict[str, Any] = {
+    "name": "photon_edit",
+    "description": (
+        "Edit one of YOUR OWN recent iMessage messages on the Photon "
+        "platform — replace the text of a bubble you sent with corrected "
+        "text, in place (Apple shows a subtle 'Edited' label). Only works "
+        "on messages YOU sent within the last 15 minutes (max 5 edits per "
+        "message). Never edit the user's messages. Pass both message_id "
+        "and the new text."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_id": {
+                "type": "string",
+                "description": "The id of the message to edit.",
+            },
+            "text": {
+                "type": "string",
+                "description": "The new text the bubble should read.",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional chat (space GUID like 'any;-;+1555…' or bare "
+                    "E.164). Defaults to the conversation currently being "
+                    "answered."
+                ),
+            },
+        },
+        "required": ["message_id", "text"],
+    },
+}
+
+
+def _live_photon_adapter():
+    """Return the running Photon adapter, or None.
+
+    Mirrors ``photon_poll_tool`` / ``photon_react_tool``.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return runner.adapters.get(Platform.PHOTON)
+    except Exception:
+        return None
+
+
+async def _resolve_chat_id(explicit: str) -> str:
+    chat_id = (explicit or "").strip()
+    if chat_id:
+        return chat_id
+    try:
+        from gateway.session_context import get_session_env
+
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    except Exception:
+        chat_id = ""
+    if chat_id:
+        return chat_id
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+    home = config.get_home_channel("photon")
+    return home.chat_id
+
+
+def _photon_edit_check() -> bool:
+    """Availability check: tool only exists when live Photon adapter in-process."""
+    return _live_photon_adapter() is not None
+
+
+async def _photon_edit(args: Dict[str, Any], **kw) -> str:
+    message_id = str(args.get("message_id") or "").strip()
+    text = str(args.get("text") or "").strip()
+    chat_id = str(args.get("chat_id") or "").strip()
+
+    def err(msg: str) -> str:
+        return tool_error(msg)
+
+    if not message_id or not text:
+        return err("Both 'message_id' and 'text' are required.")
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return err(
+            "No live Photon adapter in this process — edit requires the "
+            "gateway to be running here."
+        )
+
+    try:
+        chat_id = await _resolve_chat_id(chat_id)
+    except Exception as e:
+        return err(f"No chat context available: {e}")
+
+    result = await adapter.edit_message(chat_id, message_id, text)
+    if getattr(result, "success", True) and not getattr(result, "error", None):
+        return json.dumps(
+            {"success": True, "edited": message_id},
+            ensure_ascii=False,
+        )
+    return err(
+        getattr(result, "error", None)
+        or f"Edit failed (HTTP {getattr(result, 'raw_response', '?')})."
+    )
+
+
+registry.register(
+    name="photon_edit",
+    toolset=_TOOLSET,
+    schema=SCHEMA,
+    handler=lambda args, **kw: _photon_edit(args, **kw),
+    check_fn=_photon_edit_check,
+    is_async=True,
+    emoji="✏️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -289,6 +289,18 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    # Native iMessage interactions over Photon — each tool is only offered
+    # when a live Photon adapter is running in this process (the tools'
+    # check_fn enforces it at schema-assembly time; listing them here just
+    # names the bucket). photon_edit replaces the text of one of OUR OWN
+    # bubbles in place (Apple shows a subtle "Edited" label; 15-min window,
+    # max 5 edits per message). See tools/photon_edit_tool.py.
+    "photon_tools": {
+        "description": "Native iMessage edits over Photon (live gateway only)",
+        "tools": ["photon_edit"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",


### PR DESCRIPTION
## What does this PR do?

Adds a `photon_edit` core tool so the agent can edit one of ITS OWN
iMessage bubbles in place (Apple shows a subtle "Edited" label; 15-min
window, max 5 edits per message).

What goes in:

- **Sidecar**: new `/edit` HTTP endpoint in the same `req.url === ...`
  chain as `/send`, `/react`, `/send-poll`, `/send-effect`. Validates
  spaceId + messageId + text, resolves the space, rehydrates the target
  from the live `knownMessages` cache or via `space.getMessage()`, falls
  back to a minimal outbound record (`{id, direction:"outbound"}`) for
  ids the sidecar never cached, calls
  `space.send(spectrumEdit(spectrumText(text), target))`, surfaces
  iMessage rejections as 4xx.

- **Adapter**: new `PhotonAdapter.edit_message(chat_id, message_id,
  content, finalize=...)` + private `_sidecar_edit_message` that POSTs
  to the route, returning a `SendResult`. `finalize` is a no-op for
  iMessage (an edit is an edit), kept for signature symmetry with other
  platforms' draft finalization.

- **Tool**: `photon_edit` in the `photon_tools` toolset follows the
  `photon_poll` / `photon_effect` / `photon_react` pattern — opt-in via
  a live-adapter check_fn, chat defaults to the current conversation
  then the Photon home channel, handler returns a JSON string (registry
  result shape). Requires message_id + text explicitly (no "last sent"
  default: editing the wrong bubble is worse than failing to edit).

- **8 tests**: check_fn gating, "no adapter" error, message_id + text
  required, explicit chat, home-channel default, current-chat
  preference, provider failure propagation.

E2E proven on iMessage before this PR: `verify_edit_e2e.sh` sent a probe
bubble via `/send`, edited it via `/edit`, and the phone showed the
replacement with the native "Edited" label — same chain, now as a core
tool.