### PR TITLE
fix(desktop): same-id sessions in two profiles stop collapsing and resuming the wrong backend (#92454)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -296,7 +296,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNavigate: (item: SidebarNavItem) => void
   onLoadMoreSessions: () => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, session?: SessionInfo) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession: (sessionId: string) => void

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -99,7 +99,7 @@ interface SidebarSessionsSectionProps {
   onToggle: () => void
   sessions: SessionInfo[]
   activeSessionId: null | string
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, session?: SessionInfo) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
@@ -259,17 +259,20 @@ export function SidebarSessionsSection({
         onDelete: () => onDeleteSession(session.id),
         onPin: () => onTogglePin(sessionPinId(session)),
         onToggleUnread: () => onToggleUnread(session.id),
-        onResume: () => onResumeSession(session.id),
+        onResume: () => onResumeSession(session.id, session),
         reorderable: draggable && !branchStem,
         session,
         showProfile: showProfileTags,
         unread: session.unread === true
       }
 
+      // Key by (profile, id): twins with the same stored id in two profiles
+      // are distinct rows (#92454) — a bare-id key makes React misattribute
+      // one twin's rendered state to the other.
       return draggable && !branchStem ? (
-        <SortableSidebarSessionRow key={session.id} {...rowProps} />
+        <SortableSidebarSessionRow key={`${session.profile ?? ''}::${session.id}`} {...rowProps} />
       ) : (
-        <SidebarSessionRow key={session.id} {...rowProps} />
+        <SidebarSessionRow key={`${session.profile ?? ''}::${session.id}`} {...rowProps} />
       )
     },
     [

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -44,7 +44,7 @@ export interface VirtualSessionListProps {
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, session?: SessionInfo) => void
   onTogglePin: (sessionId: string) => void
   onToggleUnread: (sessionId: string) => void
   pinned: boolean
@@ -149,18 +149,22 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),
       onToggleUnread: () => onToggleUnread(session.id),
-      onResume: () => onResumeSession(session.id),
+      onResume: () => onResumeSession(session.id, session),
       reorderable,
       showProfile: showProfileTags,
       unread: session.unread === true
     }
 
+    // Key by (profile, id): twins with the same stored id in two profiles are
+    // distinct rows (#92454) — a bare-id key misattributes rendered state.
+    const rowKey = `${session.profile ?? ''}::${session.id}`
+
     return reorderable ? (
-      <div data-index={virtualItem.index} key={session.id} ref={virtualizer.measureElement} style={itemStyle}>
+      <div data-index={virtualItem.index} key={rowKey} ref={virtualizer.measureElement} style={itemStyle}>
         <VirtualSortableRow rowProps={commonProps} session={session} />
       </div>
     ) : (
-      <div data-index={virtualItem.index} key={session.id} ref={virtualizer.measureElement} style={itemStyle}>
+      <div data-index={virtualItem.index} key={rowKey} ref={virtualizer.measureElement} style={itemStyle}>
         <SidebarSessionRow {...commonProps} session={session} />
       </div>
     )

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -71,6 +71,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  requestSessionResume,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -990,7 +991,26 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
     // otherwise load it into main. Same door every other session link uses.
-    onResumeSession: sessionId => openSession(sessionId, navigate),
+    // The clicked ROW is the identity, not its bare id: two profiles can hold
+    // twins with the same stored id (#92454), and an id-only resume resolves
+    // against whichever cached row is found first — the user clicks a row
+    // previewing profile A and the resume dials profile B. Pin the row's own
+    // (connection, profile) as the resume owner before navigating; untagged
+    // rows (single-profile installs, legacy pages) keep the id-only path.
+    onResumeSession: (sessionId, session) => {
+      const rowProfile = session?.profile?.trim()
+
+      if (rowProfile) {
+        requestSessionResume(sessionId, {
+          connectionId: session?.connection_id?.trim() || 'local',
+          ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
+          profile: rowProfile,
+          targetProfile: rowProfile
+        })
+      }
+
+      openSession(sessionId, navigate)
+    },
     onRetryResume: sessionId => void resumeSession(sessionId, true),
     onSteer: steerPrompt,
     onSubmit: submitText,

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -328,6 +328,40 @@ describe('mergeSessionPage', () => {
     expect(mergeSessionPage(previous, incoming, [])[0]).toBe(incoming[0])
   })
 
+  it('never stitches one profile twin onto another: same id in two profiles stays two sessions (#92454)', () => {
+    // Two profiles can hold sessions with the SAME stored id (restored
+    // backups, copied state.dbs). Keyed by bare id these collapsed into one
+    // row whose title/activity carry crossed profiles — the visible seed of
+    // the cross-profile transcript/route mixups.
+    const previous = [session({ id: 'twin', last_active: 50, profile: 'testbot', title: 'Testbot work' })]
+
+    const incoming = [
+      session({ id: 'twin', last_active: 10, profile: 'quietbot' }),
+      session({ id: 'twin', last_active: 50, profile: 'testbot', title: 'Testbot work' })
+    ]
+
+    const merged = mergeSessionPage(previous, incoming, [])
+
+    // Both twins survive as distinct rows…
+    expect(merged.map(s => `${s.profile}:${s.id}`).sort()).toEqual(['quietbot:twin', 'testbot:twin'])
+    // …and testbot's title/activity is NOT stitched onto quietbot's row.
+    const quiet = merged.find(s => s.profile === 'quietbot')
+    expect(quiet?.title ?? null).toBeNull()
+    expect(quiet?.last_active).toBe(10)
+  })
+
+  it('a kept twin in another profile survives the incoming page dedupe (#92454)', () => {
+    // The incoming page carries only ONE profile's copy; the other profile's
+    // twin was in the previous list and pinned via keep. Bare-id dedupe
+    // treated the ids as equal and dropped the kept twin.
+    const previous = [session({ id: 'twin', profile: 'quietbot' })]
+    const incoming = [session({ id: 'twin', message_count: 2, profile: 'testbot' })]
+
+    const merged = mergeSessionPage(previous, incoming, ['twin'])
+
+    expect(merged.map(s => `${s.profile}:${s.id}`).sort()).toEqual(['quietbot:twin', 'testbot:twin'])
+  })
+
   it('returns the server page untouched when there is nothing to keep', () => {
     const previous = [session({ id: 'a' }), session({ id: 'b' })]
     const incoming = [session({ id: 'a' })]

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -484,18 +484,34 @@ export function mergeSessionPage(
 ): SessionInfo[] {
   const keep = keepIds instanceof Set ? keepIds : new Set(keepIds)
 
+  // Rows are identified by (profile, id), never bare id: two profiles can
+  // hold sessions with the SAME stored id (restored backups, copied
+  // state.dbs, cross-profile imports — #92454). Keyed by bare id, the twins
+  // collapse into one sidebar row whose title/preview carry can stitch one
+  // profile's content onto the other profile's route — the user clicks a row
+  // previewing profile A and the resume dials profile B. Same-profile rows
+  // (including untagged ones, which normalize together) keep the exact
+  // carry behavior below.
+  // (Local normalize: importing @/store/profile here would be circular —
+  // same '' → 'default' rule as normalizeProfileKey.)
+  const profileKeyOf = (session: SessionInfo) => (session.profile ?? '').trim() || 'default'
+  const identity = (session: SessionInfo) => `${profileKeyOf(session)}::${session.id}`
+
+  const lineageIdentity = (session: SessionInfo) =>
+    `${profileKeyOf(session)}::${session._lineage_root_id ?? session.id}`
+
   // Carry a known title onto a row that arrives title-less, so a freshly
   // submitted session (e.g. a branch draft) holds its placeholder instead of
   // flashing its raw message preview in the gap between persist and the async
   // auto-titler. A real clear sets the local title null first, so this never
   // masks one.
-  const prevById = new Map(previous.map(session => [session.id, session]))
+  const prevById = new Map(previous.map(session => [identity(session), session]))
   // Tip rotation changes the live id — carry activity/title across the lineage
   // root so a mid-turn refresh can't drop a touchSessionActivity bump.
-  const prevByLineage = new Map(previous.map(session => [session._lineage_root_id ?? session.id, session]))
+  const prevByLineage = new Map(previous.map(session => [lineageIdentity(session), session]))
 
   const merged = incoming.map(session => {
-    const prev = prevById.get(session.id) ?? prevByLineage.get(session._lineage_root_id ?? session.id)
+    const prev = prevById.get(identity(session)) ?? prevByLineage.get(lineageIdentity(session))
     // User-send stamps last_active before the DB flushes the user row
     // (last_active = MAX(messages.timestamp)). Keep the fresher of the two.
     const last_active = Math.max(prev?.last_active ?? 0, session.last_active ?? 0)
@@ -519,18 +535,20 @@ export function mergeSessionPage(
     return merged
   }
 
-  const incomingIds = new Set(merged.map(session => session.id))
+  const incomingIds = new Set(merged.map(identity))
 
   // Deduplicate by compression lineage: when auto-compression rotates the tip
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
-  // rows survive as separate sidebar entries (fixes #43483).
-  const incomingLineageKeys = new Set(merged.map(session => session._lineage_root_id ?? session.id))
+  // rows survive as separate sidebar entries (fixes #43483). Lineage keys are
+  // profile-qualified for the same reason as identity above — a twin id in
+  // another profile is a DIFFERENT session and must survive the dedupe.
+  const incomingLineageKeys = new Set(merged.map(lineageIdentity))
 
   const survivors = previous.filter(
     session =>
-      !incomingIds.has(session.id) &&
-      !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
+      !incomingIds.has(identity(session)) &&
+      !incomingLineageKeys.has(lineageIdentity(session)) &&
       (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
   )
 


### PR DESCRIPTION
## Summary
Session rows are now identified by (profile, id) instead of bare stored id, so twins — the same session id existing in two profiles' state.dbs (restored backups, copied DBs, cross-profile imports) — stop collapsing into one sidebar row and stop mis-routing clicks (#92454).

Live repro on current main (the decisive middle panel): planted `collision_twin` in both testbot and quietbot with distinguishable markers. The store's bare-id merge collapsed the twins; React keyed rows by bare id too, so the surviving row stitched one profile's preview onto the other's identity — and clicking the row previewing QUIETBOT's content dialed **testbot** ("Waking up testbot…") and **wedged forever**: both twin rows were reaped, the mismatched resume never completed and never surfaced an error. That eternal spinner is the workspace-jump/wrong-transcript shape reported in the issue.

## Changes
- `store/session.ts` `mergeSessionPage()`: identity, lineage-carry, and survivor-dedupe keys are all `(profile, id)` (local normalize — importing `@/store/profile` would be circular). A kept twin in another profile now survives the incoming-page dedupe; title/activity carry can no longer cross profiles.
- `sidebar` row keys: `sessions-section.tsx` + `virtual-session-list.tsx` key rows by `(profile, id)` — bare-id keys made React misattribute one twin's rendered state to the other (reproduced live: one twin's preview painted on multiple rows until keyed).
- Click carries the ROW's identity: `onResumeSession` passes the clicked `SessionInfo`; wiring pins the row's own (connection, profile) as the resume owner via `requestSessionResume` before navigating. Untagged rows (single-profile installs, legacy pages) keep the id-only path. `resolveStoredSession`'s existing owner-route path is fail-closed, so the pinned owner can't be silently retargeted.
- Tests: twin no-stitch + kept-twin-survives-dedupe in `session.test.ts`.

## Validation
| | Result |
|---|---|
| sabotage run (session.ts reverted) | 2/2 new tests fail |
| with fix | 89/89 session.test.ts |
| wider sweep | vitest store+sidebar+contrib: 142 files / 1592 pass |
| eslint (6 changed files) | clean |

**Live repro (real Electron + two profile backends):** on main — twins collapse to one row, click dials the wrong profile, permanent "Waking up testbot…" (no error, no retry affordance). On this branch — all-profiles view lists BOTH twins as separate rows; clicking the QUIETBOT row renders QUIETBOT's transcript ("Acknowledged — QUIETBOT-OWNED") with no wedge and no workspace jump.

Remaining #92454 residue tracked separately: the reaped-session resume that hangs without a recovery affordance is a liveness gap in the resume ladder (violates the bounded-retry rule) — filed as a follow-up rather than stretched into this identity fix.

## Live A/B screenshots

| Main (bug fires) | Fix branch |
|---|---|
| ![wrong-profile wake wedge](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETB_COLLISION_MAIN.png) | ![both twins listed, right transcript opens](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETB_TWO_ROWS_FIX.png) |
| ![stuck waking after mismatched resume](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/BUCKETB_TWIN_RESULT.png) | |

## Infographic

![Identity twins](https://v3b.fal.media/files/b/0aa7f0fb/KbF7BZ7g_qxSlGYSka1xL_oPpNCqIL.png)
