### PR TITLE
fix(mcp): render argless tool call errors in logs

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -576,6 +576,35 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_argless_tool_call_exception_logs_nonblank_reason(self, caplog):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(side_effect=asyncio.TimeoutError())
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "greet", 120)
+            with self._patch_mcp_loop(), caplog.at_level(
+                logging.ERROR, logger="tools.mcp_tool"
+            ):
+                result = json.loads(handler({"name": "world"}))
+
+            error_lines = [
+                record.getMessage()
+                for record in caplog.records
+                if "call failed" in record.getMessage()
+            ]
+            assert error_lines == [
+                "MCP tool test_srv/greet call failed: TimeoutError: TimeoutError()"
+            ]
+            assert result["error"] == (
+                "MCP call failed: TimeoutError: TimeoutError()"
+            )
+        finally:
+            _servers.pop("test_srv", None)
+
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6366,8 +6366,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
             _bump_server_error(server_name)
             logger.error(
-                "MCP tool %s/%s call failed: %s",
-                server_name, tool_name, exc,
+                "MCP tool %s/%s call failed: %s: %s",
+                server_name, tool_name, type(exc).__name__, _exc_str(exc),
             )
             return tool_error(_sanitize_error(
                 f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"


### PR DESCRIPTION
## What does this PR do?

Fixes MCP tool-call error logging for exceptions whose `str(exc)` is empty, such as bare `asyncio.TimeoutError()`.

The returned tool error already used `_exc_str(exc)`, which falls back to `repr(exc)` for arg-less exceptions. The log line still formatted the exception directly with `%s`, so logs could show:

`MCP tool <server>/<tool> call failed:`

This updates the log path to render the same `{ExceptionType}: {_exc_str(exc)}` detail as the user-facing MCP tool error.

## How this was found

While looking at repeated errors in the agent log from a scheduled MCP-heavy job, `grep ERROR` surfaced lines like:

`ERROR tools.mcp_tool: MCP tool <server>/<tool> call failed:`

with nothing after `failed:`. Reproducing the tool call interactively returned:

`{"error": "MCP call failed: TimeoutError: TimeoutError()"}`

confirming the caught exception was a bare `TimeoutError` with no message. `str(TimeoutError())` is `""`, so `%s` dropped the entire reason. The response path was fine because it already used `_exc_str`; only the log path was affected.

## Testing

- Added regression coverage for `_make_tool_handler` with a bare `asyncio.TimeoutError()`.
- Verified syntax with `python3 -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool.py`.
- Focused pytest pending/local run.