### PR TITLE
feat(memory/mem0): add auto_capture switch for per-turn fact extraction

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -30,6 +30,7 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `auto_capture` | `true` | Extract facts from every turn automatically. Set to `false` to write only what the agent saves with `mem0_add` |
 
 The plugin has three connection modes:
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -206,6 +206,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = _DEFAULT_USER_ID
         self._agent_id = "hermes"
         self._rerank_default = False
+        self._auto_capture = True
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
         self._sync_thread = None
         self._prefetch_thread = None
@@ -258,6 +259,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "false", "choices": ["true", "false"]},
+            {"key": "auto_capture", "description": "Extract facts from every turn automatically", "default": "true", "choices": ["true", "false"]},
         ]
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
@@ -362,6 +364,13 @@ class Mem0MemoryProvider(MemoryProvider):
         _rr = self._config.get("rerank", False)
         self._rerank_default = (
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
+        )
+        # Per-turn capture. When false, sync_turn() is a no-op and only
+        # explicit mem0_add calls write, so the store holds what the agent
+        # deliberately saved instead of facts extracted from every message.
+        _ac = self._config.get("auto_capture", True)
+        self._auto_capture = (
+            _ac.lower() in ("true", "1", "yes") if isinstance(_ac, str) else bool(_ac)
         )
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
@@ -478,6 +487,8 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
+        if not self._auto_capture:
+            return
         if self._backend is None or self._is_breaker_open():
             return
 

--- a/tests/plugins/memory/test_mem0_auto_capture.py
+++ b/tests/plugins/memory/test_mem0_auto_capture.py
@@ -1,0 +1,95 @@
+"""The ``auto_capture`` gate on Mem0's per-turn fact extraction.
+
+``sync_turn()`` ships every exchange to the server with ``infer=True``, so an
+LLM extractor writes its own paraphrases of ordinary chatter into the store.
+That is the right default for a personal assistant, but not for a shared store
+several agents read from: a single throwaway question can leave several
+invented "facts" behind for every other agent to recall.
+
+The sibling providers already gate the same call — ``supermemory`` on
+``auto_capture``, ``byterover`` on ``auto_extract``. These tests pin the same
+switch for mem0, and pin the part that makes it useful rather than merely off:
+explicit ``mem0_add`` keeps writing while the gate is closed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import plugins.memory.mem0 as mem0_plugin
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class RecordingBackend:
+    """Minimal backend that records the writes it is asked to perform."""
+
+    def __init__(self):
+        self.adds = []
+
+    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None):
+        self.adds.append({"messages": messages, "infer": infer})
+        return {"status": "PENDING", "event_id": "evt-test"}
+
+
+def _provider(monkeypatch, config):
+    monkeypatch.setattr(mem0_plugin, "_load_config", lambda: config)
+    provider = Mem0MemoryProvider()
+    provider.initialize("test-session")
+    provider._user_id = "u123"
+    provider._agent_id = "agent-a"
+    provider._backend = RecordingBackend()
+    return provider
+
+
+def _sync(provider):
+    provider.sync_turn("what is 17 times 23", "391")
+    if provider._sync_thread is not None:
+        provider._sync_thread.join(timeout=2)
+    return provider._backend.adds
+
+
+class TestAutoCaptureGate:
+    def test_absent_key_keeps_capturing(self, monkeypatch):
+        """Default must not change for anyone who never sets the key."""
+        provider = _provider(monkeypatch, {"host": "http://mem0.test"})
+        assert provider._auto_capture is True
+        adds = _sync(provider)
+        assert len(adds) == 1
+        assert adds[0]["infer"] is True
+
+    def test_false_skips_the_turn(self, monkeypatch):
+        provider = _provider(monkeypatch, {"host": "http://mem0.test", "auto_capture": False})
+        assert provider._auto_capture is False
+        assert _sync(provider) == []
+        assert provider._sync_thread is None
+
+    def test_string_false_skips_the_turn(self, monkeypatch):
+        """mem0.json and the setup wizard can both hand the flag over as text."""
+        provider = _provider(monkeypatch, {"host": "http://mem0.test", "auto_capture": "false"})
+        assert provider._auto_capture is False
+        assert _sync(provider) == []
+
+    def test_string_true_keeps_capturing(self, monkeypatch):
+        provider = _provider(monkeypatch, {"host": "http://mem0.test", "auto_capture": "true"})
+        assert provider._auto_capture is True
+        assert len(_sync(provider)) == 1
+
+
+class TestExplicitWritesSurviveTheGate:
+    def test_mem0_add_still_writes_when_capture_is_off(self, monkeypatch):
+        """The gate must silence the extractor, not the agent."""
+        provider = _provider(monkeypatch, {"host": "http://mem0.test", "auto_capture": False})
+
+        raw = provider.handle_tool_call("mem0_add", {"content": "the deploy key lives in vault"})
+
+        assert "error" not in json.loads(raw)
+        assert len(provider._backend.adds) == 1
+        # Explicit writes are stored verbatim — no extraction pass.
+        assert provider._backend.adds[0]["infer"] is False
+
+
+class TestSetupWizard:
+    def test_schema_exposes_the_key(self, monkeypatch):
+        monkeypatch.setattr(mem0_plugin, "_load_config", lambda: {"host": "http://mem0.test"})
+        keys = {entry["key"] for entry in Mem0MemoryProvider().get_config_schema()}
+        assert "auto_capture" in keys


### PR DESCRIPTION
## What does this PR do?

`sync_turn()` sends every exchange to Mem0 with `infer=True`, so the server's LLM extractor writes its own paraphrases of ordinary chatter into the store, unconditionally. There is no way to turn it off.

That is a sensible default for one personal assistant. It stops being one as soon as several agents share a store: a single throwaway question leaves behind facts nobody asked to save, and every other agent recalls them as if they were curated.

Concretely, on a self-hosted store shared by three agents, one `mem0_add` of a single sentence left **three** rows — the sentence, plus two the extractor derived from the surrounding turn:

```
PRUEBA-… el codigo de verificacion es turquesa-9417.          <- what was asked for
User stored the verification code … with key mem0_add.        <- extractor
Assistant confirmed that the data is stored in shared memory.  <- extractor
```

Asking the same agent an arithmetic question, with no memory tool involved at all, wrote two more.

The sibling providers already gate this exact call — `supermemory` on `auto_capture` (`plugins/memory/supermemory/__init__.py:129,741`), `byterover` on `auto_extract` (`plugins/memory/byterover/__init__.py:225,297`). mem0 had no equivalent. This adds the `supermemory` spelling.

### Approach

`auto_capture` is read from the config the provider already loads, with the same string/bool coercion `rerank` uses two lines above it — the setup wizard and `mem0.json` can both hand the flag over as text, and `bool("false")` is `True`, so the coercion is what makes the flag actually work.

Default is `true`: the patch is inert until someone sets it.

The gate is deliberately narrow. It silences the extractor, not the agent — explicit `mem0_add` still writes verbatim with `infer=False` while capture is off, which is the behaviour that makes a curated shared store usable at all. There is a test pinning exactly that.

## Related Issue

Related: #55261 — same idea, same key, same injection point, reviewed LGTM. Its author closed it themselves as a courtesy after moving off the mem0 provider, noting it "still stands on its own as mem0/supermemory parity… if a maintainer wants to pick it up". This picks it up, with four things that PR did not have:

- string coercion (`"false"` from `mem0.json` or the wizard silently did nothing before)
- the key registered in `get_config_schema()`, so `hermes memory setup` offers it
- the config table in `plugins/memory/mem0/README.md`
- tests

Credit for the original approach goes there.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/memory/mem0/__init__.py`
  - `__init__`: `self._auto_capture = True` alongside the other instance defaults.
  - `get_config_schema()`: expose `auto_capture` so the setup wizard offers it.
  - `initialize()`: read the key with the same coercion as `rerank`.
  - `sync_turn()`: early return when the gate is closed.
- `plugins/memory/mem0/README.md` — one row in the config table.
- `tests/plugins/memory/test_mem0_auto_capture.py` — new, 6 cases: absent key keeps today's behaviour; `False` and `"false"` skip the turn and start no thread; `"true"` still captures; `mem0_add` keeps writing verbatim while the gate is closed; the key reaches the setup schema.

## How to Test

With a self-hosted store and `host` set in `$HERMES_HOME/mem0.json`:

1. Ask the agent anything that needs no memory tool (`"what is 17 times 23"`), then count rows in the store — on `main` it grows.
2. Add `"auto_capture": false` to `mem0.json` and restart.
3. Repeat step 1 — the count no longer moves.
4. Ask it to save something with `mem0_add` — the count moves by exactly one, and the row is the literal text.

That is the sequence I ran against a shared Mem0 server with three agents on it (Postgres/pgvector row counts before and after each step): per-turn writes stopped on all three, explicit writes kept landing, and one `mem0_add` went from leaving 3 rows to leaving 1.

Unit tests: `pytest tests/plugins/memory/test_mem0_auto_capture.py -q` → 6 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — #55261 is the closest and is closed; see above
- [x] My PR contains **only** changes related to this feature
- [x] I've run the related suites — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.12

On the full-suite checkbox, to be precise rather than tick it blindly: I ran `pytest tests/plugins/memory/ -q` → **349 passed, 2 skipped, 6 failed**. All 6 failures are in `test_hindsight_provider.py`, an unrelated provider, and **reproduce on a clean `upstream/main` checkout with my changes stashed** (same 6, `6 failed, 77 passed`). I did not run all of `tests/` locally because some suites need optional extras my environment lacks.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `plugins/memory/mem0/README.md` config table, plus a comment at the read site explaining what closing the gate means
- [x] `cli-config.yaml.example` — N/A, this key lives in `$HERMES_HOME/mem0.json`, which that file does not cover
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure config read plus an early return, no platform-specific paths or APIs
