### PR TITLE
fix(skills): the dedup stub must mark the read for the review fork guard

### DIFF
--- a/tests/tools/test_skill_view_dedup.py
+++ b/tests/tools/test_skill_view_dedup.py
@@ -92,3 +92,61 @@ class TestSkillViewDedup:
         # conversation_compression imports this lazily; keep the seam stable.
         from tools.skills_tool import reset_skill_view_dedup as f
         f(None)
+
+
+class TestDedupStubMarksReviewRead:
+    """#95976: the stub must satisfy the background review read-before-write guard.
+
+    The guard's read marks are per-review-context (reset each turn), the dedup
+    cache is per-task — so a turn-N re-view stubs out without re-marking and
+    every fork patch is refused. The stub path now marks the verified-unchanged
+    source as read, so the guard sees the current content as loaded.
+    """
+
+    def test_stub_satisfies_read_before_write_guard(self, skills_home, monkeypatch):
+        from tools import skill_manager_tool as smt
+
+        monkeypatch.setattr(
+            "tools.skill_provenance.is_background_review", lambda: True
+        )
+        smt._reset_background_review_read_marks()
+
+        md = skills_home / "skills" / "demo-dedup-skill" / "SKILL.md"
+
+        # Turn 1: full view marks the read; simulate the next review turn by
+        # resetting the per-context marks while the task-level dedup cache
+        # survives.
+        r1 = _view("demo-dedup-skill")
+        assert "Step one" in r1.get("content", "")
+        smt._reset_background_review_read_marks()
+        assert not smt._background_review_has_read(md)
+
+        # Turn 2: the repeat view returns the stub — and must re-mark, or the
+        # fork's patch is refused.
+        r2 = _view("demo-dedup-skill")
+        assert r2.get("dedup") is True
+        assert smt._background_review_has_read(md)
+
+        # The guard that refused every fork patch now passes.
+        guard = smt._background_review_read_before_write_guard(
+            "demo-dedup-skill", md, "patch", "SKILL.md"
+        )
+        assert guard is None
+
+    def test_stub_marks_supporting_file_too(self, skills_home, monkeypatch):
+        from tools import skill_manager_tool as smt
+
+        monkeypatch.setattr(
+            "tools.skill_provenance.is_background_review", lambda: True
+        )
+        smt._reset_background_review_read_marks()
+
+        guide = skills_home / "skills" / "demo-dedup-skill" / "references" / "guide.md"
+
+        r1 = _view("demo-dedup-skill", file_path="references/guide.md")
+        assert "Guide" in r1.get("content", "")
+        smt._reset_background_review_read_marks()
+
+        r2 = _view("demo-dedup-skill", file_path="references/guide.md")
+        assert r2.get("dedup") is True
+        assert smt._background_review_has_read(guide)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2105,6 +2105,23 @@ def _check_skill_view_dedup(task_id, name, file_path) -> str | None:
             except OSError:
                 cache.pop(key, None)
                 return None
+            # The stub proves this exact file was already served to this task
+            # and is unchanged on disk — for the background review fork's
+            # read-before-write guard that counts as a read of the CURRENT
+            # content. The guard's read marks are per-review-context while
+            # this dedup cache is per-task, so without marking here every
+            # turn-N re-view stubs out and the fork's patches get refused
+            # 100% of the time (#95976). mark_... is a no-op outside the
+            # background-review origin.
+            try:
+                from pathlib import Path as _P
+                from tools.skill_manager_tool import (
+                    mark_background_review_skill_read as _mark_read,
+                )
+
+                _mark_read(_P(src))
+            except Exception:
+                pass
             return json.dumps(
                 {
                     "success": True,


### PR DESCRIPTION
## What does this PR do?

The autonomous background review fork (`agent/background_review.py`) failed to update skills **100% of the time**: every `patch`/`write_file` was refused by the read-before-write guard ("the current SKILL.md content has not been loaded in this review turn"), because the two mechanisms keep state on different lifecycles:

- the guard's read marks are **per review context** (reset at each review turn), while
- the `skill_view` repeat-view dedup cache is **per task** (cleared only on context compression).

So turn 1 views the skill (full content + mark), turn 2 re-views the unchanged skill → the dedup path returns the `content_returned: false` stub **without re-marking** → the guard refuses the turn-2 patch. The issue's production telemetry: 408 refusals over a month, zero skill updates, one wasted LLM spin-up per attempt.

Fix: the dedup stub is emitted only after verifying (mtime+size) that the file is unchanged since it was fully served to this task — which is precisely the guard's definition of "current content loaded". `_check_skill_view_dedup` now marks the verified source path via the existing `mark_background_review_skill_read` (a no-op outside the background-review origin), so a stubbed re-view satisfies the guard and the fork's patches go through.

## Related Issue

Fixes #95976

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/skills_tool.py` — `_check_skill_view_dedup` marks the verified-unchanged source as read for the background review fork before returning the stub (function-level import of the existing marker; guarded, best-effort).
- `tests/tools/test_skill_view_dedup.py` (+2 in a new `TestDedupStubMarksReviewRead`): the turn-2 stub re-marks the read and the guard that refused every fork patch now passes (SKILL.md and a supporting reference file).

## How to Test

1. `python -m pytest tests/tools/test_skill_view_dedup.py -q` — should pass (10 passed).
2. Red/green: on unpatched `main`, both new tests fail (the turn-2 stub leaves the mark unset and the guard returns the refusal dict); with this PR they pass.
3. Adjacent guard surfaces unchanged: `python -m pytest tests/tools/test_skill_ledger.py tests/tools/test_skill_manager_tool.py tests/tools/test_file_read_guards.py tests/agent/test_background_review_tool_call_guard.py tests/agent/test_background_review_usage.py -q` — should pass (117 passed).
4. Manual: on a gateway with the background reviewer enabled, let two review turns pass over an unchanged skill — the turn-2 patch now lands instead of logging "Refusing background curator patch".

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the lifecycle mismatch and the verified-unchanged rationale documented at the mark site)
- [x] New and existing unit tests pass locally (2 new; 117 across the guard surfaces)
- [x] Changes are backward compatible (non-review sessions are untouched — the marker is a no-op outside the background-review origin; stub payload unchanged)
