### PR TITLE
fix(whatsapp): ignore re-delivered inbound messages to stop the answer loop

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -24,7 +24,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
@@ -33,6 +33,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { createInboundDedupe } from './inbound_dedupe.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -280,6 +281,14 @@ const MAX_QUEUE_SIZE = 100;
 // sustained sending.
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
+
+// Inbound redelivery guard: WhatsApp re-delivers un-acked messages with the
+// SAME key.id.  Once forwarded, retries are ignored so the gateway never
+// answers the same message twice (answer loop).  Persisted to disk so a
+// gateway/bridge restart cannot re-trigger it either (see inbound_dedupe.js).
+const inboundDedupe = createInboundDedupe({
+  file: path.join(SESSION_DIR, 'inbound_deduped.json'),
+});
 const messageStore = createBoundedMessageStore(512);
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
@@ -715,6 +724,20 @@ async function startSocket() {
           update: { pollUpdates },
           selectedOptions,
           aggregation,
+        });
+        continue;
+      }
+
+      // Inbound redelivery guard: WhatsApp re-delivers un-acked messages
+      // with the SAME key.id. Once forwarded, ignore retries so the gateway
+      // never answers the same message twice (answer loop). Persisted in
+      // inbound_deduped.json so a bridge restart can't re-trigger it either.
+      if (inboundDedupe.checkAndRemember(msg.key.id)) {
+        emitDebugEvent({
+          stage: 'ignored',
+          reason: 'inbound_redelivery',
+          chatId: redactWhatsAppId(chatId),
+          messageId: msg.key.id,
         });
         continue;
       }

--- a/scripts/whatsapp-bridge/inbound_dedupe.js
+++ b/scripts/whatsapp-bridge/inbound_dedupe.js
@@ -1,0 +1,82 @@
+/**
+ * Inbound message redelivery guard for the WhatsApp bridge.
+ *
+ * When WhatsApp never receives an ack for a message (e.g. the fromMe echo
+ * copy of a thread whose encryption session is missing — "No matching
+ * sessions found"), the server re-delivers the SAME message (same key.id)
+ * roughly every 10 minutes forever.  Without a guard, every redelivery is
+ * forwarded as a fresh inbound and the gateway answers the same message
+ * repeatedly ("obsessed agent" / answer loop).
+ *
+ * This module tracks forwarded inbound ids and persists them to disk
+ * (atomic tmp+rename) so a gateway/bridge restart cannot re-trigger the
+ * loop either.  The id set is bounded (FIFO, see outbound_ids.js), so the
+ * file stays small under sustained traffic.
+ */
+import { mkdirSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { dirname } from 'path';
+
+import { createOutboundIdTracker } from './outbound_ids.js';
+
+export function createInboundDedupe({ file, maxSize = 1024 } = {}) {
+  if (!file) {
+    throw new RangeError('createInboundDedupe: file is required');
+  }
+
+  const ids = createOutboundIdTracker(maxSize);
+  try {
+    const saved = JSON.parse(readFileSync(file, 'utf8'));
+    if (Array.isArray(saved)) {
+      for (const id of saved) ids.remember(id);
+    }
+  } catch {
+    // Missing or corrupt file: start clean, the guard only needs the ids
+    // of messages forwarded since the last successful write.
+  }
+
+  let saveTimer = null;
+
+  function flush() {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    try {
+      mkdirSync(dirname(file), { recursive: true });
+      const tmp = `${file}.tmp`;
+      writeFileSync(tmp, JSON.stringify(ids.snapshot()));
+      renameSync(tmp, file);
+      return true;
+    } catch (err) {
+      console.warn('[whatsapp-bridge] failed to persist inbound dedupe:', err.message);
+      return false;
+    }
+  }
+
+  // Debounced persist: redelivery bursts (and normal message volume) would
+  // otherwise write the whole set on every single message.
+  function persist() {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      flush();
+    }, 1500);
+  }
+
+  /**
+   * @param {string} id message key.id
+   * @returns {boolean} true when the id was ALREADY forwarded (redelivery)
+   */
+  function checkAndRemember(id) {
+    if (ids.has(id)) return true;
+    ids.remember(id);
+    persist();
+    return false;
+  }
+
+  function size() {
+    return ids.size();
+  }
+
+  return { checkAndRemember, flush, size };
+}

--- a/scripts/whatsapp-bridge/inbound_dedupe.test.mjs
+++ b/scripts/whatsapp-bridge/inbound_dedupe.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createInboundDedupe } from './inbound_dedupe.js';
+
+function tempFile() {
+  return path.join(mkdtempSync(path.join(tmpdir(), 'inbound-dedupe-')), 'dedupe.json');
+}
+
+test('first sight of an id is not a duplicate; second sight is', () => {
+  const dedupe = createInboundDedupe({ file: tempFile() });
+  assert.equal(dedupe.checkAndRemember('msg-1'), false);
+  assert.equal(dedupe.checkAndRemember('msg-1'), true);
+  assert.equal(dedupe.checkAndRemember('msg-2'), false);
+  assert.equal(dedupe.size(), 2);
+});
+
+test('persists ids and a fresh instance recognises them again', () => {
+  const file = tempFile();
+  const first = createInboundDedupe({ file });
+  first.checkAndRemember('3ADBC9E571524161153A');
+  first.checkAndRemember('AC3272EA9C4DFE0C81D05EE2167BD873');
+  first.flush();
+
+  const second = createInboundDedupe({ file });
+  assert.equal(second.checkAndRemember('3ADBC9E571524161153A'), true);
+  assert.equal(second.checkAndRemember('AC3272EA9C4DFE0C81D05EE2167BD873'), true);
+  assert.equal(second.checkAndRemember('brand-new-id'), false);
+});
+
+test('tolerates a missing file', () => {
+  const file = path.join(mkdtempSync(path.join(tmpdir(), 'inbound-dedupe-')), 'absent.json');
+  const dedupe = createInboundDedupe({ file });
+  assert.equal(dedupe.checkAndRemember('x'), false);
+  assert.equal(dedupe.size(), 1);
+});
+
+test('tolerates a corrupt file and recovers on the next flush', () => {
+  const file = tempFile();
+  writeFileSync(file, '{not valid json!!');
+  const dedupe = createInboundDedupe({ file });
+  assert.equal(dedupe.checkAndRemember('y'), false);
+  dedupe.flush();
+  assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')), ['y']);
+});
+
+test('caps the remembered set (FIFO eviction, bounded file)', () => {
+  const dedupe = createInboundDedupe({ file: tempFile(), maxSize: 3 });
+  for (const id of ['a', 'b', 'c', 'd']) dedupe.checkAndRemember(id);
+  assert.equal(dedupe.size(), 3);
+  // 'a' was evicted, so a redelivery of it is treated as new again (and its
+  // re-remembering pushes the oldest survivor out — plain FIFO semantics).
+  assert.equal(dedupe.checkAndRemember('a'), false);
+  assert.equal(dedupe.checkAndRemember('c'), true);
+});
+
+test('rejects creation without a file path', () => {
+  assert.throws(() => createInboundDedupe(), RangeError);
+  assert.throws(() => createInboundDedupe({ maxSize: 8 }), RangeError);
+});

--- a/scripts/whatsapp-bridge/outbound_ids.js
+++ b/scripts/whatsapp-bridge/outbound_ids.js
@@ -41,5 +41,9 @@ export function createOutboundIdTracker(maxSize = 512) {
     return ids.size;
   }
 
-  return { remember, has, size };
+  function snapshot() {
+    return Array.from(ids);
+  }
+
+  return { remember, has, size, snapshot };
 }

--- a/scripts/whatsapp-bridge/outbound_ids.test.mjs
+++ b/scripts/whatsapp-bridge/outbound_ids.test.mjs
@@ -66,3 +66,21 @@ test('rejects non-positive maxSize', () => {
   assert.throws(() => createOutboundIdTracker(-1), RangeError);
   assert.throws(() => createOutboundIdTracker(1.5), RangeError);
 });
+
+test('snapshot returns remembered ids in insertion order', () => {
+  const tracker = createOutboundIdTracker(5);
+  tracker.remember('a');
+  tracker.remember('b');
+  tracker.remember('c');
+  assert.deepEqual(tracker.snapshot(), ['a', 'b', 'c']);
+});
+
+test('snapshot reflects eviction (bounded persistence contract)', () => {
+  // Persistence consumers (inbound_dedupe.js) rely on snapshot() NOT
+  // exceeding maxSize — the file must stay bounded under sustained traffic.
+  const tracker = createOutboundIdTracker(2);
+  tracker.remember('a');
+  tracker.remember('b');
+  tracker.remember('c');
+  assert.deepEqual(tracker.snapshot(), ['b', 'c']);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an answer-loop in the WhatsApp bridge: when WhatsApp never receives an ack for a message (e.g. the `fromMe` echo copy of a thread whose encryption session is missing — libsignal `No matching sessions found` / Bad MAC against the PN-addressed key), the server **re-delivers the same message (same `key.id`) roughly every 10 minutes, forever**. The bridge forwarded every redelivery as a fresh inbound, so the gateway answered the same message over and over — in the field: 14+ answers to one message in ~3h, immune to `/new` session resets and gateway restarts (each restart just re-forwarded the next retry).

Approach: a persistent **inbound dedupe by message `key.id`** (`inbound_dedupe.js`). Once a message is forwarded, retries with the same id are dropped. The id set is persisted to `<session>/inbound_deduped.json` (atomic tmp+rename, debounced writes) so a gateway/bridge restart cannot re-trigger the loop either. Mirror of the existing outbound echo guard (`recentlySentIds`), bounded the same way.

## Related Issue

No issue filed (bug reported in the field via WhatsApp). Happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `scripts/whatsapp-bridge/inbound_dedupe.js` — new module: persisted, bounded inbound-id guard (`checkAndRemember` / `flush` / `size`)
- `scripts/whatsapp-bridge/bridge.js` — use the guard in `messages.upsert` before `extractBridgeEvent`; dedupe check runs after intake filters (allowlist/self-chat) so ignored messages don't consume slots
- `scripts/whatsapp-bridge/outbound_ids.js` — expose `snapshot()` (FIFO insertion order, capped) so the dedupe can persist its set
- `scripts/whatsapp-bridge/inbound_dedupe.test.mjs` — new: dedupe semantics, persistence round-trip across instances, corrupt/missing file tolerance, FIFO cap
- `scripts/whatsapp-bridge/outbound_ids.test.mjs` — snapshot order + eviction contract

## How to Test

1. `cd scripts/whatsapp-bridge && node --test *.test.mjs` → 30 tests pass (5 new)
2. Repro (requires a live pairing where a PN-addressed `fromMe` echo has no session): send a message that fails to decrypt (`No matching sessions found` in bridge.log), then watch `gateway.log` — the first delivery is answered; subsequent retries (~every 10 min) produce **no** `inbound message` lines. Restart the gateway mid-retry-cycle: still no re-answer (persisted set).
3. Sanity: a NEW user message is still forwarded and answered normally (fresh id).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, ...)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A to this PR (JS-only change); bridge test suite run via `node --test` (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2 (live incident: loop reproduced, patch applied, 9+ min clean window vs 5–13 min retry cadence, gateway restart included)

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A: internal docstring-level docs (module header + inline comments) updated
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow changes)
- [x] Cross-platform impact — N/A (Node stdlib only: `fs`, `path`; no platform-specific code)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Field evidence (before): `gateway.log` showing the same inbound answered 14 times in ~3h, including after `/new`:

```
13:26:44 inbound ... msg='U know about my glasses?'
13:35:35 inbound ... msg='U know about my glasses?'
... (every 5–13 min) ...
16:49:10 inbound ... msg='U know about my glasses? U know about my glasses?'
16:58:29 inbound ... msg='U know about my glasses?'
```

Underlying cause in `bridge.log`:

```
{"key":{"remoteJid":"573505972492@s.whatsapp.net","fromMe":true,"id":"3ADBC9E571524161153A","addressingMode":"pn"},"err":{"type":"SessionError","message":"No matching sessions found for message",...}}
```

After the patch: the same retry event continues to arrive server-side but is deduplicated — `gateway.log` shows zero inbound lines across a full retry cycle and one gateway restart.