### PR TITLE
fix(providers): key_env beats inline api_key for legacy custom_providers

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1190,8 +1190,12 @@ def _resolve_named_custom_runtime(
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        # key_env before inline api_key — same precedence as the providers:
+        # dict path (_get_named_custom_provider), so rotating a credential by
+        # pointing key_env at a fresh env var also works for legacy entries.
+        # An unset/empty env var falls through to the inline literal.
         _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        str(custom_provider.get("api_key", "") or "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (_getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -160,6 +160,15 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     from hermes_cli.auth import AuthError
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    # Without this, resolution reads the REAL on-disk credential pool before
+    # ever calling the mocked resolve_qwen_runtime_credentials below — on any
+    # machine where the developer actually has qwen-oauth credentials
+    # configured, that pool hit wins and the intended auth-failure fallthrough
+    # never triggers (hermeticity regression, matches the neighboring
+    # load_pool stubs elsewhere in this file).
+    monkeypatch.setattr(
+        rp, "load_pool", lambda provider: SimpleNamespace(has_credentials=lambda: False)
+    )
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",
@@ -779,6 +788,79 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     # localhost is not openai.com — OPENAI_API_KEY must not leak to local endpoints (#28660)
     assert resolved["api_key"] == "no-key-required"
     assert resolved["requested_provider"] == "custom:local-llm"
+
+
+def test_legacy_custom_provider_key_env_beats_stale_inline_api_key(monkeypatch):
+    """key_env must win over an inline api_key in the legacy custom_providers
+    list format, matching the providers-dict precedence (see the resolver's
+    own key_env-then-api_key fallback chain). Before this fix the inline
+    (possibly stale) literal silently won, so rotating a credential by
+    pointing key_env at a fresh env var had no effect for legacy entries."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("ROTATED_KEY", "fresh-env-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Rotating",
+                    "base_url": "http://1.2.3.4:1234/v1",
+                    "api_key": "stale-inline-key",
+                    "key_env": "ROTATED_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:rotating")
+
+    assert resolved["api_key"] == "fresh-env-secret"
+
+
+def test_legacy_custom_provider_inline_api_key_still_used_when_env_unset(monkeypatch):
+    """With key_env set but the env var absent, the inline api_key remains the
+    fallback — key_env precedence must not break offline/inline setups."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("UNSET_ROTATION_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Offline",
+                    "base_url": "http://1.2.3.4:1234/v1",
+                    "api_key": "inline-fallback-key",
+                    "key_env": "UNSET_ROTATION_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:offline")
+
+    assert resolved["api_key"] == "inline-fallback-key"
 
 
 


### PR DESCRIPTION
## Summary
The `providers:` dict path resolves `key_env` before the inline `api_key`, but the legacy `custom_providers:` list path tried the inline literal first. A user rotating a credential by pointing `key_env` at a fresh env var silently kept using the stale inline key for any provider configured through the legacy list format.

## Fix
Candidate order now matches the dict path (`key_env` first, falling through to the inline literal when the env var is unset/empty).

Also fixes hermeticity of `test_qwen_oauth_auto_fallthrough_on_auth_failure`: it never mocked `load_pool`, so on any machine with real qwen-oauth credentials configured (this one included — the test reliably failed here), resolution read the real on-disk credential pool before the mocked auth-failure path ever ran, defeating the fallthrough the test exists to verify.

## Test plan
- [x] Two new tests: `test_legacy_custom_provider_key_env_beats_stale_inline_api_key` and `test_legacy_custom_provider_inline_api_key_still_used_when_env_unset` (precedence must not break offline/inline-only setups)
- [x] Full `tests/hermes_cli/test_runtime_provider_resolution.py` suite passes (66/66), including the now-hermetic qwen-oauth test