### PR TITLE
feat(kanban): add atomic exact-task dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -757,6 +757,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
                         help="Cap number of spawns this pass")
+    p_disp.add_argument(
+        "--task-id",
+        default=None,
+        help="Atomically dispatch exactly this task (requires --json)",
+    )
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -2617,6 +2622,23 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
+    task_id = getattr(args, "task_id", None)
+    if task_id and not getattr(args, "json", False):
+        print("kanban dispatch: --task-id requires --json", file=sys.stderr)
+        return 2
+    if task_id and getattr(args, "dry_run", False):
+        print(json.dumps({
+            "capability": "kanban.exact-task-dispatch",
+            "version": 1,
+            "ok": False,
+            "reason": "dry_run_unsupported",
+            "idempotent": False,
+            "selected": None,
+            "claimed": None,
+            "spawned": None,
+            "run": None,
+        }, indent=2))
+        return 2
     # Honour kanban.default_assignee as the fallback for unassigned ready
     # tasks (#27145), kanban.max_in_progress as the global concurrency cap
     # (#33488), kanban.max_in_progress_per_profile as the per-profile
@@ -2658,13 +2680,49 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+    if task_id:
+        with kb.connect_closing() as conn:
+            exact = kb.dispatch_task_once(
+                conn,
+                task_id,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                failure_limit=getattr(
+                    args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+                ),
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+        print(json.dumps({
+            "capability": "kanban.exact-task-dispatch",
+            "version": 1,
+            "ok": exact.ok,
+            "reason": exact.reason,
+            "idempotent": exact.idempotent,
+            "selected": {"task_id": exact.selected} if exact.selected else None,
+            "claimed": (
+                {"task_id": exact.claimed, "run_id": exact.run_id}
+                if exact.claimed else None
+            ),
+            "spawned": (
+                {"task_id": exact.spawned, "worker_pid": exact.worker_pid}
+                if exact.spawned else None
+            ),
+            "run": (
+                {"id": exact.run_id, "status": exact.run_status}
+                if exact.run_id is not None else None
+            ),
+        }, indent=2))
+        return 0 if exact.ok else 1
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,
             dry_run=args.dry_run,
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,
-            failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            failure_limit=getattr(
+                args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+            ),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4620,6 +4620,7 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    assign_if_unassigned: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -4675,18 +4676,31 @@ def claim_task(
                 """,
                 (now, int(stale["current_run_id"])),
             )
+        assignment = (assign_if_unassigned or "").strip() or None
+        assignment_sql = (
+            ", assignee = COALESCE(NULLIF(assignee, ''), ?)" if assignment else ""
+        )
+        assignment_guard = (
+            " AND (assignee IS NULL OR assignee = '')" if assignment else ""
+        )
+        params = [lock, expires, now]
+        if assignment:
+            params.append(assignment)
+        params.append(task_id)
         cur = conn.execute(
-            """
+            f"""
             UPDATE tasks
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
                    started_at    = COALESCE(started_at, ?)
+                   {assignment_sql}
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               {assignment_guard}
             """,
-            (lock, expires, now, task_id),
+            tuple(params),
         )
         if cur.rowcount != 1:
             return None
@@ -4720,6 +4734,14 @@ def claim_task(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
         )
+        if assignment:
+            _append_event(
+                conn,
+                task_id,
+                "assigned",
+                {"assignee": assignment, "source": "kanban.default_assignee"},
+                run_id=run_id,
+            )
         _append_event(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
@@ -8084,6 +8106,53 @@ class DispatchResult:
     deferred tasks stay queued for the next tick."""
 
 
+@dataclass
+class ExactDispatchResult:
+    """Strict outcome for one atomic named-task dispatch attempt."""
+
+    task_id: str
+    ok: bool = False
+    reason: str = "ineligible"
+    idempotent: bool = False
+    selected: Optional[str] = None
+    claimed: Optional[str] = None
+    spawned: Optional[str] = None
+    run_id: Optional[int] = None
+    run_status: Optional[str] = None
+    worker_pid: Optional[int] = None
+
+
+def _exact_workspace_preflight(task: Task, *, board: Optional[str]) -> Optional[str]:
+    """Validate workspace metadata without mutating board or filesystem state."""
+    kind = task.workspace_kind or "scratch"
+    if kind not in VALID_WORKSPACE_KINDS:
+        return "workspace_invalid"
+    if kind == "dir":
+        if not task.workspace_path or not Path(task.workspace_path).expanduser().is_absolute():
+            return "workspace_invalid"
+    if kind == "worktree":
+        raw = (task.workspace_path or "").strip()
+        if raw and not Path(raw).expanduser().is_absolute():
+            return "workspace_invalid"
+        if not raw:
+            board_slug = board if board else get_current_board()
+            default_workdir = (
+                read_board_metadata(board_slug).get("default_workdir") or ""
+            ).strip()
+            if not default_workdir or not Path(default_workdir).expanduser().is_absolute():
+                return "workspace_invalid"
+            if _git_toplevel(Path(default_workdir).expanduser()) is None:
+                return "workspace_invalid"
+        else:
+            requested = Path(raw).expanduser()
+            if (
+                _git_toplevel(requested) is None
+                and _repo_root_for_worktree_target(requested.parent) is None
+            ):
+                return "workspace_invalid"
+    return None
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -9885,6 +9954,223 @@ def dispatch_once(
     # the lock hold and stall a sibling dispatcher's tick.
     _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
     return result
+
+
+def dispatch_task_once(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    spawn_fn=None,
+    ttl_seconds: Optional[int] = None,
+    max_spawn: Optional[int] = None,
+    max_in_progress: Optional[int] = None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    board: Optional[str] = None,
+    default_assignee: Optional[str] = None,
+    max_in_progress_per_profile: Optional[int] = None,
+) -> ExactDispatchResult:
+    """Atomically dispatch only ``task_id`` under the canonical tick lock.
+
+    This edge primitive performs no board-wide maintenance and never enumerates
+    another card. Eligibility is revalidated while the canonical lock is held;
+    ineligible requests do not mutate task rows, events, or runs. Repeated calls
+    recognize only a run spawned by this exact-dispatch path.
+    """
+    result = ExactDispatchResult(task_id=task_id)
+    try:
+        db_path = kanban_db_path(board=board)
+    except Exception:
+        result.reason = "dispatch_lock_unavailable"
+        return result
+
+    with _dispatch_tick_lock(db_path) as held:
+        if not held:
+            result.reason = "dispatch_locked"
+            return result
+
+        task = get_task(conn, task_id)
+        if task is None:
+            result.reason = "not_found"
+            return result
+
+        # Provenance-bound idempotency: a task claimed by board-global dispatch
+        # must not be misreported as this request's success.
+        if task.status == "running" and task.current_run_id is not None:
+            event = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND run_id=? "
+                "AND kind='exact_dispatched' ORDER BY id DESC LIMIT 1",
+                (task_id, int(task.current_run_id)),
+            ).fetchone()
+            if event is not None:
+                try:
+                    payload = json.loads(event["payload"] or "{}")
+                except (TypeError, ValueError):
+                    payload = {}
+                result.ok = True
+                result.reason = "spawned"
+                result.idempotent = True
+                result.selected = task_id
+                result.claimed = task_id
+                result.spawned = task_id
+                result.run_id = int(task.current_run_id)
+                result.run_status = "running"
+                result.worker_pid = (
+                    int(payload["worker_pid"])
+                    if payload.get("worker_pid") is not None
+                    else task.worker_pid
+                )
+                return result
+
+        if task.status != "ready" or task.claim_lock is not None:
+            result.reason = "status_ineligible"
+            return result
+        if not _parents_satisfied(conn, task_id):
+            result.reason = "parents_not_done"
+            return result
+
+        # Exact recovery is fail-closed when the admission gate cannot be read.
+        try:
+            from agent.estop import check_paused
+            if check_paused("kanban", _log):
+                result.reason = "dispatch_suspended"
+                return result
+        except Exception:
+            result.reason = "admission_unavailable"
+            return result
+
+        assignee = (task.assignee or "").strip()
+        fallback_assignee = (default_assignee or "").strip()
+        assign_if_unassigned = None
+        if not assignee:
+            if not fallback_assignee:
+                result.reason = "unassigned"
+                return result
+            assignee = fallback_assignee
+            assign_if_unassigned = fallback_assignee
+        try:
+            from hermes_cli.profiles import profile_exists
+            if not profile_exists(assignee):
+                result.reason = "nonspawnable_assignee"
+                return result
+        except Exception:
+            result.reason = "profile_check_unavailable"
+            return result
+
+        failures = int(task.consecutive_failures or 0)
+        effective_limit = (
+            int(task.max_retries)
+            if task.max_retries is not None
+            else int(failure_limit)
+        )
+        if failures >= effective_limit:
+            result.reason = "failure_limit"
+            return result
+
+        running = count_running_tasks(conn)
+        if max_spawn is not None and running >= max_spawn:
+            result.reason = "board_cap"
+            return result
+        if max_in_progress is not None:
+            total_running = running + count_running_tasks_other_boards(board)
+            if total_running >= max_in_progress:
+                result.reason = "host_cap"
+                return result
+        if max_in_progress_per_profile is not None and max_in_progress_per_profile > 0:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM tasks "
+                "WHERE status='running' AND assignee=?",
+                (assignee,),
+            ).fetchone()
+            if int(row["n"]) >= max_in_progress_per_profile:
+                result.reason = "profile_cap"
+                return result
+
+        if _memory_pressure_level() == "critical":
+            result.reason = "memory_pressure"
+            return result
+        guard_reason = check_respawn_guard(conn, task_id)
+        if guard_reason is not None:
+            result.reason = guard_reason
+            return result
+        workspace_reason = _exact_workspace_preflight(task, board=board)
+        if workspace_reason is not None:
+            result.reason = workspace_reason
+            return result
+
+        # Materialize before claim so a malformed workspace cannot alter task
+        # state or failure counters.
+        try:
+            resolved_branch_name = None
+            if task.workspace_kind == "worktree":
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    task, board=board
+                )
+            else:
+                workspace = resolve_workspace(task, board=board)
+        except Exception:
+            result.reason = "workspace_invalid"
+            return result
+
+        claimed = claim_task(
+            conn,
+            task_id,
+            ttl_seconds=ttl_seconds,
+            assign_if_unassigned=assign_if_unassigned,
+        )
+        if claimed is None:
+            result.reason = "claim_conflict"
+            return result
+        result.selected = task_id
+        result.claimed = task_id
+        result.run_id = claimed.current_run_id
+        result.run_status = "running"
+
+        set_workspace_path(conn, task_id, str(workspace))
+        if claimed.workspace_kind == "worktree":
+            set_branch_name(
+                conn,
+                task_id,
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{task_id}",
+            )
+        _maybe_emit_scratch_tip(conn, task_id, claimed.workspace_kind)
+        spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        try:
+            import inspect
+            try:
+                sig = inspect.signature(spawn)
+                pid = (
+                    spawn(claimed, str(workspace), board=board)
+                    if "board" in sig.parameters
+                    else spawn(claimed, str(workspace))
+                )
+            except (TypeError, ValueError):
+                pid = spawn(claimed, str(workspace))
+            if pid:
+                _set_worker_pid(conn, task_id, int(pid))
+            _fire_worker_spawned_hook(conn, claimed, str(workspace), pid, board=board)
+            with write_txn(conn):
+                _append_event(
+                    conn,
+                    task_id,
+                    "exact_dispatched",
+                    {"worker_pid": int(pid) if pid else None, "version": 1},
+                    run_id=claimed.current_run_id,
+                )
+            result.ok = True
+            result.reason = "spawned"
+            result.spawned = task_id
+            result.worker_pid = int(pid) if pid else None
+        except Exception as exc:
+            _record_spawn_failure(
+                conn, task_id, str(exc), failure_limit=failure_limit
+            )
+            result.reason = "spawn_failed"
+            result.run_status = "spawn_failed"
+
+        _maybe_checkpoint_wal(conn, db_path)
+        return result
 
 
 def _dispatch_once_locked(

--- a/tests/hermes_cli/test_kanban_exact_dispatch.py
+++ b/tests/hermes_cli/test_kanban_exact_dispatch.py
@@ -1,0 +1,302 @@
+"""Atomic exact-task Kanban dispatch regressions for issue #95900."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: bool(name))
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "normal")
+    return db_path
+
+
+def _spawn(pid=4242, calls=None):
+    def inner(task, workspace, board=None):
+        if calls is not None:
+            calls.append(task.id)
+        return pid
+
+    return inner
+
+
+def test_exact_success_returns_selected_claimed_spawned_run_evidence(board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="exact", assignee="worker")
+        result = kb.dispatch_task_once(
+            conn, task_id, spawn_fn=_spawn(), board="default"
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert result.ok is True
+    assert result.reason == "spawned"
+    assert result.selected == task_id
+    assert result.claimed == task_id
+    assert result.spawned == task_id
+    assert result.run_id == task.current_run_id
+    assert result.worker_pid == 4242
+
+
+def test_exact_repeat_is_idempotent_for_same_run_and_does_not_respawn(board):
+    calls = []
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="exact", assignee="worker")
+        first = kb.dispatch_task_once(
+            conn, task_id, spawn_fn=_spawn(4242, calls), board="default"
+        )
+        second = kb.dispatch_task_once(
+            conn, task_id, spawn_fn=_spawn(9999, calls), board="default"
+        )
+
+    assert calls == [task_id]
+    assert second.ok is True
+    assert second.idempotent is True
+    assert second.run_id == first.run_id
+    assert second.worker_pid == 4242
+
+
+def test_exact_honors_default_assignee_atomically(board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fallback", assignee=None)
+        result = kb.dispatch_task_once(
+            conn,
+            task_id,
+            spawn_fn=_spawn(),
+            board="default",
+            default_assignee="worker",
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert result.ok is True
+    assert task is not None
+    assert task.assignee == "worker"
+    assert task.status == "running"
+
+
+def test_exact_respects_emergency_stop_without_mutation(board):
+    Path(board).parent.joinpath("ESTOP").write_text("{}", encoding="utf-8")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="paused", assignee="worker")
+        before = dict(
+            conn.execute(
+                "SELECT status, claim_lock, current_run_id FROM tasks WHERE id=?",
+                (task_id,),
+            ).fetchone()
+        )
+        result = kb.dispatch_task_once(
+            conn, task_id, spawn_fn=_spawn(), board="default"
+        )
+        after = dict(
+            conn.execute(
+                "SELECT status, claim_lock, current_run_id FROM tasks WHERE id=?",
+                (task_id,),
+            ).fetchone()
+        )
+
+    assert result.ok is False
+    assert result.reason == "dispatch_suspended"
+    assert after == before
+
+
+def test_exact_spawn_failure_reports_closed_run_without_spawn_evidence(board):
+    def fail_spawn(task, workspace, board=None):
+        raise RuntimeError("synthetic spawn failure")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fails", assignee="worker")
+        result = kb.dispatch_task_once(
+            conn,
+            task_id,
+            spawn_fn=fail_spawn,
+            board="default",
+            failure_limit=2,
+        )
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id=?", (result.run_id,)
+        ).fetchone()
+
+    assert result.ok is False
+    assert result.reason == "spawn_failed"
+    assert result.selected == task_id
+    assert result.claimed == task_id
+    assert result.spawned is None
+    assert result.run_status == "spawn_failed"
+    assert dict(run) == {"status": "spawn_failed", "outcome": "spawn_failed"}
+
+
+@pytest.mark.parametrize(
+    ("setup", "reason"),
+    [
+        ("missing", "not_found"),
+        ("blocked", "status_ineligible"),
+        ("dependency", "parents_not_done"),
+        ("unassigned", "unassigned"),
+        ("profile_cap", "profile_cap"),
+        ("cooldown", "rate_limit_cooldown"),
+        ("workspace", "workspace_invalid"),
+    ],
+)
+def test_exact_ineligible_fails_closed_without_mutation(
+    board, setup, reason, monkeypatch
+):
+    with kb.connect() as conn:
+        if setup == "missing":
+            task_id = "t_missing"
+        else:
+            kwargs = {
+                "title": setup,
+                "assignee": None if setup == "unassigned" else "worker",
+            }
+            task_id = kb.create_task(conn, **kwargs)
+        if setup == "blocked":
+            kb.block_task(conn, task_id, reason="hold")
+        elif setup == "dependency":
+            parent = kb.create_task(conn, title="parent", assignee="worker")
+            kb.link_tasks(conn, parent, task_id)
+            with kb.write_txn(conn):
+                conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        elif setup == "profile_cap":
+            other = kb.create_task(conn, title="running", assignee="worker")
+            assert kb.claim_task(conn, other) is not None
+        elif setup == "cooldown":
+            now = __import__("time").time()
+            with kb.write_txn(conn):
+                cur = conn.execute(
+                    "INSERT INTO task_runs(task_id, profile, status, outcome, started_at, ended_at) "
+                    "VALUES (?, 'worker', 'rate_limited', 'rate_limited', ?, ?)",
+                    (task_id, now - 1, now),
+                )
+                conn.execute(
+                    "UPDATE tasks SET last_failure_error='rate limit exceeded' WHERE id=?",
+                    (task_id,),
+                )
+        elif setup == "workspace":
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET workspace_kind='dir', workspace_path='relative/path' WHERE id=?",
+                    (task_id,),
+                )
+
+        before = conn.execute(
+            "SELECT status, assignee, claim_lock, current_run_id FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        result = kb.dispatch_task_once(
+            conn,
+            task_id,
+            spawn_fn=_spawn(),
+            board="default",
+            max_in_progress_per_profile=1 if setup == "profile_cap" else None,
+        )
+        after = conn.execute(
+            "SELECT status, assignee, claim_lock, current_run_id FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+
+    assert result.ok is False
+    assert result.reason == reason
+    assert dict(after) == dict(before) if before is not None else after is None
+
+
+def test_exact_dispatch_loses_lock_without_falling_through_or_mutating(board):
+    calls = []
+    with kb.connect() as conn:
+        named = kb.create_task(conn, title="named", assignee="worker")
+        other = kb.create_task(conn, title="other", assignee="worker")
+        with kb._dispatch_tick_lock(board) as held:
+            assert held
+            result = kb.dispatch_task_once(
+                conn, named, spawn_fn=_spawn(calls=calls), board="default"
+            )
+        rows = {
+            row["id"]: row["status"]
+            for row in conn.execute("SELECT id, status FROM tasks")
+        }
+
+    assert result.ok is False
+    assert result.reason == "dispatch_locked"
+    assert calls == []
+    assert rows == {named: "ready", other: "ready"}
+
+
+def test_cli_exact_json_is_strict_and_feature_detectable(board, monkeypatch, capsys):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="exact", assignee="worker")
+    monkeypatch.setattr(kb, "_default_spawn", _spawn())
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+
+    args = argparse.Namespace(
+        task_id=task_id,
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=True,
+    )
+    assert kanban_cli._cmd_dispatch(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {
+        "capability": "kanban.exact-task-dispatch",
+        "version": 1,
+        "ok": True,
+        "reason": "spawned",
+        "idempotent": False,
+        "selected": {"task_id": task_id},
+        "claimed": {"task_id": task_id, "run_id": payload["claimed"]["run_id"]},
+        "spawned": {"task_id": task_id, "worker_pid": 4242},
+        "run": {"id": payload["run"]["id"], "status": "running"},
+    }
+    assert payload["claimed"]["run_id"] == payload["run"]["id"]
+
+
+def test_cli_exact_requires_json(board, capsys):
+    args = argparse.Namespace(
+        task_id="t_any",
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=False,
+    )
+    assert kanban_cli._cmd_dispatch(args) == 2
+    assert "--task-id requires --json" in capsys.readouterr().err
+
+
+def test_cli_exact_failure_is_strict_json_with_zero_evidence(
+    board, monkeypatch, capsys
+):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+    args = argparse.Namespace(
+        task_id="t_missing",
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=True,
+    )
+    assert kanban_cli._cmd_dispatch(args) == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "capability": "kanban.exact-task-dispatch",
+        "version": 1,
+        "ok": False,
+        "reason": "not_found",
+        "idempotent": False,
+        "selected": None,
+        "claimed": None,
+        "spawned": None,
+        "run": None,
+    }

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -764,8 +764,9 @@ hermes kanban watch [--assignee P] [--tenant T]        # live stream ALL events 
 hermes kanban heartbeat <id> [--note "..."]            # worker liveness signal for long ops
 hermes kanban runs <id> [--json]                       # attempt history (one row per run)
 hermes kanban assignees [--json]                       # profiles on disk + per-assignee task counts
-hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
+hermes kanban dispatch [--dry-run] [--max N]           # one-shot board-global pass
         [--failure-limit N] [--json]
+hermes kanban dispatch --task-id <id> --json            # atomic exact-task dispatch
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)
         [--failure-limit N] [--pidfile PATH] [-v]
 hermes kanban stats [--json]                           # per-status + per-assignee counts
@@ -784,6 +785,8 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 ```
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
+`dispatch --task-id <id> --json` is an automation edge for recovery controllers that have already selected one canonical card. It takes the same board-scoped dispatcher lock as the global pass, revalidates dependency, emergency-stop, concurrency, profile, failure, cooldown, and workspace gates, then claims and spawns only that ID. It never falls through to another ready card. Ineligible requests return non-zero with strict JSON and null `selected` / `claimed` / `spawned` / `run` evidence; successful and idempotent repeats include `capability: "kanban.exact-task-dispatch"`, `version: 1`, and matching task/run evidence. `--dry-run` is intentionally unsupported for exact dispatch because separating selection from mutation would recreate the race this primitive avoids.
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 


### PR DESCRIPTION
## Summary

Adds the recovery-controller edge capability:

```bash
hermes kanban dispatch --task-id <id> --json
```

The exact path takes the canonical board dispatch lock once, revalidates the named card under that lock, and either claims/spawns that card or returns strict fail-closed JSON without falling through to another ready card. Board-global `hermes kanban dispatch` remains unchanged.

Closes #95900.

## Core Claims

1. **Exact selection is serialized with global dispatch.** A held canonical `<kanban.db>.dispatch.lock` returns `reason: "dispatch_locked"`, performs zero task mutation, and invokes no spawn function.
2. **No fallback card can launch.** The exact implementation fetches only the requested ID and never enumerates the ready queue; all failure evidence has null `selected`, `claimed`, `spawned`, and `run` fields unless the named task was actually claimed.
3. **Normal gates remain authoritative.** Dependency state, ESTOP suspension, explicit/default profile validity, task/board/host/profile concurrency limits, failure limits, memory pressure, respawn/cooldown rules, and workspace validity are checked under the lock before claim.
4. **Retries are provenance-bound and idempotent.** A successful exact dispatch records an `exact_dispatched` event on its run. Repeating the same request returns that same run/PID with `idempotent: true` and does not spawn again; an unrelated global-dispatch run is not misreported as exact success.
5. **Machine output is strict and feature-detectable.** JSON includes `capability: "kanban.exact-task-dispatch"`, `version: 1`, matching selected/claimed/spawned/run evidence on success, stable reason codes on failure, and non-zero exit status when no exact spawn exists.
6. **Global dispatch behavior is preserved.** The pre-existing `dispatch_once` path and its JSON/text response shape remain in place whenever `--task-id` is absent.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_exact_dispatch.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_host_cap.py -q` — 57 passed
- `python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_exact_dispatch.py` — passed
- `python -m compileall -q hermes_cli` — passed
- Broad `tests/hermes_cli/test_kanban*.py` run: 295 passed, 1 skipped, 14 order-dependent failures; every failed file passes in isolation, including lifecycle hooks, decompose, write guard, and rate-limit reclaim.

## Review Note

Exactly one semantic Codex review invocation was attempted as required (`codex -c model=gpt-5.6-sol review --base origin/main`). It could not produce review findings because the standalone Codex OAuth refresh token was invalid/expired (HTTP 401), and no second invocation was made.
