### PR TITLE
fix(mcp): correct inverted _stdio_children_dead() liveness check

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2993,10 +2993,9 @@ class MCPServerTask:
             import psutil
 
             if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+                continue  # this one is dead, check the rest
+            return False  # at least one child alive → NOT all dead
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
## Symptom

Every stdio-transport MCP call fails immediately with **"subprocess has exited; failing the call fast"**, even while the MCP subprocess is verifiably alive. Reproduced against the `shopify-mcp` server on current `main` (also present on `origin/main`).

## Root cause

Regression from the #81995 fast-fail change. `_stdio_children_dead()` returns `True` ("all dead") when **any** tracked child is still alive, and only reaches `return False` through a branch that is unreachable:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue          # this one is dead, check the rest
    return True           # BUG: reports "dead" while a child is ALIVE
    return False          # unreachable
```

`_watch_stdio_children()` then resolves immediately and cancels the in-flight RPC, so every stdio MCP call fails fast regardless of the server's real state. HTTP transports are unaffected because `_is_http()` short-circuits before this loop.

## Fix

Return `False` as soon as at least one tracked child is alive; only report "all dead" after the loop exhausts:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue          # this one is dead, check the rest
    return False          # at least one child alive → NOT all dead
return True               # every tracked child has exited
```

## Verification

- `py_compile` passes.
- Unit-style simulation of old vs new logic against real PIDs: 5/5 cases correct after the fix.
- `hermes mcp test shopify`: all 14 tools listed.
- `mcp__shopify__get_products` returns live product data end-to-end (was: instant "subprocess has exited" failure).
