### PR TITLE
Slack link unfurls can no longer duplicate an in-flight turn (salvage #95417)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5947,6 +5947,35 @@ class SlackAdapter(BasePlatformAdapter):
     async def _handle_slack_message(
         self, event: dict, payload: Optional[dict] = None
     ) -> None:
+        """Handle an incoming Slack message event.
+
+        Thin guard around :meth:`_handle_slack_message_impl`: the impl claims
+        the message ts on entry (before the slow enrichment awaits) so a link
+        unfurl arriving mid-flight can't become a second turn — but a claim
+        held by an invocation that then RAISES would permanently swallow the
+        message: neither a Slack retry nor a user edit could ever re-drive it.
+        So if this invocation newly claimed the ts and then failed, release
+        the claim before re-raising. A ts that was already claimed before we
+        started (the sequential-suppression case) is left untouched.
+        """
+        _ts = str((event or {}).get("ts") or "")
+        _was_claimed = bool(_ts) and _ts in self._processed_message_ts
+        try:
+            return await self._handle_slack_message_impl(event, payload)
+        except BaseException:
+            if _ts and not _was_claimed and _ts in self._processed_message_ts:
+                self._processed_message_ts.pop(_ts, None)
+                logger.warning(
+                    "[%s] handler failed after claiming ts=%s; claim released "
+                    "so a retry or edit can re-drive the turn",
+                    self.name,
+                    _ts,
+                )
+            raise
+
+    async def _handle_slack_message_impl(
+        self, event: dict, payload: Optional[dict] = None
+    ) -> None:
         """Handle an incoming Slack message event."""
         # DEBUG entry log — fires BEFORE any filtering so users debugging
         # bot-to-bot interop, allow_bots config, or SLACK_ALLOWED_USERS

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5045,6 +5045,27 @@ class SlackAdapter(BasePlatformAdapter):
             "user_id": user_id,
         }
 
+    def _remember_processed_message_ts(self, ts: str) -> None:
+        """Mark a Slack message ts as claimed by this handler.
+
+        Used by the ``message_changed`` guard to tell "we already took this
+        message" from "this is new". Called on ENTRY (so an unfurl arriving
+        mid-flight is suppressed) and again after successful construction
+        (refreshing recency so the LRU keeps genuinely active messages).
+
+        Bounded by ``_PROCESSED_MESSAGE_TS_MAX``: oldest entries are evicted
+        first so a busy workspace cannot grow this map without limit.
+        """
+        if not ts:
+            return
+        self._processed_message_ts[ts] = time.time()
+        if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
+            newest_items = sorted(
+                self._processed_message_ts.items(),
+                key=lambda item: item[1],
+            )[-self._PROCESSED_MESSAGE_TS_MAX :]
+            self._processed_message_ts = dict(newest_items)
+
     @staticmethod
     def _event_team_id(event: dict, body: Optional[dict] = None) -> str:
         """Resolve a workspace ID from an event plus Bolt's outer payload.
@@ -6416,6 +6437,38 @@ class SlackAdapter(BasePlatformAdapter):
                 ):
                     return
 
+        # Claim the underlying message ts now that this event is known to be a
+        # real, deliverable turn — not at the end of the coroutine.
+        #
+        # A link unfurl (or any edit) makes Slack emit `message_changed` for
+        # the SAME message, carrying a DIFFERENT event ts. That different ts
+        # misses the `_dedup` check above by design, so the only thing that
+        # stops it becoming a second user turn is the `_processed_message_ts`
+        # guard at the top of the `message_changed` branch.
+        #
+        # That guard used to be satisfied only after the first copy had walked
+        # the entire handler — thread context, permalink resolution, file
+        # downloads: several awaits and hundreds of ms of Slack API latency. An
+        # unfurl arriving inside that window found the guard still empty and
+        # was promoted to a duplicate turn, producing a spurious "Interrupting
+        # current task" plus the same answer twice.
+        #
+        # Observed 2026-08-22 02:23:30-31Z: original ts 1787365409.908499 was
+        # still resolving two permalinks when the unfurl's `message_changed`
+        # (event ts 1787365411.012100) arrived 957ms later.
+        #
+        # Placement matters in BOTH directions. Claiming right after the dedup
+        # check also claims messages the handler then discards (ignored
+        # channel, bot sender, unauthorized user, no mention). That breaks
+        # editing "@bot" INTO a previously ignored message to summon the bot
+        # (test_message_edit_with_new_mention_processed): the ignored original
+        # would claim the ts and the summoning edit would be dropped. So the
+        # claim belongs here — after every filter has passed, before the slow
+        # enrichment awaits that open the race.
+        _claim_ts = str(event.get("ts") or "")
+        if _claim_ts:
+            self._remember_processed_message_ts(_claim_ts)
+
         if is_mentioned:
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
@@ -7010,13 +7063,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         if ts:
-            self._processed_message_ts[ts] = time.time()
-            if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
-                newest_items = sorted(
-                    self._processed_message_ts.items(),
-                    key=lambda item: item[1],
-                )[-self._PROCESSED_MESSAGE_TS_MAX :]
-                self._processed_message_ts = dict(newest_items)
+            self._remember_processed_message_ts(ts)
 
         await self.handle_message(msg_event)
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5959,12 +5959,20 @@ class SlackAdapter(BasePlatformAdapter):
         started (the sequential-suppression case) is left untouched.
         """
         _ts = str((event or {}).get("ts") or "")
-        _was_claimed = bool(_ts) and _ts in self._processed_message_ts
+        # getattr: bare test doubles (object.__new__) may lack the map.
+        _claims = getattr(self, "_processed_message_ts", None)
+        _was_claimed = bool(_ts) and _claims is not None and _ts in _claims
         try:
             return await self._handle_slack_message_impl(event, payload)
         except BaseException:
-            if _ts and not _was_claimed and _ts in self._processed_message_ts:
-                self._processed_message_ts.pop(_ts, None)
+            _claims = getattr(self, "_processed_message_ts", None)
+            if (
+                _ts
+                and not _was_claimed
+                and _claims is not None
+                and _ts in _claims
+            ):
+                _claims.pop(_ts, None)
                 logger.warning(
                     "[%s] handler failed after claiming ts=%s; claim released "
                     "so a retry or edit can re-drive the turn",

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -263,7 +263,9 @@ def test_reaction_guard_pinned_to_production_expression():
     (back to ``is_dm or is_mentioned``, which reacts to unmentioned MPIMs)
     fails here instead of silently passing a self-referential lambda.
     """
-    src = inspect.getsource(SlackAdapter._handle_slack_message)
+    # The public method is a thin claim-release guard; the production
+    # expression lives in the impl.
+    src = inspect.getsource(SlackAdapter._handle_slack_message_impl)
     assert "(is_one_to_one_dm or is_mentioned)" in src, (
         "reaction guard no longer keys off is_one_to_one_dm — an unmentioned "
         "MPIM would react again (regression of the group-DM fix)"

--- a/tests/gateway/test_slack_unfurl_duplicate_turn.py
+++ b/tests/gateway/test_slack_unfurl_duplicate_turn.py
@@ -239,3 +239,67 @@ class TestClaimHelperBounded:
         adapter = _make_adapter(delivered)
         adapter._remember_processed_message_ts("")
         assert adapter._processed_message_ts == {}
+
+
+class TestClaimReleasedOnFailure:
+    """A claim made by an invocation that raises must not swallow the turn.
+
+    Trade-off pinned here: the entry-claim closes the unfurl race, but if the
+    handler dies mid-enrichment while holding a fresh claim, a Slack retry or
+    a user edit must still be able to re-drive the message. The wrapper in
+    ``_handle_slack_message`` releases only claims taken by the failed
+    invocation itself.
+    """
+
+    def test_failed_first_copy_releases_claim_so_edit_can_redrive(self):
+        delivered = []
+        adapter = _make_adapter(delivered)
+        calls = {"n": 0}
+
+        async def _flaky_user_name_resolve(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("slack api died mid-enrichment")
+            return "richard"
+
+        adapter._resolve_user_name = _flaky_user_name_resolve
+
+        edit = _unfurl_event()
+        edit["message"]["text"] = "<@U0BCLP7DB7B> edited text"
+        edit["message"]["edited"] = {"user": USER, "ts": "1787365412.000000"}
+
+        async def scenario():
+            with pytest.raises(RuntimeError):
+                await adapter._handle_slack_message(_original_event(), _body())
+            # The failed invocation must not leave the ts claimed...
+            assert ORIGINAL_TS not in adapter._processed_message_ts
+            # ...so a user edit of the unanswered message still summons the bot.
+            await adapter._handle_slack_message(edit, _body())
+
+        asyncio.run(scenario())
+        assert len(delivered) == 1
+
+    def test_failure_does_not_release_a_preexisting_claim(self):
+        """Sequential suppression survives a later failing duplicate."""
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._resolve_user_name = AsyncMock(return_value="richard")
+
+        async def scenario():
+            await adapter._handle_slack_message(_original_event(), _body())
+            assert ORIGINAL_TS in adapter._processed_message_ts
+            # A later invocation for the same ts that fails must not strip
+            # the claim the successful turn already holds.
+            adapter._resolve_user_name = AsyncMock(
+                side_effect=RuntimeError("boom")
+            )
+            second = _original_event()
+            second["client_msg_id"] = "cmid-replay"
+            try:
+                await adapter._handle_slack_message(second, _body())
+            except RuntimeError:
+                pass
+            assert ORIGINAL_TS in adapter._processed_message_ts
+
+        asyncio.run(scenario())
+        assert len(delivered) == 1

--- a/tests/gateway/test_slack_unfurl_duplicate_turn.py
+++ b/tests/gateway/test_slack_unfurl_duplicate_turn.py
@@ -1,0 +1,241 @@
+"""Regression: a link unfurl must not become a second user turn.
+
+Reproduction (Snow/adminbot, 2026-08-22 02:23:30-31Z, channel C0BF1EYUA9H):
+
+    02:23:30.718  listener=message      ts=...409.908499  dedup_hit=False
+    02:23:30.737  listener=app_mention  ts=...409.908499  dedup_hit=True
+    02:23:31.675  listener=message      ts=...411.012100  dedup_hit=False
+                  subtype=message_changed          <-- LEAKED
+
+The user posted ONE message containing two Slack permalinks. While the first
+copy was still resolving those permalinks (several awaits against the Slack
+API), Slack's link unfurl fired `message_changed` for the same message with a
+*different* event ts. That ts legitimately misses `_dedup`, so the
+`_processed_message_ts` guard is the only thing standing between it and a
+duplicate turn — but that guard was only populated at the very END of
+`_handle_slack_message`, i.e. after the in-flight work had finished.
+
+Result: spurious "Interrupting current task" plus the same answer twice.
+
+The fix claims the message ts immediately after the dedup check. These tests
+pin the behaviour at that seam.
+"""
+
+import asyncio
+import importlib
+import sys
+import time
+from importlib.machinery import PathFinder
+from types import ModuleType
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _load_installed_package(name):
+    if PathFinder.find_spec(name) is None:
+        return None
+    prefix = f"{name}."
+    displaced = {
+        m: sys.modules.pop(m)
+        for m in tuple(sys.modules)
+        if (m == name or m.startswith(prefix)) and not isinstance(sys.modules[m], ModuleType)
+    }
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        sys.modules.update(displaced)
+        return None
+
+
+_load_installed_package("slack_bolt")
+_load_installed_package("slack_sdk")
+
+_slack_mod = importlib.import_module("plugins.platforms.slack.adapter")
+SlackAdapter = _slack_mod.SlackAdapter
+
+CHANNEL = "C0BF1EYUA9H"
+TEAM = "T025KND0E"
+ORIGINAL_TS = "1787365409.908499"
+UNFURL_EVENT_TS = "1787365411.012100"
+USER = "U0374GH838U"
+
+
+def _make_adapter(delivered):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    adapter._bot_user_id = "U0BCLP7DB7B"
+
+    async def _capture(event):
+        delivered.append(event)
+
+    adapter.handle_message = _capture
+    return adapter
+
+
+def _original_event():
+    return {
+        "type": "message",
+        "user": USER,
+        "text": "<@U0BCLP7DB7B> see https://example.com/a and https://example.com/b",
+        "channel": CHANNEL,
+        "channel_type": "channel",
+        "ts": ORIGINAL_TS,
+        "team": TEAM,
+        "client_msg_id": "cmid-1",
+    }
+
+
+def _unfurl_event():
+    """Slack's link-unfurl edit: same message, different event ts."""
+    return {
+        "type": "message",
+        "subtype": "message_changed",
+        "channel": CHANNEL,
+        "channel_type": "channel",
+        "team": TEAM,
+        "ts": UNFURL_EVENT_TS,
+        "event_ts": UNFURL_EVENT_TS,
+        "message": {
+            "type": "message",
+            "user": USER,
+            "text": "<@U0BCLP7DB7B> see https://example.com/a and https://example.com/b",
+            "ts": ORIGINAL_TS,
+            "client_msg_id": "cmid-1",
+            "attachments": [{"title": "unfurled"}],
+        },
+    }
+
+
+def _body():
+    return {"team_id": TEAM, "event_id": "Ev0BRUTU4GP7"}
+
+
+class TestUnfurlDuringInflightMessage:
+    def test_unfurl_arriving_mid_flight_does_not_create_second_turn(self):
+        """THE regression: unfurl lands while the original is still awaiting."""
+        delivered = []
+        adapter = _make_adapter(delivered)
+
+        release = asyncio.Event()
+        entered = asyncio.Event()
+        calls = {"n": 0}
+
+        async def _slow_user_name_resolve(*a, **k):
+            # Stand in for the real in-flight work. In the production
+            # reproduction the first copy was resolving TWO Slack permalinks
+            # (~950ms) when the unfurl arrived. Any await AFTER the point
+            # where the handler has committed to delivering the event
+            # reproduces the same window; `_resolve_user_name` is such an
+            # await and, unlike permalink resolution, it is reached for this
+            # event shape on a plain channel message.
+            #
+            # Only the FIRST copy parks. Otherwise a leaked second copy would
+            # block here too and the test would deadlock instead of reporting
+            # the duplicate.
+            calls["n"] += 1
+            if calls["n"] == 1:
+                entered.set()
+                await release.wait()
+            return "richard"
+
+        adapter._resolve_user_name = _slow_user_name_resolve
+
+        async def scenario():
+            first = asyncio.create_task(
+                adapter._handle_slack_message(_original_event(), _body())
+            )
+            # The test is only meaningful if the first copy really is parked
+            # mid-handler when the unfurl lands.
+            await asyncio.wait_for(entered.wait(), timeout=2.0)
+
+            await asyncio.wait_for(
+                adapter._handle_slack_message(_unfurl_event(), _body()),
+                timeout=5.0,
+            )
+
+            release.set()
+            await asyncio.wait_for(first, timeout=5.0)
+
+        asyncio.run(scenario())
+
+        assert len(delivered) == 1, (
+            f"unfurl became a duplicate user turn ({len(delivered)} deliveries); "
+            "this is the spurious-interrupt bug"
+        )
+
+    def test_unfurl_after_completion_still_suppressed(self):
+        """Sequential case must keep working (the pre-existing guarantee)."""
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._resolve_user_name = AsyncMock(return_value="richard")
+
+        async def scenario():
+            await adapter._handle_slack_message(_original_event(), _body())
+            await adapter._handle_slack_message(_unfurl_event(), _body())
+
+        asyncio.run(scenario())
+        assert len(delivered) == 1
+
+
+class TestClaimDoesNotSwallowRealMessages:
+    def test_a_different_message_is_unaffected(self):
+        """Claiming one ts must not suppress an unrelated message."""
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._resolve_user_name = AsyncMock(return_value="richard")
+
+        other = _original_event()
+        other["ts"] = "1787365500.000100"
+        other["client_msg_id"] = "cmid-2"
+
+        async def scenario():
+            await adapter._handle_slack_message(_original_event(), _body())
+            await adapter._handle_slack_message(other, _body())
+
+        asyncio.run(scenario())
+        assert len(delivered) == 2
+
+    def test_a_genuine_user_edit_is_still_suppressed(self):
+        """A real edit of an already-answered message must not re-trigger.
+
+        Same contract as before the fix — re-answering an edited message the
+        bot already replied to was never wanted.
+        """
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._resolve_user_name = AsyncMock(return_value="richard")
+
+        edit = _unfurl_event()
+        edit["message"]["text"] = "<@U0BCLP7DB7B> edited text"
+        edit["message"]["edited"] = {"user": USER, "ts": "1787365412.000000"}
+
+        async def scenario():
+            await adapter._handle_slack_message(_original_event(), _body())
+            await adapter._handle_slack_message(edit, _body())
+
+        asyncio.run(scenario())
+        assert len(delivered) == 1
+
+
+class TestClaimHelperBounded:
+    def test_claim_map_is_evicted_oldest_first(self):
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._PROCESSED_MESSAGE_TS_MAX = 10
+
+        for i in range(25):
+            adapter._remember_processed_message_ts(f"{i}.0")
+            time.sleep(0.001)
+
+        assert len(adapter._processed_message_ts) <= 10
+        # newest survive, oldest evicted
+        assert "24.0" in adapter._processed_message_ts
+        assert "0.0" not in adapter._processed_message_ts
+
+    def test_empty_ts_is_ignored(self):
+        delivered = []
+        adapter = _make_adapter(delivered)
+        adapter._remember_processed_message_ts("")
+        assert adapter._processed_message_ts == {}


### PR DESCRIPTION
## Summary
A Slack link unfurl arriving while the original message is still being ingested no longer becomes a second agent turn (spurious "Interrupting current task" + the same answer twice). The message ts is now claimed after every filter has passed but before the slow enrichment awaits — the window a production capture showed the unfurl's `message_changed` (different event ts, so it legitimately misses `_dedup`) slipping through 957ms into ingestion.

Salvage of #95417 by @RichardHojunJang, cherry-picked onto current main with authorship preserved, plus one follow-up commit addressing the review finding.

## Changes
- `plugins/platforms/slack/adapter.py` (contributor): claim moved to entry (post-filter, pre-enrichment); eviction extracted into shared bounded `_remember_processed_message_ts()`.
- `plugins/platforms/slack/adapter.py` (follow-up): `_handle_slack_message` is now a thin guard around the impl — a handler that raises mid-enrichment releases the claim it took (with a warning log), so a Slack retry or user edit can still re-drive the turn; pre-existing claims from successful turns are never released. Closes the "duplicate answers traded for silently lost turns" gap flagged in review.
- `tests/gateway/test_slack_unfurl_duplicate_turn.py`: the mid-flight race (parked on a real await), sequential suppression, edit-summon contract, LRU bounds + 2 new failure-path tests.

## Validation
| | Before (main adapter) | After |
|---|---|---|
| Unfurl race test | fails (duplicate turn delivered) | passes |
| Full Slack suites | — | 235 passed, 1 skipped |
| Failure path | unpinned | claim released on raise; pre-existing claim kept |

**Live repro:** sabotage A/B — race test against main's `adapter.py` delivers 2 turns; 1 with the fix. Production capture in the test docstring (Snow/adminbot, 2026-08-22).

## Infographic

![Unfurl race closed](https://v3b.fal.media/files/b/0aa7f0db/TnMCQ0MarLLhIJp-pVLR2_76kJWR94.png)
