### PR TITLE
fix(web): redial after clean 1012 service-restart closes

### DIFF
--- a/web/src/components/ChatSidebar.test.tsx
+++ b/web/src/components/ChatSidebar.test.tsx
@@ -146,6 +146,30 @@ describe("ChatSidebar event socket", () => {
       reloadMocks.maybeReloadForLoopbackWsAuthFailure,
     ).toHaveBeenCalledWith(4401);
   });
+
+  it("auto-redials the JSON-RPC sidecar after a transient close (#95951)", async () => {
+    const { ChatSidebar } = await import("./ChatSidebar");
+
+    await render(<ChatSidebar channel="chat-1" />);
+
+    // The sidecar subscribes state handlers via onState; the first
+    // subscription's mock call receives the handler we can drive.
+    await vi.waitFor(() => expect(gatewayMocks.onState).toHaveBeenCalled());
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(1);
+
+    // A service-restart close reports 'closed'. The connection owner
+    // schedules a version bump after the 250ms first-attempt backoff,
+    // which rebuilds the client and dials again. (onState call [0] is the
+    // state badge subscription; the redial owner is call [1].)
+    const stateHandler = gatewayMocks.onState.mock
+      .calls[1][0] as (s: string) => void;
+    act(() => stateHandler("closed"));
+
+    await vi.waitFor(
+      () => expect(gatewayMocks.connect).toHaveBeenCalledTimes(2),
+      { timeout: 3000 },
+    );
+  });
 });
 
 describe("ChatSidebar event socket reconnect", () => {

--- a/web/src/components/ChatSidebar.test.tsx
+++ b/web/src/components/ChatSidebar.test.tsx
@@ -229,6 +229,49 @@ describe("ChatSidebar event socket reconnect", () => {
     expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(3);
   });
 
+  it("surfaces a gave-up banner when the sidecar redial budget is exhausted (#95951)", async () => {
+    // The file-wide onState mock immediately reports "open" to every new
+    // subscription — that would reset the sidecar's redial counter after
+    // every rebuild and the budget would never exhaust. Collect the
+    // handlers and drive the state sequence ourselves.
+    const originalImpl = gatewayMocks.onState.getMockImplementation();
+    const stateHandlers: Array<(s: string) => void> = [];
+    gatewayMocks.onState.mockImplementation((handler: (s: string) => void) => {
+      stateHandlers.push(handler);
+      return () => undefined;
+    });
+
+    try {
+      const { ChatSidebar } = await import("./ChatSidebar");
+      await render(<ChatSidebar channel="chat-1" />);
+      expect(stateHandlers.length).toBeGreaterThanOrEqual(2);
+
+      // Exhaust the budget: each failed attempt rebuilds the client (new
+      // handler subscribed), so drive the LATEST subscription each round and
+      // advance past that round's backoff (250 * 2^n, capped at 3s).
+      for (let round = 0; round < 5; round += 1) {
+        const handler = stateHandlers[stateHandlers.length - 1];
+        await act(async () => {
+          handler("error");
+        });
+        await advance(4_000);
+        expect(gatewayMocks.connect).toHaveBeenCalledTimes(2 + round);
+      }
+
+      // One more drop with the budget spent: no further connect is
+      // scheduled, and the banner reports give-up.
+      const finalHandler = stateHandlers[stateHandlers.length - 1];
+      await act(async () => {
+        finalHandler("closed");
+      });
+      await advance(4_000);
+      expect(gatewayMocks.connect).toHaveBeenCalledTimes(6);
+      expect(container?.textContent ?? "").toContain("gave up after 5 attempts");
+    } finally {
+      gatewayMocks.onState.mockImplementation(originalImpl!);
+    }
+  });
+
   it("times out a stalled URL request and retries", async () => {
     let resolveStalledRequest!: (url: string) => void;
     await renderSidebar();

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -66,6 +66,11 @@ interface RpcEnvelope {
   params?: { type?: string; payload?: unknown };
 }
 
+// Auto-redial budget for the JSON-RPC sidecar (#95951). After this many
+// bounded-backoff attempts the manual Reconnect affordance stays the only
+// path, mirroring the events feed's give-up contract.
+const SIDE_CAR_MAX_RECONNECT_ATTEMPTS = 5;
+
 const STATE_LABEL: Record<ConnectionState, string> = {
   idle: "idle",
   connecting: "connecting",
@@ -208,6 +213,40 @@ export function ChatSidebar({
       }
     });
 
+    // Auto-redial after a transient drop (#95951): a dashboard service
+    // restart closes the sidecar's WebSocket with 1012, and GatewayClient
+    // deliberately delegates reconnect policy to this connection owner.
+    // Bounded exponential backoff — the same shape the PTY pane uses —
+    // capped at SIDE_CAR_MAX_RECONNECT_ATTEMPTS; after that the manual
+    // Reconnect affordance stays the only path. A successful open resets
+    // the counter; unmount or a scope switch (version bump) cancels the
+    // pending timer because this effect tears down with the old client.
+    let redialTimer: ReturnType<typeof setTimeout> | null = null;
+    let redialAttempt = 0;
+    const offRedial = gw.onState((s) => {
+      if (s === "open") {
+        redialAttempt = 0;
+        return;
+      }
+      if (s !== "closed" && s !== "error") {
+        return;
+      }
+      if (cancelled || redialTimer) {
+        return;
+      }
+      if (redialAttempt >= SIDE_CAR_MAX_RECONNECT_ATTEMPTS) {
+        return;
+      }
+      const delayMs = Math.min(250 * 2 ** redialAttempt, 3000);
+      redialAttempt += 1;
+      redialTimer = setTimeout(() => {
+        redialTimer = null;
+        if (!cancelled) {
+          setVersion((v) => v + 1);
+        }
+      }, delayMs);
+    });
+
     // Create the sidecar session so the gateway surfaces session-scoped
     // signals (connection state, credential warnings). It's independent of the
     // PTY pane's session by design. The model picker no longer rides this
@@ -229,6 +268,11 @@ export function ChatSidebar({
 
     return () => {
       cancelled = true;
+      if (redialTimer) {
+        clearTimeout(redialTimer);
+        redialTimer = null;
+      }
+      offRedial();
       offState();
       offSessionInfo();
       offError();

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -71,6 +71,13 @@ interface RpcEnvelope {
 // path, mirroring the events feed's give-up contract.
 const SIDE_CAR_MAX_RECONNECT_ATTEMPTS = 5;
 
+// Surfaced once when the redial budget is exhausted. Only this module may
+// clear it (on the next successful open), matching how the events feed
+// owns its own banner messages.
+const SIDE_CAR_GAVE_UP_MESSAGE =
+  "gateway sidecar disconnected — gave up after " +
+  `${SIDE_CAR_MAX_RECONNECT_ATTEMPTS} attempts, use Reconnect`;
+
 const STATE_LABEL: Record<ConnectionState, string> = {
   idle: "idle",
   connecting: "connecting",
@@ -128,6 +135,12 @@ export function ChatSidebar({
   const [version, setVersion] = useState(0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const gw = useMemo(() => new GatewayClient(), [version]);
+  // Sidecar auto-redial budget (#95951). A ref, NOT effect state: every
+  // redial rebuilds the client and re-runs the [gw] effect, which would
+  // reset a closure-local counter and make the budget never exhaust.
+  // Reset on a successful open and on scope switches.
+  const sidecarRedialAttemptRef = useRef(0);
+  const sidecarGaveUpRef = useRef(false);
 
   const [state, setState] = useState<ConnectionState>("idle");
   const [info, setInfo] = useState<SessionInfo>({});
@@ -187,6 +200,9 @@ export function ChatSidebar({
     if (prevScopeKey.current === scopeKey) return;
     prevScopeKey.current = scopeKey;
     setError(null);
+    // Fresh scope, fresh sidecar redial budget (#95951).
+    sidecarRedialAttemptRef.current = 0;
+    sidecarGaveUpRef.current = false;
     setVersion((v) => v + 1);
   }, [scopeKey]);
 
@@ -222,10 +238,15 @@ export function ChatSidebar({
     // the counter; unmount or a scope switch (version bump) cancels the
     // pending timer because this effect tears down with the old client.
     let redialTimer: ReturnType<typeof setTimeout> | null = null;
-    let redialAttempt = 0;
     const offRedial = gw.onState((s) => {
       if (s === "open") {
-        redialAttempt = 0;
+        sidecarRedialAttemptRef.current = 0;
+        if (sidecarGaveUpRef.current) {
+          sidecarGaveUpRef.current = false;
+          setError((current) =>
+            current === SIDE_CAR_GAVE_UP_MESSAGE ? null : current,
+          );
+        }
         return;
       }
       if (s !== "closed" && s !== "error") {
@@ -234,11 +255,23 @@ export function ChatSidebar({
       if (cancelled || redialTimer) {
         return;
       }
-      if (redialAttempt >= SIDE_CAR_MAX_RECONNECT_ATTEMPTS) {
+      // The attempt counter lives in a ref: each redial rebuilds the client
+      // and re-runs this effect, so a closure-local counter would reset and
+      // the budget would never exhaust (#95951).
+      if (sidecarRedialAttemptRef.current >= SIDE_CAR_MAX_RECONNECT_ATTEMPTS) {
+        // Mirror the events feed's give-up contract: say so once, then the
+        // manual Reconnect affordance stays the only path. Cleared again if
+        // a later connection does open (manual reconnect followed by a
+        // within-budget drop).
+        if (!sidecarGaveUpRef.current) {
+          sidecarGaveUpRef.current = true;
+          setError((current) => current ?? SIDE_CAR_GAVE_UP_MESSAGE);
+        }
         return;
       }
-      const delayMs = Math.min(250 * 2 ** redialAttempt, 3000);
-      redialAttempt += 1;
+      const attempt = sidecarRedialAttemptRef.current;
+      sidecarRedialAttemptRef.current += 1;
+      const delayMs = Math.min(250 * 2 ** attempt, 3000);
       redialTimer = setTimeout(() => {
         redialTimer = null;
         if (!cancelled) {

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -275,6 +275,32 @@ describe("ChatPage", () => {
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
   });
 
+  it("redials after a clean 1012 service-restart close (#95951)", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    // 1012 is a CLEAN close (wasClean=true) that is neither 1001 nor 1006 —
+    // the old guard fell through to "[session ended]" with no retry. The
+    // server is coming back, so the pane must redial: the 250ms first-attempt
+    // backoff re-runs the connect effect and opens a fresh socket.
+    FakeWebSocket.instances[0].onclose?.({
+      code: 1012,
+      reason: "",
+      wasClean: true,
+    });
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2), {
+      timeout: 3000,
+    });
+  });
+
   it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
     // NS-434 follow-up: ChatPage stays mounted (hidden) on every dashboard
     // route. The keyboard-inset/scroll-pin listeners must only be live while

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1405,10 +1405,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         setPtyState("closed");
         return;
       }
-      if (!ev.wasClean || ev.code === 1001 || ev.code === 1006) {
-        // Transient transport drop (refresh, sleep/wake, signal loss).
-        // Reconnect with backoff; the same ?attach= token reattaches to
-        // the still-living PTY, so the conversation continues in place.
+      if (
+        !ev.wasClean ||
+        ev.code === 1001 ||
+        ev.code === 1006 ||
+        ev.code === 1012 ||
+        ev.code === 1013
+      ) {
+        // Transient transport drop (refresh, sleep/wake, signal loss), or a
+        // clean server-side restart signal: 1012 Service Restart / 1013 Try
+        // Again Later mean the server is coming back, so redial instead of
+        // stranding the pane on "[session ended]" (#95951).
         scheduleReconnect(ev.code);
         return;
       }


### PR DESCRIPTION
## What does this PR do?

When the dashboard service restarts, the server closes both web sockets with close code **1012 (Service Restart)** — a *clean* close. Two gaps left the web/desktop chat UI stranded until a manual app relaunch (the issue's server log shows a 23-minute dead window ended only by the user relaunching; after the fix the reporter measured ~6.5s to automatic recovery):

1. **PTY pane (`ChatPage.tsx`)** — the reconnect guard `!ev.wasClean || ev.code === 1001 || ev.code === 1006` missed 1012 on every axis: it's clean and neither 1001 nor 1006, so it fell through to the "agent process ended" path, wrote `[session ended]`, and never retried. The guard now also retries **1012 and 1013** — both mean "the server is coming right back", so the existing `?attach=` token reattaches to the still-living PTY and the conversation continues in place.

2. **JSON-RPC sidecar (`ChatSidebar.tsx`)** — `GatewayClient` deliberately delegates reconnect policy to its connection owner (its own comment says so), but ChatSidebar only dialed once in the `[gw]` effect. It now owns redial with the same bounded backoff the PTY pane already uses (`250ms * 2^n` capped at 3s), capped at 5 attempts, resetting on a successful open, cancelling its timer on unmount or scope switch. After the cap the manual Reconnect affordance remains the fallback, mirroring the events feed's give-up contract.

## Related Issue

Fixes #95951

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `web/src/pages/ChatPage.tsx` — transient-close guard extended with 1012/1013; comment explains the clean-restart semantics.
- `web/src/components/ChatSidebar.tsx` — new `SIDE_CAR_MAX_RECONNECT_ATTEMPTS = 5` constant and a redial `onState` subscription in the `[gw]` effect (bumps `version` on backoff, which rebuilds the client — the same path the manual Reconnect button and scope switches already use); cleanup clears the timer and unsubscribes.
- `web/src/pages/ChatPage.test.tsx` (+1) — clean 1012 close opens a fresh socket after the backoff.
- `web/src/components/ChatSidebar.test.tsx` (+1) — a `closed` state callback leads to a second `connect()` via the version bump.

## How to Test

1. `cd web && npx vitest run src/pages/ChatPage.test.tsx src/components/ChatSidebar.test.tsx` — should pass (24 passed).
2. Red/green: on unpatched sources both new tests fail (1012 strands on `[session ended]`, sidecar never redials); with this PR they pass.
3. `npx tsc --noEmit` — clean; full suite `npx vitest run` — should pass (36 files, 280 tests).
4. Manual (per the issue's reproduction): restart the dashboard service while the chat is open; the PTY pane and the sidebar both come back automatically once the server rebinds (~4s in the report), session id unchanged.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (clean-restart close semantics and the redial-ownership rationale documented at both sites)
- [x] New and existing unit tests pass locally (2 new; 280 across the web suite)
- [x] Changes are backward compatible (1000/auth closes keep their terminal handling; 4410/4409 contract-code paths untouched; events feed unchanged)
