### PR TITLE
fix(codex): skip empty-content following item when tool calls exist

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -701,9 +701,27 @@ def _chat_messages_to_responses_input(
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
                     # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
-                    item_sources.append(msg)
+                    # following item — UNLESS valid tool calls follow, which
+                    # already satisfy the following-item requirement (and some
+                    # Responses backends, e.g. Volcengine Ark plan endpoints,
+                    # reject empty-content messages with HTTP 400
+                    # missing `input.content`).
+                    _has_valid_tool_calls = False
+                    _tcs = msg.get("tool_calls")
+                    if isinstance(_tcs, list):
+                        for _tc in _tcs:
+                            if not isinstance(_tc, dict):
+                                continue
+                            _fn = _tc.get("function", {})
+                            if (
+                                isinstance(_fn.get("name"), str)
+                                and _fn.get("name").strip()
+                            ):
+                                _has_valid_tool_calls = True
+                                break
+                    if not _has_valid_tool_calls:
+                        items.append({"role": "assistant", "content": ""})
+                        item_sources.append(msg)
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):


### PR DESCRIPTION
## Problem

When an assistant message carries only encrypted reasoning (no visible content) plus `tool_calls`, `_chat_messages_to_responses_input` appends an empty `{"role": "assistant", "content": ""}` item as the required following item for the replayed reasoning item.

Some Responses backends reject empty-content message items. Reproduced live against the Volcengine Ark Agent Plan endpoint (`https://ark.cn-beijing.volces.com/api/plan/v3/responses`):

- `{"role": "assistant", "content": ""}` (or `[]`, or missing) in `input` -> HTTP 400 `missing input.content` (MissingParameter)
- reasoning item followed directly by `function_call` -> HTTP 200

The `function_call` items emitted right after already satisfy the following-item requirement, so the empty message is both rejected by those backends and unnecessary whenever valid tool calls are present.

## Fix

Only emit the empty assistant message when the assistant message has no valid tool calls (i.e. no `function_call` items will follow the reasoning item). The validity check mirrors the existing tool-call filtering at the `function_call` emission site (name must be a non-empty string).

## Test Plan

- Verified live against the Ark plan endpoint with a real 47-message session: empty-content item count drops 1 -> 0, request returns HTTP 200
- `tests/agent/transports/test_codex_transport.py`, `tests/agent/test_codex_responses_adapter.py`, `tests/run_agent/test_codex_xai_oauth_recovery.py`: 143 passed
