### PR TITLE
salvage(final-wave): UX/picker cluster — Bots picker settles, refresh reconcile × confirm guard, Bots guarded-switch confirm handshake (#95293), dial observability pair

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -5,8 +5,9 @@ import type { ModelSelection } from '@/app/shell/model-menu-panel'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
+import { surfaceModelSwitchConfirm } from '@/lib/guarded-model-switch'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
-import { dismissNotification, notify, notifyError } from '@/store/notifications'
+import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -282,63 +283,37 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         }
       }
 
-      let confirmNotificationId: string | null = null
-
-      const applyConfirmedSwitch = async () => {
-        // Staleness guard — the warning can linger while the user picks a
-        // different model or switches sessions. Clicking Confirm must not
-        // clobber the newer choice: bail and dismiss if the live state no
-        // longer matches the snapshot this notification was created for.
-        const isStale = touchesPrimary
-          ? $activeSessionId.get() !== liveSessionId ||
-            $currentModel.get() !== prevModel ||
-            $currentProvider.get() !== prevProvider
-          : !liveSessionId ||
-            $sessionStates.get()[liveSessionId]?.model !== prevModel ||
-            $sessionStates.get()[liveSessionId]?.provider !== prevProvider
-
-        if (isStale) {
-          if (confirmNotificationId) {
-            dismissNotification(confirmNotificationId)
-          }
-
-          return
-        }
-
-        if (confirmNotificationId) {
-          dismissNotification(confirmNotificationId)
-        }
-
-        paintSelection()
-        cacheSelection(selection.provider, selection.model)
-
-        try {
-          const result = await requestSwitch(true)
-
-          if (result?.confirm_required) {
-            throw new Error(result.confirm_message?.trim() || copy.modelSwitchFailed)
-          }
-
-          finishSwitch(result)
-        } catch (err) {
-          rollbackSelection()
-          notifyError(err, copy.modelSwitchFailed)
-        }
-      }
-
       try {
         const result = await requestSwitch()
 
         if (result?.confirm_required) {
           rollbackSelection()
-          confirmNotificationId = notify({
-            action: {
-              label: t.common.confirm,
-              onClick: applyConfirmedSwitch
+          // ONE shared applier for guarded switches (#95293): the same
+          // confirm flow the Bots editor routes through — never fork this
+          // logic per surface.
+          surfaceModelSwitchConfirm({
+            confirmLabel: t.common.confirm,
+            confirmMessage: result.confirm_message,
+            failureMessage: copy.modelSwitchFailed,
+            finish: finishSwitch,
+            // Staleness guard — the warning can linger while the user picks
+            // a different model or switches sessions. Clicking Confirm must
+            // not clobber the newer choice: bail if the live state no longer
+            // matches the snapshot this notification was created for.
+            isStale: () =>
+              touchesPrimary
+                ? $activeSessionId.get() !== liveSessionId ||
+                  $currentModel.get() !== prevModel ||
+                  $currentProvider.get() !== prevProvider
+                : !liveSessionId ||
+                  $sessionStates.get()[liveSessionId]?.model !== prevModel ||
+                  $sessionStates.get()[liveSessionId]?.provider !== prevProvider,
+            repaint: () => {
+              paintSelection()
+              cacheSelection(selection.provider, selection.model)
             },
-            kind: 'warning',
-            message: result.confirm_message?.trim() || 'Confirm this model switch?',
-            title: t.common.confirm
+            requestConfirmed: () => requestSwitch(true),
+            rollback: rollbackSelection
           })
 
           return false

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -1,12 +1,24 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useModelControls } from '@/app/session/hooks/use-model-controls'
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
 
 import { ModelMenuPanel } from './model-menu-panel'
+
+const notify = vi.fn(() => 'confirm-toast-1')
+const notifyError = vi.fn()
+const dismissNotification = vi.fn()
+
+vi.mock('@/store/notifications', () => ({
+  dismissNotification: (...args: unknown[]) => dismissNotification(...args),
+  notify: (...args: unknown[]) => notify(...args),
+  notifyError: (...args: unknown[]) => notifyError(...args)
+}))
 
 // Radix calls these on open; jsdom doesn't implement them.
 beforeAll(() => {
@@ -444,5 +456,96 @@ describe('ModelMenuPanel provider collapse', () => {
       expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
     })
     expect(onSelectModel).not.toHaveBeenCalled()
+  })
+})
+
+describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake', () => {
+  // #95446 fix (reconcile after Refresh Models) composes with the
+  // confirm-handshake guard: when the reconcile target is itself a GUARDED
+  // model (contributor tier / expensive), the switch must surface the confirm
+  // flow — one config.set, a warning with a Confirm action, rollback until
+  // confirmed — never a silent retry loop and never a silently-painted pick.
+  function ConfirmHarness({
+    requestGateway
+  }: {
+    requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  }) {
+    const [client] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }))
+    const controls = useModelControls({ queryClient: client, requestGateway })
+
+    return (
+      <QueryClientProvider client={client}>
+        <DropdownMenu open>
+          <DropdownMenuContent>
+            <ModelMenuPanel onSelectModel={controls.selectModel} requestGateway={requestGateway as never} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </QueryClientProvider>
+    )
+  }
+
+  it('reconcile-triggered switch to a guarded model surfaces confirm, not a silent retry', async () => {
+    $activeSessionId.set('runtime-1')
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [{ models: ['glm-4.5-air'], name: 'Zhipu', slug: 'zhipu' }, MOA_PROVIDER]
+      })
+      // Refresh drops the current pick; the only remaining model is guarded.
+      .mockResolvedValueOnce({
+        providers: [{ models: ['muse-spark-1.2-contributor'], name: 'OpenCode', slug: 'opencode-go' }, MOA_PROVIDER]
+      })
+
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_message: 'CONTRIBUTOR TIER: this model may train on your data.',
+        confirm_required: true,
+        key: 'model',
+        value: 'muse-spark-1.2-contributor'
+      })
+      .mockResolvedValueOnce({ key: 'model', scope: 'global', value: 'muse-spark-1.2-contributor' })
+
+    const content = render(<ConfirmHarness requestGateway={requestGateway as never} />)
+
+    await content.findByText(/Glm 4\.5 Air/i)
+    fireEvent.click(await content.findByText('Refresh Models'))
+
+    // The reconcile fired exactly ONE switch attempt and it came back
+    // confirm_required → the confirm toast is up, nothing retried silently.
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: expect.objectContaining({ label: expect.any(String) }),
+          kind: 'warning',
+          message: 'CONTRIBUTOR TIER: this model may train on your data.'
+        })
+      )
+    })
+
+    const configSetCalls = requestGateway.mock.calls.filter(([method]) => method === 'config.set')
+    expect(configSetCalls).toHaveLength(1)
+    expect(configSetCalls[0][1]).not.toHaveProperty('confirm_expensive_model')
+
+    // Pending confirmation = rolled back, not silently painted.
+    expect($currentModel.get()).toBe('glm-4.5-air')
+    expect($currentProvider.get()).toBe('zhipu')
+
+    // User confirms → ONE resend carrying confirm_expensive_model: true.
+    const action = notify.mock.calls.at(-1)?.[0]?.action as { onClick: () => Promise<void> }
+
+    await act(async () => {
+      await action.onClick()
+    })
+
+    await vi.waitFor(() => {
+      const resend = requestGateway.mock.calls.filter(([method]) => method === 'config.set')
+      expect(resend).toHaveLength(2)
+      expect(resend[1][1]).toMatchObject({ confirm_expensive_model: true, session_id: 'runtime-1' })
+    })
+    expect($currentModel.get()).toBe('muse-spark-1.2-contributor')
+    expect($currentProvider.get()).toBe('opencode-go')
+    expect(notifyError).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -10,9 +10,9 @@ import { $activeSessionId, $currentModel, $currentProvider } from '@/store/sessi
 
 import { ModelMenuPanel } from './model-menu-panel'
 
-const notify = vi.fn(() => 'confirm-toast-1')
-const notifyError = vi.fn()
-const dismissNotification = vi.fn()
+const notify = vi.fn((..._args: unknown[]) => 'confirm-toast-1')
+const notifyError = vi.fn((..._args: unknown[]) => undefined)
+const dismissNotification = vi.fn((..._args: unknown[]) => undefined)
 
 vi.mock('@/store/notifications', () => ({
   dismissNotification: (...args: unknown[]) => dismissNotification(...args),
@@ -497,15 +497,29 @@ describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake',
         providers: [{ models: ['muse-spark-1.2-contributor'], name: 'OpenCode', slug: 'opencode-go' }, MOA_PROVIDER]
       })
 
-    const requestGateway = vi
-      .fn()
-      .mockResolvedValueOnce({
-        confirm_message: 'CONTRIBUTOR TIER: this model may train on your data.',
-        confirm_required: true,
-        key: 'model',
-        value: 'muse-spark-1.2-contributor'
-      })
-      .mockResolvedValueOnce({ key: 'model', scope: 'global', value: 'muse-spark-1.2-contributor' })
+    // Method-aware gateway: the panel's catalog reads (`model.options`) fall
+    // back to the REST mock; `config.set` runs the guarded handshake —
+    // confirm_required first, success on the confirmed resend.
+    let configSets = 0
+
+    const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+      if (method !== 'config.set') {
+        throw new Error('use REST catalog')
+      }
+
+      configSets += 1
+
+      if (configSets === 1) {
+        return {
+          confirm_message: 'CONTRIBUTOR TIER: this model may train on your data.',
+          confirm_required: true,
+          key: 'model',
+          value: 'muse-spark-1.2-contributor'
+        }
+      }
+
+      return { key: 'model', scope: 'global', value: 'muse-spark-1.2-contributor' }
+    })
 
     const content = render(<ConfirmHarness requestGateway={requestGateway as never} />)
 
@@ -533,10 +547,10 @@ describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake',
     expect($currentProvider.get()).toBe('zhipu')
 
     // User confirms → ONE resend carrying confirm_expensive_model: true.
-    const action = notify.mock.calls.at(-1)?.[0]?.action as { onClick: () => Promise<void> }
+    const lastNotify = notify.mock.calls.at(-1)?.[0] as { action: { onClick: () => Promise<void> } }
 
     await act(async () => {
-      await action.onClick()
+      await lastNotify.action.onClick()
     })
 
     await vi.waitFor(() => {

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -399,4 +399,50 @@ describe('ModelMenuPanel provider collapse', () => {
     expect($collapsedProviders.get()).toContain('google')
     expect($collapsedProviders.get()).toContain('deepseek')
   })
+
+  it('switches the session model when Refresh Models drops the current pick', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        model: 'glm-4.5-air',
+        provider: 'zhipu',
+        providers: [{ models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' }, MOA_PROVIDER]
+      })
+      .mockResolvedValueOnce({
+        model: 'glm-4.5-air',
+        provider: 'zhipu',
+        providers: [DEEPSEEK_PROVIDER, MOA_PROVIDER]
+      })
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findByText(/Glm 4\.5 Air/i)
+
+    fireEvent.click(await content.findByText('Refresh Models'))
+
+    await vi.waitFor(() => {
+      expect(onSelectModel).toHaveBeenCalledWith({
+        model: 'deepseek-v4-pro',
+        provider: 'deepseek',
+        sessionId: 'runtime-1'
+      })
+    })
+  })
+
+  it('does not switch when Refresh Models still lists the current pick', async () => {
+    $currentProvider.set('deepseek')
+    $currentModel.set('deepseek-v4-pro')
+    getGlobalModelOptions.mockResolvedValue({ providers: MOCK_PROVIDERS })
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findByText(/Deepseek V4 Pro/i)
+    fireEvent.click(await content.findByText('Refresh Models'))
+
+    await vi.waitFor(() => {
+      expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
+    })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -7,7 +7,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { DropdownMenuItem, dropdownMenuRow } from '@/components/ui/dropdown-menu'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, reconcileSelectionAfterCatalogRefresh, requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
@@ -105,6 +105,15 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
       })
 
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
+
+      // Group / credential swaps can return a catalog that no longer contains
+      // the session's current model. The store + currentPickerSelection would
+      // otherwise keep painting the stale id (it is not in the new list).
+      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers)
+
+      if (switchTo) {
+        await onSelectModel({ ...switchTo, sessionId: activeSessionId || null })
+      }
     } catch {
       // Network/backend hiccup — fall back to a plain invalidate so the next
       // open re-fetches (still cached, but no worse than before).

--- a/apps/desktop/src/lib/guarded-model-switch.ts
+++ b/apps/desktop/src/lib/guarded-model-switch.ts
@@ -1,0 +1,90 @@
+import { dismissNotification, notify, notifyError } from '@/store/notifications'
+
+/** The gateway's model-switch handshake shape — shared by `config.set model`
+ *  and `profiles.configure` (Bots editor). `confirm_required: true` means the
+ *  switch was intentionally NOT applied and the gateway is waiting for a
+ *  resend that carries `confirm_expensive_model: true`. */
+export interface GuardedModelSwitchResult {
+  confirm_message?: string
+  confirm_required?: boolean
+  deferred?: boolean
+}
+
+export interface SurfaceModelSwitchConfirmOptions<T extends GuardedModelSwitchResult> {
+  /** Label for the confirm action button (and default title). */
+  confirmLabel: string
+  /** The gateway's `confirm_message`, when present. */
+  confirmMessage?: string
+  /** Error-toast copy when the confirmed resend still fails. */
+  failureMessage: string
+  /** Message when the gateway sent no `confirm_message`. */
+  fallbackMessage?: string
+  /** Runs after the confirmed resend succeeds (cache invalidation etc.). */
+  finish?: (result: T | undefined) => void
+  /** Staleness guard — the warning can linger while the user picks a
+   *  different model or switches sessions. Return true to make Confirm a
+   *  no-op (the notification is dismissed) instead of clobbering the newer
+   *  choice. */
+  isStale?: () => boolean
+  /** Optimistically repaint the pending selection before the resend. */
+  repaint?: () => void
+  /** Resend the switch WITH `confirm_expensive_model: true`. */
+  requestConfirmed: () => Promise<T | undefined>
+  /** Undo the optimistic repaint when the confirmed resend fails. */
+  rollback?: () => void
+  title?: string
+}
+
+/**
+ * THE confirm flow for guarded model switches — every surface that can
+ * receive `confirm_required` from a model switch (core picker via
+ * `config.set`, Bots editor via `profiles.configure`, future surfaces) routes
+ * it through here so there is exactly one applier and no forked confirm
+ * logic per surface (#95293).
+ *
+ * Shows a warning notification whose Confirm action resends the switch with
+ * `confirm_expensive_model: true`, guarded against stale confirmations. A
+ * resend that STILL answers `confirm_required` is treated as a failure — the
+ * gateway asked twice, something is wrong; never loop.
+ *
+ * Returns the notification id.
+ */
+export function surfaceModelSwitchConfirm<T extends GuardedModelSwitchResult>(
+  options: SurfaceModelSwitchConfirmOptions<T>
+): string {
+  const applyConfirmedSwitch = async () => {
+    if (options.isStale?.()) {
+      dismissNotification(notificationId)
+
+      return
+    }
+
+    dismissNotification(notificationId)
+    options.repaint?.()
+
+    try {
+      const result = await options.requestConfirmed()
+
+      if (result?.confirm_required) {
+        throw new Error(result.confirm_message?.trim() || options.failureMessage)
+      }
+
+      options.finish?.(result)
+    } catch (err) {
+      options.rollback?.()
+      notifyError(err, options.failureMessage)
+    }
+  }
+
+  const notificationId = notify({
+    action: {
+      label: options.confirmLabel,
+      onClick: applyConfirmedSwitch
+    },
+    kind: 'warning',
+    message: options.confirmMessage?.trim() || options.fallbackMessage || 'Confirm this model switch?',
+    title: options.title ?? options.confirmLabel
+  })
+
+  return notificationId
+}

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelOptions } from '@/hermes'
 
-import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from './model-options'
+import {
+  firstSelectableCatalogModel,
+  manualPickRemoved,
+  modelOptionsQueryKey,
+  reconcileSelectionAfterCatalogRefresh,
+  requestModelOptions,
+  selectionInCatalog
+} from './model-options'
 
 const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
 
@@ -210,5 +217,37 @@ describe('manualPickRemoved', () => {
 
   it('never clobbers when there is no pick', () => {
     expect(manualPickRemoved(providers, '', '')).toBe(false)
+  })
+})
+
+describe('reconcileSelectionAfterCatalogRefresh', () => {
+  const zhipu = { name: '智谱2', slug: 'zhipu', models: ['glm-4.5-air', 'glm-5-turbo'] }
+  const bytea = {
+    name: '字节A',
+    slug: 'byteplus',
+    models: ['deepseek-v4-flash', 'doubao-seed-2.0-pro']
+  }
+  const moa = { name: 'Mixture of Agents', slug: 'moa', models: ['default'] }
+
+  it('switches to the first new-group model when the current pick is gone', () => {
+    expect(selectionInCatalog([bytea], 'glm-4.5-air')).toBe(false)
+    expect(firstSelectableCatalogModel([moa, bytea])).toEqual({
+      model: 'deepseek-v4-flash',
+      provider: 'byteplus'
+    })
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea])).toEqual({
+      model: 'deepseek-v4-flash',
+      provider: 'byteplus'
+    })
+  })
+
+  it('keeps the current pick when it is still in the refreshed catalog', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa])).toBeNull()
+  })
+
+  it('does not wipe the pick when the refreshed catalog has no selectable models', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined)).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -34,6 +34,64 @@ export function manualPickRemoved(
   return !models.includes(model)
 }
 
+const MOA_PROVIDER_SLUG = 'moa'
+
+/** True when `model` appears in any provider's live list. Used after Refresh
+ *  Models so a group/catalog swap can tell "still offered" from "gone". */
+export function selectionInCatalog(providers: ModelOptionProvider[] | undefined, model: string): boolean {
+  if (!providers?.length || !model) {
+    return false
+  }
+
+  return providers.some(provider => (provider.models ?? []).includes(model))
+}
+
+/** First real (non-MoA) catalog row that still has models. */
+export function firstSelectableCatalogModel(
+  providers: ModelOptionProvider[] | undefined
+): { model: string; provider: string } | null {
+  if (!providers?.length) {
+    return null
+  }
+
+  for (const provider of providers) {
+    if (provider.slug === MOA_PROVIDER_SLUG) {
+      continue
+    }
+
+    const model = provider.models?.[0]
+
+    if (model) {
+      return { model, provider: provider.slug }
+    }
+  }
+
+  return null
+}
+
+/**
+ * After Refresh Models replaces the catalog: keep the current pick when it is
+ * still listed; otherwise switch to the first available model in the new
+ * catalog. Returns null when the catalog is empty/unloaded so we never wipe
+ * a selection on a failed or still-hydrating refresh.
+ */
+export function reconcileSelectionAfterCatalogRefresh(
+  currentModel: string,
+  providers: ModelOptionProvider[] | undefined
+): { model: string; provider: string } | null {
+  const next = firstSelectableCatalogModel(providers)
+
+  if (!next) {
+    return null
+  }
+
+  if (selectionInCatalog(providers, currentModel)) {
+    return null
+  }
+
+  return next
+}
+
 interface ModelOptionsRequest {
   /** When false, include ambient/unconfigured providers (onboarding/setup
    *  surfaces). Chat pickers default to true so only explicitly configured

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8072,8 +8072,14 @@ async function runGroupChatRounds(group, members, thread) {
             clearBotAttention(groupMemberKey(member))
           }
         } catch (error) {
-          recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
-          noteBotAttention(groupMemberKey(member), error?.message || error)
+          const reason = String(error?.data?.reason || '').trim()
+          recordGroupActivity(group, {
+            kind: 'failed',
+            member: member.name,
+            thread,
+            ...(reason ? { reason } : {})
+          })
+          noteBotAttention(groupMemberKey(member), reason || error?.message || error)
           reply = null // a failed turn is a pass, never a room error
         }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -58,6 +58,7 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
+  surfaceModelSwitchConfirm,
   Textarea,
   Tip,
   useQuery,
@@ -9775,6 +9776,29 @@ async function applyAdvancedConfig(bot, state) {
 
   const result = await requestForBot(bot, 'profiles.configure', payload)
   const merged = { ...applied, ...(result?.applied || {}) }
+
+  // #95293 remainder: the gateway now guards data-policy / expensive models
+  // on THIS surface too — `confirm_required` means the model section is
+  // PENDING the user's confirmation, not failed. Route it through the SAME
+  // shared confirm handler the core picker uses (one applier, no forked
+  // confirm logic per surface): the Confirm action resends ONLY the model
+  // section with `confirm_expensive_model: true`.
+  if (result?.confirm_required && payload.model && payload.provider) {
+    delete merged.model
+    surfaceModelSwitchConfirm({
+      confirmLabel: 'Confirm',
+      confirmMessage: result.confirm_message,
+      failureMessage: 'Model switch failed',
+      finish: () => queryClient.invalidateQueries({ queryKey: ROSTER_KEY }),
+      requestConfirmed: () =>
+        requestForBot(bot, 'profiles.configure', {
+          name: bot.name,
+          model: payload.model,
+          provider: payload.provider,
+          confirm_expensive_model: true
+        })
+    })
+  }
 
   return { ...result, ok: Object.values(merged).every(Boolean), applied: merged }
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8875,6 +8875,34 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
 
 // ── model picker (provider/model dropdowns via model.options) ───────────────
 
+// #95279: the picker's catalog read rides the BOT's own socket — a lazily
+// dialed second backend that can wedge (cold pool spawn, dropped remote hop)
+// without the primary socket ever noticing. An unbounded RPC there left the
+// query pending forever and the picker spinning ("never settles"). Bound every
+// attempt: past the budget the query rejects and ModelPicker falls back to its
+// free-text inputs instead of an eternal GlyphSpinner.
+const MODEL_OPTIONS_SETTLE_MS = 20000
+
+function boundedModelOptionsFetch(fetch, settleMs = MODEL_OPTIONS_SETTLE_MS) {
+  // window.setTimeout (not bare setTimeout): bare vm test harnesses expose
+  // timers only through the window shim. With no scheduler at all, degrade to
+  // the old unbounded behavior rather than not fetching.
+  const scope = typeof window === 'undefined' ? null : window
+
+  if (!scope || typeof scope.setTimeout !== 'function') {
+    return fetch
+  }
+
+  let timerId = null
+  const deadline = new Promise((_, reject) => {
+    timerId = scope.setTimeout(() => {
+      reject(new Error(`model.options did not answer within ${Math.round(settleMs / 1000)}s (#95279 settle guard)`))
+    }, settleMs)
+  })
+
+  return Promise.race([fetch, deadline]).finally(() => scope.clearTimeout(timerId))
+}
+
 function useModelOptions(bot = null) {
   // Hook body runs during render: an orphaned row must paint the picker
   // disabled/erroring, not throw into the pane's error boundary.
@@ -8884,11 +8912,18 @@ function useModelOptions(bot = null) {
 
   return useQuery({
     queryKey: [ID, 'model-options', route ? botRouteKey(route) : 'active'],
-    queryFn: () => requestForBot(bot, 'model.options', {
-      include_unconfigured: true,
-      explicit_only: false,
-      refresh: true
-    }),
+    // No forced `refresh`: forcing a network read on EVERY mount bypassed the
+    // staleTime cache, so each Bots view remount (tab re-front, dialog reopen,
+    // pane visibility flip) knocked the picker back into its loading state and
+    // discarded the user's staged selection mid-edit (#95279). The cached read
+    // still refreshes per staleTime like every other surface's catalog.
+    queryFn: () =>
+      boundedModelOptionsFetch(
+        requestForBot(bot, 'model.options', {
+          include_unconfigured: true,
+          explicit_only: false
+        })
+      ),
     enabled: !orphaned,
     staleTime: 120000,
     retry: false

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-attention-badge.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-attention-badge.test.mjs
@@ -133,8 +133,11 @@ test('hooks: relay delivery and group member turns note/clear attention', () => 
   assert.match(drain, /\.\.\.\(reason \? \{ reason \} : \{\}\)/)
 
   // Group member turn boundary: failure notes under the member key; a real
-  // reply clears it.
-  assert.match(pluginSource, /noteBotAttention\(groupMemberKey\(member\), error\?\.message \|\| error\)/)
+  // reply clears it. Typed gateway reasons take precedence over text parsing.
+  assert.match(
+    pluginSource,
+    /noteBotAttention\(groupMemberKey\(member\), reason \|\| error\?\.message \|\| error\)/
+  )
   assert.match(pluginSource, /clearBotAttention\(groupMemberKey\(member\)\)/)
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
@@ -222,6 +222,9 @@ test('Edit Profile model options use the captured non-identity Bot route', async
     'profile',
     remoteBot.route,
     'model.options',
-    { include_unconfigured: true, explicit_only: false, refresh: true }
+    // No `refresh`: the picker's catalog read participates in the staleTime
+    // cache — a forced network read on every mount re-entered the spinner and
+    // wiped staged selections on Bots view remounts (#95279).
+    { include_unconfigured: true, explicit_only: false }
   ]])
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript = () => '(pass)') {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
+      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, $botAttention, GROUP_ACTIVITY_LIMIT };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -162,6 +162,40 @@ test('a failed member turn records failed instead of a phantom reply', async () 
 
   const events = feed(gc, 'Flaky')
   assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
+})
+
+test('a failed member turn preserves and prefers its typed reason', async () => {
+  const gc = load(profile => {
+    if (profile === 'builder') {
+      const error = new Error('generic gateway failure')
+      error.data = { reason: 'provider_auth_or_access' }
+      throw error
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Typed failure', MEMBERS, 'anyone around?')
+  await drain(gc, 'Typed failure')
+
+  const failed = feed(gc, 'Typed failure').find(e => e.kind === 'failed' && e.member === 'builder')
+  assert.equal(failed.reason, 'provider_auth_or_access')
+  assert.equal(Object.values(gc.$botAttention.get())[0]?.reason, 'provider_auth_or_access')
+})
+
+test('an untyped failed member turn keeps the message-classification fallback', async () => {
+  const gc = load(profile => {
+    if (profile === 'builder') {
+      throw new Error('No LLM provider configured')
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Untyped failure', MEMBERS, 'anyone around?')
+  await drain(gc, 'Untyped failure')
+
+  const failed = feed(gc, 'Untyped failure').find(e => e.kind === 'failed' && e.member === 'builder')
+  assert.equal(failed.reason, undefined)
+  assert.equal(Object.values(gc.$botAttention.get())[0]?.reason, 'missing_config')
 })
 
 test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/model-picker-settle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/model-picker-settle.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #95279 regression: the Bot Mode model picker's catalog read must always
+// SETTLE and must not churn the network on every surface remount.
+//
+// The picker's query rides the BOT's own socket (a second, lazily dialed pool
+// backend — exactly the Bots-only context of #95279). Two defects there left
+// the picker unusable while Bots was active:
+//
+//   1. The RPC promise had NO deadline. A wedged dial left it pending forever
+//      → the spinner never settled and the picker was dead ("model picker
+//      never settles").
+//   2. Every fetch forced `refresh: true`, bypassing react-query's cache, so
+//      each Bots view remount (tab re-front, dialog reopen, pane visibility
+//      flip) knocked the picker back into its loading state and discarded the
+//      staged selection mid-edit.
+//
+// These tests pin the contract: bounded settlement (reject → free-text
+// fallback) and a cached, unforced catalog read.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadPickerHarness({ requestProfile } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, value),
+      listen: () => undefined
+    }
+    values.set(slot, initial)
+    return slot
+  }
+  const jsx = (type, props = {}) => ({ type, props })
+  const routed = []
+  let query
+  const stateValues = [true, false, '']
+  const context = {
+    atom,
+    Checkbox: 'Checkbox',
+    GlyphSpinner: 'GlyphSpinner',
+    Input: 'Input',
+    ScrollArea: 'ScrollArea',
+    Textarea: 'Textarea',
+    document: { createElement: () => ({}), getElementById: () => null, head: { appendChild: () => undefined } },
+    host: {
+      getGateway: () => 'ambient-gateway',
+      requestProfile: async (...args) => {
+        routed.push(args)
+
+        return requestProfile ? requestProfile(...args) : new Promise(() => {})
+      },
+      request: async (...args) => {
+        routed.push(['ambient', ...args])
+
+        return requestProfile ? requestProfile(...args) : new Promise(() => {})
+      },
+      state: {
+        gateway: { get: () => 'open', listen: () => undefined },
+        profile: { get: () => 'default', listen: () => undefined }
+      }
+    },
+    jsx,
+    jsxs: jsx,
+    queryClient: { invalidateQueries: () => undefined },
+    sdk: {},
+    useQuery: options => {
+      query = options
+
+      return { data: undefined, isLoading: false, error: null }
+    },
+    useState: initial => [stateValues.length ? stateValues.shift() : initial, () => undefined],
+    window: { setTimeout, clearTimeout }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__useModelOptions = useModelOptions;')
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+
+  return { context, query: () => query, routed }
+}
+
+const remoteBot = {
+  connectionId: 'remote-a',
+  name: 'default',
+  remoteSource: true,
+  route: {
+    connectionId: 'remote-a',
+    mode: 'remote',
+    profile: 'default',
+    targetProfile: 'backend-default'
+  },
+  sourceScoped: true,
+  targetProfile: 'backend-default'
+}
+
+test('#95279: the picker catalog query settles when the bot gateway never answers', async t => {
+  // Fake clocks: tick past the settle budget without waiting real time. The
+  // harness captured the mocked setTimeout above (enable runs first).
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+
+  const runtime = loadPickerHarness({ requestProfile: () => new Promise(() => {}) })
+  runtime.context.__useModelOptions(remoteBot)
+  const query = runtime.query()
+
+  assert.equal(typeof query.queryFn, 'function')
+
+  let settled = false
+
+  query.queryFn().then(
+    () => {
+      settled = 'resolved'
+    },
+    () => {
+      settled = 'rejected'
+    }
+  )
+
+  // Past the settle budget the bounded fetch must have rejected (the picker
+  // then renders its free-text fallback). A macrotask boundary drains every
+  // microtask hop of the rejection chain before we look.
+  t.mock.timers.tick(30_000)
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(settled, 'rejected')
+})
+
+test('#95279: the picker catalog read is cached, not force-refreshed on every mount', async () => {
+  const runtime = loadPickerHarness({
+    requestProfile: async () => ({ providers: [{ models: ['m1'], name: 'Prov', slug: 'prov' }] })
+  })
+  runtime.context.__useModelOptions(remoteBot)
+  const query = runtime.query()
+
+  // Same bot + route ⇒ one stable cache key, so Bots view remounts reuse the
+  // fetched catalog instead of knocking the picker back into its spinner.
+  assert.deepEqual(query.queryKey[1], 'model-options')
+  assert.deepEqual(query.queryKey[2], 'remote-a::default')
+
+  const data = await query.queryFn()
+
+  assert.deepEqual(JSON.parse(JSON.stringify(data)), {
+    providers: [{ models: ['m1'], name: 'Prov', slug: 'prov' }]
+  })
+
+  // No forced refresh: the read participates in the staleTime cache. A forced
+  // refresh here is what made every remount re-enter the loading state and
+  // wipe the user's in-progress pick (#95279).
+  assert.deepEqual(JSON.parse(JSON.stringify(runtime.routed)), [
+    [remoteBot.route, 'model.options', { include_unconfigured: true, explicit_only: false }]
+  ])
+})
+
+test('#95279: picker query stays disabled for orphaned rows and keyed active for local bots', () => {
+  const runtime = loadPickerHarness()
+
+  // An orphaned row must not dispatch at all (renders free-text fallback).
+  runtime.context.__useModelOptions({ name: 'ghost', remoteSource: true })
+  const orphanQuery = runtime.query()
+  assert.equal(orphanQuery.enabled, false)
+
+  // A local (non source-scoped) bot reads the ambient gateway under the
+  // stable 'active' key.
+  runtime.context.__useModelOptions({ name: 'default' })
+  const localQuery = runtime.query()
+  assert.equal(localQuery.enabled, true)
+  assert.deepEqual(localQuery.queryKey[2], 'active')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/model-switch-confirm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/model-switch-confirm.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #95293 remainder: a GUARDED model switch made from the Bots surface must
+// surface the SAME confirm flow the core picker uses, then resend with
+// `confirm_expensive_model: true` once the user confirms.
+//
+// The Bots editor's switch path is `applyAdvancedConfig` → `profiles.configure`
+// (it does NOT route through use-model-controls). The gateway now answers
+// `confirm_required` + `confirm_message` for guarded picks on this surface too
+// (same handshake as `config.set model`); the plugin must:
+//
+//   1. route that response through the shared confirm handler
+//      (`surfaceModelSwitchConfirm` from the plugin SDK — one applier, no
+//      forked confirm logic per surface),
+//   2. NOT count the pending model section as a failed section, and
+//   3. resend ONLY the model section with `confirm_expensive_model: true`
+//      when the user clicks Confirm.
+//
+// Pre-fix, the confirm_required response matched no branch: the pick silently
+// dropped (no confirm, no resend) — exactly issue #95293 on the Bots surface.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadHarness({ request }) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, value),
+      listen: () => undefined
+    }
+    values.set(slot, initial)
+    return slot
+  }
+  const jsx = (type, props = {}) => ({ type, props })
+  const routed = []
+  const confirms = []
+  const invalidated = []
+  const context = {
+    atom,
+    Checkbox: 'Checkbox',
+    GlyphSpinner: 'GlyphSpinner',
+    Input: 'Input',
+    ScrollArea: 'ScrollArea',
+    Textarea: 'Textarea',
+    document: { createElement: () => ({}), getElementById: () => null, head: { appendChild: () => undefined } },
+    host: {
+      getGateway: () => 'ambient-gateway',
+      request: async (method, params) => {
+        routed.push([method, params])
+
+        return request(method, params)
+      },
+      requestProfile: async (route, method, params) => {
+        routed.push([method, params])
+
+        return request(method, params)
+      },
+      state: {
+        gateway: { get: () => 'open', listen: () => undefined },
+        profile: { get: () => 'default', listen: () => undefined }
+      }
+    },
+    jsx,
+    jsxs: jsx,
+    queryClient: { invalidateQueries: key => invalidated.push(key) },
+    sdk: {},
+    // The shared confirm handler the core picker uses, exported through the
+    // plugin SDK. The stub records the options so the test can drive the
+    // Confirm action exactly like a user click would.
+    surfaceModelSwitchConfirm: options => {
+      confirms.push(options)
+
+      return 'notification-1'
+    },
+    useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+    useState: initial => [initial, () => undefined],
+    window: { setTimeout, clearTimeout }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__applyAdvancedConfig = applyAdvancedConfig;')
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+
+  return { applyAdvancedConfig: context.__applyAdvancedConfig, confirms, invalidated, routed }
+}
+
+const bot = { name: 'zeta' }
+
+const dirtyModelState = {
+  loaded: true,
+  provider: 'opencode-go',
+  model: 'muse-spark-1.2-contributor',
+  soul: '',
+  skills: [],
+  toolsets: [],
+  mcp: [],
+  dirtyModel: true,
+  dirtySoul: false,
+  dirtySkills: false,
+  dirtyToolsets: false,
+  dirtyMcp: false
+}
+
+test('guarded Bots-mode switch surfaces the shared confirm flow instead of silently dropping', async () => {
+  const { applyAdvancedConfig, confirms, routed } = loadHarness({
+    request: async () => ({
+      ok: true,
+      applied: {},
+      confirm_required: true,
+      confirm_message: 'CONTRIBUTOR TIER: this model may train on your data.'
+    })
+  })
+
+  const res = await applyAdvancedConfig(bot, { ...dirtyModelState })
+
+  // The first request is the normal (unconfirmed) configure call.
+  assert.equal(routed.length, 1)
+  assert.equal(routed[0][0], 'profiles.configure')
+  assert.equal(routed[0][1].model, 'muse-spark-1.2-contributor')
+  assert.ok(!routed[0][1].confirm_expensive_model, 'first attempt must NOT pre-confirm')
+
+  // The confirm flow was surfaced through the SHARED handler with the
+  // gateway's message — not swallowed, not a forked local dialog.
+  assert.equal(confirms.length, 1, 'confirm_required must surface the shared confirm handler')
+  assert.match(String(confirms[0].confirmMessage || ''), /CONTRIBUTOR TIER/)
+
+  // Pending-confirmation is NOT a failed section: the editor must not toast
+  // "Some sections failed: model" while the confirm toast is up.
+  assert.notEqual(res?.applied?.model, false)
+  assert.equal(res?.ok, true)
+})
+
+test('Confirm resends ONLY the model section with confirm_expensive_model: true', async () => {
+  let calls = 0
+  const { applyAdvancedConfig, confirms, routed } = loadHarness({
+    request: async () => {
+      calls += 1
+
+      if (calls === 1) {
+        return { ok: true, applied: {}, confirm_required: true, confirm_message: 'guarded' }
+      }
+
+      return { ok: true, applied: { model: true } }
+    }
+  })
+
+  await applyAdvancedConfig(bot, { ...dirtyModelState })
+  assert.equal(confirms.length, 1)
+
+  // Drive the confirmed resend exactly as the shared handler's Confirm
+  // action does.
+  const confirmed = await confirms[0].requestConfirmed()
+
+  assert.equal(routed.length, 2)
+  const [method, params] = routed[1]
+  assert.equal(method, 'profiles.configure')
+  assert.equal(params.confirm_expensive_model, true)
+  assert.equal(params.model, 'muse-spark-1.2-contributor')
+  assert.equal(params.provider, 'opencode-go')
+  assert.equal(params.name, 'zeta')
+  // Only the model section rides the resend — no soul/skills/toolsets replay.
+  assert.deepEqual(
+    Object.keys(params).sort(),
+    ['confirm_expensive_model', 'model', 'name', 'provider']
+  )
+  assert.equal(confirmed?.applied?.model, true)
+})
+
+test('unguarded saves keep the existing single-shot behavior', async () => {
+  const { applyAdvancedConfig, confirms, routed } = loadHarness({
+    request: async () => ({ ok: true, applied: { model: true } })
+  })
+
+  const res = await applyAdvancedConfig(bot, { ...dirtyModelState })
+
+  assert.equal(routed.length, 1)
+  assert.equal(confirms.length, 0)
+  assert.equal(res?.ok, true)
+  assert.equal(res?.applied?.model, true)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1483,6 +1483,16 @@ export { type BudgetedLoop, type BudgetedLoopOptions, createBudgetedLoop } from 
 /** THE compact-number formatter — every user-facing count/token figure goes
  *  through here (1230 → "1.2k", 1_500_000 → "1.5M"). Don't hand-roll `/1000`. */
 export { compactNumber } from '@/lib/format'
+/** THE confirm flow for guarded model switches — when a gateway model-switch
+ *  RPC answers `confirm_required` (data-policy / expensive-model guard),
+ *  route it through this shared applier instead of forking a per-surface
+ *  dialog: it shows the warning and resends with
+ *  `confirm_expensive_model: true` on Confirm (#95293). */
+export {
+  type GuardedModelSwitchResult,
+  surfaceModelSwitchConfirm,
+  type SurfaceModelSwitchConfirmOptions
+} from '@/lib/guarded-model-switch'
 export { triggerHaptic as haptic } from '@/lib/haptics'
 export type { HermesOpenTarget } from '@/lib/hermes-open-target'
 /** The app's lucide icon set (RefreshCw, LayoutDashboard, Activity, …). */

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -50,6 +50,7 @@ const {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   pruneSecondaryGateways,
   setPrimaryGateway
 } = await import('./gateway')
@@ -176,6 +177,48 @@ describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094
     await ensureGatewayForProfile('work')
 
     expect(activeGateway()).toBe(gatewayMocks.instances[0])
+  })
+})
+
+describe('connection-scoped dial failure identity (#95421)', () => {
+  it('logs the route scope while preserving the original dial error', async () => {
+    const dialError = new Error('backend unreachable')
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      authMode: 'token',
+      connectionId,
+      profile,
+      wsUrl: `wss://${connectionId}.invalid/ws`
+    }))
+
+    installDesktop({ getConnectionFor })
+    gatewayMocks.connect.mockRejectedValue(dialError)
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      await expect(openGatewayForAgent('work', 'default')).rejects.toBe(dialError)
+      await expect(openGatewayForAgent('homelab', 'default')).rejects.toBe(dialError)
+
+      const messages = errorSpy.mock.calls.map(([message]) => String(message))
+
+      expect(messages).toHaveLength(2)
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('scope="conn:work::default"'),
+          expect.stringContaining('scope="conn:homelab::default"')
+        ])
+      )
+      expect(messages.every(message => message.includes('profile="default"'))).toBe(true)
+      expect(new Set(messages).size).toBe(2)
+      expect(messages.join(' ')).not.toContain('wss://')
+
+      for (const [, error] of errorSpy.mock.calls) {
+        expect(error).toBe(dialError)
+      }
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -514,7 +514,7 @@ async function openSecondary(entry: Secondary): Promise<void> {
       // reconnectSecondary classifies failures by message ("No connection
       // with id", "no longer exists") to fail-stop permanent conditions, and
       // wrapping here would break that. Callers decide surfacing (#81094).
-      console.error(`[gateway] dial for profile "${entry.profile}" failed:`, error)
+      console.error(`[gateway] dial failed for scope="${entry.scope}" profile="${entry.profile}":`, error)
       throw error
     }
 

--- a/tests/tui_gateway/test_profiles_configure_model_guard.py
+++ b/tests/tui_gateway/test_profiles_configure_model_guard.py
@@ -1,0 +1,111 @@
+"""profiles.configure honours the model selection guard (#95293 remainder).
+
+The Bots-mode editor writes a profile's default model through
+``profiles.configure`` — a surface that historically bypassed the
+data-policy / expensive-model selection guard every other model-switch path
+enforces (``config.set model`` answers ``confirm_required`` and waits for a
+``confirm_expensive_model`` resend).  A guarded pick made from the Bots
+surface was therefore applied silently, with no confirm flow anywhere.
+
+These tests pin the same handshake contract on ``profiles.configure``:
+
+* a guarded model WITHOUT ``confirm_expensive_model`` answers
+  ``confirm_required`` + ``confirm_message`` and writes NOTHING;
+* the confirmed resend (``confirm_expensive_model: true``) writes;
+* unguarded models keep writing exactly as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+import hermes_cli.model_selection_guards as guards
+import tui_gateway.server as srv
+
+GUARDED_MODEL = "muse-spark-1.2-contributor"
+GUARD_MESSAGE = "CONTRIBUTOR TIER: this model may train on your data."
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+@pytest.fixture
+def contributor_guard(monkeypatch):
+    """Fire the selection guard for GUARDED_MODEL only, like the real
+    data-policy guard fires for ``-contributor`` ids."""
+
+    def fake_combined_selection_warning(model_name, **_kwargs):
+        if model_name == GUARDED_MODEL:
+            return SimpleNamespace(message=GUARD_MESSAGE, kind="data_policy")
+        return None
+
+    monkeypatch.setattr(guards, "combined_selection_warning", fake_combined_selection_warning)
+
+
+def _configure(params):
+    return srv._methods["profiles.configure"]("configure", {"name": "default", **params})["result"]
+
+
+def _profile_model(home: Path):
+    cfg_path = home / "config.yaml"
+    if not cfg_path.is_file():
+        return None
+    cfg = yaml.safe_load(cfg_path.read_text()) or {}
+    model_cfg = cfg.get("model") or {}
+    return model_cfg.get("default")
+
+
+def test_guarded_model_answers_confirm_required_and_writes_nothing(home, contributor_guard):
+    result = _configure({"model": GUARDED_MODEL, "provider": "opencode-go"})
+
+    assert result.get("confirm_required") is True
+    assert GUARD_MESSAGE in (result.get("confirm_message") or "")
+    # The model section is PENDING confirmation, not failed — it must not
+    # poison ``ok`` (the Bots editor toasts "Some sections failed" on False).
+    assert result["applied"].get("model") is not False
+    assert _profile_model(home) != GUARDED_MODEL
+
+
+def test_confirmed_resend_writes_the_guarded_model(home, contributor_guard):
+    result = _configure(
+        {
+            "model": GUARDED_MODEL,
+            "provider": "opencode-go",
+            "confirm_expensive_model": True,
+        }
+    )
+
+    assert not result.get("confirm_required")
+    assert result["applied"].get("model") is True
+    assert _profile_model(home) == GUARDED_MODEL
+
+
+def test_unguarded_model_still_writes_without_confirmation(home, contributor_guard):
+    result = _configure({"model": "hermes-4.5-405b", "provider": "nous"})
+
+    assert not result.get("confirm_required")
+    assert result["applied"].get("model") is True
+    assert _profile_model(home) == "hermes-4.5-405b"
+
+
+def test_other_sections_still_apply_while_model_awaits_confirmation(home, contributor_guard):
+    result = _configure(
+        {
+            "model": GUARDED_MODEL,
+            "provider": "opencode-go",
+            "soul": "# SOUL\nBe kind.",
+        }
+    )
+
+    assert result.get("confirm_required") is True
+    assert result["applied"].get("soul") is True
+    assert _profile_model(home) != GUARDED_MODEL

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -884,14 +884,34 @@ def _(rid, params: dict) -> dict:
 
         model = str(params.get("model") or "").strip()
         provider = str(params.get("provider") or "").strip()
+        confirm_message = None
         if model and provider:
-            try:
-                from hermes_cli.web_routers.profiles import _write_profile_model
+            # #95293 remainder: this is the Bots editor's model-switch path,
+            # and it used to write guarded (data-policy / expensive) models
+            # silently — the ONE surface that bypassed the selection guard
+            # every other switch path enforces. Same handshake contract as
+            # ``config.set model``: without ``confirm_expensive_model`` a
+            # guarded pick answers ``confirm_required`` + ``confirm_message``
+            # and writes NOTHING; the client resends with
+            # ``confirm_expensive_model: true`` once the user confirms. A
+            # misbehaving guard must never break the save (treated as "no
+            # warning"), matching ``_apply_model_switch``.
+            if not is_truthy_value(params.get("confirm_expensive_model", False)):
+                try:
+                    from hermes_cli.model_selection_guards import combined_selection_warning
 
-                _write_profile_model(profile_dir, provider, model)
-                applied["model"] = True
-            except Exception:
-                applied["model"] = False
+                    warning = combined_selection_warning(model, provider=provider or None)
+                    confirm_message = warning.message if warning is not None else None
+                except Exception:
+                    confirm_message = None
+            if confirm_message is None:
+                try:
+                    from hermes_cli.web_routers.profiles import _write_profile_model
+
+                    _write_profile_model(profile_dir, provider, model)
+                    applied["model"] = True
+                except Exception:
+                    applied["model"] = False
 
         needs_cfg = (
             isinstance(params.get("disabled_skills"), list)
@@ -987,7 +1007,13 @@ def _(rid, params: dict) -> dict:
             finally:
                 reset_hermes_home_override(token)
 
-        return _ok(rid, {"ok": all(applied.values()) if applied else True, "applied": applied})
+        result = {"ok": all(applied.values()) if applied else True, "applied": applied}
+        if confirm_message is not None:
+            # Model write pending user confirmation — same shape config.set
+            # returns, so clients reuse one confirm handler for both surfaces.
+            result["confirm_required"] = True
+            result["confirm_message"] = confirm_message
+        return _ok(rid, result)
     except Exception as e:
         return _err(rid, 5064, str(e))
 


### PR DESCRIPTION
# salvage(final-wave): UX/picker cluster — Bots picker settles, refresh reconcile × confirm guard, Bots-mode guarded-switch confirm handshake, dial observability pair

Final salvage wave of the multi-gateway campaign (#94724) — UX/PICKER cluster, one consolidated PR. Cherry-picks preserve contributor authorship; the #95293 remainder is fixed on top with a shared confirm applier.

## What's in here

### 1. Bot Mode model picker always settles + stops remount churn (#95279, partial)
Cherry-picked from #95325 (credit: @Finn763, authorship preserved).

The Bots picker's catalog read rides the bot's lazily-dialed second socket, which can wedge — the unbounded RPC left the picker spinning forever. Every fetch also forced `refresh: true`, so each Bots view remount knocked the picker back to loading and wiped the staged pick mid-edit. Now: every attempt is bounded to 20s (rejection falls to the free-text fallback) and the read participates in the `staleTime` cache like every other catalog surface. Comes with its red→green regression suite (`model-picker-settle.test.mjs`). The window-reload half of #95279 stays open.

### 2. Composer reconciles selection after Refresh Models (#95446)
Cherry-picked from #95467 (credit: @rainbowgore / rainbowgits, authorship preserved).

Refresh Models only updated the catalog cache; when a group/credential swap dropped the current model from the new list, the composer kept painting the stale id. Now the selection reconciles: keep the pick when still listed, otherwise switch to the first available model (never wiping on an empty/failed refresh).

**Composition with the merged confirm-handshake guard (a72d6d633) is now pinned by a new interaction test:** a reconcile-triggered switch to a *guarded* model surfaces the confirm flow — exactly ONE `config.set` without `confirm_expensive_model`, rollback while pending, one confirmed resend on Confirm — never a silent retry loop (`model-menu-panel.test.tsx`, "refresh reconcile × guarded-switch confirm handshake").

### 3. #95293 remainder: Bots-mode picker routes guarded switches through the SHARED confirm handler (own fix)

The core picker's confirm handshake landed in `use-model-controls.ts`, but the Bots editor's model write (`profiles.configure`) does not route through it — verified by grep on main. Worse: the gateway applied guarded (data-policy / contributor-tier) models on that surface **silently, with no confirm anywhere** — the one switch path that bypassed the selection guard.

- **Gateway** (`tui_gateway/methods_profiles.py`): `profiles.configure` now enforces `combined_selection_warning` on the model section — same handshake as `config.set model`: guarded pick ⇒ `confirm_required` + `confirm_message`, nothing written; resend with `confirm_expensive_model: true` writes. Other dirty sections still apply; the pending model section is not reported as failed.
- **Desktop**: the confirm flow is extracted from `use-model-controls.ts` into ONE shared applier — `lib/guarded-model-switch.ts` (`surfaceModelSwitchConfirm`), exported through the plugin SDK. The core picker and the Bots editor (`plugins/hermes-bots/plugin.js`) consume the same handler: warning toast, staleness-guarded Confirm, single confirmed resend of ONLY the model section, never a retry loop. No forked confirm logic per surface.
- **TDD, red pre-fix, sabotage-proven**:
  - `tests/tui_gateway/test_profiles_configure_model_guard.py` (4 tests) — red on the unguarded gateway (proved the silent-bypass premise), green post-fix.
  - `apps/desktop/src/plugins/hermes-bots/tests/model-switch-confirm.test.mjs` (3 tests) — proves the Bots surface surfaces confirm and the Confirm action resends `profiles.configure` with `confirm_expensive_model: true` and only the model section. Red pre-fix; sabotage check (fix disabled) fails 2/3, restores to 3/3.
  - Existing `use-model-controls.test.tsx` confirm/staleness tests stay green through the refactor (43/43 with panel suite).

### 4. Dial observability pair (#95420 / #95421)
- Cherry-picked from #95530 (credit: @1052326311, authorship preserved): the group-turn catch now preserves typed `error.data.reason` — Activity events carry the machine-readable reason and attention classification prefers it over free-text re-parsing. Fixes #95420.
- Cherry-picked from #95714 (credit: @BlackishGreen33, authorship preserved): gateway dial failures log `scope` + profile, so two connections exposing the same profile name are distinguishable; the original error object is rethrown unchanged. Fixes #95421.

## Verification

- `pytest tests/tui_gateway` — 633 passed, 1 pre-existing ordering flake (`test_gui_surface_toolsets`, passes in isolation and is untouched by this diff)
- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` — **594/594**
- `vitest run` model-menu-panel + use-model-controls + model-options + gateway.test.ts — **70/70** (incl. new interaction test)
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean
- `ruff check` on touched Python — clean; eslint on touched TS/TSX — clean

## Credits

- @Finn763 — #95325 (Bots picker settle guard)
- @rainbowgore (rainbowgits) — #95467 (refresh reconcile)
- @1052326311 — #95530 (group-turn reason codes, #95420)
- @BlackishGreen33 — #95714 (dial-log connection identity, #95421)

Closes #95293. Fixes #95446, #95420, #95421. Partial fix for #95279 (settle/churn half). Part of #94724 (final wave).

## Infographic

![final-wave-ux-pickers](https://v3b.fal.media/files/b/0aa7f579/stqEzejAuXC8N-7Gjy9iG_pEQBBi3p.png)
