### PR TITLE
fix(desktop): navigate to branched session route

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1602,8 +1602,11 @@ describe('branchStoredSession desktop source tagging', () => {
     await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
 
     // The branch becomes the primary session — this is what routes the main
-    // workspace area to it, not just a new sidebar row.
+    // workspace area to it, not just a new sidebar row. Selection alone is not
+    // enough: leaving the URL on the parent makes chat/index see a permanent
+    // routeSessionMismatch and keeps the central loader mounted.
     expect($selectedStoredSessionId.get()).toBe('branch-stored')
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('branch-stored'), { replace: true })
     // It must not ALSO exist as a tile: a session is either the main thread or
     // a tile, never both (resumeSession closes any tile with the same id).
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(false)
@@ -1655,6 +1658,7 @@ describe('branchStoredSession desktop source tagging', () => {
     // Branching a session that is not the one currently open must not steal
     // the user's active view — "stored-other" stays selected.
     expect($selectedStoredSessionId.get()).toBe('stored-other')
+    expect(navigate).not.toHaveBeenCalled()
     // The branch instead opens as its own tile.
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(true)
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1902,6 +1902,7 @@ export function useSessionActions({
         // unconditionally). resumeSession reuses the runtime warm-cached above
         // (ensureSessionState/updateSessionState) instead of an extra resume RPC.
         if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
+          navigate(sessionRoute(routedSessionId), { replace: true })
           await resumeSession(routedSessionId)
         } else {
           openSessionTile(routedSessionId, 'center')
@@ -1926,6 +1927,7 @@ export function useSessionActions({
       copy,
       creatingSessionRef,
       ensureSessionState,
+      navigate,
       requestGateway,
       resumeSession,
       selectedStoredSessionIdRef,


### PR DESCRIPTION
## Summary

When branching the session already open in the primary workspace, navigate the router to the child session before resuming it.

This is a narrow follow-up to #93663. That change correctly made the child the selected primary session, but the URL could remain on the parent. The primary chat then saw `routeSessionMismatch` and kept its centered loading spinner mounted even though the branched child existed and was readable.

## Root cause

`forkBranch()` called:

```ts
await resumeSession(routedSessionId)
```

`resumeSession()` updates `$selectedStoredSessionId`, but it does not change the route. The resulting state was:

- routed session: parent
- selected session: child
- `routeSessionMismatch`: true

This also let route-resume keep trying to restore the parent instead of converging on the child.

## Change

- Navigate to `sessionRoute(routedSessionId)` with `replace: true` before resuming the child.
- Add a regression assertion to the existing primary-workspace branch test.
- Preserve the background/sidebar branch path unchanged, so branching another session still opens a tile and does not steal focus (#69750).

## Regression proof

With the production `navigate(...)` line temporarily removed, the focused test fails with:

```text
expected navigate to be called with ['/branch-stored', { replace: true }]
Number of calls: 0
```

Restoring the line makes the complete `use-session-actions.test.tsx` suite pass: **83/83**.

## Verification

- `npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx` — 83 passed
- `npm run check` — passed (typecheck, lint, UI, Desktop, platform, and plugin gates; Electron platform tail: 586/586)
- Packaged Desktop manual verification on Linux: branching the current session opened the child immediately; no `Session not found` retry-loop log appeared after waiting beyond the previous retry interval.

## Relationship to existing reports

- Follow-up to #93663 / #93444: completes the main-workspace transition by keeping route and selection aligned.
- Related to #93959, specifically the variant where the child is already durable/readable but the Desktop remains on the loading spinner.
- Does not overlap #94208's gateway persistence fix for seeded branches whose child row does not yet exist.
