### PR TITLE
feat(models): add gemini-3.7-flash to Vertex curated catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -692,6 +692,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "vertex": [
         "google/gemini-3.1-pro-preview",
         "google/gemini-3-pro-preview",
+        "google/gemini-3.7-flash",
         "google/gemini-3.6-flash",
         "google/gemini-3.5-flash",
         "google/gemini-3.5-flash-lite",


### PR DESCRIPTION
## Summary
Add `google/gemini-3.7-flash` to the `vertex` curated model list in `hermes_cli/models.py`.

## Why
The desktop/TUI model picker's "Google Vertex AI" section is generated from `_PROVIDER_MODELS["vertex"]` (a curated snapshot from 2026-07-21). That list predates `gemini-3.7-flash`, so the model cannot be selected from the picker even though it is available on Vertex AI.

The Vertex OpenAI-compatible endpoint has no `/models` listing route (per the comment in `models.py`), so this static list is the only way the picker can offer the model.

## Verification
- `google/gemini-3.7-flash` returns HTTP 200 on the Vertex OpenAI-compatible endpoint with the `google/` publisher prefix (required — without it Vertex returns `400 Malformed publisher model`):
  - `hermes --provider vertex -m google/gemini-3.7-flash` → real Vertex response, confirmed via agent logs (`API call #1: model=google/gemini-3.7-flash provider=vertex`, no fallback)
- Picker payload (`build_model_options_payload`) lists the model under the vertex row after this change.

## Scope
Single line, static catalog addition. No behavioral changes elsewhere.
