### PR TITLE
fix(gateway): keep sessions.json entry when startup recovery succeeds with same session id

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1618,6 +1618,26 @@ class SessionStore:
                         recovered_keys += 1
                         continue
 
+                    # A non-None recovery with the SAME session id is a successful
+                    # resume: _recover_session_from_db only returns non-None after
+                    # passing all safety gates (recoverable end reason, reset
+                    # boundary NOT EXISTS, source-scope match, active-profile
+                    # check, _should_reset). Keep the routing entry in place — it
+                    # is still valid, not a dead route. The `!=` guard above is
+                    # only for the compression-rotation case where a newer live
+                    # child session exists; a same-id recovery must NOT fall
+                    # through to the prune branch (#95957).
+                    if recovered_entry is not None:
+                        logger.warning(
+                            "gateway.session: keeping stale sessions.json entry "
+                            "%r -> %s (end_reason=%r); recovery succeeded with "
+                            "same session id",
+                            key, entry.session_id, row["end_reason"],
+                        )
+                        self._entries[key] = recovered_entry
+                        recovered_keys += 1
+                        continue
+
                     logger.warning(
                         "gateway.session: pruning stale sessions.json entry "
                         "%r -> %s (end_reason=%r); left by a crashed gateway",

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -104,6 +104,41 @@ class TestPruneStaleSessionsLocked:
         assert key in store._entries
         assert store._entries[key].session_id == "sid_parent"
 
+    def test_keeps_stale_entry_when_recovery_returns_same_session_id(self, tmp_path):
+        """A successful same-id recovery must NOT prune the routing entry.
+
+        When the startup sweep finds a stale entry whose session has ended in
+        state.db but ``_recover_session_from_db`` succeeds and returns the SAME
+        session id (proving the route is still resumable — the ``!=`` repoint
+        guard only exists for the compression-rotation child case), the entry
+        must be kept in place. The old code fell through to the prune branch
+        whenever the recovered id did not differ, deleting a perfectly valid
+        resumable mapping (#95957).
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning(
+            {"sid_parent": {"end_reason": "agent_close", "id": "sid_parent"}}
+        )
+        # Recovery returns the row for sid_parent itself — same id as the entry.
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_parent",
+            "started_at": (datetime.now() - timedelta(hours=5)).timestamp(),
+            "last_activity_at": (
+                datetime.now() - timedelta(hours=4)
+            ).timestamp(),
+        }
+        store = _make_store_with_db(tmp_path, db)  # default mode="none"
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        with patch.object(store, "_save") as mock_save:
+            store._prune_stale_sessions_locked()
+
+        # The successfully-recovered route must survive the sweep.
+        assert key in store._entries
+        assert store._entries[key].session_id == "sid_parent"
+        mock_save.assert_called_once()
+
+
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
         with patch("gateway.session.SessionStore._ensure_loaded"):


### PR DESCRIPTION
## Summary

`SessionStore._prune_stale_sessions_locked()` (`gateway/session.py`) calls
`_recover_session_from_db()` at startup to decide whether a stale `sessions.json`
routing entry is salvageable. The repoint branch only fires when recovery returns a
**different** session id:

```python
if recovered_entry is not None and recovered_entry.session_id != entry.session_id:
    ...repoint...
    continue
```

When recovery returns the **same** id — which is proof the route is still valid —
the `!=` guard is `False` and control falls straight through to the prune branch. A
successful same-id recovery is therefore indistinguishable from a dead route: the
routing entry is deleted and the platform peer (e.g. a Telegram forum topic) maps to
nothing until the user happens to send a fresh message from another surface.

`_recover_session_from_db()` already applies every safety gate before returning
non-`None` (recoverable end reasons, reset-boundary `NOT EXISTS`, source-scope match,
active-profile check, `_should_reset`). A non-`None` return is a positive verdict that
the row is resumable, so discarding it is strictly wrong. The `!=` guard exists only
for the compression-rotation case where a newer live child session exists.

## Changes

- **`gateway/session.py`**: after the existing different-id repoint branch, added a
  branch for the same-id successful-recovery case — keep the recovered entry in place
  (`self._entries[key] = recovered_entry`, `recovered_keys += 1`, `continue`). The
  prune path (`stale_keys.append`) now only runs when `recovered_entry is None`.
  Alive-session, non-DB, recovery-lookup-exception, and different-id repoint behavior
  are unchanged.
- **`tests/gateway/test_session_store_stale_prune.py`**: added
  `test_keeps_stale_entry_when_recovery_returns_same_session_id`, which proves the
  same-id recovery path keeps the routing entry (it fails against the original code
  and passes with the fix).

## Tests

- Regression test proven: fails on un-fixed code (`assert key in store._entries` →
  entry pruned), passes with the fix.
- Full stale-prune file: `9 passed`.
- Related code-path tests (`test_session_db_recovery.py`,
  `test_session_store_runtime_stale_guard.py`): `27 passed`.

Closes #95957
