### PR TITLE
fix(desktop): leave Gateway Settings before reconnect

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,5 +1,8 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { leaveGatewaySettingsForReconnect } from './gateway-settings'
 
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
@@ -27,13 +30,28 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  window.history.replaceState(window.history.state, '', '#/')
 })
 
 describe('GatewaySettings', () => {
+  it('leaves the gateway Settings hash before applying a reconnect', () => {
+    const navigate = vi.fn()
+    window.history.replaceState(window.history.state, '', '#/settings?tab=gateway')
+
+    leaveGatewaySettingsForReconnect(navigate)
+
+    expect(window.location.hash).toBe('#/')
+    expect(navigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
   it('loads the machine-level connection config (no profile scoping)', async () => {
     const { GatewaySettings } = await import('./gateway-settings')
 
-    render(<GatewaySettings />)
+    render(
+      <MemoryRouter>
+        <GatewaySettings />
+      </MemoryRouter>
+    )
     expect(await screen.findByText('Local gateway')).toBeTruthy()
     expect(
       screen.getByText('Start a private Hermes backend on localhost. This is the default and works offline.')

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
 
+import { NEW_CHAT_ROUTE } from '@/app/routes'
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
@@ -97,6 +99,14 @@ export function savedCloudConnectionUrl(config: Pick<GatewaySettingsState, 'mode
   return config.mode === 'cloud' ? config.remoteUrl.trim().replace(/\/+$/, '').toLowerCase() : ''
 }
 
+export function leaveGatewaySettingsForReconnect(navigate: (to: string, options: { replace: boolean }) => void) {
+  // applyConnectionConfig re-homes the backend and reloads the Electron window.
+  // HashRouter state must leave Settings synchronously or that reload restores
+  // `#/settings?tab=gateway` and makes a successful reconnect look like a no-op.
+  window.history.replaceState(window.history.state, '', '#/')
+  navigate(NEW_CHAT_ROUTE, { replace: true })
+}
+
 function ModeCard({
   active,
   description,
@@ -152,6 +162,7 @@ function ModeCard({
 // reconnect action), so only the connection controls render.
 export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {}) {
   const { t } = useI18n()
+  const navigate = useNavigate()
   const g = t.settings.gateway
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -502,6 +513,12 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     setSaving(true)
 
     try {
+      // The main process reloads immediately after a successful apply. Change
+      // the hash first so the fresh renderer cannot reopen this Settings tab.
+      if (apply) {
+        leaveGatewaySettingsForReconnect(navigate)
+      }
+
       const next = apply
         ? await window.hermesDesktop.applyConnectionConfig(payload(allowPlainTextToken))
         : await window.hermesDesktop.saveConnectionConfig(payload(allowPlainTextToken))


### PR DESCRIPTION
## Summary
- leave the Gateway Settings hash route before applying a reconnecting gateway configuration
- use replace navigation so an Electron renderer reload opens the normal chat route instead of restoring `#/settings?tab=gateway`
- add a regression test for the hash and router transition

## Scope
This addresses a UI state mismatch after a successful reconnect. It deliberately does not change backend lifecycle or WebSocket orphan-reaping behavior.

## Verification
- `npm --workspace apps/desktop run test:ui -- --run src/app/settings/gateway-settings.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run lint` (passes with existing repository warnings only)

Related to #94196.
