### PR TITLE
fix(skills): give background-review fork its own skill_view dedup namespace

### DIFF
--- a/tests/tools/test_skill_view_dedup.py
+++ b/tests/tools/test_skill_view_dedup.py
@@ -88,6 +88,44 @@ class TestSkillViewDedup:
         r2 = json.loads(_skill_view_with_bump(args, task_id=None))
         assert "Step one" in r2.get("content", "")
 
+    def test_background_review_has_its_own_dedup_namespace(self, skills_home):
+        from tools.skill_provenance import (
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        _view("demo-dedup-skill")
+
+        token = set_current_write_origin("background_review")
+        try:
+            review = _view("demo-dedup-skill")
+        finally:
+            reset_current_write_origin(token)
+
+        assert review["success"] is True
+        assert "Step one" in review.get("content", "")
+        assert review.get("dedup") is None
+        assert review.get("content_returned") is None
+
+    def test_background_review_does_not_pollute_foreground_cache(self, skills_home):
+        from tools.skill_provenance import (
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        token = set_current_write_origin("background_review")
+        try:
+            _view("demo-dedup-skill")
+        finally:
+            reset_current_write_origin(token)
+
+        foreground = _view("demo-dedup-skill")
+        assert "Step one" in foreground.get("content", "")
+
+        repeat = _view("demo-dedup-skill")
+        assert repeat.get("dedup") is True
+        assert repeat.get("content_returned") is False
+
     def test_compression_hook_importable(self):
         # conversation_compression imports this lazily; keep the seam stable.
         from tools.skills_tool import reset_skill_view_dedup as f

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -79,6 +79,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, Any, List, Optional, Set, Tuple
 
 from tools.registry import registry, tool_error
+from tools.skill_provenance import is_background_review
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
@@ -2078,6 +2079,17 @@ def _record_skill_view(task_id, name, file_path, payload: dict) -> None:
                 break
 
 
+def _skill_view_dedup_task_id(task_id):
+    """Return the repeat-view namespace for the active provenance context."""
+    if not task_id:
+        return task_id
+    if is_background_review():
+        # Keep the review fork from inheriting the parent session's dedup
+        # state, while leaving the real task/session id untouched elsewhere.
+        return f"__bg_review__:{task_id}"
+    return task_id
+
+
 def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
     """Return a dedup stub when this exact skill file was already served
     to this task and is unchanged on disk; None otherwise."""
@@ -2138,6 +2150,7 @@ def _skill_view_with_bump(args, **kw):
     telemetry failure never breaks the tool call."""
     name = args.get("name", "")
     task_id = kw.get("task_id")
+    dedup_task_id = _skill_view_dedup_task_id(task_id)
     # ── Repeat-view dedup ────────────────────────────────────────────
     # Mirrors read_file's unchanged-stub: when this session already
     # loaded the SAME skill file and it hasn't changed on disk, return a
@@ -2148,7 +2161,7 @@ def _skill_view_with_bump(args, **kw):
     # "skills must be loaded fully" rule is preserved — and the cache is
     # cleared on context compression (same hook as read_file's dedup)
     # so a post-compression re-view returns full content again.
-    stub = _check_skill_view_dedup(task_id, name, args.get("file_path"))
+    stub = _check_skill_view_dedup(dedup_task_id, name, args.get("file_path"))
     if stub is not None:
         return stub
     result = skill_view(
@@ -2157,7 +2170,9 @@ def _skill_view_with_bump(args, **kw):
     try:
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
-            _record_skill_view(task_id, name, args.get("file_path"), parsed)
+            _record_skill_view(
+                dedup_task_id, name, args.get("file_path"), parsed
+            )
             # Use the resolved skill name from the payload when present —
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name


### PR DESCRIPTION
## What was broken

The autonomous background review fork (`agent/background_review.py`) is supposed to update skills after each turn, but in practice **every skill patch is refused 100% of the time**, wasting tokens with zero skill updates landing.

Two mechanisms conflict structurally:

1. **Read-before-write guard** (`tools/skill_manager_tool.py::_background_review_read_before_write_guard`) rejects `patch`/`write_file` unless the fork has actually `skill_view`-ed the file in the same review turn. The "read" mark is only set by `mark_background_review_skill_read()`, which `skill_view` calls only on the path that really reads and returns content.
2. **Repeat-view dedup** (`tools/skills_tool.py::_skill_view_tracker`) returns a `content_returned: false` stub when the same task already viewed an unchanged file — and on that path `mark_background_review_skill_read` is never called.
3. The fork **reuses the parent's session** (`review_agent.session_id = agent.session_id`) for prefix-cache parity, and the dedup cache is keyed by `task_id` (== `session_id` in the gateway) in a module-level dict. So the fork's `skill_view` almost always hits the parent's dedup stub → never marks read → patch is refused.

Production evidence: **408** `Refusing background curator patch …` refusals (07-24 → 08-26), and completion telemetry shows `result=skill` **0 times** across 41 forks (`result=memory` 9, `result=none` 32).

## What I changed

Give the review fork its own dedup namespace so its `skill_view` performs a real read (which marks the file as read), instead of inheriting the parent session's dedup stub.

`tools/skills_tool.py`:
- Import `is_background_review` from `tools.skill_provenance` at module top.
- Add `_skill_view_dedup_task_id(task_id)` helper returning `__bg_review__:{task_id}` when running under the background-review origin (and passing `None` through unchanged).
- In `_skill_view_with_bump`, use that namespaced id **only** for `_check_skill_view_dedup` / `_record_skill_view`; the `skill_view()` call and `bump_use()` keep the original `task_id`, so nothing else is disturbed.

The fork is single-lifecycle, so its namespaced dedup entries are dropped immediately — no effect on the parent session's cache.

## Tests

`tests/tools/test_skill_view_dedup.py`:
- `test_background_review_has_its_own_dedup_namespace` — under `background_review` origin, a second `skill_view` of an unchanged skill still returns full content (no stub).
- `test_background_review_does_not_pollute_foreground_cache` — after a review-origin view, the foreground cache is untouched (repeat view still dedups as before).

Verification: `scripts/run_tests.sh tests/tools/test_skill_view_dedup.py tests/tools/test_skill_provenance.py tests/tools/test_skill_manager_tool.py -q` → **62 passed, 0 failed**.