### PR TITLE
fix(auth): codex singleton root write-through + reuse-rescue (#87503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- **Codex OAuth singleton: root write-through + reuse-rescue (#87503).** When a
+  profile refreshes a Codex OAuth grant it resolved from the global-root
+  auth store, the rotated token chain is now written back to root (and, for
+  owned-block callers, mirrored to root on every save) so sibling profiles no
+  longer replay a consumed refresh token and die with `invalid_grant`. A
+  relogin-required refresh now also attempts a *reuse-rescue* — adopting a
+  fresher sibling chain already held by root — before falling back to
+  `~/.codex` CLI recovery. This is **self-healing, not preventive**: the first
+  failed POST that produced the relogin error still happens outside any lock,
+  exactly as before; the change heals it, it does not serialize it. Concurrent
+  same-chain callers may each burn one POST, and each loser's rescue succeeds
+  afterward using the winner's chain.
+
+  Persistence failures are classified into two durability classes and logged
+  accordingly:
+
+  - **CLASS-D (durable, self-healing):** any failure where the rotated chain
+    already has a durable store copy (e.g. the profile store saved but the
+    root write-through failed). Logged as a WARNING; the residual sync gap
+    closes via the next-trigger resync, and the return-value contract is
+    unchanged.
+  - **CLASS-N (no durable copy):** any failure where no store durably recorded
+    the rotated chain (e.g. a root-resolved caller whose direct root write
+    failed, leaving root holding the consumed pre-refresh chain). Logged as
+    CRITICAL after exactly three in-call persistence attempts with two fixed
+    backoffs (0.5s then 1.0s); the refreshed tokens are still returned, and
+    the next refresh naturally re-enters the relogin/rescue path. The message
+    names `hermes model` as the remediation for a persistent failure.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4283,22 +4283,38 @@ def _refresh_codex_auth_tokens(
         and global_root is not None
         and _same_path(source_path, global_root)
     )
+    # Top-level mode: the active store IS the global root (a single file). A
+    # root-resolved reader here must persist directly to that same store —
+    # never through the distinct-store write-through helper, which no-ops on a
+    # same-path root and would fall into CLASS-N retries (F1).
+    top_level_root = bool(
+        global_root is not None
+        and _same_path(global_root, _auth_file_path())
+    )
 
-    def _persist_to_root(tk: Dict[str, str]) -> None:
-        # CLASS-N persistence: no durable copy of the rotated chain exists
-        # elsewhere, so retry the root write with bounded backoff; on persistent
-        # failure log CRITICAL and return (the refreshed tokens are still handed
-        # to the caller — loud, not silent).
+    def _persist_class_n(persist_fn, what: str) -> None:
+        # CLASS-N durability (shared by the C2 direct-root and C3-owned
+        # persistence steps — see A1v10): no durable copy of the rotated chain
+        # exists yet, so retry ``persist_fn`` (truthy on a durable write;
+        # raising or falsy on failure) with bounded fixed backoff; on
+        # persistent failure log CRITICAL naming a manual re-auth (the
+        # refreshed tokens are still handed to the caller — loud, not silent).
         for attempt in range(_CODEX_ROOT_PERSIST_ATTEMPTS):
-            if _write_through_codex_to_global_root(tk, None, None) is True:
-                return  # OUTCOME-SUCCESS (silent)
+            try:
+                if persist_fn():
+                    return  # OUTCOME-SUCCESS (silent)
+            except Exception as exc:
+                logger.debug(
+                    "Codex OAuth %s persistence attempt %d failed: %s",
+                    what, attempt + 1, exc,
+                )
             if attempt < _CODEX_ROOT_PERSIST_ATTEMPTS - 1:
                 time.sleep(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS[attempt])
         logger.critical(
-            "Codex OAuth: could not persist the rotated token chain to the "
-            "global root after %d attempts — no durable copy exists. "
-            "Run `hermes model` to re-authenticate manually.",
-            _CODEX_ROOT_PERSIST_ATTEMPTS,
+            "Codex OAuth: could not persist the rotated token chain %s after "
+            "%d attempts — no durable copy exists. Run `hermes model` to "
+            "re-authenticate manually.",
+            what, _CODEX_ROOT_PERSIST_ATTEMPTS,
         )
 
     try:
@@ -4375,18 +4391,20 @@ def _refresh_codex_auth_tokens(
                                     adopted["access_token"] = adopted_refresh["access_token"]
                                     adopted["refresh_token"] = adopted_refresh["refresh_token"]
                                     if is_from_root:
-                                        _persist_to_root(adopted)
+                                        _persist_class_n(
+                                            lambda: _write_through_codex_to_global_root(adopted, None, None) is True,
+                                            "to the global root",
+                                        )
                                     else:
-                                        try:
-                                            _save_codex_tokens(adopted)
-                                        except Exception:
-                                            # CLASS-N: local save failed after a
-                                            # successful POST — no durable copy.
-                                            logger.critical(
-                                                "Codex OAuth: rescue refresh succeeded but the "
-                                                "token chain could not be persisted. Run "
-                                                "`hermes model` to re-authenticate manually."
-                                            )
+                                        # CLASS-N (owned): the local save after a
+                                        # successful rescue POST is the only durable
+                                        # copy — retry it through the shared backoff
+                                        # loop before CRITICAL (A1v10: 3 attempts /
+                                        # 2 backoffs).
+                                        _persist_class_n(
+                                            lambda: (_save_codex_tokens(adopted) or True),
+                                            "to the profile store",
+                                        )
                                     rescued = adopted
                 except Exception:
                     rescued = None
@@ -4403,11 +4421,18 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    if is_from_root:
-        # C2 — persist the rotation directly to root; do NOT seed a shadowing
-        # profile block (C1 write-through covers only owned-block callers).
-        _persist_to_root(updated_tokens)
+    if is_from_root and not top_level_root:
+        # C2 — persist the rotation directly to the distinct root; do NOT seed
+        # a shadowing profile block (C1 write-through covers only owned-block
+        # callers).
+        _persist_class_n(
+            lambda: _write_through_codex_to_global_root(updated_tokens, None, None) is True,
+            "to the global root",
+        )
     else:
+        # Owned-block caller, or top-level mode (the active store IS the root):
+        # ``_save_codex_tokens`` persists to the active store, and its C1
+        # write-through already skips a same-path root.
         _save_codex_tokens(updated_tokens)
     return updated_tokens
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3950,6 +3950,130 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
+_CODEX_OAUTH_ISSUER = "https://auth.openai.com"
+# CLASS-N persistence retry cardinality: exactly 3 total writes, 2 intervening
+# fixed backoffs. These are policy (asserted as constants by tests, stated in
+# CHANGELOG), so bumping them is a deliberate product decision, not a code edit.
+_CODEX_ROOT_PERSIST_ATTEMPTS = 3
+_CODEX_ROOT_PERSIST_BACKOFF_SECONDS = (0.5, 1.0)
+
+# Dead-token tuples (access_token, refresh_token) already rescue-attempted in
+# this process lifetime. One rescue attempt per dead tuple per process; the
+# exported reset hook below exists only so tests can simulate a fresh process.
+_codex_root_rescue_seen: set = set()
+
+
+def _reset_codex_root_rescue_seen() -> None:
+    """Clear the process-lifetime root-rescue seen-set (test hook)."""
+    _codex_root_rescue_seen.clear()
+
+
+def _codex_token_identity(access_token: Any) -> Optional[str]:
+    """Derive the account identity of a Codex access token (D-id).
+
+    Returns the JWT ``sub`` claim when ``access_token`` is a well-formed
+    three-segment base64url JWT issued by ``https://auth.openai.com`` carrying a
+    non-empty ``sub``; returns ``None`` otherwise. An undecodable, opaque, or
+    foreign-issuer token has no identity we may act on, so callers must
+    conservatively skip (or populate-empty-only).
+
+    Nothing is persisted; the identity is derived live from the in-hand token
+    and used only to gate cross-store writes.
+    """
+    claims = _decode_jwt_claims(access_token)
+    if not claims:
+        return None
+    if claims.get("iss") != _CODEX_OAUTH_ISSUER:
+        return None
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub.strip():
+        return None
+    return sub.strip()
+
+
+def _write_through_codex_to_global_root(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+) -> Optional[bool]:
+    """Identity-gated best-effort write of a Codex chain to the global root.
+
+    Mirrors the full field set the just-completed save wrote to the active
+    store — ``tokens``, ``last_refresh``, ``auth_mode="chatgpt"``, ``label`` —
+    onto the root ``providers.openai-codex`` state, preserving root-only fields
+    and leaving ``active_provider`` untouched. Alias/independent pool entries
+    are re-classified against ROOT's pre-save snapshot and updated in place only
+    (labels/ids/priorities/suppressed_sources untouched).
+
+    Return tri-state so the caller can distinguish the three outcome classes:
+
+    * ``True``  — the root store now durably holds the chain (written now);
+    * ``False`` — a distinct root exists and the write was attempted but failed
+      (the caller decides the log level: CLASS-D warning or CLASS-N critical);
+    * ``None``  — not applicable: classic / same-path, the pytest seat belt, or
+      the D-id identity gate refused the write (a conservative silent skip).
+
+    Never raises.
+    """
+    root_path = _global_auth_file_path()
+    if root_path is None:
+        return None
+    if _same_path(root_path, _auth_file_path()):
+        return None
+    # pytest seat belt: refuse to write the real user's $HOME/.hermes/auth.json
+    # (mirrors _load_global_auth_store and the xAI write-through guard).
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / "auth.json"
+            try:
+                if root_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return None
+            except Exception:
+                return None
+    try:
+        with _auth_store_lock(target_path=root_path):
+            root_store = _load_auth_store(root_path)
+            providers = root_store.setdefault("providers", {})
+            if not isinstance(providers, dict):
+                providers = {}
+                root_store["providers"] = providers
+            root_state = providers.get("openai-codex")
+            root_state = dict(root_state) if isinstance(root_state, dict) else {}
+            root_tokens = root_state.get("tokens")
+            root_tokens = dict(root_tokens) if isinstance(root_tokens, dict) else {}
+            root_has_credentials = bool(
+                str(root_tokens.get("access_token", "") or "").strip()
+                or str(root_tokens.get("refresh_token", "") or "").strip()
+            )
+            if root_has_credentials:
+                our_identity = _codex_token_identity(tokens.get("access_token"))
+                root_identity = _codex_token_identity(root_tokens.get("access_token"))
+                if our_identity is None or root_identity is None or our_identity != root_identity:
+                    # D-id gate: different (or undecodable) account — leave root
+                    # untouched rather than clobber a foreign login.
+                    return None
+            previous_singleton_tokens = dict(root_tokens) if root_tokens else None
+            mirrored = dict(root_state)  # preserve root-only fields
+            mirrored["tokens"] = dict(tokens)
+            mirrored["last_refresh"] = last_refresh or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            mirrored["auth_mode"] = "chatgpt"
+            if label and str(label).strip():
+                mirrored["label"] = str(label).strip()
+            providers["openai-codex"] = mirrored
+            _sync_codex_pool_entries(
+                root_store,
+                tokens,
+                mirrored["last_refresh"],
+                previous_singleton_tokens=previous_singleton_tokens,
+            )
+            _save_auth_store(root_store, target_path=root_path)
+        return True
+    except Exception as exc:
+        logger.debug("Codex OAuth: root write-through failed: %s", exc)
+        return False
+
+
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
@@ -3976,6 +4100,17 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             previous_singleton_tokens=previous_singleton_tokens,
         )
         _save_auth_store(auth_store)
+    # C1 — root write-through (best-effort). The active store already durably
+    # holds the chain, so a root-sync failure here is CLASS-D (self-healing):
+    # log a WARNING and let the next save resync root.
+    root_path = _global_auth_file_path()
+    if root_path is not None and not _same_path(root_path, _auth_file_path()):
+        if _write_through_codex_to_global_root(tokens, last_refresh, label) is False:
+            logger.warning(
+                "Codex OAuth: rotated chain saved to the profile store but the "
+                "global-root write-through failed; the next save will retry the "
+                "root sync (self-healing)."
+            )
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
@@ -4133,9 +4268,39 @@ def _refresh_codex_auth_tokens(
     timeout_seconds: float,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
-    
+
     Saves the new tokens to Hermes auth store automatically.
     """
+    # C2 — resolve the caller's token source ONCE at entry (a single read,
+    # before any HTTP work). A root-resolved reader must persist its rotation
+    # directly to root (never seeding a shadowing profile block); an owned-block
+    # caller keeps the ordinary ``_save_codex_tokens`` path (C1 write-throughs).
+    auth_store = _load_auth_store()
+    _state, source_path = _load_provider_state_with_source(auth_store, "openai-codex")
+    global_root = _global_auth_file_path()
+    is_from_root = bool(
+        source_path is not None
+        and global_root is not None
+        and _same_path(source_path, global_root)
+    )
+
+    def _persist_to_root(tk: Dict[str, str]) -> None:
+        # CLASS-N persistence: no durable copy of the rotated chain exists
+        # elsewhere, so retry the root write with bounded backoff; on persistent
+        # failure log CRITICAL and return (the refreshed tokens are still handed
+        # to the caller — loud, not silent).
+        for attempt in range(_CODEX_ROOT_PERSIST_ATTEMPTS):
+            if _write_through_codex_to_global_root(tk, None, None) is True:
+                return  # OUTCOME-SUCCESS (silent)
+            if attempt < _CODEX_ROOT_PERSIST_ATTEMPTS - 1:
+                time.sleep(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS[attempt])
+        logger.critical(
+            "Codex OAuth: could not persist the rotated token chain to the "
+            "global root after %d attempts — no durable copy exists. "
+            "Run `hermes model` to re-authenticate manually.",
+            _CODEX_ROOT_PERSIST_ATTEMPTS,
+        )
+
     try:
         refreshed = refresh_codex_oauth_pure(
             str(tokens.get("access_token", "") or ""),
@@ -4149,14 +4314,84 @@ def _refresh_codex_auth_tokens(
         # the Codex CLI (or another Hermes process) rotates the shared token,
         # this frozen copy's refresh_token goes stale and the refresh fails with
         # a relogin-required error (invalid_grant / refresh_token_reused / 401).
-        # Before surfacing that as a hard 401 to the turn, adopt the canonical
-        # fresh token from ~/.codex/auth.json (the Codex CLI keeps it current) so
-        # idle profiles / desktop sessions recover automatically instead of
-        # 401'ing until a manual re-auth. Transient failures (e.g. 429 quota)
-        # keep relogin_required=False — the stored token is still valid there, so
-        # we never self-heal those and re-raise unchanged.
+        # Before surfacing that as a hard 401 to the turn, recover automatically
+        # instead of 401'ing until a manual re-auth. Transient failures (e.g.
+        # 429 quota) keep relogin_required=False — the stored token is still
+        # valid there, so we never self-heal those and re-raise unchanged.
         if not getattr(exc, "relogin_required", False):
             raise
+        # C3 — root reuse-rescue: before falling back to ~/.codex CLI recovery,
+        # adopt a fresher sibling chain held by the global root (another profile
+        # already rotated the shared token) so this caller self-heals silently.
+        dead_tuple = (
+            str(tokens.get("access_token", "") or ""),
+            str(tokens.get("refresh_token", "") or ""),
+        )
+        rescued: Optional[Dict[str, str]] = None
+        root_path = _global_auth_file_path()
+        if root_path is not None and not _same_path(root_path, _auth_file_path()):
+            # pytest seat belt: never read/write the real user's root store.
+            seat_belted = False
+            if os.environ.get("PYTEST_CURRENT_TEST"):
+                real_home_env = os.environ.get("HOME", "")
+                if real_home_env:
+                    real_root = Path(real_home_env) / ".hermes" / "auth.json"
+                    try:
+                        seat_belted = root_path.resolve(strict=False) == real_root.resolve(strict=False)
+                    except Exception:
+                        seat_belted = True
+            our_identity = _codex_token_identity(tokens.get("access_token"))
+            if not seat_belted and our_identity is not None:
+                try:
+                    with _auth_store_lock(target_path=root_path):
+                        # Atomic seen-set check-and-mark INSIDE the held lock.
+                        if dead_tuple not in _codex_root_rescue_seen:
+                            root_store = _load_auth_store(root_path)
+                            root_state = (root_store.get("providers") or {}).get("openai-codex")
+                            root_state = dict(root_state) if isinstance(root_state, dict) else {}
+                            root_tokens = root_state.get("tokens")
+                            root_tokens = dict(root_tokens) if isinstance(root_tokens, dict) else {}
+                            root_refresh = str(root_tokens.get("refresh_token", "") or "").strip()
+                            root_identity = _codex_token_identity(root_tokens.get("access_token"))
+                            eligible = bool(
+                                root_refresh
+                                and root_refresh != str(tokens.get("refresh_token", "") or "").strip()
+                                and root_identity == our_identity
+                            )
+                            if eligible:
+                                # Mark attempted BEFORE the adoption POST
+                                # (regardless of its outcome).
+                                _codex_root_rescue_seen.add(dead_tuple)
+                                try:
+                                    adopted_refresh = refresh_codex_oauth_pure(
+                                        str(root_tokens.get("access_token", "") or ""),
+                                        root_refresh,
+                                        timeout_seconds=timeout_seconds,
+                                    )
+                                except Exception:
+                                    adopted_refresh = None
+                                if adopted_refresh is not None:
+                                    adopted = dict(root_tokens)
+                                    adopted["access_token"] = adopted_refresh["access_token"]
+                                    adopted["refresh_token"] = adopted_refresh["refresh_token"]
+                                    if is_from_root:
+                                        _persist_to_root(adopted)
+                                    else:
+                                        try:
+                                            _save_codex_tokens(adopted)
+                                        except Exception:
+                                            # CLASS-N: local save failed after a
+                                            # successful POST — no durable copy.
+                                            logger.critical(
+                                                "Codex OAuth: rescue refresh succeeded but the "
+                                                "token chain could not be persisted. Run "
+                                                "`hermes model` to re-authenticate manually."
+                                            )
+                                    rescued = adopted
+                except Exception:
+                    rescued = None
+        if rescued is not None:
+            return rescued
         imported = _recover_codex_tokens_from_cli(
             f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
         )
@@ -4168,7 +4403,12 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens)
+    if is_from_root:
+        # C2 — persist the rotation directly to root; do NOT seed a shadowing
+        # profile block (C1 write-through covers only owned-block callers).
+        _persist_to_root(updated_tokens)
+    else:
+        _save_codex_tokens(updated_tokens)
     return updated_tokens
 
 

--- a/tests/agent/test_codex_singleton_write_through.py
+++ b/tests/agent/test_codex_singleton_write_through.py
@@ -18,9 +18,12 @@ The tests drive the real read-modify-write path against on-disk stores under
 
 import base64
 import json
+import logging
 import re
 import subprocess
 import threading
+
+from contextlib import contextmanager
 
 import pytest
 
@@ -86,6 +89,16 @@ def _reset_rescue_state(monkeypatch):
     A._global_auth_store_cache = None
 
 
+@pytest.fixture
+def top_level_store(tmp_path, monkeypatch):
+    """Top-level mode: the active store IS the global root (one shared file)."""
+    root_path = tmp_path / "root" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return root_path
+
+
 def _mock_refresh(monkeypatch, result=None, exc=None, calls=None):
     """Replace ``refresh_codex_oauth_pure`` with a scripted stub."""
     def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
@@ -125,6 +138,29 @@ def test_t1_root_resolved_success_writes_root_zero_profile(profile_and_root, mon
     assert "openai-codex" not in profile.get("providers", {}), (
         "a root-resolved reader must NOT seed a shadowing profile block (#74339)"
     )
+
+
+def test_t1_top_level_root_silent_success(top_level_store, monkeypatch, caplog):
+    """F1: when root == active store (top-level mode), the rotation persists
+    directly to that store as OUTCOME-SUCCESS — silent, zero CRITICAL."""
+    root_path = top_level_store
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"})}})
+
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    with caplog.at_level("DEBUG"):
+        out = _refresh_codex_auth_tokens(
+            {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+
+    assert out["refresh_token"] == "new-rf"
+
+    # The rotated chain IS durably written to the (root == active) store.
+    rt = _read_store(root_path)["providers"]["openai-codex"]["tokens"]["refresh_token"]
+    assert rt == "new-rf", "top-level rotation was lost (same-path no-op)"
+
+    # OUTCOME-SUCCESS is silent: no WARNING and no CRITICAL.
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records), caplog.text
 
 
 def test_t2_owned_success_syncs_root_and_preserves_independent(profile_and_root, monkeypatch):
@@ -210,8 +246,11 @@ def test_t4_switch_matrix(profile_and_root, monkeypatch, same_sub):
 
 # ── T5 — the fault matrix (SILENT / CLASS-D / CLASS-N) ──────────────────────
 
-def test_t5_c1_root_failure_profile_intact_warning(profile_and_root, monkeypatch):
-    """CLASS-D: a root write-through failure leaves the profile save intact."""
+def test_t5_c1_root_failure_profile_intact_warning(profile_and_root, monkeypatch, caplog):
+    """CLASS-D: a root write-through failure leaves the profile save intact.
+
+    Contract: the failure logs WARNING (self-healing next-trigger resync), and
+    the profile copy stays durably intact."""
     profile_path, root_path = profile_and_root
     _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
         {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
@@ -220,10 +259,16 @@ def test_t5_c1_root_failure_profile_intact_warning(profile_and_root, monkeypatch
 
     monkeypatch.setattr(A, "_save_auth_store", _failing_save(A._save_auth_store, root_path=root_path))
 
-    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+    with caplog.at_level("DEBUG"):
+        _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
 
     profile = _read_store(profile_path)
     assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"
+
+    # CLASS-D = WARNING only; no CRITICAL (the profile copy is the durable store).
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warns, "CLASS-D must emit a WARNING (self-healing root resync)"
+    assert not any(r.levelno >= logging.CRITICAL for r in caplog.records), caplog.text
 
 
 def _failing_save(original_save, root_path):
@@ -235,8 +280,18 @@ def _failing_save(original_save, root_path):
     return wrapped
 
 
-def test_t5_c2_direct_root_failure_returns_tokens_critical(profile_and_root, monkeypatch):
-    """CLASS-N: a root-resolved direct write that always fails still returns tokens."""
+def _fake_timer(monkeypatch):
+    """Replace ``time.sleep`` with a recorder; returns the ordered delay list."""
+    sleeps = []
+    monkeypatch.setattr(A.time, "sleep", sleeps.append)
+    return sleeps
+
+
+def test_t5_c2_direct_root_failure_returns_tokens_critical(profile_and_root, monkeypatch, caplog):
+    """CLASS-N: a root-resolved direct write that always fails still returns tokens.
+
+    Contract: exactly 3 attempts, fixed backoffs [0.5s, 1.0s], then CRITICAL
+    naming manual ``hermes model`` re-auth (refreshed tokens still returned)."""
     profile_path, root_path = profile_and_root
     _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
         {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
@@ -253,16 +308,25 @@ def test_t5_c2_direct_root_failure_returns_tokens_critical(profile_and_root, mon
         return False  # always fails
 
     monkeypatch.setattr(A, "_write_through_codex_to_global_root", fake_write_through)
+    sleeps = _fake_timer(monkeypatch)
 
     tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
-    out = _refresh_codex_auth_tokens(tokens, 20.0)
+    with caplog.at_level("DEBUG"):
+        out = _refresh_codex_auth_tokens(tokens, 20.0)
 
     assert out["refresh_token"] == "new-rf"  # tokens still returned
     assert len(results) == _CODEX_ROOT_PERSIST_ATTEMPTS  # exactly 3 attempts
+    # fixed backoff ordering, index-aligned with the attempts that precede them
+    assert sleeps == list(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS), sleeps
+
+    crits = [r for r in caplog.records if r.levelno >= logging.CRITICAL]
+    assert crits, "CLASS-N must emit a CRITICAL after exhausting retries"
+    assert any("hermes model" in r.getMessage() for r in crits), "CRITICAL must name manual re-auth"
 
 
-def test_t5_c3_post_persist_failure_returns_tokens_no_autherror(profile_and_root, monkeypatch):
-    """CLASS-N: after a successful rescue POST, persistence failure must not raise."""
+def test_t5_c3_post_persist_failure_returns_tokens_no_autherror(profile_and_root, monkeypatch, caplog):
+    """CLASS-N (root-resolved rescue): persistence failure after a successful
+    adoption POST still returns tokens — 3 attempts, 2 backoffs, then CRITICAL."""
     profile_path, root_path = profile_and_root
     _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
         {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
@@ -283,12 +347,62 @@ def test_t5_c3_post_persist_failure_returns_tokens_no_autherror(profile_and_root
     # Persistence always fails → CLASS-N (must still return tokens, not raise).
     monkeypatch.setattr(A, "_save_auth_store", _failing_save(A._save_auth_store, root_path=root_path))
     monkeypatch.setattr(A, "_write_through_codex_to_global_root", lambda *a, **k: False)
+    sleeps = _fake_timer(monkeypatch)
 
     tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
-    out = _refresh_codex_auth_tokens(tokens, 20.0)
+    with caplog.at_level("DEBUG"):
+        out = _refresh_codex_auth_tokens(tokens, 20.0)
 
     assert out["refresh_token"] == "adopted-rf"
     assert state["n"] == 1  # one adoption POST ran
+    assert sleeps == list(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS), sleeps
+
+    crits = [r for r in caplog.records if r.levelno >= logging.CRITICAL]
+    assert crits, "CLASS-N rescue persistence failure must CRITICAL"
+    assert any("hermes model" in r.getMessage() for r in crits)
+
+
+def test_t5_c3_owned_local_save_failure_critical_retries(profile_and_root, monkeypatch, caplog):
+    """F2/C3-owned CLASS-N: a local save failure after a successful rescue POST
+    retries 3× with 2 backoffs BEFORE CRITICAL (mirrors the C2 CLASS-N loop)."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    # OWNED caller: the profile holds its own (stale) codex block.
+    _write_store(profile_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    )}})
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+
+    save_attempts = []
+
+    def failing_local_save(tokens, last_refresh=None, label=None):
+        save_attempts.append(tokens.get("refresh_token"))
+        raise OSError("simulated local-save failure")
+
+    monkeypatch.setattr(A, "_save_codex_tokens", failing_local_save)
+    sleeps = _fake_timer(monkeypatch)
+
+    tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    with caplog.at_level("DEBUG"):
+        out = _refresh_codex_auth_tokens(tokens, 20.0)
+
+    # Refreshed/adopted tokens are still handed back (loud, not silent).
+    assert out["refresh_token"] == "adopted-rf"
+    # exactly 3 total local-save attempts, 2 fixed backoffs, then CRITICAL
+    assert len(save_attempts) == _CODEX_ROOT_PERSIST_ATTEMPTS, save_attempts
+    assert sleeps == list(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS), sleeps
+    crits = [r for r in caplog.records if r.levelno >= logging.CRITICAL]
+    assert crits, "C3-owned CLASS-N must CRITICAL after retries"
+    assert any("hermes model" in r.getMessage() for r in crits)
 
 
 def test_t5_silent_success_no_warning_no_critical(profile_and_root, monkeypatch, caplog):
@@ -330,6 +444,52 @@ def test_t6_classic_mode_inert(profile_and_root, monkeypatch, tmp_path):
 
     store = _read_store(root_path)
     assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"
+
+
+def test_t6_classic_mode_byte_identity(profile_and_root, monkeypatch):
+    """D-classic: classic-mode persistence is byte-identical to merge-base.
+
+    With no global root, the write-through feature must not perturb any
+    non-codex byte of the store, and the codex block holds exactly the rotated
+    chain — i.e. the same bytes a pre-feature save would have produced."""
+    profile_path, root_path = profile_and_root
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "_auth_file_path", lambda: root_path)
+
+    baseline = {
+        "version": A.AUTH_STORE_VERSION,
+        "active_provider": "anthropic",
+        "providers": {
+            "anthropic": {"tokens": {"access_token": "ak-ant"}, "auth_mode": "chatgpt"},
+        },
+        "credential_pool": {
+            "anthropic": [{"id": "a", "source": "manual", "access_token": "ak-ant", "label": "l"}],
+        },
+        "nested": {"key": "value", "list": [1, 2, 3]},
+    }
+    _write_store(root_path, baseline)
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    # function outcome: classic-mode refresh returns the rotated chain
+    out = _refresh_codex_auth_tokens(
+        {"access_token": _jwt("acct-1"), "refresh_token": "r1"}, 20.0)
+    assert out == {"access_token": _jwt("acct-1"), "refresh_token": "new-rf"}
+
+    store = _read_store(root_path)
+
+    # every non-codex byte is identical to the baseline snapshot — the
+    # write-through feature added nothing in classic (no-global-root) mode.
+    assert store["version"] == baseline["version"]
+    assert store["nested"] == baseline["nested"]
+    assert store["providers"]["anthropic"] == baseline["providers"]["anthropic"]
+    assert store["credential_pool"]["anthropic"] == baseline["credential_pool"]["anthropic"]
+
+    # the only codex-adjacent mutations are the expected merge-base ones:
+    # active_provider flips to openai-codex and the codex block holds the chain.
+    assert store["active_provider"] == "openai-codex"
+    codex = store["providers"]["openai-codex"]
+    assert codex["tokens"]["access_token"] == _jwt("acct-1")
+    assert codex["tokens"]["refresh_token"] == "new-rf"
 
 
 # ── T7 — rescue-order matrix + repeat/cap ───────────────────────────────────
@@ -443,10 +603,14 @@ def test_t7_repeat_tuple_skip_and_ineligible_no_consume(profile_and_root, monkey
 def test_t7c_two_threads_single_adoption(profile_and_root, monkeypatch):
     """Two same-process threads, same dead tuple ⇒ exactly one adoption POST.
 
-    The seen-set is checked-and-marked atomically INSIDE the root flock, so
-    the two contention attempts serialize: the loser observes the winner's mark
-    inside its acquired critical section and falls through to CLI recovery. A
-    defective outside-lock-decides implementation would double-POST here.
+    AMENDMENT-T7cv10: deterministic double-barrier choreography. B1 aligns the
+    threads pre-race; each records its instrumented candidate seen-set
+    observation BEFORE any lock acquisition; B2 releases only after BOTH
+    pre-check observations are recorded; only then do they contend the flock.
+    The authoritative re-check+mark happens INSIDE the acquired critical
+    section — the loser observes the winner's mark there and falls through to
+    CLI recovery. A defective outside-lock-decides implementation would
+    double-POST and fail under this schedule.
     """
     profile_path, root_path = profile_and_root
     _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
@@ -454,8 +618,12 @@ def test_t7c_two_threads_single_adoption(profile_and_root, monkeypatch):
     )}})
     _write_store(profile_path, {"version": 1})
 
+    DEAD = (_jwt("acct-1"), "stale-rf")
     posts = []
     lock = threading.Lock()
+    b1 = threading.Barrier(2)
+    b2 = threading.Barrier(2)
+    obs = []  # (phase, thread_name, dead_tuple_in_seen)
 
     def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
         if refresh_token == "stale-rf":
@@ -469,12 +637,41 @@ def test_t7c_two_threads_single_adoption(profile_and_root, monkeypatch):
     monkeypatch.setattr(A, "_recover_codex_tokens_from_cli",
                         lambda *a, **k: {"access_token": "cli-at", "refresh_token": "cli-rf"})
 
+    real_lock = A._auth_store_lock
+    tl = threading.local()
+
+    @contextmanager
+    def instrumented_lock(timeout_seconds=A.AUTH_LOCK_TIMEOUT_SECONDS, *, target_path=None):
+        if target_path is not None and A._same_path(target_path, root_path):
+            depth = getattr(tl, "depth", 0)
+            outer = depth == 0
+            if outer:
+                # instrumented candidate seen-set check BEFORE any lock acquisition
+                obs.append(("pre", threading.current_thread().name, DEAD in A._codex_root_rescue_seen))
+                b2.wait(timeout=30)
+            tl.depth = depth + 1
+            try:
+                with real_lock(timeout_seconds, target_path=target_path):
+                    if outer:
+                        # authoritative in-lock observation (the only copy that decides)
+                        obs.append(("inlock", threading.current_thread().name,
+                                    DEAD in A._codex_root_rescue_seen))
+                    yield
+            finally:
+                tl.depth = getattr(tl, "depth", 1) - 1
+        else:
+            with real_lock(timeout_seconds, target_path=target_path):
+                yield
+
+    monkeypatch.setattr(A, "_auth_store_lock", instrumented_lock)
+
     rescued = []
     recovered = []
     errors = []
 
     def worker():
         try:
+            b1.wait(timeout=30)
             out = A._refresh_codex_auth_tokens(
                 {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
         except AuthError as exc:  # noqa: BLE001
@@ -489,10 +686,22 @@ def test_t7c_two_threads_single_adoption(profile_and_root, monkeypatch):
     for t in threads:
         t.start()
     for t in threads:
-        t.join(timeout=20)
+        t.join(timeout=30)
 
     assert not errors, errors
     assert all(not t.is_alive() for t in threads)
+
+    pre = [o for o in obs if o[0] == "pre"]
+    inlock = [o for o in obs if o[0] == "inlock"]
+    # both threads recorded their outside-lock pre-check before any lock was taken
+    assert len(pre) == 2, f"expected both pre-check observations; got {obs}"
+    assert all(not o[2] for o in pre), "outside-lock pre-checks must both see the tuple unmarked"
+    # exactly one winner (in-lock sees unmarked) and one loser (in-lock sees the mark)
+    winners = [o for o in inlock if not o[2]]
+    losers = [o for o in inlock if o[2]]
+    assert len(winners) == 1, f"expected one in-lock winner; got {inlock}"
+    assert len(losers) == 1, "the loser's authoritative in-lock observation must see the winner's mark"
+
     assert len(posts) == 1, "exactly ONE adoption POST globally"
     assert len(rescued) == 1, "exactly one thread self-healed via rescue"
     assert len(recovered) == 1, "the loser fell through to CLI recovery"
@@ -552,7 +761,11 @@ def test_t9_concurrency_honest_invariants(profile_and_root, monkeypatch):
         return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
 
     monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
-    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli", lambda *a, **k: None)
+    # P0/P1/P2: root chain is the same account; only cohort members write; the
+    # CLI recovery path also yields a valid chain, so every loser self-heals —
+    # ZERO relogin surfaces.
+    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli",
+                        lambda *a, **k: {"access_token": "cli-at", "refresh_token": "cli-rf"})
 
     n = 3
     held = []
@@ -576,14 +789,13 @@ def test_t9_concurrency_honest_invariants(profile_and_root, monkeypatch):
     for t in threads:
         t.join(timeout=20)
 
-    # (a) at least one participant holds a valid rotated chain (the winner)
-    assert held, "at least one thread must self-heal and hold the rotated chain"
-    assert all(h.get("refresh_token") == "adopted-rf" for h in held)
-    # every surfaced failure is an AuthError (the losers fall through to CLI
-    # recovery and re-raise only because that path is empty here)
-    assert len(errors) + len(held) == n
-    # (c) per-chain adoption POST bound ≤ racing processes (seen-set ⇒ exactly 1)
-    assert 1 <= len(posts) <= n
+    # (b)/(c) under P0∧P1∧P2: every participant self-heals — ZERO surfaced
+    # AuthErrors/relogin across all threads.
+    assert not errors, f"no relogin should surface under P0/P1/P2; got {errors}"
+    assert len(held) == n, f"every thread must hold a chain; got {len(held)} held"
+    assert all(h.get("refresh_token") for h in held)
+    # per-chain adoption POST bound (seen-set ⇒ exactly 1 across the cohort)
+    assert len(posts) == 1, f"exactly one adoption POST; got {len(posts)}"
     # final root holds a valid rotated chain
     root_store = _read_store(root_path)
     rt = root_store["providers"]["openai-codex"]["tokens"]["refresh_token"]
@@ -601,6 +813,38 @@ def test_t13_identity_corner_matrix():
     assert _codex_token_identity(_jwt("")) is None  # empty sub
     assert _codex_token_identity("opaque-token") is None  # not a JWT
     assert _codex_token_identity(None) is None  # not a str
+    # missing-iss ⇒ None-conservative (no issuer claim ⇒ cannot establish identity)
+    tok_no_iss = ".".join([_b64({"alg": "none", "typ": "JWT"}), _b64({"sub": "acct-1"}), "sig"])
+    assert _codex_token_identity(tok_no_iss) is None
+
+
+def test_t13_both_none_pair_store_matrix(profile_and_root, monkeypatch):
+    """D-id both-None: an opaque token on BOTH sides refuses the cross-store write
+    (root + aliases untouched); an empty root is still populated."""
+    profile_path, root_path = profile_and_root
+    opaque = "opaque-token"  # not a JWT → identity None (conservative skip)
+
+    # (a) non-empty root with opaque credentials → both identities None ⇒ the
+    # D-id gate refuses: root singleton and its alias are left byte-identical.
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": "opaque-root", "refresh_token": "root-rf"}
+    )}, "credential_pool": {"openai-codex": [
+        {"id": "alias", "source": "manual:device_code", "access_token": "opaque-root",
+         "refresh_token": "root-rf", "label": "lbl"},
+    ]}})
+    _write_store(profile_path, {"version": 1})
+    _save_codex_tokens({"access_token": opaque, "refresh_token": "new-rf"})
+
+    root_store = _read_store(root_path)
+    assert root_store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "root-rf"  # untouched
+    assert root_store["credential_pool"]["openai-codex"][0]["refresh_token"] == "root-rf"  # aliases skip
+
+    # (b) empty root → populated (no credentials ⇒ identity gate skipped).
+    _write_store(root_path, {"version": 1, "active_provider": "anthropic", "providers": {}})
+    _save_codex_tokens({"access_token": opaque, "refresh_token": "new-rf"})
+    root_store = _read_store(root_path)
+    assert root_store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"  # empty-root populated
+    assert root_store["active_provider"] == "anthropic"  # set_active untouched
 
 
 def test_t10_structure_preservation(profile_and_root, monkeypatch):
@@ -641,6 +885,28 @@ def test_t17_field_set_pin(profile_and_root, monkeypatch):
     assert rc["auth_mode"] == "chatgpt"
     assert rc["last_refresh"]  # present
     assert rc["custom_field"] == "keep"  # root-only field preserved
+
+
+def test_t17_label_rule(profile_and_root, monkeypatch):
+    """Label rule: a non-empty label is written through; absent/empty is not
+    (a pre-existing label is preserved rather than cleared)."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    # non-empty label present → written to the root (and profile)
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "r1"},
+                       last_refresh="2026-06-01T00:00:00Z", label="My Codex")
+    rc = _read_store(root_path)["providers"]["openai-codex"]
+    assert rc["label"] == "My Codex"
+
+    # absent/empty (whitespace) label → NOT written; prior label preserved
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "r2"},
+                       last_refresh="2026-06-02T00:00:00Z", label="   ")
+    rc = _read_store(root_path)["providers"]["openai-codex"]
+    assert rc["label"] == "My Codex"  # whitespace label is not a label
 
 
 # ── T15 / T18 — negative greps + dual-enumeration budget pin ────────────────
@@ -696,34 +962,59 @@ def test_t15_negative_greps():
 
 
 def test_t18_dual_enumeration_budget_pin():
-    """R17′/T18: production symbol + non-production file budget (vs merge-base)."""
+    """R17′prod/§SB: EXACT production-symbol + non-production-file budgets."""
     changed = _changed_files()
 
     allowed_nonprod = {
         "CHANGELOG.md",
         "tests/agent/test_codex_singleton_write_through.py",
-        "tests/agent/test_credential_pool_oauth_writethrough.py",
     }
-    nonprod = {f for f in changed if f != "hermes_cli/auth.py" and not f.endswith("auth.py")}
-    assert nonprod <= allowed_nonprod, f"unexpected non-production files: {nonprod - allowed_nonprod}"
-    assert len(nonprod) <= 3, f"non-production budget ≤3, got {len(nonprod)}: {nonprod}"
+    nonprod = {f for f in changed if f != "hermes_cli/auth.py"}
+    assert nonprod == allowed_nonprod, (
+        f"non-production files must EXACTLY equal {sorted(allowed_nonprod)}; got {sorted(nonprod)}"
+    )
 
     diff = _auth_diff_text()
-    funcs = set(re.findall(r"(?m)^\+def\s+([A-Za-z_]\w*)\s*\(", diff))
-    vars_ = set(re.findall(r"(?m)^\+([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
 
-    allowed_funcs = {
-        "_save_codex_tokens",
-        "_refresh_codex_auth_tokens",
+    # §SB amended symbol budget (exact-equality, NOT subset). The diff
+    # INTRODUCES exactly three helpers and four module-data symbols, and REMOVES
+    # nothing. The two host functions (_save_codex_tokens / _refresh_codex_auth_tokens)
+    # are MODIFIED in place: their `def` lines predate this change, so they appear
+    # in neither the added- nor removed-symbol sets and are asserted separately
+    # via the hunk-scope check below.
+    added_funcs = set(re.findall(r"(?m)^\+def\s+([A-Za-z_]\w*)\s*\(", diff))
+    removed_funcs = set(re.findall(r"(?m)^-def\s+([A-Za-z_]\w*)\s*\(", diff))
+    added_data = set(re.findall(r"(?m)^\+([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
+    removed_data = set(re.findall(r"(?m)^-([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
+
+    expected_helpers = {
         "_codex_token_identity",
         "_write_through_codex_to_global_root",
         "_reset_codex_root_rescue_seen",
     }
-    allowed_vars = {
+    expected_data = {
         "_CODEX_OAUTH_ISSUER",
         "_CODEX_ROOT_PERSIST_ATTEMPTS",
         "_CODEX_ROOT_PERSIST_BACKOFF_SECONDS",
         "_codex_root_rescue_seen",
     }
-    assert funcs <= allowed_funcs, f"unexpected added/modified functions: {funcs - allowed_funcs}"
-    assert vars_ <= allowed_vars, f"unexpected added module data: {vars_ - allowed_vars}"
+    assert added_funcs == expected_helpers, (
+        f"introduced-function budget {sorted(expected_helpers)} != {sorted(added_funcs)}"
+    )
+    assert added_data == expected_data, (
+        f"introduced-data budget {sorted(expected_data)} != {sorted(added_data)}"
+    )
+    assert removed_funcs == set(), f"no function may be removed: {removed_funcs}"
+    assert removed_data == set(), f"no module data may be removed: {removed_data}"
+
+    # The two host functions must be the ONLY modified functions. The helper
+    # block lands in the diff hunk header of the following `_sync_codex_pool_entries`
+    # (insertion context, not a symbol this change authored).
+    modified = set(re.findall(r"(?m)^@@.*?\bdef\s+([A-Za-z_]\w*)\s*\(", diff))
+    expected_modified = {"_save_codex_tokens", "_refresh_codex_auth_tokens"}
+    assert expected_modified <= modified, (
+        f"host functions must be modified; hunk scope was {modified}"
+    )
+    assert modified <= ({"_sync_codex_pool_entries"} | expected_modified), (
+        f"unexpected modified-function scope: {modified}"
+    )

--- a/tests/agent/test_codex_singleton_write_through.py
+++ b/tests/agent/test_codex_singleton_write_through.py
@@ -1,0 +1,729 @@
+"""Codex OAuth singleton root write-through + reuse-rescue (spec v11, #87503).
+
+Covers the three production changes in ``hermes_cli/auth.py``:
+
+* C1 — ``_save_codex_tokens`` mirrors a saved chain to the global root.
+* C2 — ``_refresh_codex_auth_tokens`` resolves the caller's token source once
+  and, for a root-resolved reader, persists its rotation directly to root.
+* C3 — a relogin-required refresh attempts a root reuse-rescue (adopting a
+  fresher sibling chain) before falling back to ``~/.codex`` CLI recovery.
+
+Plus D-id (identity gating) and the three-outcome durability contract
+(OUTCOME-SUCCESS silent / CLASS-D warning / CLASS-N critical+retry).
+
+All token endpoints are mocked (autospec-friendly); no interactive OAuth runs.
+The tests drive the real read-modify-write path against on-disk stores under
+``tmp_path``, mirroring ``tests/agent/test_credential_pool_oauth_writethrough.py``.
+"""
+
+import base64
+import json
+import re
+import subprocess
+import threading
+
+import pytest
+
+import hermes_cli.auth as A
+from hermes_cli.auth import (
+    AuthError,
+    _CODEX_ROOT_PERSIST_ATTEMPTS,
+    _CODEX_ROOT_PERSIST_BACKOFF_SECONDS,
+    _codex_root_rescue_seen,
+    _codex_token_identity,
+    _refresh_codex_auth_tokens,
+    _reset_codex_root_rescue_seen,
+    _save_codex_tokens,
+    _write_through_codex_to_global_root,
+)
+
+
+# ── token / store helpers ────────────────────────────────────────────────────
+
+def _b64(obj) -> str:
+    return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+
+def _jwt(sub="acct-1", iss="https://auth.openai.com") -> str:
+    """A valid three-segment base64url JWT with the given ``sub``/``iss``."""
+    header = _b64({"alg": "none", "typ": "JWT"})
+    return ".".join([header, _b64({"sub": sub, "iss": iss}), "sig"])
+
+
+def _write_store(path, store) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _read_store(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _codex_state(tokens, last_refresh="2026-06-01T00:00:00Z", **extra):
+    state = {"tokens": dict(tokens), "last_refresh": last_refresh, "auth_mode": "chatgpt"}
+    state.update(extra)
+    return state
+
+
+@pytest.fixture
+def profile_and_root(tmp_path, monkeypatch):
+    """Wire a profile auth store + a distinct global-root auth store on disk."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return profile_path, root_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_rescue_state(monkeypatch):
+    """Clear the process-lifetime rescue seen-set and global-store memo."""
+    _reset_codex_root_rescue_seen()
+    A._global_auth_store_cache = None
+    yield
+    _reset_codex_root_rescue_seen()
+    A._global_auth_store_cache = None
+
+
+def _mock_refresh(monkeypatch, result=None, exc=None, calls=None):
+    """Replace ``refresh_codex_oauth_pure`` with a scripted stub."""
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if calls is not None:
+            calls.append((access_token, refresh_token))
+        if exc is not None:
+            raise exc
+        return dict(result or {"access_token": "new-at", "refresh_token": "new-rf"})
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    return fake
+
+
+# ── T1 / T2 / T3 / T4 — the R1′/R2′/R3′/switch persistence matrix ───────────
+
+def test_t1_root_resolved_success_writes_root_zero_profile(profile_and_root, monkeypatch):
+    """R1′: a root-resolved reader persists to root and never seeds a profile block."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {
+        "openai-codex": _codex_state({"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}),
+    }})
+    _write_store(profile_path, {"version": 1})  # no openai-codex block
+
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    out = _refresh_codex_auth_tokens(tokens, 20.0)
+
+    assert out["access_token"] == _jwt("acct-1")
+    assert out["refresh_token"] == "new-rf"
+
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"
+    assert root["providers"]["openai-codex"]["auth_mode"] == "chatgpt"
+
+    profile = _read_store(profile_path)
+    assert "openai-codex" not in profile.get("providers", {}), (
+        "a root-resolved reader must NOT seed a shadowing profile block (#74339)"
+    )
+
+
+def test_t2_owned_success_syncs_root_and_preserves_independent(profile_and_root, monkeypatch):
+    """R2′: an owned save updates profile + root; independent account untouched."""
+    profile_path, root_path = profile_and_root
+    root = {
+        "version": 1,
+        "providers": {"openai-codex": _codex_state(
+            {"access_token": _jwt("acct-1"), "refresh_token": "root-old-rf"}
+        )},
+        "credential_pool": {"openai-codex": [
+            {"id": "dev", "source": "device_code", "access_token": _jwt("acct-1"),
+             "refresh_token": "root-old-rf", "label": "singleton"},
+            {"id": "alias", "source": "manual:device_code", "access_token": _jwt("acct-1"),
+             "refresh_token": "root-old-rf", "label": "legacy-alias", "priority": 5},
+            {"id": "indep", "source": "manual:device_code", "access_token": _jwt("acct-9"),
+             "refresh_token": "indep-rf", "label": "independent", "priority": 1},
+        ]},
+    }
+    _write_store(root_path, root)
+    _write_store(profile_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "profile-old-rf"}
+    )}})
+
+    _save_codex_tokens(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresh-rf"},
+        last_refresh="2026-06-12T00:00:00Z",
+        label="My Codex",
+    )
+
+    root_store = _read_store(root_path)
+    rc = root_store["providers"]["openai-codex"]
+    assert rc["tokens"]["refresh_token"] == "fresh-rf"
+    assert rc["auth_mode"] == "chatgpt"
+    assert rc["label"] == "My Codex"
+
+    by_id = {e["id"]: e for e in root_store["credential_pool"]["openai-codex"]}
+    # device_code singleton alias synced
+    assert by_id["dev"]["refresh_token"] == "fresh-rf"
+    # legacy alias (access_token matched previous singleton) synced
+    assert by_id["alias"]["refresh_token"] == "fresh-rf"
+    assert by_id["alias"]["priority"] == 5  # non-token fields untouched
+    # independent account (#39236) byte-identical
+    assert by_id["indep"]["refresh_token"] == "indep-rf"
+    assert by_id["indep"]["access_token"] == _jwt("acct-9")
+
+
+def test_t3_identity_mismatch_untouched_empty_root_populated(profile_and_root, monkeypatch):
+    """R3′: mismatched identity leaves root untouched; empty root is populated."""
+    profile_path, root_path = profile_and_root
+    # (a) mismatched identity — root holds a different account
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-OTHER"), "refresh_token": "other-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "mine-rf"})
+    root_store = _read_store(root_path)
+    assert root_store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "other-rf"
+
+    # (b) empty root — populated with set_active left alone
+    _write_store(root_path, {"version": 1, "active_provider": "anthropic", "providers": {}})
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "mine-rf"})
+    root_store = _read_store(root_path)
+    assert root_store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "mine-rf"
+    assert root_store["active_provider"] == "anthropic"  # set_active untouched
+
+
+@pytest.mark.parametrize("same_sub", [True, False], ids=["same-sub-propagated", "diff-sub-untouched"])
+def test_t4_switch_matrix(profile_and_root, monkeypatch, same_sub):
+    """login-introduced rotation: same-sub propagates, different-sub does not."""
+    profile_path, root_path = profile_and_root
+    root_sub = "acct-root"
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt(root_sub), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+    save_sub = root_sub if same_sub else "acct-else"
+    _save_codex_tokens({"access_token": _jwt(save_sub), "refresh_token": "new-rf"})
+    root_store = _read_store(root_path)
+    got = root_store["providers"]["openai-codex"]["tokens"]["refresh_token"]
+    assert got == ("new-rf" if same_sub else "root-rf")
+
+
+# ── T5 — the fault matrix (SILENT / CLASS-D / CLASS-N) ──────────────────────
+
+def test_t5_c1_root_failure_profile_intact_warning(profile_and_root, monkeypatch):
+    """CLASS-D: a root write-through failure leaves the profile save intact."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    monkeypatch.setattr(A, "_save_auth_store", _failing_save(A._save_auth_store, root_path=root_path))
+
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    profile = _read_store(profile_path)
+    assert profile["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"
+
+
+def _failing_save(original_save, root_path):
+    """Fail ``_save_auth_store`` only when targetting the root path."""
+    def wrapped(store, target_path=None):
+        if target_path is not None and A._same_path(target_path, root_path):
+            raise OSError("root write failure")
+        return original_save(store, target_path=target_path)
+    return wrapped
+
+
+def test_t5_c2_direct_root_failure_returns_tokens_critical(profile_and_root, monkeypatch):
+    """CLASS-N: a root-resolved direct write that always fails still returns tokens."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    monkeypatch.setattr(A, "_save_auth_store", _failing_save(A._save_auth_store, root_path=root_path))
+
+    results = []
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    def fake_write_through(*a, **k):
+        results.append(("attempt", a, k))
+        return False  # always fails
+
+    monkeypatch.setattr(A, "_write_through_codex_to_global_root", fake_write_through)
+
+    tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    out = _refresh_codex_auth_tokens(tokens, 20.0)
+
+    assert out["refresh_token"] == "new-rf"  # tokens still returned
+    assert len(results) == _CODEX_ROOT_PERSIST_ATTEMPTS  # exactly 3 attempts
+
+
+def test_t5_c3_post_persist_failure_returns_tokens_no_autherror(profile_and_root, monkeypatch):
+    """CLASS-N: after a successful rescue POST, persistence failure must not raise."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})  # root-resolved (no own block)
+
+    # First POST (our stale token) relogin-fails; adoption POST succeeds.
+    state = {"n": 0}
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        state["n"] += 1
+        return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    # Persistence always fails → CLASS-N (must still return tokens, not raise).
+    monkeypatch.setattr(A, "_save_auth_store", _failing_save(A._save_auth_store, root_path=root_path))
+    monkeypatch.setattr(A, "_write_through_codex_to_global_root", lambda *a, **k: False)
+
+    tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    out = _refresh_codex_auth_tokens(tokens, 20.0)
+
+    assert out["refresh_token"] == "adopted-rf"
+    assert state["n"] == 1  # one adoption POST ran
+
+
+def test_t5_silent_success_no_warning_no_critical(profile_and_root, monkeypatch, caplog):
+    """OUTCOME-SUCCESS is silent: no warning/critical on a fully durable save."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    with caplog.at_level("WARNING"):
+        _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+
+    assert not any(r.levelno >= 30 for r in caplog.records), caplog.text
+
+
+# ── T6 — classic mode byte-identity ─────────────────────────────────────────
+
+def test_t6_classic_mode_inert(profile_and_root, monkeypatch, tmp_path):
+    """D-classic: with no global root, C1/C2/C3 paths are inert."""
+    profile_path, root_path = profile_and_root
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "_auth_file_path", lambda: root_path)  # single store
+
+    wt_calls = []
+    monkeypatch.setattr(A, "_write_through_codex_to_global_root",
+                        lambda *a, **k: wt_calls.append(("wt", a, k)) or True)
+
+    _write_store(root_path, {"version": 1})
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "r1"})
+
+    assert wt_calls == []  # C1 write-through never fires in classic mode
+
+    out = _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "r1"}, 20.0)
+    assert out["refresh_token"] == "new-rf"
+    assert wt_calls == []  # C2 direct root write also inert (owned path)
+
+    store = _read_store(root_path)
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "new-rf"
+
+
+# ── T7 — rescue-order matrix + repeat/cap ───────────────────────────────────
+
+def _relogin_stub_then_rescue(monkeypatch, rescue_result, calls):
+    """The caller's POST fails relogin; the adoption POST succeeds once."""
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        calls.append(refresh_token)
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        return dict(rescue_result)
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+
+
+def test_t7_eligible_rescue_skips_cli_recovery(profile_and_root, monkeypatch):
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    calls = []
+    _relogin_stub_then_rescue(monkeypatch,
+                              {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}, calls)
+    cli = []
+    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli", lambda *a, **k: cli.append(1) or None)
+
+    out = _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+
+    assert out["refresh_token"] == "adopted-rf"
+    assert cli == []  # CLI recovery unused when rescue eligible
+
+
+def test_t7_ineligible_uses_cli_recovery(profile_and_root, monkeypatch):
+    """When root's refresh token equals ours (nothing fresher), fall to CLI."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}  # same — ineligible
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        raise AuthError("rejected", provider="openai-codex",
+                        code="invalid_grant", relogin_required=True)
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    monkeypatch.setattr(A, "_import_codex_cli_tokens", lambda: {"access_token": "cli-at", "refresh_token": "cli-rf"})
+
+    out = _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+    assert out["refresh_token"] == "cli-rf"
+
+
+def test_t7_classic_direct_cli_recovery(profile_and_root, monkeypatch):
+    profile_path, root_path = profile_and_root
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    _write_store(profile_path, {"version": 1})
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        raise AuthError("rejected", provider="openai-codex",
+                        code="invalid_grant", relogin_required=True)
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    monkeypatch.setattr(A, "_import_codex_cli_tokens", lambda: {"access_token": "cli-at", "refresh_token": "cli-rf"})
+
+    out = _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+    assert out["refresh_token"] == "cli-rf"
+
+
+def test_t7_repeat_tuple_skip_and_ineligible_no_consume(profile_and_root, monkeypatch):
+    """The seen-set caps one adoption per dead tuple per process; reset re-arms."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    posts = []
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        posts.append(refresh_token)
+        return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli", lambda *a, **k: None)
+
+    tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
+    # first: rescue eligible → one adoption POST, returns the adopted chain
+    out = _refresh_codex_auth_tokens(tokens, 20.0)
+    assert out["refresh_token"] == "adopted-rf"
+    assert len(posts) == 1  # one adoption POST
+
+    # second run, same process, same dead tuple → skipped entirely (no POST),
+    # falls through to CLI recovery (empty here) → the original error surfaces
+    with pytest.raises(AuthError):
+        _refresh_codex_auth_tokens(tokens, 20.0)
+    assert len(posts) == 1  # no second adoption POST
+
+    # reset simulates a fresh process → attempts again
+    _reset_codex_root_rescue_seen()
+    out = _refresh_codex_auth_tokens(tokens, 20.0)
+    assert out["refresh_token"] == "adopted-rf"
+    assert len(posts) == 2
+
+
+# ── T7c — double-barrier single-adoption ────────────────────────────────────
+
+def test_t7c_two_threads_single_adoption(profile_and_root, monkeypatch):
+    """Two same-process threads, same dead tuple ⇒ exactly one adoption POST.
+
+    The seen-set is checked-and-marked atomically INSIDE the root flock, so
+    the two contention attempts serialize: the loser observes the winner's mark
+    inside its acquired critical section and falls through to CLI recovery. A
+    defective outside-lock-decides implementation would double-POST here.
+    """
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    posts = []
+    lock = threading.Lock()
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        with lock:
+            posts.append(threading.current_thread().name)
+        return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli",
+                        lambda *a, **k: {"access_token": "cli-at", "refresh_token": "cli-rf"})
+
+    rescued = []
+    recovered = []
+    errors = []
+
+    def worker():
+        try:
+            out = A._refresh_codex_auth_tokens(
+                {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+        except AuthError as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+            return
+        with lock:
+            (rescued if out.get("refresh_token") == "adopted-rf" else recovered).append(
+                threading.current_thread().name)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+
+    assert not errors, errors
+    assert all(not t.is_alive() for t in threads)
+    assert len(posts) == 1, "exactly ONE adoption POST globally"
+    assert len(rescued) == 1, "exactly one thread self-healed via rescue"
+    assert len(recovered) == 1, "the loser fell through to CLI recovery"
+
+
+# ── T8 — pool-sync previous-singleton equivalence ───────────────────────────
+
+def test_t8_pool_sync_previous_singleton_equivalence(profile_and_root, monkeypatch):
+    """R7′: the pre-save singleton capture still drives alias classification."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "profile-rf"}
+    )}})
+
+    captured = []
+    real_sync = A._sync_codex_pool_entries
+    def spy_sync(auth_store, tokens, last_refresh, previous_singleton_tokens=None):
+        captured.append(previous_singleton_tokens)
+        real_sync(auth_store, tokens, last_refresh,
+                  previous_singleton_tokens=previous_singleton_tokens)
+
+    monkeypatch.setattr(A, "_sync_codex_pool_entries", spy_sync)
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "fresh-rf"})
+
+    # The in-profile sync is fed the PRE-save singleton tokens (byte-unchanged
+    # capture); the root write-through feed the ROOT pre-save snapshot.
+    assert any(v and v.get("refresh_token") == "profile-rf" for v in captured), (
+        "in-profile pool sync must receive the pre-save singleton tokens"
+    )
+    assert any(v and v.get("refresh_token") == "root-rf" for v in captured), (
+        "root write-through must classify against the ROOT pre-save snapshot"
+    )
+
+
+# ── T9-v6 — concurrency (honest R16′ invariants) ────────────────────────────
+
+def test_t9_concurrency_honest_invariants(profile_and_root, monkeypatch):
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "fresher-rf"}
+    )}})
+    _write_store(profile_path, {"version": 1})
+
+    posts = []
+    errors = []
+    lock = threading.Lock()
+
+    def fake(access_token, refresh_token, timeout_seconds=20.0, **kw):
+        if refresh_token == "stale-rf":
+            raise AuthError("rejected", provider="openai-codex",
+                            code="invalid_grant", relogin_required=True)
+        with lock:
+            posts.append(refresh_token)
+        return {"access_token": _jwt("acct-1"), "refresh_token": "adopted-rf"}
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake)
+    monkeypatch.setattr(A, "_recover_codex_tokens_from_cli", lambda *a, **k: None)
+
+    n = 3
+    held = []
+    errors = []
+    lock = threading.Lock()
+
+    def worker():
+        try:
+            out = A._refresh_codex_auth_tokens(
+                {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+        except AuthError as exc:
+            with lock:
+                errors.append(exc)
+            return
+        with lock:
+            held.append(out)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+
+    # (a) at least one participant holds a valid rotated chain (the winner)
+    assert held, "at least one thread must self-heal and hold the rotated chain"
+    assert all(h.get("refresh_token") == "adopted-rf" for h in held)
+    # every surfaced failure is an AuthError (the losers fall through to CLI
+    # recovery and re-raise only because that path is empty here)
+    assert len(errors) + len(held) == n
+    # (c) per-chain adoption POST bound ≤ racing processes (seen-set ⇒ exactly 1)
+    assert 1 <= len(posts) <= n
+    # final root holds a valid rotated chain
+    root_store = _read_store(root_path)
+    rt = root_store["providers"]["openai-codex"]["tokens"]["refresh_token"]
+    assert rt in ("fresher-rf", "adopted-rf")
+
+
+# ── A2 premises / T10 / T13 — identity + structure ──────────────────────────
+
+def test_t13_identity_corner_matrix():
+    """D-id corner cases: valid, 2-segment, non-JSON, foreign-iss, empty-sub, opaque."""
+    assert _codex_token_identity(_jwt("acct-1")) == "acct-1"  # positive control
+    assert _codex_token_identity("a.b") is None  # 2 segments
+    assert _codex_token_identity("a.b.c") is None  # non-JSON payload
+    assert _codex_token_identity(_jwt("acct-1", iss="https://evil.example")) is None  # foreign iss
+    assert _codex_token_identity(_jwt("")) is None  # empty sub
+    assert _codex_token_identity("opaque-token") is None  # not a JWT
+    assert _codex_token_identity(None) is None  # not a str
+
+
+def test_t10_structure_preservation(profile_and_root, monkeypatch):
+    """Alias labels/ids/priority/suppressed_sources untouched; token fields in place."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}
+    )}, "credential_pool": {"openai-codex": [
+        {"id": "alias", "source": "manual:device_code", "access_token": _jwt("acct-1"),
+         "refresh_token": "root-rf", "label": "lbl", "priority": 7, "suppressed_sources": ["x"]},
+    ]}})
+    _write_store(profile_path, {"version": 1})
+
+    _save_codex_tokens({"access_token": _jwt("acct-1"), "refresh_token": "fresh-rf"})
+
+    entry = _read_store(root_path)["credential_pool"]["openai-codex"][0]
+    assert entry["refresh_token"] == "fresh-rf"  # mutated in place
+    assert entry["id"] == "alias"
+    assert entry["label"] == "lbl"
+    assert entry["priority"] == 7
+    assert entry["suppressed_sources"] == ["x"]
+
+
+def test_t17_field_set_pin(profile_and_root, monkeypatch):
+    """C2 field set: root carries tokens + last_refresh + auth_mode + label."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"openai-codex": _codex_state(
+        {"access_token": _jwt("acct-1"), "refresh_token": "root-rf"}, custom_field="keep"
+    )}})
+    _write_store(profile_path, {"version": 1})
+    _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
+
+    _refresh_codex_auth_tokens({"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}, 20.0)
+
+    rc = _read_store(root_path)["providers"]["openai-codex"]
+    assert rc["tokens"]["refresh_token"] == "new-rf"
+    assert rc["tokens"]["access_token"] == _jwt("acct-1")
+    assert rc["auth_mode"] == "chatgpt"
+    assert rc["last_refresh"]  # present
+    assert rc["custom_field"] == "keep"  # root-only field preserved
+
+
+# ── T15 / T18 — negative greps + dual-enumeration budget pin ────────────────
+
+def _git(*args):
+    root = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True).stdout.strip()
+    return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+
+
+def _diff_base():
+    # The branch descends from upstream commit 77001a6be; upstream/main has
+    # since advanced, so resolve the true fork point via merge-base rather than
+    # diffing against the (moved) tip.
+    for ref in ("upstream/main", "origin/main"):
+        r = _git("rev-parse", "--verify", ref)
+        if r.returncode == 0 and r.stdout.strip():
+            m = _git("merge-base", "HEAD", r.stdout.strip())
+            if m.returncode == 0 and m.stdout.strip():
+                return m.stdout.strip()
+            return r.stdout.strip()
+    return "77001a6be"
+
+
+def _diff_text():
+    base = _diff_base()
+    committed = _git("diff", base, "HEAD").stdout or ""
+    worktree = _git("diff", base).stdout or ""
+    return committed + "\n" + worktree
+
+
+def _auth_diff_text():
+    """Diff of the single production file under budget (auth.py) only."""
+    base = _diff_base()
+    committed = _git("diff", base, "HEAD", "--", "hermes_cli/auth.py").stdout or ""
+    worktree = _git("diff", base, "--", "hermes_cli/auth.py").stdout or ""
+    return committed + "\n" + worktree
+
+
+def _changed_files():
+    base = _diff_base()
+    changed = _git("diff", "--name-only", base).stdout.split()
+    changed += _git("diff", "--name-only", base, "HEAD").stdout.split()
+    changed += _git("ls-files", "--others", "--exclude-standard").stdout.split()
+    return {f for f in changed if f}
+
+
+def test_t15_negative_greps():
+    """No provenance parameter and no id_token usage in the codex paths."""
+    diff = _auth_diff_text()
+    assert "provenance" not in diff
+    assert "id_token" not in diff
+
+
+def test_t18_dual_enumeration_budget_pin():
+    """R17′/T18: production symbol + non-production file budget (vs merge-base)."""
+    changed = _changed_files()
+
+    allowed_nonprod = {
+        "CHANGELOG.md",
+        "tests/agent/test_codex_singleton_write_through.py",
+        "tests/agent/test_credential_pool_oauth_writethrough.py",
+    }
+    nonprod = {f for f in changed if f != "hermes_cli/auth.py" and not f.endswith("auth.py")}
+    assert nonprod <= allowed_nonprod, f"unexpected non-production files: {nonprod - allowed_nonprod}"
+    assert len(nonprod) <= 3, f"non-production budget ≤3, got {len(nonprod)}: {nonprod}"
+
+    diff = _auth_diff_text()
+    funcs = set(re.findall(r"(?m)^\+def\s+([A-Za-z_]\w*)\s*\(", diff))
+    vars_ = set(re.findall(r"(?m)^\+([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
+
+    allowed_funcs = {
+        "_save_codex_tokens",
+        "_refresh_codex_auth_tokens",
+        "_codex_token_identity",
+        "_write_through_codex_to_global_root",
+        "_reset_codex_root_rescue_seen",
+    }
+    allowed_vars = {
+        "_CODEX_OAUTH_ISSUER",
+        "_CODEX_ROOT_PERSIST_ATTEMPTS",
+        "_CODEX_ROOT_PERSIST_BACKOFF_SECONDS",
+        "_codex_root_rescue_seen",
+    }
+    assert funcs <= allowed_funcs, f"unexpected added/modified functions: {funcs - allowed_funcs}"
+    assert vars_ <= allowed_vars, f"unexpected added module data: {vars_ - allowed_vars}"

--- a/tests/agent/test_codex_singleton_write_through.py
+++ b/tests/agent/test_codex_singleton_write_through.py
@@ -19,6 +19,7 @@ The tests drive the real read-modify-write path against on-disk stores under
 import base64
 import json
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -349,12 +350,31 @@ def test_t5_c3_post_persist_failure_returns_tokens_no_autherror(profile_and_root
     monkeypatch.setattr(A, "_write_through_codex_to_global_root", lambda *a, **k: False)
     sleeps = _fake_timer(monkeypatch)
 
+    # COUNT persistence attempts: every CLASS-N row must run the full
+    # 3-attempt ladder against the failing root persist, with the two
+    # intervening backoffs in contract order.
+    wt_calls = []
+    real_wt = A._write_through_codex_to_global_root
+
+    def counting_wt(*a, **k):
+        wt_calls.append(1)
+        return False
+
+    monkeypatch.setattr(A, "_write_through_codex_to_global_root", counting_wt)
+
     tokens = {"access_token": _jwt("acct-1"), "refresh_token": "stale-rf"}
     with caplog.at_level("DEBUG"):
         out = _refresh_codex_auth_tokens(tokens, 20.0)
 
     assert out["refresh_token"] == "adopted-rf"
     assert state["n"] == 1  # one adoption POST ran
+    # R16'/A1v10 contract: the persistence ladder runs the FULL attempt count
+    # (== _CODEX_ROOT_PERSIST_ATTEMPTS) against the failing root persist —
+    # asserting sleeps alone would allow a single-attempt implementation.
+    assert len(wt_calls) == A._CODEX_ROOT_PERSIST_ATTEMPTS, (
+        f"expected {A._CODEX_ROOT_PERSIST_ATTEMPTS} root-RMW attempts, saw {len(wt_calls)}"
+    )
+    assert len(sleeps) == A._CODEX_ROOT_PERSIST_ATTEMPTS - 1, sleeps
     assert sleeps == list(_CODEX_ROOT_PERSIST_BACKOFF_SECONDS), sleeps
 
     crits = [r for r in caplog.records if r.levelno >= logging.CRITICAL]
@@ -468,6 +488,7 @@ def test_t6_classic_mode_byte_identity(profile_and_root, monkeypatch):
         "nested": {"key": "value", "list": [1, 2, 3]},
     }
     _write_store(root_path, baseline)
+    _t6_pre = _read_store(root_path)
     _mock_refresh(monkeypatch, result={"access_token": _jwt("acct-1"), "refresh_token": "new-rf"})
 
     # function outcome: classic-mode refresh returns the rotated chain
@@ -477,12 +498,29 @@ def test_t6_classic_mode_byte_identity(profile_and_root, monkeypatch):
 
     store = _read_store(root_path)
 
-    # every non-codex byte is identical to the baseline snapshot — the
-    # write-through feature added nothing in classic (no-global-root) mode.
-    assert store["version"] == baseline["version"]
-    assert store["nested"] == baseline["nested"]
-    assert store["providers"]["anthropic"] == baseline["providers"]["anthropic"]
-    assert store["credential_pool"]["anthropic"] == baseline["credential_pool"]["anthropic"]
+    # byte-identity vs the PRE-FUNCTION on-disk snapshot: the classic-mode
+    # (no-global-root) save must produce exactly the merge-base bytes — i.e.
+    # compare against what an UNCHANGED baseline module would have written,
+    # not merely selected fields. Non-codex subtrees must be untouched AND
+    # structural formatting/order preserved, so we diff raw objects.
+    pre = _t6_pre
+    # `updated_at` is stamped by _save_auth_store at EVERY save (merge-base
+    # L1431 behavior, unchanged) — it is the one legitimate post-save addition.
+    assert set(store.keys()) - set(pre.keys()) == {"updated_at"}, "top-level key drift in classic mode"
+    assert store["version"] == pre["version"]
+    assert store["nested"] == pre["nested"]
+    assert store["active_provider"] == "openai-codex"  # expected codex-adjacent mutation
+    assert store["providers"]["anthropic"] == pre["providers"]["anthropic"]
+    assert store["credential_pool"]["anthropic"] == pre["credential_pool"]["anthropic"]
+    # providers/credential_pool gained ONLY the openai-codex key, nothing else:
+    assert set(store["providers"].keys()) - set(pre["providers"].keys()) == {"openai-codex"}
+    assert set(pre["providers"].keys()) - set(store["providers"].keys()) == set()
+    assert set(store["credential_pool"].keys()) == set(pre["credential_pool"].keys())
+    # the codex block itself must equal exactly what merge-base logic writes:
+    # tokens + auth_mode="chatgpt" (+ label rule), no write-through extras.
+    codex_block = store["providers"]["openai-codex"]
+    assert set(codex_block.keys()) <= {"tokens", "last_refresh", "auth_mode", "label"}
+    assert "write_through" not in json.dumps(store)
 
     # the only codex-adjacent mutations are the expected merge-base ones:
     # active_provider flips to openai-codex and the codex block holds the chain.
@@ -917,6 +955,11 @@ def _git(*args):
     return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
 
 
+def _git_repo_root() -> str:
+    return subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True).stdout.strip()
+
+
 def _diff_base():
     # The branch descends from upstream commit 77001a6be; upstream/main has
     # since advanced, so resolve the true fork point via merge-base rather than
@@ -961,8 +1004,46 @@ def test_t15_negative_greps():
     assert "id_token" not in diff
 
 
+def _ast_top_level_symbols(source_text: str) -> dict:
+    """Map every top-level symbol name -> stable AST dump of its definition."""
+    import ast as _ast
+    tree = _ast.parse(source_text)
+    out = {}
+    for node in tree.body:
+        if isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef, _ast.ClassDef)):
+            out[node.name] = _ast.dump(node)
+        elif isinstance(node, _ast.Assign):
+            for t in node.targets:
+                if isinstance(t, _ast.Name):
+                    out[t.id] = _ast.dump(node)
+        elif isinstance(node, _ast.AnnAssign) and isinstance(node.target, _ast.Name):
+            out[node.target.id] = _ast.dump(node)
+    return out
+
+
+def _auth_symbol_maps():
+    """{merge_base: symbols, worktree_HEAD: symbols} for hermes_cli/auth.py."""
+    import ast as _ast
+    base_sha = _diff_base()
+    base_text = _git("show", f"{base_sha}:hermes_cli/auth.py").stdout
+    head_path = os.path.join(_git_repo_root(), "hermes_cli", "auth.py")
+    with open(head_path) as fh:
+        head_text = fh.read()
+    return (
+        _ast_top_level_symbols(base_text),
+        _ast_top_level_symbols(head_text),
+    )
+
+
 def test_t18_dual_enumeration_budget_pin():
-    """R17′prod/§SB: EXACT production-symbol + non-production-file budgets."""
+    """R17'prod/§SB: EXACT production-symbol + non-production-file budgets.
+
+    Structural, not heuristic: parse BOTH versions of hermes_cli/auth.py with
+    ``ast`` and compare their top-level symbol trees exactly. Any added,
+    removed, or modified production symbol outside the §SB enumeration fails —
+    including symbol kinds regex-on-diff hunks would miss (classes, imports,
+    ann-assigns, mid-file inserts).
+    """
     changed = _changed_files()
 
     allowed_nonprod = {
@@ -974,47 +1055,34 @@ def test_t18_dual_enumeration_budget_pin():
         f"non-production files must EXACTLY equal {sorted(allowed_nonprod)}; got {sorted(nonprod)}"
     )
 
-    diff = _auth_diff_text()
+    base_syms, head_syms = _auth_symbol_maps()
+    added = set(head_syms) - set(base_syms)
+    removed = set(base_syms) - set(head_syms)
 
-    # §SB amended symbol budget (exact-equality, NOT subset). The diff
-    # INTRODUCES exactly three helpers and four module-data symbols, and REMOVES
-    # nothing. The two host functions (_save_codex_tokens / _refresh_codex_auth_tokens)
-    # are MODIFIED in place: their `def` lines predate this change, so they appear
-    # in neither the added- nor removed-symbol sets and are asserted separately
-    # via the hunk-scope check below.
-    added_funcs = set(re.findall(r"(?m)^\+def\s+([A-Za-z_]\w*)\s*\(", diff))
-    removed_funcs = set(re.findall(r"(?m)^-def\s+([A-Za-z_]\w*)\s*\(", diff))
-    added_data = set(re.findall(r"(?m)^\+([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
-    removed_data = set(re.findall(r"(?m)^-([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", diff))
-
-    expected_helpers = {
-        "_codex_token_identity",
-        "_write_through_codex_to_global_root",
-        "_reset_codex_root_rescue_seen",
+    # §SB amended budget: exactly these NEW top-level symbols.
+    expected_added = {
+        "_codex_token_identity",                    # helper (D-id identity computation)
+        "_write_through_codex_to_global_root",      # helper (C1/C2/C3 root RMW)
+        "_reset_codex_root_rescue_seen",            # hook (rescue cap reset)
+        "_CODEX_OAUTH_ISSUER",                      # constant (D-id issuer pin)
+        "_CODEX_ROOT_PERSIST_ATTEMPTS",             # constant (A1v10 retry count)
+        "_CODEX_ROOT_PERSIST_BACKOFF_SECONDS",      # constant (A1v10 backoff ladder)
+        "_codex_root_rescue_seen",                  # seen-set store
     }
-    expected_data = {
-        "_CODEX_OAUTH_ISSUER",
-        "_CODEX_ROOT_PERSIST_ATTEMPTS",
-        "_CODEX_ROOT_PERSIST_BACKOFF_SECONDS",
-        "_codex_root_rescue_seen",
-    }
-    assert added_funcs == expected_helpers, (
-        f"introduced-function budget {sorted(expected_helpers)} != {sorted(added_funcs)}"
+    assert added == expected_added, (
+        f"production-symbol additions EXACTLY {sorted(expected_added)} required; "
+        f"got added={sorted(added)}"
     )
-    assert added_data == expected_data, (
-        f"introduced-data budget {sorted(expected_data)} != {sorted(added_data)}"
-    )
-    assert removed_funcs == set(), f"no function may be removed: {removed_funcs}"
-    assert removed_data == set(), f"no module data may be removed: {removed_data}"
+    assert removed == set(), f"no production symbol may be removed: {sorted(removed)}"
 
-    # The two host functions must be the ONLY modified functions. The helper
-    # block lands in the diff hunk header of the following `_sync_codex_pool_entries`
-    # (insertion context, not a symbol this change authored).
-    modified = set(re.findall(r"(?m)^@@.*?\bdef\s+([A-Za-z_]\w*)\s*\(", diff))
+    # Of pre-existing symbols, ONLY the two host functions may have CHANGED
+    # bodies/defaults. Everything else must be AST-identical to merge-base.
     expected_modified = {"_save_codex_tokens", "_refresh_codex_auth_tokens"}
-    assert expected_modified <= modified, (
-        f"host functions must be modified; hunk scope was {modified}"
-    )
-    assert modified <= ({"_sync_codex_pool_entries"} | expected_modified), (
-        f"unexpected modified-function scope: {modified}"
+    changed_bodies = {
+        name for name in (set(base_syms) & set(head_syms))
+        if base_syms[name] != head_syms[name]
+    }
+    assert changed_bodies == expected_modified, (
+        f"only {sorted(expected_modified)} may be modified in place; "
+        f"found {sorted(changed_bodies)}"
     )


### PR DESCRIPTION
Implements spec v11 (root write-through + root-resolved direct-write + reuse-rescue) for the OpenAI Codex OAuth singleton. Closes #87503.

## What changed (production `hermes_cli/auth.py` only)

- **C1** — `_save_codex_tokens` mirrors a saved chain to the global root after the existing active-store save + pool sync (identity-gated, full field set incl. `auth_mode="chatgpt"`/`label`, alias/independent classification against the root pre-save snapshot, `set_active` untouched, best-effort warning-on-failure).
- **C2** — `_refresh_codex_auth_tokens` resolves the caller's token source ONCE at entry; a root-resolved reader persists its rotation directly to root (never seeding a shadowing profile block); owned-block callers are unchanged.
- **C3** — a relogin-required refresh attempts a root reuse-rescue (adopt a fresher sibling chain) BEFORE `~/.codex` CLI recovery, under one continuous root lock, with a process-lifetime seen-set checked-and-marked atomically inside the lock.
- **D-id** — account identity gate from the live access-token `sub` claim (`iss==https://auth.openai.com`, non-empty `sub`).
- **Three-outcome durability contract** (A1v10): OUTCOME-SUCCESS (silent) / CLASS-D (WARNING, self-healing) / CLASS-N (3 attempts, 2 fixed backoffs 0.5s/1.0s, CRITICAL naming `hermes model`, tokens still returned).

New production symbols: `_codex_token_identity`, `_write_through_codex_to_global_root`, `_codex_root_rescue_seen`, `_reset_codex_root_rescue_seen()`, and constants `_CODEX_OAUTH_ISSUER` / `_CODEX_ROOT_PERSIST_ATTEMPTS` / `_CODEX_ROOT_PERSIST_BACKOFF_SECONDS`.

## Scenario matrix (§6)

| Path | Trigger | Outcome |
|---|---|---|
| C1 owned save + root write-through OK | `_save_codex_tokens` with distinct root | OUTCOME-SUCCESS — silent |
| C1 owned save OK + root write-through fails | root `_save_auth_store` raises | CLASS-D — WARNING, self-heal next save |
| C1 root skip (classic/seat-belt/identity-mismatch) | no root, or foreign account | no-op — conservative silent skip |
| C2 root-resolved success | reader resolved from root | OUTCOME-SUCCESS — root-only, zero profile writes |
| C2 root-resolved persist fails (×3) | root write always fails | CLASS-N — CRITICAL, tokens still returned |
| C3 eligible rescue + POST + persist OK | sibling chain fresher, same identity | OUTCOME-SUCCESS — silent |
| C3 rescue POST OK + persist fails | persist raises after POST | CLASS-N — CRITICAL, tokens returned, no AuthError |
| C3 ineligible / POST fails / already-seen | chain not fresher / mark present | fall-through to CLI recovery (unchanged) |

## Durable-stage audit table (R19)

| C-path outcome | Durable copy? | Class | Log | Retry |
|---|---|---|---|---|
| C1 root write-through success | root + profile | SUCCESS | debug | — |
| C1 root write-through failure | profile | CLASS-D | WARNING | next-trigger resync |
| C2 root-resolved success | root | SUCCESS | debug | — |
| C2/C3-root-resolved persist failure | none | CLASS-N | CRITICAL | 3 attempts, 0.5s/1.0s backoffs |
| C3 owned local-save failure after POST | none | CLASS-N | CRITICAL | loud-and-continue |

## Autospec boundary statement

Every HTTP/token boundary is mocked; no interactive OAuth and no `~/.codex` write ever runs:
- `refresh_codex_oauth_pure` — scripted to return rotated tokens or raise `AuthError` (the only token-endpoint boundary; all rescue/adoption POSTs are stubs).
- `_recover_codex_tokens_from_cli` / `_import_codex_cli_tokens` — spied/stubbed so CLI-recovery ordering is asserted without touching `~/.codex`.
- `_save_auth_store` — selectively failed (root target only) to exercise CLASS-D/CLASS-N.
- `_write_through_codex_to_global_root` — monkeypatched in fault-matrix rows only; success rows drive the real read-modify-write path against `tmp_path` stores.
- The store read/write path itself (`_load_auth_store`, `_save_auth_store`, `_sync_codex_pool_entries`, `_auth_store_lock`) runs for real on on-disk JSON under `tmp_path`.

## T18 dual grep

```
$ BASE=$(git merge-base HEAD upstream/main)   # 77001a6be…
$ git diff --name-only "$BASE" HEAD
CHANGELOG.md
hermes_cli/auth.py
tests/agent/test_codex_singleton_write_through.py
$ git diff "$BASE" HEAD -- hermes_cli/auth.py | grep -E '^\+def |^\+_[A-Za-z]' | grep -vE '^\+ *#'
+_CODEX_OAUTH_ISSUER = "https://auth.openai.com"
+_CODEX_ROOT_PERSIST_ATTEMPTS = 3
+_CODEX_ROOT_PERSIST_BACKOFF_SECONDS = (0.5, 1.0)
+_codex_root_rescue_seen: set = set()
+def _reset_codex_root_rescue_seen() -> None:
+def _codex_token_identity(access_token: Any) -> Optional[str]:
+def _write_through_codex_to_global_root(
$ git diff "$BASE" HEAD -- hermes_cli/auth.py | grep -nE 'provenance|id_token'   # → (no matches)
```

Non-production diff = 2 files (≤3): `CHANGELOG.md`, `tests/agent/test_codex_singleton_write_through.py`. The two modified named functions (`_save_codex_tokens`, `_refresh_codex_auth_tokens`) have unchanged signatures, so they don't appear as `+def` lines.

## Tests

New module `tests/agent/test_codex_singleton_write_through.py` — 22 tests covering T1–T18 (T1 root-resolved zero-profile; T2 owned+alias; T3 identity/empty-root; T4 switch matrix; T5 fault matrix SILENT/CLASS-D/CLASS-N; T6 classic inert; T7 rescue-order + repeat/cap; T7c two-thread single-adoption; T8 pool-sync previous-singleton; T9-v6 concurrency; T10 structure preservation; T13 identity corners; T15 negative greps; T17 field-set pin; T18 dual-enumeration budget).

Full run: `scripts/run_tests.sh tests/agent tests/hermes_cli -k "codex or auth"` → **1278 passed, 2 failed, 4 skipped** in 56.0s.

The two failures are pre-existing and unrelated to this change (the shared release venv used for testing lacks the `anthropic` dev dependency, so two anthropic-wire tests raise `ImportError: The 'anthropic' package is required …` before reaching any codex code): `test_command_token_source.py::TestCallableKeyGetsBearerAuth::test_callable_takes_the_bearer_hook_path` and `test_nous_portal_anthropic_wire.py::TestClientShape::test_portal_jwt_authenticates_with_bearer_not_x_api_key`.

## git status

```
## codex-oauth-singleton-writethrough...origin/main [ahead 9543]
```
Clean tree; branch pushed to `origin` (fork `eulahwu917/hermes-agent`).
