### PR TITLE
fix(update): recycled PIDs no longer fail the fleet check as phantom stale gateways (#93258, salvage #93363)

### DIFF
--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -391,6 +391,12 @@ def collect_fleet_versions(
                 # stop, startup failure, stale record from a long-dead
                 # gateway) keeps the historical no-row behavior so the
                 # feature's rollout can't false-positive.
+                #
+                # ``_pre_restart`` is a bare set of PIDs, not (pid, start_time)
+                # pairs, so a recycled PID from gateway A landing in B's stale
+                # record could still mislabel B as down if A's PID happened to
+                # be in the pre-restart snapshot — inherent to the snapshot's
+                # data model, not something this guard can fix on its own.
                 gw_state = record.get("gateway_state")
                 if (
                     pid in _pre_restart

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -320,7 +320,7 @@ def collect_fleet_versions(
         expected_sha = None
 
     try:
-        from gateway.status import _pid_exists, read_runtime_status
+        from gateway.status import read_runtime_status, runtime_status_pid_is_live
         from hermes_cli.profiles import (
             _get_default_hermes_home,
             _get_profiles_root,
@@ -382,13 +382,15 @@ def collect_fleet_versions(
                 pid = int(pid)
             except (TypeError, ValueError):
                 continue
-            if not _pid_exists(pid):
-                # Dead PID: a DOWN row only when this exact pid was alive at
-                # update start AND the record still claims a running state —
-                # "the restart phase stopped it and nothing came back."
-                # Everything else (clean stop, startup failure, stale record
-                # from a long-dead gateway) keeps the historical no-row
-                # behavior so the feature's rollout can't false-positive.
+            if not runtime_status_pid_is_live(record):
+                # Dead PID (or a live PID recycled by an unrelated process
+                # during the update's own churn — #93258): a DOWN row only
+                # when this exact pid was alive at update start AND the
+                # record still claims a running state — "the restart phase
+                # stopped it and nothing came back." Everything else (clean
+                # stop, startup failure, stale record from a long-dead
+                # gateway) keeps the historical no-row behavior so the
+                # feature's rollout can't false-positive.
                 gw_state = record.get("gateway_state")
                 if (
                     pid in _pre_restart

--- a/tests/hermes_cli/test_fleet_matrix_down_state.py
+++ b/tests/hermes_cli/test_fleet_matrix_down_state.py
@@ -71,6 +71,30 @@ def test_cleanly_stopped_gateway_is_not_down(monkeypatch, tmp_path):
         assert ur.collect_fleet_versions(pre_restart_pids=[_DEAD_PID]) == []
 
 
+def test_recycled_pid_is_not_reported_stale(monkeypatch, tmp_path):
+    """A dead gateway's PID reused by an unrelated process (#93258) must not
+    be reported STALE just because *some* process now answers to that PID.
+    """
+    from gateway.status import _get_process_start_time
+
+    reused_pid = os.getpid()
+    wrong_start_time = (_get_process_start_time(reused_pid) or 0) + 12345
+    _setup(
+        monkeypatch,
+        tmp_path,
+        {
+            "pid": reused_pid,
+            "start_time": wrong_start_time,
+            "gateway_state": "running",
+            "code_sha": "OLDSHA",
+            "kind": "hermes-gateway",
+        },
+    )
+    fleet = ur.collect_fleet_versions(pre_restart_pids=[reused_pid])
+    assert len(fleet) == 1
+    assert fleet[0]["state"] == "down"
+
+
 def test_live_gateway_rows_unchanged(monkeypatch, tmp_path):
     """The live-pid path is untouched by the down-state addition."""
     _setup(

--- a/tests/hermes_cli/test_fleet_matrix_down_state.py
+++ b/tests/hermes_cli/test_fleet_matrix_down_state.py
@@ -95,6 +95,27 @@ def test_recycled_pid_is_not_reported_stale(monkeypatch, tmp_path):
     assert fleet[0]["state"] == "down"
 
 
+def test_matching_start_time_is_still_live(monkeypatch, tmp_path):
+    """A record whose start_time matches the live process is not recycled."""
+    from gateway.status import _get_process_start_time
+
+    pid = os.getpid()
+    _setup(
+        monkeypatch,
+        tmp_path,
+        {
+            "pid": pid,
+            "start_time": _get_process_start_time(pid),
+            "gateway_state": "running",
+            "code_sha": "HEADSHA",
+            "kind": "hermes-gateway",
+        },
+    )
+    fleet = ur.collect_fleet_versions(pre_restart_pids=[pid])
+    assert len(fleet) == 1
+    assert fleet[0]["state"] == "current"
+
+
 def test_live_gateway_rows_unchanged(monkeypatch, tmp_path):
     """The live-pid path is untouched by the down-state addition."""
     _setup(


### PR DESCRIPTION
## Summary

The post-update fleet check no longer reports a recycled PID as a STALE gateway (#93258; salvage of #93363 by @chelsealong, both commits cherry-picked with authorship preserved). When a gateway exits during the update and the OS hands its PID to an unrelated process, `collect_fleet_versions` treated "PID alive" as "gateway alive on old code" and failed the whole update with exit 1 — the reporter hit this on Windows, where PID recycling is aggressive. Fleet relevance (#91277): another source of false update failures on healthy machines, same family as the #95859 boot-window fix.

## Changes

- `hermes_cli/update_receipt.py`: before trusting a state-file PID, the check now verifies process identity — PID **and** recorded `start_time` must both match the live process (the same identity discipline the spawn ledger uses). A live-but-foreign process on the recorded PID yields no row instead of a false STALE. His second commit documents the per-PID data-model gap in `pre_restart_pids` and pins the matching-start_time path.
- New `tests/hermes_cli/test_fleet_matrix_down_state.py` cases (7 total pass).

## Validation

| | Result |
|---|---|
| Suite at head | 22/22 receipt + 7/7 fleet-matrix tests |
| A/B (update_receipt.py reverted to merge-base, tests kept) | `test_recycled_pid_is_not_reported_stale` FAILED — bug shape proven |
| Live E2E | REAL foreign live process (`sleep`) planted on the recorded PID with a mismatched start_time in a real `gateway_state.json`: merge-base semantics would read it as a gateway; at head it yields no stale row |

**Live repro:** the E2E above — real process, real state file, no mocks on the identity path.

Fixes #93258. Credit: @chelsealong.

## Infographic

![Not the same process](https://files.catbox.moe/4b2yjx.png)
