### PR TITLE
fix(config): refuse to overwrite an unparseable config.yaml on save

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3408,11 +3408,24 @@ def read_raw_config_readonly() -> Dict[str, Any]:
 
 
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
-    """Refuse to replace an existing config.yaml that cannot be read."""
+    """Refuse to replace an existing config.yaml that cannot be read or parsed.
+
+    Two independent failure modes land here, both because
+    ``read_raw_config()`` collapses them to the same ``{}``: an
+    I/O-unreadable file (permission error, broken mount) and a
+    byte-readable-but-syntactically-corrupt one (bad YAML — truncated
+    write, stray editor characters). Either way, a load->mutate->save
+    flow (setup wizard, ``hermes config set``, gateway platform-field
+    writes) would otherwise persist a defaults-only or partial config
+    over the user's file, silently erasing every override it couldn't
+    read back. The corrupt/unreadable file is left in place (already
+    snapshotted to ``.bak`` by ``_warn_config_parse_failure`` on the read
+    side) for the user to repair rather than being overwritten.
+    """
     if config_path is None:
         config_path = get_config_path()
     try:
-        config_path.stat()
+        st = config_path.stat()
     except FileNotFoundError:
         return
     except OSError as exc:
@@ -3428,6 +3441,19 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
         raise RuntimeError(
             f"Refusing to overwrite {config_path}: existing config.yaml cannot be read "
             f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+
+    if st.st_size == 0:
+        return
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            fast_safe_load(f)
+    except Exception as exc:
+        # A comments-only file parses to None, not an exception — that's
+        # parseable and falls through. Only a genuine parse failure raises.
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: existing config.yaml is not valid YAML "
+            f"({exc}). Fix the file by hand or move it aside first."
         ) from exc
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,7 +37,18 @@ class TestGetHermesHome:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_HOME", None)
             home = get_hermes_home()
-            assert home == Path.home() / ".hermes"
+            if sys.platform == "win32":
+                # Windows default is %LOCALAPPDATA%\hermes — see
+                # hermes_constants._get_platform_default_hermes_home.
+                local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+                base = (
+                    Path(local_appdata)
+                    if local_appdata
+                    else Path.home() / "AppData" / "Local"
+                )
+                assert home == base / "hermes"
+            else:
+                assert home == Path.home() / ".hermes"
 
 
 class TestEnsureHermesHome:
@@ -423,6 +435,41 @@ class TestSaveConfigAtomicity:
                 raw = yaml.safe_load(f)
             assert raw["model"] == "test/atomic-model"
             assert raw["agent"]["max_turns"] == 77
+
+    def test_refuses_to_overwrite_unparseable_config(self, tmp_path):
+        """save_config must never clobber an existing-but-unparseable
+        config.yaml.
+
+        A fresh process (no in-memory "last known good" from
+        TestLoadConfigParseFailure to fall back on) that loads an
+        already-corrupt config.yaml gets DEFAULT_CONFIG out of
+        load_config(). Saving that back would silently erase every
+        override the corrupt file still holds. The corrupt file is left
+        in place — already snapshotted to .bak by
+        _warn_config_parse_failure on the read side — for the user to
+        repair rather than being overwritten with defaults.
+        """
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            broken = "model:\n  default: my-model\n\tbroken tab indent:\n"
+            (tmp_path / "config.yaml").write_text(broken, encoding="utf-8")
+
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                save_config({"agent": {"max_turns": 5}})
+
+            assert (tmp_path / "config.yaml").read_text(encoding="utf-8") == broken
+
+    def test_empty_config_file_is_still_a_valid_write_target(self, tmp_path):
+        """A zero-byte config.yaml (e.g. `touch`ed but never written) is not
+        "corrupt" — it's the same as absent, and saving must proceed."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("", encoding="utf-8")
+
+            save_config({"agent": {"max_turns": 5}})
+
+            with open(config_path, encoding="utf-8") as f:
+                raw = yaml.safe_load(f)
+            assert raw["agent"]["max_turns"] == 5
 
 
 class TestSanitizeEnvLines:


### PR DESCRIPTION
## Summary
`require_readable_config_before_write()` (the single chokepoint `save_config` and friends route through) already refused writes when an existing `config.yaml` couldn't be read at the byte level (permission error, broken mount) — but never attempted to actually parse it. A byte-readable-but-syntactically-corrupt YAML file (truncated write, stray editor characters) still passed the guard and got silently overwritten with `DEFAULT_CONFIG` by the next load→mutate→save flow (setup wizard, `hermes config set`, gateway platform-field writes), erasing every override the corrupt file still held.

## Fix
Extends the same guard function with a parse attempt on top of the existing I/O checks, refusing the write on failure with the same `RuntimeError` shape as the existing I/O-failure branches. A genuinely empty file (or comments-only, parsing to `None`) still passes through unchanged.

Also fixes `TestGetHermesHome.test_default_path`, which assumed `~/.hermes` on every platform — the Windows default is `%LOCALAPPDATA%/hermes`, failing independent of everything else here.

## Test plan
- [x] Two new tests: `test_refuses_to_overwrite_unparseable_config` (save on a corrupt file raises and leaves it untouched) and `test_empty_config_file_is_still_a_valid_write_target` (a zero-byte file is not "corrupt")
- [x] Full `tests/hermes_cli/test_config.py` suite passes (108/108)