### PR TITLE
fix(state): resume display history must include compaction-archived rows

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11490,41 +11490,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     [session_id],
                 )
                 all_rows = cursor.fetchall()
-            seen: dict = {}
-            for row in all_rows:
-                dedupe_content = row["content"]
-                if row["role"] == "user":
-                    from agent.context_compressor import split_user_originated_turn
-
-                    candidate = {
-                        "role": "user",
-                        "content": self._decode_content(row["content"]),
-                        "display_kind": row["display_kind"],
-                        "display_metadata": self._decode_display_metadata(
-                            row["display_metadata"]
-                        ),
-                    }
-                    handoff, live_view = split_user_originated_turn(candidate)
-                    if handoff is not None and live_view is not None:
-                        dedupe_content = self._encode_content(
-                            live_view.get("content")
-                        )
-                # Tool fields participate in the dedupe key: compaction copies
-                # them verbatim, so identical tool messages across generations
-                # still collapse, while distinct tool calls that happen to
-                # share role/content/timestamp are never merged.
-                key = (
-                    row["role"],
-                    dedupe_content,
-                    row["timestamp"],
-                    row["tool_call_id"],
-                    row["tool_calls"],
-                    row["tool_name"],
-                )
-                cur = seen.get(key)
-                if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
-                    seen[key] = row
-            rows = sorted(seen.values(), key=lambda r: r["id"])
+            rows = self._dedupe_compacted_display_rows(all_rows)
             if latest:
                 rows = rows[::-1]
             rows = rows[offset:]
@@ -11815,6 +11781,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_row_ids=include_row_ids,
         )
 
+    def _dedupe_compacted_display_rows(self, rows) -> List[Dict[str, Any]]:
+        """Collapse cross-generation copies of the same logical message.
+
+        Compaction epochs copy the protected tail into each new generation,
+        so the same logical message can exist as several rows (identical
+        role/content/timestamp) with different active flags and ids. A
+        display read must surface each message exactly once: prefer the live
+        row, then the newest generation. Shared by the ``include_compacted``
+        branch of :meth:`get_messages` and the display projection of
+        :meth:`get_resume_conversations` so both display surfaces apply the
+        SAME dedupe semantics — a resume and a paged REST read of the same
+        compacted session must agree on what the transcript shows. ``rows``
+        must carry ``active`` and ``content`` (either SELECT satisfies this).
+        """
+        seen: dict = {}
+        for row in rows:
+            dedupe_content = row["content"]
+            if row["role"] == "user":
+                from agent.context_compressor import split_user_originated_turn
+
+                candidate = {
+                    "role": "user",
+                    "content": self._decode_content(row["content"]),
+                    "display_kind": row["display_kind"],
+                    "display_metadata": self._decode_display_metadata(
+                        row["display_metadata"]
+                    ),
+                }
+                handoff, live_view = split_user_originated_turn(candidate)
+                if handoff is not None and live_view is not None:
+                    dedupe_content = self._encode_content(
+                        live_view.get("content")
+                    )
+            # Tool fields participate in the dedupe key: compaction copies
+            # them verbatim, so identical tool messages across generations
+            # still collapse, while distinct tool calls that happen to
+            # share role/content/timestamp are never merged.
+            key = (
+                row["role"],
+                dedupe_content,
+                row["timestamp"],
+                row["tool_call_id"],
+                row["tool_calls"],
+                row["tool_name"],
+            )
+            cur = seen.get(key)
+            if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
+                seen[key] = row
+        return sorted(seen.values(), key=lambda r: r["id"])
+
     # Columns every conversation projection decodes. Shared by
     # get_messages_as_conversation and get_resume_conversations so a single
     # SELECT can feed both the model-fed and display views.
@@ -12028,7 +12044,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           (the live-replay working conversation). Equivalent to
           ``get_messages_as_conversation(session_id, repair_alternation=True)``.
         - ``display_history`` — the full compression lineage (ancestors → tip),
-          verbatim, with replayed-user dedup. Explicit ``/branch`` sessions are
+          verbatim, with replayed-user dedup, INCLUDING rows preserved by
+          in-place compaction (``active=0, compacted=1``): without them the
+          transcript silently ends at the compaction boundary and earlier
+          turns are unreachable in the UI (#95906, mirroring the
+          ``include_compacted`` display semantics of :meth:`get_messages`).
+          Explicit ``/branch`` sessions are
           excluded from this lineage because their own rows already contain the
           copied transcript; including the live parent's rows would let messages
           written to the original after the fork leak into the branch.
@@ -12046,8 +12067,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
-                f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
-                f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
+                # ``active`` is selected so the model-fed projection below can
+                # re-filter to active rows only — the model must never see
+                # compaction-archived rows, only the summary + protected tail.
+                # The display projection keeps them and dedupes cross-generation
+                # copies with the SAME helper ``get_messages`` uses for
+                # ``include_compacted`` reads, so resume and paged REST reads
+                # of one session agree on what the transcript shows (#95906).
+                f"SELECT session_id, active, {self._CONVERSATION_ROW_COLUMNS} "
+                f"FROM messages WHERE session_id IN ({placeholders}) "
+                "AND (active = 1 OR compacted = 1) "
                 # ORDER BY id (insertion order) — see get_messages_as_conversation
                 # for why timestamp ordering is unsafe.
                 "ORDER BY id",
@@ -12056,8 +12085,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         # Tip rows are exactly the model-fed set (get_messages_as_conversation
         # with session_ids=[session_id]); filtering the lineage fetch preserves
-        # their relative id order.
-        tip_rows = [r for r in rows if r["session_id"] == session_id]
+        # their relative id order. Active-only: the AI context stays
+        # compressed-only (summary + protected tail) even though the display
+        # projection below surfaces the full durable history.
+        tip_rows = [
+            r for r in rows if r["session_id"] == session_id and r["active"]
+        ]
         model_history = self._rows_to_conversation(
             tip_rows,
             session_id=session_id,
@@ -12070,7 +12103,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_summary_markers=True,
         )
         display_history = self._rows_to_conversation(
-            rows,
+            self._dedupe_compacted_display_rows(rows),
             session_id=session_id,
             include_ancestors=True,
             repair_alternation=False,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12058,6 +12058,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rows are part of the lineage), so serving both from one lineage SELECT
         halves the resume's DB work versus two separate calls, with byte-identical
         output (see test_get_resume_conversations_matches_separate_reads).
+
+        A payload-free probe gates the archived-row fetch and the display
+        dedupe: lineages with no compaction-archived rows (the common case)
+        stay on the active-only SELECT and skip the cross-generation dedupe
+        entirely — nothing to dedupe — while compacted lineages keep the full
+        archived-history semantics above.
         """
         session_ids = (
             [session_id]
@@ -12066,20 +12072,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
+            # Bounded-read gate (same shape as the get_messages gate in #97440):
+            # only a lineage that actually contains compaction-archived rows can
+            # have cross-generation copies to dedupe. The payload-free probe
+            # keeps never-compacted lineages — the common case — on the cheap
+            # active-only SELECT and out of the O(total rows) dedupe below. A
+            # concurrent compaction committing after the probe cannot mix
+            # duplicate generations into this response: its archived originals
+            # stay active=0 and out of the active-only fetch.
+            has_archived = conn.execute(
+                "SELECT 1 FROM messages "
+                f"WHERE session_id IN ({placeholders}) "
+                "AND active = 0 AND compacted = 1 LIMIT 1",
+                tuple(session_ids),
+            ).fetchone()
+            # ``active`` is selected so the model-fed projection below can
+            # re-filter to active rows only — the model must never see
+            # compaction-archived rows, only the summary + protected tail.
+            # When archived rows exist, the display projection keeps them and
+            # dedupes cross-generation copies with the SAME helper
+            # ``get_messages`` uses for ``include_compacted`` reads, so resume
+            # and paged REST reads of one session agree on what the
+            # transcript shows (#95906).
             rows = conn.execute(
-                # ``active`` is selected so the model-fed projection below can
-                # re-filter to active rows only — the model must never see
-                # compaction-archived rows, only the summary + protected tail.
-                # The display projection keeps them and dedupes cross-generation
-                # copies with the SAME helper ``get_messages`` uses for
-                # ``include_compacted`` reads, so resume and paged REST reads
-                # of one session agree on what the transcript shows (#95906).
                 f"SELECT session_id, active, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders}) "
-                "AND (active = 1 OR compacted = 1) "
+                + (
+                    "AND (active = 1 OR compacted = 1) "
+                    if has_archived
+                    else "AND active = 1 "
+                )
                 # ORDER BY id (insertion order) — see get_messages_as_conversation
                 # for why timestamp ordering is unsafe.
-                "ORDER BY id",
+                + "ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 
@@ -12102,8 +12127,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # summaries after a process restart (marker survives restart).
             include_summary_markers=True,
         )
+        display_rows = (
+            self._dedupe_compacted_display_rows(rows) if has_archived else rows
+        )
         display_history = self._rows_to_conversation(
-            self._dedupe_compacted_display_rows(rows),
+            display_rows,
             session_id=session_id,
             include_ancestors=True,
             repair_alternation=False,

--- a/tests/hermes_state/test_resume_display_compacted.py
+++ b/tests/hermes_state/test_resume_display_compacted.py
@@ -1,0 +1,122 @@
+"""Resume display projection must surface compaction-archived rows (#95906).
+
+``get_resume_conversations`` used to fetch its lineage with ``active = 1``
+only, so after in-place compaction the resume's ``display_history`` silently
+ended at the compaction boundary — earlier turns were unreachable in the UI
+even though ``get_messages(include_compacted=True)`` (the REST/backfill read)
+served them. The two display surfaces disagreed; this pins the fixed contract:
+
+  * ``display_history`` includes ``active=0, compacted=1`` rows (deduped
+    cross-generation with the same helper ``get_messages`` uses), while
+  * ``model_history`` stays active-only (the AI context keeps the compressed
+    summary + protected tail), and
+  * soft-deleted Undo/Rewind rows (``active=0, compacted=0``) stay excluded.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed_compacted(db, sid="s1"):
+    """4 archived (compacted) turns + summary + 1 live turn."""
+    db.create_session(sid, source="cli")
+    db.append_messages_batch(
+        sid,
+        [
+            {"role": "user", "content": "old q1"},
+            {"role": "assistant", "content": "old a1"},
+            {"role": "user", "content": "old q2"},
+            {"role": "assistant", "content": "old a2"},
+        ],
+    )
+    db.archive_and_compact(
+        sid,
+        [
+            {"role": "assistant", "content": "summary of old turns"},
+            {"role": "user", "content": "live q1"},
+            {"role": "assistant", "content": "live a1"},
+        ],
+    )
+
+
+class TestResumeDisplayCompacted:
+    def test_display_includes_compacted_rows_model_stays_active_only(self, db):
+        _seed_compacted(db)
+        model_history, display_history = db.get_resume_conversations("s1")
+        display_contents = [m["content"] for m in display_history]
+        # The archived turns are durable display history: they must be in the
+        # resume's display projection instead of ending at the summary.
+        for archived in ("old q1", "old a1", "old q2", "old a2"):
+            assert archived in display_contents
+        # The model-fed projection is unchanged: compressed summary + live
+        # tail only — the model must never see the archived rows again.
+        model_contents = [m["content"] for m in model_history]
+        for archived in ("old q1", "old a1", "old q2", "old a2"):
+            assert archived not in model_contents
+        assert "summary of old turns" in model_contents
+        assert "live q1" in model_contents
+
+    def test_display_agrees_with_include_compacted_rest_read(self, db):
+        """Resume display and the paged REST display read must agree."""
+        _seed_compacted(db)
+        _, display_history = db.get_resume_conversations("s1")
+        rest_rows = db.get_messages("s1", include_compacted=True)
+        assert [m["content"] for m in display_history] == [
+            m["content"] for m in rest_rows
+        ]
+
+    def test_display_dedupes_cross_generation_copies(self, db):
+        """A compaction epoch's verbatim tail copy must appear exactly once."""
+        db.create_session("s1", source="cli")
+        db.append_messages_batch(
+            "s1",
+            [
+                {"role": "user", "content": "carry q"},
+                {"role": "assistant", "content": "carry a"},
+            ],
+        )
+        live_ids = [m["id"] for m in db.get_messages("s1")]
+
+        # Simulate one compaction epoch: duplicate the rows verbatim (same
+        # content AND timestamp — the real copy-protected-tail behaviour) as
+        # active=0, compacted=1.
+        def _copy_tail(conn):
+            placeholders = ",".join("?" * len(live_ids))
+            conn.execute(
+                f"""
+                INSERT INTO messages
+                    (session_id, role, content, tool_call_id, tool_calls,
+                     tool_name, timestamp, active, compacted)
+                SELECT session_id, role, content, tool_call_id, tool_calls,
+                       tool_name, timestamp, 0, 1
+                FROM messages
+                WHERE session_id = ? AND id IN ({placeholders})
+                """,
+                ["s1", *live_ids],
+            )
+
+        db._execute_write(_copy_tail)
+        _, display_history = db.get_resume_conversations("s1")
+        contents = [m["content"] for m in display_history]
+        assert contents.count("carry q") == 1
+        assert contents.count("carry a") == 1
+        # Dedupe winner is the live row (same semantics as get_messages).
+        assert [m.get("_row_id") for m in display_history] == live_ids
+
+    def test_soft_deleted_rows_stay_excluded_from_display(self, db):
+        _seed_compacted(db)
+        live = db.get_messages("s1")
+        user_msg = next(m for m in reversed(live) if m["role"] == "user")
+        db.rewind_to_message("s1", user_msg["id"])
+        _, display_history = db.get_resume_conversations("s1")
+        # rewind_to_message soft-deletes the user row and everything after it
+        # (active=0, compacted=0) — audit rows, not display history.
+        assert "live q1" not in [m["content"] for m in display_history]
+        # The compacted rows remain reachable.
+        assert "old q1" in [m["content"] for m in display_history]

--- a/tests/hermes_state/test_resume_display_compacted.py
+++ b/tests/hermes_state/test_resume_display_compacted.py
@@ -120,3 +120,66 @@ class TestResumeDisplayCompacted:
         assert "live q1" not in [m["content"] for m in display_history]
         # The compacted rows remain reachable.
         assert "old q1" in [m["content"] for m in display_history]
+
+
+class TestBoundedUncompactedResume:
+    """Never-compacted lineages must not pay the archived-history cost.
+
+    The archived-row fetch and the cross-generation dedupe are only needed
+    when compaction-archived rows exist. A lineage without them (the common
+    case) must stay on the active-only SELECT and skip the O(total rows)
+    dedupe — the same bounded-read gate ``get_messages`` gains in #97440 —
+    while compacted lineages keep the full archived-history semantics.
+    """
+
+    def _seed_uncompacted(self, db):
+        db.create_session("s1", source="cli")
+        db.append_messages_batch(
+            "s1",
+            [
+                message
+                for index in range(6)
+                for message in (
+                    {"role": "user", "content": f"q {index}"},
+                    {"role": "assistant", "content": f"a {index}"},
+                )
+            ],
+        )
+    def test_uncompacted_resume_skips_display_dedupe(self, db, monkeypatch):
+        """No archived rows → the dedupe helper must not run at all."""
+        self._seed_uncompacted(db)
+        dedupe_calls = []
+        original = db._dedupe_compacted_display_rows
+
+        def _spied(rows):
+            dedupe_calls.append(len(rows))
+            return original(rows)
+
+        monkeypatch.setattr(db, "_dedupe_compacted_display_rows", _spied)
+
+        model_history, display_history = db.get_resume_conversations("s1")
+
+        assert dedupe_calls == []
+        assert [m["content"] for m in display_history] == [
+            text for index in range(6) for text in (f"q {index}", f"a {index}")
+        ]
+
+    def test_compacted_resume_still_runs_display_dedupe(self, db, monkeypatch):
+        """Archived rows exist → the dedupe helper must run (gate opens)."""
+        _seed_compacted(db)
+        dedupe_calls = []
+        original = db._dedupe_compacted_display_rows
+
+        def _spied(rows):
+            dedupe_calls.append(len(rows))
+            return original(rows)
+
+        monkeypatch.setattr(db, "_dedupe_compacted_display_rows", _spied)
+
+        _, display_history = db.get_resume_conversations("s1")
+
+        assert len(dedupe_calls) == 1
+        # Archived rows were fetched (4 old turns), not just the live set.
+        assert dedupe_calls[0] > len([m for m in db.get_messages("s1")])
+        for archived in ("old q1", "old a1", "old q2", "old a2"):
+            assert archived in [m["content"] for m in display_history]


### PR DESCRIPTION
## What does this PR do?

`get_resume_conversations()` fetched its lineage with `active = 1` only, so after in-place context compaction the resume's `display_history` silently ended at the compaction boundary — while `get_messages(include_compacted=True)` (the REST / backfill read, fixed earlier via #83757) served those same archived rows. The two display surfaces disagreed, and earlier turns became unreachable in the UI exactly as reported in #95906 (and the #90473 family): the desktop transcript resumes with the newest window and "Show earlier" can never page past the compaction boundary because the resume payload never contained the archived rows in the first place.

This fixes the resume display projection:

- the lineage SELECT now takes `(active = 1 OR compacted = 1)` rows and selects `active` so the projections can diverge correctly;
- `model_history` re-filters to active rows only — the AI context is unchanged (compressed summary + protected tail; the model must never see archived rows again);
- `display_history` now includes the archived rows, deduped across compaction generations;
- the cross-generation dedupe logic is extracted from `get_messages`' `include_compacted` branch into a shared `_dedupe_compacted_display_rows()` helper consumed by both, so a resume and a paged REST read of the same compacted session apply the SAME dedupe semantics instead of two parallel implementations.

Soft-deleted Undo/Rewind rows (`active=0, compacted=0`) stay excluded from the display projection, matching `get_messages`.

## Related Issue

Fixes #95906

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_state.py`
  - Added `_dedupe_compacted_display_rows()` — the dedupe previously inlined in `get_messages`' `include_compacted` branch (key: role/content/timestamp/tool fields, winner: live row then newest generation, incl. the user-handoff unwrap), now shared.
  - `get_messages(include_compacted=True)` now calls that helper — pure extraction, no behavior change.
  - `get_resume_conversations()` — SELECT widened to `(active = 1 OR compacted = 1)` with `active` selected; `tip_rows` (model-fed set) re-filters to `r["active"]`; the display projection runs the shared dedupe; docstring updated.
- `tests/hermes_state/test_resume_display_compacted.py` (new, 4 tests): display includes archived rows while model history stays active-only; resume display agrees item-for-item with `get_messages(include_compacted=True)`; cross-generation copies surface exactly once with the live row winning; soft-deleted rewind rows stay excluded.

## How to Test

1. `python -m pytest tests/hermes_state/test_resume_display_compacted.py -q` — should pass (4 passed).
2. Red/green: on unpatched `main`, the first three tests fail (archived rows absent / disagreement / duplicates if epochs copied); with this PR all four pass.
3. Extraction is behavior-neutral for the REST path: `python -m pytest tests/hermes_state/test_get_messages_include_compacted.py -q` — should pass (all existing include_compacted pins).
4. Consumers unchanged: `python -m pytest tests/cli/test_cli_resume_command.py tests/cli/test_resume_display.py tests/test_compression_watermark_commit.py tests/agent/test_pre_compress_checkpoint_contract.py tests/test_session_db_read_path_split.py -q` — should pass (68 passed).
5. Observed pre-existing failures on this machine (verified identical on unpatched `main`, unrelated to this diff): `test_aux_usage_accounting::test_aux_usage_rows_and_merge`, `test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, and 15 `test_tui_gateway_server.py` config-write tests.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the model/display projection split and shared-dedupe rationale documented at the SELECT)
- [x] New and existing unit tests pass locally (4 new; 183 passed in tests/hermes_state/ minus 1 pre-existing; 68 consumer tests)
- [x] Changes are backward compatible (model history byte-identical; display history strictly wider, matching the REST display read)
