### PR TITLE
Fix two liveness false-negatives: MCP stdio subprocess + builtin cron ticker

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -78,6 +78,15 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
+        # The gateway runtime lock is held for exactly the gateway's lifetime, so it
+        # is a more reliable "is the ticker's process alive" signal than PID scanning
+        # — and inside the gateway process it short-circuits to True, so the in-gateway
+        # cron tool never emits a false "gateway not running" (find_gateway_pids can
+        # transiently miss the gateway just after a restart).
+        from gateway.status import is_gateway_runtime_lock_active
+
+        if is_gateway_runtime_lock_active():
+            return True
         from hermes_cli.gateway import find_gateway_pids
 
         return bool(find_gateway_pids())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2999,11 +2999,9 @@ class MCPServerTask:
             # os.kill probe below only runs when psutil is unavailable.
             import psutil
 
-            if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            if psutil.pid_exists(pid):
+                return False  # at least one child alive → not all have exited
+        return True  # no tracked child is alive → every child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
Two independent liveness checks report a *live* thing as dead; each surfaces as a spurious, user-facing failure. Both were found and fixed while running Hermes on macOS (launchd) and verified live.

## 1. `tools/mcp_tool.py::_stdio_children_dead` — inverted loop (commit 1)

Documented as *"True when every stdio child we spawned has exited"*, but the loop returns `True` as soon as it finds a child that is still **alive**:

```python
    if not psutil.pid_exists(pid):
        continue          # dead → check next
    return True           # ← a LIVE child wrongly reports "all dead"
    return False          # ← unreachable dead code
```

So the `#81995` fast-fail path (`_stdio_children_dead()` → `TimeoutError`) aborts **every** stdio MCP tool call with `MCP stdio subprocess for 'X' has exited` while the servers are perfectly alive — the processes (and their watchdog/sudo wrappers) are running; only this client-side liveness check is wrong. It triggers whenever `_stdio_child_pids` is populated, taking down all stdio MCP tools at once.

**Fix:** return `False` as soon as any tracked child is alive; `True` only when none are — the correct meaning of the docstring.

## 2. `hermes_cli/cron.py::_builtin_gateway_liveness` — flaky PID scan (commit 2)

It decides whether the builtin cron ticker can fire via `find_gateway_pids()` (a PID scan). That scan can transiently return empty even while the gateway is up (e.g. right after a restart), so the in-gateway `cronjob` tool emits a false `Gateway is not running — jobs won't fire` while jobs are firing on schedule.

**Fix:** prefer the gateway runtime lock — it is held for exactly the gateway's lifetime (a reliable liveness signal) and short-circuits to `True` inside the gateway process, so the in-gateway check can never false-alarm. Falls back to the PID scan only when the lock reads inactive (the external-CLI path).

Both changes are minimal and self-contained.
