### PR TITLE
fix(mcp): stop leaking the _watch_stdio_children coroutine on raced calls

### DIFF
--- a/tests/tools/test_mcp_watcher_coroutine_leak.py
+++ b/tests/tools/test_mcp_watcher_coroutine_leak.py
@@ -1,0 +1,118 @@
+"""Regression tests for the _watch_stdio_children coroutine leak (#95938).
+
+The fast-fail race (#81995) used to call ``_watch_children()`` once inside
+``inspect.isawaitable(...)`` — creating a coroutine that was immediately
+discarded — and then a SECOND time for ``asyncio.ensure_future(...)``. Every
+fast-fail-raced MCP call therefore leaked one never-awaited coroutine and
+emitted ``RuntimeWarning: coroutine MCPServerTask._watch_stdio_children was
+never awaited``.
+
+The fix creates the watcher awaitable once (after the cheap ``_call_coro``
+coroutine check, so no watcher coroutine is created at all when it could
+never be scheduled) and schedules that same object.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+
+
+class _StubSession:
+    def __init__(self, *, hang=False):
+        self._hang = hang
+
+    async def call_tool(self, name, arguments=None):
+        if self._hang:
+            await asyncio.sleep(30)
+        return SimpleNamespace(content=[SimpleNamespace(text="ok")], is_error=False)
+
+
+class _StubServer:
+    """Minimal stdio-server double for the fast-fail race path."""
+
+    def __init__(self, *, watcher_returns_fast=False):
+        self.session = _StubSession(hang=watcher_returns_fast)
+        self._rpc_lock = asyncio.Lock()
+        self._watcher_returns_fast = watcher_returns_fast
+        # Counts coroutine CREATIONS (the factory below), not executions:
+        # a watcher coroutine that is created and then discarded never runs
+        # its body, so only the factory can see the leak (#95938).
+        self.watcher_calls = 0
+
+    def _stdio_children_dead(self):
+        return False
+
+    def _watch_stdio_children(self):
+        self.watcher_calls += 1
+        return self._watcher_coro()
+
+    async def _watcher_coro(self):
+        if self._watcher_returns_fast:
+            return
+        await asyncio.sleep(30)
+
+
+@pytest.fixture
+def handler(monkeypatch):
+    monkeypatch.setattr(mcp_tool, "_trust_gate_check", lambda *a, **k: None)
+    monkeypatch.setattr(mcp_tool, "_server_error_counts", {})
+    monkeypatch.setattr(mcp_tool, "_server_breaker_opened_at", {})
+    monkeypatch.setattr(
+        mcp_tool, "_run_on_mcp_loop", lambda fn, timeout: asyncio.run(fn())
+    )
+    return mcp_tool._make_tool_handler("stub", "echo", 5.0)
+
+
+def _install_server(monkeypatch, server):
+    monkeypatch.setattr(
+        mcp_tool, "_get_connected_server_for_call", lambda name: server
+    )
+
+
+class TestWatcherCoroutineLeak:
+    def test_raced_call_creates_watcher_coroutine_once(self, handler, monkeypatch):
+        """A fast-fail-raced call must create exactly one watcher coroutine.
+
+        The orphaned coroutine's RuntimeWarning ("was never awaited") fires
+        from ``coroutine.__del__``, where warnings can't be turned into
+        errors — so the observable red/green signal is the CREATION count:
+        the stub's watcher factory counts every ``_watch_children()``
+        invocation, and the pre-fix code called it twice (once inside
+        ``inspect.isawaitable``, once for ``ensure_future``) while scheduling
+        only the second.
+        """
+        server = _StubServer()
+        _install_server(monkeypatch, server)
+
+        result = handler({})
+
+        assert '"result": "ok"' in result
+        assert server.watcher_calls == 1
+
+    def test_fast_fail_semantics_unchanged(self, handler, monkeypatch):
+        """A dead subprocess still fails the call fast after the refactor."""
+        server = _StubServer(watcher_returns_fast=True)
+        _install_server(monkeypatch, server)
+
+        result = handler({})
+
+        assert "exited mid-call; failing the call fast" in result
+
+    def test_non_coroutine_call_coro_creates_no_watcher(self, handler, monkeypatch):
+        """The cheap ``iscoroutine(_call_coro)`` gate must run first.
+
+        A stubbed (MagicMock-style) session returning a non-coroutine used to
+        still create the watcher coroutine inside isawaitable() before the
+        third condition discarded it. With the gate first, no watcher
+        coroutine is created at all.
+        """
+        server = _StubServer()
+        server.session = SimpleNamespace(call_tool=lambda *a, **k: "plain")
+        _install_server(monkeypatch, server)
+
+        result = handler({})
+
+        assert server.watcher_calls == 0

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6151,10 +6151,25 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
+                    # Create the watcher awaitable ONCE (#95938): calling it
+                    # inside inspect.isawaitable() created a coroutine that was
+                    # then discarded, and the race branch below called
+                    # _watch_children() a SECOND time — so every
+                    # fast-fail-raced call leaked one never-awaited coroutine.
+                    # Checking the cheap _call_coro condition first means no
+                    # watcher coroutine is created at all when it could never
+                    # be scheduled.
+                    _watch_coro = (
+                        _watch_children()
+                        if (
+                            _watch_children is not None
+                            and asyncio.iscoroutine(_call_coro)
+                        )
+                        else None
+                    )
                     _watch_ok = (
-                        _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
-                        and asyncio.iscoroutine(_call_coro)
+                        _watch_coro is not None
+                        and inspect.isawaitable(_watch_coro)
                     )
                     if not _watch_ok:
                         # Stubbed sessions (MagicMock in tests) return a
@@ -6172,7 +6187,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # the call immediately instead of riding out the full
                         # tool timeout.
                         rpc_task = asyncio.ensure_future(_call_coro)
-                        watch_task = asyncio.ensure_future(_watch_children())
+                        watch_task = asyncio.ensure_future(_watch_coro)
                         try:
                             done, _pending = await asyncio.wait(
                                 {rpc_task, watch_task},


### PR DESCRIPTION
## What does this PR do?

Every fast-fail-raced MCP tool call leaked one never-awaited coroutine and emitted:

```text
RuntimeWarning: coroutine MCPServerTask._watch_stdio_children was never awaited
```

In `_make_tool_handler`'s `_call()`, `_watch_ok` was computed as `inspect.isawaitable(_watch_children())` — calling the watcher **created a coroutine that `isawaitable` merely inspected and then discarded** — and the race branch subsequently called `_watch_children()` a **second** time for `asyncio.ensure_future(...)`. The first coroutine was never awaited or closed.

The fix creates the watcher awaitable **once**, with the cheap `asyncio.iscoroutine(_call_coro)` condition evaluated first so no watcher coroutine is created at all when it could never be scheduled (the stubbed/MagicMock path), and the race branch schedules that same object. Truth-table-equivalent to the old `_watch_ok` on every input combination.

## Related Issue

Fixes #95938

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/mcp_tool.py`
  - `_call()` in `_make_tool_handler`: replaced the `inspect.isawaitable(_watch_children())` probe with a single gated creation (`_watch_coro = _watch_children() if ... iscoroutine(_call_coro) else None`), `_watch_ok` now inspects that saved object, and `asyncio.ensure_future(_watch_coro)` schedules it instead of calling `_watch_children()` again.
- `tests/tools/test_mcp_watcher_coroutine_leak.py` (new, 3 tests): creation-count leak pin, fast-fail semantics pin (dead subprocess still fails the call fast — the #81995 behavior is unchanged), and the no-watcher-created pin for non-coroutine stub sessions.

## How to Test

1. `python -m pytest tests/tools/test_mcp_watcher_coroutine_leak.py -q` — should pass (3 passed).
2. Red/green: on unpatched `main` the leak pin fails (`watcher_calls == 2`: one coroutine created for the `isawaitable` probe, a second for `ensure_future`) and the non-coroutine-gate pin fails (`watcher_calls == 1` where 0 is expected); with this PR both pass.
3. Why the pin counts creations instead of relying on the warning: the "was never awaited" `RuntimeWarning` fires from `coroutine.__del__`, where warnings are reported as "Exception ignored" and cannot be raised into the test — the factory-counting stub is the observable signal.
4. Adjacent suites unchanged: `python -m pytest tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_trust_gating.py tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_resource_content.py -q` — should pass (53 passed).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the create-once rationale documented at the call site)
- [x] New and existing unit tests pass locally (3 new; 53 adjacent)
- [x] Changes are backward compatible (fast-fail semantics pinned unchanged; `_watch_ok` truth-table-equivalent)
