### PR TITLE
fix(desktop): preserve expanded SSH runtime paths

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { exec as execCallback, spawn } from 'node:child_process'
+import { exec as execCallback, execFile as execFileCallback, spawn } from 'node:child_process'
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -44,6 +44,7 @@ import {
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
 const exec = promisify(execCallback)
+const execFile = promisify(execFileCallback)
 
 test('SSH reuse proof rejects a backend whose runtime was replaced', () => {
   assert.equal(
@@ -825,6 +826,70 @@ test('buildSpawnCommand atomically reserves the ownership slot through spawn and
   assert.match(cmd, /lock_json/)
   assert.match(cmd, /trap .*rm -rf/)
   assert.ok(cmd.indexOf('lock_json') > cmd.indexOf('serve --isolated'))
+})
+
+test('buildSpawnCommand preserves expanded paths when assigning shell variables', async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), 'hermes-shell-path-home-'))
+  const harness = await mkdtemp(path.join(os.tmpdir(), 'hermes-shell-path-harness-'))
+  const fakePython = path.join(harness, 'python3')
+  const payloadReport = path.join(harness, 'payload')
+
+  await writeFile(fakePython, '#!/bin/sh\nprintf \'%s\' "$4" > "$HERMES_TEST_PAYLOAD"\n')
+  await chmod(fakePython, 0o755)
+
+  try {
+    const command = buildSpawnCommand('/x/hermes', '', {
+      hermesHome: '~/.hermes',
+      logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+      ownershipId: OWNERSHIP_ID,
+      reservationNonce: SPAWN_NONCE,
+      spawnNonce: SPAWN_NONCE,
+      tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
+      lockMetadata: {
+        ownershipId: OWNERSHIP_ID,
+        spawnNonce: SPAWN_NONCE,
+        port: 0,
+        profile: '',
+        hermesPath: '/x/hermes',
+        hermesHome: '~/.hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+        tokenFingerprint: fingerprintToken('stored-token'),
+        protocolVersion: PROTOCOL_VERSION,
+        startedAt: '2026-07-14T00:00:00.000Z'
+      }
+    })
+
+    await exec(command, {
+      shell: '/bin/sh',
+      env: {
+        ...process.env,
+        HERMES_TEST_PAYLOAD: payloadReport,
+        PATH: `${harness}:${process.env.PATH || ''}`
+      }
+    })
+
+    const payload = await readFile(payloadReport, 'utf8')
+    const reservationStart = payload.indexOf('reservation=')
+    const reservationNonceStart = payload.indexOf('reservation_nonce=', reservationStart)
+    const assignments = payload.slice(reservationStart, reservationNonceStart)
+
+    const result = await execFile(
+      '/bin/sh',
+      ['-c', `${assignments}printf '%s\\n' "$reservation" "$lock" "$owner_file"`],
+      { env: { ...process.env, HOME: home } }
+    )
+
+    const expected = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID)
+
+    assert.deepEqual(result.stdout.trim().split('\n'), [
+      path.join(expected, '.connect.lock'),
+      path.join(expected, 'backend.lock.json'),
+      path.join(expected, '.connect.lock', 'owner')
+    ])
+  } finally {
+    await rm(home, { recursive: true, force: true })
+    await rm(harness, { recursive: true, force: true })
+  }
 })
 
 test.skipIf(process.platform === 'win32')('detached backend does not inherit the update mutex descriptor', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1083,7 +1083,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   return withRemoteUpdateMutex(
     `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
-      `reservation=${shq(reservation)}; lock=${shq(lockPath)}; owner_file=${shq(ownerPath)}; ` +
+      `reservation=${reservation}; lock=${lockPath}; owner_file=${ownerPath}; ` +
       `reservation_nonce=${shq(reservationNonce)}; ` +
       `i=0; while ! mkdir "$reservation" 2>/dev/null; do ` +
       `owner_data=$(cat "$owner_file" 2>/dev/null || true); owner_pid=${'${owner_data%%:*}'}; ` +


### PR DESCRIPTION
## Background

Hermes Desktop SSH startup builds a remote shell payload in `buildSpawnCommand`. Paths returned by `expandRemotePath()` are already shell expressions, so they must be inserted into the payload without another shell-quoting pass.

On a POSIX SSH remote, this can prevent the Desktop-owned connection reservation from ever being created. The remote `serve` process is then never launched, no backend port is published, and Desktop retries the SSH connection after the startup timeout.

## Reproduction

1. Use a clean Hermes Agent checkout and a POSIX SSH remote configured with a generic alias such as `remote-host`.
2. Start an SSH connection from Hermes Desktop.
3. Let Desktop generate the remote `buildSpawnCommand` payload.
4. Observe the reservation assignments in the generated shell payload.

For a home-relative runtime path, `expandRemotePath()` produces a shell expression such as:

```sh
"$HOME"'/.hermes/desktop-ssh/<anonymous-ownership-id>/.connect.lock'
```

The previous code passed that expression through `shq()` again while assigning `reservation`, `lock`, and `owner_file`. The shell then received a literal quoted expression instead of the intended filesystem path. The reservation loop could not create the directory, so the remote backend never reached its ready-port announcement.

## Fix

Assign the already-expanded shell expressions directly and keep `shq()` for ordinary scalar values such as the reservation nonce. This preserves the escaping performed by `expandRemotePath()` while avoiding a second quoting layer.

A regression test captures the actual payload passed through the update-mutex wrapper, executes the path assignments with `/bin/sh` under an anonymous temporary `$HOME`, and verifies the resolved reservation, lockfile, and owner paths.

## Verification

- `npm run typecheck` — passed
- `npm run test:desktop:platforms` — 1902 tests passed, 6 skipped; one unrelated pre-existing environment failure remains in `managed-ssh-update.test.ts`, and two Electron-dependent suites cannot run without the Electron binary installation
- `vitest run --project electron electron/remote-lifecycle.test.ts` — 90 tests passed
- Prettier check — passed
- ESLint on the changed files — passed
- `git diff --check` — passed

The change is limited to remote shell path assignment and its regression coverage; token handling, permissions, locking protocol, and process lifecycle behavior are otherwise unchanged.