### PR TITLE
fix(state): identify state.db holders by dev+inode, not path string

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5117,6 +5117,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             _canonical(db_path + "-wal"),
             _canonical(db_path + "-shm"),
         }
+
+        # A path string does not identify a file.  On a container host the
+        # guest's /root/.hermes/state.db shows up in the host's /proc with a
+        # string-identical path, so a pure path match flags an unrelated
+        # database on another filesystem as a holder and defers automatic FTS
+        # maintenance forever.  Pin identity to (st_dev, st_ino), and keep the
+        # path match only as a same-filesystem fallback for unlinked sidecars,
+        # whose inodes are no longer reachable by path.
+        watched_ids: Set[Tuple[int, int]] = set()
+        db_dev: Optional[int] = None
+        for _candidate in (db_path, db_path + "-wal", db_path + "-shm"):
+            try:
+                _st = os.stat(_candidate)
+            except OSError:
+                continue
+            watched_ids.add((_st.st_dev, _st.st_ino))
+            if _candidate == db_path:
+                db_dev = _st.st_dev
+
         holders: List[Tuple[int, str]] = []
 
         # On Linux, read /proc/<pid>/fd symlinks directly.  psutil's
@@ -5150,11 +5169,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             holders.append((pid, f"uninspectable holder: {cmdline[:80]}"))
                         continue
                     for fd in fds:
+                        fd_path = f"{fd_dir}/{fd}"
                         try:
-                            target = os.readlink(f"{fd_dir}/{fd}")
+                            target = os.readlink(fd_path)
                         except OSError:
                             continue
-                        if _canonical(target) in watched:
+                        if _canonical(target) not in watched:
+                            continue
+                        # Resolve the descriptor itself: this works across
+                        # mount namespaces and for unlinked sidecars, both of
+                        # which defeat a stat() of the literal path.
+                        try:
+                            fd_st = os.stat(fd_path)
+                        except OSError:
+                            # Identity unprovable; treat the path match as a
+                            # holder rather than assume quiescence.
+                            holders.append((pid, target))
+                            continue
+                        if (fd_st.st_dev, fd_st.st_ino) in watched_ids or (
+                            db_dev is not None and fd_st.st_dev == db_dev
+                        ):
                             holders.append((pid, target))
             except Exception as exc:
                 logger.warning(

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -227,6 +227,66 @@ class TestRuntimeFtsRebuild:
         holders = db._foreign_state_db_holders()
         assert holders == [(222, db_path_wal + " (deleted)")]
 
+    def test_foreign_holder_ignores_same_path_on_other_filesystem(
+        self, db, tmp_path, monkeypatch
+    ):
+        """A container guest's state.db is not a holder of the host's.
+
+        On a container host (Proxmox/LXC, Docker), a guest process appears in
+        the host's /proc with a string-identical path -- /root/.hermes/state.db
+        -- for a completely different file on a different filesystem.  Matching
+        on the path string alone flags it as a foreign holder, which defers
+        automatic FTS maintenance forever while corruption compounds.
+
+        Identity must come from (st_dev, st_ino), not the path text.
+        """
+        db_path = tmp_path / "state.db"
+
+        proc_root = tmp_path / "proc"
+        for pid in (111, 222):
+            (proc_root / str(pid) / "fd").mkdir(parents=True)
+        # PID 222 = container process holding ITS OWN state.db, which happens
+        # to have the identical absolute path inside its mount namespace.
+        guest_db = tmp_path / "guest_state.db"
+        guest_db.touch()
+        os.symlink(str(guest_db), str(proc_root / "222" / "fd" / "3"))
+
+        monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+        monkeypatch.setattr(hermes_state.sys, "platform", "linux")
+
+        real_listdir = os.listdir
+        def _listdir(path):
+            if isinstance(path, str):
+                path = path.replace("/proc", str(proc_root))
+            return real_listdir(path)
+        monkeypatch.setattr(hermes_state.os, "listdir", _listdir)
+
+        # The guest fd reports the host's path (identical string), which is
+        # exactly what the kernel shows across mount namespaces.
+        def _readlink(path):
+            path = path.replace("/proc", str(proc_root))
+            if path.endswith(f"{proc_root}/222/fd/3") or "222" in path:
+                return str(db_path)
+            return os.readlink(path)
+        monkeypatch.setattr(hermes_state.os, "readlink", _readlink)
+
+        # ...but stat()ing the descriptor resolves to the guest's own file on
+        # a different device.
+        real_stat = os.stat
+        def _stat(path, *a, **kw):
+            path_s = str(path).replace("/proc", str(proc_root))
+            st = real_stat(path_s, *a, **kw)
+            if path_s.endswith("/222/fd/3"):
+                fields = list(st)
+                # os.stat_result positional layout: st_dev is index 2.
+                fields[2] = st.st_dev + 1000
+                return os.stat_result(fields)
+            return st
+        monkeypatch.setattr(hermes_state.os, "stat", _stat)
+
+        assert db._foreign_state_db_holders() == []
+
     def test_foreign_holder_uninspectable_process_cmdline_fallback(
         self, db, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

`_foreign_state_db_holders()` compared `/proc/<pid>/fd` readlink targets against the watched paths **as strings**. A path string does not identify a file: on a container host, a guest process shows up in the host's `/proc` with a string-identical path for a different file on a different filesystem. The guard matched it, concluded the database was busy, and deferred automatic FTS maintenance for as long as the container kept running.

This pins holder identity to `(st_dev, st_ino)`, obtained by `stat()`ing the descriptor path `/proc/<pid>/fd/<n>` rather than the literal path. That resolves correctly across mount namespaces **and** for unlinked files — both of which defeat a `stat()` of the path text.

The path match is kept as a **same-filesystem** fallback, so the split-brain unlinked-sidecar detection the guard was written for still works (an unlinked WAL's inode is no longer reachable by path). An un-stat-able descriptor still counts as a holder, so the guard never assumes quiescence it cannot prove.

### Relationship to #92419

Same function, different branch. #92419 fixes the **cmdline fallback** (unreadable fd tables); this fixes the **descriptor path**. They are complementary, and I'd expect a small conflict in `_foreign_state_db_holders()` and in `tests/state/test_fts_runtime_rebuild.py` depending on merge order — happy to rebase on whichever lands first.

Worth flagging: #92419's analysis says *"The descriptor-based holder guard is not the source of the false positive; it only reports watched database paths and remains unchanged."* That is true only when every filesystem is the same one. With mount namespaces, "watched database path" matches an unrelated database.

### Why this is not cosmetic

On the reporting host, repair never ran and the damage progressed from the FTS indexes into canonical B-trees (`PRAGMA quick_check`: malformed pages across 10 trees, plus wrong index entry counts). The gateway began refusing turns with *"the turn was stopped because session storage could not be written"*. Recovery required an offline `sqlite3 .recover`; 4 `sessions` rows were lost, and since Hermes runs with `PRAGMA foreign_keys=ON`, their surviving messages were left as an integrity violation.

## Related Issue

Fixes #96009

Sibling: #92401 / #92419 (cmdline path)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `_foreign_state_db_holders()`: build a `(st_dev, st_ino)` identity set for the DB and its sidecars; match descriptors by stat'ing `/proc/<pid>/fd/<n>`; keep the path match as a same-filesystem fallback; treat an un-stat-able descriptor as a holder.
- `tests/state/test_fts_runtime_rebuild.py` — add `test_foreign_holder_ignores_same_path_on_other_filesystem`.

## How to Test

1. `pytest tests/state/test_fts_runtime_rebuild.py -q`
2. The new test simulates the container case: `/proc/222/fd/3` readlinks to the host DB path, but `stat()` reports a different `st_dev`.
   - On `main` it fails: `assert [(222, '.../state.db')] == []`
   - With this patch it passes.
3. The existing deleted-WAL split-brain test (`test_foreign_holder_detection_proc_readlink_deleted_wal`) still passes, covering the same-filesystem fallback.

Verified on the live host that produced the bug: with the gateway stopped the guard reports `[]` (container excluded, 19 path-identical container fds present); with the gateway running it reports the host gateway's PID, whose fd resolves to `dev=64513 inode=5248191` — an exact match for the host DB. It discriminates in both directions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #92419, which covers the sibling cmdline path; see above
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian / Proxmox VE 9.x, Linux 7.0.14-12-pve, Python 3.11.15

**Note on the test checkbox, rather than ticking it inaccurately:** I ran `pytest tests/state/ -q` on this branch — **89 passed, 1 failed**. The failure is `test_foreign_holder_uninspectable_process_cmdline_fallback`, and it is **pre-existing and unrelated**: it reproduces identically on unpatched `origin/main` at the same base commit (7a1aafb4e). It assumes `chmod 0o000` makes an fd directory unlistable, which is not true when the suite runs as root — that test appears to require a non-root runner. I did not run the full `tests/` suite: this is a production host with a live gateway, and I wasn't willing to run the whole suite against it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments in the changed function) — the rationale is recorded inline
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact: the change is inside the existing `sys.platform.startswith("linux")` branch. The Windows early-return and the macOS/BSD `psutil.open_files()` path are untouched.
