### PR TITLE
fix(update): raise the desktop step-idle watchdog default to 10 minutes

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -713,7 +713,7 @@ if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
 # cancellation trigger, never evidence that the process tree is safe to overlap:
 # every step is assigned to a private, non-breakaway Windows job and a timed-out
 # step is retryable only after that job reports zero active processes.
-$script:StepIdleTimeoutSeconds = 300
+$script:StepIdleTimeoutSeconds = 600
 if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
     $parsedIdle = 0
     if ([int]::TryParse($env:HERMES_UPDATE_STEP_IDLE_SECONDS, [ref]$parsedIdle) -and $parsedIdle -gt 0) {


### PR DESCRIPTION
## Summary
Raises the Windows desktop updater's step-idle watchdog default from 300s to 600s. Desktop builds legitimately produce no output for minutes (the updater terminal is static until a step completes), so a 5-minute ceiling risks cancelling healthy long steps; 10 minutes keeps the watchdog meaningful for true stalls while clearing slow builds. `HERMES_UPDATE_STEP_IDLE_SECONDS` still overrides. Per Teknium's review of the #95625 salvage.

Note: the #95625 watchdog itself was merged by a parallel session as #95897 (adb29d852) while this branch was in flight — this PR is now solely the review-requested default adjustment on top (1 line).

## Validation
| | |
|---|---|
| Default | 300 → 600, override path untouched |
| windows.ps1 | unchanged otherwise; the twice-passed windows-latest suite runs from the salvage lanes ([33020472297](https://github.com/NousResearch/hermes-agent/actions/runs/33020472297), [33024500609](https://github.com/NousResearch/hermes-agent/actions/runs/33024500609)) exercised the watchdog machinery this constant feeds |

## Infographic

![Stall watchdog](https://files.catbox.moe/o1cmfq.png)