### PR TITLE
fix(cron): multiplex deliveries use the owning profile's adapters and credentials

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3065,6 +3065,51 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+@contextlib.contextmanager
+def _delivery_secret_scope():
+    """Re-install the current profile's secret scope around delivery.
+
+    ``run_one_job`` resets the job's secret scope once the agent turn ends,
+    BEFORE delivery runs — the agent's credential scope must not leak past
+    the conversation turn. But the standalone delivery fallback (no live
+    gateway lane available, or the fallback attempt after a live-lane send
+    fails) reads platform tokens from the ambient credential resolution;
+    inside a multiplexed ticker thread that would otherwise mean whichever
+    profile started the PROCESS. Secondary-profile cron deliveries then
+    authenticate as a foreign bot, and platforms like Discord reject DMs
+    from a non-participant with 403 50001 Missing Access.
+
+    Mirrors ``run_job``'s per-job scope so standalone delivery resolves the
+    OWNING profile's ``<home>/.env`` (plus its configured external secret
+    sources). Gated on multiplexing being active: single-profile processes
+    keep the exact legacy behavior (no scope, ``os.environ`` reads).
+    """
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        is_multiplex_active,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    if not is_multiplex_active():
+        yield
+        return
+
+    token = set_secret_scope(build_profile_secret_scope(_get_hermes_home()))
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+
+
+def _deliver_result_with_profile_scope(
+    job: dict, content: str, adapters=None, loop=None
+) -> Optional[str]:
+    """Call ``_deliver_result`` under the owning profile's secret scope."""
+    with _delivery_secret_scope():
+        return _deliver_result(job, content, adapters=adapters, loop=loop)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -7265,7 +7310,7 @@ def _run_one_job_body(
                         if not owns_delivery:
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
-                        delivery_error = _deliver_result(
+                        delivery_error = _deliver_result_with_profile_scope(
                             job,
                             deliver_content,
                             adapters=adapters,
@@ -7423,7 +7468,7 @@ def _run_one_job_body(
             else:
                 try:
                     delivery_attempted = True
-                    delivery_error = _deliver_result(
+                    delivery_error = _deliver_result_with_profile_scope(
                         job,
                         # Composed exactly like the normal failure delivery above.
                         # mark_job_run below records THIS run in failure_streak
@@ -7551,6 +7596,24 @@ def create_job_with_scheduler_registration(**kwargs) -> dict:
 # to None to force a reap on the next tick.
 _DEAD_OWNER_REAP_INTERVAL_SECONDS = 300.0
 _last_dead_owner_reap_at: Optional[float] = None
+
+
+def _adapters_for_profile(base_adapters, profile_adapters, profile_name):
+    """Resolve the live-adapter map for ONE profile's cron tick.
+
+    ``profile_adapters`` maps profile name → {Platform: live adapter} and is
+    composed by the multiplexed gateway (see ``gateway/run.py``). The active
+    profile keeps ``base_adapters`` (the runner's own flat map); every other
+    profile resolves ONLY its own entry — a profile whose adapters are not
+    connected gets an EMPTY map, so its deliveries fall back to standalone
+    sends under that profile's own credentials instead of riding whatever
+    other identity happens to hold the platform slot in the shared process.
+    """
+    if not profile_adapters:
+        return base_adapters
+    if not profile_name:
+        return base_adapters
+    return profile_adapters.get(profile_name) or {}
 
 
 def tick(

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -532,6 +532,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -559,6 +560,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -630,6 +632,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -638,9 +641,22 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_adapters`` maps profile name → {Platform: live adapter}. It
+        keeps delivery identity aligned with the job's owning profile: each
+        tick is offered ONLY that profile's adapters. A profile whose adapter
+        is not connected resolves no live transport at all — its deliveries
+        then fall back to standalone sends under that profile's own
+        credentials (see ``cron.scheduler._delivery_secret_scope``) — never
+        onto another profile's bot. Sharing one flat map across profiles
+        meant a secondary profile's DM-bound cron delivery could go out as
+        whichever OTHER identity happened to win the platform slot; Discord
+        (like most platforms) rejects DMs from a non-participant with 403
+        50001 Missing Access. Per-profile maps make that class of
+        cross-profile send structurally impossible.
         """
         import logging
-        from cron.scheduler import tick as cron_tick
+        from cron.scheduler import _adapters_for_profile, tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -682,13 +698,16 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_adapters_for_profile(
+                                        adapters, profile_adapters, profile_name
+                                    ),
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31626,6 +31626,46 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile live-adapter maps so each profile's scheduled
+                # deliveries are offered ONLY its own adapters: runner.adapters
+                # is the ACTIVE profile's flat map, while secondary profiles
+                # live in runner._profile_adapters. Passing only
+                # runner.adapters made every secondary-profile delivery
+                # resolve the active profile's adapter for the whole logical
+                # platform — e.g. one profile's bot DM sent by ANOTHER
+                # profile's bot, which Discord rejects with 403 50001 because
+                # the sender is not a DM participant. Maps are shared by
+                # REFERENCE, so reconnect / swap bookkeeping on the runner
+                # stays visible to the ticker.
+                _active_home = None
+                try:
+                    from hermes_constants import get_hermes_home
+
+                    _active_home = Path(get_hermes_home()).resolve()
+                except Exception:
+                    pass
+                profile_adapters: Dict[str, Dict[Any, Any]] = {}
+                for _entry in profile_homes:
+                    _p_name = _entry[0] if isinstance(_entry, tuple) else None
+                    _p_home = _entry[1] if isinstance(_entry, tuple) else None
+                    if not _p_name:
+                        continue
+                    # The ACTIVE profile owns the flat runner map; every other
+                    # served profile owns its per-profile secondary map.
+                    _is_active = (
+                        _p_home is not None
+                        and _active_home is not None
+                        and Path(_p_home).resolve() == _active_home
+                    ) or (_p_home is None and _p_name == "default")
+                    if _is_active:
+                        profile_adapters[_p_name] = runner.adapters
+                    elif _p_name in runner._profile_adapters:
+                        profile_adapters[_p_name] = runner._profile_adapters[_p_name]
+                    else:
+                        # Secondary not up yet / disabled: resolve NO live
+                        # transport for it rather than another profile's.
+                        profile_adapters[_p_name] = {}
+                cron_start_kwargs["profile_adapters"] = profile_adapters
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_cron_multiplex_delivery_identity.py
+++ b/tests/cron/test_cron_multiplex_delivery_identity.py
@@ -1,0 +1,241 @@
+"""Regression tests: multiplexed cron deliveries must use the OWNING profile.
+
+Two defects shipped together in the multiplexed gateway's cron path:
+
+1. ``InProcessCronScheduler`` received only the ACTIVE profile's flat adapter
+   map (``runner.adapters``); every secondary profile's scheduled delivery
+   therefore resolved whichever OTHER bot held the platform slot — e.g. one
+   profile's DM-bound brief sent as another profile's Discord bot, rejected
+   server-side with 403 50001 Missing Access because the sender is not a DM
+   participant. The fix threads ``profile_adapters`` (profile name → own
+   adapter map) through ``start()`` → ``_start_multiplex()`` → each profile's
+   ``tick(adapters=...)``, and ``cron.scheduler._adapters_for_profile``
+   resolves ONLY the owning profile's map.
+
+2. ``run_one_job`` resets the job's secret scope BEFORE ``_deliver_result``
+   runs. The standalone delivery fallback then resolved platform tokens from
+   process-global ``os.environ`` — under a multiplexer that is whatever
+   profile STARTED the process, again the wrong bot. The fix re-installs the
+   owning profile's secret scope around delivery
+   (``cron.scheduler._delivery_secret_scope``), gated on multiplexing being
+   active so single-profile behavior is untouched.
+"""
+
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def profile_home(tmp_path):
+    """A minimal profile home with its own DISCORD_BOT_TOKEN in .env."""
+    home = tmp_path / "profiles" / "coach"
+    home.mkdir(parents=True)
+    (home / ".env").write_text(
+        'DISCORD_BOT_TOKEN="tok-coach-from-profile-env"\n',
+        encoding="utf-8",
+    )
+    return home
+
+
+@pytest.fixture()
+def multiplex_on():
+    """Turn multiplex mode on for the test, always restoring it."""
+    from agent import secret_scope
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield True
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+
+# ───────────────────────── _adapters_for_profile ─────────────────────────
+
+
+class TestAdaptersForProfile:
+    def test_active_profile_gets_base_map(self):
+        from cron.scheduler import _adapters_for_profile
+
+        base = {"discord": object()}
+        result = _adapters_for_profile(base, {"default": base}, "default")
+        assert result is base
+
+    def test_secondary_profile_gets_only_its_own_map(self):
+        from cron.scheduler import _adapters_for_profile
+
+        base = {"discord": "wrong-bot"}
+        own = {"discord": "rickclawin-adapter"}
+        result = _adapters_for_profile(base, {"coach": own}, "coach")
+        assert result is own
+
+    def test_unknown_secondary_resolves_empty_map(self):
+        """A secondary whose adapters are not connected must resolve NO live
+        transport — never another profile's adapter."""
+        from cron.scheduler import _adapters_for_profile
+
+        base = {"discord": "wrong-bot"}
+        result = _adapters_for_profile(base, {"coach": {}}, "hdops")
+        assert result == {}
+        assert result is not base
+
+    def test_no_profile_adapters_is_legacy_passthrough(self):
+        """Without profile_adapters (non-multiplex callers, older providers),
+        the base map is handed through unchanged."""
+        from cron.scheduler import _adapters_for_profile
+
+        base = {"discord": object()}
+        assert _adapters_for_profile(base, None, "coach") is base
+        assert _adapters_for_profile(base, {}, "coach") is base
+
+    def test_none_profile_name_gets_base(self):
+        """String-only profile_homes entries (no name tuple) keep old shape."""
+        from cron.scheduler import _adapters_for_profile
+
+        base = {"discord": object()}
+        assert _adapters_for_profile(base, {"coach": {}}, None) is base
+
+
+# ─────────────────────── _delivery_secret_scope ──────────────────────────
+
+
+class TestDeliverySecretScope:
+    def test_scope_reinstalled_from_profile_env_when_multiplex_on(
+        self, profile_home, multiplex_on, monkeypatch
+    ):
+        import cron.scheduler as scheduler
+        from agent.secret_scope import current_secret_scope, get_secret
+
+        # Simulate a mux ticker thread scoped to this profile's home.
+        monkeypatch.setattr(scheduler, "_hermes_home", profile_home)
+
+        # No ambient scope before delivery.
+        assert current_secret_scope() is None
+
+        with scheduler._delivery_secret_scope():
+            assert current_secret_scope() is not None
+            # The standalone fallback resolves the OWNING profile's token,
+            # not whatever sits in os.environ / the launching profile's env.
+            assert (
+                get_secret("DISCORD_BOT_TOKEN")
+                == "tok-coach-from-profile-env"
+            )
+
+        # Scope is gone again once delivery finishes.
+        assert current_secret_scope() is None
+
+    def test_no_scope_installed_when_multiplex_off(self, profile_home, monkeypatch):
+        """Single-profile processes keep legacy behavior: no scope, plain
+        os.environ resolution."""
+        import cron.scheduler as scheduler
+        from agent.secret_scope import current_secret_scope, get_secret
+
+        monkeypatch.setattr(scheduler, "_hermes_home", profile_home)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok-from-process-env")
+
+        with scheduler._delivery_secret_scope():
+            assert current_secret_scope() is None
+            assert get_secret("DISCORD_BOT_TOKEN") == "tok-from-process-env"
+
+    def test_scoped_read_wins_over_process_env(self, profile_home, multiplex_on, monkeypatch):
+        """Under an active multiplexer the profile scope is authoritative."""
+        import cron.scheduler as scheduler
+        from agent.secret_scope import get_secret
+
+        monkeypatch.setattr(scheduler, "_hermes_home", profile_home)
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok-wrong-process-bot")
+
+        with scheduler._delivery_secret_scope():
+            assert get_secret("DISCORD_BOT_TOKEN") == "tok-coach-from-profile-env"
+
+    def test_wrapper_passes_through_and_restores_scope(
+        self, profile_home, multiplex_on, monkeypatch
+    ):
+        import cron.scheduler as scheduler
+        from agent.secret_scope import current_secret_scope
+
+        monkeypatch.setattr(scheduler, "_hermes_home", profile_home)
+
+        seen = {}
+
+        def fake_deliver(job, content, adapters=None, loop=None):
+            seen["job"] = job
+            seen["content"] = content
+            seen["scope_active"] = current_secret_scope() is not None
+            return None
+
+        monkeypatch.setattr(scheduler, "_deliver_result", fake_deliver)
+
+        job = {"id": "j1"}
+        result = scheduler._deliver_result_with_profile_scope(
+            job, "body", adapters={"discord": object()}, loop=None
+        )
+        assert result is None
+        assert seen["content"] == "body"
+        assert seen["scope_active"] is True
+        assert current_secret_scope() is None
+
+
+# ─────────────── provider-level: per-profile tick routing ────────────────
+
+
+class TestMultiplexTickRoutesPerProfileAdapters:
+    def test_each_profile_tick_receives_its_own_adapter_map(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end wiring: start(profile_homes=..., profile_adapters=...)
+        hands each profile's tick ONLY that profile's live-adapter map."""
+        from cron.scheduler_provider import InProcessCronScheduler
+
+        base_map = {"discord": "active-profile-adapter"}
+        coach_map = {"discord": "coach-profile-adapter"}
+        profile_adapters = {"default": base_map, "coach": coach_map}
+
+        homes = [
+            ("default", tmp_path / "default"),
+            ("coach", tmp_path / "profiles" / "coach"),
+            ("hdops", tmp_path / "profiles" / "hdops"),  # adapters missing
+        ]
+        for _, home in homes:
+            home.mkdir(parents=True)
+
+        # Store-side noise is irrelevant here; stub it hermetically.
+        for name in (
+            "record_ticker_heartbeat",
+            "record_ticker_error",
+            "clear_ticker_error",
+        ):
+            monkeypatch.setattr(f"cron.jobs.{name}", lambda *a, **k: None)
+
+        received = []
+        stop_event = threading.Event()
+
+        def fake_tick(*args, **kwargs):
+            received.append(kwargs.get("adapters"))
+            if len(received) >= len(homes):
+                stop_event.set()
+
+        monkeypatch.setattr("cron.scheduler.tick", fake_tick)
+
+        provider = InProcessCronScheduler()
+        provider.recover_interrupted = lambda *a, **k: 0
+
+        provider.start(
+            stop_event,
+            adapters=base_map,
+            loop=None,
+            interval=3600,
+            profile_homes=homes,
+            profile_adapters=profile_adapters,
+        )
+
+        assert len(received) == len(homes)
+        # Active profile keeps the runner's flat map (by reference).
+        assert received[0] is base_map
+        # Coach resolves ONLY its own map.
+        assert received[1] is coach_map
+        # Unconnected secondary resolves NO live transport — crucially NOT
+        # another profile's adapter.
+        assert received[2] == {}


### PR DESCRIPTION
## Summary

Under a multiplexed gateway (`gateway.multiplex_profiles: true`), scheduled cron jobs belonging to secondary profiles **execute correctly but deliver through the wrong bot identity**. The in-process cron ticker only ever receives `runner.adapters` — the *active* profile's flat platform map — so every secondary profile's delivery resolves whatever other identity holds the platform slot. On Discord this means sending a profile's DM brief as a bot that is not a participant of that conversation; Discord rejects it with `403 Forbidden (error code: 50001): Missing Access`. The job reports `last_status: ok` with an error string in `last_delivery_error`, and the output is silently stranded.

The standalone delivery fallback cannot rescue it either: `run_one_job` resets the job's secret scope before `_deliver_result` runs (correctly — agent-turn credentials must not leak past the turn), so the fallback resolves platform tokens from process-global `os.environ`, which under a multiplexer holds whichever profile started the process. Again the wrong bot.

This PR fixes both halves so delivery identity always matches the owning profile:

- **`gateway/run.py`** composes a `profile_adapters` map (profile name → that profile's live adapters). The active profile keeps `runner.adapters`; secondaries resolve their entry from `runner._profile_adapters`; an unconnected/disabled secondary gets `{}` rather than another profile's map. Maps are shared **by reference**, so reconnect/swap bookkeeping performed on the runner stays visible to the ticker.
- **`cron/scheduler_provider.py`** (`InProcessCronScheduler.start` / `_start_multiplex`) hands each profile's tick ONLY its own adapter map via the new `cron.scheduler._adapters_for_profile`. A profile with no connected adapters resolves no live transport at all — never another profile's bot.
- **`cron/scheduler.py`** adds `_delivery_secret_scope` and wraps both `_deliver_result` call sites (normal delivery and failure-alert delivery) so the standalone fallback reads the owning profile's `<home>/.env` plus its configured external secret sources, mirroring exactly what `run_job` already does per job run. Gated on multiplexing being active, so single-profile processes keep legacy behavior byte-for-byte.

## Reproduction

1. Run two profiles under one multiplexer, each with its own Discord bot token (e.g. default + coach).
2. From the coach bot's DM with user U, schedule any cron job with `deliver` targeting that DM.
3. At fire time the job runs and saves output, but delivery fails: `403 Forbidden (50001): Missing Access`, emitted by the **default profile's** discord adapter logger, every night.
4. `curl -H "Authorization: Bot <coach-token>" -X POST .../channels/<dm>/messages` succeeds — proving the token/channel are fine and the wrong identity was used on the scheduled path.

With several profiles configured, whichever adapter last won the flat `discord` slot wins for *everyone*; with reconnects in play the winner can even vary between runs.

## Testing

New regression tests (`tests/cron/test_cron_multiplex_delivery_identity.py`, 10 cases):

- `_adapters_for_profile`: active-profile passthrough by reference, secondary resolves ONLY its own map, unknown/unconnected secondary resolves `{}`, non-multiplex callers keep legacy passthrough, string-only profile-home entries keep old shape.
- `_delivery_secret_scope`: scope re-installed from the owning profile's `.env` when multiplexing is active (token readable inside the context, restored after), no scope when multiplexing is off, scoped value wins over process env under mux, wrapper passes args through and restores state.
- Provider-level end-to-end: `start(profile_homes=…, profile_adapters=…)` routes each tick's `adapters=` to the right map (active keeps runner map by reference, secondary gets its own, unconnected secondary gets `{}`).

All 10 new tests pass; full `tests/cron/` suite: **988 passed**, 3 pre-existing failures reproducible on clean `origin/main` (process-tree / timezone-sensitive tests unrelated to cron delivery); `tests/cron/test_scheduler_provider.py`, `tests/gateway/test_multiplex_lifecycle.py`, `tests/hermes_cli/test_desktop_cron_ticker_profiles.py`, `tests/agent/test_secret_scope.py` all green.