### PR TITLE
fix(acp): sanitize session cwd against nonexistent client paths

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -34,10 +34,23 @@ def _translate_acp_cwd(cwd: str) -> str:
     ``\\\\wsl.localhost\\`` UNC paths. Store and execute against the POSIX form so
     agents, tools, and persisted ACP sessions all agree on the usable workspace.
     Native Linux/macOS keeps the original cwd unchanged.
+
+    Also guards against ACP clients that send a cwd which does not exist on the
+    host actually running Hermes — e.g. the Rabbit R1 node sends a POSIX-style
+    ``/home/yt`` even when Hermes runs on Windows. Pinning a nonexistent cwd
+    makes the terminal tool spawn its probe shells in a bad directory (MSYS
+    bash wedges during init, so the probe never exits and every command hangs).
+    Fall back to a real directory instead.
     """
     from hermes_constants import translate_cwd_for_wsl_backend
 
-    return translate_cwd_for_wsl_backend(str(cwd))
+    translated = translate_cwd_for_wsl_backend(str(cwd))
+    if translated and os.path.isdir(translated):
+        return translated
+    home = os.path.expanduser("~")
+    if home and os.path.isdir(home):
+        return home
+    return os.getcwd()
 
 
 def _normalize_cwd_for_compare(cwd: str | None) -> str:

--- a/tests/acp_adapter/test_session_cwd_sanitize.py
+++ b/tests/acp_adapter/test_session_cwd_sanitize.py
@@ -1,0 +1,35 @@
+"""Regression tests for ACP session cwd sanitization.
+
+The Rabbit R1 node sends a POSIX-style cwd (``/home/yt``) that does not exist
+on the host actually running Hermes (e.g. Windows). Pinning it used to make
+the terminal tool spawn its probe shells in a bad directory — MSYS bash wedges
+during init and every command hangs forever. ``_translate_acp_cwd`` must fall
+back to a real directory instead of trusting the client value blindly.
+"""
+
+import os
+from unittest import mock
+
+from acp_adapter.session import _translate_acp_cwd
+
+
+def test_nonexistent_posix_cwd_falls_back_to_home():
+    # Rabbit R1 sends /home/yt on a Windows host -> must not be pinned.
+    home = os.path.expanduser("~")
+    with mock.patch("hermes_constants.translate_cwd_for_wsl_backend", side_effect=lambda c: c):
+        with mock.patch("acp_adapter.session.os.path.isdir", side_effect=lambda p: p == home):
+            result = _translate_acp_cwd("/home/yt")
+    assert result == home
+    assert os.path.isdir(result)
+
+
+def test_existing_cwd_passes_through():
+    cwd = os.getcwd()
+    assert _translate_acp_cwd(cwd) == cwd
+
+
+def test_falls_back_to_process_cwd_when_home_missing():
+    # Neither the client cwd nor home exist -> process cwd must win.
+    with mock.patch("hermes_constants.translate_cwd_for_wsl_backend", side_effect=lambda c: c):
+        with mock.patch("acp_adapter.session.os.path.isdir", side_effect=lambda p: False):
+            assert _translate_acp_cwd("/home/yt") == os.getcwd()


### PR DESCRIPTION
## Problem

The Rabbit R1 node (rabbitOS 2.3 "Hermes Agent" integration) spawns `hermes acp` on the user's PC and the R1 service sends a POSIX-style cwd (`/home/yt`) in the session initialize request — a path that does not exist on the host actually running Hermes (e.g. Windows).

Pinning that nonexistent cwd as the session/task cwd makes the terminal tool spawn its probe shells in a bad directory: on Windows/MSYS the probe bash (`bash --noprofile --norc -c "/usr/bin/true; /usr/bin/cat --version >/dev/null"`) wedges during MSYS init and never exits. The terminal tool waits forever, the agent never completes its turn, and the R1 shows "thinking" indefinitely. Reproduced live with the R1; sessions only recovered after manually killing the orphaned probe process.

## Fix

`_translate_acp_cwd` now validates the client-supplied cwd on the host actually running Hermes: if the translated path does not exist (`os.path.isdir`), fall back to the user home, then to the process cwd. Because `create_session`, `fork_session`, and `update_cwd` all funnel through this one function, every cwd entry point is covered, and the task-cwd override registered for the terminal tool can never pin a nonexistent directory.

WSL behavior is preserved: a translated `/mnt/...` workspace that exists in WSL passes the isdir check unchanged; a missing path falls back rather than hanging.

## Test

`tests/acp_adapter/test_session_cwd_sanitize.py` covers: nonexistent POSIX cwd → home fallback, existing cwd passthrough, and process-cwd fallback when home is missing.