### PR TITLE
fix(desktop): Bot Chat opens survive slow cold backends with a 60s hydration budget (#89617 tail, salvage #94282)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5634,6 +5634,12 @@ async function openStoredBotChat(owner, storedId, summary) {
   const hasAuthoritativeCount =
     typeof summary?.message_count === 'number' && Number.isFinite(summary.message_count)
   const expectHistory = hasAuthoritativeCount ? summary.message_count > 0 : true
+  // Current SDKs export the Bot-specific budget. The fallback preserves
+  // compatibility with older hosts and isolated plugin test harnesses.
+  const hydrationTimeoutMs =
+    typeof sdk !== 'undefined' && Number.isFinite(sdk.BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS)
+      ? sdk.BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS
+      : 60_000
 
   // A profile backend that just woke up can lose the hydration-timeout race
   // even though the session is fine (hermes-agent#89617) — clicking Retry
@@ -5655,6 +5661,7 @@ async function openStoredBotChat(owner, storedId, summary) {
     awaitHydration: true,
     expectHistory,
     forceResume: true,
+    hydrationTimeoutMs,
     keepAllProfilesScope: true,
     workspaceMode: 'bots',
     workspaceOwnerKey: ownerKey,

--- a/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
@@ -77,6 +77,11 @@ test('pref defaults OFF and persists via ctx.storage under activity-toasts', () 
   assert.match(source, /storage\?\.get\?\.\('activity-toasts'\)/)
 })
 
+test('Bot Chat opens pass the exported 60-second hydration budget', () => {
+  assert.match(source, /sdk\.BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS/)
+  assert.match(source, /hydrationTimeoutMs,/)
+})
+
 test('activity in the hidden canonical Bot Chat still badges (the "6d ago" class)', () => {
   // The canonical Bot Chat is hidden from session lists, so last_session
   // never advances when a DM lands there — only canonical_session does.

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -311,7 +311,12 @@ const $activeConnectionId = computed($connection, connection => {
   return connection.mode === 'local' ? 'local' : null
 })
 
-const DEFAULT_SESSION_HYDRATION_TIMEOUT_MS = 20_000
+/** Ordinary session opens fail fast when their gateway or socket is dead. */
+export const DEFAULT_SESSION_HYDRATION_TIMEOUT_MS = 20_000
+/** Cold Bot profiles get a larger per-attempt budget to start their backend
+ *  and paint durable history. Bot Mode opts into one retry, so its effective
+ *  ceiling is two bounded attempts rather than an unbounded wait. */
+export const BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS = 60_000
 let openSessionGeneration = 0
 
 export interface PluginOpenSessionOptions {

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -104,7 +104,9 @@ vi.mock('@/store/gateway', async () => {
   }
 })
 
-const { host } = await import('./index')
+const { BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS, DEFAULT_SESSION_HYDRATION_TIMEOUT_MS, host } =
+  await import('./index')
+
 const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile, hermesApi } = await import('@/hermes')
 
@@ -832,6 +834,65 @@ describe('profile-aware plugin session opens', () => {
 
     expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('stranded-bot-chat')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('keeps the ordinary session hydration default at 20 seconds', async () => {
+    vi.useFakeTimers()
+
+    try {
+      expect(DEFAULT_SESSION_HYDRATION_TIMEOUT_MS).toBe(20_000)
+      $activeGatewayProfile.set('hyoseob')
+
+      const outcome = host
+        .openSession('slow-bot-chat', {
+          profile: 'hyoseob',
+          awaitHydration: true,
+          expectHistory: true
+        })
+        .then(
+          () => 'resolved',
+          error => String(error)
+        )
+
+      await vi.advanceTimersByTimeAsync(19_999)
+      expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(await outcome).toMatch(/timed out loading/i)
+      expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('slow-bot-chat')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('honors the exported 60-second Bot Chat hydration override', async () => {
+    vi.useFakeTimers()
+
+    try {
+      expect(BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS).toBe(60_000)
+      $activeGatewayProfile.set('hyoseob')
+
+      const outcome = host
+        .openSession('slow-bot-chat', {
+          profile: 'hyoseob',
+          awaitHydration: true,
+          expectHistory: true,
+          hydrationTimeoutMs: BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS
+        })
+        .then(
+          () => 'resolved',
+          error => String(error)
+        )
+
+      await vi.advanceTimersByTimeAsync(BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS - 1)
+      expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(await outcome).toMatch(/timed out loading/i)
+      expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('slow-bot-chat')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('retries a Bot Chat hydration timeout once without ever arming the Retry surface (#89617)', async () => {


### PR DESCRIPTION
## Summary
Bot Chat opens now carry their own 60-second hydration budget instead of the global 20-second default, so a cold bot backend (the #89556 reporter measured 63–87s from READY to listening on a 127MB state.db) no longer loses a race it would have won. Salvage of #94282 by @shaqalaka, authorship preserved.

The wake stays bounded: past 60s the one-retry Retry surface still appears — this widens the budget for the slow-cold-start case, it never reintroduces an eternal spinner. Non-bot session opens keep the 20s default unchanged.

## Changes
- `sdk/index.ts`: exports `BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS = 60_000`.
- `hermes-bots` plugin: bot-chat opens pass `hydrationTimeoutMs` (60s fallback literal for older hosts).
- Tests: fake-timer coverage for both the 20s default and the 60s bot override (profile-routing suite) + plugin vm test pinning that bot opens pass the exported budget.

## Validation
| | Result |
|---|---|
| profile-routing suite | 46/46 (incl. the PR's new fake-timer tests) |
| plugin vm tests | 5/5 |
| eslint (changed files) | 0 errors |
| premise | `BOT_CHAT_SESSION_HYDRATION_TIMEOUT_MS` absent on main (verified) |

**Live check (real Electron + backends):** on this branch the exported budget reads 60000 in the live renderer and a bot open through the full click path mounts cleanly with no premature Retry toast. (A true 63s cold start isn't reproducible on this dev box — the fake-timer tests pin both boundary behaviors.)

Follow-up to #89556 (closed today — its desktop hang fix landed as 3a50a6bea8; this covers the slow-cold-start tail). Original PR #94282 to be closed with credit after merge.

## Infographic

![60 seconds to wake](https://v3b.fal.media/files/b/0aa7f587/9cjkoLM_KLuM5qBEz9mxO_cSyoMjJM.png)
