### PR TITLE
fix(agent): never seed subdirectory hints from the Hermes install tree

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2946,8 +2946,15 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    # Resolve once here so the tracker shares the session's canonical cwd
+    # (session override → TERMINAL_CWD → launch dir) instead of silently
+    # falling back to os.getcwd() — which on desktop/gateway surfaces is the
+    # Hermes install tree. The tracker itself refuses install-tree working
+    # dirs as a second line of defense (see SubdirectoryHintTracker).
+    from agent.runtime_cwd import resolve_agent_cwd
+
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=str(resolve_agent_cwd()),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -60,6 +60,29 @@ _EXCLUDED_DIR_NAMES = frozenset({
 })
 
 
+def _is_install_tree(p: Path) -> bool:
+    """True when *p* is or sits inside the Hermes package/source root.
+
+    Mirrors ``agent.runtime_cwd._is_install_tree`` without importing it at
+    module import time (``agent_init`` imports this module early in the
+    bootstrap; keep the dependency lazy to avoid import cycles).
+    """
+    try:
+        from agent.runtime_cwd import _is_install_tree as _runtime_check
+
+        return _runtime_check(p)
+    except Exception:  # pragma: no cover - defensive during early bootstrap
+        try:
+            from hermes_constants import get_hermes_home
+
+            _ = get_hermes_home  # keep bootstrap import resolved
+            pkg_root = Path(__file__).resolve().parent.parent
+            p = Path(p).resolve()
+            return p == pkg_root or pkg_root in p.parents
+        except Exception:
+            return False
+
+
 def _is_ancestor_or_same(a: Path, b: Path) -> bool:
     """Check if *a* is the same as or an ancestor of *b* (parent directory check)."""
     try:
@@ -83,7 +106,8 @@ class SubdirectoryHintTracker:
     """
 
     def __init__(self, working_dir: Optional[str] = None):
-        self.working_dir = Path(working_dir or os.getcwd()).resolve()
+        resolved = self._resolve_working_dir(working_dir)
+        self.working_dir = resolved
         self._loaded_dirs: Set[Path] = set()
         # Content digests already injected — prevents re-sending the same file
         # reachable through symlinks, hardlinks, or duplicated copies.
@@ -91,6 +115,40 @@ class SubdirectoryHintTracker:
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
         self._seed_working_dir_digest()
+
+    @staticmethod
+    def _resolve_working_dir(working_dir: Optional[str]) -> Path:
+        """Resolve the tracker's working directory, refusing the install tree.
+
+        A fallback into the Hermes package/source root (the desktop app's
+        default spawn location) must never seed subdirectory hints — the repo's
+        contributor AGENTS.md files are development guides, not user project
+        context (#64590, #85668). ``prompt_builder`` already suppresses these
+        for the system prompt; this extends the same invariant to lazy hint
+        discovery. Fall back to the home directory, matching the desktop
+        launcher's own last-resort choice.
+        """
+        candidate: Optional[Path] = None
+        if working_dir and working_dir.strip():
+            try:
+                candidate = Path(working_dir).expanduser().resolve()
+            except OSError:
+                candidate = None
+        if candidate is None:
+            try:
+                from agent.runtime_cwd import resolve_agent_cwd
+
+                candidate = resolve_agent_cwd()
+            except Exception:
+                candidate = Path(os.getcwd())
+        if _is_install_tree(candidate):
+            logger.warning(
+                "subdirectory hints: working directory %s resolves inside the "
+                "Hermes install tree; using home directory instead",
+                candidate,
+            )
+            candidate = Path.home()
+        return candidate.resolve()
 
     def _seed_working_dir_digest(self) -> None:
         """Record the CWD context file's digest so it is never re-injected.
@@ -235,6 +293,13 @@ class SubdirectoryHintTracker:
             if not _is_ancestor_or_same(self.working_dir, path):
                 return False
         if self._is_excluded(path):
+            return False
+        # Never treat a path inside the Hermes install tree as project
+        # context — the repo's contributor AGENTS.md files are development
+        # guides, not user project context (#64590, #85668). Needed even when
+        # working_dir is a legitimate parent (e.g. the home directory), since
+        # the install tree sits below it.
+        if _is_install_tree(path):
             return False
         return True
 

--- a/tests/agent/test_subdirectory_hints_install_tree.py
+++ b/tests/agent/test_subdirectory_hints_install_tree.py
@@ -1,0 +1,60 @@
+"""Install-tree refusal: subdirectory hints must never seed from the Hermes package root.
+
+Companion to the prompt_builder fallback guard (#64590) — see #85668. When a
+desktop/gateway session falls back into the install tree, the tracker must
+re-home to the user's home directory instead of treating the repo's
+contributor AGENTS.md files as project context.
+"""
+
+from pathlib import Path
+
+from agent.subdirectory_hints import SubdirectoryHintTracker, _is_install_tree
+
+# The real package root: whatever checkout is running these tests.
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_install_tree_detection():
+    assert _is_install_tree(PACKAGE_ROOT)
+    assert _is_install_tree(PACKAGE_ROOT / "agent" / "subdir")
+    # Ancestors of the package root are legitimate workspaces.
+    parent = PACKAGE_ROOT.parent
+    if parent != PACKAGE_ROOT:
+        assert not _is_install_tree(parent)
+
+
+def test_working_dir_inside_install_tree_falls_back_to_home(tmp_path, monkeypatch):
+    # Explicitly point the tracker at a directory inside the install tree.
+    monkeypatch.chdir(PACKAGE_ROOT)
+    tracker = SubdirectoryHintTracker(working_dir=str(PACKAGE_ROOT / "agent"))
+    assert tracker.working_dir == Path.home().resolve()
+    # Nothing from the install tree may be marked loaded.
+    assert tracker.working_dir not in (
+        PACKAGE_ROOT,
+        PACKAGE_ROOT / "agent",
+    )
+
+
+def test_working_dir_explicit_install_tree_root_falls_back_to_home():
+    tracker = SubdirectoryHintTracker(working_dir=str(PACKAGE_ROOT))
+    assert tracker.working_dir == Path.home().resolve()
+
+
+def test_legitimate_workspace_outside_install_tree_is_kept(tmp_path):
+    ws = tmp_path / "my-project"
+    ws.mkdir()
+    tracker = SubdirectoryHintTracker(working_dir=str(ws))
+    assert tracker.working_dir == ws.resolve()
+
+
+def test_home_fallback_does_not_inject_repo_agents_md(tmp_path, monkeypatch):
+    """E2E shape: cwd = install tree, tracker must never return repo hints."""
+    monkeypatch.chdir(PACKAGE_ROOT)
+    tracker = SubdirectoryHintTracker(working_dir=None)  # None → runtime cwd resolution
+    # Whatever it resolved to, it must not be inside the install tree...
+    assert not _is_install_tree(tracker.working_dir)
+    # ...and a probe into the install tree must yield no hints (outside tree).
+    hints = tracker.check_tool_call(
+        "read_file", {"path": str(PACKAGE_ROOT / "AGENTS.md")}
+    )
+    assert hints is None or "Hermes Agent - Development Guide" not in hints


### PR DESCRIPTION
## What does this PR do?

Closes the remaining agent-layer leak behind #85668, complementary to #85697.

`build_context_files_prompt()` already refuses *fallback-resolved* working directories inside the Hermes install tree (#64590) — but `SubdirectoryHintTracker` bypassed that guard entirely:

1. `agent_init.py` constructed it with a raw `TERMINAL_CWD-or-os.getcwd()` fallback, so a desktop/gateway session that fell back into the install tree pointed the tracker at the clone.
2. Even with a correct working dir, any tool-call path into the install tree injected hints, because the target-path check only rejected paths *outside* the working dir — and home (a legitimate working dir) is an ancestor of the install tree.

Reproduced live: a session with cwd=$HOME touching `~/.hermes/hermes-agent/AGENTS.md` injected the ~95KB development guide as a "subdirectory context discovered" hint. The new test `test_home_fallback_does_not_inject_repo_agents_md` failed before the fix and passes after.

## Changes

- **`agent/agent_init.py`** — resolve the tracker's working dir via `resolve_agent_cwd()` (session override → `TERMINAL_CWD` → launch dir) so it agrees with the system prompt and terminal surfaces.
- **`agent/subdirectory_hints.py`** — refuse install-tree working dirs (re-home to home, matching the desktop launcher's last resort) and reject install-tree *target* paths regardless of the working dir.
- **`tests/agent/test_subdirectory_hints_install_tree.py`** — detection, working-dir refusal, target-path rejection, home-ancestor case, and the E2E repro above.

## Relationship to #85697

#85697 fixes gateway session-cwd resolution (where the session *points* when a project is active). This PR is defense-in-depth at the agent layer: it covers sessions with **no active project** (fallback can still land in the clone) and any tool path that touches the install tree from a legitimate parent workspace. Both can merge independently; this one is safe even if #85697 lands first.

## How to Test

```shell
bash scripts/run_tests.sh tests/agent/test_subdirectory_hints_install_tree.py tests/agent/test_subdirectory_hints.py tests/agent/test_subdirectory_hints_tilde.py
```

Result: 33 passed.

## Checklist

- [x] Conventional Commits (`fix(agent):`)
- [x] Searched existing PRs — #85697 is complementary, not a duplicate
- [x] Tests added (required for bug fix)
- [x] Only changes related to this fix
- [x] Tested on Linux (Arch, Python 3.11, v0.20.5 tree)