### PR TITLE
fix(agent): parse relative x-ratelimit-reset headers as seconds-from-now

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4453,7 +4453,25 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                 pass
         ratelimit_reset = headers.get("x-ratelimit-reset")
         if ratelimit_reset and "reset_at" not in context:
-            context["reset_at"] = ratelimit_reset
+            # Providers disagree on this header's unit: OpenRouter sends epoch
+            # milliseconds, GitHub-style APIs send epoch seconds, and many
+            # OpenAI-compat shims send relative "seconds until reset" (the
+            # convention of the x-ratelimit-reset-requests/-tokens family —
+            # see rate_limit_tracker.py). Plausible epochs pass through raw
+            # (credential_pool._parse_absolute_timestamp handles s vs ms);
+            # small numerics are relative deltas and must be offset from now,
+            # or the pool would read "42" as epoch-1970+42s — a cooldown
+            # already expired, nullifying the credential's exhaustion window.
+            try:
+                _reset_numeric = float(ratelimit_reset)
+            except (TypeError, ValueError):
+                # Non-numeric (e.g. ISO-8601) — downstream parses it.
+                context["reset_at"] = ratelimit_reset
+            else:
+                if _reset_numeric >= 1_000_000_000:
+                    context["reset_at"] = ratelimit_reset
+                elif _reset_numeric >= 0:
+                    context["reset_at"] = time.time() + _reset_numeric
 
     if "message" not in context:
         raw_message = str(error).strip()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5463,6 +5463,58 @@ class TestCredentialPoolRecovery:
         assert context["message"] == "Weekly credits exhausted."
         assert context["reset_at"] == "2026-04-12T10:30:00Z"
 
+    def test_extract_api_error_context_relative_ratelimit_reset_header(
+        self, agent, monkeypatch
+    ):
+        """x-ratelimit-reset carrying relative "seconds until reset" (the
+        convention of the x-ratelimit-reset-* family) must be converted to an
+        absolute timestamp. Stored raw, credential_pool's
+        _parse_absolute_timestamp would read "42" as epoch-1970+42s — a
+        cooldown already decades in the past — so the just-rate-limited
+        credential would be immediately re-selectable in a tight loop."""
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body=None,
+            response=SimpleNamespace(headers={"x-ratelimit-reset": "42"}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reset_at"] == pytest.approx(1_042.0)
+
+    def test_extract_api_error_context_epoch_ratelimit_reset_header(self, agent):
+        """Plausible epoch values (seconds or milliseconds) must be kept
+        as-is — credential_pool._parse_absolute_timestamp handles both."""
+        error = SimpleNamespace(
+            body=None,
+            response=SimpleNamespace(
+                headers={"x-ratelimit-reset": "1767381900"}
+            ),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reset_at"] == "1767381900"
+
+    def test_extract_api_error_context_retry_after_beats_ratelimit_reset(
+        self, agent, monkeypatch
+    ):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body=None,
+            response=SimpleNamespace(
+                headers={"retry-after": "30", "x-ratelimit-reset": "42"}
+            ),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reset_at"] == pytest.approx(1_030.0)
+
     def test_extract_api_error_context_uses_type_as_reason(self, agent):
         error = SimpleNamespace(
             body={


### PR DESCRIPTION
## Summary
`extract_api_error_context` stored the `x-ratelimit-reset` header raw while its sibling `retry-after` branch correctly offset from `time.time()`. Providers disagree on this header's unit: OpenRouter sends epoch milliseconds, GitHub-style APIs send epoch seconds, and many OpenAI-compat shims send relative "seconds until reset" (the convention documented in `rate_limit_tracker.py` for the `x-ratelimit-reset-requests`/`-tokens` family).

A relative value like `"42"` reached `credential_pool._parse_absolute_timestamp` as epoch-1970+42s — a cooldown already decades expired — so a just-rate-limited credential was immediately re-selectable, nullifying the exhaustion window and enabling tight rotate/429 loops with no backoff.

## Fix
Plausible epochs (`>= 1e9`) still pass through raw — `credential_pool._parse_absolute_timestamp` already handles seconds vs. milliseconds for those. Smaller numerics are now offset from `time.time()`. Non-numerics (ISO-8601) keep the existing pass-through.

## Test plan
- [x] `test_extract_api_error_context_relative_ratelimit_reset_header` — a relative `"42"` becomes `time.time() + 42`
- [x] `test_extract_api_error_context_epoch_ratelimit_reset_header` — plausible epoch values (seconds or milliseconds) pass through unchanged