### PR TITLE
fix(tui): keep edited recalled prompts from being lost

### DIFF
--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -7,6 +7,7 @@ import {
   handleIdleHotkeyExit,
   resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
+  shouldDetachEditedHistoryInput,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
 
@@ -57,6 +58,22 @@ describe('shouldAllowIdleHotkeyExit', () => {
 
   it('disables idle exit hotkeys in dashboard chat', () => {
     expect(shouldAllowIdleHotkeyExit(true)).toBe(false)
+  })
+})
+
+describe('shouldDetachEditedHistoryInput', () => {
+  const history = ['older message', 'line one\nline two']
+
+  it('detaches a recalled entry as soon as the user edits it', () => {
+    expect(shouldDetachEditedHistoryInput(1, history, 'line one edited\nline two')).toBe(true)
+  })
+
+  it('keeps unchanged recalled entries in history navigation', () => {
+    expect(shouldDetachEditedHistoryInput(1, history, 'line one\nline two')).toBe(false)
+  })
+
+  it('does not detach an ordinary current draft', () => {
+    expect(shouldDetachEditedHistoryInput(null, history, 'new draft')).toBe(false)
   })
 })
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -167,6 +167,10 @@ export function dismissSensitivePrompt(
 
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
 
+export function shouldDetachEditedHistoryInput(historyIdx: null | number, history: readonly string[], value: string) {
+  return historyIdx !== null && value !== history[historyIdx]
+}
+
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const { actions, composer, gateway, terminal, voice, wheelStep } = ctx
   const { actions: cActions, refs: cRefs, state: cState } = composer

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -60,7 +60,7 @@ import { $uiState, getUiState, patchUiState } from './uiStore.js'
 import { useBatteryPoll } from './useBatteryPoll.js'
 import { useComposerState } from './useComposerState.js'
 import { useConfigSync } from './useConfigSync.js'
-import { useInputHandlers } from './useInputHandlers.js'
+import { shouldDetachEditedHistoryInput, useInputHandlers } from './useInputHandlers.js'
 import { useLongRunToolCharms } from './useLongRunToolCharms.js'
 import { useSessionLifecycle } from './useSessionLifecycle.js'
 import { useSubmission } from './useSubmission.js'
@@ -1199,10 +1199,15 @@ export function useMainApp(gw: GatewayClient) {
 
         composerActions.syncTokens(value)
 
+        if (shouldDetachEditedHistoryInput(composerState.historyIdx, composerRefs.historyRef.current, value)) {
+          composerRefs.historyDraftRef.current = value
+          composerActions.setHistoryIdx(null)
+        }
+
         return value
       })
     },
-    [composerActions]
+    [composerActions, composerRefs, composerState.historyIdx]
   )
 
   const appComposer = useMemo(


### PR DESCRIPTION
## What does this PR do?

Editing a recalled TUI history entry now promotes the changed text to the current draft immediately. This prevents Down-arrow history navigation from replacing unsubmitted multiline edits while leaving unchanged entries navigable through history.

The composer previously retained the recalled entry's history index after text changes. A later Down press therefore entered the history-navigation branch and replaced the edited text. The input update path now detects the first difference from the recalled entry, saves that value as the current history draft, and clears the history index.

## Related Issue

Closes #95912

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/useInputHandlers.ts` - add the edited-history detachment predicate.
- `ui-tui/src/app/useMainApp.ts` - promote changed recalled input to the current draft during text updates.
- `ui-tui/src/__tests__/useInputHandlers.test.ts` - cover edited, unchanged, and ordinary draft states.

## How to Test

1. Recall a previously submitted multiline prompt with Up.
2. Edit the recalled text, then press Down past its final line.
3. Confirm the edited text remains in the composer instead of being replaced by another history entry.
4. Run the focused regression test and TUI typecheck:

```bash
cd ui-tui
npm test -- src/__tests__/useInputHandlers.test.ts
npm run typecheck
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Vitest test and TypeScript typecheck, and both pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior is covered by tests and the existing TUI history interaction
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the state transition is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

Focused regression test: 23 passed. TypeScript typecheck completed successfully.
