### PR TITLE
fix(tools): rebuild DaemonThreadPoolExecutor on public Executor ABC

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -1,4 +1,4 @@
-"""Shared daemon-thread ThreadPoolExecutor.
+"""Shared daemon-thread Executor.
 
 Stdlib ``ThreadPoolExecutor`` workers are non-daemon AND are registered in
 ``concurrent.futures.thread._threads_queues``, whose atexit hook
@@ -9,56 +9,149 @@ exit forever.  This is the root cause of multi-minute CLI exits on long
 sessions: every abandoned concurrent-tool batch leaves workers that the
 exit hook insists on joining.
 
-``DaemonThreadPoolExecutor`` spawns daemon workers and skips the
-``_threads_queues`` registration, so:
+``DaemonThreadPoolExecutor`` spawns daemon workers instead, so:
 
-  - ``_python_exit`` never joins them, and
+  - ``_python_exit`` never joins them (they're never registered with it), and
   - the interpreter's non-daemon thread join at shutdown skips them.
 
-Semantics are otherwise identical (initializer/initargs, work queue,
-idle-thread reuse).  Use it for any pool whose work is best-effort or
-independently interruptible and must never hold the process open:
-concurrent tool execution, background memory sync, catalog fan-out,
-subagent timeout wrappers.  Do NOT use it for work that must complete
-before exit (durable writes) — those belong on foreground threads with
-explicit bounded joins.
+Use it for any pool whose work is best-effort or independently
+interruptible and must never hold the process open: concurrent tool
+execution, background memory sync, catalog fan-out, subagent timeout
+wrappers. Do NOT use it for work that must complete before exit (durable
+writes) — those belong on foreground threads with explicit bounded joins.
+
+Built directly on the public ``concurrent.futures.Executor`` ABC and only
+stable primitives (``threading``, ``queue.SimpleQueue``, ``weakref``,
+``concurrent.futures.Future``) — no CPython-private ``ThreadPoolExecutor``
+internals. An earlier version subclassed ``ThreadPoolExecutor`` and
+mirrored its private ``_adjust_thread_count`` to get daemon workers;
+CPython 3.14 restructured those internals (``__init__`` now stores a
+``_create_worker_context`` instead of ``_initializer``/``_initargs``),
+which broke that approach with ``AttributeError: ... no attribute
+'_initializer'`` on every submit. Building on the public ABC means a
+future CPython internals change can't break this again.
 """
 
 from __future__ import annotations
 
+import os
+import queue
 import threading
 import weakref
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures.thread import _worker
+from concurrent.futures import Executor, Future
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
+_WorkItem = tuple[Future, object, tuple, dict]
 
-class DaemonThreadPoolExecutor(ThreadPoolExecutor):
-    """ThreadPoolExecutor variant whose workers do not block process exit."""
 
-    def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+class DaemonThreadPoolExecutor(Executor):
+    """Executor variant whose workers do not block process exit."""
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+        initializer=None,
+        initargs: tuple = (),
+    ) -> None:
+        if max_workers is None:
+            max_workers = min(32, (os.cpu_count() or 1) + 4)
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        self._max_workers = max_workers
+        self._thread_name_prefix = thread_name_prefix or str(self)
+        self._initializer = initializer
+        self._initargs = initargs
+        self._work_queue: queue.SimpleQueue[_WorkItem | None] = queue.SimpleQueue()
+        self._idle_semaphore = threading.Semaphore(0)
+        self._threads: list[threading.Thread] = []
+        self._lock = threading.Lock()
+        self._shutdown_flag = False
+
+    def submit(self, fn, /, *args, **kwargs) -> Future:
+        with self._lock:
+            if self._shutdown_flag:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            future: Future = Future()
+            self._work_queue.put((future, fn, args, kwargs))
+            self._spawn_worker_if_needed()
+            return future
+
+    def _spawn_worker_if_needed(self) -> None:
+        # Mirrors the pool's lazy-reuse heuristic: only spawn a new
+        # worker when no idle one is already waiting on the queue.
         if self._idle_semaphore.acquire(timeout=0):
             return
+        if len(self._threads) >= self._max_workers:
+            return
+        work_queue = self._work_queue
 
-        def weakref_cb(_, q=self._work_queue):
+        def _on_executor_collected(_ref, q=work_queue) -> None:
             q.put(None)
 
-        num_threads = len(self._threads)
-        if num_threads < self._max_workers:
-            thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
-                daemon=True,
-            )
-            t.start()
-            self._threads.add(t)
+        thread = threading.Thread(
+            name=f"{self._thread_name_prefix}_{len(self._threads)}",
+            target=_worker_loop,
+            args=(weakref.ref(self, _on_executor_collected), work_queue),
+            daemon=True,
+        )
+        self._threads.append(thread)
+        thread.start()
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._lock:
+            self._shutdown_flag = True
+            if cancel_futures:
+                # Only drains what's still queued — anything a worker
+                # already claimed via set_running_or_notify_cancel() runs
+                # to completion, matching stdlib's documented semantics.
+                while True:
+                    try:
+                        queued = self._work_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if queued is not None:
+                        queued[0].cancel()
+            for _ in self._threads:
+                self._work_queue.put(None)
+        if wait:
+            for thread in self._threads:
+                thread.join()
+
+
+def _worker_loop(executor_ref, work_queue) -> None:
+    """Run submitted work items until shut down or the pool is collected.
+
+    Takes a *weak* reference to the executor (not a bound method) so a
+    pool that's dropped without an explicit ``shutdown()`` doesn't keep
+    itself alive forever via its own worker threads — collection fires
+    the weakref callback registered in ``_spawn_worker_if_needed``, which
+    queues a sentinel so this loop notices and exits.
+    """
+    executor = executor_ref()
+    initializer = executor._initializer if executor is not None else None
+    initargs = executor._initargs if executor is not None else ()
+    del executor
+    if initializer is not None:
+        try:
+            initializer(*initargs)
+        except BaseException:
+            return
+    while True:
+        item = work_queue.get()
+        if item is None:
+            return
+        future, fn, args, kwargs = item
+        executor = executor_ref()
+        if executor is not None:
+            executor._idle_semaphore.release()
+        del executor
+        if not future.set_running_or_notify_cancel():
+            continue
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as exc:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)


### PR DESCRIPTION
## Summary
`tools/daemon_pool.py`'s `DaemonThreadPoolExecutor` subclassed `ThreadPoolExecutor` and mirrored its private `_adjust_thread_count` to get daemon workers (so a wedged tool call can't block interpreter exit — see the module's own docstring for the full rationale). CPython 3.14 restructured those private internals (`__init__` now stores a `_create_worker_context` indirection instead of `_initializer`/`_initargs`), which breaks the override with `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'` on every single `submit()` call under 3.14.

Concretely: any install that ends up running under a 3.14 interpreter (a stray venv, a future managed-runtime migration, etc.) gets **every** concurrent tool call failing at once, since all four call sites (`agent/conversation_compression.py`, `agent/memory_manager.py`, `agent/relay_runtime.py`, `agent/tool_executor.py`) go through this class.

## Fix
Rebuilds the same daemon-worker behavior directly on the public `concurrent.futures.Executor` ABC using only stable primitives (`threading`, `queue.SimpleQueue`, `weakref`, `concurrent.futures.Future`) — no CPython-private `ThreadPoolExecutor` internals at all, so a future internals change can't break it again. Same semantics preserved: workers are daemon threads never registered in `concurrent.futures.thread._threads_queues` (so the atexit join hook can't block exit on a wedged worker), lazy idle-thread reuse, `initializer`/`initargs` support, and the weakref-triggered auto-cleanup if a pool is dropped without an explicit `shutdown()`.

## Test plan
- [x] Existing suite (`tests/tools/test_daemon_pool.py`) passes unchanged on 3.13.12
- [x] Verified directly against a 3.14.4 interpreter (the exact version that broke the original) — the same test scenarios pass
- [x] Manual checks for behavior not covered by the existing suite: `cancel_futures=True`, `initializer`/`initargs`, exception propagation through `Future.result()`, submit-after-`shutdown()` raising `RuntimeError`, context-manager protocol