### PR TITLE
feat(a2a): hermes-gateway peer transport — call hosted Hermes instances through their dashboard auth

### DIFF
--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -40,6 +40,42 @@ The agent gets five tools:
 - `a2a_orchestrate(capability, message, mode?)` — fan-out a task to every
   peer advertising a capability (`all` / `first` / `best`).
 
+### Calling hosted Hermes instances (`transport: hermes-gateway`)
+
+A peer that is itself a Hermes instance with a dashboard (Hermes Cloud, or
+anything running `hermes dashboard`) doesn't need to run the A2A listener —
+it already exposes an authenticated conversation API. Point a peer at it with
+the `hermes-gateway` transport:
+
+```yaml
+a2a_agents:
+  team-monitor:
+    url: "https://my-instance.example.com"
+    transport: hermes-gateway
+    timeout: 420          # heavy queries (DB scans) can run minutes
+    capabilities: [analytics]
+```
+
+Then sign in once (browser opens; RFC 8252 loopback + PKCE — the same flow
+the desktop app uses):
+
+```bash
+hermes a2a login team-monitor
+hermes a2a status          # list stored credentials (no secrets shown)
+```
+
+After that, `a2a_call` / `a2a_orchestrate` / `a2a_history` work unchanged and
+unattended — access tokens refresh automatically (rotated refresh tokens are
+persisted). Tokens live in `~/.hermes/credentials/a2a-gateway-tokens.json`
+(0600), a separate token family from the desktop app's connections, so UI
+actions there can't break agent access.
+
+Semantics worth knowing: the credential acts as the user who signed in, with
+that user's permissions on the peer; each call lands as a durable, honestly
+titled session in the peer's own history; `context_id` is the peer's session
+id, and passing it back continues that session. Revocation is on the peer's
+auth provider side (deleting the local file just stops this client).
+
 ## Inbound — be callable
 
 When the `a2a` platform is enabled, Hermes serves a v1.0 Agent Card at

--- a/plugins/platforms/a2a/__init__.py
+++ b/plugins/platforms/a2a/__init__.py
@@ -104,7 +104,26 @@ def register(ctx) -> None:
     except Exception:
         logger.warning("A2A: failed to register client tools", exc_info=True)
 
-    # 2) Inbound platform adapter.
+    # 2) CLI: `hermes a2a login <peer>` / `hermes a2a status` — auth for peers
+    #    using the hermes-gateway transport (hosted Hermes instances).
+    try:
+        from .gateway_transport import handle_cli, setup_cli
+        ctx.register_cli_command(
+            name="a2a",
+            help="A2A peer auth (hermes-gateway transport): login, status",
+            setup_fn=setup_cli,
+            handler_fn=handle_cli,
+            description=(
+                "Manage credentials for a2a_agents peers with transport: "
+                "hermes-gateway. 'login' runs a one-time browser sign-in "
+                "against the peer's dashboard; 'status' lists stored "
+                "credentials without revealing them."
+            ),
+        )
+    except Exception:
+        logger.warning("A2A: failed to register CLI command", exc_info=True)
+
+    # 3) Inbound platform adapter.
     try:
         from .adapter import A2AAdapter
         ctx.register_platform(

--- a/plugins/platforms/a2a/gateway_transport.py
+++ b/plugins/platforms/a2a/gateway_transport.py
@@ -1,0 +1,561 @@
+"""
+hermes-gateway transport for A2A client tools.
+
+Lets ``a2a_call`` (and friends) reach a peer that is a *hosted Hermes instance*
+— anything running ``hermes dashboard`` / Hermes Cloud — through the
+authenticated conversation API that instance already exposes, instead of
+requiring the peer to run the A2A listener with static bearer tokens.
+
+Peer config (config.yaml)::
+
+    a2a_agents:
+      hmb:
+        url: "https://my-instance.example.com"
+        transport: hermes-gateway     # default is "a2a"
+        timeout: 420
+
+Auth is the gateway's RFC 8252 native-app flow (the same one the desktop app
+uses): a one-time interactive ``hermes a2a login <peer>`` opens the system
+browser, catches the redirect on a loopback listener, exchanges the code with
+PKCE, and stores the token set under ``~/.hermes/credentials/`` (0600). After
+that, calls are unattended: the access token is refreshed on expiry and the
+rotated refresh token is persisted back (rotation means a skipped save-back
+kills the credential).
+
+Wire sequence per call:
+
+    POST /api/auth/ws-ticket  (Bearer access token)  -> single-use ~30s ticket
+    WSS  /api/ws?ticket=...                          -> JSON-RPC
+      session.create {cols, source}                  -> {session_id}
+      session.title  {session_id, title}             (best effort)
+      prompt.submit  {session_id, text}              (returns immediately)
+      ... wait for notification:
+          {"method":"event","params":{"type":"message.complete",
+           "session_id"|"sid":..., "payload":{"text":..., "status":...}}}
+      session.close  {session_id}
+
+Field notes baked in (each cost a debugging cycle against a live deployment):
+CDNs in front of some dashboards 403 Python's default User-Agent (HTML body
+``error code: 1010``) — send a browser UA everywhere including the WS upgrade;
+the WSS route can hang at TCP connect over IPv6 while HTTPS works — connect via
+an IPv4-resolved socket; tickets are single-use, mint one per connect; replies
+are JSON-RPC *notifications*, not responses — unwrap ``params``.
+
+Stdlib + the ``websockets`` package (already a core dependency, used by the
+relay transport). Tokens and tickets are never logged.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import logging
+import os
+import secrets
+import socket
+import ssl
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+TRANSPORT_NAME = "hermes-gateway"
+
+# Some deployments front the dashboard with a CDN that rejects Python's
+# default urllib UA outright (403, body "error code: 1010"). A browser UA is
+# required on every request, including the WebSocket upgrade.
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+)
+
+_LOGIN_TIMEOUT_S = 300
+_TICKET_TIMEOUT_S = 30
+_RPC_TIMEOUT_S = 60
+_TOKEN_SKEW_S = 60
+
+_DONE_HTML = (
+    b'<!doctype html><meta charset="utf-8"><title>Signed in</title>'
+    b'<body style="font:15px system-ui;margin:3rem;text-align:center">'
+    b"<h2>&#10003; Signed in</h2><p>This credential belongs to your Hermes "
+    b"agent. You can close this window.</p>"
+    b"<script>setTimeout(()=>window.close(),800)</script>"
+)
+
+
+# --------------------------------------------------------------------------
+# Credential store
+# --------------------------------------------------------------------------
+
+def _store_path() -> Path:
+    home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+    return home / "credentials" / "a2a-gateway-tokens.json"
+
+
+def _load_store() -> dict:
+    try:
+        return json.loads(_store_path().read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_store(store: dict) -> None:
+    path = _store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        json.dump(store, fh, indent=1)
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _normalize_token_response(body: dict, fallback_refresh: str = "") -> dict:
+    """Accept both snake_case (gateway) and camelCase shapes; validate."""
+    access = str(body.get("access_token") or body.get("accessToken") or "")
+    if not access:
+        raise ValueError("gateway token response missing access_token")
+    expires_at = body.get("expires_at") or body.get("expiresAt")
+    if not expires_at:
+        expires_at = time.time() + int(body.get("expires_in") or 3300)
+    return {
+        "accessToken": access,
+        "refreshToken": str(
+            body.get("refresh_token") or body.get("refreshToken") or fallback_refresh
+        ),
+        "expiresAt": int(expires_at),
+        "provider": str(body.get("provider") or ""),
+        "userId": str(body.get("user_id") or body.get("userId") or ""),
+    }
+
+
+def stored_credential(base_url: str) -> Optional[dict]:
+    return _load_store().get(base_url.rstrip("/"))
+
+
+# --------------------------------------------------------------------------
+# HTTP helpers (urllib, browser UA, JSON)
+# --------------------------------------------------------------------------
+
+def _http_json(
+    url: str,
+    body: Optional[dict] = None,
+    bearer: str = "",
+    timeout: int = 30,
+) -> dict:
+    headers = {"User-Agent": _UA, "Accept": "application/json"}
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode("utf-8")
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST" if body is not None else "GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (operator-configured peer)
+        return json.loads(resp.read().decode("utf-8") or "{}")
+
+
+def _auth_endpoint(base_url: str, leaf: str) -> str:
+    parsed = urllib.parse.urlsplit(base_url)
+    prefix = parsed.path.rstrip("/")
+    return f"{parsed.scheme}://{parsed.netloc}{prefix}/auth/native/{leaf}"
+
+
+def _api_endpoint(base_url: str, leaf: str) -> str:
+    parsed = urllib.parse.urlsplit(base_url)
+    prefix = parsed.path.rstrip("/")
+    return f"{parsed.scheme}://{parsed.netloc}{prefix}/api/{leaf}"
+
+
+# --------------------------------------------------------------------------
+# Interactive login (RFC 8252: loopback + system browser + PKCE)
+# --------------------------------------------------------------------------
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    captured: dict = {}
+
+    def do_GET(self):  # noqa: N802 - stdlib naming
+        self.send_response(200)
+        self.send_header("content-type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(_DONE_HTML)
+        params = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+        if "code" in params or "error" in params:
+            _CallbackHandler.captured = {k: v[0] for k, v in params.items()}
+
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        return
+
+
+def gateway_supports_native_login(base_url: str) -> tuple[bool, str]:
+    """Probe /api/status for the native_pkce auth flow. Returns (ok, detail)."""
+    try:
+        status = _http_json(_api_endpoint(base_url, "status"), timeout=15)
+    except Exception as e:
+        return False, f"cannot reach {base_url}/api/status: {e}"
+    flows = status.get("auth_flows") or []
+    if "native_pkce" not in flows:
+        return False, f"gateway does not advertise native_pkce (auth_flows={flows})"
+    return True, str(status.get("version") or "")
+
+
+def interactive_login(base_url: str, provider: str = "", open_browser: bool = True) -> dict:
+    """Run the loopback PKCE login against ``base_url`` and persist the tokens.
+
+    Returns the stored credential entry. Raises RuntimeError on failure.
+    """
+    base_url = base_url.rstrip("/")
+    ok, detail = gateway_supports_native_login(base_url)
+    if not ok:
+        raise RuntimeError(detail)
+
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    state = _b64url(secrets.token_bytes(24))
+
+    _CallbackHandler.captured = {}
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    q = {
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "redirect_uri": f"http://127.0.0.1:{port}/callback",
+        "state": state,
+    }
+    if provider:
+        q["provider"] = provider
+    authorize_url = _auth_endpoint(base_url, "authorize") + "?" + urllib.parse.urlencode(q)
+
+    print(f"Opening browser to sign in to {base_url} …")
+    print(f"(loopback listener on 127.0.0.1:{port}; waiting up to {_LOGIN_TIMEOUT_S}s)")
+    if open_browser:
+        webbrowser.open(authorize_url)
+    else:
+        print("\nOpen this URL to sign in:\n\n" + authorize_url + "\n")
+
+    deadline = time.time() + _LOGIN_TIMEOUT_S
+    try:
+        while time.time() < deadline and not _CallbackHandler.captured:
+            time.sleep(0.25)
+    finally:
+        server.shutdown()
+
+    captured = _CallbackHandler.captured
+    if not captured:
+        raise RuntimeError("timed out waiting for the browser callback")
+    if captured.get("error"):
+        raise RuntimeError(
+            f"gateway rejected login: {captured['error']} {captured.get('error_description', '')}"
+        )
+    if captured.get("state") != state:
+        # Never redeem a code that arrived with a mismatched state (CSRF).
+        raise RuntimeError("callback state mismatch — aborted without redeeming the code")
+
+    body = _http_json(
+        _auth_endpoint(base_url, "token"),
+        body={"code": captured["code"], "code_verifier": verifier},
+        timeout=30,
+    )
+    entry = _normalize_token_response(body)
+    store = _load_store()
+    store[base_url] = entry
+    _save_store(store)
+    return entry
+
+
+class CredentialError(RuntimeError):
+    """No usable credential; an interactive ``hermes a2a login`` is needed."""
+
+
+def _fresh_access_token(base_url: str) -> str:
+    """Return a live access token for ``base_url``, refreshing if stale.
+
+    Refresh tokens rotate: the rotated pair is persisted before returning, or
+    the credential would die on the next call.
+    """
+    base_url = base_url.rstrip("/")
+    entry = stored_credential(base_url)
+    if not entry:
+        raise CredentialError(
+            f"no gateway credential for {base_url}. Run: hermes a2a login <peer>"
+        )
+    if int(entry.get("expiresAt") or 0) > time.time() + _TOKEN_SKEW_S:
+        return entry["accessToken"]
+
+    refresh = entry.get("refreshToken") or ""
+    if not refresh:
+        raise CredentialError(
+            f"stored credential for {base_url} has no refresh token. Run: hermes a2a login <peer>"
+        )
+    try:
+        body = _http_json(
+            _auth_endpoint(base_url, "refresh"),
+            body={"refresh_token": refresh, "provider": entry.get("provider") or ""},
+            timeout=30,
+        )
+    except urllib.error.HTTPError as e:
+        if e.code in (400, 401, 403):
+            raise CredentialError(
+                f"refresh rejected (HTTP {e.code}) — credential for {base_url} is dead. "
+                f"Run: hermes a2a login <peer>"
+            ) from e
+        raise
+    new_entry = _normalize_token_response(body, fallback_refresh=refresh)
+    new_entry["provider"] = new_entry["provider"] or entry.get("provider", "")
+    new_entry["userId"] = new_entry["userId"] or entry.get("userId", "")
+    store = _load_store()
+    store[base_url] = new_entry
+    _save_store(store)
+    return new_entry["accessToken"]
+
+
+# --------------------------------------------------------------------------
+# Conversation over the gateway WebSocket
+# --------------------------------------------------------------------------
+
+def _connect_ws(base_url: str, ticket: str):
+    """Open the gateway WebSocket over an IPv4-resolved TLS socket.
+
+    IPv4 is deliberate: the WSS route has been observed hanging at TCP connect
+    over IPv6 while plain HTTPS to the same host worked (happy-eyeballs masks
+    the broken route for urllib but not for a raw socket connect).
+    """
+    from websockets.sync.client import connect  # lazy: core dep, but import cost
+
+    parsed = urllib.parse.urlsplit(base_url)
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    infos = socket.getaddrinfo(host, port, socket.AF_INET, socket.SOCK_STREAM)
+    if not infos:
+        raise OSError(f"no IPv4 address for {host}")
+    addr = infos[0][4]
+    sock = socket.create_connection((str(addr[0]), int(addr[1])), timeout=30)
+
+    ssl_context = None
+    if parsed.scheme == "https":
+        ssl_context = ssl.create_default_context()  # verifies cert + hostname
+
+    ws_url = f"{'wss' if parsed.scheme == 'https' else 'ws'}://{parsed.netloc}"
+    prefix = parsed.path.rstrip("/")
+    ws_url += f"{prefix}/api/ws?ticket={urllib.parse.quote(ticket)}"
+
+    return connect(
+        ws_url,
+        sock=sock,
+        ssl=ssl_context,
+        server_hostname=host if ssl_context else None,
+        additional_headers={"User-Agent": _UA},
+        open_timeout=30,
+        close_timeout=10,
+        max_size=16 * 1024 * 1024,
+    )
+
+
+def _rpc(ws, counter: list, method: str, params: dict, timeout: float = _RPC_TIMEOUT_S) -> dict:
+    counter[0] += 1
+    req_id = f"a2agw{counter[0]}"
+    ws.send(json.dumps({"id": req_id, "method": method, "params": params}))
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            raw = ws.recv(timeout=max(0.5, deadline - time.time()))
+        except TimeoutError:
+            continue
+        msg = json.loads(raw)
+        if msg.get("id") == req_id:
+            if msg.get("error"):
+                raise RuntimeError(f"{method}: {json.dumps(msg['error'])[:300]}")
+            return msg.get("result") or {}
+        # Anything else is an event/notification for someone else — skip.
+    raise TimeoutError(f"{method} timed out after {timeout}s")
+
+
+def send_gateway_task(
+    agent_label: str,
+    peer: dict,
+    message: str,
+    session_title: str = "",
+    resume_session_id: str = "",
+) -> tuple[str, str, str]:
+    """Send ``message`` to a hermes-gateway peer; wait for the reply.
+
+    Returns ``(reply_text, session_id, state)`` — the session_id doubles as the
+    context handle reported back to the caller (pass it back as
+    ``resume_session_id`` to continue the same conversation on the peer).
+    ``state`` is "completed" or "failed" to mirror the A2A short states.
+    """
+    base_url = str(peer.get("url") or "").rstrip("/")
+    if not base_url:
+        raise ValueError("peer has no url")
+    timeout = int(peer.get("timeout") or 420)
+
+    token = _fresh_access_token(base_url)
+
+    # Tickets are single-use with a short TTL: mint immediately before connect.
+    ticket_body = _http_json(
+        _api_endpoint(base_url, "auth/ws-ticket"),
+        body={},
+        bearer=token,
+        timeout=_TICKET_TIMEOUT_S,
+    )
+    ticket = str(ticket_body.get("ticket") or "")
+    if not ticket:
+        raise RuntimeError(f"ws-ticket mint failed: {json.dumps(ticket_body)[:200]}")
+
+    ws = _connect_ws(base_url, ticket)
+    counter = [0]
+    session_id = ""
+    try:
+        # Continue the prior session when the caller passes one back; fall
+        # back to a fresh session if the peer no longer accepts it (pruned,
+        # archived, or an old id from before a peer reset).
+        if resume_session_id:
+            try:
+                _rpc(ws, counter, "prompt.submit",
+                     {"session_id": resume_session_id, "text": message}, timeout=60)
+                session_id = resume_session_id
+            except (RuntimeError, TimeoutError) as e:
+                logger.info("a2a gateway: resume of %s failed (%s); starting fresh", resume_session_id, e)
+
+        if not session_id:
+            created = _rpc(ws, counter, "session.create", {"cols": 96, "source": "desktop"}, timeout=45)
+            session_id = str(created.get("session_id") or "")
+            if not session_id:
+                raise RuntimeError(f"session.create returned no session_id: {json.dumps(created)[:200]}")
+
+            # Title the session honestly — it is a durable record on the peer.
+            try:
+                _rpc(ws, counter, "session.title", {
+                    "session_id": session_id,
+                    "title": session_title or f"A2A from {socket.gethostname()}",
+                }, timeout=15)
+            except Exception:
+                pass  # cosmetic
+
+            _rpc(ws, counter, "prompt.submit", {"session_id": session_id, "text": message}, timeout=60)
+
+        reply: Optional[str] = None
+        state = "completed"
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                raw = ws.recv(timeout=min(30.0, max(0.5, deadline - time.time())))
+            except TimeoutError:
+                continue
+            msg = json.loads(raw)
+            params = msg.get("params") if msg.get("method") == "event" else msg
+            if not isinstance(params, dict) or params.get("type") != "message.complete":
+                continue
+            msg_sid = params.get("session_id") or params.get("sid")
+            if msg_sid not in (session_id, None):
+                continue
+            payload = params.get("payload") or {}
+            reply = str(payload.get("text") or "")
+            if payload.get("status") == "error":
+                state = "failed"
+            break
+
+        if reply is None:
+            raise TimeoutError(
+                f"no reply from '{agent_label}' within {timeout}s (heavy queries can "
+                f"exceed the default; raise the peer's 'timeout' in a2a_agents)"
+            )
+        return reply, session_id, state
+    finally:
+        try:
+            if session_id:
+                _rpc(ws, counter, "session.close", {"session_id": session_id}, timeout=10)
+        except Exception:
+            pass
+        try:
+            ws.close()
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------
+# CLI: hermes a2a login <peer> / hermes a2a status
+# --------------------------------------------------------------------------
+
+def _peer_url_from_config(peer_name: str) -> str:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        cfg = {}
+    entry = (cfg.get("a2a_agents") or {}).get(peer_name) or {}
+    return str(entry.get("url") or "").rstrip("/")
+
+
+def setup_cli(subparser) -> None:
+    """argparse wiring for ``hermes a2a …`` (registered by the plugin)."""
+    sub = subparser.add_subparsers(dest="a2a_cmd")
+
+    login = sub.add_parser(
+        "login",
+        help="Sign in to a hermes-gateway A2A peer (one-time browser flow)",
+    )
+    login.add_argument("peer", help="peer name from a2a_agents, or a full https:// URL")
+    login.add_argument("--provider", default="", help="auth provider id (omit to let the gateway pick)")
+    login.add_argument("--no-browser", action="store_true", help="print the sign-in URL instead of opening a browser")
+
+    sub.add_parser("status", help="Show stored hermes-gateway credentials (no secrets)")
+
+
+def handle_cli(args) -> int:
+    cmd = getattr(args, "a2a_cmd", None)
+    if cmd == "login":
+        target = args.peer
+        base_url = target if target.startswith(("http://", "https://")) else _peer_url_from_config(target)
+        if not base_url:
+            print(
+                f"Unknown peer '{target}': not a URL and not found under a2a_agents in config.yaml."
+            )
+            return 1
+        try:
+            entry = interactive_login(base_url, provider=args.provider, open_browser=not args.no_browser)
+        except Exception as e:
+            print(f"Login failed: {e}")
+            return 1
+        expiry = time.strftime("%Y-%m-%d %H:%M:%SZ", time.gmtime(entry["expiresAt"]))
+        print(f"Signed in to {base_url}")
+        print(f"  user     : {entry['userId'] or '(not reported)'}")
+        print(f"  expires  : {expiry} (auto-refreshed on use)")
+        print(f"  refresh  : {'yes' if entry['refreshToken'] else 'NO — re-login will be needed'}")
+        print(f"  store    : {_store_path()}")
+        return 0
+
+    if cmd == "status":
+        store = _load_store()
+        if not store:
+            print(f"No gateway credentials stored ({_store_path()}).")
+            return 0
+        now = time.time()
+        for url, entry in store.items():
+            exp = int(entry.get("expiresAt") or 0)
+            live = "live" if exp > now else "expired (auto-refresh on next use)"
+            expiry = time.strftime("%Y-%m-%d %H:%M:%SZ", time.gmtime(exp)) if exp else "?"
+            print(f"{url}")
+            print(f"  user: {entry.get('userId') or '?'}  access: {live}  expires: {expiry}")
+            print(f"  refresh token: {'present' if entry.get('refreshToken') else 'MISSING'}")
+        return 0
+
+    print("Usage: hermes a2a login <peer|url> | hermes a2a status")
+    return 1

--- a/plugins/platforms/a2a/gateway_transport.py
+++ b/plugins/platforms/a2a/gateway_transport.py
@@ -102,7 +102,7 @@ def _store_path() -> Path:
 
 def _load_store() -> dict:
     try:
-        return json.loads(_store_path().read_text())
+        return json.loads(_store_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 
@@ -112,7 +112,7 @@ def _save_store(store: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as fh:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
         json.dump(store, fh, indent=1)
     os.replace(tmp, path)
     try:

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -30,7 +30,7 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional, TypedDict
 
-from . import protocol, security
+from . import gateway_transport, protocol, security
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ def _load_config() -> dict:
 def _resolve_peer(agent: str) -> Optional[dict]:
     """Resolve a peer name to {url, auth, timeout, capabilities}, or treat ``agent`` as a URL."""
     if agent.startswith("http://") or agent.startswith("https://"):
-        return {"url": agent, "auth": {}, "timeout": _DEFAULT_TIMEOUT, "capabilities": []}
+        return {"url": agent, "auth": {}, "timeout": _DEFAULT_TIMEOUT, "capabilities": [], "transport": "a2a"}
     cfg = _load_config()
     peers = cfg.get("a2a_agents") or {}
     entry = peers.get(agent)
@@ -65,6 +65,7 @@ def _resolve_peer(agent: str) -> Optional[dict]:
         "timeout": int(entry.get("timeout", _DEFAULT_TIMEOUT)),
         "capabilities": entry.get("capabilities", []) or [],
         "tenant": entry.get("tenant", ""),
+        "transport": str(entry.get("transport", "a2a") or "a2a").strip().lower(),
     }
 
 
@@ -146,12 +147,53 @@ def _short_state(state: str) -> str:
     return state.replace("TASK_STATE_", "").replace("_", "-").lower() if state else ""
 
 
+def _send_gateway_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str]:
+    """hermes-gateway transport leg of _send_task.
+
+    Mirrors the A2A leg's contract and side effects: outbound redaction,
+    audit log, conversation persistence, metrics. The peer's gateway session
+    id serves as the context id. Auth errors surface as ValueError with a
+    hint at ``hermes a2a login`` instead of an HTTP-shaped error, since the
+    fix is a local login rather than a config token.
+    """
+    safe_message = security.redact_outbound(message)
+    task_id = protocol.new_task_id()
+    ctx = context_id or ""
+
+    security.audit("outbound", agent_label, task_id, safe_message)
+    protocol.metrics.outbound_total += 1
+
+    try:
+        reply, session_id, state = gateway_transport.send_gateway_task(
+            agent_label,
+            peer,
+            safe_message,
+            session_title=f"A2A call from peer config '{agent_label}'",
+            resume_session_id=ctx,
+        )
+    except gateway_transport.CredentialError as e:
+        raise ValueError(f"Peer '{agent_label}': {e}") from e
+
+    reply_ctx = session_id or ctx
+    protocol.persist_message(reply_ctx, "user", safe_message, task_id)
+    protocol.persist_message(reply_ctx, "agent", reply, task_id)
+    protocol.metrics.inbound_total += 1
+    return reply, reply_ctx, state
+
+
 def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str]:
     """Send one message/send to a peer. Returns (reply_text, context_id, state).
 
     Raises urllib errors / ValueError for the caller to format. Handles
     outbound redaction, audit, persistence, and metrics.
+
+    Peers with ``transport: hermes-gateway`` are hosted Hermes instances
+    reached over their dashboard conversation API instead of the A2A wire —
+    same redaction/audit/persistence treatment, different transport.
     """
+    if str(peer.get("transport") or "a2a") == gateway_transport.TRANSPORT_NAME:
+        return _send_gateway_task(agent_label, peer, message, context_id)
+
     base_url = peer.get("url", "")
     headers = _auth_header(peer.get("auth", {}) or {})
     timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))

--- a/tests/plugins/test_a2a_gateway_transport.py
+++ b/tests/plugins/test_a2a_gateway_transport.py
@@ -1,0 +1,322 @@
+"""Tests for the A2A hermes-gateway transport.
+
+Covers the credential store (0600, rotation-safe refresh persist), token
+refresh behavior (expiry skew, rotated pair saved back, dead-credential
+surfacing), peer resolution + transport routing in tools._send_task, and an
+end-to-end send_gateway_task conversation against a live in-process mock of
+the dashboard gateway (HTTP ticket endpoint + WebSocket JSON-RPC server).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import stat
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from plugins.platforms.a2a import gateway_transport, tools
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture()
+def cred_home(tmp_path, monkeypatch):
+    """Point the credential store at a temp HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+# --------------------------------------------------------------------------
+# Credential store
+# --------------------------------------------------------------------------
+
+class TestCredentialStore:
+    def test_round_trip_and_permissions(self, cred_home):
+        entry = {"accessToken": "at1", "refreshToken": "rt1", "expiresAt": 123, "provider": "p", "userId": "u"}
+        gateway_transport._save_store({"https://gw.example.com": entry})
+        assert gateway_transport.stored_credential("https://gw.example.com") == entry
+        # trailing slash normalizes to the same entry
+        assert gateway_transport.stored_credential("https://gw.example.com/") == entry
+        mode = stat.S_IMODE(os.stat(gateway_transport._store_path()).st_mode)
+        assert mode == 0o600
+
+    def test_missing_credential_is_none(self, cred_home):
+        assert gateway_transport.stored_credential("https://nowhere.example.com") is None
+
+    def test_normalize_accepts_both_shapes(self):
+        snake = gateway_transport._normalize_token_response(
+            {"access_token": "a", "refresh_token": "r", "expires_at": 5, "user_id": "u"}
+        )
+        camel = gateway_transport._normalize_token_response(
+            {"accessToken": "a", "refreshToken": "r", "expiresAt": 5, "userId": "u"}
+        )
+        assert snake == camel
+
+    def test_normalize_requires_access_token(self):
+        with pytest.raises(ValueError):
+            gateway_transport._normalize_token_response({"refresh_token": "r"})
+
+
+# --------------------------------------------------------------------------
+# Token refresh
+# --------------------------------------------------------------------------
+
+class TestTokenRefresh:
+    BASE = "https://gw.example.com"
+
+    def _store(self, expires_in: float, refresh: str = "rt-old"):
+        gateway_transport._save_store({
+            self.BASE: {
+                "accessToken": "at-old",
+                "refreshToken": refresh,
+                "expiresAt": int(time.time() + expires_in),
+                "provider": "nous",
+                "userId": "u1",
+            }
+        })
+
+    def test_live_token_used_without_refresh(self, cred_home, monkeypatch):
+        self._store(expires_in=3600)
+        monkeypatch.setattr(
+            gateway_transport, "_http_json",
+            lambda *a, **k: pytest.fail("refresh should not be called for a live token"),
+        )
+        assert gateway_transport._fresh_access_token(self.BASE) == "at-old"
+
+    def test_stale_token_refreshes_and_persists_rotation(self, cred_home, monkeypatch):
+        self._store(expires_in=10)  # inside the 60s skew -> refresh
+        calls = {}
+
+        def fake_http(url, body=None, bearer="", timeout=0):
+            calls["url"] = url
+            calls["body"] = body
+            return {"access_token": "at-new", "refresh_token": "rt-new", "expires_in": 3300}
+
+        monkeypatch.setattr(gateway_transport, "_http_json", fake_http)
+        token = gateway_transport._fresh_access_token(self.BASE)
+        assert token == "at-new"
+        assert calls["url"].endswith("/auth/native/refresh")
+        assert calls["body"]["refresh_token"] == "rt-old"
+        # Rotation persisted: the store now holds the NEW pair.
+        stored = gateway_transport.stored_credential(self.BASE)
+        assert stored["refreshToken"] == "rt-new"
+        assert stored["accessToken"] == "at-new"
+
+    def test_no_credential_raises_credential_error(self, cred_home):
+        with pytest.raises(gateway_transport.CredentialError):
+            gateway_transport._fresh_access_token(self.BASE)
+
+    def test_dead_refresh_raises_credential_error(self, cred_home, monkeypatch):
+        import urllib.error
+
+        self._store(expires_in=-100)
+
+        def fake_http(url, body=None, bearer="", timeout=0):
+            raise urllib.error.HTTPError(url, 401, "unauthorized", None, None)
+
+        monkeypatch.setattr(gateway_transport, "_http_json", fake_http)
+        with pytest.raises(gateway_transport.CredentialError):
+            gateway_transport._fresh_access_token(self.BASE)
+
+
+# --------------------------------------------------------------------------
+# Peer resolution + transport routing
+# --------------------------------------------------------------------------
+
+class TestTransportRouting:
+    def test_resolve_peer_default_transport_is_a2a(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: {
+            "a2a_agents": {"plain": {"url": "http://localhost:9999"}}
+        })
+        peer = tools._resolve_peer("plain")
+        assert peer["transport"] == "a2a"
+
+    def test_resolve_peer_gateway_transport(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: {
+            "a2a_agents": {
+                "hosted": {"url": "https://gw.example.com", "transport": "hermes-gateway"}
+            }
+        })
+        peer = tools._resolve_peer("hosted")
+        assert peer["transport"] == gateway_transport.TRANSPORT_NAME
+
+    def test_url_peer_defaults_to_a2a_transport(self):
+        peer = tools._resolve_peer("https://direct.example.com")
+        assert peer["transport"] == "a2a"
+
+    def test_send_task_routes_gateway_transport(self, monkeypatch):
+        sent = {}
+
+        def fake_gateway_send(label, peer, message, session_title="", resume_session_id=""):
+            sent["label"] = label
+            sent["message"] = message
+            sent["resume"] = resume_session_id
+            return "hello from peer", "sess-1", "completed"
+
+        monkeypatch.setattr(gateway_transport, "send_gateway_task", fake_gateway_send)
+        peer = {"url": "https://gw.example.com", "transport": "hermes-gateway", "timeout": 5}
+        reply, ctx, state = tools._send_task("hosted", peer, "ping", "")
+        assert reply == "hello from peer"
+        assert ctx == "sess-1"
+        assert state == "completed"
+        assert sent["label"] == "hosted"
+        # Outbound redaction ran (message arrives, possibly transformed).
+        assert "ping" in sent["message"]
+
+    def test_send_task_gateway_passes_context_for_resume(self, monkeypatch):
+        seen = {}
+
+        def fake_gateway_send(label, peer, message, session_title="", resume_session_id=""):
+            seen["resume"] = resume_session_id
+            return "ok", resume_session_id or "sess-new", "completed"
+
+        monkeypatch.setattr(gateway_transport, "send_gateway_task", fake_gateway_send)
+        peer = {"url": "https://gw.example.com", "transport": "hermes-gateway"}
+        _, ctx, _ = tools._send_task("hosted", peer, "again", "sess-prior")
+        assert seen["resume"] == "sess-prior"
+        assert ctx == "sess-prior"
+
+    def test_credential_error_surfaces_as_value_error(self, monkeypatch):
+        def fake_gateway_send(label, peer, message, session_title="", resume_session_id=""):
+            raise gateway_transport.CredentialError("no gateway credential — run hermes a2a login")
+
+        monkeypatch.setattr(gateway_transport, "send_gateway_task", fake_gateway_send)
+        peer = {"url": "https://gw.example.com", "transport": "hermes-gateway"}
+        with pytest.raises(ValueError, match="hermes a2a login"):
+            tools._send_task("hosted", peer, "ping", "")
+
+    def test_a2a_call_reports_login_hint(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: {
+            "a2a_agents": {"hosted": {"url": "https://gw.example.com", "transport": "hermes-gateway"}}
+        })
+
+        def fake_gateway_send(label, peer, message, session_title="", resume_session_id=""):
+            raise gateway_transport.CredentialError("no gateway credential. Run: hermes a2a login <peer>")
+
+        monkeypatch.setattr(gateway_transport, "send_gateway_task", fake_gateway_send)
+        out = tools.a2a_call({"agent": "hosted", "message": "ping"})
+        assert "hermes a2a login" in out
+
+
+# --------------------------------------------------------------------------
+# End-to-end: send_gateway_task against a live mock gateway
+# --------------------------------------------------------------------------
+
+class _TicketHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path.endswith("/api/auth/ws-ticket"):
+            body = json.dumps({"ticket": "tik-1"}).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+
+@pytest.mark.integration
+class TestGatewayConversationE2E:
+    """Real HTTP ticket mint + real WebSocket JSON-RPC round trip."""
+
+    def _start_ws_server(self, port: int, behavior: str = "normal"):
+        """Serve one gateway-ish WS connection: session.create/title/prompt.submit,
+        then emit a message.complete event, honoring the JSON-RPC id contract."""
+        from websockets.sync.server import serve
+
+        def handler(ws):
+            session_id = "gw-sess-1"
+            for raw in ws:
+                msg = json.loads(raw)
+                method, req_id = msg.get("method"), msg.get("id")
+                params = msg.get("params") or {}
+                if method == "session.create":
+                    ws.send(json.dumps({"id": req_id, "result": {"session_id": session_id}}))
+                elif method == "session.title":
+                    ws.send(json.dumps({"id": req_id, "result": {}}))
+                elif method == "prompt.submit":
+                    if behavior == "resume-reject" and params.get("session_id") != session_id:
+                        ws.send(json.dumps({"id": req_id, "error": {"message": "unknown session"}}))
+                        continue
+                    ws.send(json.dumps({"id": req_id, "result": {}}))
+                    # Interleave an unrelated event first — clients must skip it.
+                    ws.send(json.dumps({"method": "event", "params": {"type": "gateway.ready"}}))
+                    ws.send(json.dumps({
+                        "method": "event",
+                        "params": {
+                            "type": "message.complete",
+                            "session_id": params.get("session_id") or session_id,
+                            "payload": {"text": "reply-from-gateway", "status": "complete"},
+                        },
+                    }))
+                elif method == "session.close":
+                    ws.send(json.dumps({"id": req_id, "result": {}}))
+                    return
+
+        server = serve(handler, "127.0.0.1", port)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server
+
+    @pytest.fixture()
+    def mock_gateway(self, cred_home, monkeypatch):
+        http_port, ws_port = _free_port(), _free_port()
+        httpd = HTTPServer(("127.0.0.1", http_port), _TicketHandler)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        ws_server = self._start_ws_server(ws_port)
+
+        base_url = f"http://127.0.0.1:{http_port}"
+        gateway_transport._save_store({
+            base_url: {
+                "accessToken": "at-live",
+                "refreshToken": "rt",
+                "expiresAt": int(time.time() + 3600),
+                "provider": "nous",
+                "userId": "u1",
+            }
+        })
+
+        # Route the WS connect at the WS server (the mock's HTTP and WS live
+        # on different ports, unlike a real gateway behind one origin).
+        real_connect = gateway_transport._connect_ws
+
+        def patched_connect(url, ticket):
+            from websockets.sync.client import connect
+            assert ticket == "tik-1"
+            return connect(f"ws://127.0.0.1:{ws_port}/api/ws?ticket={ticket}", open_timeout=10)
+
+        monkeypatch.setattr(gateway_transport, "_connect_ws", patched_connect)
+        yield base_url
+        httpd.shutdown()
+        ws_server.shutdown()
+
+    def test_full_round_trip(self, mock_gateway):
+        peer = {"url": mock_gateway, "timeout": 15}
+        reply, session_id, state = gateway_transport.send_gateway_task("mock", peer, "hello")
+        assert reply == "reply-from-gateway"
+        assert session_id == "gw-sess-1"
+        assert state == "completed"
+
+    def test_resume_uses_prior_session(self, mock_gateway):
+        peer = {"url": mock_gateway, "timeout": 15}
+        reply, session_id, state = gateway_transport.send_gateway_task(
+            "mock", peer, "hello again", resume_session_id="gw-sess-1"
+        )
+        assert reply == "reply-from-gateway"
+        assert session_id == "gw-sess-1"
+        assert state == "completed"

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -64,6 +64,30 @@ a2a_agents:
 
 Then just ask: *"Ask the researcher agent to summarize today's arXiv postings."* Direct URLs work too — `a2a_call` accepts any A2A endpoint.
 
+### Calling hosted Hermes instances (`transport: hermes-gateway`)
+
+A peer that is itself a Hermes instance with a dashboard (Hermes Cloud, or anything running `hermes dashboard`) doesn't need to run the A2A listener — it already exposes an authenticated conversation API. Declare the peer with the `hermes-gateway` transport:
+
+```yaml
+a2a_agents:
+  team-monitor:
+    url: "https://my-instance.example.com"
+    transport: hermes-gateway   # default is "a2a"
+    timeout: 420                # heavy queries (DB scans) can run minutes
+    capabilities: [analytics]
+```
+
+Sign in once — a browser opens for the gateway's own login (RFC 8252 loopback + PKCE, the same flow the desktop app uses):
+
+```bash
+hermes a2a login team-monitor
+hermes a2a status              # list stored credentials (no secrets shown)
+```
+
+After that the same tools work unchanged and unattended over either transport. Access tokens refresh automatically; credentials live in `~/.hermes/credentials/a2a-gateway-tokens.json` (0600), independent of the desktop app's own connections.
+
+Worth knowing: the credential acts as the user who signed in, with that user's permissions on the peer; each call lands as a durable, honestly titled session in the peer's history; `context_id` is the peer's session id, and passing it back continues that session. Revoke on the peer's auth provider side — deleting the local file only stops this client.
+
 ## Inbound: being callable
 
 With the platform enabled, Hermes serves:


### PR DESCRIPTION
a2a_call and friends currently require the peer to run the A2A listener (agent card, port 9900, static bearer or per-peer tokens). But a peer that is itself a hosted Hermes instance — Hermes Cloud, or anything running `hermes dashboard` — already exposes an authenticated conversation API with per-user OAuth. This adds a second peer transport that speaks it, so a team instance becomes callable by the agent without the operator standing up a parallel A2A listener with a weaker static-token auth story (#80534 shows where that path leads behind reverse proxies).

```yaml
a2a_agents:
  team-monitor:
    url: "https://<instance>.example.com"
    transport: hermes-gateway   # default stays "a2a"
```

One-time auth: `hermes a2a login team-monitor` (RFC 8252 loopback + PKCE against the gateway's /auth/native/* endpoints — the same flow the desktop app uses, ported to stdlib Python). Tokens land in `~/.hermes/credentials/a2a-gateway-tokens.json` (0600, atomic writes); access tokens refresh on use and the rotated refresh token is persisted back. `hermes a2a status` lists credentials without revealing them.

After that, the existing tools work unchanged: `_send_task` branches on the peer's transport, so a2a_call / a2a_orchestrate / a2a_history get the same outbound redaction, audit log, conversation persistence, and metrics on both legs. The gateway leg mints a single-use ws-ticket, opens the gateway WebSocket, runs session.create → session.title (honest attribution — the session is a durable record on the peer) → prompt.submit, waits for the message.complete event, and closes. `context_id` is the peer's session id; passing it back resumes that session, with a clean fallback to a fresh one if the peer no longer accepts it.

Transport details that came from running this against a live hosted instance rather than from specs: a browser User-Agent on every request including the WS upgrade (some deployments front the dashboard with a CDN that 403s Python's default UA with body `error code: 1010`); the WS connect goes over an IPv4-resolved socket (the WSS route has hung at TCP connect on IPv6 while HTTPS to the same host worked); tickets are minted immediately before each connect (single-use, ~30s TTL); replies are matched as JSON-RPC notifications (`method: "event"`, `params.type: "message.complete"`), skipping unrelated frames like `gateway.ready`.

No new model tools, no core edits: the CLI subcommand rides `ctx.register_cli_command`, everything else stays inside the plugin. Uses the `websockets` package already in core deps (the relay transport uses it); stdlib otherwise.

Closes #95981.

Testing: 17 new tests in tests/plugins/test_a2a_gateway_transport.py — credential store round-trip and 0600 perms, both token-response shapes, refresh-on-expiry with rotation persisted, dead-refresh surfacing as a login hint, transport routing through _resolve_peer/_send_task including context resume and the CredentialError → user-facing hint path, plus two integration tests running the full conversation against a live in-process mock gateway (real HTTP ticket endpoint, real WebSocket JSON-RPC server, interleaved unrelated events). Existing A2A suites: 151 passed, unchanged. Plugin registration smoke-tested (5 tools + cli + platform). Also verified end to end against a real hosted instance: the branch's _send_task with a `transport: hermes-gateway` peer completed a live round-trip ("a2a gateway transport E2E OK") against a production Hermes Cloud dashboard.
