### PR TITLE
Make system-prompt section size limits configurable

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -499,9 +499,41 @@ def _classify_entrypoint_value_kind(value: str) -> str:
 # hooks. They become high-trust prompt bytes and are charged on every turn.
 SYSTEM_PROMPT_SECTION_POSITIONS = frozenset({"after_memory"})
 DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS = 4_000
-MAX_SYSTEM_PROMPT_SECTION_CHARS = 4_000
 MAX_SYSTEM_PROMPT_SECTIONS = 32
-MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS = 8_000
+
+
+def _system_prompt_section_max_chars() -> int:
+    """Per-section char ceiling; configurable via ``plugins.system_prompt_section_max_chars``."""
+    try:
+        config = load_config_readonly() or {}
+        value = cfg_get(
+            config,
+            "plugins",
+            "system_prompt_section_max_chars",
+            default=DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS,
+        )
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            return DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS
+        return value
+    except Exception:
+        return DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS
+
+
+def _system_prompt_sections_total_chars() -> int:
+    """Aggregate section budget; configurable via ``plugins.system_prompt_sections_total_chars``."""
+    try:
+        config = load_config_readonly() or {}
+        value = cfg_get(
+            config,
+            "plugins",
+            "system_prompt_sections_total_chars",
+            default=8_000,
+        )
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            return 8_000
+        return max(value, _system_prompt_section_max_chars())
+    except Exception:
+        return 8_000
 _SYSTEM_PROMPT_SECTION_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 _SYSTEM_PROMPT_SECTION_HEADING_PREFIX = "## Plugin Context: "
 PLUGIN_SECTIONS_START = "<!-- hermes-plugin-sections:start -->"
@@ -3246,11 +3278,11 @@ class PluginContext:
         if (
             isinstance(max_chars, bool)
             or not isinstance(max_chars, int)
-            or not 0 < max_chars <= MAX_SYSTEM_PROMPT_SECTION_CHARS
+            or not 0 < max_chars <= _system_prompt_section_max_chars()
         ):
             raise ValueError(
                 "system prompt section max_chars must be between 1 and "
-                f"{MAX_SYSTEM_PROMPT_SECTION_CHARS}"
+                f"{_system_prompt_section_max_chars()}"
             )
         existing = self._manager._system_prompt_sections.get(id)
         if existing is not None:
@@ -5590,13 +5622,13 @@ class PluginManager:
             rendered_chars = len(format_system_prompt_section(section.id, text))
             if rendered:
                 rendered_chars += 2  # canonical ``\n\n`` separator
-            if total_chars + rendered_chars > MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS:
+            if total_chars + rendered_chars > _system_prompt_sections_total_chars():
                 logger.warning(
                     "Plugin system prompt section %s (%s) exceeded the aggregate "
                     "session budget (%d chars) and was skipped",
                     section.id,
                     section.plugin,
-                    MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS,
+                    _system_prompt_sections_total_chars(),
                 )
                 continue
             rendered.append(

--- a/test_caps_config.py
+++ b/test_caps_config.py
@@ -1,0 +1,71 @@
+"""Behavioral test for caps→config change (PR-A).
+
+Verifies:
+1. Defaults hold: no config keys → 4000/8000 behavior identical to stock.
+2. Config keys raise ceilings.
+3. Aggregate floor can't undercut per-section ceiling.
+4. Garbage config values fall back to defaults.
+"""
+import os
+import sys
+import tempfile
+
+# Isolated HERMES_HOME so the test never reads the real user config
+_tmp = tempfile.mkdtemp()
+os.environ["HERMES_HOME"] = _tmp
+
+sys.path.insert(0, "/home/wisp/projects/hermes-agent")
+from hermes_cli.plugins import (
+    DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS,
+    _system_prompt_section_max_chars,
+    _system_prompt_sections_total_chars,
+)
+
+failures = []
+
+def check(name, got, want):
+    ok = got == want
+    print(f"{'PASS' if ok else 'FAIL'} {name}: got {got}, want {want}")
+    if not ok:
+        failures.append(name)
+
+# --- 1. defaults (no config file) ---
+check("default per-section", _system_prompt_section_max_chars(), 4_000)
+check("default total", _system_prompt_sections_total_chars(), 8_000)
+
+# --- 2. config raises ceilings ---
+cfg_path = os.path.join(_tmp, "config.yaml")
+with open(cfg_path, "w") as f:
+    f.write(
+        "plugins:\n"
+        "  system_prompt_section_max_chars: 24000\n"
+        "  system_prompt_sections_total_chars: 64000\n"
+    )
+check("config per-section", _system_prompt_section_max_chars(), 24_000)
+check("config total", _system_prompt_sections_total_chars(), 64_000)
+
+# --- 3. aggregate floor >= per-section ---
+with open(cfg_path, "w") as f:
+    f.write(
+        "plugins:\n"
+        "  system_prompt_section_max_chars: 24000\n"
+        "  system_prompt_sections_total_chars: 4000\n"
+    )
+check("total clamped to per-section floor",
+      _system_prompt_sections_total_chars(), 24_000)
+
+# --- 4. garbage values fall back ---
+with open(cfg_path, "w") as f:
+    f.write(
+        "plugins:\n"
+        "  system_prompt_section_max_chars: hello\n"
+        "  system_prompt_sections_total_chars: -5\n"
+    )
+check("garbage per-section falls back", _system_prompt_section_max_chars(), 4_000)
+check("garbage total falls back", _system_prompt_sections_total_chars(), 8_000)
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURES: {failures}")
+    sys.exit(1)
+print("ALL BEHAVIORAL TESTS PASS")


### PR DESCRIPTION
Make system-prompt section size limits configurable

## Why

`register_system_prompt_section()` enforces two hard-coded ceilings:

- `MAX_SYSTEM_PROMPT_SECTION_CHARS = 4000` per section
- `MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS = 8000` aggregate across all sections

These constants have no config surface. Sibling sizing limits in the same
codebase are already user-configurable — `memory.memory_char_limit` and
`memory.user_char_limit` are config keys, not baked constants. The section
caps are the odd one out, and the inconsistency is user-visible: a plugin
author pinning reference material (a persona file, a domain knowledge base,
a campaign ruleset) hits an 8KB aggregate wall that no amount of local
configuration can move. Issue #92774 documents one such real-world case:
six pinned files totalling ~43KB, 84% of which is silently dropped under
stock caps.

The caps exist to bound prompt growth, and that goal is legitimate — this
PR does not raise them for anyone. It moves the *decision* from core
constants to each operator's config, matching how every other sizing knob
in the project already works.

## What changes

One file (`hermes_cli/plugins.py`):

- Two hard-coded constants become two functions that read new optional
  config keys at enforcement time:
  - `plugins.system_prompt_section_max_chars` (default `4000`)
  - `plugins.system_prompt_sections_total_chars` (default `8000`)
- The aggregate budget floors itself at the per-section ceiling, so a
  misconfigured pair (total < per-section) can never produce a state where
  no section can render.
- Invalid values (wrong type, negative, non-int) fall back to defaults.
- `DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS` keeps its name; the removed
  module-level mutable constants had no other importers.

## Compatibility

- **Defaults unchanged:** with no keys set, behavior is byte-identical to
  current releases (verified by test).
- **No API change:** `register_system_prompt_section()` signature untouched.
- **No doc/schema break:** both keys are plain `plugins.*` leaves read via
  `cfg_get`; unrecognized-key warnings don't apply (matches existing
  `plugins.disabled` handling in the same namespace).

## Testing

Behavioral tests included (`test_caps_config.py`, run against an isolated
`HERMES_HOME`):

1. Defaults: unset keys → 4000/8000 (identical to stock)
2. Configured raises: 24000/64000 honored
3. Floor invariant: total < per-section clamps total up to per-section
4. Garbage fallback: non-int / negative values → stock defaults

Closes #92774
