### PR TITLE
fix(desktop): prevent Bots home flash during bot switches

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5618,6 +5618,24 @@ const canonicalCreations = new Map()
  *  adoption, stored-session lookups). */
 const PROFILE_SESSION_LIST_LIMIT = 200
 let botOpenGeneration = 0
+let botOpenInFlight = 0
+
+function beginBotOpen() {
+  const generation = ++botOpenGeneration
+  botOpenInFlight = generation
+  return generation
+}
+
+function finishBotOpen(generation) {
+  if (botOpenInFlight === generation) {
+    botOpenInFlight = 0
+  }
+}
+
+function cancelBotOpen() {
+  botOpenGeneration += 1
+  botOpenInFlight = 0
+}
 
 /** The one canonical title. (profile, CANONICAL_CHAT_TITLE) IS the bot's
  *  forever-chat identity — see the header above. */
@@ -6013,7 +6031,7 @@ async function ensureBotMetadata(bot) {
  *  remembers only this transient opened-view observation; it never stores or
  *  resolves a canonical-chat id. */
 async function openRosterBot(bot) {
-  const generation = ++botOpenGeneration
+  const generation = beginBotOpen()
   const key = botRosterKey(bot)
   const meta = botRosterMeta(bot, $botMeta.get())
   // Keep the currently visible group as a fallback until this explicit action
@@ -6066,6 +6084,7 @@ async function openRosterBot(bot) {
     await prepareBotSource(bot)
   } catch (error) {
     if (generation === botOpenGeneration) {
+      finishBotOpen(generation)
       $openBotChat.set(null)
       restorePreviousGroup()
       syncBotsHomeWorkspace()
@@ -6077,6 +6096,7 @@ async function openRosterBot(bot) {
   }
 
   if (generation !== botOpenGeneration) {
+    finishBotOpen(generation)
     return false
   }
 
@@ -6084,6 +6104,7 @@ async function openRosterBot(bot) {
     const opened = await openBotCanonicalChat(bot, () => generation === botOpenGeneration)
 
     if (generation !== botOpenGeneration) {
+      finishBotOpen(generation)
       return false
     }
 
@@ -6101,11 +6122,13 @@ async function openRosterBot(bot) {
         openedRegistryId: opened.registryId,
         openedSessionId: opened.openedId
       })
+      finishBotOpen(generation)
       closeBotsHomeWorkspace()
       return true
     }
   } catch (error) {
     if (generation === botOpenGeneration) {
+      finishBotOpen(generation)
       $openBotChat.set(null)
       restorePreviousGroup()
       syncBotsHomeWorkspace()
@@ -6119,6 +6142,7 @@ async function openRosterBot(bot) {
   // An older Desktop without the profile-scoped draft API has no safe fallback:
   // do not navigate the current workspace or create a draft on the wrong owner.
   if (typeof host.newChat !== 'function') {
+    finishBotOpen(generation)
     $openBotChat.set(null)
     restorePreviousGroup()
     syncBotsHomeWorkspace()
@@ -6126,6 +6150,7 @@ async function openRosterBot(bot) {
   }
 
   $openBotChat.set({ key, openedRegistryId: '' })
+  finishBotOpen(generation)
   closeBotsHomeWorkspace()
   newBotChat(bot)
   return true
@@ -13983,6 +14008,7 @@ function botsHomeMayOpen(explicit) {
     $botsPaneVisible.get() &&
     !$groupChatWorkspace.get() &&
     !$openBotChat.get() &&
+    !botOpenInFlight &&
     (explicit || !sessionOwnsWorkspace())
   )
 }
@@ -14151,7 +14177,7 @@ function openGroupChat(group) {
   // A room selection supersedes any bot-open transition still hydrating.
   // The in-flight host navigation may complete underneath this workspace,
   // but it may not later close or visually steal the room the user chose.
-  botOpenGeneration += 1
+  cancelBotOpen()
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
   const ownerKey = groupWorkspaceOwnerKey(group)
   setBotsWorkspaceOwner(ownerKey, null, 'New group conversations start in the group composer.')
@@ -15498,7 +15524,7 @@ export default {
           // workspace token too; this plugin generation prevents that expected
           // cancellation from repainting Bots home or showing an error after
           // the user deliberately returned to Sessions.
-          botOpenGeneration += 1
+          cancelBotOpen()
           host.setWorkspaceScope?.('sessions')
         }
         // A generic composer has no stored-session owner, so passive sync

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
@@ -715,6 +715,51 @@ test('a failed local open cannot re-register a group tombstoned after retirement
   assert.equal(t.$openBotChat.get(), null)
 })
 
+test('switching bots does not let the home cover the current chat while the next chat opens', async () => {
+  const t = load({ focusedStoredSessionId: 'chat-alpha' })
+  t.setPluginCtx({ storage: { set: () => undefined } })
+  t.$botsPaneVisible.set(true)
+  t.$openBotChat.set({
+    key: 'local::alpha',
+    openedRegistryId: 'chat-alpha',
+    openedSessionId: 'chat-alpha'
+  })
+  t.host.request = async method => {
+    if (method === 'session.list') {
+      return { sessions: [{ id: 'chat-beta', title: 'Bot Chat', message_count: 4 }] }
+    }
+
+    return {}
+  }
+
+  let finishOpen
+  let markOpenStarted
+  const openStarted = new Promise(resolve => {
+    markOpenStarted = resolve
+  })
+  t.host.openSession = () =>
+    new Promise(resolve => {
+      finishOpen = resolve
+      markOpenStarted()
+    })
+
+  const opening = t.openRosterBot({ connectionId: 'local', name: 'beta' })
+  await openStarted
+
+  // The destination focus edge releases the old chat claim before the async
+  // open has returned its replacement claim. Passive workspace reconciliation
+  // must not use that handoff gap to put Bots home in front.
+  t.focused.set(null)
+  t.releaseStaleOpenBotChat(null)
+  t.syncBotsHomeWorkspace()
+
+  assert.equal(t.opened.some(entry => entry.id === 'hermes-bots:home'), false)
+
+  finishOpen()
+  assert.equal(await opening, true)
+  assert.equal(t.$openBotChat.get()?.openedRegistryId, 'chat-beta')
+})
+
 test('choosing a group prevents a stale canonical-chat open from closing it later', async () => {
   const t = load()
   t.setPluginCtx({ storage: { set: () => undefined } })


### PR DESCRIPTION
## What does this PR do?

Prevents the Bots home workspace from flashing in front of the current chat while a different bot's canonical chat is still opening.

A bot switch now owns the handoff from the moment source preparation begins until the destination chat succeeds, fails, or is canceled. Passive workspace reconciliation cannot open Bots home during that interval. The guard is generation-scoped so an older async completion cannot clear a newer switch, and choosing a group or leaving Bot Mode cancels it immediately.

This is the remaining pre-open handoff gap after #92901. It is related to but not covered by #95838, which changes which already-open tab a roster click selects. Both touch openRosterBot and may need a small consolidation or rebase if #95838 lands first.

## Related Issue

Related: #92901, #95838

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added a generation-scoped in-flight bot-open guard in apps/desktop/src/plugins/hermes-bots/plugin.js.
- Prevented Bots home from opening during an active bot-chat handoff.
- Cleared the guard on success, failure, supersession, group selection, and Bot Mode exit.
- Added a regression that releases the old chat focus while the destination open is pending and verifies Bots home never fronts.

## How to Test

1. From apps/desktop, run: node --test src/plugins/hermes-bots/tests/bots-home.test.mjs src/plugins/hermes-bots/tests/bots-home-refront-loop.test.mjs src/plugins/hermes-bots/tests/bot-open-focus-identity.test.mjs
2. Confirm all 57 focused Bot Mode tests pass.
3. Start on one bot chat, switch to another bot while its chat is resolving, and confirm the current chat remains visible until the destination chat opens.

Local result: 57 passed, 0 failed on Windows 11.

Typecheck was not run locally because the clean worktree has no installed node_modules. CI remains the authoritative TypeScript check.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass (not applicable to this Desktop-only JavaScript change; no Python tests were run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) - N/A, no user-facing workflow changed
- [x] I've updated cli-config.yaml.example if I added/changed config keys - N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - renderer-only state logic, no platform-specific path
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The regression test models the exact focus handoff: the previous bot claim is released while the destination open remains pending, then workspace reconciliation is run before the destination resolves. No Bots home workspace is opened during that gap.