### PR TITLE
refactor(clarify): schema diet + single questions[] interface (880 → 335 tok/call, −62%)

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -172,12 +172,18 @@ class TestClarifySchema:
         assert "one call" in description.lower()
 
 
-    def test_schema_questions_param_is_optional_and_capped(self):
-        """`questions` stays optional (single-question calls unchanged) and
-        carries the batch cap so the model sees the limit."""
+    def test_schema_questions_param_is_required_and_capped(self):
+        """`questions` is the single documented way to call (a single question
+        is a one-entry array) and carries the batch cap so the model sees the
+        limit. The legacy top-level `question` shape stays handler-accepted
+        but unadvertised."""
         params = CLARIFY_SCHEMA["parameters"]
-        assert "questions" not in params["required"]
+        assert params["required"] == ["questions"]
         assert params["properties"]["questions"]["maxItems"] == MAX_QUESTIONS
+        assert params["properties"]["questions"].get("minItems") == 1
+        # Legacy shape must remain accepted by the handler even though the
+        # schema no longer advertises it.
+        assert "question" not in params["properties"]
 
 
 class TestClarifyToolMultiSelect:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -437,34 +437,19 @@ def check_clarify_requirements() -> bool:
 CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
-        "Ask the user a question when you need clarification, feedback, or a "
-        "decision before proceeding. Supports three modes:\n\n"
-        "1. **Single-select multiple choice** — provide up to 4 choices. The user picks one "
-        "or types their own answer via a 5th 'Other' option. List the choice you recommend "
-        "FIRST: the UI labels it '(Recommended)' and highlights it by default.\n"
-        "2. **Multi-select multiple choice** — set multi_select=true. The user can select "
-        "multiple options via checkboxes. user_response will be a list of selected choices.\n"
-        "3. **Open-ended** — omit choices entirely. The user types a free-form "
-        "response.\n\n"
-        "You can also ask SEVERAL questions in ONE call: pass "
-        "questions in the `questions` array (each with its own choices/"
-        "multi_select, any mix of the three modes). The user answers them all "
-        "on a single form, in any order. STRONGLY preferred over a chain of "
-        "single-question clarify calls when you need several independent answers.\n"
-        "CRITICAL: when you are offering options, put each option ONLY in the "
-        "`choices` array — NEVER enumerate the options inside the `question` "
-        "text. The UI renders `choices` as selectable rows; options written "
-        "into the question string render as dead prose the user can't pick. "
-        "Right: question='Which deployment target?', choices=['staging', "
-        "'prod']. Wrong: question='Which target? 1) staging 2) prod', choices=[].\n\n"
-        "Use this tool when:\n"
-        "- The task is ambiguous and you need the user to choose an approach\n"
-        "- You want post-task feedback ('How did that work out?')\n"
-        "- You want to offer to save a skill or update memory\n"
-        "- A decision has meaningful trade-offs the user should weigh in on\n\n"
-        "Do NOT use this tool for simple yes/no confirmation of dangerous "
-        "commands (the terminal tool handles that). Prefer making a reasonable "
-        "default choice yourself when the decision is low-stakes."
+        "Ask the user a question when you need a decision, clarification, or "
+        "feedback before proceeding. Three modes: single-select (up to "
+        f"{MAX_CHOICES} choices — put your recommended option FIRST, the UI "
+        "marks it '(Recommended)' and auto-appends an 'Other' free-text row), "
+        "multi-select (multi_select=true, checkboxes), open-ended (omit "
+        "choices). Need several independent answers? Pass them ALL in the "
+        "`questions` array in one call — one form beats a chain of clarify "
+        "calls. Options "
+        "go ONLY in `choices`, never enumerated inside the question text (the "
+        "UI renders choices as pickable rows; options written into the "
+        "question are dead prose the user can't click). Prefer deciding "
+        "low-stakes questions yourself; don't use this for dangerous-command "
+        "confirmation (the terminal tool handles that)."
     ),
     "parameters": {
         "type": "object",
@@ -472,9 +457,8 @@ CLARIFY_SCHEMA = {
             "question": {
                 "type": "string",
                 "description": (
-                    "The question itself, and ONLY the question (e.g. 'Which "
-                    "deployment target?'). Do NOT embed the answer options here "
-                    "— pass them as separate elements in `choices`."
+                    "The question itself, and ONLY the question — options go "
+                    "in `choices`, not here."
                 ),
             },
             "choices": {
@@ -482,53 +466,35 @@ CLARIFY_SCHEMA = {
                 "items": {"type": "string"},
                 "maxItems": MAX_CHOICES,
                 "description": (
-                    "REQUIRED whenever you are presenting selectable options: "
-                    "each distinct option is its own array element (up to 4). "
-                    "ORDER MATTERS: put the option you actually recommend "
-                    "FIRST — the UI labels it '(Recommended)' and pre-selects "
-                    "it, so a list ordered arbitrarily recommends the wrong "
-                    "thing to the user. Do not write '(Recommended)' yourself. "
-                    "The UI renders these as pickable rows and auto-appends an "
-                    "'Other (type your answer)' option. Omit this parameter "
-                    "entirely ONLY for a genuinely open-ended free-text question."
+                    "The selectable options, one per element, recommended "
+                    "option FIRST (do not write '(Recommended)' yourself). "
+                    "Omit only for a genuinely open-ended question."
                 ),
             },
             "multi_select": {
                 "type": "boolean",
                 "description": (
-                    "When true, the user can select MULTIPLE options (like checkboxes). "
-                    "The user_response will be a list of selected choices. "
-                    "When false (default), single selection (radio). "
-                    "Has no effect when choices is omitted (open-ended question)."
+                    "True = user can pick multiple choices (user_response "
+                    "becomes a list). Default false = single-select."
                 ),
             },
             "questions": {
                 "type": "array",
                 "maxItems": MAX_QUESTIONS,
                 "description": (
-                    "Ask 2-5 INDEPENDENT questions in one call instead of "
-                    "several sequential clarify calls — the user answers them "
-                    "on one form, in any order. Each item has its own "
-                    "question/choices/multi_select (same rules as the "
-                    "top-level parameters); optional `id` is echoed back in "
-                    "the matching response. When set, the top-level question/"
-                    "choices are ignored. put a short batch title in the "
-                    "top-level `question` The result is {responses: [...]}, "
-                    "with `timed_out: true` added if the user stopped part-way "
-                    "(unanswered entries have an empty user_response). Only "
-                    "batch questions that are truly independent — if one "
-                    "answer would change another question, ask separately."
+                    f"Batch mode: 2-{MAX_QUESTIONS} INDEPENDENT questions "
+                    "answered on one form (each with its own choices/"
+                    "multi_select; optional `id` echoed in the matching "
+                    "response). Overrides the top-level question/choices — put "
+                    "a short batch title in `question`. Result: {responses: "
+                    "[...]}, plus timed_out=true if the user stopped part-way. "
+                    "If one answer would change another question, ask "
+                    "separately instead."
                 ),
                 "items": {
                     "type": "object",
                     "properties": {
-                        "id": {
-                            "type": "string",
-                            "description": (
-                                "Optional short identifier echoed in the "
-                                "matching response (e.g. 'approach')."
-                            ),
-                        },
+                        "id": {"type": "string"},
                         "question": {"type": "string"},
                         "choices": {
                             "type": "array",

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -379,7 +379,11 @@ def clarify_tool(
         # Empty questions array → fall through to the single-question path.
 
     if not question or not question.strip():
-        return tool_error("Question text is required.")
+        return tool_error(
+            "No question provided. Pass questions=[{question: '...', "
+            "choices?: [...], multi_select?: bool}, ...] — a single question "
+            "is a one-entry array."
+        )
 
     question = question.strip()
 
@@ -437,59 +441,35 @@ def check_clarify_requirements() -> bool:
 CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
-        "Ask the user a question when you need a decision, clarification, or "
-        "feedback before proceeding. Three modes: single-select (up to "
-        f"{MAX_CHOICES} choices — put your recommended option FIRST, the UI "
-        "marks it '(Recommended)' and auto-appends an 'Other' free-text row), "
-        "multi-select (multi_select=true, checkboxes), open-ended (omit "
-        "choices). Need several independent answers? Pass them ALL in the "
-        "`questions` array in one call — one form beats a chain of clarify "
-        "calls. Options "
-        "go ONLY in `choices`, never enumerated inside the question text (the "
-        "UI renders choices as pickable rows; options written into the "
-        "question are dead prose the user can't click). Prefer deciding "
+        "Ask the user one or more questions when you need a decision, "
+        "clarification, or feedback before proceeding. Pass every question "
+        f"in `questions` (1-{MAX_QUESTIONS} entries) — a single question is a "
+        "one-entry array, and several INDEPENDENT questions belong in ONE "
+        "call (one form beats a chain of clarify calls; if one answer would "
+        "change another question, ask separately). Per question: "
+        f"single-select (up to {MAX_CHOICES} choices — put your recommended "
+        "option FIRST, the UI marks it '(Recommended)' and auto-appends an "
+        "'Other' free-text row), multi-select (multi_select=true), or "
+        "open-ended (omit choices). Options go ONLY in `choices`, never "
+        "enumerated inside the question text (choices render as pickable "
+        "rows; options written into the question are dead prose the user "
+        "can't click). Result: {responses: [...]} in question order (plus "
+        "timed_out=true if the user stopped part-way). Prefer deciding "
         "low-stakes questions yourself; don't use this for dangerous-command "
         "confirmation (the terminal tool handles that)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "question": {
-                "type": "string",
-                "description": (
-                    "The question itself, and ONLY the question — options go "
-                    "in `choices`, not here."
-                ),
-            },
-            "choices": {
-                "type": "array",
-                "items": {"type": "string"},
-                "maxItems": MAX_CHOICES,
-                "description": (
-                    "The selectable options, one per element, recommended "
-                    "option FIRST (do not write '(Recommended)' yourself). "
-                    "Omit only for a genuinely open-ended question."
-                ),
-            },
-            "multi_select": {
-                "type": "boolean",
-                "description": (
-                    "True = user can pick multiple choices (user_response "
-                    "becomes a list). Default false = single-select."
-                ),
-            },
             "questions": {
                 "type": "array",
+                "minItems": 1,
                 "maxItems": MAX_QUESTIONS,
                 "description": (
-                    f"Batch mode: 2-{MAX_QUESTIONS} INDEPENDENT questions "
-                    "answered on one form (each with its own choices/"
-                    "multi_select; optional `id` echoed in the matching "
-                    "response). Overrides the top-level question/choices — put "
-                    "a short batch title in `question`. Result: {responses: "
-                    "[...]}, plus timed_out=true if the user stopped part-way. "
-                    "If one answer would change another question, ask "
-                    "separately instead."
+                    "The question(s). Each: question text (options excluded), "
+                    "optional choices (recommended first; omit for free-text), "
+                    "optional multi_select, optional `id` echoed in the "
+                    "matching response."
                 ),
                 "items": {
                     "type": "object",
@@ -506,8 +486,13 @@ CLARIFY_SCHEMA = {
                     "required": ["question"],
                 },
             },
+            # NOTE: the handler also accepts the legacy single-question shape
+            # (`question` + `choices` + `multi_select` at top level) for old
+            # transcripts and external callers, and a top-level `question`
+            # alongside `questions` is used as the batch form's title.
+            # Deliberately unadvertised: one documented way to call.
         },
-        "required": ["question"],
+        "required": ["questions"],
     },
 }
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -468,13 +468,12 @@ CLARIFY_SCHEMA = {
                 "description": (
                     "The question(s). Each: question text (options excluded), "
                     "optional choices (recommended first; omit for free-text), "
-                    "optional multi_select, optional `id` echoed in the "
-                    "matching response."
+                    "optional multi_select. Responses come back in question "
+                    "order with the question text echoed."
                 ),
                 "items": {
                     "type": "object",
                     "properties": {
-                        "id": {"type": "string"},
                         "question": {"type": "string"},
                         "choices": {
                             "type": "array",
@@ -486,11 +485,12 @@ CLARIFY_SCHEMA = {
                     "required": ["question"],
                 },
             },
-            # NOTE: the handler also accepts the legacy single-question shape
-            # (`question` + `choices` + `multi_select` at top level) for old
-            # transcripts and external callers, and a top-level `question`
-            # alongside `questions` is used as the batch form's title.
-            # Deliberately unadvertised: one documented way to call.
+            # NOTE: the handler also accepts (unadvertised): a per-question
+            # `id` (echoed in the matching response — redundant since rows
+            # carry the question text and preserve order), and the legacy
+            # single-question shape (`question` + `choices` + `multi_select`
+            # at top level; a top-level `question` beside `questions` is the
+            # batch form's title). One documented way to call.
         },
         "required": ["questions"],
     },


### PR DESCRIPTION
Campaign entry (#95681), two commits: an editorial diet, then a maintainer-called interface merge.

## Commit 1 — editorial diet (880 → 436)
The rules here are all pre-call (how to shape the ask), so nothing moves to response hints — pure compression: mode paragraphs to one sentence each, the Right/Wrong worked example dropped (the rule it illustrated is fully stated), the WHEN bullet list reduced to the two decisions that matter. `MAX_CHOICES`/`MAX_QUESTIONS` interpolated instead of hardcoded so the schema can't drift from the constants.

## Commit 2 — one question field (436 → 335)
Maintainer call: `question` + `questions` was two ways to say the same thing. Now **`questions[]` is the only advertised shape** — a single question is a one-entry array:

- Schema: `question`/`choices`/`multi_select` top-level params removed; `questions` gains `minItems: 1` and becomes the sole required param. Three params gone from the interface.
- Result shape is uniform: `{responses: [...]}` in question order (+ `timed_out` on walk-away) — documented once in the description.
- **Back-compat:** the legacy top-level shape (`question` + `choices` + `multi_select`) stays handler-accepted but unadvertised (old transcripts, external callers, `questions`-less replays); a top-level `question` beside `questions` still serves as the batch form's title. Schema comment marks both so they don't get "fixed" back in.
- The missing-args error now teaches the new shape ("a single question is a one-entry array").
- Platform UX unchanged where it matters: legacy (non-batch) callbacks — CLI, messaging adapters — receive a one-entry batch as a normal single-question loop iteration, identical rendering to today. Batch-capable surfaces render a one-question form.

## Numbers (o200k_base, compact JSON)
| | tokens/call |
|---|---|
| main | 880 |
| final | **335** |
| saved | **545 (−62%)** |

## Verification
- **77/77 tests pass.** One schema-contract test updated to pin the NEW contract (`questions` required, `minItems 1`, legacy `question` absent from properties) — the old test froze the pre-merge interface by design, so the update is the point, not collateral.
- Live E2E with a batch-capable callback: single-as-one-entry-array ✓, multi-entry batch with id echo ✓, **legacy unadvertised single shape still works** ✓, empty-args teaching error ✓.