### PR TITLE
feat(claude): 위험한 Bash 명령어 차단 훅 추가

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool. Blocks a fixed list of destructive
+# command patterns before they execute. Registered on the "Bash" matcher
+# in .claude/settings.local.json.
+#
+# Input:  hook payload JSON on stdin, e.g. {"tool_name":"Bash","tool_input":{"command":"..."}}
+# Output: on a match, JSON on stdout telling Claude Code to deny the call.
+#         On no match, prints nothing and exits 0 so the command proceeds.
+#
+# This is a pattern-based heuristic, not a shell parser — it can be evaded
+# by sufficiently obfuscated input and can over-block safe commands that
+# merely contain a matching substring (e.g. inside a quoted string). Treat
+# it as a safety net, not a security boundary.
+
+set -euo pipefail
+
+input="$(cat)"
+command="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+deny() {
+  # $1 = human-readable reason shown to the user/model.
+  jq -n --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# 1. rm -rf and equivalents: combined flag cluster in either order
+#    (-rf, -fr, -Rf, -rfv, -vrf, ...) plus the long-form pair split across
+#    separate flags (-r --force, --recursive -f, --recursive --force, ...).
+if printf '%s' "$command" | grep -Eqi -- 'rm[[:space:]]+(-[a-z]*r[a-z]*f[a-z]*|-[a-z]*f[a-z]*r[a-z]*)\b'; then
+  deny "재귀+강제 삭제(rm -rf 계열) 명령은 차단됩니다: $command"
+fi
+if printf '%s' "$command" | grep -Eqi -- 'rm\b.*(--recursive\b|-[a-z]*r[a-z]*\b)' \
+  && printf '%s' "$command" | grep -Eqi -- 'rm\b.*(--force\b|-[a-z]*f[a-z]*\b)'; then
+  deny "재귀+강제 삭제(rm -rf 계열) 명령은 차단됩니다: $command"
+fi
+
+# 2. git push --force / -f / --force-with-lease / --force-if-includes
+if printf '%s' "$command" | grep -Eqi -- 'git[[:space:]]+push\b.*(--force([a-z-]*)?\b|[[:space:]]-f([[:space:]]|$))'; then
+  deny "강제 푸시(git push --force 계열) 명령은 차단됩니다: $command"
+fi
+
+# 3. DROP TABLE (SQL)
+if printf '%s' "$command" | grep -Eqi -- '\bdrop[[:space:]]+table\b'; then
+  deny "DROP TABLE 명령은 차단됩니다: $command"
+fi
+
+# 4. dd if=... (raw disk/device writes)
+if printf '%s' "$command" | grep -Eqi -- '\bdd\b.*\bif='; then
+  deny "dd if= 명령은 차단됩니다: $command"
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,8 @@ infographics/
 infograficos/
 infografico/
 native/fts5_cjk/*.so
+# Personal Claude Code hook/permission overrides — not shared with the team.
+.claude/settings.local.json
 # Runtime marker written by hermes update when a lazy dependency refresh is
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).


### PR DESCRIPTION
## 요약
- Bash 도구 실행 전 파괴적인 명령어 패턴을 차단하는 `PreToolUse` 훅 로직을 `.claude/hooks/block-dangerous-commands.sh`로 분리했습니다.
- 차단 대상 패턴:
  - `rm -rf` 계열 (`-rf`, `-fr`, `-Rf`, 분리된 `-r --force` 등 플래그 순서 무관)
  - `git push --force` 계열 (`--force`, `-f`, `--force-with-lease`, `--force-if-includes`)
  - `DROP TABLE` (대소문자 무관)
  - `dd if=` (원본 디스크/디바이스 쓰기)
- 훅 활성화 설정(`.claude/settings.local.json`)은 개인 설정이라 `.gitignore`에 추가해 커밋 대상에서 제외했습니다. 스크립트 자체는 커밋되므로 다른 기여자도 각자의 로컬 설정에서 재사용할 수 있습니다.

## 동작 방식
- 스크립트는 훅 stdin으로 들어온 JSON에서 `tool_input.command`를 추출해 정규식으로 검사합니다.
- 패턴이 매치되면 `hookSpecificOutput.permissionDecision: "deny"`를 반환해 Claude Code가 해당 Bash 호출을 차단합니다.
- 패턴 기반 휴리스틱이므로 완벽한 보안 경계가 아니라 안전망(safety net)입니다. 문자열 안에 패턴이 우연히 포함된 안전한 명령(예: `echo "rm -rf ..."`)도 차단될 수 있는 트레이드오프를 의도적으로 감수했습니다.

## 테스트
- `rm -rf`, `rm -fr`, `rm -r --force`, `git push --force`, `git push -f`, `git push --force-with-lease`, `DROP TABLE`(대소문자 변형 포함), `dd if=...` 등 위험 패턴 케이스 모두 차단 확인
- `ls`, `rm foo.txt`, `git push origin main` 등 일반 명령은 통과 확인
- `jq -e`로 훅 JSON 출력 스키마 검증 완료

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01NofwuEDMabz4kABWKGn227