### PR TITLE
fix(env): warn on stderr when .env corruption repair cannot be written

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -463,8 +463,22 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
                 except OSError:
                     pass
                 raise
-    except Exception:
-        pass  # best-effort — don't block gateway startup
+    except Exception as exc:
+        # Best-effort — don't block gateway startup. But say WHY the repair
+        # was skipped: on Windows a locked .env (open editor, OneDrive sync)
+        # makes atomic_replace raise PermissionError, and python-dotenv then
+        # parses the still-corrupted file — the exact mangled-values failure
+        # this function exists to prevent (#8908). Silent skip made that
+        # undiagnosable.
+        try:
+            sys.stderr.write(
+                f"⚠️  hermes env: could not repair corrupted {path}: {exc}. "
+                f"Values from this file may load mangled; close any program "
+                f"holding the file open and restart.\n"
+            )
+            sys.stderr.flush()
+        except Exception:
+            pass
 
 
 def load_hermes_dotenv(

--- a/tests/hermes_cli/test_env_sanitize_on_load.py
+++ b/tests/hermes_cli/test_env_sanitize_on_load.py
@@ -84,3 +84,32 @@ def test_env_loader_does_not_split_concatenated_text():
         assert parsed_token == f"{token}ANTHROPIC_API_KEY=sk-ant-test"
     finally:
         env_path.unlink(missing_ok=True)
+
+
+def test_env_loader_warns_when_repair_write_fails(capsys):
+    """A failed .env repair (e.g. Windows file lock during atomic_replace)
+    must warn on stderr instead of silently leaving the corrupted file for
+    python-dotenv to mis-parse — the exact failure mode of #8908."""
+    from hermes_cli import env_loader
+
+    corrupted = "TELEGRAM_BOT_TOKEN=0123456789:testANTHROPIC_API_KEY=sk-ant\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".env", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(corrupted)
+        env_path = Path(f.name)
+
+    def _locked_replace(src, dst):
+        raise PermissionError("[WinError 32] file is in use")
+
+    try:
+        with patch.object(env_loader, "atomic_replace", _locked_replace):
+            env_loader._sanitize_env_file_if_needed(env_path)
+
+        err = capsys.readouterr().err
+        assert "hermes env:" in err
+        assert str(env_path) in err
+        # File must be left as-is (repair failed, nothing destroyed)
+        assert Path(env_path).read_text(encoding="utf-8") == corrupted
+    finally:
+        env_path.unlink(missing_ok=True)

--- a/tests/hermes_cli/test_env_sanitize_on_load.py
+++ b/tests/hermes_cli/test_env_sanitize_on_load.py
@@ -89,10 +89,19 @@ def test_env_loader_does_not_split_concatenated_text():
 def test_env_loader_warns_when_repair_write_fails(capsys):
     """A failed .env repair (e.g. Windows file lock during atomic_replace)
     must warn on stderr instead of silently leaving the corrupted file for
-    python-dotenv to mis-parse — the exact failure mode of #8908."""
+    python-dotenv to mis-parse — the exact failure mode of #8908.
+
+    Uses an embedded-null-byte corruption rather than a concatenated-line
+    one: per test_env_loader_does_not_split_concatenated_text /
+    test_load_env_preserves_concatenated_text_as_value_data above, a
+    concatenated line is now deliberately left untouched (ambiguous —
+    could be opaque value data), so it never reaches the write attempt
+    this test needs to exercise. A null byte is unconditionally stripped
+    regardless of that heuristic, reliably triggering the rewrite.
+    """
     from hermes_cli import env_loader
 
-    corrupted = "TELEGRAM_BOT_TOKEN=0123456789:testANTHROPIC_API_KEY=sk-ant\n"
+    corrupted = "TELEGRAM_BOT_TOKEN=my\x00token\n"
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".env", delete=False, encoding="utf-8"
     ) as f:


### PR DESCRIPTION
## Summary
`_sanitize_env_file_if_needed` swallowed every failure of its sanitize-and-replace step. On Windows a locked `.env` (open editor, OneDrive sync) makes `atomic_replace` raise `PermissionError`, the repair is dropped with zero signal, and python-dotenv parses the still-corrupted file — the exact mangled-values failure the function exists to prevent. Startup is still never blocked; the skip is just no longer silent.

## Fix
Catches the write failure and warns on stderr with the path and reason, instead of silently continuing with a corrupted `.env`.

Includes a fix to the test itself: the original corruption fixture (a concatenated line with no newline) no longer triggers a rewrite at all, since that case is now deliberately left untouched elsewhere in this file (ambiguous — could be opaque value data, see the neighboring `test_env_loader_does_not_split_concatenated_text`). Switched to an embedded-null-byte fixture, which is stripped unconditionally regardless of that heuristic and reliably reaches the write attempt this test needs to exercise.

## Test plan
- [x] `test_env_loader_warns_when_repair_write_fails` — a locked-file write failure now warns with the path and reason on stderr
- [x] Full `tests/hermes_cli/test_env_sanitize_on_load.py` suite passes (4/4)