### PR TITLE
fix(tools): reject directory targets in open_preview (#95853)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -33,3 +33,60 @@ def test_emitter_failure_is_reported():
 
     desktop_ui.set_emitter(_boom)
     assert "no window" in json.loads(op.open_preview_tool("https://x.example"))["error"]
+
+
+def _capture_emits():
+    emitted: list = []
+
+    def _emit(_sid, event, payload):
+        emitted.append((event, payload))
+
+    desktop_ui.set_emitter(_emit)
+    return emitted
+
+
+def test_existing_directory_is_an_error_not_success(tmp_path):
+    """#95853: a directory must not report success while opening nothing."""
+    emitted = _capture_emits()
+    folder = tmp_path / "Active"
+    folder.mkdir()
+
+    result = json.loads(op.open_preview_tool(str(folder)))
+
+    assert "error" in result
+    assert "director" in result["error"].lower()
+    assert result.get("success") is not True
+    assert emitted == []
+
+
+def test_existing_file_still_opens(tmp_path):
+    emitted = _capture_emits()
+    path = tmp_path / "notes.md"
+    path.write_text("hi", encoding="utf-8")
+
+    result = json.loads(op.open_preview_tool(str(path)))
+
+    assert result["success"] is True
+    assert result["url"] == str(path)
+    assert emitted == [("preview.open", {"url": str(path), "label": ""})]
+
+
+def test_https_url_is_not_treated_as_a_directory():
+    emitted = _capture_emits()
+    result = json.loads(op.open_preview_tool("https://example.com/docs"))
+
+    assert result["success"] is True
+    assert emitted[0][0] == "preview.open"
+
+
+def test_file_uri_directory_is_an_error(tmp_path):
+    emitted = _capture_emits()
+    folder = tmp_path / "docs"
+    folder.mkdir()
+    uri = folder.resolve().as_uri()
+
+    result = json.loads(op.open_preview_tool(uri))
+
+    assert "error" in result
+    assert "director" in result["error"].lower()
+    assert emitted == []

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -90,3 +90,14 @@ def test_file_uri_directory_is_an_error(tmp_path):
     assert "error" in result
     assert "director" in result["error"].lower()
     assert emitted == []
+
+
+def test_missing_path_still_emits(tmp_path):
+    """Reject only existing directories — a missing path is the renderer's call."""
+    emitted = _capture_emits()
+    missing = tmp_path / "no-such-folder"
+
+    result = json.loads(op.open_preview_tool(str(missing)))
+
+    assert result["success"] is True
+    assert emitted == [("preview.open", {"url": str(missing), "label": ""})]

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -66,6 +66,9 @@ def _is_existing_directory(target: str) -> bool:
     try:
         return path.is_dir()
     except OSError:
+        # Stat failed (permissions, broken reparse, etc.). Do not treat that
+        # as "this is a directory" — reject only when we positively observe
+        # an existing directory. The renderer still sees the original target.
         return False
 
 

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -10,7 +10,10 @@ steals focus for a background session.
 """
 
 import json
+import os
 import re
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from tools import desktop_ui
 from tools.registry import registry, tool_error
@@ -33,6 +36,39 @@ def _normalize_target(raw: str) -> str:
     return v
 
 
+def _local_fs_path(target: str) -> Path | None:
+    """Return a filesystem path for local targets; None for http(s) URLs."""
+    raw = (target or "").strip()
+    if not raw:
+        return None
+    if "://" in raw:
+        parsed = urlparse(raw)
+        if parsed.scheme.lower() != "file":
+            return None
+        path = unquote(parsed.path or "")
+        if parsed.netloc and parsed.netloc not in {"", "localhost"}:
+            path = f"//{parsed.netloc}{path}"
+        elif (
+            os.name == "nt"
+            and len(path) >= 3
+            and path[0] == "/"
+            and path[2] == ":"
+        ):
+            path = path[1:]
+        return Path(path) if path else None
+    return Path(raw).expanduser()
+
+
+def _is_existing_directory(target: str) -> bool:
+    path = _local_fs_path(target)
+    if path is None:
+        return False
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def open_preview_tool(url: str, label: str = "") -> str:
     """Ask the desktop GUI to show ``url`` in the preview pane beside the chat."""
     target = _normalize_target(url or "")
@@ -40,6 +76,11 @@ def open_preview_tool(url: str, label: str = "") -> str:
         return tool_error(
             "url is required — a web URL (https://…), a localhost dev server, or a "
             "file path to show in the preview pane."
+        )
+    if _is_existing_directory(target):
+        return tool_error(
+            "directories are not previewable — pass a file path or a URL. "
+            f"{target} is a directory."
         )
 
     label = (label or "").strip()


### PR DESCRIPTION
## Summary

`open_preview` on an existing directory returned `success: true` and emitted `preview.open`, while the desktop preview pane opened nothing. Agents could not tell the call failed.

This PR fail-closes that path: existing directories return an explicit error and do **not** emit. HTTP(S) URLs and regular files are unchanged.

Directory listing in the pane is out of scope (issue option 1). This is issue option 2.

## Test Plan

- [x] `pytest tests/tools/test_open_preview_tool.py` — 6 passed (watched directory case fail before the guard)
- [x] Sibling preview tools: `test_desktop_ui.py`, `test_close_preview_tool.py`, `test_drive_preview_tool.py`, `test_annotate_preview_tool.py` — 37 passed
- [x] ruff clean

Closes #95853

## Verification Summary

- Check 1: PASS — `open_preview_tool.py`, tests, attribution only
- Check 2: PASS — only `open_preview` emits `preview.open`; sibling preview tests run
- Check 3: PASS — close/drive/annotate do not open paths; no other false-success sibling
- Check 4: PASS — native dir, `file:` URI dir, regular file, https URL; `OSError` on `is_dir` does not reject
- Check 5: PASS — branched from current `upstream/main`
- Check 6: PASS — would approve. Known limit: tool schema blurb still describes files/URLs only (error text is explicit)