### PR TITLE
salvage: final wave — transport/routing cluster (#95343, #95592, #95379, #95606, #95389, #95371)

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -140,4 +140,61 @@ describe('main.ts wiring for #90812', () => {
     expect(body).toContain('backendDialClaims.run(backendScopeKey(id, profile)')
     expect(body).toContain('ensureRegistryBackend(id, profile)')
   })
+
+  // The four IPC/probe surfaces below call ensureRegistryBackend()/ensureBackend()
+  // directly, bypassing backendDialClaims entirely — so a renderer's guarded
+  // reconnect dial and one of these can independently race the SAME
+  // ensureRegistryBackend() await-before-pool-check window (main.ts) and each
+  // bootstrap its own SSH tunnel / remote dashboard for the same
+  // (connectionId, profile) scope.
+
+  it('routes a media-stream connection resolve through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('resolveRemoteConnection: ({ connectionId, profile }) =>')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 300)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connectionId, profile)')
+    expect(body).toContain('ensureRegistryBackend(connectionId, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes a terminal-pane backend resolve through the single-owner claim on both the registry and local branches', () => {
+    const handlerStart = mainSource.indexOf('async function ensureTerminalBackend(webContentsId: number) {')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 900)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(windowRoute.connectionId, windowRoute.profile)')
+    expect(body).toContain('ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)')
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(null, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes the roster-enumeration probe through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function enumerateRegistryAgentSources')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 3_700)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
+    expect(body).toContain('ensureRegistryBackend(connection.id, null)')
+    expect(body).toContain("getJsonForBackend(descriptor, '/api/profiles'")
+  })
+
+  it('routes the connections update-all dispatch through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:connections:update-all',")
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 2_000)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
+    expect(body).toContain('ensureRegistryBackend(connection.id, null)')
+    expect(body).toContain("postJsonForBackend(descriptor, '/api/hermes/update'")
+  })
+
+  it('routes every registry-scoped REST dispatch (hermes:api) through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function dispatchRegistryApiRequest(')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 900)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile)')
+    expect(body).toContain('ensureRegistryBackend(registryConnectionId, routeProfile)')
+  })
 })

--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -182,7 +182,9 @@ describe('main.ts wiring for #90812', () => {
   it('routes the connections update-all dispatch through the single-owner claim', () => {
     const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:connections:update-all',")
     expect(handlerStart).toBeGreaterThan(-1)
-    const body = mainSource.slice(handlerStart, handlerStart + 2_000)
+    // The handler grew on main (renderer-side exclusions + the managed-SSH
+    // dispatch branch) — keep the scan window comfortably past the dial.
+    const body = mainSource.slice(handlerStart, handlerStart + 3_000)
 
     expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
     expect(body).toContain('ensureRegistryBackend(connection.id, null)')

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1362,8 +1362,13 @@ function registerMediaProtocol() {
 
       return resolvedPath
     },
+    // Claim-guarded (#90812): a media stream load can race a renderer's own
+    // reconnect dial for the same (connectionId, profile) scope; coalescing
+    // here avoids bootstrapping a second SSH tunnel / remote dashboard.
     resolveRemoteConnection: ({ connectionId, profile }) =>
-      connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
+      backendDialClaims.run(backendScopeKey(connectionId, profile), () =>
+        connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
+      )
   })
 
   protocol.handle(MEDIA_PROTOCOL, handler)
@@ -9932,11 +9937,18 @@ function activeSshTerminalTarget(webContentsId?: number) {
 async function ensureTerminalBackend(webContentsId: number) {
   const windowRoute = windowConnectionRoutes.get(webContentsId)
 
+  // Claim-guarded (#90812): opening a terminal pane can race a renderer's own
+  // reconnect dial for the same (connectionId, profile) scope; coalescing
+  // here avoids bootstrapping a second SSH tunnel / remote dashboard.
   if (windowRoute?.registryScoped && windowRoute.connectionId) {
-    return ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)
+    return backendDialClaims.run(backendScopeKey(windowRoute.connectionId, windowRoute.profile), () =>
+      ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)
+    )
   }
 
-  return ensureBackend(windowRoute?.profile ?? primaryProfileKey())
+  const profile = windowRoute?.profile ?? primaryProfileKey()
+
+  return backendDialClaims.run(backendScopeKey(null, profile), () => ensureBackend(profile))
 }
 
 // Loopback reach for the browser pane. Scoped to the SSH connection that
@@ -14953,8 +14965,15 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             }
           }
 
+          // Claim-guarded (#90812): this ~5s roster poll can race a renderer's
+          // own reconnect dial for the same connection; coalescing avoids
+          // bootstrapping a second SSH tunnel / remote dashboard.
           const descriptor: any = await withEnumerationDeadline(
-            Promise.resolve(ensureRegistryBackend(connection.id, null))
+            Promise.resolve(
+              backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+                ensureRegistryBackend(connection.id, null)
+              )
+            )
           )
 
           const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
@@ -15169,7 +15188,11 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
             }
           }
 
-          const descriptor: any = await ensureRegistryBackend(connection.id, null)
+          // Claim-guarded (#90812): coalesce with a concurrent renderer dial
+          // for the same connection instead of bootstrapping a second backend.
+          const descriptor: any = await backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+            ensureRegistryBackend(connection.id, null)
+          )
 
           const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', {}, { timeoutMs: 15_000 })
 
@@ -15809,7 +15832,13 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
-  const connection: any = await ensureRegistryBackend(registryConnectionId, routeProfile)
+  // Claim-guarded (#90812): every registry-scoped REST call funnels through
+  // here, so it can race a renderer's own WS reconnect dial for the same
+  // (connectionId, profile) scope; coalescing avoids bootstrapping a second
+  // SSH tunnel / remote dashboard.
+  const connection: any = await backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile), () =>
+    ensureRegistryBackend(registryConnectionId, routeProfile)
+  )
 
   const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
 

--- a/apps/desktop/src/api/plugins.test.ts
+++ b/apps/desktop/src/api/plugins.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from '@/hermes'
+
+import { activeConnection } from './plugins'
+
+// desktop.getConnection/getConnectionFor are IPC round-trips into the main
+// process with no timeout of their own (#93454). A wedged main-process
+// round-trip must reject instead of hanging pluginSocket's connect() forever.
+describe('activeConnection connection timeout (#93454)', () => {
+  afterEach(() => {
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.useRealTimers()
+  })
+
+  it('rejects instead of hanging forever when getConnection() wedges', async () => {
+    vi.useFakeTimers()
+    setApiRequestProfile('coder')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { getConnection: vi.fn(() => new Promise(() => undefined)) }
+    })
+
+    const pending = expect(activeConnection()).rejects.toThrow('Timed out connecting to profile "coder"')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+
+  it('rejects instead of hanging forever when getConnectionFor() wedges', async () => {
+    vi.useFakeTimers()
+    setApiRequestConnection('gw-tailscale')
+    setApiRequestProfile('research')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getConnection: vi.fn(() => new Promise(() => undefined)),
+        getConnectionFor: vi.fn(() => new Promise(() => undefined))
+      }
+    })
+
+    const pending = expect(activeConnection()).rejects.toThrow('Timed out connecting to profile "research"')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+})

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -1,5 +1,6 @@
 import type { HermesConnection } from '@/global'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 
 import { getApiRequestConnection, getApiRequestProfile, hermesApi, profileScoped } from './client'
 
@@ -8,16 +9,33 @@ import { getApiRequestConnection, getApiRequestProfile, hermesApi, profileScoped
  *  registry agent's descriptor comes from getConnectionFor (its SOURCE
  *  connection), everything else from the profile-keyed local pool. The
  *  getConnectionFor bridge is optional (older Desktop mains); without it the
- *  profile-scoped pool lookup is the best available answer. */
-async function activeConnection(): Promise<HermesConnection> {
+ *  profile-scoped pool lookup is the best available answer.
+ *
+ *  Both branches are IPC round-trips into the main process with no timeout of
+ *  their own (#93454) — a wedged main-process round-trip otherwise hangs
+ *  pluginSocket's connect() forever instead of falling back to the polling
+ *  fallback every consumer already has. Bound the same way store/gateway's
+ *  openSecondary bounds the same *For/plain pair.
+ *
+ *  Exported for tests. */
+export async function activeConnection(): Promise<HermesConnection> {
   const getConnectionFor = window.hermesDesktop.getConnectionFor
   const connectionId = getApiRequestConnection()
+  const profile = getApiRequestProfile()
 
   if (connectionId && getConnectionFor) {
-    return getConnectionFor({ connectionId, profile: getApiRequestProfile() })
+    return withTimeout(
+      getConnectionFor({ connectionId, profile }),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out connecting to profile "${profile}"`
+    )
   }
 
-  return window.hermesDesktop.getConnection(getApiRequestProfile())
+  return withTimeout(
+    window.hermesDesktop.getConnection(profile),
+    RECONNECT_ATTEMPT_TIMEOUT_MS,
+    `Timed out connecting to profile "${profile}"`
+  )
 }
 
 /** Options for a plugin REST call — mirrors the app's own `hermesDesktop.api`

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   activeGateway,
   closeSecondaryGateways,
+  disposeSecondariesForConnection,
   ensureGatewayForAgent,
   isActivePrimary,
   requestGatewayForAgent
@@ -1142,6 +1143,65 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(callsBeforeDrop)
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('onActiveConnectionInvalidated: a fallback getConnection() that hangs rejects on its own instead of latching $connection forever (#93454 sibling)', async () => {
+    // Repro: the active connection is a registered secondary (e.g. a Bots-pane
+    // source). It gets removed/invalidated (disposeSecondariesForConnection),
+    // which falls back to redialing the primary profile via
+    // desktop.getConnection(fallbackProfile) — the one getConnection() await
+    // in this file the #93454 bound-every-IPC-round-trip sweep never reached.
+    // A wedged main-process round-trip here must reject instead of leaving
+    // $connection pointed at a promise that never settles.
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & {
+      getConnectionFor: ReturnType<typeof vi.fn>
+    }
+
+    desktop.getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      ...coderConn,
+      connectionId,
+      profile
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect($connection.get()).not.toBeNull()
+
+    let opening!: Promise<boolean>
+
+    act(() => {
+      opening = ensureGatewayForAgent('cloud', 'default')
+    })
+    await flushAsync()
+    await opening
+    expect(isActivePrimary()).toBe(false)
+
+    // The active secondary is about to be evicted; the fallback re-dial for
+    // the primary profile hangs indefinitely.
+    desktop.getConnection.mockImplementation(() => new Promise(() => undefined))
+
+    act(() => {
+      disposeSecondariesForConnection('cloud')
+    })
+    await flushAsync()
+
+    expect(isActivePrimary()).toBe(true)
+    expect(desktop.getConnection).toHaveBeenCalledWith('default')
+    // Still stuck behind the hung fallback dial — the invalidation handler's
+    // .then()/.catch() has not run yet.
+    expect($connection.get()).not.toBeNull()
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // fallback getConnection() must reject so the handler's catch publishes
+    // null, instead of latching $connection on a connection that will never
+    // resolve.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($connection.get()).toBeNull()
   })
 
   it('a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout, not only when main eventually gives up (#93454)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $desktopBoot } from '@/store/boot'
 import {
   $connectionsRegistry,
@@ -39,7 +40,7 @@ import {
   setActiveSessionId,
   setSelectedStoredSessionId
 } from '@/store/session'
-import { $sessionTiles } from '@/store/session-states'
+import { $sessionTiles, $workingSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 import { deferred } from '../../../test/deferred'
 
@@ -1686,6 +1687,100 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     })
 
     expect(FakeWebSocket.instances.length).toBe(socketCountBefore)
+    expect($gatewayState.get()).toBe('open')
+  })
+
+  // #95327: every focus/visibility/power-resume nudge probes an OPEN socket
+  // and force-closes it when the liveness ping times out. A backend that is
+  // merely BUSY (a long silent tool call holding the loop) fails that probe
+  // without being dead — closing the socket mid-turn is exactly what feeds the
+  // gateway's ws_orphan_reap interrupt ("Operation interrupted." placeholder).
+  // While any session still reports working, one inconclusive timeout must
+  // defer the teardown (bounded re-probe) instead of killing the transport.
+  it('wake probe: a timeout while a turn is IN FLIGHT defers the force-close', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const socketCountBefore = FakeWebSocket.instances.length
+
+    // A turn is running on this very socket; backend silence is expected until
+    // the tool call returns.
+    act(() => {
+      publishSessionState('rt-live-turn', {
+        ...createClientSessionState(null),
+        storedSessionId: 's-live-turn',
+        busy: true
+      })
+    })
+    expect($workingSessionIds.get()).toContain('s-live-turn')
+
+    // Busy-but-alive: the ping is swallowed (loop starved), not refused.
+    FakeWebSocket.pingMode = 'silent'
+
+    act(() => window.dispatchEvent(new Event('online')))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100)
+    })
+
+    // First inconclusive probe with work in flight: the socket must survive —
+    // not merely "some socket is open again after a teardown + redial", but
+    // THIS incarnation, whose transcript stream the running turn rides on.
+    expect($gatewayState.get()).toBe('open')
+    const survivingSocket = FakeWebSocket.instances[socketCountBefore - 1]
+
+    expect(survivingSocket.readyState).toBe(FakeWebSocket.OPEN)
+
+    clearAllSessionStates()
+
+    // Recovery must not wedge once the working flag is gone: persistent
+    // silence still exhausts the streak and rebuilds the transport.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000)
+    })
+
+    FakeWebSocket.pingMode = 'pong'
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($gatewayState.get()).toBe('open')
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(socketCountBefore)
+  })
+
+  it('wake probe: repeated timeouts while busy still rebuild the socket (no deadlock)', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const socketCountBefore = FakeWebSocket.instances.length
+
+    act(() => {
+      publishSessionState('rt-live-turn-2', {
+        ...createClientSessionState(null),
+        storedSessionId: 's-live-turn-2',
+        busy: true
+      })
+    })
+
+    // Genuinely dead under the working flag: EVERY probe keeps timing out.
+    FakeWebSocket.pingMode = 'silent'
+
+    for (let nudge = 0; nudge < 3; nudge += 1) {
+      act(() => window.dispatchEvent(new Event('online')))
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+    }
+
+    clearAllSessionStates()
+
+    // The streak guard only DELAYS the teardown; a persistently unresponsive
+    // socket is still rebuilt rather than trusted forever.
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(socketCountBefore)
+
+    FakeWebSocket.pingMode = 'pong'
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
     expect($gatewayState.get()).toBe('open')
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { BACKEND_BOOT_WAIT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -113,18 +113,12 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
-// desktop.revalidateConnection() / getConnection() / resolveGatewayWsUrl() are
-// IPC round-trips into the main process with no timeout of their own (#93454).
-// A remote backend that looks alive to a fresh probe but leaves the
-// main-process reconnect path stuck (e.g. a wedged revalidation after a
-// liveness-probe trip) hangs these awaits forever. While any is pending,
-// `reconnecting` never clears, so scheduleReconnect()/attemptReconnect()
-// early-return permanently and the backoff loop is latched — the UI stays
-// "reconnecting" until the app is restarted even though the gateway is
-// reachable again. Bound all three so a stall rejects instead, letting the
-// existing catch/finally clear the guard and resume backoff. gateway.connect()
-// already has its own connect timeout.
-const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
+// While any of the RECONNECT_ATTEMPT_TIMEOUT_MS-bounded awaits below is
+// pending, `reconnecting` never clears, so scheduleReconnect()/
+// attemptReconnect() early-return permanently and the backoff loop is
+// latched — the UI stays "reconnecting" until the app is restarted even
+// though the gateway is reachable again. gateway.connect() already has its
+// own connect timeout.
 
 /** Registry identity whose runtimes died with the primary connection. */
 export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'connectionId' | 'mode'>): null | string {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -715,8 +715,15 @@ export function useGatewayBoot({
       },
       onActiveConnectionInvalidated: (fallbackProfile, invalidationEpoch) => {
         $activeGatewayProfile.set(fallbackProfile)
-        void desktop
-          .getConnection(fallbackProfile)
+        // Bounded like every other getConnection() call in this file (#93454):
+        // an eviction fallback (idle reap, connection removal, profile delete)
+        // must not latch the profile atom to a connection that never resolves
+        // if the main-process IPC round-trip wedges.
+        void withTimeout(
+          desktop.getConnection(fallbackProfile),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out resolving the fallback gateway connection'
+        )
           .then(connection => {
             if (!cancelled && gatewayActivationEpoch() === invalidationEpoch) {
               publish(connection)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -6,6 +6,7 @@ import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
+import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
@@ -96,7 +97,10 @@ const RECONNECT_ESCALATE_AFTER_MS = 300_000
 // ride out a busy-but-healthy backend's scheduling jitter, short enough that a
 // half-open socket fails fast instead of hanging the wake path. Independent of
 // PROMPT_SUBMIT_REQUEST_TIMEOUT_MS (30 min) — that long timeout is correct for
-// an in-flight turn, but must never be what a dead connection burns.
+// an in-flight turn, but must never be what a dead connection burns. A probe
+// TIMEOUT alone no longer tears the socket down mid-turn (#95327): while a
+// turn is in flight the first timeout defers behind one bounded re-probe, so
+// only a STREAK of unanswered pings rebuilds the transport.
 const GATEWAY_LIVENESS_PROBE_TIMEOUT_MS = 5_000
 
 // Bounded self-heal for a failed REMOTE boot (#82679): when the primary boot
@@ -214,6 +218,14 @@ export function useGatewayBoot({
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
+    // Consecutive unanswered liveness probes (#95327): a busy-but-healthy
+    // backend can fail one probe; only a STREAK proves a genuinely dead
+    // socket while turns are in flight. Reset on any successful probe or a
+    // clean socket open.
+    let livenessProbeFailures = 0
+    // Bounded re-probe scheduled instead of an immediate teardown when a
+    // probe times out mid-turn (see gateway-liveness-policy.ts).
+    let livenessReprobeTimer: ReturnType<typeof setTimeout> | null = null
     // Wall-clock start of the current disconnect episode (first failed
     // reconnect attempt); null while healthy. Drives the time-based
     // escalation below. Reset on a clean open or a manual/wake reconnect.
@@ -261,6 +273,28 @@ export function useGatewayBoot({
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
+    }
+
+    const clearLivenessReprobeTimer = () => {
+      if (livenessReprobeTimer !== null) {
+        clearTimeout(livenessReprobeTimer)
+        livenessReprobeTimer = null
+      }
+    }
+
+    // One bounded retry before a mid-turn teardown: the first probe timeout
+    // while work is in flight is inconclusive (a busy backend starves the
+    // loop without being dead), so re-probe once after a short delay instead
+    // of force-closing a socket a running turn still rides on (#95327).
+    const scheduleLivenessReprobe = () => {
+      if (cancelled || livenessReprobeTimer !== null || $gatewaySwitching.get()) {
+        return
+      }
+
+      livenessReprobeTimer = setTimeout(() => {
+        livenessReprobeTimer = null
+        void reconnectNow()
+      }, LIVENESS_REPROBE_DELAY_MS)
     }
 
     const attemptReconnect = async () => {
@@ -436,18 +470,43 @@ export function useGatewayBoot({
       // ping; on failure force the socket down so the onState handler above
       // schedules a reconnect (and resetTileRuntimeBindings re-resumes tiles),
       // instead of letting the user's next submit hang against a dead socket.
+      //
+      // A TIMEOUT is not always proof of death, though (#95327): a backend
+      // mid-tool-call can starve its loop past this budget while perfectly
+      // alive, and tearing the socket down then feeds the gateway's
+      // ws_orphan_reap interrupt — the turn dies as a bare "Operation
+      // interrupted." placeholder. While any session still reports working,
+      // one inconclusive probe DEFERS the teardown behind a bounded re-probe;
+      // only an exhausted streak (or no in-flight work) closes.
       try {
         await gateway.request('ping', {}, GATEWAY_LIVENESS_PROBE_TIMEOUT_MS)
+        livenessProbeFailures = 0
       } catch (probeErr) {
         // A version-skewed backend that predates the ping method answers
         // -32601 (method not found) — a HEALTHY response, not a dead socket.
         // Force-closing on it would spin the reconnect loop forever. Every
         // other failure (timeout on a swallowed ping, transport error) means
-        // the socket is not actually alive and must be rebuilt.
+        // the socket is not PROVABLY alive and must eventually be rebuilt.
         if (probeErr instanceof JsonRpcGatewayError && probeErr.code === -32601) {
+          livenessProbeFailures = 0
+
           return
         }
 
+        livenessProbeFailures += 1
+
+        const decision = decideLivenessForceClose({
+          workingSessionCount: $workingSessionIds.get().length,
+          consecutiveFailures: livenessProbeFailures
+        })
+
+        if (!decision.close) {
+          scheduleLivenessReprobe()
+
+          return
+        }
+
+        livenessProbeFailures = 0
         gateway.close()
       }
     }
@@ -523,6 +582,8 @@ export function useGatewayBoot({
         const ownsSwitch = () => !cancelled && switchToken !== null && isCurrentGatewaySwitch(switchToken)
         clearReconnectTimer()
         clearBootRetryTimer()
+        clearLivenessReprobeTimer()
+        livenessProbeFailures = 0
         bootRetryAttempt = 0
         reconnectAttempt = 0
         reconnectFailingSince = null
@@ -747,7 +808,9 @@ export function useGatewayBoot({
         reconnectFailingSince = null
         reauthNotified = false
         escalated = false
+        livenessProbeFailures = 0
         clearReconnectTimer()
+        clearLivenessReprobeTimer()
 
         // A revalidate-driven reconnect can rebuild the backend in place when the
         // cached remote was found dead, which re-drives the boot-progress overlay.
@@ -1076,6 +1139,7 @@ export function useGatewayBoot({
       endGatewaySwitch()
       clearReconnectTimer()
       clearBootRetryTimer()
+      clearLivenessReprobeTimer()
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -358,4 +358,34 @@ describe('useGatewayRequest', () => {
     expect(desktop.getConnectionFor).not.toHaveBeenCalled()
     expect(desktop.getGatewayWsUrlFor).not.toHaveBeenCalled()
   })
+
+  it('rejects instead of hanging forever when the reconnect getConnection() wedges (#93454)', async () => {
+    // Repro: a request lands on a dropped socket, the "not connected" catch
+    // kicks off a reconnect, and the IPC round-trip into main
+    // (desktop.getConnection) never settles — e.g. a wedged revalidation after
+    // a liveness-probe trip. Without an internal timeout on that await,
+    // reconnectingRef never clears and requestGateway hangs forever instead of
+    // surfacing the original transport error.
+    vi.useFakeTimers()
+
+    const dropped = {
+      connectionState: 'closed',
+      request: vi.fn().mockRejectedValue(new Error('connection closed'))
+    } as unknown as HermesGateway
+    const getConnection = vi.fn(() => new Promise(() => undefined))
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { getConnection }
+    $gateway.set(dropped)
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    const pending = expect(result.current.requestGateway('some.method')).rejects.toThrow('connection closed')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // getConnection() await must reject so the reconnect gives up and the
+    // original transport error surfaces, instead of requestGateway() never
+    // settling.
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
@@ -72,8 +73,17 @@ export function useGatewayRequest() {
       try {
         // Reconnect to whichever profile the gateway is currently routed to (not
         // always the primary), so a sleep/wake reconnect keeps the user on the
-        // profile they were chatting in.
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        // profile they were chatting in. Both awaits below are IPC round-trips
+        // into the main process with no timeout of their own (#93454) — a
+        // wedged main-process round-trip otherwise hangs this await forever,
+        // latching reconnectingRef.current so every later requestGateway() call
+        // returns the same never-settling promise. Bound the same way
+        // use-gateway-boot.ts bounds the primary boot/soft-switch equivalents.
+        const conn = await withTimeout(
+          desktop.getConnection($activeGatewayProfile.get()),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
         connectionRef.current = conn
         setConnection(conn)
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
@@ -82,7 +92,11 @@ export function useGatewayRequest() {
         // auth rejection becomes a reauth error; transport failures remain
         // retryable. Stash only the former so requestGateway can show the
         // actionable "sign in again" message.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out re-minting the gateway WebSocket URL'
+        )
         await existing.connect(wsUrl)
 
         return existing

--- a/apps/desktop/src/lib/gateway-liveness-policy.test.ts
+++ b/apps/desktop/src/lib/gateway-liveness-policy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  decideLivenessForceClose,
+  LIVENESS_PROBE_FAILURE_STREAK,
+  LIVENESS_REPROBE_DELAY_MS
+} from './gateway-liveness-policy'
+
+describe('decideLivenessForceClose', () => {
+  it('keeps the socket on the first timeout while a turn is in flight (#95327)', () => {
+    const decision = decideLivenessForceClose({ workingSessionCount: 1, consecutiveFailures: 1 })
+
+    expect(decision.close).toBe(false)
+    expect(decision.reason).toBe('in-flight-work-deferred')
+  })
+
+  it('defers for every busy session count, not just one', () => {
+    for (const workingSessionCount of [1, 2, 7]) {
+      const decision = decideLivenessForceClose({ workingSessionCount, consecutiveFailures: 1 })
+
+      expect(decision).toEqual({ close: false, reason: 'in-flight-work-deferred' })
+    }
+  })
+
+  it('closes once the unanswered streak reaches the limit even while busy', () => {
+    const decision = decideLivenessForceClose({
+      workingSessionCount: 3,
+      consecutiveFailures: LIVENESS_PROBE_FAILURE_STREAK
+    })
+
+    expect(decision.close).toBe(true)
+    expect(decision.reason).toBe('failure-streak-exhausted')
+  })
+
+  it('closes immediately with no work in flight (legacy shape unchanged)', () => {
+    const decision = decideLivenessForceClose({ workingSessionCount: 0, consecutiveFailures: 1 })
+
+    expect(decision.close).toBe(true)
+    expect(decision.reason).toBe('no-in-flight-work')
+  })
+
+  it('never lets a deferred defer outlive the streak boundary', () => {
+    // Walk the whole streak: every failure below the limit defers; the limit
+    // itself and anything beyond close.
+    for (let failures = 1; failures <= LIVENESS_PROBE_FAILURE_STREAK + 2; failures += 1) {
+      const decision = decideLivenessForceClose({ workingSessionCount: 1, consecutiveFailures: failures })
+
+      expect(decision.close).toBe(failures >= LIVENESS_PROBE_FAILURE_STREAK)
+    }
+  })
+
+  it('coerces malformed counters defensively instead of throwing', () => {
+    expect(decideLivenessForceClose({ workingSessionCount: Number.NaN, consecutiveFailures: 0 })).toEqual({
+      close: true,
+      reason: 'no-in-flight-work'
+    })
+    expect(decideLivenessForceClose({ workingSessionCount: -3, consecutiveFailures: -10 })).toEqual({
+      close: true,
+      reason: 'no-in-flight-work'
+    })
+  })
+
+  it('keeps the re-probe delay far below the probe budget stack so detection stays bounded', () => {
+    // The re-probe is a second 5s liveness ping after this delay; together
+    // they must stay well under the reconnect-escalation horizon (5 min).
+    expect(LIVENESS_REPROBE_DELAY_MS).toBeGreaterThan(0)
+    expect(LIVENESS_REPROBE_DELAY_MS).toBeLessThan(60_000)
+  })
+})

--- a/apps/desktop/src/lib/gateway-liveness-policy.ts
+++ b/apps/desktop/src/lib/gateway-liveness-policy.ts
@@ -1,0 +1,85 @@
+/**
+ * Liveness-probe force-close policy for the primary gateway socket (#95327).
+ *
+ * Why this exists
+ * ───────────────
+ * Every window-lifecycle recovery signal (power resume, network online,
+ * focus, visibility) nudges `reconnectNow()`. When the socket still reports
+ * open, that path probes liveness with a short-bounded ping and FORCE-CLOSES
+ * the socket when the ping times out — "a half-open TCP connection must not
+ * swallow the user's next submit".
+ *
+ * A ping timeout proves a dead TRANSPORT, but it also fires for a live,
+ * BUSY backend: a long silent tool call (a quiet build, an OCR worker, a
+ * large download) starves the gateway's event loop past the 5s probe budget
+ * (#74874's GIL-stall family, amplified on Windows by AV/filter-driver
+ * latency). Tearing down the renderer↔backend WebSocket at that moment is a
+ * false kill: the gateway sees its client vanish mid-turn, the
+ * `ws_orphan_reap` grace expires, and the running turn is interrupted into a
+ * bare "Operation interrupted." placeholder — the exact #95327 report.
+ *
+ * Policy
+ * ──────
+ * While ANY session still reports working (`$workingSessionIds`), backend
+ * silence is EXPECTED, so a probe timeout is inconclusive rather than proof
+ * of death. The first such timeout is deferred: keep the socket and schedule
+ * one bounded re-probe instead. Only when the failure STREAK reaches
+ * `LIVENESS_PROBE_FAILURE_STREAK` (the re-probe also went unanswered — or no
+ * turn is in flight at all) do we treat the socket as genuinely dead and let
+ * the normal close→backoff→redial machinery take over. Worst case this adds
+ * one re-probe interval to genuine-dead detection; it removes the mid-turn
+ * teardown entirely for busy-but-healthy backends.
+ *
+ * Pure and Electron-free so the streak boundaries are assertable directly
+ * (mirroring gateway-liveness usage in use-gateway-boot).
+ */
+
+/** Consecutive unanswered probes tolerated while work is in flight. */
+export const LIVENESS_PROBE_FAILURE_STREAK = 2
+
+/** How long after a deferred probe we try again (bounded, coalesced). */
+export const LIVENESS_REPROBE_DELAY_MS = 3_000
+
+export interface LivenessForceCloseInput {
+  /**
+   * How many sessions currently report working (mid-turn). Zero means no
+   * turn is riding this socket, so silence has no innocent explanation.
+   */
+  workingSessionCount: number
+  /**
+   * Length of the CURRENT unanswered-probe streak, INCLUDING the failure
+   * being decided (first failure = 1).
+   */
+  consecutiveFailures: number
+}
+
+export type LivenessForceCloseReason = 'in-flight-work-deferred' | 'failure-streak-exhausted' | 'no-in-flight-work'
+
+export interface LivenessForceCloseDecision {
+  close: boolean
+  reason: LivenessForceCloseReason
+}
+
+/**
+ * Decide whether one liveness-probe failure should force the socket down.
+ *
+ * - No work in flight            → close immediately (unchanged legacy shape:
+ *                                  a dead idle socket buys nothing by waiting).
+ * - Work in flight, streak < max → keep the socket; the caller schedules a
+ *                                  bounded re-probe ('in-flight-work-deferred').
+ * - Work in flight, streak ≥ max → close anyway ('failure-streak-exhausted'):
+ *                                  a persistently unresponsive socket must
+ *                                  still be rebuilt, never trusted forever.
+ */
+export function decideLivenessForceClose(input: LivenessForceCloseInput): LivenessForceCloseDecision {
+  const workingSessionCount = Math.max(0, Math.floor(input.workingSessionCount))
+  const consecutiveFailures = Math.max(1, Math.floor(input.consecutiveFailures))
+
+  if (workingSessionCount > 0 && consecutiveFailures < LIVENESS_PROBE_FAILURE_STREAK) {
+    return { close: false, reason: 'in-flight-work-deferred' }
+  }
+
+  return workingSessionCount > 0
+    ? { close: true, reason: 'failure-streak-exhausted' }
+    : { close: true, reason: 'no-in-flight-work' }
+}

--- a/apps/desktop/src/lib/voice-playback.routing.test.ts
+++ b/apps/desktop/src/lib/voice-playback.routing.test.ts
@@ -41,6 +41,7 @@ describe('resolveSpeakStreamUrl', () => {
     setApiRequestConnection(null)
     setApiRequestProfile(null)
     Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.useRealTimers()
   })
 
   it('resolves through the registry (connection, profile) bridges when a registry connection is active', async () => {
@@ -101,5 +102,21 @@ describe('resolveSpeakStreamUrl', () => {
     // descriptor's own wsUrl (no cross-scope re-mint).
     expect(url).toContain('/api/audio/speak-stream')
     expect(getConnection).toHaveBeenCalledWith('research')
+  })
+
+  it('resolves to null instead of hanging forever when getConnection() wedges (#93454)', async () => {
+    // desktop.getConnection/getConnectionFor/resolveGatewayWsUrl are IPC
+    // round-trips into the main process with no timeout of their own. A
+    // wedged main-process round-trip otherwise hangs voice mode's "speaking"
+    // state forever instead of falling back to playSpeechText.
+    vi.useFakeTimers()
+    setApiRequestProfile('coder')
+    getConnection.mockImplementation(() => new Promise(() => undefined))
+
+    const pending = resolveSpeakStreamUrl()
+
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    await expect(pending).resolves.toBeNull()
   })
 })

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -7,6 +7,7 @@ import {
   type DirectTtsConfig,
   synthesizeSpeechClientDirect
 } from '@/lib/voice-client-direct'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $voicePlayback,
   setVoicePlaybackState,
@@ -125,10 +126,23 @@ export async function resolveSpeakStreamUrl(): Promise<null | string> {
     const profile = getApiRequestProfile()
     const connectionId = getApiRequestConnection()
 
+    // Both awaits below are IPC round-trips into the main process with no
+    // timeout of their own (#93454) — a wedged main-process round-trip
+    // otherwise hangs voice mode's "speaking" state forever instead of
+    // falling back to playSpeechText. Bound the same way
+    // store/gateway's openSecondary bounds the same *For/plain pair.
     const conn =
       connectionId && desktop.getConnectionFor
-        ? await desktop.getConnectionFor({ connectionId, profile })
-        : await desktop.getConnection(profile)
+        ? await withTimeout(
+            desktop.getConnectionFor({ connectionId, profile }),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${profile}"`
+          )
+        : await withTimeout(
+            desktop.getConnection(profile),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${profile}"`
+          )
 
     const wsDeps =
       connectionId && desktop.getGatewayWsUrlFor
@@ -137,7 +151,11 @@ export async function resolveSpeakStreamUrl(): Promise<null | string> {
           ? {}
           : desktop
 
-    const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
+    const wsUrl = await withTimeout(
+      resolveGatewayWsUrl(wsDeps, conn),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out re-minting the gateway WebSocket URL for profile "${profile}"`
+    )
     const url = new URL(wsUrl)
 
     if (!url.pathname.endsWith('/api/ws')) {

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -5,8 +5,15 @@
  * healthy cold boot publishes well within this; anything longer means the
  * backend is not coming and the caller should fail instead of hanging.
  * Reconnect-class awaits against an already-spawned backend use the shorter
- * RECONNECT_ATTEMPT_TIMEOUT_MS (use-gateway-boot.ts) instead. */
+ * RECONNECT_ATTEMPT_TIMEOUT_MS below instead. */
 export const BACKEND_BOOT_WAIT_TIMEOUT_MS = 45_000
+
+// desktop.getConnection() / getConnectionFor() / revalidateConnection() /
+// resolveGatewayWsUrl() are IPC round-trips into the main process with no
+// timeout of their own (#93454). A wedged main-process round-trip (e.g. a
+// stuck revalidation after a liveness-probe trip) otherwise hangs an awaiting
+// caller forever. Every caller of these bounds them with this shared budget.
+export const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
 
 /** Rejection raised by withTimeout. The bounded work is NOT cancelled — the
  * caller decides what a straggler that settles later means. */

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5242,6 +5242,31 @@ function botSourceStatus(bot) {
 
   return { available: true, key: 'unknown', label: 'Status unknown', tone: 'muted' }
 }
+
+/** Drop unreachable same-name copies from the top-level agent list.
+ *
+ *  Group rooms persist source-qualified members. After Desktop moves to the
+ *  built-in This-device source, the old loopback row (127.0.0.1:port, not
+ *  listening) still sits next to the live profile and looks like a second
+ *  agent (#92286). Routing identities stay intact: this only filters sidebar
+ *  tiles. $lastRoster, group members, and @-mentions still see every
+ *  (connectionId, profile) row.
+ *
+ *  Ghosts stay: a selected-but-offline owner must remain visible rather than
+ *  being replaced by a same-named twin on another gateway. A name with no
+ *  reachable copy is kept, so a genuinely down source still has a row. */
+function preferReachableSameNameRows(bots) {
+  const rows = Array.isArray(bots) ? bots : []
+  const reachableNames = new Set()
+
+  for (const bot of rows) {
+    if (botSourceStatus(bot).available) {
+      reachableNames.add(bot?.name)
+    }
+  }
+
+  return rows.filter(bot => botSourceStatus(bot).available || bot?.ghost || !reachableNames.has(bot?.name))
+}
 // ── cross-connection routing ─────────────────────────────────────────────────
 // A bot from another registered connection (remoteSource rows) is reached
 // through host.requestProfile with a route descriptor; local bots keep the
@@ -14491,7 +14516,7 @@ function BotsPane() {
   const botRows =
     rowKindFilter === 'groups'
       ? []
-      : filteredRoster.map(bot => ({
+      : preferReachableSameNameRows(filteredRoster).map(bot => ({
           kind: 'bot',
           bot,
           pinned: isPinned(bot),

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__botConnectionRoute = botConnectionRoute;\nglobalThis.__resolveBotConnectionRoute = resolveBotConnectionRoute;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__botConnectionRoute = botConnectionRoute;\nglobalThis.__resolveBotConnectionRoute = resolveBotConnectionRoute;\nglobalThis.__preferReachableSameNameRows = preferReachableSameNameRows;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -714,5 +714,155 @@ test('source contract: active roster queries use the SDK ambient owner route', (
     source.match(/requestForBot\(activeBot, 'profiles\.list', \{\}\)/g)?.length,
     2,
     'roster hydration and the session sweep must both use the upstream ambient-owner route'
+  )
+})
+
+test('preferReachableSameNameRows: drops a dead loopback twin when This device is live', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const live = {
+    name: 'profile-a',
+    handle: 'profile-a-this-device',
+    connectionId: 'local',
+    connectionKind: 'local',
+    connectionLabel: 'This device',
+    sourceReachable: true
+  }
+  const dead = {
+    name: 'profile-a',
+    handle: 'profile-a-127-0-0-1-19119',
+    connectionId: 'loopback-19119',
+    connectionKind: 'remote',
+    connectionLabel: '127.0.0.1:19119',
+    remoteSource: true,
+    sourceScoped: true,
+    sourceReachable: false
+  }
+  const other = {
+    name: 'profile-b',
+    handle: 'profile-b-127-0-0-1-19119',
+    connectionId: 'loopback-19119',
+    connectionKind: 'remote',
+    connectionLabel: '127.0.0.1:19119',
+    remoteSource: true,
+    sourceScoped: true,
+    sourceReachable: false
+  }
+
+  const out = prefer([dead, live, other])
+
+  assert.equal(out.length, 2)
+  assert.equal(out[0], live)
+  assert.equal(out[1], other)
+})
+
+test('preferReachableSameNameRows: keeps two live sources with the same profile name', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const local = {
+    name: 'research',
+    connectionId: 'local',
+    connectionLabel: 'This device',
+    sourceReachable: true
+  }
+  const homelab = {
+    name: 'research',
+    connectionId: 'homelab',
+    connectionLabel: 'Homelab',
+    remoteSource: true,
+    sourceReachable: true
+  }
+
+  const out = prefer([local, homelab])
+
+  assert.equal(out.length, 2)
+  assert.equal(out[0], local)
+  assert.equal(out[1], homelab)
+})
+
+test('preferReachableSameNameRows: keeps an unreachable row when no live twin exists', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const dead = {
+    name: 'research',
+    connectionId: 'loopback-19119',
+    sourceReachable: false
+  }
+
+  const out = prefer([dead])
+
+  assert.equal(out.length, 1)
+  assert.equal(out[0], dead)
+})
+
+test('preferReachableSameNameRows: connect-on-demand counts as reachable', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const onDemand = {
+    name: 'research',
+    connectionId: 'mac-mini',
+    sourceError: 'connect-on-demand',
+    sourceReachable: false
+  }
+  const dead = {
+    name: 'research',
+    connectionId: 'loopback-19119',
+    sourceReachable: false
+  }
+
+  const out = prefer([onDemand, dead])
+
+  assert.equal(out.length, 1)
+  assert.equal(out[0], onDemand)
+})
+
+test('preferReachableSameNameRows: sourceMissing drops when a live same-name row exists', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const live = { name: 'research', connectionId: 'local', sourceReachable: true }
+  const missing = {
+    name: 'research',
+    connectionId: 'gone',
+    sourceMissing: true,
+    sourceReachable: false
+  }
+
+  const out = prefer([missing, live])
+
+  assert.equal(out.length, 1)
+  assert.equal(out[0], live)
+})
+
+test('preferReachableSameNameRows: ghosts stay so a selected offline owner is not replaced', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const live = { name: 'research', connectionId: 'local', sourceReachable: true }
+  const ghost = {
+    name: 'research',
+    connectionId: 'loopback-19119',
+    ghost: true,
+    sourceReachable: false
+  }
+
+  const out = prefer([ghost, live])
+
+  assert.equal(out.length, 2)
+  assert.equal(out[0], ghost)
+  assert.equal(out[1], live)
+})
+
+test('preferReachableSameNameRows: does not mutate the input list', () => {
+  const { __preferReachableSameNameRows: prefer } = runtime()
+  const rows = [
+    { name: 'research', connectionId: 'loopback-19119', sourceReachable: false },
+    { name: 'research', connectionId: 'local', sourceReachable: true }
+  ]
+
+  prefer(rows)
+
+  assert.equal(rows.length, 2)
+  assert.equal(rows[0].connectionId, 'loopback-19119')
+})
+
+test('source contract: presentation collapses unreachable twins; shared roster does not', () => {
+  assert.match(source, /preferReachableSameNameRows\(filteredRoster\)/)
+  assert.match(source, /\$lastRoster\.set\(roster\.filter\(row => !row\?\.ghost\)\)/)
+  assert.doesNotMatch(
+    source.slice(source.indexOf('function groupChatMemberBots'), source.indexOf('function durableGroupChatMembers')),
+    /preferReachableSameNameRows/
   )
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -125,6 +125,38 @@ test('groupChatMemberBots: seats local meta members plus stored remote descripto
   assert.equal(members[2], roster[2])
 })
 
+test('groupChatMemberBots: persisted unreachable source members stay seated next to a live same-name twin', () => {
+  const { groupChatMemberBots, $groupChats } = load()
+  const live = {
+    name: 'profile-a',
+    handle: 'profile-a-this-device',
+    connectionId: 'local',
+    connectionKind: 'local',
+    connectionLabel: 'This device',
+    sourceReachable: true
+  }
+  const stored = {
+    name: 'profile-a',
+    handle: 'profile-a-127-0-0-1-19119',
+    connectionId: 'loopback-19119',
+    connectionKind: 'remote',
+    connectionLabel: '127.0.0.1:19119',
+    remoteSource: true,
+    sourceScoped: true,
+    sourceReachable: false
+  }
+  $groupChats.set({ Research: { log: [], members: [stored] } })
+
+  const members = groupChatMemberBots('Research', [live, stored], {
+    'profile-a': { group: 'Research' }
+  })
+
+  assert.equal(members.length, 2)
+  assert.equal(members[0], live)
+  assert.equal(members[1], stored)
+  assert.equal(members[1].handle, 'profile-a-127-0-0-1-19119')
+})
+
 test('groupChatMemberBots: stored descriptors beat presentation-only ghosts', () => {
   const { groupChatMemberBots, $groupChats } = load()
   const ghost = {

--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -94,6 +94,16 @@ afterEach(() => {
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
+
+// Flush microtasks until the dial registers its secondary (or bail). The dial
+// path's hop count is an implementation detail — #95343's withTimeout wrapper
+// added an await hop and broke the previous exactly-two-Promise.resolve flush.
+async function flushUntilSecondaryRegistered(max = 20): Promise<void> {
+  for (let i = 0; i < max && secondaryGateways.length === 0; i++) {
+    await Promise.resolve()
+  }
+}
+
 describe('activation lease vs. the live-work pruner (#89622)', () => {
   it('a prune during the switch dial does not dispose the target and the switch lands', async () => {
     let releaseConnect: () => void = () => undefined
@@ -103,8 +113,7 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
 
     const switching = ensureGatewayForProfile('bot')
     // Let the dial start (createSecondary + connect() now pending on the gate).
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushUntilSecondaryRegistered()
     expect(secondaryGateways).toHaveLength(1)
 
     // The exact recompute that killed the switch: no live sessions, target not
@@ -159,8 +168,7 @@ describe('activation lease vs. the live-work pruner (#89622)', () => {
 
     // Dial starts and never settles (wedged bridge call).
     void ensureGatewayForProfile('bot')
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushUntilSecondaryRegistered()
     expect(secondaryGateways).toHaveLength(1)
 
     // Inside the lease window: spared.

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -295,6 +295,11 @@ describe('secondary connection timeout (#93454)', () => {
 
     installDesktop({ getConnection })
 
+    // The #92434 pin above leaves gatewayMocks.connect latched on a
+    // never-resolving mockImplementation (vi.clearAllMocks() clears calls, not
+    // implementations). Restore the default resolving dial for this test.
+    gatewayMocks.connect.mockImplementation(async () => undefined)
+
     const pending = ensureGatewayForProfile('work')
 
     await vi.advanceTimersByTimeAsync(20_000)

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -234,3 +234,75 @@ describe('profile switch mid-WS-handshake (#92434 close-candidate pin)', () => {
     expect(gatewayMocks.instances).toHaveLength(1)
   })
 })
+
+describe('secondary connection timeout (#93454)', () => {
+  it("rejects instead of hanging forever when openSecondary's getConnection() wedges", async () => {
+    // Repro: desktop.getConnection is an IPC round-trip into the main process
+    // with no timeout of its own. A wedged main-process round-trip (e.g. a
+    // stuck revalidation) hangs this await forever, latching
+    // entry.connectPromise so every routed action against this secondary
+    // (SSH terminal, messaging DELETE, session send, …) never settles either.
+    vi.useFakeTimers()
+
+    let callCount = 0
+    const getConnection = vi.fn(({ profile }: { profile: string }) => {
+      callCount += 1
+
+      // First call is sharedPrimaryRoute's probe — resolves fast, not the
+      // shared primary. Every call after (openSecondary's actual dial) wedges.
+      if (callCount === 1) {
+        return Promise.resolve({ sharedPrimary: false })
+      }
+
+      return new Promise(() => undefined)
+    })
+
+    installDesktop({ getConnection })
+
+    const pending = expect(ensureGatewayForProfile('work')).rejects.toThrow('Timed out connecting to profile "work"')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // await must reject instead of hanging forever.
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+
+  it('does not let a wedged shared-primary-route probe block the secondary dial forever', async () => {
+    // Same unbounded-IPC hazard as above, but for sharedPrimaryRoute's own
+    // getConnection() probe, which runs BEFORE openSecondary on every route —
+    // a wedge there must resolve to "not the shared primary" and fall through
+    // to the ordinary secondary dial instead of hanging the whole route
+    // decision forever.
+    vi.useFakeTimers()
+
+    let callCount = 0
+    const getConnection = vi.fn(({ profile }: { profile: string }) => {
+      callCount += 1
+
+      if (callCount === 1) {
+        return new Promise(() => undefined)
+      }
+
+      return Promise.resolve({
+        authMode: 'token',
+        baseUrl: `https://${profile}.invalid`,
+        mode: 'local',
+        profile,
+        token: 'fake-test-token',
+        wsUrl: `wss://${profile}.invalid/ws`
+      })
+    })
+
+    installDesktop({ getConnection })
+
+    const pending = ensureGatewayForProfile('work')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+
+    // The probe's own bound (not just openSecondary's) is what let this
+    // resolve after a single 20s timeout instead of two stacked ones.
+    expect(callCount).toBe(2)
+    expect(activeGateway()).toBe(gatewayMocks.instances[0])
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -4,6 +4,7 @@ import { atom } from 'nanostores'
 import type { HermesConnection } from '@/global'
 import { HermesGateway, setApiRequestConnection } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
 
@@ -487,11 +488,25 @@ async function openSecondary(entry: Secondary): Promise<void> {
     }
 
     // Registry-scoped entries dial through getConnectionFor when the bridge has
-    // it. Local/legacy entries retain the existing getConnection path.
+    // it. Local/legacy entries retain the existing getConnection path. Both are
+    // IPC round-trips into the main process with no timeout of their own
+    // (#93454) — a wedged main-process round-trip otherwise hangs this await
+    // forever, latching entry.connectPromise so every routed action against
+    // this secondary (SSH terminal, messaging DELETE, session send, …) never
+    // settles either. Bound the same way use-gateway-boot.ts bounds the
+    // primary's equivalent awaits.
     const conn =
       entry.connectionId && desktop.getConnectionFor
-        ? await desktop.getConnectionFor({ connectionId: entry.connectionId, profile: entry.profile })
-        : await desktop.getConnection(entry.profile)
+        ? await withTimeout(
+            desktop.getConnectionFor({ connectionId: entry.connectionId, profile: entry.profile }),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${entry.profile}"`
+          )
+        : await withTimeout(
+            desktop.getConnection(entry.profile),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${entry.profile}"`
+          )
 
     entry.connection = conn
 
@@ -505,7 +520,11 @@ async function openSecondary(entry: Secondary): Promise<void> {
           ? {}
           : desktop
 
-    const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
+    const wsUrl = await withTimeout(
+      resolveGatewayWsUrl(wsDeps, conn),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out re-minting the gateway WebSocket URL for profile "${entry.profile}"`
+    )
 
     try {
       await entry.gateway.connect(wsUrl)
@@ -696,7 +715,15 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   }
 
   try {
-    const conn = await desktop.getConnection(profile)
+    // Unbounded IPC round-trip into main (#93454) — a wedge here must reject
+    // like any other failure, not hang the route decision forever, since
+    // every caller (gatewayForProfile → requestGatewayForProfile/Agent) awaits
+    // this before it can fall back to dialing a secondary.
+    const conn = await withTimeout(
+      desktop.getConnection(profile),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out resolving the shared-primary route for profile "${profile}"`
+    )
 
     return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -97,8 +97,17 @@ describe('selectProfile startup preference (#79886)', () => {
 
   beforeEach(() => {
     rememberProfile.mockClear()
+
+    const getConnection = vi.fn(async () => ({ mode: 'local' }))
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
+
     ;(globalThis as { window?: unknown }).window = {
-      hermesDesktop: { profile: { remember: rememberProfile } }
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
     }
   })
 
@@ -137,6 +146,62 @@ describe('selectProfile startup preference (#79886)', () => {
     selectProfile('researcher')
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'researcher'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+  })
+
+  it('remembers an already-active local profile after returning from All Profiles', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+    $activeGatewayProfile.set('tilly')
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+  })
+
+  it('keeps local startup persistence when the backend descriptor lookup fails', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    const getConnection = vi.fn(async () => {
+      throw new Error('descriptor unavailable')
+    })
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly'))
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+  })
+
+  it('does not replace the local startup preference for a profile SSH override', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    const getConnection = vi.fn(async () => ({ mode: 'remote', remoteKind: 'ssh' }))
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'ssh' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+
+    selectProfile('macmini-hermes')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('macmini-hermes'))
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledWith('macmini-hermes'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
     expect(rememberProfile).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -784,9 +784,11 @@ export function selectProfile(name: string): void {
   // preference.
   const onPrimary = activeGatewayConnectionId() == null
 
-  void activateOnCurrentSource(target)
-    .then(() => {
-      if (onPrimary) {
+  const shouldRememberStartupProfile = onPrimary ? isLocalDesktopProfile(target) : Promise.resolve(false)
+
+  void Promise.all([activateOnCurrentSource(target), shouldRememberStartupProfile])
+    .then(([, shouldRemember]) => {
+      if (shouldRemember) {
         return window.hermesDesktop?.profile?.remember(target)
       }
 
@@ -797,6 +799,28 @@ export function selectProfile(name: string): void {
         notifyError(error, `Failed to switch to profile "${target}"`)
       }
     })
+}
+
+// Resolve persistence from the saved per-profile Desktop route, rather than the
+// live backend descriptor. A descriptor lookup is intentionally best-effort:
+// failure must not discard a successful local selection's startup preference.
+// Conversely, `ssh`, `remote`, and `cloud` here are per-profile overrides and
+// must never replace the local Desktop startup profile.
+async function isLocalDesktopProfile(target: string): Promise<boolean> {
+  const getConnectionConfig = window.hermesDesktop?.getConnectionConfig
+
+  if (!getConnectionConfig) {
+    return true
+  }
+
+  try {
+    return (await getConnectionConfig(target)).mode === 'local'
+  } catch {
+    // Preserve the pre-fix local-primary behavior when Electron's config bridge
+    // is temporarily unavailable. The next successful config read will still
+    // exclude any remote override.
+    return true
+  }
 }
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the


### PR DESCRIPTION
# Salvage: final wave — transport/routing cluster (desktop gateway)

Consolidated salvage of the transport/routing cluster from the multi-gateway campaign. Five contributor fixes re-verified against current main and cherry-picked with authorship preserved. Refs #94724.

## Per-fix credits + verification

### 1. #95343 — bound `getConnection()`/`resolveGatewayWsUrl()` on every remaining route (@nftpoetrist)
Premise re-verified on current main: `store/gateway.ts` (`openSecondary`, `sharedPrimaryRoute`), `api/plugins.ts` (`activeConnection`), `lib/voice-playback.ts`, and `use-gateway-request.ts` all still awaited these IPC round-trips unbounded. Extracts `RECONNECT_ATTEMPT_TIMEOUT_MS` into shared `lib/with-timeout.ts`.
**A/B:** tests-only on main → **6 failed** (4 vitest-level timeouts, 2 TypeErrors on not-yet-exported `activeConnection`); with the pick → all 4 suites green.
Follow-up (ours): the #92434 mid-handshake pin (added on main after this PR branched) latches `gatewayMocks.connect` on a never-resolving `mockImplementation` that `vi.clearAllMocks()` doesn't restore — the salvaged wedged-probe test now restores the default resolving dial explicitly.

### 2. #95592 — bound the `onActiveConnectionInvalidated` fallback `getConnection()` (@nftpoetrist)
**Stacked-PR check:** #95343 does NOT cover this site (`use-gateway-boot.ts:725` was still unbounded after picking #95343), so both land.
**A/B:** test-only on main → 1 failed / 39 skipped; with the pick → 40/40 green.

### 3. #95379 — defer gateway liveness force-close while a turn is in flight (@Finn763, fixes #95327)
Sequenced after #95343 (both touch `use-gateway-boot.ts`); applied cleanly.
**A/B:** `gateway-liveness-policy.test.ts` cannot even import without the new module (fix absent = suite unloadable); with the pick → 49/49 green across the policy + boot suites.

### 4. #95606 — claim-guard every remaining `ensureRegistryBackend()`/`ensureBackend()` call in Electron main (@nftpoetrist)
Direct extension of merged #90812/#95497. Re-verified the await-then-check race sites still exist on current main (media-protocol resolver, terminal-pane resolver, roster-enumeration probe, connections update-all dispatch, `dispatchRegistryApiRequest` were all still unguarded).
**A/B:** tests-only on main → 5 failed / 9 passed; with the pick → 14/14 green.
Follow-up (ours): main's `hermes:connections:update-all` handler grew (renderer-side exclusions + managed-SSH dispatch branch) past the test's 2,000-char scan window — widened to 3,000.

### 5. #95389 — retain local startup profile across SSH switches (@kim-miram)
Re-verified: `selectProfile` on main still remembered any primary pick, including per-profile ssh/remote/cloud overrides. Conflict in `activateOnCurrentSource` resolved in favor of main's `profilePickConnectionId()` (semantically identical to the PR's rewrite).
**A/B:** tests-only on main → 1 failed / 10 passed (the startup-profile regression test); with the pick → 11/11 green.

### 6. #95371 — hide unreachable same-name Bot Mode roster twins (@686f6c61, fixes #92286)
Re-verified STILL LIVE after the quarantine (62e2d6e1e) and no-loopback-spawn (1e9a12a71) merges: those address malformed registry entries and child spawning, not persisted source-qualified group-room member rows — `BotsPane` still mapped `filteredRoster` unfiltered, so a dead loopback twin still rendered next to the live profile.
**A/B:** tests-only on main → assertion failure (`preferReachableSameNameRows(filteredRoster)` absent from plugin source); with the pick → 45/45 `node --test` green.

Note: #95396 was already merged on main and is excluded.

## Tests

- `vitest run` on all 8 touched suites (plugins, gateway store, gateway request/boot hooks, voice-playback routing, liveness policy, profile-select-source, backend-dial-claim): **101/101 passed**
- `node --test` hermes-bots roster suites: **45/45 passed**
- `audit_pr_attribution.py`: all contributor emails mapped
- Pre-push stale-base gate: rebased onto current main, 0 behind, diff = only the 20 files these fixes touch

## Infographic

![final-wave-transport](https://v3b.fal.media/files/b/0aa7f55b/iIlsCa5CJMU2Tb0zEzRmd_co90dr4b.png)
