### PR TITLE
fix(matrix): enforce DM-inclusive room allowlists

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2412,6 +2412,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in rooms
         "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
         "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        "allowed_rooms_apply_to_dms": False, # With allowed_rooms, enforce it for DMs and room invites
     },
 
     # Approval mode for dangerous commands:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2264,6 +2264,13 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return room name and type (dm/group)."""
+        if not self._strict_room_policy_allows(chat_id):
+            return {
+                "name": chat_id,
+                "type": "group",
+                "chat_id": chat_id,
+                "allowed": False,
+            }
         identity = await self._resolve_room_identity(chat_id)
         chat_type = "dm" if identity.chat_type == "dm" else "group"
         return {"name": identity.display_name, "type": chat_type}
@@ -3207,6 +3214,13 @@ class MatrixAdapter(BasePlatformAdapter):
         allowed_rooms = getattr(self, "_allowed_room_ids", set())
         return not allowed_rooms or room_id in allowed_rooms
 
+    def _strict_room_policy_active(self) -> bool:
+        """Return whether a non-empty allowlist is the complete room authority."""
+        return bool(
+            getattr(self, "_allowed_rooms_apply_to_dms", False)
+            and getattr(self, "_allowed_room_ids", set())
+        )
+
     def _strict_room_policy_allows(self, room_id: str) -> bool:
         """Fail closed for direct room operations when strict policy is active.
 
@@ -3216,8 +3230,7 @@ class MatrixAdapter(BasePlatformAdapter):
         disabled, or with an empty list, historical behavior is unchanged.
         """
         allowed = not (
-            getattr(self, "_allowed_rooms_apply_to_dms", False)
-            and getattr(self, "_allowed_room_ids", set())
+            self._strict_room_policy_active()
             and room_id not in self._allowed_room_ids
         )
         if not allowed:
@@ -3234,10 +3247,7 @@ class MatrixAdapter(BasePlatformAdapter):
         personal chats still work when operators use a room allowlist for
         project rooms.
         """
-        if (
-            getattr(self, "_allowed_rooms_apply_to_dms", False)
-            and getattr(self, "_allowed_room_ids", set())
-        ):
+        if self._strict_room_policy_active():
             return self._strict_room_policy_allows(room_id)
         if self._is_allowed_matrix_room(room_id):
             return True
@@ -4464,6 +4474,13 @@ class MatrixAdapter(BasePlatformAdapter):
         preset: str = "private_chat",
     ) -> Optional[str]:
         """Create a new Matrix room."""
+        # A newly allocated room ID cannot be present in a fixed preconfigured
+        # allowlist. Keep strict mode closed rather than silently widening it.
+        if self._strict_room_policy_active():
+            logger.warning(
+                "Matrix: room creation is disabled while the strict room allowlist is active"
+            )
+            return None
         if not self._client:
             return None
         if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in (

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1273,7 +1273,8 @@ class MatrixAdapter(BasePlatformAdapter):
             self._free_rooms: Set[str] = {
                 r.strip() for r in str(free_rooms_raw).split(",") if r.strip()
             }
-        # If non-empty, bot ONLY responds in these rooms (whitelist); DMs exempt.
+        # If non-empty, bot ONLY responds in these rooms (whitelist); DMs are
+        # exempt unless allowed_rooms_apply_to_dms is explicitly enabled in YAML.
         allowed_rooms_raw = config.extra.get("allowed_rooms")
         if allowed_rooms_raw is None:
             allowed_rooms_raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
@@ -1285,6 +1286,13 @@ class MatrixAdapter(BasePlatformAdapter):
             self._allowed_rooms: Set[str] = {
                 r.strip() for r in str(allowed_rooms_raw).split(",") if r.strip()
             }
+        allowed_rooms_apply_to_dms_raw = config.extra.get("allowed_rooms_apply_to_dms", False)
+        if isinstance(allowed_rooms_apply_to_dms_raw, str):
+            self._allowed_rooms_apply_to_dms = (
+                allowed_rooms_apply_to_dms_raw.strip().lower() in {"true", "1", "yes"}
+            )
+        else:
+            self._allowed_rooms_apply_to_dms = bool(allowed_rooms_apply_to_dms_raw)
         self._allow_room_mentions: bool = os.getenv(
             "MATRIX_ALLOW_ROOM_MENTIONS", "false"
         ).lower() in ("true", "1", "yes")
@@ -2196,6 +2204,9 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a message to a Matrix room."""
 
+        if not self._strict_room_policy_allows(chat_id):
+            return SendResult(success=False, error="Matrix room is not allowed")
+
         if not content:
             return SendResult(success=True)
 
@@ -2314,6 +2325,8 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
         """Send a typing indicator."""
+        if not self._strict_room_policy_allows(chat_id):
+            return
         if self._client:
             try:
                 await self._client.set_typing(RoomID(chat_id), timeout=30000)
@@ -2322,6 +2335,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def stop_typing(self, chat_id: str) -> None:
         """Clear the typing indicator."""
+        if not self._strict_room_policy_allows(chat_id):
+            return
         if self._client:
             try:
                 await self._client.set_typing(RoomID(chat_id), timeout=0)
@@ -2333,6 +2348,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, message_id: str, content: str, *, finalize: bool = False
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
+
+        if not self._strict_room_policy_allows(chat_id):
+            return SendResult(success=False, error="Matrix room is not allowed")
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
@@ -2881,6 +2899,8 @@ class MatrixAdapter(BasePlatformAdapter):
         voice_metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
+        if not self._strict_room_policy_allows(room_id):
+            return SendResult(success=False, error="Matrix room is not allowed")
         if len(data) > self._max_media_bytes:
             return SendResult(
                 success=False,
@@ -3184,7 +3204,28 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def _is_allowed_matrix_room(self, room_id: str) -> bool:
         """Return True when MATRIX_ALLOWED_ROOMS permits the room."""
-        return not self._allowed_room_ids or room_id in self._allowed_room_ids
+        allowed_rooms = getattr(self, "_allowed_room_ids", set())
+        return not allowed_rooms or room_id in allowed_rooms
+
+    def _strict_room_policy_allows(self, room_id: str) -> bool:
+        """Fail closed for direct room operations when strict policy is active.
+
+        This synchronous check is intentionally independent of DM discovery:
+        strict mode makes the configured room IDs the complete authority for
+        every inbound and outbound room-target operation. With strict mode
+        disabled, or with an empty list, historical behavior is unchanged.
+        """
+        allowed = not (
+            getattr(self, "_allowed_rooms_apply_to_dms", False)
+            and getattr(self, "_allowed_room_ids", set())
+            and room_id not in self._allowed_room_ids
+        )
+        if not allowed:
+            logger.warning(
+                "Matrix: rejecting operation targeting unlisted room %s under strict room allowlist",
+                room_id,
+            )
+        return allowed
 
     async def _is_allowed_matrix_room_event(self, room_id: str) -> bool:
         """Return True when a room event may proceed past intake filters.
@@ -3193,6 +3234,11 @@ class MatrixAdapter(BasePlatformAdapter):
         personal chats still work when operators use a room allowlist for
         project rooms.
         """
+        if (
+            getattr(self, "_allowed_rooms_apply_to_dms", False)
+            and getattr(self, "_allowed_room_ids", set())
+        ):
+            return self._strict_room_policy_allows(room_id)
         if self._is_allowed_matrix_room(room_id):
             return True
         try:
@@ -3822,7 +3868,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _join_room_by_id(self, room_id: str) -> bool:
         """Join a room by ID and refresh local caches on success."""
-        if not room_id:
+        if not room_id or not self._strict_room_policy_allows(room_id):
             return False
         if room_id in self._joined_rooms:
             return True
@@ -3860,6 +3906,11 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         """Schedule an invite join without blocking sync or gateway readiness."""
         if not room_id or room_id in self._joined_rooms:
+            return
+        # Reject before allocating a task; _join_room_by_id repeats the same
+        # centralized policy at the definitive join sink. Inviter authorization
+        # remains at the callers so the two policies compose independently.
+        if not self._strict_room_policy_allows(room_id):
             return
         existing = self._invite_join_tasks.get(room_id)
         if existing and not existing.done():
@@ -3907,7 +3958,7 @@ class MatrixAdapter(BasePlatformAdapter):
         Returns the reaction event_id on success, None on failure.
         """
 
-        if not self._client:
+        if not self._strict_room_policy_allows(room_id) or not self._client:
             return None
         content = {
             "m.relates_to": {
@@ -4010,11 +4061,17 @@ class MatrixAdapter(BasePlatformAdapter):
         sender = str(getattr(event, "sender", ""))
         if self._is_self_sender(sender):
             return
+        room_id = str(getattr(event, "room_id", ""))
+        # Room admission precedes deduplication and every prompt lookup/mutation.
+        # User-wide allow-all affects sender authorization only and cannot
+        # override this independent room boundary.
+        if not self._strict_room_policy_allows(room_id):
+            logger.info("Matrix: ignoring reaction from unauthorized room %s", room_id)
+            return
         event_id = str(getattr(event, "event_id", ""))
         if self._is_duplicate_event(event_id):
             return
 
-        room_id = str(getattr(event, "room_id", ""))
         content = getattr(event, "content", None)
         if content:
             relates_to = (
@@ -4345,7 +4402,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_read_receipt(self, room_id: str, event_id: str) -> bool:
         """Send a read receipt (m.read) for an event."""
-        if not self._client:
+        if not self._strict_room_policy_allows(room_id) or not self._client:
             return False
         try:
             room = RoomID(room_id)
@@ -4380,7 +4437,7 @@ class MatrixAdapter(BasePlatformAdapter):
         reason: str = "",
     ) -> bool:
         """Redact (delete) a message or event from a room."""
-        if not self._client:
+        if not self._strict_room_policy_allows(room_id) or not self._client:
             return False
         try:
             await self._client.redact(
@@ -4440,7 +4497,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def invite_user(self, room_id: str, user_id: str) -> bool:
         """Invite a user to a room."""
-        if not self._client:
+        if not self._strict_room_policy_allows(room_id) or not self._client:
             return False
         try:
             await self._client.invite_user(RoomID(room_id), UserID(user_id))
@@ -4457,7 +4514,7 @@ class MatrixAdapter(BasePlatformAdapter):
         from_token: str = "",
     ) -> list[dict[str, Any]]:
         """Fetch recent Matrix room history using the live client."""
-        if not self._client:
+        if not self._strict_room_policy_allows(room_id) or not self._client:
             return []
         limit = max(1, min(int(limit or 20), 100))
         try:
@@ -4547,6 +4604,8 @@ class MatrixAdapter(BasePlatformAdapter):
         msgtype: str,
     ) -> SendResult:
         """Send a simple message (emote, notice) with optional HTML formatting."""
+        if not self._strict_room_policy_allows(chat_id):
+            return SendResult(success=False, error="Matrix room is not allowed")
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
 
@@ -5220,6 +5279,29 @@ async def _standalone_send(
     """
     extra = getattr(pconfig, "extra", {}) or {}
     token = getattr(pconfig, "token", None)
+    allowed_rooms_raw = extra.get("allowed_rooms")
+    if allowed_rooms_raw is None:
+        allowed_rooms_raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
+    if isinstance(allowed_rooms_raw, list):
+        allowed_room_ids = {
+            str(room_id).strip()
+            for room_id in allowed_rooms_raw
+            if str(room_id).strip()
+        }
+    else:
+        allowed_room_ids = {
+            room_id.strip()
+            for room_id in str(allowed_rooms_raw).split(",")
+            if room_id.strip()
+        }
+    strict_raw = extra.get("allowed_rooms_apply_to_dms", False)
+    strict_enabled = (
+        strict_raw.strip().lower() in {"true", "1", "yes"}
+        if isinstance(strict_raw, str)
+        else bool(strict_raw)
+    )
+    if strict_enabled and allowed_room_ids and chat_id not in allowed_room_ids:
+        return {"error": "Matrix room is not allowed"}
     try:
         import aiohttp
     except ImportError:
@@ -5376,7 +5458,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    take precedence for legacy settings. Room-policy settings are returned for
+    profile-local seeding into PlatformConfig.extra.
     """
     if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
         os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
@@ -5410,7 +5493,17 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
-    return None
+    # Keep both halves of the strict policy profile-local. In multiplex mode,
+    # process-global MATRIX_ALLOWED_ROOMS may have been populated while loading
+    # another profile and must never substitute for this profile's YAML values.
+    seeded = {}
+    if "allowed_rooms" in matrix_cfg:
+        seeded["allowed_rooms"] = matrix_cfg["allowed_rooms"]
+    if "allowed_rooms_apply_to_dms" in matrix_cfg:
+        seeded["allowed_rooms_apply_to_dms"] = matrix_cfg[
+            "allowed_rooms_apply_to_dms"
+        ]
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_matrix_strict_room_policy.py
+++ b/tests/gateway/test_matrix_strict_room_policy.py
@@ -1,0 +1,407 @@
+"""Strict Matrix room-allowlist policy regressions.
+
+The default remains backward-compatible: DMs bypass ``allowed_rooms``. Operators
+that enable ``allowed_rooms_apply_to_dms`` with a non-empty room list require an
+explicit room ID for every message and invite path, including rooms Matrix
+classifies as DMs.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from plugins.platforms.matrix.adapter import (
+    MatrixAdapter,
+    _apply_yaml_config,
+    _standalone_send,
+)
+
+
+ALLOWED_ROOM = "!allowed:example.org"
+OTHER_ROOM = "!other:example.org"
+
+
+def _make_adapter(*, strict=True, allowed_rooms=None) -> MatrixAdapter:
+    if allowed_rooms is None:
+        allowed_rooms = [ALLOWED_ROOM]
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@hermes:example.org",
+                "allowed_rooms": allowed_rooms,
+                "allowed_rooms_apply_to_dms": strict,
+            },
+        )
+    )
+    adapter._text_batch_delay_seconds = 0
+    adapter._startup_ts = time.time() - 10
+    adapter.handle_message = AsyncMock()
+    adapter._client = MagicMock()
+    adapter._join_room_by_id = AsyncMock(return_value=True)
+    adapter._record_dm_room = AsyncMock()
+    return adapter
+
+
+async def _drain_invite_tasks(adapter: MatrixAdapter) -> None:
+    tasks = list(adapter._invite_join_tasks.values())
+    if tasks:
+        await asyncio.gather(*tasks)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(True, True), ("true", True), ("yes", True), (False, False), ("false", False)],
+)
+def test_allowed_rooms_apply_to_dms_parses_yaml_booleans_and_strings(raw, expected):
+    adapter = _make_adapter(strict=raw)
+    assert adapter._allowed_rooms_apply_to_dms is expected
+
+
+def test_top_level_matrix_yaml_seeds_dm_inclusive_policy_without_new_env_var():
+    seeded = _apply_yaml_config(
+        {},
+        {
+            "allowed_rooms": [ALLOWED_ROOM],
+            "allowed_rooms_apply_to_dms": True,
+        },
+    )
+    assert seeded == {
+        "allowed_rooms": [ALLOWED_ROOM],
+        "allowed_rooms_apply_to_dms": True,
+    }
+
+
+def test_room_policy_yaml_seed_omits_absent_keys():
+    assert _apply_yaml_config({}, {"enabled": True}) is None
+
+
+def test_real_gateway_load_preserves_legacy_env_only_room_allowlist(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "config.yaml").write_text(
+        "matrix:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!env-only:example.org")
+
+    config = load_gateway_config()
+    adapter = MatrixAdapter(config.platforms[Platform.MATRIX])
+
+    assert adapter._allowed_room_ids == {"!env-only:example.org"}
+    assert adapter._allowed_rooms_apply_to_dms is False
+
+
+def test_real_gateway_load_keeps_matrix_room_policy_profile_scoped(
+    tmp_path, monkeypatch
+):
+    """A foreign process-global room list cannot replace this profile's YAML."""
+    (tmp_path / "config.yaml").write_text(
+        "matrix:\n"
+        "  enabled: true\n"
+        "  allowed_rooms: []\n"
+        "  allowed_rooms_apply_to_dms: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", "!foreign:example.org")
+
+    config = load_gateway_config()
+    extra = config.platforms[Platform.MATRIX].extra
+
+    assert extra["allowed_rooms"] == []
+    assert extra["allowed_rooms_apply_to_dms"] is True
+    adapter = MatrixAdapter(config.platforms[Platform.MATRIX])
+    assert adapter._allowed_room_ids == set()
+    assert adapter._strict_room_policy_allows("!any:example.org") is True
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_rejects_unlisted_dm_but_allows_listed_dm():
+    adapter = _make_adapter()
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="dm")
+    )
+
+    assert await adapter._is_allowed_matrix_room_event(OTHER_ROOM) is False
+    assert await adapter._is_allowed_matrix_room_event(ALLOWED_ROOM) is True
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_blocks_unlisted_dm_on_real_message_intake():
+    adapter = _make_adapter()
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="dm")
+    )
+    event = SimpleNamespace(
+        room_id=OTHER_ROOM,
+        sender="@alice:example.org",
+        event_id="$unlisted",
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_with_empty_room_list_remains_unrestricted():
+    adapter = _make_adapter(allowed_rooms=[])
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="dm")
+    )
+
+    assert await adapter._is_allowed_matrix_room_event(OTHER_ROOM) is True
+
+
+@pytest.mark.asyncio
+async def test_default_policy_preserves_dm_exemption():
+    adapter = _make_adapter(strict=False)
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="dm")
+    )
+
+    assert await adapter._is_allowed_matrix_room_event(OTHER_ROOM) is True
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_blocks_unlisted_invite_at_join_sink():
+    adapter = _make_adapter()
+
+    adapter._schedule_invite_join(OTHER_ROOM, is_direct=True, inviter="@alice:example.org")
+    await _drain_invite_tasks(adapter)
+
+    adapter._join_room_by_id.assert_not_awaited()
+    adapter._record_dm_room.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_allows_listed_invite_at_join_sink():
+    adapter = _make_adapter()
+
+    adapter._schedule_invite_join(ALLOWED_ROOM, is_direct=True, inviter="@alice:example.org")
+    await _drain_invite_tasks(adapter)
+
+    adapter._join_room_by_id.assert_awaited_once_with(ALLOWED_ROOM)
+    adapter._record_dm_room.assert_awaited_once_with(
+        ALLOWED_ROOM, "@alice:example.org"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_blocks_unlisted_pending_invite_after_restart():
+    adapter = _make_adapter()
+    sync_data = {"rooms": {"invite": {OTHER_ROOM: {}}}}
+
+    adapter._schedule_pending_invite_joins(sync_data)
+    await _drain_invite_tasks(adapter)
+
+    adapter._join_room_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allowed_room", "authorized_inviter", "allow_all", "should_join"),
+    [
+        (True, True, False, True),
+        (True, False, False, False),
+        (False, True, False, False),
+        (False, False, True, False),
+    ],
+)
+async def test_live_invite_room_and_inviter_policies_compose(
+    monkeypatch, allowed_room, authorized_inviter, allow_all, should_join
+):
+    """Room IDs remain independent alongside inviter authorization (#87258)."""
+    adapter = _make_adapter()
+    adapter._allowed_user_ids = {"@authorized:example.org"}
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true" if allow_all else "false")
+    room_id = ALLOWED_ROOM if allowed_room else OTHER_ROOM
+    inviter = (
+        "@authorized:example.org" if authorized_inviter else "@intruder:example.org"
+    )
+    event = SimpleNamespace(
+        room_id=room_id,
+        sender=inviter,
+        content=SimpleNamespace(is_direct=True),
+    )
+
+    await adapter._on_invite(event)
+    await _drain_invite_tasks(adapter)
+
+    if should_join:
+        adapter._join_room_by_id.assert_awaited_once_with(room_id)
+    else:
+        adapter._join_room_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_common_join_sink_rejects_unlisted_room_even_if_already_joined():
+    adapter = _make_adapter()
+    adapter._join_room_by_id = MatrixAdapter._join_room_by_id.__get__(adapter)
+    adapter._joined_rooms.add(OTHER_ROOM)
+
+    assert await adapter._join_room_by_id(OTHER_ROOM) is False
+    adapter._client.join_room.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_strict_outbound_room_guard_blocks_every_direct_room_sink():
+    adapter = _make_adapter()
+    adapter._client.send_message_event = AsyncMock(return_value="$sent")
+    adapter._client.upload_media = AsyncMock(return_value="mxc://example/media")
+    adapter._client.redact = AsyncMock()
+    adapter._client.invite_user = AsyncMock()
+    adapter._client.messages = AsyncMock(return_value={"chunk": []})
+    adapter._client.set_fully_read_marker = AsyncMock()
+    adapter._client.set_typing = AsyncMock()
+
+    send_result = await adapter.send(OTHER_ROOM, "secret")
+    edit_result = await adapter.edit_message(OTHER_ROOM, "$event", "edited")
+    media_result = await adapter._upload_and_send(
+        OTHER_ROOM, b"secret", "secret.txt", "text/plain", "m.file"
+    )
+    reaction_result = await adapter._send_reaction(OTHER_ROOM, "$event", "✅")
+    redact_result = await adapter.redact_message(OTHER_ROOM, "$event")
+    history_result = await adapter.fetch_history(OTHER_ROOM)
+    invite_result = await adapter.invite_user(OTHER_ROOM, "@bob:example.org")
+    receipt_result = await adapter.send_read_receipt(OTHER_ROOM, "$event")
+    await adapter.send_typing(OTHER_ROOM)
+    await adapter.stop_typing(OTHER_ROOM)
+
+    assert send_result.success is False
+    assert edit_result.success is False
+    assert media_result.success is False
+    assert reaction_result is None
+    assert redact_result is False
+    assert history_result == []
+    assert invite_result is False
+    assert receipt_result is False
+    adapter._client.send_message_event.assert_not_awaited()
+    adapter._client.upload_media.assert_not_awaited()
+    adapter._client.redact.assert_not_awaited()
+    adapter._client.invite_user.assert_not_awaited()
+    adapter._client.messages.assert_not_awaited()
+    adapter._client.set_fully_read_marker.assert_not_awaited()
+    adapter._client.set_typing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("strict", "allowed_rooms"),
+    [(False, [ALLOWED_ROOM]), (True, [])],
+)
+async def test_outbound_guard_preserves_default_and_empty_list_behavior(
+    strict, allowed_rooms
+):
+    adapter = _make_adapter(strict=strict, allowed_rooms=allowed_rooms)
+    adapter._client.send_message_event = AsyncMock(return_value="$sent")
+
+    result = await adapter.send(OTHER_ROOM, "still allowed")
+
+    assert result.success is True
+    adapter._client.send_message_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_blocks_standalone_send_before_network():
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "allowed_rooms": [ALLOWED_ROOM],
+            "allowed_rooms_apply_to_dms": True,
+        },
+    )
+
+    result = await _standalone_send(config, OTHER_ROOM, "secret")
+
+    assert result == {"error": "Matrix room is not allowed"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("strict", "allowed_rooms"),
+    [(False, [ALLOWED_ROOM]), (True, [])],
+)
+async def test_reaction_guard_preserves_default_and_empty_list_behavior(
+    strict, allowed_rooms
+):
+    adapter = _make_adapter(strict=strict, allowed_rooms=allowed_rooms)
+    event = SimpleNamespace(
+        room_id=OTHER_ROOM,
+        sender="@alice:example.org",
+        event_id="$default-reaction",
+        content={
+            "m.relates_to": {
+                "event_id": "$ordinary-event",
+                "key": "✅",
+            }
+        },
+    )
+
+    await adapter._on_reaction(event)
+
+    assert "$default-reaction" in adapter._processed_events_set
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prompt_kind", ["approval", "model", "choice"])
+async def test_unlisted_room_reaction_cannot_mutate_any_prompt_before_dedup(
+    monkeypatch, prompt_kind
+):
+    adapter = _make_adapter()
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    callback = AsyncMock(return_value="done")
+    prompt = SimpleNamespace(
+        chat_id=OTHER_ROOM,
+        message_id="$prompt",
+        session_key="matrix:room:user",
+        requester_user_id="@alice:example.org",
+        expires_at=time.monotonic() + 60,
+        resolved=False,
+        bot_reaction_events={},
+        choices=(
+            {"1️⃣": ("model", "provider")}
+            if prompt_kind == "model"
+            else {"1️⃣": "choice"}
+        ),
+        on_model_selected=callback,
+        on_choice_selected=callback,
+    )
+    target = {
+        "approval": adapter._approval_prompts_by_event,
+        "model": adapter._model_picker_prompts_by_event,
+        "choice": adapter._choice_picker_prompts_by_event,
+    }[prompt_kind]
+    target["$prompt"] = prompt
+    event = SimpleNamespace(
+        room_id=OTHER_ROOM,
+        sender="@alice:example.org",
+        event_id="$reaction",
+        content={
+            "m.relates_to": {
+                "event_id": "$prompt",
+                "key": "✅" if prompt_kind == "approval" else "1️⃣",
+            }
+        },
+    )
+
+    with patch(
+        "tools.approval.resolve_gateway_approval",
+        side_effect=AssertionError("approval resolver reached"),
+    ):
+        await adapter._on_reaction(event)
+
+    assert prompt.resolved is False
+    assert target["$prompt"] is prompt
+    callback.assert_not_awaited()
+    assert "$reaction" not in adapter._processed_events_set

--- a/tests/gateway/test_matrix_strict_room_policy.py
+++ b/tests/gateway/test_matrix_strict_room_policy.py
@@ -294,6 +294,71 @@ async def test_strict_outbound_room_guard_blocks_every_direct_room_sink():
 
 
 @pytest.mark.asyncio
+async def test_strict_policy_disables_room_creation_before_client_call():
+    adapter = _make_adapter()
+    adapter._client.create_room = AsyncMock(return_value="!new:example.org")
+
+    result = await adapter.create_room(name="escape")
+
+    assert result is None
+    adapter._client.create_room.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_blocks_unlisted_chat_info_before_state_lookup():
+    adapter = _make_adapter()
+    adapter._resolve_room_identity = AsyncMock(
+        side_effect=AssertionError("unlisted room metadata was queried")
+    )
+
+    result = await adapter.get_chat_info(OTHER_ROOM)
+
+    assert result == {
+        "name": OTHER_ROOM,
+        "type": "group",
+        "chat_id": OTHER_ROOM,
+        "allowed": False,
+    }
+    adapter._resolve_room_identity.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_strict_policy_resolves_allowlisted_chat_info():
+    adapter = _make_adapter()
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="group", display_name="Allowed room")
+    )
+
+    result = await adapter.get_chat_info(ALLOWED_ROOM)
+
+    assert result == {"name": "Allowed room", "type": "group"}
+    adapter._resolve_room_identity.assert_awaited_once_with(ALLOWED_ROOM)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("strict", "allowed_rooms"),
+    [(False, [ALLOWED_ROOM]), (True, [])],
+)
+async def test_room_management_preserves_default_and_empty_list_behavior(
+    strict, allowed_rooms
+):
+    adapter = _make_adapter(strict=strict, allowed_rooms=allowed_rooms)
+    adapter._client.create_room = AsyncMock(return_value="!new:example.org")
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=SimpleNamespace(chat_type="dm", display_name="Other room")
+    )
+
+    created = await adapter.create_room(name="still allowed")
+    info = await adapter.get_chat_info(OTHER_ROOM)
+
+    assert created == "!new:example.org"
+    assert info == {"name": "Other room", "type": "dm"}
+    adapter._client.create_room.assert_awaited_once()
+    adapter._resolve_room_identity.assert_awaited_once_with(OTHER_ROOM)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("strict", "allowed_rooms"),
     [(False, [ALLOWED_ROOM]), (True, [])],

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -88,6 +88,7 @@ matrix:
     - "@alice:matrix.org"
   allowed_rooms:                  # Matrix rooms allowed to trigger agent turns
     - "!abc123:matrix.org"
+  allowed_rooms_apply_to_dms: false    # Also enforce allowed_rooms for DMs and invites
   free_response_rooms:            # Rooms exempt from mention requirement
     - "!abc123:matrix.org"
   ignore_user_patterns:           # Bridge/appservice ghost users to ignore
@@ -99,6 +100,16 @@ matrix:
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)
   max_message_length: 16000       # Outbound chunk size in chars (default: 16000, max: 65535)
 ```
+
+By default, DMs remain exempt from `allowed_rooms` for backward compatibility.
+Set `allowed_rooms_apply_to_dms: true` with a non-empty `allowed_rooms` list to
+require every inbound event, outbound room operation, and room invite to use
+one of those IDs.
+An empty `allowed_rooms` list keeps the existing unrestricted-room behavior.
+This option is available only in `config.yaml`; it does not have an
+environment-variable equivalent. Enabling it does not automatically leave
+rooms the account had already joined, so audit existing memberships before
+using the setting as a confinement boundary.
 
 Or via environment variables:
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -109,7 +109,10 @@ An empty `allowed_rooms` list keeps the existing unrestricted-room behavior.
 This option is available only in `config.yaml`; it does not have an
 environment-variable equivalent. Enabling it does not automatically leave
 rooms the account had already joined, so audit existing memberships before
-using the setting as a confinement boundary.
+using the setting as a confinement boundary. Room creation is disabled while
+this strict boundary is active because a server-assigned room ID cannot be
+pre-authorized. Operators can still leave existing rooms for remediation through
+another Matrix client or administrative tooling.
 
 Or via environment variables:
 


### PR DESCRIPTION
## What does this PR do?

Matrix intentionally exempts DM-classified rooms from `allowed_rooms`. Because any two-member room is classified as a DM, multiple Hermes profiles sharing one Matrix account can auto-join and process one another's profile rooms even when each profile names a different room.

This PR implements the config.yaml follow-up requested when #54554 was closed: `matrix.allowed_rooms_apply_to_dms` is opt-in, defaults to `false`, and is effective only with a non-empty `allowed_rooms`. When enabled, the room list becomes the boundary for DM/shared-room intake, reactions, direct outbound room operations, and live or reconciled invite joins. Existing default and empty-list behavior remain unchanged.

## Related Issue

Fixes #54461.

Follow-up to #54554's source-backed approach, using the requested `config.yaml` surface instead of a new environment variable. Credit to @Sahil-SS9 for the original three-path diagnosis and implementation direction. Closed predecessor #31402 enforced allowed rooms for DMs globally while bundling threading/config changes; this PR keeps the behavior opt-in and room-policy-only. The profile-scoping seam overlaps narrowly with #88559; pending-invite **inviter** authorization remains owned by #87258 and is tested in a temporary combined tree rather than duplicated here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: parse the opt-in YAML setting, enforce a common strict-room guard on inbound messages/reactions, invite joins, direct room-target operations, and metadata lookup; disable dynamic room creation while the fixed boundary is active; and preserve default DM exemption/empty-list semantics.
- `plugins/platforms/matrix/adapter.py`: seed both `allowed_rooms` and `allowed_rooms_apply_to_dms` into `PlatformConfig.extra` so one profile's process environment cannot substitute another profile's configured room list.
- `hermes_cli/config_defaults.py`: declare the backward-compatible default.
- `website/docs/user-guide/messaging/matrix.md`: document the setting, empty-list semantics, and the fact that enabling it does not leave rooms already joined.
- `tests/gateway/test_matrix_strict_room_policy.py`: cover YAML parsing/plumbing, DM intake, reactions, outbound sinks, live/pending invites, allow-all interaction, and compatibility defaults.

## How to Test

1. Focused/canonical Matrix plus Matrix CLI checks:
   ```bash
   HERMES_PYTHON=/Users/jj/.hermes/venvs/hermes-matrix-room-dev/bin/python \
     scripts/run_tests.sh tests/gateway/test_matrix*.py \
       tests/hermes_cli/test_setup_matrix_e2ee.py \
       tests/hermes_cli/test_fleet_matrix_down_state.py -q
   ```
   Result on the reviewed branch plus this diff: **227 passed, 0 failed, 1 skipped**; the strict-room file contributes **35 passed**.
2. Temporary branch + #87258 pending-inviter stack, same suite: **240 passed, 0 failed, 1 skipped**; the earlier dedicated four-case pending-invite composition probe also passed **4/4**.
3. Regression sabotage: **9 expected failures** across config parsing, DM intake, invite admission, dynamic room creation, and unlisted chat-metadata access.
4. Repository checks: `ruff check .` passed; Windows-footgun scan passed across **1,019 files**; `py_compile` and `git diff --check` passed. Advisory `ty` diff reported no new production-code diagnostic (new entries are test-mock/module-resolution diagnostics plus a tool panic). A full canonical run on the preceding base `upstream/main@790e1eb6` recorded **124 failures across 39 unrelated files** and no Matrix failure, so the full-suite checklist remains honestly unchecked and draft CI is the next broad gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs/issues and reconciled #54554, #87258, and #88559
- [x] My PR contains only changes related to DM-inclusive Matrix room confinement
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.6.2 with Python 3.11 through `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] Relevant Matrix documentation updated
- [x] `cli-config.yaml.example` — N/A; it has no Matrix configuration block
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; no platform-specific APIs added
- [x] Tool descriptions/schemas — N/A

## Risks and exclusions

- Default behavior is unchanged; operators must explicitly enable the YAML setting and provide at least one room ID.
- Enabling the setting does not automatically leave rooms already joined; operators must audit existing membership.
- Dynamic room creation is unavailable while the strict fixed-room boundary is active; operators can leave existing rooms through another Matrix client or administrative tooling.
- #87258 remains the source of truth for pending-invite inviter extraction/authorization. This PR supplies the independent room-ID gate and verifies the combined behavior without copying that work.
- No production gateway, account, token, room, or service was changed while developing this patch.

## Screenshots / Logs

N/A — policy behavior is covered by automated regression tests.
