### PR TITLE
fix(gateway): block direct-spawn self-lifecycle

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -438,6 +438,39 @@ class TestCronCreateLifecycleBlock:
 # Defense 1: gateway stop/restart refuse inside gateway
 # ---------------------------------------------------------------------------
 
+class TestGatewayProcessIdentity:
+    """The live gateway identity is distinct from external supervision."""
+
+    def test_detached_gateway_is_live_gateway_without_supervisor(self, monkeypatch):
+        """Regression: a Windows direct-spawn gateway owns the PID file but has
+        no systemd/launchd supervisor. Lifecycle guards must still identify it
+        as the live gateway so it cannot kill its own terminal tool mid-restart.
+        """
+        from gateway import restart, status
+        from tools import process_registry
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(restart, "is_gateway_supervisor_process", lambda: False)
+        monkeypatch.setattr(
+            status, "get_running_pid", lambda cleanup_stale=False: os.getpid()
+        )
+
+        assert process_registry._is_gateway_process() is True
+        assert process_registry._is_supervised_gateway_process() is False
+
+    def test_inherited_marker_without_pid_ownership_is_not_gateway(self, monkeypatch):
+        """Descendants inherit the marker but do not own the live gateway PID."""
+        from gateway import status
+        from tools import process_registry
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            status, "get_running_pid", lambda cleanup_stale=False: os.getpid() + 1
+        )
+
+        assert process_registry._is_gateway_process() is False
+
+
 class TestGatewaySelfTargetingGuard:
     """Verify destructive gateway commands refuse inside the gateway."""
 
@@ -490,6 +523,43 @@ class TestGatewaySelfTargetingGuard:
 # Defense 3: terminal_tool hard-blocks gateway lifecycle commands inside gateway
 # ---------------------------------------------------------------------------
 
+class TestExecuteCodeGatewayLifecycleGuard:
+    """execute_code must not bypass the detached-gateway lifecycle guard."""
+
+    def test_detached_gateway_blocks_lifecycle_code(self, monkeypatch):
+        from tools import approval, code_execution_tool, process_registry, terminal_tool
+
+        monkeypatch.setattr(code_execution_tool, "SANDBOX_AVAILABLE", True)
+        monkeypatch.setattr(process_registry, "_is_gateway_process", lambda: True)
+        monkeypatch.setattr(
+            process_registry, "_is_supervised_gateway_process", lambda: False
+        )
+        monkeypatch.setattr(
+            approval,
+            "check_execute_code_guard",
+            lambda *args, **kwargs: {"approved": True},
+        )
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {"env_type": "ssh", "host_access": False},
+        )
+        monkeypatch.setattr(
+            code_execution_tool,
+            "_execute_remote",
+            lambda *args, **kwargs: json.dumps({"status": "success"}),
+        )
+
+        result = json.loads(
+            code_execution_tool.execute_code(
+                "import os; os.system('hermes gateway restart')"
+            )
+        )
+
+        assert "error" in result
+        assert "Blocked" in result["error"]
+
+
 class TestTerminalToolGatewayLifecycleGuard:
     """terminal_tool must refuse gateway lifecycle commands when _HERMES_GATEWAY=1.
 
@@ -518,6 +588,10 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         monkeypatch.setattr(
+            process_registry, "_is_gateway_process",
+            lambda: inside_gateway,
+        )
+        monkeypatch.setattr(
             process_registry, "_is_supervised_gateway_process",
             lambda: inside_gateway,
         )
@@ -544,6 +618,34 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+
+    def test_detached_gateway_blocks_lifecycle_command(self, monkeypatch):
+        """A Windows direct-spawn gateway is live but not externally supervised.
+        Its own terminal tool must still refuse a self-restart.
+        """
+        import tools.terminal_tool as tt
+        from tools import process_registry
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
+        monkeypatch.setattr(process_registry, "_is_gateway_process", lambda: True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda command, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+        assert calls == []
 
     def test_force_true_cannot_bypass_block(self, monkeypatch):
         import tools.terminal_tool as tt
@@ -1836,6 +1938,10 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_process",
+            lambda: inside_gateway,
+        )
         monkeypatch.setattr(
             process_registry, "_is_supervised_gateway_process",
             lambda: inside_gateway,

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -753,9 +753,8 @@ class TestTerminalToolGatewayLifecycleGuard:
                 return {"output": "", "returncode": 0}
 
         # Simulate a CLI agent session: _HERMES_GATEWAY=1 is in the
-        # environment (inherited from the gateway), but
-        # _is_supervised_gateway_process() returns False because the
-        # process does not own the gateway PID file.
+        # environment (inherited from the gateway), but _is_gateway_process()
+        # returns False because this process does not own the gateway PID file.
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         monkeypatch.setattr(

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1305,8 +1305,8 @@ def execute_code(
     # identical command inside `os.system(...)` / `subprocess.run([...])`
     # here sailed through and SIGTERM'd the gateway mid-task. Gated on
     # PID-file ownership, not the inherited env marker (#92560).
-    from tools.process_registry import _is_supervised_gateway_process
-    if _is_supervised_gateway_process():
+    from tools.process_registry import _is_gateway_process
+    if _is_gateway_process():
         from cron.lifecycle_guard import contains_gateway_lifecycle_command
         if contains_gateway_lifecycle_command(code):
             return tool_error(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -255,26 +255,35 @@ def _systemd_run_user_scope_available() -> bool:
         return available
 
 
-def _is_supervised_gateway_process() -> bool:
-    """Return whether this process is in a supervised Hermes gateway runtime.
+def _is_gateway_process() -> bool:
+    """Return whether this process owns the live Hermes gateway PID file.
 
-    Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
-    descendant, and importing ``gateway.run`` also sets the latter. Require
-    this process to own the live gateway PID file as well. That keeps transient
-    systemd scopes limited to the gateway itself instead of terminal children
-    or unrelated interactive CLIs in the same supervised process tree.
+    ``_HERMES_GATEWAY`` is inherited by descendants, so the marker alone is
+    insufficient. PID-file ownership distinguishes the gateway itself from
+    terminal children and unrelated CLI/TUI processes while still recognizing
+    detached Windows gateways that have no external supervisor.
     """
     if os.environ.get("_HERMES_GATEWAY") != "1":
         return False
 
     try:
-        from gateway.restart import is_gateway_supervisor_process
         from gateway.status import get_running_pid
 
-        return (
-            is_gateway_supervisor_process()
-            and get_running_pid(cleanup_stale=False) == os.getpid()
-        )
+        return get_running_pid(cleanup_stale=False) == os.getpid()
+    except Exception as exc:
+        logger.debug("Could not verify gateway process identity: %s", exc)
+        return False
+
+
+def _is_supervised_gateway_process() -> bool:
+    """Return whether this process is the live externally supervised gateway."""
+    if not _is_gateway_process():
+        return False
+
+    try:
+        from gateway.restart import is_gateway_supervisor_process
+
+        return is_gateway_supervisor_process()
     except Exception as exc:
         logger.debug("Could not verify supervised gateway process identity: %s", exc)
         return False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3069,17 +3069,16 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
-        # Gate on the SUPERVISED-gateway probe, not the raw _HERMES_GATEWAY
+        # Gate on live gateway PID ownership, not the raw _HERMES_GATEWAY
         # marker: gateway.run sets it at import time, so it leaks into every
         # process that merely imports gateway.run (hermes serve --isolated,
         # CLI, web server) which are NOT the gateway and must be able to
-        # restart it. A plain foreground `hermes gateway run` (env set, PID
-        # owned, no supervisor) now also PASSES this guard: intentional and
-        # harmless, since without a supervisor there is no KeepAlive to turn a
-        # self-restart into a respawn loop.
-        from tools.process_registry import _is_supervised_gateway_process
+        # restart it. PID ownership still recognizes detached Windows gateways
+        # that have no external supervisor; those can otherwise kill this tool
+        # before gateway_windows.restart() reaches its start() phase.
+        from tools.process_registry import _is_gateway_process
 
-        if _is_supervised_gateway_process():
+        if _is_gateway_process():
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,


### PR DESCRIPTION
## What does this PR do?

Prevents a live Windows gateway started via direct spawn from stopping or restarting itself through the `terminal` or `execute_code` tools.

The lifecycle guards previously relied on `_is_supervised_gateway_process()`. A direct-spawn Windows gateway owns the live gateway PID file but has no systemd/launchd supervisor, so the guard returned false. If an agent then ran `hermes gateway restart` through its own terminal tool, the gateway stopped itself and interrupted the tool before the replacement process could be launched.

This separates **live gateway identity** from **external supervision**:

- `_is_gateway_process()` verifies `_HERMES_GATEWAY=1` plus ownership of the live gateway PID file.
- `_is_supervised_gateway_process()` builds on that identity and separately checks for a supervisor.
- The `terminal` and `execute_code` lifecycle guards use live gateway identity, covering direct-spawn Windows gateways without treating descendants that merely inherit `_HERMES_GATEWAY` as the gateway.

## Related Issue

No matching issue or PR was found in a repository search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py`: distinguish live gateway PID ownership from external supervision.
- `tools/terminal_tool.py`: block gateway lifecycle commands from any live gateway, including Windows direct-spawn processes.
- `tools/code_execution_tool.py`: apply the same guard to lifecycle commands embedded in generated code.
- `tests/hermes_cli/test_gateway_restart_loop.py`: add direct-spawn identity and terminal/execute-code regressions while preserving inherited-environment CLI behavior.

## How to Test

1. Run the focused regression set:
   ```bash
   uv run --isolated --with pytest python -m pytest \
     tests/hermes_cli/test_gateway_restart_loop.py::TestGatewayProcessIdentity \
     tests/hermes_cli/test_gateway_restart_loop.py::TestExecuteCodeGatewayLifecycleGuard \
     tests/hermes_cli/test_gateway_restart_loop.py::TestTerminalToolGatewayLifecycleGuard::test_detached_gateway_blocks_lifecycle_command \
     tests/hermes_cli/test_gateway_restart_loop.py::TestTerminalToolGatewayLifecycleGuard::test_cli_agent_session_not_blocked_by_inherited_env \
     -q --tb=short
   ```
2. Start the gateway on Windows via direct spawn and externally restart it once.
3. Verify the replacement PID owns the gateway PID file, Discord reconnects, and cron heartbeat remains healthy.

## Validation

- Focused regressions: **5 passed**.
- Ruff on all four changed files: **passed**.
- `git diff --check`: **passed**.
- Full `test_gateway_restart_loop.py` comparison on native Windows 11:
  - clean `origin/main`: **236 passed, 61 failed**
  - patched branch: **240 passed, 61 failed**
  - no new failures; the identical 61 failures are existing POSIX/macOS assumptions under native Windows (`/bin/bash`, `os.mkfifo`, symlink privileges, Unix wrapper commands, and Windows path tokenization).
- Relevant process-registry/code-execution sibling comparison:
  - clean `origin/main`: **133 passed, 54 skipped, 8 failed**
  - patched branch: **133 passed, 54 skipped, 8 failed**
  - no new failures; the 8 failures are existing native-Windows incompatibilities (`/bin/bash`, POSIX process groups, winpty surrogate handling, and `AF_UNIX`).
- Manual Windows 11 validation: external restart replaced PID 26456 with PID 8948; all six deep gateway probes passed; Discord reconnected as `Hermes-Bot#7360`; cron ticker heartbeat was current.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs/issues and found no duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (the repository has existing native-Windows failures; exact baseline comparisons are documented above)
- [x] I've added tests for the bug
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A; internal lifecycle safety behavior is covered by comments and tests
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow or architecture contract changed
- [x] Cross-platform impact considered; supervision-specific behavior remains in `_is_supervised_gateway_process()`
- [x] Tool descriptions/schemas update — N/A; tool schemas are unchanged

## Screenshots / Logs

Observed failure before the fix: the direct-spawn gateway accepted its own `hermes gateway restart`, stopped, and the invoking terminal tool exited before the start phase. After the fix, the lifecycle command is rejected at the tool boundary, while an external restart completes normally and the replacement gateway remains healthy.
