### PR TITLE
fix(agent): tear down the backend probe's throwaway sandbox

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1344,6 +1344,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
 
+    env = None
     try:
         config = _get_env_config()
         # Build the environment the same way tools/terminal_tool.py does for a
@@ -1423,6 +1424,20 @@ def _probe_remote_backend(env_type: str) -> str | None:
         logger.debug("Backend probe failed: %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        # The probe only needs a one-shot `uname`. Without this teardown the
+        # backend leaves a second idle sandbox (task_id="prompt-backend-probe")
+        # running for the whole process lifetime, alongside the agent's own
+        # "default" sandbox. force_remove overrides persist mode for this
+        # throwaway env; backends whose cleanup() takes no kwargs fall back.
+        if env is not None:
+            try:
+                try:
+                    env.cleanup(force_remove=True)
+                except TypeError:
+                    env.cleanup()
+            except Exception:
+                logger.debug("Backend probe cleanup failed", exc_info=True)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -875,6 +875,96 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in line
         assert "root" in line
 
+    def test_probe_remote_backend_tears_down_its_sandbox(self, monkeypatch):
+        """THE BUG: the probe leaked a second, permanently idle sandbox.
+
+        ``_probe_remote_backend`` spins up an environment with
+        ``task_id="prompt-backend-probe"`` purely to run one ``uname``. Container
+        backends default to ``container_persistent`` /
+        ``docker_persist_across_processes``, so that throwaway sandbox stayed up
+        for the whole process lifetime *next to* the agent's own ``default``
+        sandbox — one wasted idle container per profile, forever. The probe owns
+        that environment, so it must tear it down.
+        """
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _pb._clear_backend_probe_cache()
+
+        cleaned = {}
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/root\n"
+                        "cwd=/workspace\nuser=root\n"
+                    ),
+                }
+
+            def cleanup(self, *, force_remove=False):
+                cleaned["force_remove"] = force_remove
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _FakeEnv())
+
+        assert _pb._probe_remote_backend("docker") is not None
+        # force_remove=True: persist mode would otherwise leave it running.
+        assert cleaned == {"force_remove": True}
+
+    def test_probe_remote_backend_tears_down_sandbox_on_failure(self, monkeypatch):
+        """Teardown must also run when the probe command blows up — a flaky
+        backend would otherwise leak the container the probe just created."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _pb._clear_backend_probe_cache()
+
+        cleaned = []
+
+        class _ExplodingEnv:
+            def execute(self, cmd, timeout=None):
+                raise RuntimeError("backend went away")
+
+            def cleanup(self, *, force_remove=False):
+                cleaned.append(force_remove)
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _ExplodingEnv())
+
+        assert _pb._probe_remote_backend("docker") is None
+        assert cleaned == [True]
+
+    def test_probe_remote_backend_tolerates_kwargless_cleanup(self, monkeypatch):
+        """Backends that inherit the base ``cleanup(self)`` take no kwargs; the
+        probe must fall back to the bare call instead of dying on TypeError."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        _pb._clear_backend_probe_cache()
+
+        calls = []
+
+        class _LegacyEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/home/u\n"
+                        "cwd=/home/u\nuser=u\n"
+                    ),
+                }
+
+            def cleanup(self):
+                calls.append("bare")
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _LegacyEnv())
+
+        assert _pb._probe_remote_backend("ssh") is not None
+        assert calls == ["bare"]
+
 
     def test_environment_hint_from_env_var_is_appended(self, monkeypatch):
         """HERMES_ENVIRONMENT_HINT lets an embedder describe the runtime env."""


### PR DESCRIPTION
## Problem

`_probe_remote_backend()` creates an environment with `task_id="prompt-backend-probe"` purely to run a single `uname` for the system prompt's environment hints — then drops the reference without cleaning it up.

Container backends default to `container_persistent=True` and `docker_persist_across_processes=True`, so that throwaway sandbox stays **running for the entire process lifetime**, idle, next to the agent's own `default` sandbox.

I hit this on a host running three Docker-backend profiles:

```
NAME                CPU %   MEM USAGE      LABELS
hermes-49367d98     0.00%   24.48MiB       hermes-task-id=default
hermes-e3b73290     0.00%   780KiB         hermes-task-id=prompt-backend-probe   <-- idle forever
hermes-3808e8e2     0.00%   2.609MiB       hermes-task-id=default
hermes-c7bc86e6     0.00%   816KiB         hermes-task-id=prompt-backend-probe   <-- idle forever
hermes-58a13e0f     0.00%   1.93MiB        hermes-task-id=default
hermes-0570dd6b     0.00%   1.637MiB       hermes-task-id=prompt-backend-probe   <-- idle forever
```

Six containers, three doing any work. Each profile permanently pays for a container whose only job was one `uname` at startup. The waste scales linearly with profile count, and it is not reclaimed by `reap_orphan_containers()` while the owning process lives.

## Fix

Wrap the probe in `try/finally` and call `env.cleanup(force_remove=True)`.

That is exactly the path `DockerEnvironment.cleanup` already documents:

> `force_remove=True` overrides persist mode and always tears the container down [...] **No current caller passes `force_remove=True`; the parameter is here so the explicit-teardown semantics can be wired up later without changing this method's signature.**

This is that caller. Persist mode is right for the agent's real sandbox (background processes must survive `/quit`); it is wrong for a one-shot probe that owns its environment outright.

Backends inheriting the kwarg-less base `cleanup(self)` fall back to the bare call, so non-Docker backends are unaffected.

## Testing

**Live verification** on an aarch64 Docker backend — probe container created, used, and reclaimed within the same call:

```
BEFORE:   (none)
PROBE OK: True     # OS: Linux 6.1.176 aarch64 / User: root / Home: /root
AFTER:    (none - reclaimed)
```

**Three regression tests** added, covering the success path, the exception path (a flaky backend must not leak the container it just created), and the kwarg-less `cleanup()` fallback. All three fail on `main` and pass with this change:

```
$ git stash push agent/prompt_builder.py && pytest -k "tears_down or kwargless_cleanup"
3 failed
$ git stash pop && pytest tests/agent/test_prompt_builder.py
74 passed, 1 skipped
```

**No new failures**: `pytest tests/agent` produces an identical set of 178 pre-existing failures before and after this change (`diff` of the two `FAILED` lists is empty on this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLbMzWqHVTPNBFisM8UiNB
