### PR TITLE
Detect fabricated tool-use claims in completed turns with no real tool call

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5416,6 +5416,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _CODEX_INCOMPLETE_NUDGE,
             _DROPPED_TOOLCALL_NUDGE_CONTENT,
             _EMPTY_TOOL_RESPONSE_NUDGE,
+            _FABRICATED_TOOL_USE_NUDGE_CONTENT,
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX,
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
@@ -5429,6 +5430,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _CODEX_ACK_CONTINUATION_NUDGE,
             _DROPPED_TOOLCALL_NUDGE_CONTENT,
             _EMPTY_TOOL_RESPONSE_NUDGE,
+            _FABRICATED_TOOL_USE_NUDGE_CONTENT,
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7423,6 +7423,11 @@ def run_conversation(
                 # was recovered — refresh that budget too so it guards each
                 # stall independently rather than capping the whole run.
                 agent._dropped_toolcall_retries = 0
+                # A real tool call this turn means any later completed-turn
+                # text in the SAME turn (e.g. a summary of this result) must
+                # never be mistaken for a fabricated-tool-use claim — see
+                # the fabricated-tool-use check below.
+                agent._landed_real_tool_call_this_turn = True
 
                 previous_msg = messages[-1] if messages else None
                 current_interim_visible = agent._interim_assistant_visible_text(assistant_msg)
@@ -8264,10 +8269,56 @@ def run_conversation(
                     final_response = None
                     continue
 
-                # Reached finalization without the dropped-tool-call mismatch —
-                # a genuine turn end. Clear the consecutive-stall budget so the
-                # next turn starts fresh.
+                # ── Fabricated tool-use recovery (any provider, any tool) ──
+                # A completed turn (any finish_reason, including "stop") whose
+                # text either leaks a raw tool-call JSON fragment or
+                # affirmatively claims a completed tool action with a result,
+                # while tool_calls came back empty. Unlike the dropped-toolcall
+                # guard above, this does NOT gate on finish_reason=="tool_calls"
+                # — that guard's own comment notes "finish_reason='stop' text
+                # finishes never enter this guard," which is exactly the gap
+                # this closes. Guarded by _landed_real_tool_call_this_turn so a
+                # genuine post-tool-call summary (whose text may legitimately
+                # say things like "the search returned...") is never mistaken
+                # for a fabrication. See
+                # docs/rfcs/2026-08-fabricated-tool-use-detection.md.
+                elif (
+                    not assistant_message.tool_calls
+                    and not getattr(agent, "_landed_real_tool_call_this_turn", False)
+                    and _looks_like_fabricated_tool_use(final_response)
+                    and getattr(agent, "_fabricated_tool_use_retries", 0) < 3
+                ):
+                    agent._fabricated_tool_use_retries = getattr(agent, "_fabricated_tool_use_retries", 0) + 1
+                    logger.warning(
+                        "completed turn's text claims tool use with no real "
+                        "tool_calls (fabricated-tool-use pattern) — "
+                        "re-prompting (retry %d/3, model=%s provider=%s)",
+                        agent._fabricated_tool_use_retries, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "↻ Reply looked like a fabricated tool result with no "
+                        f"real tool call — re-prompting ({agent._fabricated_tool_use_retries}/3)"
+                    )
+                    final_msg["_fabricated_tool_use_nudge"] = True
+                    append_message(messages, final_msg)
+                    append_message(messages, {
+                        "role": "user",
+                        "content": _FABRICATED_TOOL_USE_NUDGE_CONTENT,
+                        "_fabricated_tool_use_nudge": True,
+                    })
+                    agent._session_messages = messages
+                    final_response = None
+                    continue
+
+                # Reached finalization without either mismatch — a genuine
+                # turn end. Clear both consecutive-stall budgets, and the
+                # landed-real-tool-call flag, so the NEXT turn starts fresh.
+                # Without resetting the flag here, a single real tool call
+                # anywhere in the session would permanently disable the
+                # fabricated-tool-use check for every later turn.
                 agent._dropped_toolcall_retries = 0
+                agent._fabricated_tool_use_retries = 0
+                agent._landed_real_tool_call_this_turn = False
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending either a final response or a
@@ -8282,6 +8333,7 @@ def run_conversation(
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
                         or messages[-1].get("_dropped_toolcall_nudge")
+                        or messages[-1].get("_fabricated_tool_use_nudge")
                     )
                 ):
                     messages.pop()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1241,6 +1241,60 @@ _DROPPED_TOOLCALL_NUDGE_CONTENT = (
     "the actual tool call now to continue the task."
 )
 
+# Re-prompt sent when a completed turn's text either leaks a raw tool-call
+# JSON fragment or affirmatively claims a completed tool action with a
+# result, while the turn's real tool_calls came back empty -- the
+# fabricated-tool-use recovery below. Named for the same reason as the
+# nudges above.
+_FABRICATED_TOOL_USE_NUDGE_CONTENT = (
+    "Your previous reply described or implied a tool result, but no tool "
+    "was actually called this turn. Do not describe a result you did not "
+    "get — issue the actual tool call now, or answer without claiming to "
+    "have used a tool."
+)
+
+# Structural signal: a `"name": "..."` key and an `"arguments":` key both
+# appearing in the text, in either order — the literal shape of a
+# tool-call payload (OpenAI/Responses-API function-call JSON), independent
+# of whatever prose wording surrounds it. Two separate regexes (not one
+# spanning both) so neither key's position relative to the other, nor how
+# much text sits between them, matters.
+_FABRICATED_TOOL_USE_HAS_NAME_KEY = re.compile(r'"name"\s*:\s*"[^"]*"')
+_FABRICATED_TOOL_USE_HAS_ARGUMENTS_KEY = re.compile(r'"arguments"\s*:')
+
+# Self-claim signal: text affirmatively claiming a COMPLETED tool action
+# with a result ("here's the result from my search", "the search
+# returned..."), as opposed to a proposal ("let me check") or an honest
+# disclaimer ("I can't look that up right now") — the latter two are not
+# this bug and must never match. Seeded from one real captured incident;
+# unlike the JSON check above, this is a wording-based list and will need
+# new entries from future real incidents, same as its prior-art equivalent
+# has already needed twice (see the RFC for the history).
+_FABRICATED_TOOL_USE_PATTERNS = (
+    re.compile(r"here('s| is) the result[s]? (from|of) (my|the) search", re.IGNORECASE),
+    re.compile(r"\bthe search returned\b", re.IGNORECASE),
+    re.compile(r"\bmy search (returned|found|showed)\b", re.IGNORECASE),
+)
+
+
+def _looks_like_fabricated_tool_use(text: str) -> bool:
+    """True when ``text`` either leaks a tool-call-shaped JSON fragment or
+    affirmatively claims a completed tool action with a result.
+
+    Caller must separately confirm no real tool_calls exist for this turn —
+    this function only inspects text, matching the same division of
+    responsibility as the dropped-tool-call check below.
+    """
+    if not text:
+        return False
+    if (
+        _FABRICATED_TOOL_USE_HAS_NAME_KEY.search(text)
+        and _FABRICATED_TOOL_USE_HAS_ARGUMENTS_KEY.search(text)
+    ):
+        return True
+    return any(pattern.search(text) for pattern in _FABRICATED_TOOL_USE_PATTERNS)
+
+
 # Re-prompt sent when the model returns an empty response after executing tool
 # calls (#9400). Named for the same reason as the nudges above — its
 # _empty_recovery_synthetic metadata flag doesn't survive SessionDB projection.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1258,7 +1258,11 @@ _FABRICATED_TOOL_USE_NUDGE_CONTENT = (
 # tool-call payload (OpenAI/Responses-API function-call JSON), independent
 # of whatever prose wording surrounds it. Two separate regexes (not one
 # spanning both) so neither key's position relative to the other, nor how
-# much text sits between them, matters.
+# much text sits between them, matters. Accepted false-positive class:
+# legitimate prose that quotes a tool-call-shaped JSON example (e.g.
+# explaining an API schema) will also match — the retry cost of a
+# wrong-but-bounded re-prompt is judged cheaper than the complexity of
+# disambiguating intent here.
 _FABRICATED_TOOL_USE_HAS_NAME_KEY = re.compile(r'"name"\s*:\s*"[^"]*"')
 _FABRICATED_TOOL_USE_HAS_ARGUMENTS_KEY = re.compile(r'"arguments"\s*:')
 
@@ -1277,7 +1281,7 @@ _FABRICATED_TOOL_USE_PATTERNS = (
 )
 
 
-def _looks_like_fabricated_tool_use(text: str) -> bool:
+def _looks_like_fabricated_tool_use(text: Optional[str]) -> bool:
     """True when ``text`` either leaks a tool-call-shaped JSON fragment or
     affirmatively claims a completed tool action with a result.
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8270,20 +8270,26 @@ def run_conversation(
                     continue
 
                 # ── Fabricated tool-use recovery (any provider, any tool) ──
-                # A completed turn (any finish_reason, including "stop") whose
-                # text either leaks a raw tool-call JSON fragment or
-                # affirmatively claims a completed tool action with a result,
-                # while tool_calls came back empty. Unlike the dropped-toolcall
-                # guard above, this does NOT gate on finish_reason=="tool_calls"
-                # — that guard's own comment notes "finish_reason='stop' text
-                # finishes never enter this guard," which is exactly the gap
-                # this closes. Guarded by _landed_real_tool_call_this_turn so a
-                # genuine post-tool-call summary (whose text may legitimately
+                # A completed turn (any finish_reason other than "tool_calls",
+                # including "stop") whose text either leaks a raw tool-call
+                # JSON fragment or affirmatively claims a completed tool
+                # action with a result, while tool_calls came back empty.
+                # Unlike the dropped-toolcall guard above, this does NOT gate
+                # on finish_reason=="tool_calls" being PRESENT — that guard's
+                # own comment notes "finish_reason='stop' text finishes never
+                # enter this guard," which is exactly the gap this closes.
+                # Excludes finish_reason=="tool_calls" deliberately: that's
+                # the dropped-toolcall check's own territory above, and
+                # letting both checks apply to the same overlap case would
+                # silently double the effective retry budget to 6 instead of
+                # the stated 3. Guarded by _landed_real_tool_call_this_turn so
+                # a genuine post-tool-call summary (whose text may legitimately
                 # say things like "the search returned...") is never mistaken
                 # for a fabrication. See
                 # docs/rfcs/2026-08-fabricated-tool-use-detection.md.
                 elif (
-                    not assistant_message.tool_calls
+                    finish_reason != "tool_calls"
+                    and not assistant_message.tool_calls
                     and not getattr(agent, "_landed_real_tool_call_this_turn", False)
                     and _looks_like_fabricated_tool_use(final_response)
                     and getattr(agent, "_fabricated_tool_use_retries", 0) < 3

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -600,6 +600,16 @@ def build_turn_context(
     agent._incomplete_scratchpad_retries = 0
     agent._codex_incomplete_retries = 0
     agent._thinking_prefill_retries = 0
+    # These three are also reset at run_conversation()'s own "genuine turn
+    # end" fallthrough, but that point is skipped by any early return in the
+    # turn loop (e.g. a user interrupt during the empty-response retry
+    # backoff) -- resetting here too, at the one point every turn
+    # unconditionally passes through, is what actually guarantees a stale
+    # value from an aborted turn can never suppress detection on the next,
+    # unrelated turn.
+    agent._dropped_toolcall_retries = 0
+    agent._fabricated_tool_use_retries = 0
+    agent._landed_real_tool_call_this_turn = False
     agent._post_tool_empty_retried = False
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -1,5 +1,7 @@
 # Fabricated tool-use detection in `run_conversation()`
 
+**Status: Implemented** (branch `feat/fabricated-tool-use-detection`).
+
 ## Problem
 
 Under certain conditions (observed live: a search backend that's registered as "available" but

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -26,7 +26,7 @@ This is not a new failure class for this codebase. `agent/codex_responses_adapte
 `finish_reason` becomes `"incomplete"` after that adapter's own processing. Its own comment names
 the exact risk: *"the parent sees a confident-looking summary with no audit trail (empty
 tool_trace) and no tools actually ran."* A second, sibling mechanism — the "dropped tool call"
-retry in `agent/conversation_loop.py:8039-8079` — recovers when `finish_reason == "tool_calls"`
+retry in `agent/conversation_loop.py:8102-8134` — recovers when `finish_reason == "tool_calls"`
 but `tool_calls` came back empty. Neither covers a genuinely `stop`-style completion, which is
 this bug's actual shape; the dropped-toolcall code's own surrounding comment says so explicitly
 (`conversation_loop.py:8036`): *"finish_reason='stop' text finishes never enter this guard."*
@@ -41,7 +41,7 @@ recovering via the same retry mechanism already proven for the dropped-toolcall 
 **Explicitly out of scope:**
 - Replacing or modifying the existing Codex-specific leak-recovery path
   (`codex_responses_adapter.py:1585-1611`) or the existing dropped-toolcall path
-  (`conversation_loop.py:8039-8079`). Both keep working exactly as they do today; this is a new,
+  (`conversation_loop.py:8102-8134`). Both keep working exactly as they do today; this is a new,
   third sibling check, not a refactor of the other two.
 - Detecting a hallucination that reads as ordinary, ungrounded prose with **no** structural JSON
   marker and **no** self-claiming language at all (e.g. a wrong fact stated as flatly as a
@@ -59,7 +59,7 @@ recovering via the same retry mechanism already proven for the dropped-toolcall 
 ### Where it lives
 
 A new `elif` branch alongside the existing dropped-toolcall check, inside `run_conversation()`
-in `agent/conversation_loop.py` (~line 8039). Both checks read from the same normalized,
+in `agent/conversation_loop.py` (~line 8157). Both checks read from the same normalized,
 provider-agnostic `assistant_message`/`finish_reason` produced once per turn by
 `_transport.normalize_response(response)` (`conversation_loop.py:6637-6639`) — the one call site
 all four transports (`anthropic`, `codex`, `chat_completions`, `bedrock`) funnel through
@@ -108,14 +108,31 @@ turn, since it's just delivering the final text) can legitimately contain the sa
 language the detector looks for — e.g. *"the search returned $2,650/oz"* while accurately
 summarizing a real tool result from an earlier round in the same turn. The existing
 dropped-toolcall check avoids this by construction (it's gated on `finish_reason == "tool_calls"`,
-which a normal summary never has); this new check deliberately does not gate on `finish_reason`,
-so it needs its own guard.
+which a normal summary never has); this new check needs its own guard.
 
 Fix: a new agent attribute, `agent._landed_real_tool_call_this_turn`, set `True` at the same point
 `agent._dropped_toolcall_retries` already gets reset after a successful tool round
 (`conversation_loop.py:~7234`), and reset to `False` alongside the other counters at genuine turn
 end (`~8079`). The new check additionally requires
 `not getattr(agent, "_landed_real_tool_call_this_turn", False)`.
+
+### Second refinement, found during code review: the two retry budgets could compound
+
+Because this check does not gate on `finish_reason` the way the dropped-toolcall check does, an
+overlap case is possible: a stall with `finish_reason == "tool_calls"` and empty `tool_calls`,
+whose narration text ALSO happens to match the fabrication pattern (a plausible variant of the
+same provider-contract violation the dropped-toolcall check exists for). Without a fix, once the
+dropped-toolcall check's own 3-retry budget is exhausted, control would fall through to this new
+check, which — not gating on `finish_reason` — would grant 3 *more* retries, silently doubling the
+effective bound to 6 for that one overlap case, contradicting the "bounded to 3" invariant stated
+above.
+
+Fix: the check additionally requires `finish_reason != "tool_calls"` — that value is squarely the
+dropped-toolcall check's own territory (it's the condition that check exists for), so once its
+budget is exhausted for that finish_reason, the turn now correctly falls through to genuine turn
+end instead of getting a second budget from this check. This does not narrow the check's actual
+target: `finish_reason="stop"` (and every other non-`"tool_calls"` value) — the gap this whole
+design exists to close — is completely unaffected by the exclusion.
 
 Accepted tradeoff: once any real tool call has landed anywhere in a turn's multi-round loop, later
 text in that same turn is never checked again for fabrication, even if it's a distinct, unrelated
@@ -168,6 +185,14 @@ Cases:
    retries), mirroring `test_persistent_dropped_tool_calls_are_bounded`.
 8. **Ephemeral scaffolding.** The nudge pair does not survive into `result["messages"]` after a
    successful retry, mirroring `test_nudge_pair_is_ephemeral_scaffolding`.
+9. **Flag does not leak across turns.** Added during implementation once the
+   `_landed_real_tool_call_this_turn` refinement above was written: a real tool call in one
+   `run_conversation()` call must not permanently suppress detection in a later, separate call on
+   the same long-lived agent — proves the flag resets at genuine turn end, not just within a turn.
+10. **The two retry budgets don't compound.** Added after code review caught the gap described in
+    "Second refinement" above: a stall that is simultaneously `finish_reason == "tool_calls"` (with
+    empty `tool_calls`) and fabrication-shaped must cap at 4 total calls (the dropped-toolcall
+    check's own budget), not 7 (both budgets stacked).
 
 `scripts/run_tests.sh tests/run_agent/` must stay green throughout, alongside the full existing
 `test_dropped_tool_call_recovery.py` suite (unmodified, still passing — this is additive, not a

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -151,6 +151,21 @@ retry, both scaffolding messages are stripped from final persisted history via t
 `_is_ephemeral_scaffolding` mechanism (`run_agent.py`), unchanged from how the dropped-toolcall
 pair already does this. No new retry infrastructure is introduced.
 
+### Third refinement, found in independent post-merge review: the two new counters/flag must also reset at turn START, not just turn end
+
+`agent._dropped_toolcall_retries`, `agent._fabricated_tool_use_retries`, and `agent._landed_real_tool_call_this_turn`
+were originally reset only at `run_conversation()`'s own "genuine turn end" fallthrough. That point is skipped by
+any of the function's ~35 early-return paths — concretely, a user interrupt during the empty-response retry
+backoff returns immediately without ever reaching it. A real tool call landing in one turn, followed by that
+same turn exiting early via such a path, left `_landed_real_tool_call_this_turn` stuck `True` and silently
+suppressed fabricated-tool-use detection for the *next*, unrelated turn on the same long-lived agent object —
+defeating the exact bug class this whole design exists to catch.
+
+Fix: also reset all three in `build_turn_context()` (`agent/turn_context.py`), the prologue every
+`run_conversation()` call unconditionally passes through at its very start, alongside the dozen other
+per-turn retry counters it already resets there. The turn-end reset stays in place too (harmless, idempotent) —
+this is a second, more reliable reset point, not a replacement for the first.
+
 ## Testing
 
 New file `tests/run_agent/test_fabricated_tool_use_recovery.py`, mirroring

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -97,6 +97,28 @@ going in: the JSON check generalizes cleanly from shape and needs no maintenance
 check is inherently reactive and will need new entries as new wordings are observed live, same as
 its prior-art equivalent already has needed twice.
 
+### Refinement found during planning: a real earlier tool call must suppress this check
+
+A genuine post-tool-call summary turn (`finish_reason="stop"`, no `tool_calls` in *that specific*
+turn, since it's just delivering the final text) can legitimately contain the same self-claim
+language the detector looks for — e.g. *"the search returned $2,650/oz"* while accurately
+summarizing a real tool result from an earlier round in the same turn. The existing
+dropped-toolcall check avoids this by construction (it's gated on `finish_reason == "tool_calls"`,
+which a normal summary never has); this new check deliberately does not gate on `finish_reason`,
+so it needs its own guard.
+
+Fix: a new agent attribute, `agent._landed_real_tool_call_this_turn`, set `True` at the same point
+`agent._dropped_toolcall_retries` already gets reset after a successful tool round
+(`conversation_loop.py:~7234`), and reset to `False` alongside the other counters at genuine turn
+end (`~8079`). The new check additionally requires
+`not getattr(agent, "_landed_real_tool_call_this_turn", False)`.
+
+Accepted tradeoff: once any real tool call has landed anywhere in a turn's multi-round loop, later
+text in that same turn is never checked again for fabrication, even if it's a distinct, unrelated
+claim. Favors false-negative risk over false-positive risk here — consistent with this whole
+design's stated posture — and a model that has already demonstrated it can call tools correctly
+this turn is less likely (though not guaranteed) to then also fabricate something unrelated.
+
 ### Response: reuse existing recovery mechanics exactly
 
 Same `continue`-based pattern as the dropped-toolcall block: flag the bad assistant turn

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -1,0 +1,148 @@
+# Fabricated tool-use detection in `run_conversation()`
+
+## Problem
+
+Under certain conditions (observed live: a search backend that's registered as "available" but
+unreachable, with no keyless fallback), a completed turn (`finish_reason: "stop"` or equivalent,
+normal token usage, no error) can return text that either:
+
+1. Leaks a raw tool-call-shaped JSON fragment as prose — e.g.
+   `{"arguments": {"query": "local LLM inference"}, "name": "web_search"}` — with no real
+   `tool_calls` anywhere in the response, or
+2. Fully fabricates a plausible-looking tool result with no structural marker at all — e.g.
+   `"I'll perform a quick web search. Here's the result from my search: ... The current gold
+   price is USD $... per troy ounce."` with placeholder-shaped content (`example.com`, `20XX`,
+   `$...`) presented as fact, again with no real `tool_calls`.
+
+Both are silent: no error, no warning, `status: completed`, plausible token usage. The only way
+to tell the reply apart from a genuine answer is to read the response's structured `output`/
+`tool_calls` field directly — something no caller does by default.
+
+This is not a new failure class for this codebase. `agent/codex_responses_adapter.py:60-68,
+1585-1611` already detects and recovers from one specific instance of it — a literal Harmony
+`to=functions.<name>` leak token, only on the Codex/xAI/GitHub Responses transport, only when
+`finish_reason` becomes `"incomplete"` after that adapter's own processing. Its own comment names
+the exact risk: *"the parent sees a confident-looking summary with no audit trail (empty
+tool_trace) and no tools actually ran."* A second, sibling mechanism — the "dropped tool call"
+retry in `agent/conversation_loop.py:8039-8079` — recovers when `finish_reason == "tool_calls"`
+but `tool_calls` came back empty. Neither covers a genuinely `stop`-style completion, which is
+this bug's actual shape; the dropped-toolcall code's own surrounding comment says so explicitly
+(`conversation_loop.py:8036`): *"finish_reason='stop' text finishes never enter this guard."*
+
+## Scope
+
+**In scope:** detecting, for *any* transport/provider and *any* tool, a completed turn whose
+text either (a) contains a tool-call-shaped JSON fragment, or (b) affirmatively claims a
+completed tool action with a result, while the turn's real `tool_calls` are empty — and
+recovering via the same retry mechanism already proven for the dropped-toolcall case.
+
+**Explicitly out of scope:**
+- Replacing or modifying the existing Codex-specific leak-recovery path
+  (`codex_responses_adapter.py:1585-1611`) or the existing dropped-toolcall path
+  (`conversation_loop.py:8039-8079`). Both keep working exactly as they do today; this is a new,
+  third sibling check, not a refactor of the other two.
+- Detecting a hallucination that reads as ordinary, ungrounded prose with **no** structural JSON
+  marker and **no** self-claiming language at all (e.g. a wrong fact stated as flatly as a
+  correct one, no "I searched" framing). This would require classifying whether a given message
+  "needed" a tool at all — the same fuzzier, higher-false-positive-risk problem an earlier,
+  narrower fix in a downstream consumer of this framework explicitly deferred. A semantic
+  verifier pass could close this gap in a future iteration; not attempted here.
+- Fixing whatever root cause makes the model behave this way in the first place (resource
+  contention, cold model load, a misconfigured backend). This treats the symptom at the
+  detect-and-retry layer, matching how every existing sibling mechanism in this codebase already
+  does the same.
+
+## Design
+
+### Where it lives
+
+A new `elif` branch alongside the existing dropped-toolcall check, inside `run_conversation()`
+in `agent/conversation_loop.py` (~line 8039). Both checks read from the same normalized,
+provider-agnostic `assistant_message`/`finish_reason` produced once per turn by
+`_transport.normalize_response(response)` (`conversation_loop.py:6637-6639`) — the one call site
+all four transports (`anthropic`, `codex`, `chat_completions`, `bedrock`) funnel through
+(`agent/transports/{name}.py`, each implementing the shared `NormalizedResponse` contract at
+`agent/transports/types.py:89-109`). Placing the check here, rather than per-transport, means one
+implementation covers every provider this framework supports, not just whichever one a future bug
+happens to surface on.
+
+Ordering: this new check is chained as an `elif` after the existing dropped-toolcall condition
+(not an independent `if`), so if both conditions happen to be true for the same turn, the
+existing, more specific check fires first and this one is skipped — no double-fire, no new
+ambiguity in an already-working path.
+
+### Detection: two independent signals
+
+Both signals are gated on `not assistant_message.tool_calls` (falsy-uniform, matching how the
+existing check at line 8041 already treats `None` vs `[]`) — a real tool call in this turn always
+wins over either signal, exactly like the existing checks.
+
+**1. Structural — JSON tool-call shape (`_FABRICATED_TOOL_USE_JSON_RE`).** Two independent
+regexes, `"name"\s*:\s*"[^"]*"` and `"arguments"\s*:`, both required to match somewhere in the
+text (order-independent, no single regex spanning both keys). This is tool-agnostic and
+wording-agnostic by construction — it does not need to know what the leaked JSON's surrounding
+prose says, only that the payload shape is present. (This mirrors a structural fix already
+shipped and verified in a downstream consumer of this framework, ported here so every consumer
+benefits, not just that one.)
+
+**2. Self-claim language (`_FABRICATED_TOOL_USE_PATTERNS`).** A small, curated, evidence-seeded
+list of regexes for text that affirmatively claims a *completed* tool action with a *result* —
+seeded from the one real captured case: *"here's the result from my search"*-style framing.
+Deliberately narrow, matching only affirmative completed-action claims, not proposals ("let me
+check that") or honest disclaimers ("I don't have a way to look that up right now") — the latter
+is the opposite of the bug and must never be flagged. Documented in the code, the same way
+`TOOL_CALL_LEAK_SIGNATURES`-style lists already are in this codebase's own conventions, as a
+starting set that will need to grow from future real incidents — this is the tradeoff accepted
+going in: the JSON check generalizes cleanly from shape and needs no maintenance; the language
+check is inherently reactive and will need new entries as new wordings are observed live, same as
+its prior-art equivalent already has needed twice.
+
+### Response: reuse existing recovery mechanics exactly
+
+Same `continue`-based pattern as the dropped-toolcall block: flag the bad assistant turn
+(`_fabricated_tool_use_nudge`), append it plus a new synthetic user nudge message
+(`_FABRICATED_TOOL_USE_NUDGE_CONTENT`) to `messages`, set `agent._session_messages = messages`,
+`final_response = None`, `continue` the outer loop. Capped at 3 attempts via a new counter,
+`agent._fabricated_tool_use_retries` (matching the existing precedent's cap). On a successful
+retry, both scaffolding messages are stripped from final persisted history via the existing
+`_is_ephemeral_scaffolding` mechanism (`run_agent.py`), unchanged from how the dropped-toolcall
+pair already does this. No new retry infrastructure is introduced.
+
+## Testing
+
+New file `tests/run_agent/test_fabricated_tool_use_recovery.py`, mirroring
+`tests/run_agent/test_dropped_tool_call_recovery.py`'s exact fixture and mocking style
+(`loop_agent` fixture, mocked OpenAI client, a `_fabricated_response(content)` helper analogous
+to `_dropped_tool_call_response(content)`).
+
+Cases:
+
+1. **True positive — JSON leak.** The real captured leak text
+   (`{"arguments": {"query": "local LLM inference"}, "name": "web_search"}`), `tool_calls=None`,
+   `finish_reason="stop"`. Asserts a retry fires (`call_count == 2`).
+2. **True positive — self-claim fabrication.** The real captured fake-search-result text.
+   Same assertion.
+3. **True positive — a different tool.** A synthetic case using the JSON-shape signal with
+   `"name": "terminal"` instead of `"web_search"`, proving the structural check is genuinely
+   tool-agnostic, not accidentally coupled to search.
+4. **True negative — clean correct reply.** An ordinary `finish_reason="stop"` answer with no
+   JSON shape and no self-claim language. Mirrors the existing
+   `test_clean_stop_text_turn_is_unaffected` almost exactly; must not trigger a retry
+   (`call_count == 1`).
+5. **True negative — honest disclaimer.** Text that explicitly says the model *can't* look
+   something up right now. Must not trigger — this is the specific false-positive risk this
+   design accepts responsibility for guarding against, made an explicit regression test rather
+   than an assumption.
+6. **True negative — real tool call with similar-sounding summary text.** A turn with real,
+   populated `tool_calls` whose accompanying text happens to say "the search returned..." while
+   summarizing a genuine result. Must not trigger, mirroring the existing
+   `test_does_not_flag_a_real_function_call_even_if_leak_like_text_is_also_present`-equivalent
+   guarantee already proven at the detection-shape level in the downstream consumer.
+7. **Bounded retries.** Repeated fabricated responses cap at `call_count <= 4` (1 initial + 3
+   retries), mirroring `test_persistent_dropped_tool_calls_are_bounded`.
+8. **Ephemeral scaffolding.** The nudge pair does not survive into `result["messages"]` after a
+   successful retry, mirroring `test_nudge_pair_is_ephemeral_scaffolding`.
+
+`scripts/run_tests.sh tests/run_agent/` must stay green throughout, alongside the full existing
+`test_dropped_tool_call_recovery.py` suite (unmodified, still passing — this is additive, not a
+replacement).

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -169,9 +169,11 @@ this is a second, more reliable reset point, not a replacement for the first.
 ## Testing
 
 New file `tests/run_agent/test_fabricated_tool_use_recovery.py`, mirroring
-`tests/run_agent/test_dropped_tool_call_recovery.py`'s exact fixture and mocking style
-(`loop_agent` fixture, mocked OpenAI client, a `_fabricated_response(content)` helper analogous
-to `_dropped_tool_call_response(content)`).
+`tests/run_agent/test_dropped_tool_call_recovery.py`'s exact fixture and mocking style. The
+`loop_agent` fixture (mocked-`AIAgent` construction, same shape as `test_dropped_tool_call_recovery.py`'s
+own) was found in post-merge review to already be duplicated verbatim across several files in this
+directory — moved to `tests/run_agent/conftest.py` (which already exists as the designated home
+for shared fixtures in this directory) rather than adding an Nth copy here.
 
 Cases:
 

--- a/docs/rfcs/2026-08-fabricated-tool-use-detection.md
+++ b/docs/rfcs/2026-08-fabricated-tool-use-detection.md
@@ -81,9 +81,11 @@ wins over either signal, exactly like the existing checks.
 regexes, `"name"\s*:\s*"[^"]*"` and `"arguments"\s*:`, both required to match somewhere in the
 text (order-independent, no single regex spanning both keys). This is tool-agnostic and
 wording-agnostic by construction — it does not need to know what the leaked JSON's surrounding
-prose says, only that the payload shape is present. (This mirrors a structural fix already
-shipped and verified in a downstream consumer of this framework, ported here so every consumer
-benefits, not just that one.)
+prose says, only that the payload shape is present. Accepted false-positive class: legitimate
+prose that quotes a tool-call-shaped JSON example (e.g. explaining an API schema) will also match
+— the retry cost of a wrong-but-bounded re-prompt is judged cheaper than the complexity of
+disambiguating intent here. (This mirrors a structural fix already shipped and verified in a
+downstream consumer of this framework, ported here so every consumer benefits, not just that one.)
 
 **2. Self-claim language (`_FABRICATED_TOOL_USE_PATTERNS`).** A small, curated, evidence-seeded
 list of regexes for text that affirmatively claims a *completed* tool action with a *result* —

--- a/run_agent.py
+++ b/run_agent.py
@@ -251,6 +251,11 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     # drive the bounded retry. Persisting them would replay the internal
     # retry instruction as user-authored context on resume.
     "_dropped_toolcall_nudge",
+    # fabricated tool-use re-prompt pair (a completed turn's text leaked a
+    # tool-call JSON shape or claimed a completed tool action with no real
+    # tool_calls behind it): same reasoning as the dropped-toolcall pair
+    # above, just for a different provider-contract mismatch.
+    "_fabricated_tool_use_nudge",
 )
 
 

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -220,6 +220,21 @@ def test_max_iterations_nudge_is_synthetic_not_actionable():
     assert ContextCompressor._transcript_has_real_user_turn([human, nudge]) is True
 
 
+def test_fabricated_tool_use_nudge_is_synthetic_not_actionable():
+    """The fabricated-tool-use recovery nudge (agent/conversation_loop.py) is
+    runtime scaffolding, not a human turn — same recognition requirement as
+    every other sibling nudge in this function, and for the same reason:
+    SessionDB preserves role/content but not underscore-prefixed metadata,
+    so content-based recognition is authoritative after projection."""
+    from agent.conversation_loop import _FABRICATED_TOOL_USE_NUDGE_CONTENT
+
+    nudge = {"role": "user", "content": _FABRICATED_TOOL_USE_NUDGE_CONTENT}
+    assert ContextCompressor._is_synthetic_compression_user_turn(nudge) is True
+
+    human = {"role": "user", "content": "What's the price of gold?"}
+    assert ContextCompressor._is_synthetic_compression_user_turn(human) is False
+
+
 def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     """The tail anchor must resolve to the human task, not the nudge that the
     runtime appended after it when iterations were exhausted."""

--- a/tests/agent/test_fabricated_tool_use_detection.py
+++ b/tests/agent/test_fabricated_tool_use_detection.py
@@ -63,3 +63,12 @@ class TestLooksLikeFabricatedToolUse:
     def test_returns_false_for_empty_or_none_text(self):
         assert _looks_like_fabricated_tool_use("") is False
         assert _looks_like_fabricated_tool_use(None) is False
+
+    def test_flags_legitimate_schema_discussion_as_an_accepted_tradeoff(self):
+        """KNOWN, ACCEPTED limitation: prose that legitimately quotes a
+        tool-call-shaped JSON example (e.g. explaining an API schema) also
+        matches. Pinned here deliberately so this boundary is visible and
+        intentional, not a silent gap -- see the comment above
+        _FABRICATED_TOOL_USE_HAS_NAME_KEY."""
+        text = 'Your schema should look like {"name": "get_weather", "arguments": {"location": "string"}}'
+        assert _looks_like_fabricated_tool_use(text) is True

--- a/tests/agent/test_fabricated_tool_use_detection.py
+++ b/tests/agent/test_fabricated_tool_use_detection.py
@@ -1,0 +1,65 @@
+"""Unit tests for the fabricated-tool-use text classifier.
+
+Pure-function tests, no agent/loop mocking -- see
+tests/run_agent/test_fabricated_tool_use_recovery.py for the full
+retry-loop integration tests.
+"""
+
+from __future__ import annotations
+
+from agent.conversation_loop import _looks_like_fabricated_tool_use
+
+
+class TestLooksLikeFabricatedToolUse:
+    def test_flags_real_captured_json_leak(self):
+        """Captured live, 2026-08-26: a raw tool-call JSON fragment leaked
+        as prose with no real tool_calls behind it."""
+        text = '{"arguments": {"query": "local LLM inference"}, "name": "web_search"}'
+        assert _looks_like_fabricated_tool_use(text) is True
+
+    def test_flags_real_captured_narrated_json_leak(self):
+        text = (
+            "Of course, here are my steps to find the current price of gold "
+            "online:\n\n<EXPLANATION>\n"
+            '{"arguments": {"query": "current price of gold"}, "name": "web_search"}'
+        )
+        assert _looks_like_fabricated_tool_use(text) is True
+
+    def test_flags_real_captured_self_claim_fabrication(self):
+        """Captured live, 2026-08-26: a fully fabricated fake search result,
+        no JSON marker at all -- placeholder URLs/prices presented as fact."""
+        text = (
+            "I'll perform a quick web search. Here's the result from my "
+            "search:\n1 | Gold Price Today - December X, 20XX\n"
+            "   url: https://example.com/gold\n"
+            "The current gold price is USD $... per troy ounce. This search "
+            "returned results from the authoritative historical charting "
+            "service I trusted to give factual up-to-date information."
+        )
+        assert _looks_like_fabricated_tool_use(text) is True
+
+    def test_flags_json_shape_for_a_different_tool(self):
+        """The JSON-shape signal is tool-agnostic -- not coupled to search."""
+        text = (
+            'I ran the command. Here is what happened: '
+            '{"name": "terminal", "arguments": {"command": "ls"}}'
+        )
+        assert _looks_like_fabricated_tool_use(text) is True
+
+    def test_does_not_flag_an_ordinary_clean_reply(self):
+        assert _looks_like_fabricated_tool_use("Here is your answer: 4.") is False
+
+    def test_does_not_flag_an_honest_disclaimer(self):
+        text = (
+            "I don't have a way to look that up right now, but based on "
+            "general knowledge, gold has historically traded around "
+            "$2000/oz."
+        )
+        assert _looks_like_fabricated_tool_use(text) is False
+
+    def test_does_not_flag_a_proposal_to_check_later(self):
+        assert _looks_like_fabricated_tool_use("Let me check that for you.") is False
+
+    def test_returns_false_for_empty_or_none_text(self):
+        assert _looks_like_fabricated_tool_use("") is False
+        assert _looks_like_fabricated_tool_use(None) is False

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -284,6 +284,27 @@ def test_turn_start_replaces_stale_parent_history_with_compression_child():
     assert all(message.get("content") != "stale parent" for message in ctx.messages)
 
 
+def test_resets_dropped_toolcall_and_fabricated_tool_use_state():
+    """A stale value on any of these three must never survive into a new
+    turn -- run_conversation()'s own "genuine turn end" reset (near the
+    bottom of its main loop) is skipped by ~35 early-return paths (e.g. a
+    user interrupt during the empty-response retry backoff), so
+    build_turn_context() -- called unconditionally at the START of every
+    run_conversation() invocation -- is the only reset point that reliably
+    covers every path. Before this fix, a real tool call landing in one
+    turn, followed by that same turn exiting early via one of those
+    early-return paths, silently disabled the fabricated-tool-use detector
+    for the next, unrelated turn on the same agent."""
+    agent = _FakeAgent()
+    agent._dropped_toolcall_retries = 2
+    agent._fabricated_tool_use_retries = 1
+    agent._landed_real_tool_call_this_turn = True
+    _build(agent)
+    assert agent._dropped_toolcall_retries == 0
+    assert agent._fabricated_tool_use_retries == 0
+    assert agent._landed_real_tool_call_this_turn is False
+
+
 def test_applies_agent_side_effects():
     agent = _FakeAgent()
     _build(agent)

--- a/tests/run_agent/conftest.py
+++ b/tests/run_agent/conftest.py
@@ -20,7 +20,42 @@ monkeypatch ``run_agent.time.sleep`` locally (see
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client, ready to stage a
+    ``.chat.completions.create`` response sequence.
+
+    Shared here because this exact fixture body was independently
+    duplicated across several files in this directory (test_run_agent.py's
+    original, test_dropped_tool_call_recovery.py, and others) before being
+    consolidated — new tests should depend on this one rather than adding
+    another copy.
+    """
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
 
 
 @pytest.fixture(autouse=True)

--- a/tests/run_agent/test_fabricated_tool_use_recovery.py
+++ b/tests/run_agent/test_fabricated_tool_use_recovery.py
@@ -1,0 +1,314 @@
+"""Regression tests for fabricated tool-use recovery.
+
+Under real conditions (observed live: a search backend that reports itself
+available but is unreachable, with no keyless fallback), a genuinely
+completed turn (finish_reason="stop", normal token usage, no error) can
+return text that either leaks a raw tool-call-shaped JSON fragment as
+prose, or fully fabricates a plausible-looking tool result — both with an
+empty tool_calls array. Before this fix, neither the existing
+dropped-tool-call recovery (gated on finish_reason="tool_calls") nor the
+Codex-specific Harmony-leak recovery (gated on that one transport and
+finish_reason="incomplete") ever saw this: a finish_reason="stop" text
+finish never entered either guard.
+
+The fix keys on the turn's own content (a JSON tool-call shape, or
+affirmative self-claiming language) independent of finish_reason and
+provider, and re-prompts, bounded to 3 consecutive stalls, with the budget
+resetting after any successful tool round — the same recovery discipline
+already proven for the dropped-tool-call case. A genuine clean answer, an
+honest disclaimer, or a real tool call's own summary text are all
+unaffected. See docs/rfcs/2026-08-fabricated-tool-use-detection.md.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors
+    test_dropped_tool_call_recovery's fixture)."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+FAKE_GOLD_SEARCH_TEXT = (
+    "I'll perform a quick web search. Here's the result from my "
+    "search:\n1 | Gold Price Today - December X, 20XX\n"
+    "   url: https://example.com/gold\n"
+    "The current gold price is USD $... per troy ounce. This search "
+    "returned results from the authoritative historical charting "
+    "service I trusted to give factual up-to-date information."
+)
+
+RAW_JSON_LEAK_TEXT = (
+    '{"arguments": {"query": "local LLM inference"}, "name": "web_search"}'
+)
+
+
+class TestFabricatedToolUseRecovery:
+    def test_json_leak_reprompts_instead_of_publishing(self, loop_agent):
+        """A raw tool-call JSON leak with finish_reason=stop and empty
+        tool_calls must re-prompt, not be treated as the final answer."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=RAW_JSON_LEAK_TEXT, finish_reason="stop"),
+            _mock_response(content="Gold is trading around $2,650/oz today.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2, (
+            "A leaked tool-call JSON fragment must trigger a re-prompt, not "
+            "be published as the final answer."
+        )
+        assert "$2,650" in result["final_response"]
+
+    def test_self_claim_fabrication_reprompts_instead_of_publishing(self, loop_agent):
+        """The real captured fake-search-result text (no JSON marker at all)
+        must also trigger a re-prompt."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=FAKE_GOLD_SEARCH_TEXT, finish_reason="stop"),
+            _mock_response(content="Gold is trading around $2,650/oz today.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert "$2,650" in result["final_response"]
+
+    def test_reprompt_asks_for_a_real_call_not_a_claim(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=FAKE_GOLD_SEARCH_TEXT, finish_reason="stop"),
+            _mock_response(content="Gold is trading around $2,650/oz today.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            loop_agent.run_conversation("what's the price of gold")
+
+        second_call = loop_agent.client.chat.completions.create.call_args_list[1]
+        msgs = second_call.kwargs.get("messages") or second_call.args[0].get("messages")
+        last_user = next((m for m in reversed(msgs) if m.get("role") == "user"), None)
+        assert last_user is not None
+        assert "tool" in (last_user.get("content") or "").lower()
+
+    def test_clean_stop_text_turn_is_unaffected(self, loop_agent):
+        """A genuine finish_reason=stop text response must exit normally —
+        the recovery path must not fire on ordinary final answers."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="Here is your answer.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1, (
+            "An ordinary clean answer must not trigger a re-prompt."
+        )
+        assert "Here is your answer." in result["final_response"]
+
+    def test_honest_disclaimer_is_unaffected(self, loop_agent):
+        """An honest 'I can't look that up' admission is the OPPOSITE of
+        this bug and must never be flagged."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        disclaimer = (
+            "I don't have a way to look that up right now, but based on "
+            "general knowledge, gold has historically traded around "
+            "$2000/oz."
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=disclaimer, finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count == 1
+        assert disclaimer in result["final_response"]
+
+    def test_real_tool_call_with_similar_summary_text_is_unaffected(self, loop_agent):
+        """A genuine tool call whose summary text happens to say 'the
+        search returned' must not be flagged — a real tool_calls entry in
+        an earlier round of the same turn always wins (the
+        _landed_real_tool_call_this_turn guard)."""
+        from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
+
+        loop_agent.valid_tool_names = {"web_search"}
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments='{"query": "gold price"}', call_id="c1")],
+        )
+        summary = _mock_response(
+            content="The search returned $2,650/oz as today's gold price.",
+            finish_reason="stop",
+        )
+        loop_agent.client.chat.completions.create.side_effect = [tool_turn, summary]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="gold: $2,650/oz"),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2, (
+            "A real tool call followed by a summary must not trigger an "
+            "extra re-prompt even though the summary text matches a "
+            "fabrication pattern."
+        )
+        assert "$2,650" in result["final_response"]
+
+    def test_landed_flag_does_not_leak_into_a_later_separate_turn(self, loop_agent):
+        """_landed_real_tool_call_this_turn must reset at genuine turn end —
+        otherwise one real tool call anywhere in a session would permanently
+        disable this check for every later, unrelated turn."""
+        from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
+
+        loop_agent.valid_tool_names = {"web_search"}
+
+        # First turn: a real tool call lands and completes cleanly.
+        first_turn_tool_call = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments='{"query": "weather"}', call_id="c1")],
+        )
+        first_turn_summary = _mock_response(content="It's sunny.", finish_reason="stop")
+
+        # Second, separate turn: a fabrication with no real tool call at all.
+        second_turn_fabrication = _mock_response(content=FAKE_GOLD_SEARCH_TEXT, finish_reason="stop")
+        second_turn_recovered = _mock_response(
+            content="Gold is trading around $2,650/oz today.", finish_reason="stop",
+        )
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            first_turn_tool_call, first_turn_summary,
+            second_turn_fabrication, second_turn_recovered,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="sunny, 72F"),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            first_result = loop_agent.run_conversation("what's the weather")
+            second_result = loop_agent.run_conversation("what's the price of gold")
+
+        assert "sunny" in first_result["final_response"]
+        # If the flag leaked from turn 1, this would be 1 (no re-prompt) —
+        # 2 proves the fabrication was still caught in the second, separate turn.
+        assert loop_agent.client.chat.completions.create.call_count == 4, (
+            "The second turn's fabrication must still be caught — a real "
+            "tool call in an EARLIER, separate turn must not permanently "
+            "disable this check."
+        )
+        assert "$2,650" in second_result["final_response"]
+
+    def test_persistent_fabrications_are_bounded(self, loop_agent):
+        """If the model never stops fabricating, recovery must give up
+        after a bounded number of consecutive stalls."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=FAKE_GOLD_SEARCH_TEXT, finish_reason="stop") for _ in range(9)
+        ] + [_mock_response(content="done", finish_reason="stop")]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count <= 4, (
+            "Consecutive fabrications must be bounded (no infinite loop)."
+        )
+        assert result is not None
+
+    def test_nudge_pair_is_ephemeral_scaffolding(self, loop_agent):
+        """The re-prompt pair must be flagged as ephemeral scaffolding so
+        persistence never writes it to the durable transcript."""
+        from run_agent import _is_ephemeral_scaffolding
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=RAW_JSON_LEAK_TEXT, finish_reason="stop"),
+            _mock_response(content="Gold is trading around $2,650/oz today.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("what's the price of gold")
+
+        assert result["completed"] is True
+        leftover = [
+            m for m in result["messages"]
+            if isinstance(m, dict) and m.get("_fabricated_tool_use_nudge")
+        ]
+        assert not leftover, (
+            "The re-prompt pair must be stripped at finalization, not kept "
+            "in the returned transcript."
+        )
+        assert _is_ephemeral_scaffolding(
+            {"role": "user", "content": "nudge", "_fabricated_tool_use_nudge": True}
+        ), (
+            "_fabricated_tool_use_nudge messages must be classified as "
+            "ephemeral scaffolding so they are never persisted."
+        )

--- a/tests/run_agent/test_fabricated_tool_use_recovery.py
+++ b/tests/run_agent/test_fabricated_tool_use_recovery.py
@@ -184,7 +184,7 @@ class TestFabricatedToolUseRecovery:
         _landed_real_tool_call_this_turn guard)."""
         from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
 
-        loop_agent.valid_tool_names = {"web_search"}
+        loop_agent.valid_tool_names.add("web_search")
 
         tool_turn = _mock_response(
             content="",
@@ -218,7 +218,7 @@ class TestFabricatedToolUseRecovery:
         disable this check for every later, unrelated turn."""
         from tests.run_agent.test_run_agent import _mock_response, _mock_tool_call
 
-        loop_agent.valid_tool_names = {"web_search"}
+        loop_agent.valid_tool_names.add("web_search")
 
         # First turn: a real tool call lands and completes cleanly.
         first_turn_tool_call = _mock_response(
@@ -278,6 +278,34 @@ class TestFabricatedToolUseRecovery:
             "Consecutive fabrications must be bounded (no infinite loop)."
         )
         assert result is not None
+
+    def test_tool_calls_finish_reason_does_not_compound_both_budgets(self, loop_agent):
+        """A finish_reason=tool_calls stall whose narration ALSO happens to
+        match the fabrication pattern must be bounded by the dropped-toolcall
+        check's own budget (3) alone -- not get 3 MORE retries from the
+        fabrication check once that budget is exhausted."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        # Text that is BOTH a dropped-toolcall stall (finish_reason=tool_calls,
+        # empty tool_calls) AND matches the fabrication pattern.
+        overlapping_stall = _mock_response(
+            content=RAW_JSON_LEAK_TEXT, finish_reason="tool_calls", tool_calls=None,
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            overlapping_stall for _ in range(9)
+        ] + [_mock_response(content="done", finish_reason="stop")]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            loop_agent.run_conversation("what's the price of gold")
+
+        assert loop_agent.client.chat.completions.create.call_count <= 4, (
+            "The dropped-toolcall and fabrication budgets must not compound: "
+            "an overlap case is bounded by 3 total consecutive retries, not 6."
+        )
 
     def test_nudge_pair_is_ephemeral_scaffolding(self, loop_agent):
         """The re-prompt pair must be flagged as ephemeral scaffolding so

--- a/tests/run_agent/test_fabricated_tool_use_recovery.py
+++ b/tests/run_agent/test_fabricated_tool_use_recovery.py
@@ -12,12 +12,16 @@ finish_reason="incomplete") ever saw this: a finish_reason="stop" text
 finish never entered either guard.
 
 The fix keys on the turn's own content (a JSON tool-call shape, or
-affirmative self-claiming language) independent of finish_reason and
-provider, and re-prompts, bounded to 3 consecutive stalls, with the budget
-resetting after any successful tool round — the same recovery discipline
-already proven for the dropped-tool-call case. A genuine clean answer, an
-honest disclaimer, or a real tool call's own summary text are all
-unaffected. See docs/rfcs/2026-08-fabricated-tool-use-detection.md.
+affirmative self-claiming language) independent of provider and of the
+specific value of finish_reason -- other than "tool_calls", which is the
+dropped-tool-call check's own territory and is deliberately excluded here
+so the two checks' retry budgets can't compound (see
+test_tool_calls_finish_reason_does_not_compound_both_budgets below). It
+re-prompts, bounded to 3 consecutive stalls, with the budget resetting
+after any successful tool round — the same recovery discipline already
+proven for the dropped-tool-call case. A genuine clean answer, an honest
+disclaimer, or a real tool call's own summary text are all unaffected.
+See docs/rfcs/2026-08-fabricated-tool-use-detection.md.
 """
 
 from __future__ import annotations

--- a/tests/run_agent/test_fabricated_tool_use_recovery.py
+++ b/tests/run_agent/test_fabricated_tool_use_recovery.py
@@ -26,36 +26,10 @@ See docs/rfcs/2026-08-fabricated-tool-use-detection.md.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
-
-
-@pytest.fixture()
-def loop_agent():
-    """AIAgent with a mocked OpenAI client (mirrors
-    test_dropped_tool_call_recovery's fixture)."""
-    from run_agent import AIAgent
-    with (
-        patch("run_agent.get_tool_definitions", return_value=[]),
-        patch("run_agent.check_toolset_requirements", return_value={}),
-        patch("run_agent.OpenAI"),
-    ):
-        agent = AIAgent(
-            api_key="test-key-1234567890",
-            base_url="https://openrouter.ai/api/v1",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
-        agent.client = MagicMock()
-        agent._cached_system_prompt = "You are helpful."
-        agent._use_prompt_caching = False
-        agent.tool_delay = 0
-        agent.compression_enabled = False
-        agent.save_trajectories = False
-        return agent
-
+# `loop_agent` is defined in tests/run_agent/conftest.py (shared across this
+# directory) rather than redefined here.
 
 FAKE_GOLD_SEARCH_TEXT = (
     "I'll perform a quick web search. Here's the result from my "


### PR DESCRIPTION
## Summary

Under certain conditions (observed live: a search backend that reports itself available but is unreachable, with no keyless fallback), a genuinely completed turn (`finish_reason="stop"`, normal token usage, no error) can return text that either:

1. Leaks a raw tool-call-shaped JSON fragment as prose — e.g. `{"arguments": {"query": "..."}, "name": "web_search"}` — with no real `tool_calls` in the response, or
2. Fully fabricates a plausible-looking tool result (fake URLs, fake prices) with no structural marker at all, again with no real `tool_calls`.

Both are silent: no error, no warning, `status: completed`, plausible token usage — the only way to tell is to read the response's structured `tool_calls` field directly, which no caller does by default.

This isn't a new failure class for this codebase: `agent/codex_responses_adapter.py` already detects and recovers from one specific instance of it (a literal Harmony `to=functions.<name>` leak token), but only on the Codex/xAI/GitHub Responses transport and only when `finish_reason` becomes `"incomplete"`. A second, sibling mechanism (the "dropped tool call" retry in `agent/conversation_loop.py`) recovers when `finish_reason == "tool_calls"` but `tool_calls` came back empty. Neither covers a genuinely `"stop"`-style completion — the dropped-toolcall check's own comment says so explicitly: *"finish_reason='stop' text finishes never enter this guard."*

This PR adds a third, transport-agnostic check that closes that gap, for any provider and any tool:

- **Detection** (`_looks_like_fabricated_tool_use` in `agent/conversation_loop.py`): two independent signals — a structural `"name"`/`"arguments"` JSON-key-pair check (tool-agnostic, wording-agnostic), and a small, evidence-seeded set of self-claim language patterns ("here's the result from my search", "the search returned...").
- **Recovery**: reuses the existing dropped-toolcall check's exact `continue`-based nudge/retry mechanics (bounded to 3 consecutive stalls, ephemeral scaffolding stripped from persisted history) — no new retry infrastructure.
- **Guard against false positives on real tool use**: a new `agent._landed_real_tool_call_this_turn` flag prevents a genuine post-tool-call summary (which may legitimately say things like "the search returned...") from being misclassified.
- **Guard against budget compounding**: the new check explicitly excludes `finish_reason == "tool_calls"` (that's the dropped-toolcall check's own territory) so the two checks' retry budgets can't stack to 6 instead of the stated 3 in an overlap case.
- Registers the new recovery nudge as synthetic scaffolding with both the ephemeral-message-persistence filter (`run_agent.py`) and the context-compression subsystem's synthetic-turn recognizer (`agent/context_compressor.py`), matching every sibling recovery nudge exactly.

Full design rationale, accepted tradeoffs, and false-positive-risk reasoning are in `docs/rfcs/2026-08-fabricated-tool-use-detection.md` (included in this PR).

## Test plan

- [x] New pure-function unit tests (`tests/agent/test_fabricated_tool_use_detection.py`, 9 tests) covering both real captured failure texts, a cross-tool case, and negative cases (ordinary replies, honest disclaimers, proposals to check later).
- [x] New integration tests (`tests/run_agent/test_fabricated_tool_use_recovery.py`, 10 tests) covering both true-positive shapes, bounded retries, ephemeral-scaffolding stripping, cross-turn flag reset, and the budget-compounding fix.
- [x] Existing `tests/run_agent/test_dropped_tool_call_recovery.py` (4 tests) still passes unmodified — additive, not a replacement.
- [x] Existing `tests/agent/test_context_compressor_zero_user_provenance.py` (16 tests) and `tests/agent/test_skill_todo_retention_parity.py` (12 tests) — the other consumers of the synthetic-turn recognizer — still pass, ruling out an accidental behavior change to that shared function.
- [x] `ruff check` on all three modified files: no new violations.
- [x] Rebased onto current `main` and re-ran the full suite above to confirm compatibility (all 51 tests passing).

51/51 tests passing.