### PR TITLE
fix(update): Windows gateway relaunches count in runtime reconciliation instead of reading as unaccounted (salvage #93284)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5754,6 +5754,20 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
                 exc,
             )
 
+    # Surface the outcome on the token (#91277 Phase 2 plan-vs-execution
+    # reconciliation): the git-based update path's fleet reconciliation
+    # cross-checks every planned runtime against restarted_services /
+    # relaunched_profiles / externally_supervised_profiles / killed_pids —
+    # bookkeeping this Windows-specific pause/resume never fed, so a
+    # correctly-paused-and-relaunched Windows gateway was reported
+    # "unaccounted" (loud warning + exit 1) even though the restart
+    # succeeded. The caller merges this into the shared
+    # relaunched_profiles list before reconciliation runs. A profile whose
+    # relaunch genuinely failed is deliberately left off this list — it
+    # must still surface as unaccounted so the user is told to restart it
+    # manually (Windows has no watcher to recover a failed relaunch).
+    token["relaunched_profiles"] = relaunched
+
     # Respawn unmapped gateways (no profile→PID-file mapping, e.g. a Scheduled
     # Task) by replaying the argv we snapshotted before force-killing them.
     unmapped_relaunched = 0
@@ -8612,6 +8626,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 pass
 
         _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+        if _windows_gateway_resume:
+            # Feed Windows's own pause/resume outcome into the same
+            # relaunched_profiles bookkeeping the systemd/launchd restart
+            # phase populates, so the #91277 Phase 2 reconciliation below
+            # does not report a correctly-relaunched Windows gateway as
+            # "unaccounted" (a runtime the plan saw but no bookkeeping
+            # mentions — the reconciliation's blind-spot tripwire). A
+            # profile whose relaunch genuinely failed is intentionally
+            # left out of the token's list, so it still surfaces there.
+            # Best-effort: the restart-phase try/except above may have
+            # raised before relaunched_profiles was initialized, so this
+            # must never itself abort the update.
+            try:
+                for _win_profile in _windows_gateway_resume.get("relaunched_profiles") or []:
+                    if _win_profile not in relaunched_profiles:
+                        relaunched_profiles.append(_win_profile)
+            except Exception as _win_reconcile_exc:
+                logger.debug(
+                    "Could not merge Windows relaunch outcome into fleet "
+                    "reconciliation bookkeeping: %s",
+                    _win_reconcile_exc,
+                )
 
         # Warn if legacy Hermes gateway unit files are still installed.
         # When both hermes.service (from a pre-rename install) and the

--- a/tests/hermes_cli/test_windows_update_restart_reconciliation.py
+++ b/tests/hermes_cli/test_windows_update_restart_reconciliation.py
@@ -1,0 +1,145 @@
+"""Regression: Windows gateway pause/resume must feed the #91277 Phase 2
+plan-vs-execution reconciliation, not report a correctly-relaunched Windows
+gateway as "unaccounted".
+
+``_pause_windows_gateways_for_update`` / ``_resume_windows_gateways_after_update``
+are Windows's own gateway restart mechanism — separate from the
+systemd/launchd restart phase in ``_cmd_update_impl`` that populates
+``restarted_services`` / ``relaunched_profiles`` / ``killed_pids`` /
+``externally_supervised_profiles``. Before this fix, a Windows gateway that
+was correctly paused and relaunched left no trace in that bookkeeping, so
+``match_runtime_outcomes`` classified it "unaccounted" — the plan saw it and
+NO bookkeeping mentions it — and ``report_unaccounted_runtimes`` escalated
+that into ``sys.exit(1)`` even though the update (and the restart) succeeded.
+
+``_resume_windows_gateways_after_update`` now writes the profiles it
+successfully relaunched onto ``token["relaunched_profiles"]``; the update
+command merges that into the shared ``relaunched_profiles`` list before
+reconciliation runs (mirrored here directly, since driving the full
+``_cmd_update_impl`` end to end is impractical).
+"""
+
+from unittest.mock import patch
+
+import hermes_cli.gateway as gateway
+import hermes_cli.main as hm
+from hermes_cli.update_cmd import _resume_windows_gateways_after_update
+from hermes_cli.update_inventory import (
+    RuntimeRecord,
+    UpdatePlan,
+    match_runtime_outcomes,
+    report_unaccounted_runtimes,
+)
+
+
+def _token(profiles: dict) -> dict:
+    return {
+        "resume_needed": True,
+        "profiles": profiles,
+        "unmapped_pids": [],
+        "unmapped": [],
+    }
+
+
+def test_resume_records_successfully_relaunched_profiles_on_the_token(monkeypatch):
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    token = _token({"default": 1111, "work": 2222})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    assert sorted(token["relaunched_profiles"]) == ["default", "work"]
+
+
+def test_resume_omits_profiles_whose_relaunch_failed(monkeypatch):
+    """A profile whose relaunch genuinely fails must NOT be marked
+    'relaunched' — it needs to keep surfacing as unaccounted so the user is
+    told to restart it manually (Windows has no watcher to recover it)."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+
+    def _relaunch(profile, _old_pid):
+        return profile == "default"  # "work" fails to relaunch
+
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", _relaunch
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    token = _token({"default": 1111, "work": 2222})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    assert token["relaunched_profiles"] == ["default"]
+
+
+def test_merged_windows_relaunch_resolves_as_restarted_not_unaccounted(monkeypatch):
+    """End-to-end shape of the actual fix: the token's relaunched_profiles,
+    merged into the shared list _cmd_update_impl passes to
+    match_runtime_outcomes, must turn a Windows gateway's plan row from
+    'unaccounted' (loud warning + exit 1) into 'restarted' (clean)."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    old_pid = 4242
+    token = _token({"default": old_pid})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    # collect_runtime_inventory() would have recorded the pre-update PID —
+    # the plan is built BEFORE the pause/relaunch, so it still names the old
+    # pid even though a fresh process now owns the port.
+    plan = UpdatePlan()
+    plan.runtimes = [
+        RuntimeRecord(
+            kind="gateway", profile="default", pid=old_pid, supervisor="manual",
+            restart_via="manual",
+        )
+    ]
+
+    # Without the merge (the pre-fix state): unaccounted, escalates.
+    pre_fix_outcomes = match_runtime_outcomes(
+        plan, restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert pre_fix_outcomes[0]["outcome"] == "unaccounted"
+    assert report_unaccounted_runtimes(pre_fix_outcomes) is True
+
+    # With the merge _cmd_update_impl now performs: restarted, clean.
+    relaunched_profiles: list = []
+    for profile in token.get("relaunched_profiles") or []:
+        if profile not in relaunched_profiles:
+            relaunched_profiles.append(profile)
+
+    post_fix_outcomes = match_runtime_outcomes(
+        plan, restarted_services=[], relaunched_profiles=relaunched_profiles,
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert post_fix_outcomes[0]["outcome"] == "restarted"
+    assert report_unaccounted_runtimes(post_fix_outcomes) is False
+
+
+def test_resume_with_no_relaunched_profiles_key_does_not_crash_the_merge():
+    """A token from an early-return path (e.g. cold-start, no profiles) may
+    never gain a 'relaunched_profiles' key at all — the merge in
+    _cmd_update_impl must tolerate that (.get(...) or [])."""
+    token = {"resume_needed": False}
+    relaunched_profiles: list = []
+    for profile in token.get("relaunched_profiles") or []:
+        relaunched_profiles.append(profile)
+    assert relaunched_profiles == []


### PR DESCRIPTION
## Summary

Windows gateway relaunches are now recorded in the update's runtime reconciliation (#91277 Phase 2 gap; salvage of #93284 by @pierrenode, his commit cherry-picked with authorship preserved). The receipt's bookkeeping requires every pre-update runtime to be accounted for — restarted, killed, or relaunched — but `_resume_windows_gateways_after_update()` only built a local list for printing and never wrote its successes anywhere reconciliation could see (our own `_fleet_probe_expected_runtimes` docstring admits the pause/resume path "populates NEITHER restarted_services NOR killed_pids"). A perfectly healthy Windows resume therefore classified as `unaccounted` and degraded the receipt.

Complements #95859 (which fixed the version-snapshot half); this fixes the outcome-reconciliation half — the two touch different stages of the same post-update verdict.

## Changes

- `hermes_cli/update_cmd.py`: the Windows resume records successfully-relaunched profiles onto the resume token (`relaunched_profiles`); `_cmd_update_impl` merges that into the shared list before `match_runtime_outcomes()` runs. Failed relaunches deliberately stay off the list (they should surface).
- New `tests/hermes_cli/test_windows_update_restart_reconciliation.py` (4 tests).

## Validation

| | Result |
|---|---|
| Suite at head | 4/4 passed |
| A/B (update_cmd.py reverted to merge-base, tests kept) | 3/4 FAILED — gap proven |
| Live E2E | real `_resume_windows_gateways_after_update()` + real `match_runtime_outcomes()`: token carries `['default','work']` after resume, reconciliation classifies both `restarted` (merge-base: `unaccounted`) |

**Live repro:** the E2E above — real functions end to end, only the Windows spawn helper stubbed (Linux host).

Credit: @pierrenode. Related: #93258/#95896 (PID-reuse guard) is the sibling fleet-check fix in flight.

## Infographic

![Clean books](https://files.catbox.moe/gn381n.png)
