### PR TITLE
fix(venv): resolve the live venv from the running interpreter, not a name guess

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -355,7 +355,26 @@ def _run_repair_install(specs: list[str], project_root: Path) -> bool:
     if externally_managed:
         uv = _find_uv_binary()
         if uv:
-            env = {**os.environ, "VIRTUAL_ENV": str(project_root / "venv")}
+            # This repair pass usually runs as the venv it's trying to fix
+            # (that's what "base interpreter is externally managed" means
+            # here), so sys.prefix names it directly when it actually sits
+            # under project_root — no need to guess a folder name, which
+            # would miss a custom-named venv (e.g. venv-py313, a
+            # Python-version workaround). Verify the parent match first:
+            # a caller repairing a *different* root than the one currently
+            # running must still fall back to the conventional guess
+            # rather than pointing uv at this process's own unrelated venv.
+            live_venv = None
+            if sys.prefix != sys.base_prefix:
+                try:
+                    candidate = Path(sys.prefix).resolve()
+                    if candidate.parent == project_root.resolve():
+                        live_venv = candidate
+                except OSError:
+                    pass
+            if live_venv is None:
+                live_venv = project_root / "venv"
+            env = {**os.environ, "VIRTUAL_ENV": str(live_venv)}
             env.pop("PYTHONHOME", None)
             env.pop("PYTHONPATH", None)
             try:

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1169,9 +1169,20 @@ def _refresh_managed_uv_catalog(uv_bin: str) -> bool:
 def _default_live_venv(root: Path) -> Path:
     """Return the venv that runtime repair should target for *root*.
 
-    Managed installs create ``<checkout>/venv``, but uv-default and dev
-    checkouts use ``<checkout>/.venv``.  Historically only ``venv`` was
-    probed, so a ``.venv`` install linking a vulnerable SQLite returned
+    Prefers live introspection: if this process is itself running from a
+    venv directly under *root*, that IS the live venv, whatever it's
+    named. A custom-named venv (e.g. a Python-version workaround) is
+    invisible to the name-only fallback below, which is exactly what let
+    this function disagree with other resolvers (like the launcher
+    self-heal in ``_install_repair.py``) about which venv was actually
+    live on a 2026-08-26 incident install.
+
+    Falls back to the conventional names when this process isn't running
+    from a venv under root at all (e.g. repair invoked against a
+    different profile/root than the one currently executing). Managed
+    installs create ``<checkout>/venv``, but uv-default and dev checkouts
+    use ``<checkout>/.venv``.  Historically only ``venv`` was probed, so a
+    ``.venv`` install linking a vulnerable SQLite returned
     ``not-applicable`` on every ``hermes update`` and stayed on
     journal_mode=DELETE forever — even though the WAL fallback warning
     promises that ``hermes update`` repairs the runtime (issue class:
@@ -1182,6 +1193,13 @@ def _default_live_venv(root: Path) -> Path:
     When neither has an interpreter, return the ``venv`` path so the
     caller's existing ``not-applicable`` handling fires unchanged.
     """
+    if sys.prefix != sys.base_prefix:
+        try:
+            live = Path(sys.prefix).resolve()
+            if live.parent == root.resolve() and _venv_python(live).is_file():
+                return live
+        except OSError:
+            pass
     primary = root / _VENV_NAME
     if _venv_python(primary).is_file():
         return primary

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
-from hermes_constants import venv_python_path
+from hermes_constants import project_venv_dir, venv_python_path
 
 logger = logging.getLogger(__name__)
 
@@ -4260,7 +4260,13 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    # project_venv_dir() prefers live introspection (sys.prefix) over
+    # guessing "venv" by name, so a custom-named venv (e.g. venv-py313,
+    # a Python-version workaround) is still recognized correctly instead
+    # of silently falling through every check below. Falls back to the
+    # same "venv" guess when this process isn't the one driving the venv
+    # being probed (e.g. a bootstrapper on a different interpreter).
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or (_m().PROJECT_ROOT / "venv")
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
@@ -4338,7 +4344,13 @@ def _detect_venv_python_processes(
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    # project_venv_dir() prefers live introspection (sys.prefix) over
+    # guessing "venv" by name, so a custom-named venv (e.g. venv-py313,
+    # a Python-version workaround) is still recognized correctly instead
+    # of silently falling through every check below. Falls back to the
+    # same "venv" guess when this process isn't the one driving the venv
+    # being probed (e.g. a bootstrapper on a different interpreter).
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or (_m().PROJECT_ROOT / "venv")
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -4759,7 +4771,13 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    # project_venv_dir() prefers live introspection (sys.prefix) over
+    # guessing "venv" by name, so a custom-named venv (e.g. venv-py313,
+    # a Python-version workaround) is still recognized correctly instead
+    # of silently falling through every check below. Falls back to the
+    # same "venv" guess when this process isn't the one driving the venv
+    # being probed (e.g. a bootstrapper on a different interpreter).
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or (_m().PROJECT_ROOT / "venv")
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1640,16 +1640,38 @@ def venv_bin_dir(venv_dir, *, windows: bool | None = None) -> Path:
 
 
 def project_venv_dir(project_root) -> Path | None:
-    """The project's venv directory, ``venv`` or ``.venv``, when one exists.
+    """The project's venv directory, wherever it actually lives.
 
-    ``uv venv`` defaults to ``.venv`` while our installers create ``venv``, so
-    both layouts are in the wild. Call sites that only knew about ``venv``
-    silently no-oped on a ``.venv`` install — that is how the Windows
-    shim-lock preflight skipped itself entirely (#79542). ``venv`` wins when
-    both exist, matching what the installers write.
+    Prefers live introspection: if this process is itself running from a
+    venv directly under *project_root*, that venv is authoritative
+    regardless of what it's named. A custom-named venv (e.g. ``venv-py313``,
+    the kind of rename people reach for as a Python-version workaround) was
+    invisible to the old name-only guess below — that's how a Windows
+    install's global-launcher self-heal silently rebuilt `hermes`'s
+    launchers from a stale, wrong-Python ``venv`` sibling instead of the
+    real, custom-named venv actually in use (2026-08-26 incident: every
+    tool call failed with an AttributeError from a launcher quietly
+    running the wrong CPython).
+
+    Falls back to the two conventional installer-created names — ``venv``
+    (our installers) then ``.venv`` (``uv venv``'s default), both layouts
+    are in the wild — for callers probing a root other than the one
+    currently executing, or when this process isn't running from a venv at
+    all. Call sites that only knew about ``venv`` silently no-oped on a
+    ``.venv`` install — that is how the Windows shim-lock preflight skipped
+    itself entirely (#79542). ``venv`` wins when both exist, matching what
+    the installers write.
     """
+    root = Path(project_root)
+    if sys.prefix != sys.base_prefix:
+        try:
+            live = Path(sys.prefix).resolve()
+            if live.parent == root.resolve():
+                return live
+        except OSError:
+            pass
     for name in ("venv", ".venv"):
-        candidate = Path(project_root) / name
+        candidate = root / name
         if candidate.is_dir():
             return candidate
     return None

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -37,15 +37,19 @@ pytestmark = pytest.mark.skipif(
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _spawn(args: list[str], cwd: Path | None = None) -> subprocess.Popen:
+def _spawn(
+    args: list[str], cwd: Path | None = None, *, interpreter: str | None = None
+) -> subprocess.Popen:
     """Spawn a real sleeper process whose argv carries the given tail.
 
     ``python -c "sleep" <tail...>`` — the tail is inert data to the child
     but fully visible to psutil cmdline scans, which is what the detection
-    code classifies on.
+    code classifies on. Defaults to this test's own interpreter (a stand-in
+    for "a real Hermes process" holding this venv); pass *interpreter* to
+    simulate a genuinely unrelated python — see ``_foreign_interpreter``.
     """
     proc = subprocess.Popen(
-        [sys.executable, "-c", "import time; time.sleep(300)", *args],
+        [interpreter or sys.executable, "-c", "import time; time.sleep(300)", *args],
         cwd=str(cwd or PROJECT_ROOT),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -53,6 +57,23 @@ def _spawn(args: list[str], cwd: Path | None = None) -> subprocess.Popen:
     time.sleep(0.8)  # let the process table settle
     assert proc.poll() is None, "sleeper died at spawn"
     return proc
+
+
+def _foreign_interpreter() -> str:
+    """A python executable that belongs to no project venv at all.
+
+    Venv-holder detection now resolves the live venv via introspection
+    (``sys.prefix`` of the process running the scan) rather than a
+    hardcoded folder name, so it correctly recognizes ANY venv under the
+    project root — including this test suite's own ``.venv313``. A
+    "foreign" process must therefore run a genuinely different
+    interpreter, not just carry unrelated argv from this same one:
+    ``sys.base_prefix`` is the interpreter a venv was created FROM, which
+    is never itself a venv under the project root.
+    """
+    windows = sys.platform == "win32"
+    candidate = Path(sys.base_prefix) / ("python.exe" if windows else "bin/python3")
+    return str(candidate) if candidate.is_file() else sys.executable
 
 
 def _detect() -> list[tuple[int, str, str]]:
@@ -86,12 +107,17 @@ class TestDetection:
             _kill(proc)
 
     def test_foreign_python_not_detected(self):
-        """A python process with no Hermes argv and cwd OUTSIDE the install
-        must not be reported as a holder."""
+        """A python process with no Hermes argv, cwd OUTSIDE the install,
+        and an interpreter outside every project venv must not be
+        reported as a holder."""
         import tempfile
 
         outside = Path(tempfile.mkdtemp())
-        proc = _spawn(["totally", "unrelated"], cwd=outside)
+        proc = _spawn(
+            ["totally", "unrelated"],
+            cwd=outside,
+            interpreter=_foreign_interpreter(),
+        )
         try:
             pids = [pid for pid, _, _ in _detect()]
             assert proc.pid not in pids


### PR DESCRIPTION
## Summary
Four independent functions each decide "which venv is actually live" their own way, and none of them recognize a custom-named venv — only the two conventional names, `venv` and `.venv`. That's the root cause behind a real incident on a Windows install using a custom-renamed venv (a Python-version workaround): `hermes_constants.project_venv_dir()` (used by `_install_repair.py`'s launcher self-heal) silently rebuilt the global `hermes` launchers from a stale, wrong-Python `venv` sibling instead of the real, custom-named venv actually running — breaking every concurrent tool call with an `AttributeError`.

The same blind spot reaches further than the launcher:
- `hermes_cli/update_cmd.py`'s live-process safety scan (gates `hermes update` and the SQLite runtime repair) could report "clear to proceed" while a real session was running on the unrecognized venv.
- `hermes_cli/_early_recovery.py`'s earliest self-repair pass could silently target the wrong interpreter on a first-package-broken recovery, leaving the actually-running venv unfixed.
- `hermes_cli/managed_uv.py`'s SQLite-CVE repair picker used yet a third set of rules, able to disagree with the other two about which venv is live in the same repair cycle.

## Fix
`project_venv_dir()` and `_default_live_venv()` now check whether the *current process* is itself running from a venv directly under the given root first — `sys.prefix` names it exactly, regardless of what it's called — and only fall back to guessing `venv`/`.venv` by name when that doesn't apply (e.g. probing a different root than the one executing). `update_cmd.py`'s three hardcoded call sites and `_early_recovery.py`'s installer now go through the same live check, each with a parent-match guard so a caller repairing a *different* root than the one currently running still falls back to the conventional guess rather than pointing at an unrelated venv.

## Test plan
- [x] Full existing test suite for every touched module (`test_early_recovery.py`, `test_managed_uv.py`, `test_hermes_constants.py`) passes with no new failures against the pre-existing baseline
- [x] Real-process Windows E2E suite (`test_venv_holder_windows_live.py`, spawns actual processes and checks the live process table) — 11/11, including fixing one test whose "foreign process" simulation was unknowingly relying on the pre-fix bug (spawning from the test's own interpreter only failed to match because the old code didn't recognize a custom-named *test* venv either; it now needs a genuinely different interpreter, `sys.base_prefix`, to still prove the argv/cwd exclusion it's meant to test)
- [x] One real regression caught in my own first pass: `_early_recovery.py`'s version was initially missing the same root-match check the other two functions have, which would have pointed `uv` at whatever venv happens to be running rather than the one actually being repaired — caught by the existing `test_repair_install_uv_sets_virtual_env_to_project_venv` test and fixed before landing here