### PR TITLE
fix(desktop): stop unresumable sessions from waking forever

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
@@ -10,10 +10,24 @@ import { resumeStoredRuntimeSession, SessionRecoveryAborted, withSessionNotFound
 
 afterEach(() => {
   clearSingleFlightSessionResumeState()
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
 describe('singleFlightSessionResume', () => {
+  it('allows a valid resume to settle inside the ordinary gateway request budget', async () => {
+    vi.useFakeTimers()
+
+    const flight = singleFlightSessionResume(
+      'stored-slow',
+      () => new Promise<string>(resolve => setTimeout(() => resolve('runtime-slow'), 25_000))
+    )
+
+    await vi.advanceTimersByTimeAsync(25_000)
+
+    await expect(flight).resolves.toBe('runtime-slow')
+  })
+
   it('two concurrent resume callers for the same stored id produce ONE session.resume RPC', async () => {
     const requestGateway = vi.fn(async (method: string) => {
       expect(method).toBe('session.resume')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -21,7 +21,10 @@ const _inFlightResumeByStoredSessionId = new Map<string, Promise<unknown>>()
 // deadline therefore belongs here too: a caller that joins an older wedged
 // flight must inherit the same bounded settlement and identity-safe eviction,
 // rather than depending on whichever surface happened to create the flight.
-const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 20_000
+// Keep this beyond HermesGateway's ordinary 30s request budget. The transport
+// should get the first chance to settle or reject a valid resume; this outer
+// deadline only breaks flights from non-standard callers that never settle.
+const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 35_000
 
 export function singleFlightSessionResume<T>(storedSessionId: string, run: () => Promise<T>): Promise<T> {
   const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -13,7 +13,15 @@
  * `session_id`); joiners receive whatever the winning call returns.
  */
 
+import { withTimeout } from '@/lib/with-timeout'
+
 const _inFlightResumeByStoredSessionId = new Map<string, Promise<unknown>>()
+
+// Every session.resume entry point converges on this module-level flight. The
+// deadline therefore belongs here too: a caller that joins an older wedged
+// flight must inherit the same bounded settlement and identity-safe eviction,
+// rather than depending on whichever surface happened to create the flight.
+const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 20_000
 
 export function singleFlightSessionResume<T>(storedSessionId: string, run: () => Promise<T>): Promise<T> {
   const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)
@@ -25,8 +33,11 @@ export function singleFlightSessionResume<T>(storedSessionId: string, run: () =>
   // Promise.resolve().then(run) tolerates run() being synchronous, returning a
   // bare value, or throwing synchronously (test doubles and legacy callers do
   // all three) — a raw run().finally() would crash on a non-promise return.
-  const flight = Promise.resolve()
-    .then(run)
+  const flight = withTimeout(
+    Promise.resolve().then(run),
+    SESSION_RESUME_SETTLEMENT_TIMEOUT_MS,
+    `Timed out resuming session ${storedSessionId}`
+  )
     .finally(() => {
       if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
         _inFlightResumeByStoredSessionId.delete(storedSessionId)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -832,6 +832,7 @@ function ResumeTimerHarness({
 describe('resumeSession failure recovery', () => {
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
     setMessages([])
@@ -997,6 +998,66 @@ describe('resumeSession failure recovery', () => {
     // The window is no longer silently stranded: the failure latch is armed for
     // the stored session, which use-route-resume consumes to retry.
     expect($resumeFailedSessionId.get()).toBe('stored-1')
+  })
+
+  it('times out a never-settling resume and releases the single-flight for retry', async () => {
+    vi.useFakeTimers()
+
+    let resumeCalls = 0
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method !== 'session.resume') {
+        return {} as never
+      }
+
+      resumeCalls += 1
+
+      if (resumeCalls === 1) {
+        return new Promise<never>(() => undefined)
+      }
+
+      return {
+        info: {},
+        message_count: 0,
+        messages: [],
+        messages_omitted: true,
+        resumed: 'stored-1',
+        running: false,
+        session_id: 'runtime-retry',
+        session_key: 'stored-1'
+      } as never
+    })
+
+    // The initial prefetch and post-timeout fallback both fail, matching an
+    // unresumable/unreachable row whose RPC never settles.
+    vi.mocked(getLatestSessionMessages).mockRejectedValue(new Error('network down'))
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={requestGateway} />)
+    expect(resume).not.toBeNull()
+
+    let firstResume!: Promise<unknown>
+    await act(async () => {
+      firstResume = resume!('stored-1', true)
+      await vi.advanceTimersByTimeAsync(20_000)
+      await firstResume
+    })
+
+    expect($resumeFailedSessionId.get()).toBe('stored-1')
+    expect(resumeCalls).toBe(1)
+
+    // The timeout rejects INSIDE singleFlightSessionResume, so its finally
+    // removes the stale flight. A later retry must dispatch a fresh RPC rather
+    // than rejoin the permanently pending first request.
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-1' } as never)
+
+    await act(async () => {
+      await resume!('stored-1', true)
+    })
+
+    expect(resumeCalls).toBe(2)
+    expect($activeSessionId.get()).toBe('runtime-retry')
+    expect($resumeFailedSessionId.get()).toBeNull()
   })
 
   it('does NOT arm the failure latch when the resume RPC fails but the REST fallback paints history', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -79,6 +79,7 @@ import { deferred } from '../../../test/deferred'
 import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
+import { singleFlightSessionResume } from './use-prompt-actions/single-flight-resume'
 import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
 
@@ -1000,7 +1001,7 @@ describe('resumeSession failure recovery', () => {
     expect($resumeFailedSessionId.get()).toBe('stored-1')
   })
 
-  it('times out a never-settling resume and releases the single-flight for retry', async () => {
+  it('times out when joining an earlier never-settling resume and releases the shared flight for retry', async () => {
     vi.useFakeTimers()
 
     let resumeCalls = 0
@@ -1011,10 +1012,6 @@ describe('resumeSession failure recovery', () => {
       }
 
       resumeCalls += 1
-
-      if (resumeCalls === 1) {
-        return new Promise<never>(() => undefined)
-      }
 
       return {
         info: {},
@@ -1032,6 +1029,12 @@ describe('resumeSession failure recovery', () => {
     // unresumable/unreachable row whose RPC never settles.
     vi.mocked(getLatestSessionMessages).mockRejectedValue(new Error('network down'))
 
+    // Another resume surface wins the module-level flight before the route
+    // resolver starts. The resolver must still inherit the shared deadline;
+    // putting a timeout only inside its callback cannot bound this join path.
+    const earlierFlight = singleFlightSessionResume('stored-1', () => new Promise<never>(() => undefined))
+    earlierFlight.catch(() => undefined)
+
     let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
     render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={requestGateway} />)
     expect(resume).not.toBeNull()
@@ -1044,18 +1047,17 @@ describe('resumeSession failure recovery', () => {
     })
 
     expect($resumeFailedSessionId.get()).toBe('stored-1')
-    expect(resumeCalls).toBe(1)
+    expect(resumeCalls).toBe(0)
 
-    // The timeout rejects INSIDE singleFlightSessionResume, so its finally
-    // removes the stale flight. A later retry must dispatch a fresh RPC rather
-    // than rejoin the permanently pending first request.
+    // The shared timeout removes exactly the stale flight. A later retry must
+    // dispatch a fresh RPC rather than rejoin the permanently pending request.
     vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-1' } as never)
 
     await act(async () => {
       await resume!('stored-1', true)
     })
 
-    expect(resumeCalls).toBe(2)
+    expect(resumeCalls).toBe(1)
     expect($activeSessionId.get()).toBe('runtime-retry')
     expect($resumeFailedSessionId.get()).toBeNull()
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1042,7 +1042,7 @@ describe('resumeSession failure recovery', () => {
     let firstResume!: Promise<unknown>
     await act(async () => {
       firstResume = resume!('stored-1', true)
-      await vi.advanceTimersByTimeAsync(20_000)
+      await vi.advanceTimersByTimeAsync(35_000)
       await firstResume
     })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -18,7 +18,6 @@ import {
 } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
-import { withTimeout } from '@/lib/with-timeout'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
@@ -180,13 +179,6 @@ interface SessionActionsOptions {
 // bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
-
-// `requestGateway` normally settles `session.resume` quickly because Desktop
-// asks the gateway for a deferred-history acknowledgement. Keep a client-side
-// deadline anyway: a transport/dispatcher wedge can otherwise leave the
-// promise pending forever, so the catch below never arms the existing bounded
-// retry ladder and the window stays on "Waking up…" indefinitely (#95910).
-const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 20_000
 
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
@@ -1399,25 +1391,21 @@ export function useSessionActions({
         const resumeStartedAt = Date.now() / 1000
 
         const resumePromise = singleFlightSessionResume(storedSessionId, () =>
-          withTimeout(
-            requestForSession<SessionResumeResponse>('session.resume', {
-              session_id: storedSessionId,
-              cols: 96,
-              source: 'desktop',
-              defer_history: !watchWindow,
-              // REST is the transcript authority for Desktop. Avoid duplicating a
-              // potentially huge compression lineage in the WebSocket response.
-              // Watch windows attach lazily (live mirror). Every other cold resume
-              // gets the gateway's default deferred build: the RPC returns the
-              // transcript immediately instead of blocking the switch on _make_agent
-              // (MCP discovery / prompt build), and the agent pre-warms in the
-              // background while the prefetch above paints the transcript.
-              ...(watchWindow ? { lazy: true } : { omit_messages: true }),
-              ...(sessionProfile ? { profile: sessionProfile } : {})
-            }),
-            SESSION_RESUME_SETTLEMENT_TIMEOUT_MS,
-            `Timed out resuming session ${storedSessionId}`
-          )
+          requestForSession<SessionResumeResponse>('session.resume', {
+            session_id: storedSessionId,
+            cols: 96,
+            source: 'desktop',
+            defer_history: !watchWindow,
+            // REST is the transcript authority for Desktop. Avoid duplicating a
+            // potentially huge compression lineage in the WebSocket response.
+            // Watch windows attach lazily (live mirror). Every other cold resume
+            // gets the gateway's default deferred build: the RPC returns the
+            // transcript immediately instead of blocking the switch on _make_agent
+            // (MCP discovery / prompt build), and the agent pre-warms in the
+            // background while the prefetch above paints the transcript.
+            ...(watchWindow ? { lazy: true } : { omit_messages: true }),
+            ...(sessionProfile ? { profile: sessionProfile } : {})
+          })
         ).then(resumed => {
           resumeRuntimeBaselineMessages =
             sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { withTimeout } from '@/lib/with-timeout'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
@@ -179,6 +180,13 @@ interface SessionActionsOptions {
 // bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
+
+// `requestGateway` normally settles `session.resume` quickly because Desktop
+// asks the gateway for a deferred-history acknowledgement. Keep a client-side
+// deadline anyway: a transport/dispatcher wedge can otherwise leave the
+// promise pending forever, so the catch below never arms the existing bounded
+// retry ladder and the window stays on "Waking up…" indefinitely (#95910).
+const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 20_000
 
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
@@ -1391,21 +1399,25 @@ export function useSessionActions({
         const resumeStartedAt = Date.now() / 1000
 
         const resumePromise = singleFlightSessionResume(storedSessionId, () =>
-          requestForSession<SessionResumeResponse>('session.resume', {
-            session_id: storedSessionId,
-            cols: 96,
-            source: 'desktop',
-            defer_history: !watchWindow,
-            // REST is the transcript authority for Desktop. Avoid duplicating a
-            // potentially huge compression lineage in the WebSocket response.
-            // Watch windows attach lazily (live mirror). Every other cold resume
-            // gets the gateway's default deferred build: the RPC returns the
-            // transcript immediately instead of blocking the switch on _make_agent
-            // (MCP discovery / prompt build), and the agent pre-warms in the
-            // background while the prefetch above paints the transcript.
-            ...(watchWindow ? { lazy: true } : { omit_messages: true }),
-            ...(sessionProfile ? { profile: sessionProfile } : {})
-          })
+          withTimeout(
+            requestForSession<SessionResumeResponse>('session.resume', {
+              session_id: storedSessionId,
+              cols: 96,
+              source: 'desktop',
+              defer_history: !watchWindow,
+              // REST is the transcript authority for Desktop. Avoid duplicating a
+              // potentially huge compression lineage in the WebSocket response.
+              // Watch windows attach lazily (live mirror). Every other cold resume
+              // gets the gateway's default deferred build: the RPC returns the
+              // transcript immediately instead of blocking the switch on _make_agent
+              // (MCP discovery / prompt build), and the agent pre-warms in the
+              // background while the prefetch above paints the transcript.
+              ...(watchWindow ? { lazy: true } : { omit_messages: true }),
+              ...(sessionProfile ? { profile: sessionProfile } : {})
+            }),
+            SESSION_RESUME_SETTLEMENT_TIMEOUT_MS,
+            `Timed out resuming session ${storedSessionId}`
+          )
         ).then(resumed => {
           resumeRuntimeBaselineMessages =
             sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages


### PR DESCRIPTION
## What does this PR do?

Resuming an ended or otherwise unresumable Desktop session can leave the chat on "Waking up..." forever when `session.resume` never settles. The existing retry and Retry-UI ladder only arms after rejection, so this change gives the resume acknowledgement a 20-second deadline and routes timeout through the existing bounded recovery path.

### Symptom

Clicking an affected stored session can leave Desktop showing "Waking up..." indefinitely, with no error or Retry action.

### Impact

The selected conversation remains inaccessible for the lifetime of the window unless another external event recovers the connection.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` / the cold `resumeSession` path awaiting `session.resume`.

**Causal chain:**
1. Desktop selects a stored session and dispatches `session.resume`.
2. A transport or dispatcher failure leaves that RPC pending rather than resolved or rejected.
3. The catch block never runs, `$resumeFailedSessionId` never arms, and the existing bounded retry ladder cannot reach its terminal Retry UI.

**Why it is wrong:** A recovery path that depends only on explicit rejection has no terminal state for a permanently pending request.

**Working sibling / contrast:** Explicit RPC rejection already enters the fallback and bounded retry path correctly.

**Ruled out:** Increasing gateway build time is not the cause on this path. Desktop requests `defer_history`, so the gateway normally acknowledges before agent construction and hydrates history in the background.

### Fix

Wrap the cold `session.resume` request in the existing `withTimeout` helper inside the stored-session single-flight. A timeout now rejects the flight, lets its `finally` remove the stale entry, and reaches the existing REST fallback and retry latch. The regression test proves both terminal failure arming and a fresh RPC on the next retry.

## Related Issue

Closes #95910

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` - bound cold `session.resume` settlement and feed timeout into the existing recovery ladder.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx` - cover a never-settling RPC, failure-latch arming, and fresh single-flight retry.

## How to Test

1. Run the focused resume suites:

```bash
cd apps/desktop
npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
```

2. Run renderer typechecking and linting:

```bash
npx tsc -p tsconfig.json --noEmit
npx eslint src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-session-actions.test.tsx
```

3. Verified locally: 106 focused tests passed; typecheck and lint passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] N/A for Python pytest; the relevant Desktop Vitest suites pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing contract or configuration changed
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - renderer timers and Promises are platform-neutral
- [x] Tool descriptions/schemas: N/A - no tool behavior changed

## Screenshots / Logs

N/A - automated coverage reproduces the never-settling Promise and verifies the recovery transition.
