### PR TITLE
fix(tui): probe DEC 2026 with DECRQM so SSH sessions stop flickering

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -25,6 +25,7 @@ import { decrqm, oscColor, TerminalQuerier, xtversion } from '../terminal-querie
 import {
   isXtermJs,
   parseOscColor,
+  setSynchronizedOutputSupported,
   setTerminalBackgroundHex,
   setTerminalForegroundHex,
   setXtversionName,
@@ -360,12 +361,34 @@ export default class App extends PureComponent<Props, State> {
           // FOREGROUND is the polarity tiebreaker for transparent profiles:
           // those report the unset-default background (pure black) but the
           // theme's real foreground, whose luminance reveals the pole.
+          // DECRQM mode 2026 rides the same batch. Env detection can't see
+          // synchronized-output support over SSH (sshd forwards TERM but not
+          // TERM_PROGRAM/KITTY_WINDOW_ID/VTE_VERSION/WT_SESSION), so remote
+          // sessions fall back to un-atomic frame writes and visibly flicker.
+          // The query reaches the client terminal through the pty; the DA1
+          // sentinel bounds it, and no reply simply leaves the env guess.
           void Promise.all([
             this.querier.send(xtversion()),
             this.querier.send(oscColor(11)),
             this.querier.send(oscColor(10)),
+            this.querier.send(decrqm(DEC.SYNCHRONIZED_UPDATE)),
             this.querier.flush()
-          ]).then(([r, bg, fg]) => {
+          ]).then(([r, bg, fg, sync]) => {
+            // NOT_RECOGNIZED / PERMANENTLY_RESET mean the terminal can't do
+            // DEC 2026; SET or RESET both prove it knows the mode.
+            if (sync) {
+              const supported =
+                sync.status !== DECRPM_STATUS.NOT_RECOGNIZED &&
+                sync.status !== DECRPM_STATUS.PERMANENTLY_RESET
+
+              setSynchronizedOutputSupported(supported)
+              logForDebugging(
+                `DECRQM 2026: synchronized output ${supported ? 'supported' : 'unsupported'} (status ${sync.status})`
+              )
+            } else {
+              logForDebugging('DECRQM 2026: no reply (terminal ignored query)')
+            }
+
             if (r) {
               setXtversionName(r.name)
               logForDebugging(`XTVERSION: terminal identified as "${r.name}"`)

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -76,10 +76,10 @@ import {
   updateSelection
 } from './selection.js'
 import {
+  isSyncOutputSupported,
   needsAltScreenResizeScrollbackClear,
   skipKittyKeyboardProtocol,
   supportsExtendedKeys,
-  SYNC_OUTPUT_SUPPORTED,
   type Terminal,
   writeDiffToTerminal
 } from './terminal.js'
@@ -1004,8 +1004,8 @@ export default class Ink {
       // DECSTBM needs BSU/ESU atomicity — without it the outer terminal
       // renders the scrolled-but-not-yet-repainted intermediate state.
       // tmux is the main case (re-emits DECSTBM with its own timing and
-      // doesn't implement DEC 2026, so SYNC_OUTPUT_SUPPORTED is false).
-      SYNC_OUTPUT_SUPPORTED
+      // doesn't implement DEC 2026, so this reads false).
+      isSyncOutputSupported()
     )
 
     const diffMs = performance.now() - tDiff
@@ -1218,8 +1218,9 @@ export default class Ink {
       // the stream with their own timing, so the markers buy no atomicity and
       // stale frames get pushed into main-screen scrollback as repeated
       // chrome (#66490). Supported terminals keep today's behavior on both
-      // screens (skip=false → BSU/ESU wrapped).
-      !SYNC_OUTPUT_SUPPORTED,
+      // screens (skip=false → BSU/ESU wrapped). Read per-frame: the DECRQM
+      // probe may upgrade this shortly after startup (notably over SSH).
+      !isSyncOutputSupported(),
       trackDrain
         ? () => {
             // Callback fires once Node has flushed the chunk to the OS.

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isSynchronizedOutputSupported, needsAltScreenResizeScrollbackClear, writeDiffToTerminal } from './terminal.js'
+import {
+  isSynchronizedOutputSupported,
+  isSyncOutputSupported,
+  needsAltScreenResizeScrollbackClear,
+  setSynchronizedOutputSupported,
+  writeDiffToTerminal
+} from './terminal.js'
 import { BSU, ESU } from './termio/dec.js'
 
 describe('terminal resize quirks', () => {
@@ -35,6 +41,67 @@ describe('synchronized output detection', () => {
 
   it('reports no support for an unknown terminal', () => {
     expect(isSynchronizedOutputSupported({ TERM: 'xterm-256color' })).toBe(false)
+  })
+})
+
+describe('DECRQM 2026 probe upgrades the env-based guess', () => {
+  const withEnv = (vars: Record<string, string | undefined>, run: () => void) => {
+    const saved = { TMUX: process.env.TMUX, ZELLIJ: process.env.ZELLIJ }
+
+    for (const [k, v] of Object.entries(vars)) {
+      if (v === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = v
+      }
+    }
+
+    try {
+      run()
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) {
+          delete process.env[k]
+        } else {
+          process.env[k] = v
+        }
+      }
+    }
+  }
+
+  it('turns sync output on when the terminal answers DECRQM (the SSH case)', () => {
+    // sshd forwards TERM but not TERM_PROGRAM, so the env guess is false on a
+    // perfectly capable remote terminal. The probe reply is the real answer.
+    withEnv({ TMUX: undefined, ZELLIJ: undefined }, () => {
+      setSynchronizedOutputSupported(false)
+      expect(isSyncOutputSupported()).toBe(false)
+
+      setSynchronizedOutputSupported(true)
+      expect(isSyncOutputSupported()).toBe(true)
+    })
+  })
+
+  it('never upgrades inside tmux, which proxies the query to the outer terminal', () => {
+    withEnv({ TMUX: '/tmp/tmux-1/default,1,0', ZELLIJ: undefined }, () => {
+      setSynchronizedOutputSupported(false)
+      setSynchronizedOutputSupported(true)
+      expect(isSyncOutputSupported()).toBe(false)
+    })
+  })
+
+  it('never upgrades inside Zellij', () => {
+    withEnv({ TMUX: undefined, ZELLIJ: '0' }, () => {
+      setSynchronizedOutputSupported(false)
+      setSynchronizedOutputSupported(true)
+      expect(isSyncOutputSupported()).toBe(false)
+    })
+  })
+
+  it('always honours a downgrade, multiplexer or not', () => {
+    withEnv({ TMUX: '/tmp/tmux-1/default,1,0', ZELLIJ: undefined }, () => {
+      setSynchronizedOutputSupported(false)
+      expect(isSyncOutputSupported()).toBe(false)
+    })
   })
 })
 

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -346,9 +346,35 @@ export function hasCursorUpViewportYankBug(): boolean {
   return process.platform === 'win32' || !!process.env.WT_SESSION
 }
 
-// Computed once at module load — terminal capabilities don't change mid-session.
-// Exported so callers can pass a sync-skip hint gated to specific modes.
-export const SYNC_OUTPUT_SUPPORTED = isSynchronizedOutputSupported()
+// Seeded at module load from env vars, then upgraded by the DECRQM probe.
+//
+// Env detection alone is blind over SSH: sshd forwards TERM but not
+// TERM_PROGRAM, KITTY_WINDOW_ID, VTE_VERSION, WT_SESSION or ZED_TERM, so a
+// remote session on a DEC 2026-capable terminal reads as unsupported
+// (TERM normalizes to xterm-256color) and every frame paints un-atomically —
+// visible tearing/flicker on exactly the terminals that could avoid it.
+// DECRQM goes through the pty, so the query reaches the *client* terminal and
+// the reply comes back on stdin — the same trick XTVERSION already uses.
+// Readers must call isSyncOutputSupported() at use time, not snapshot it.
+let syncOutputSupported = isSynchronizedOutputSupported()
+
+/** True when frames may be wrapped in BSU/ESU (DEC 2026). */
+export function isSyncOutputSupported(): boolean {
+  return syncOutputSupported
+}
+
+/** Record the DECRQM mode-2026 probe result. Called from App.tsx when the
+ *  reply arrives. Multiplexers are never upgraded: tmux/Zellij proxy the
+ *  query to the outer terminal, so an affirmative reply describes the OUTER
+ *  terminal while the multiplexer has already broken frame atomicity by
+ *  re-chunking the stream (#66490). Downgrades always apply. */
+export function setSynchronizedOutputSupported(supported: boolean): void {
+  if (supported && (process.env.TMUX || process.env.ZELLIJ)) {
+    return
+  }
+
+  syncOutputSupported = supported
+}
 
 export type Terminal = {
   stdout: Writable


### PR DESCRIPTION
## What does this PR do?

Fixes TUI flicker over SSH by detecting DEC 2026 (synchronized output) with a runtime DECRQM probe instead of guessing from environment variables.

`isSynchronizedOutputSupported()` (`ink/terminal.ts`) decides support purely from env: `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `VTE_VERSION`, `WT_SESSION`, `ZED_TERM`. **sshd forwards none of these.** Only `TERM` survives, normalized to `xterm-256color`. So every remote session — even on Ghostty, kitty, WezTerm, iTerm2 or Windows Terminal — reads as unsupported.

That false value flows into the renderer, which passes `skipSyncMarkers = !SYNC_OUTPUT_SUPPORTED` on **both** the main and alt screen paths (`ink.tsx`). No frame gets wrapped in BSU/ESU, so the terminal is free to display half-written frames. That is the flicker. The same value also gates off the DECSTBM scroll-region path in `log.render()`, so affected sessions repaint more than necessary on top.

**Why this approach:** the TUI already solved this exact class of problem. `TerminalQuerier` sends queries through the pty, so they reach the *client* terminal and replies return on stdin — which is precisely why XTVERSION is used for terminal identity where `TERM_PROGRAM` can't be trusted (see the comment above `setXtversionName`). `decrqm(2026)` is even the worked example in `TerminalQuerier`'s own docstring. It was simply never wired to the capability it documents. This PR connects the two, adding one query to a batch that already runs at startup.

## Related Issue

No existing issue covers the SSH case specifically. The nearest neighbours are all about *not* emitting markers when unsupported, whereas this is about *correctly detecting* support:

- #66490 / #86384 (merged) — never emit BSU/ESU on unsupported terminals, any screen. This PR keeps that guarantee intact and makes the input to it accurate.
- #77408 — CLI/TUI polish proposal, which lists differential rendering; this addresses the atomicity half.

Fixes #95955

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`ui-tui/packages/hermes-ink/src/ink/terminal.ts`** — the env check now *seeds* the capability instead of freezing it at module load. Adds `isSyncOutputSupported()` (read) and `setSynchronizedOutputSupported()` (record probe result). **Multiplexers are never upgraded:** tmux and Zellij proxy the query to the outer terminal, so an affirmative reply describes a terminal whose frame atomicity they have already broken by re-chunking the stream (#66490). Downgrades always apply.
- **`ui-tui/packages/hermes-ink/src/ink/components/App.tsx`** — `decrqm(DEC.SYNCHRONIZED_UPDATE)` joins the existing startup query batch beside XTVERSION and OSC 10/11. The DA1 sentinel already bounds that batch, so there is no timeout and no new round-trip stage. A terminal that ignores DECRQM leaves the env guess untouched. Status 1/2/3 prove the mode is known; only 0 (not recognized) and 4 (permanently reset) mean unsupported.
- **`ui-tui/packages/hermes-ink/src/ink/ink.tsx`** — both readers call `isSyncOutputSupported()` per frame instead of capturing a module-load constant, so the probe result actually takes effect.
- **`ui-tui/packages/hermes-ink/src/ink/terminal.test.ts`** — 4 tests: probe upgrades the guess (the SSH case), tmux and Zellij are never upgraded, and downgrades always apply.

No config keys, no public API changes, no behavior change for terminals that were already detected correctly by env.

## How to Test

1. From a DEC 2026-capable terminal (Ghostty, kitty, WezTerm, iTerm2, Windows Terminal), SSH to another machine and run the TUI there. On `main` the status bar and streaming output visibly tear.
2. Confirm the env blind spot on the remote host — `TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID`, `VTE_VERSION` are all unset and `TERM=xterm-256color`, so `isSynchronizedOutputSupported()` returns `false` even though the client terminal is fully capable.
3. Confirm the terminal's real capability through the pty:
   ```bash
   printf '\033[?2026$p'; IFS= read -rs -t 2 -d 'y' r; printf '%q\n' "$r"
   ```
   A reply of `\E[?2026;2$` means status 2 — mode recognized, currently reset — i.e. **supported**.
4. With this PR, the startup probe reports that status, `isSyncOutputSupported()` flips to `true`, and frames are BSU/ESU wrapped again. The tearing stops.

Verified on Ubuntu 24.04 (Linux 6.8) over SSH against a client terminal answering status 2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *not run: this change is TypeScript-only and touches no Python. The relevant gate is `npm run check` in `ui-tui`, which passes (see below).*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Linux 6.8, Node 22.22.2

`npm run check` in `ui-tui` (`build:ink && typecheck && test && lint`):

- `build:ink` — pass
- `typecheck` (`tsc --noEmit`) — pass
- `test` (`vitest run`) — **1717 passed / 159 files**
- `lint` (`eslint src/ packages/`) — 0 errors (2 pre-existing warnings in `useSessionLifecycle.ts` and `textInput.tsx`, both untouched here)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the rationale lives in the code comments next to the probe and the setter, matching how XTVERSION's SSH caveat is documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — see note below

## Cross-platform / reviewer notes

**Windows Terminal, VTE, Zed** already detect correctly via env locally and are unaffected; over SSH they now gain correct detection like everyone else.

**Terminals that ignore DECRQM** are unchanged — the DA1 sentinel resolves the query as `undefined` and the env guess stands.

**One interaction worth a reviewer's eye:** #79798 reports that Apple Terminal doesn't implement DECRQM and echoes the query's trailing `p` as a printable character. This PR adds one more DECRQM query, so on Apple Terminal it is one more opportunity for that echo. Note the exposure is pre-existing and not introduced here — the same startup batch already sends XTVERSION and two OSC colour queries, and the mouse watchdog sends `decrqm(1000)` every 2s. #79798's `forceRedraw()` on a proven-ignored probe would cover this one too. Happy to gate the 2026 probe behind that fix, or to land it after, if maintainers prefer.

**Stale neighbour:** #75304 targets the older `this.altScreenActive && !SYNC_OUTPUT_SUPPORTED` expression, which #86384 has since replaced on `main`. This PR builds on the post-#86384 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uKEcEdccbyMYNx6psPeE1
