### PR TITLE
fix(auth): preserve authoritative Codex pool order

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -754,6 +754,8 @@ class CredentialPool:
 
     def has_available(self) -> bool:
         """True if at least one entry is not currently in exhaustion cooldown."""
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex("inspect") is not None
         # ``_available_entries`` is not read-only: it prunes aged-out DEAD
         # manual entries (rebinding ``self._entries``) and persists.  It must
         # run under ``self._lock`` like every other caller (``select`` etc.),
@@ -773,11 +775,12 @@ class CredentialPool:
         "unavailable".
 
         Like :meth:`has_available`, expired cooldowns are left uncleared
-        (``clear_expired=False``); the only writes are the same
-        re-auth/token sync paths ``has_available`` already performs — which
-        is exactly why this must run under ``self._lock`` like every other
-        ``_available_entries`` caller (see the comment on ``has_available``).
+        (``clear_expired=False``).  Mixed manual Codex pools are inspected and
+        pruned from the locked authoritative rows; other pools retain the
+        legacy in-memory path under ``self._lock``.
         """
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex("next_available")
         with self._lock:
             available, _pending = self._available_entries()
             if available:
@@ -856,6 +859,144 @@ class CredentialPool:
                 removed_ids=removed_ids,
             )
 
+    def _has_manual_codex_entries(self) -> bool:
+        if self.provider != "openai-codex":
+            return False
+        with self._lock:
+            if any(
+                entry.source == SOURCE_MANUAL_DEVICE_CODE
+                for entry in self._entries
+            ):
+                return True
+        try:
+            found, _saved = auth_mod.mutate_credential_pool(
+                self.provider,
+                lambda rows: any(
+                    isinstance(row, dict)
+                    and row.get("source") == SOURCE_MANUAL_DEVICE_CODE
+                    for row in rows
+                ),
+            )
+            return bool(found)
+        except Exception:
+            logger.debug(
+                "Failed to inspect authoritative Codex pool sources",
+                exc_info=True,
+            )
+            return False
+
+    def _manual_codex_candidate(self, entry_id=None, api_key=None):
+        if self.provider != "openai-codex":
+            return None
+        with self._lock:
+            return next((entry for entry in self._entries
+                         if (entry_id and entry.id == entry_id)
+                         or (api_key and entry.runtime_api_key == api_key)),
+                        None if entry_id or api_key else
+                        self._current_unlocked() or (self._entries[0] if self._entries else None))
+
+    def _manual_codex_transaction(
+        self,
+        mutator,
+        *,
+        include_provider_state=False,
+        lock_timeout_seconds=None,
+    ):
+        result, saved = auth_mod.mutate_credential_pool(
+            self.provider, mutator,
+            include_provider_state=include_provider_state,
+            lock_timeout_seconds=lock_timeout_seconds,
+        )
+        adopted = [
+            PooledCredential.from_dict(self.provider, row)
+            for row in saved
+            if isinstance(row, dict)
+        ]
+        with self._lock:
+            self._entries = adopted
+            if self._current_id and not any(
+                entry.id == self._current_id for entry in adopted
+            ):
+                self._current_id = None
+        return result
+
+    def _codex_singleton_from_provider_state(
+        self,
+        entry: PooledCredential,
+        state: Optional[Dict[str, Any]],
+    ) -> PooledCredential:
+        if entry.source != "device_code" or not isinstance(state, dict):
+            return entry
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return entry
+        store_access = tokens.get("access_token", "")
+        store_refresh = tokens.get("refresh_token", "")
+        current_access = entry.access_token or ""
+        current_refresh = entry.refresh_token or ""
+        should_adopt = bool(
+            store_access and (
+                store_access != current_access
+                or (store_refresh and store_refresh != current_refresh)
+            )
+        ) or bool(
+            store_refresh
+            and store_refresh != current_refresh
+            and not store_access
+        )
+        if not should_adopt:
+            return entry
+        if store_refresh and not store_access:
+            logger.info(
+                "Pool entry %s: auth.json has newer refresh_token "
+                "but no access_token; adopting refresh_token to "
+                "avoid replaying consumed token",
+                entry.id,
+            )
+        field_updates: Dict[str, Any] = {
+            "access_token": store_access or entry.access_token,
+            "refresh_token": store_refresh or entry.refresh_token,
+            "last_status": None,
+            "last_status_at": None,
+            "last_error_code": None,
+            "last_error_reason": None,
+            "last_error_message": None,
+            "last_error_reset_at": None,
+        }
+        if state.get("last_refresh"):
+            field_updates["last_refresh"] = state["last_refresh"]
+        return replace(entry, **field_updates)
+
+    def _marked_failure_entry(
+        self,
+        entry: PooledCredential,
+        status_code: Optional[int],
+        error_context: Optional[Dict[str, Any]] = None,
+        *,
+        failure_reason: Optional[str] = None,
+    ) -> PooledCredential:
+        normalized_error = _normalize_error_context(error_context)
+        status = (
+            STATUS_DEAD
+            if self._is_terminal_auth_failure(status_code, normalized_error)
+            else STATUS_EXHAUSTED
+        )
+        updated_extra = dict(entry.extra)
+        if failure_reason:
+            updated_extra["failure_reason"] = failure_reason
+        else:
+            updated_extra.pop("failure_reason", None)
+        return replace(
+            entry,
+            last_status=status,
+            last_status_at=time.time(),
+            last_error_code=status_code,
+            last_error_reason=normalized_error.get("reason"),
+            last_error_message=normalized_error.get("message"),
+            last_error_reset_at=normalized_error.get("reset_at"),
+            extra=updated_extra,
+        )
+
     def _is_terminal_auth_failure(
         self,
         status_code: Optional[int],
@@ -893,36 +1034,11 @@ class CredentialPool:
         persist: bool = True,
         failure_reason: Optional[str] = None,
     ) -> PooledCredential:
-        normalized_error = _normalize_error_context(error_context)
-        # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
-        # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
-        # a revoked credential gets a 1-hour TTL cooldown and then re-enters
-        # rotation, failing immediately every hour until the user manually
-        # removes it (issue #32849).  DEAD entries are excluded from rotation
-        # unconditionally and only clear via an explicit re-auth write-side
-        # sync (``_save_codex_tokens`` after a fresh device-code login).
-        if self._is_terminal_auth_failure(status_code, normalized_error):
-            terminal_status = STATUS_DEAD
-        else:
-            terminal_status = STATUS_EXHAUSTED
-        # Carry the classifier's verdict onto the entry so the cooldown can be
-        # sized by what actually failed, not just the HTTP status (a billing
-        # 403 must not get the sole-credential transient cooldown). Absent a
-        # classification, clear any stale verdict from a previous failure.
-        updated_extra = dict(entry.extra)
-        if failure_reason:
-            updated_extra["failure_reason"] = failure_reason
-        else:
-            updated_extra.pop("failure_reason", None)
-        updated = replace(
+        updated = self._marked_failure_entry(
             entry,
-            last_status=terminal_status,
-            last_status_at=time.time(),
-            last_error_code=status_code,
-            last_error_reason=normalized_error.get("reason"),
-            last_error_message=normalized_error.get("message"),
-            last_error_reset_at=normalized_error.get("reset_at"),
-            extra=updated_extra,
+            status_code,
+            error_context,
+            failure_reason=failure_reason,
         )
         self._replace_entry(entry, updated)
         if persist:
@@ -1103,70 +1219,33 @@ class CredentialPool:
                 )
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "openai-codex")
-            if not isinstance(state, dict):
-                return entry
-            tokens = state.get("tokens")
-            if not isinstance(tokens, dict):
-                return entry
-            store_access = tokens.get("access_token", "")
-            store_refresh = tokens.get("refresh_token", "")
-            # Adopt auth.json tokens when either side differs.  Codex refresh
-            # tokens are single-use too, so a fresh refresh_token from
-            # another process means our entry's pair is consumed/stale.
-            #
-            # Also adopt when the store has a refresh_token but no
-            # access_token — another process may have rotated the pair
-            # and the store entry's access_token was already consumed;
-            # the important signal is the refresh_token difference.
-            entry_access = entry.access_token or ""
-            entry_refresh = entry.refresh_token or ""
-            should_adopt = False
-            if store_access and (
-                store_access != entry_access
-                or (store_refresh and store_refresh != entry_refresh)
-            ):
-                should_adopt = True
-            elif (
-                store_refresh
-                and store_refresh != entry_refresh
-                and not store_access
-            ):
-                # Store has only a refresh_token (no access_token) —
-                # another process rotated the pair.  Adopt the
-                # refresh_token so we don't replay the consumed one.
-                logger.info(
-                    "Pool entry %s: auth.json has newer refresh_token "
-                    "but no access_token; adopting refresh_token to "
-                    "avoid replaying consumed token",
-                    entry.id,
+            def _adopt_singleton(rows, state):
+                index = next((
+                    i for i, row in enumerate(rows)
+                    if isinstance(row, dict)
+                    and row.get("id") == entry.id
+                    and row.get("source") == entry.source
+                ), None)
+                if index is None:
+                    return None
+                current = PooledCredential.from_dict(self.provider, rows[index])
+                updated = self._codex_singleton_from_provider_state(
+                    current, state
                 )
-                should_adopt = True
+                if updated is not current:
+                    rows[index] = updated.to_dict()
+                return current.id
 
-            if should_adopt:
-                logger.debug(
-                    "Pool entry %s: syncing Codex tokens from auth.json "
-                    "(refreshed by another process)",
-                    entry.id,
-                )
-                field_updates: Dict[str, Any] = {
-                    "access_token": store_access or entry.access_token,
-                    "refresh_token": store_refresh or entry.refresh_token,
-                    "last_status": None,
-                    "last_status_at": None,
-                    "last_error_code": None,
-                    "last_error_reason": None,
-                    "last_error_message": None,
-                    "last_error_reset_at": None,
-                }
-                if state.get("last_refresh"):
-                    field_updates["last_refresh"] = state["last_refresh"]
-                updated = replace(entry, **field_updates)
-                self._replace_entry(entry, updated)
-                self._persist()
-                return updated
+            synced_id = self._manual_codex_transaction(
+                _adopt_singleton, include_provider_state=True,
+            )
+            with self._lock:
+                synced = next((
+                    current for current in self._entries
+                    if current.id == synced_id and current.source == entry.source
+                ), None)
+            if synced is not None:
+                return synced
         except Exception as exc:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
         return entry
@@ -1484,6 +1563,11 @@ class CredentialPool:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+        if (
+            self.provider == "openai-codex"
+            and entry.source == SOURCE_MANUAL_DEVICE_CODE
+        ):
+            return self._mutate_manual_codex("refresh", id=entry.id, force=force)
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -1515,9 +1599,14 @@ class CredentialPool:
                 if self.provider == "xai-oauth"
                 else self._sync_anthropic_entry_from_pool_store
             )
-            with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
-            ):
+            lock = (
+                auth_mod._locked_profile_global_auth_stores(
+                    self._single_use_refresh_lock_timeout())
+                if self.provider == "openai-codex"
+                else _auth_store_lock(
+                    timeout_seconds=self._single_use_refresh_lock_timeout())
+            )
+            with lock:
                 synced = sync_entry(entry)
                 if self.provider == "openai-codex":
                     if synced is not entry:
@@ -2168,7 +2257,204 @@ class CredentialPool:
             return False
         return False
 
+    def _mutate_manual_codex(self, operation: str, **values):
+        def _mutate(rows, state=None):
+            entries = [PooledCredential.from_dict(self.provider, row)
+                       for row in rows if isinstance(row, dict)]
+            result = None
+            if operation in {"select", "inspect", "lease", "next_available"}:
+                if operation == "next_available":
+                    entries = [
+                        self._codex_singleton_from_provider_state(item, state)
+                        for item in entries
+                    ]
+                working = CredentialPool(self.provider, entries)
+                working._strategy = self._strategy
+                working._persist = lambda **_kwargs: None
+                working._sync_codex_entry_from_auth_store = lambda entry: entry
+                if operation == "select":
+                    chosen, _pending = working._select_unlocked(refresh=False)
+                else:
+                    available, _pending = working._available_entries(
+                        clear_expired=operation == "lease")
+                    if operation == "lease" and available:
+                        leases = values["leases"]
+                        below = [item for item in available
+                                 if leases.get(item.id, 0) < self._max_concurrent]
+                        chosen = min(below or available,
+                                     key=lambda item: (leases.get(item.id, 0),
+                                                       item.priority))
+                    elif operation == "next_available":
+                        chosen = None
+                        if not available:
+                            sole_credential = sum(
+                                1 for item in working._entries
+                                if item.last_status != STATUS_DEAD
+                            ) <= 1
+                            candidates = [
+                                until
+                                for item in working._entries
+                                if item.last_status == STATUS_EXHAUSTED
+                                for until in [
+                                    _exhausted_until(
+                                        item,
+                                        sole_credential=sole_credential,
+                                    )
+                                ]
+                                if until is not None
+                            ]
+                            result = min(candidates) if candidates else None
+                    else:
+                        chosen = available[0] if available else None
+                entries = working._entries
+                if operation != "next_available":
+                    result = chosen.id if chosen else None
+            elif operation == "refresh":
+                index = next((i for i, entry in enumerate(entries)
+                              if entry.id == values.get("id")
+                              and (not values.get("source")
+                                   or entry.source == values["source"])), None)
+                if index is None and values.get("hint"):
+                    index = next((i for i, entry in enumerate(entries)
+                                  if entry.runtime_api_key == values["hint"]), None)
+                if index is not None:
+                    entry = self._codex_singleton_from_provider_state(
+                        entries[index], state
+                    )
+                    entries[index] = entry
+                    if not values["force"] and not self._entry_needs_refresh(entry):
+                        result = entry.id
+                    elif not entry.refresh_token:
+                        entries[index] = self._marked_failure_entry(entry, None)
+                    else:
+                        try:
+                            fresh = auth_mod.refresh_codex_oauth_pure(
+                                entry.access_token, entry.refresh_token)
+                            entries[index] = replace(
+                                entry, access_token=fresh["access_token"],
+                                refresh_token=fresh["refresh_token"],
+                                last_refresh=fresh.get("last_refresh"),
+                                last_status=STATUS_OK, last_status_at=None,
+                                last_error_code=None, last_error_reason=None,
+                                last_error_message=None, last_error_reset_at=None)
+                            result = entry.id
+                            if (
+                                entry.source == "device_code"
+                                and isinstance(state, dict)
+                            ):
+                                tokens = state.get("tokens")
+                                if not isinstance(tokens, dict):
+                                    tokens = {}
+                                tokens["access_token"] = fresh["access_token"]
+                                tokens["refresh_token"] = fresh["refresh_token"]
+                                state["tokens"] = tokens
+                                if fresh.get("last_refresh"):
+                                    state["last_refresh"] = fresh["last_refresh"]
+                        except Exception as exc:
+                            terminal = auth_mod._is_terminal_codex_oauth_refresh_error(exc)
+                            if terminal and entry.source == "device_code":
+                                if isinstance(state, dict):
+                                    tokens = state.get("tokens")
+                                    if not isinstance(tokens, dict):
+                                        tokens = {}
+                                    tokens.pop("access_token", None)
+                                    tokens.pop("refresh_token", None)
+                                    state["tokens"] = tokens
+                                    state["last_auth_error"] = {
+                                        "provider": "openai-codex",
+                                        "code": getattr(exc, "code", "unknown"),
+                                        "message": str(exc),
+                                        "reason": "credential_pool_refresh_failure",
+                                        "relogin_required": True,
+                                        "at": datetime.now(timezone.utc).isoformat(),
+                                    }
+                                entries = [
+                                    item for item in entries
+                                    if item.source != "device_code"
+                                ]
+                            else:
+                                entries[index] = self._marked_failure_entry(
+                                    entry, 401 if terminal else None,
+                                    {"reason": getattr(exc, "code", None),
+                                     "message": str(exc)} if terminal else None)
+            elif operation == "mark":
+                entry = next((item for item in entries
+                              if item.id == values.get("id")
+                              and (not values.get("source")
+                                   or item.source == values["source"])), None)
+                hinted = next((item for item in entries
+                               if values.get("hint")
+                               and item.runtime_api_key == values["hint"]), None)
+                if hinted is not None and (entry is None or
+                                           entry.runtime_api_key != values["hint"]):
+                    entry = hinted
+                if entry is None and not (values.get("id") or values.get("hint")):
+                    entry = next((item for item in entries
+                                  if item.id == values.get("current")),
+                                 entries[0] if entries else None)
+                if entry is not None:
+                    key = entry.runtime_api_key
+                    entries = [self._marked_failure_entry(
+                        item, values["status"], values.get("error"),
+                        failure_reason=values.get("failure_reason"))
+                        if item.id == entry.id or (key and item.runtime_api_key == key)
+                        else item for item in entries]
+                entries = [
+                    self._codex_singleton_from_provider_state(item, state)
+                    for item in entries
+                ]
+                working = CredentialPool(self.provider, entries)
+                working._strategy = self._strategy
+                working._persist = lambda **_kwargs: None
+                working._sync_codex_entry_from_auth_store = lambda entry: entry
+                chosen, _pending = working._select_unlocked(refresh=False)
+                entries, result = working._entries, chosen.id if chosen else None
+            elif operation == "reset":
+                result = sum(bool(item.last_status or item.last_status_at
+                                  or item.last_error_code) for item in entries)
+                entries = [replace(item, last_status=None, last_status_at=None,
+                                   last_error_code=None, last_error_reason=None,
+                                   last_error_message=None, last_error_reset_at=None)
+                           if item.last_status or item.last_status_at
+                           or item.last_error_code else item for item in entries]
+            elif operation == "remove" and 1 <= values["index"] <= len(entries):
+                removed = entries.pop(values["index"] - 1)
+                entries = [replace(item, priority=i) for i, item in enumerate(entries)]
+                result = removed.to_dict()
+            elif operation == "add":
+                added = replace(values["entry"], priority=_next_priority(entries))
+                entries.append(added)
+                result = added.id
+            rows[:] = [entry.to_dict() for entry in entries]
+            return result
+
+        provider_state_operation = operation in {
+            "next_available", "refresh", "mark",
+        }
+        result = self._manual_codex_transaction(
+            _mutate,
+            include_provider_state=provider_state_operation,
+            lock_timeout_seconds=(
+                self._single_use_refresh_lock_timeout()
+                if operation == "refresh" else None
+            ),
+        )
+        if operation in {"select", "inspect", "lease", "refresh", "mark", "add"}:
+            with self._lock:
+                if operation != "inspect":
+                    self._current_id = result
+                return next((entry for entry in self._entries
+                             if entry.id == result), None)
+        return result
+
     def select(self) -> Optional[PooledCredential]:
+        if self._has_manual_codex_entries():
+            entry = self._mutate_manual_codex("select")
+            if entry is not None and self._entry_needs_refresh(entry):
+                entry = self._refresh_entry(entry, force=False)
+            if entry is not None:
+                self._unmatched_rotation_streak = 0
+            return entry
         entry, pending_refresh = self._select_under_lock()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
@@ -2429,6 +2715,8 @@ class CredentialPool:
         return entry, pending_refresh
 
     def peek(self) -> Optional[PooledCredential]:
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex("inspect")
         # Single lock acquisition for the whole read; call the unlocked
         # helpers so we don't re-enter the non-reentrant ``self._lock``.
         with self._lock:
@@ -2447,6 +2735,14 @@ class CredentialPool:
         credential_id: Optional[str] = None,
         failure_reason: Optional[str] = None,
     ) -> Optional[PooledCredential]:
+        candidate = self._manual_codex_candidate(credential_id, api_key_hint)
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex(
+                "mark", status=status_code, error=error_context,
+                hint=api_key_hint, id=credential_id,
+                source=candidate.source if candidate else None,
+                current=candidate.id if candidate else None,
+                failure_reason=failure_reason)
         with self._lock:
             entry = None
             identity_supplied = bool(credential_id or api_key_hint)
@@ -2616,6 +2912,19 @@ class CredentialPool:
         a stable tie-breaker. When every credential is already at the soft cap,
         still return the least-leased one instead of blocking.
         """
+        if credential_id is None and self._has_manual_codex_entries():
+            with self._lock:
+                leases = dict(self._active_leases)
+            chosen = self._mutate_manual_codex("lease", leases=leases)
+            if chosen is None:
+                return None
+            if self._entry_needs_refresh(chosen):
+                chosen = self._refresh_entry(chosen, force=False)
+                if chosen is None:
+                    return self.acquire_lease()
+            with self._lock:
+                self._active_leases[chosen.id] = self._active_leases.get(chosen.id, 0) + 1
+            return chosen.id
         chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
@@ -2667,7 +2976,11 @@ class CredentialPool:
 
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:
-            return self._try_refresh_current_unlocked()
+            current = self._current_unlocked()
+        return (
+            self.try_refresh_matching(credential_id=current.id)
+            if current is not None else None
+        )
 
     def try_refresh_matching(
         self,
@@ -2682,6 +2995,15 @@ class CredentialPool:
         the normal proactive refresh; the forced refresh below must consume a
         rotating refresh token exactly once.
         """
+        candidate = self._manual_codex_candidate(credential_id, api_key_hint)
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex(
+                "refresh",
+                id=candidate.id if candidate else credential_id,
+                source=candidate.source if candidate else None,
+                hint=api_key_hint,
+                force=True,
+            )
         with self._lock:
             entry = None
             if credential_id:
@@ -2710,18 +3032,28 @@ class CredentialPool:
             if entry is None:
                 return None
             self._current_id = entry.id
-            return self._try_refresh_current_unlocked()
-
-    def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
-        entry = self._current_unlocked()
-        if entry is None:
-            return None
         refreshed = self._refresh_entry(entry, force=True)
-        if refreshed is not None:
-            self._current_id = refreshed.id
-        return refreshed
+        if refreshed is None:
+            return None
+        with self._lock:
+            adopted = next(
+                (
+                    current
+                    for current in self._entries
+                    if current.id == refreshed.id
+                ),
+                None,
+            )
+            if adopted is None:
+                if self._current_id == refreshed.id:
+                    self._current_id = None
+                return None
+            self._current_id = adopted.id
+            return adopted
 
     def reset_statuses(self) -> int:
+        if self._has_manual_codex_entries():
+            return self._mutate_manual_codex("reset")
         with self._lock:
             count = 0
             new_entries = []
@@ -2747,6 +3079,11 @@ class CredentialPool:
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
+        if self._has_manual_codex_entries():
+            removed = self._mutate_manual_codex("remove", index=index)
+            if not isinstance(removed, dict):
+                return None
+            return PooledCredential.from_dict(self.provider, removed)
         with self._lock:
             if index < 1 or index > len(self._entries):
                 return None
@@ -2791,6 +3128,14 @@ class CredentialPool:
             return None, None, f'No credential matching "{raw}".'
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
+        if (
+            self.provider == "openai-codex"
+            and (
+                entry.source == SOURCE_MANUAL_DEVICE_CODE
+                or self._has_manual_codex_entries()
+            )
+        ):
+            return self._mutate_manual_codex("add", entry=entry)
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1059,11 +1059,48 @@ class CredentialPool:
         though fresh credentials are sitting on disk — and every request
         fails with "no available entries (all exhausted or empty)".
 
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
+        Mirrors the Nous/Anthropic resync paths above.  The singleton-seeded
+        ``device_code`` entry syncs from provider state.  A
+        ``manual:device_code`` entry may be an independent account or a legacy
+        singleton alias; the write-side alias check updates only true aliases
+        in their exact persisted rows.  Runtime manual entries therefore adopt
+        their authoritative persisted pool before any later write can restore
+        stale in-memory order or state.
         """
-        if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
+        if self.provider != "openai-codex" or entry.source not in (
+            "device_code",
+            SOURCE_MANUAL_DEVICE_CODE,
+        ):
+            return entry
+        if entry.source == SOURCE_MANUAL_DEVICE_CODE:
+            try:
+                persisted_entries = [
+                    PooledCredential.from_dict(self.provider, payload)
+                    for payload in read_credential_pool(self.provider)
+                    if isinstance(payload, dict)
+                ]
+                with self._lock:
+                    persisted = next(
+                        (
+                            candidate
+                            for candidate in persisted_entries
+                            if candidate.id == entry.id
+                        ),
+                        None,
+                    )
+                    if persisted is None or persisted_entries == self._entries:
+                        return entry
+                    logger.debug(
+                        "Pool entry %s: adopting authoritative persisted Codex pool",
+                        entry.id,
+                    )
+                    self._entries = persisted_entries
+                    return persisted
+            except Exception as exc:
+                logger.debug(
+                    "Failed to sync manual Codex entry from credential pool: %s",
+                    exc,
+                )
             return entry
         try:
             with _auth_store_lock():
@@ -2228,7 +2265,7 @@ class CredentialPool:
             # frozen behind last_error_reset_at (can be hours in the
             # future for ChatGPT weekly windows).
             if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
+                    and entry.source in ("device_code", SOURCE_MANUAL_DEVICE_CODE)
                     and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -33,6 +33,7 @@ import threading
 import time
 import uuid
 import webbrowser
+from copy import deepcopy
 
 # httpx is imported lazily: it costs ~30ms at import time and hermes_cli.auth
 # is on the interactive-CLI startup path via credential_pool → auxiliary_client
@@ -73,7 +74,7 @@ else:
             delattr(self._resolve(), name)
 
     httpx = _LazyHttpx()
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -1520,6 +1521,41 @@ def _load_provider_state_with_source(
 
 
 @contextmanager
+def _locked_profile_global_auth_stores(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Lock and load the active and existing global auth stores in path order."""
+    target_path = _auth_file_path()
+    source_path = _global_auth_file_path()
+    if source_path is not None and _same_path(source_path, target_path):
+        source_path = None
+    if source_path is not None and os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home = os.environ.get("HOME", "")
+        if real_home and _same_path(source_path, Path(real_home) / ".hermes" / "auth.json"):
+            source_path = None
+
+    paths = {os.path.normcase(os.path.realpath(target_path)): target_path}
+    if source_path is not None and source_path.exists():
+        paths[os.path.normcase(os.path.realpath(source_path))] = source_path
+    with ExitStack() as locks:
+        for path in (paths[key] for key in sorted(paths)):
+            locks.enter_context(_auth_store_lock(
+                timeout_seconds=timeout_seconds, target_path=path,
+            ))
+        target_store = _load_auth_store(target_path)
+        source_store = _load_auth_store(source_path) if source_path in paths.values() else {}
+        yield target_path, target_store, source_path, source_store
+
+
+def _provider_state_from_locked_stores(provider_id, target_path, target_store,
+                                       source_path, source_store):
+    for path, store in ((target_path, target_store), (source_path, source_store)):
+        providers = store.get("providers")
+        state = providers.get(provider_id) if isinstance(providers, dict) else None
+        if isinstance(state, dict):
+            return dict(state), path
+    return None, None
+
+
+@contextmanager
 def _provider_state_transaction(provider_id: str):
     """Lock the active auth store and any global fallback source in order.
 
@@ -1528,26 +1564,13 @@ def _provider_state_transaction(provider_id: str):
     target lock is acquired prevents both stale refreshes and whole-file lost
     updates without inverting the documented auth -> shared lock order.
     """
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        state, source_path = _load_provider_state_with_source(
-            auth_store,
-            provider_id,
+    with _locked_profile_global_auth_stores() as (
+        target_path, auth_store, global_path, global_store,
+    ):
+        state, source_path = _provider_state_from_locked_stores(
+            provider_id, target_path, auth_store, global_path, global_store,
         )
-        active_path = _auth_file_path()
-        if source_path is None or _same_path(source_path, active_path):
-            yield auth_store, state, source_path
-            return
-
-        with _auth_store_lock(target_path=source_path):
-            source_store = _load_auth_store(source_path)
-            source_providers = source_store.get("providers")
-            source_state = None
-            if isinstance(source_providers, dict):
-                raw_state = source_providers.get(provider_id)
-                if isinstance(raw_state, dict):
-                    source_state = dict(raw_state)
-            yield auth_store, source_state, source_path
+        yield auth_store, state, source_path
 
 
 def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
@@ -1866,6 +1889,74 @@ def write_credential_pool(
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
         return _save_auth_store(auth_store)
+
+
+def mutate_credential_pool(
+    provider_id: str,
+    mutator: Callable[[List[Dict[str, Any]]], Any],
+    *,
+    include_provider_state: bool = False,
+    lock_timeout_seconds: Optional[float] = None,
+) -> Tuple[Any, List[Dict[str, Any]]]:
+    """Mutate locked authoritative rows, always saving to the active profile."""
+    lock_timeout = (
+        AUTH_LOCK_TIMEOUT_SECONDS
+        if lock_timeout_seconds is None else lock_timeout_seconds
+    )
+    with _locked_profile_global_auth_stores(lock_timeout) as (
+        target_path, target_store, source_path, source_store,
+    ):
+        pool = target_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            pool = {}
+            target_store["credential_pool"] = pool
+        target_rows = pool.get(provider_id)
+        rows = target_rows if isinstance(target_rows, list) and target_rows else []
+        if not rows and source_store:
+            source_pool = source_store.get("credential_pool")
+            source_rows = source_pool.get(provider_id) if isinstance(source_pool, dict) else None
+            if isinstance(source_rows, list):
+                rows = source_rows
+
+        working = deepcopy(rows)
+        state = None
+        state_before = None
+        state_path = None
+        if include_provider_state:
+            state, state_path = _provider_state_from_locked_stores(
+                provider_id, target_path, target_store, source_path, source_store,
+            )
+            if not isinstance(state, dict):
+                state = {}
+                state_path = target_path
+            state_before = deepcopy(state)
+            result = mutator(working, state)
+        else:
+            result = mutator(working)
+        saved = [
+            sanitize_borrowed_credential_payload(row, provider_id)
+            if isinstance(row, dict) else row
+            for row in working
+        ]
+        target_changed = saved != rows
+        source_changed = False
+        if include_provider_state and state != state_before:
+            if state_path is not None and _same_path(state_path, target_path):
+                _store_provider_state(
+                    target_store, provider_id, state, set_active=False,
+                )
+                target_changed = True
+            elif state_path is not None and source_store:
+                _store_provider_state(
+                    source_store, provider_id, state, set_active=False,
+                )
+                source_changed = True
+        if target_changed:
+            pool[provider_id] = saved
+            _save_auth_store(target_store, target_path=target_path)
+        if source_changed and source_path is not None:
+            _save_auth_store(source_store, target_path=source_path)
+        return result, deepcopy(saved)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2376,3 +2376,818 @@ def test_dead_manual_codex_alias_refreshed_on_disk_is_selectable(
     assert selected.id == "legacy-alias"
     assert selected.access_token == "fresh-access"
     assert selected.refresh_token == "fresh-refresh"
+
+
+def _manual_codex_row(
+    entry_id: str,
+    priority: int,
+    *,
+    status: str | None = None,
+    status_at: float | None = None,
+    refresh_token: str | None = None,
+) -> dict:
+    return {
+        "id": entry_id,
+        "label": entry_id,
+        "auth_type": "oauth",
+        "priority": priority,
+        "source": "manual:device_code",
+        "access_token": f"{entry_id}-access",
+        "refresh_token": (
+            f"{entry_id}-refresh" if refresh_token is None else refresh_token
+        ),
+        "last_status": status,
+        "last_status_at": status_at,
+        "last_error_code": 429 if status == "exhausted" else None,
+        "last_error_reason": "rate_limit" if status == "exhausted" else None,
+    }
+
+
+def _load_manual_codex_pool(tmp_path, monkeypatch, rows):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {"openai-codex": rows},
+        },
+    )
+    from agent.credential_pool import load_pool
+
+    return load_pool("openai-codex")
+
+
+def test_manual_codex_mark_uses_transaction_snapshot_after_external_delete(
+    tmp_path, monkeypatch
+):
+    """A completed pre-sync cannot make a later stale mark authoritative."""
+    rows = [_manual_codex_row("deleted", 0), _manual_codex_row("survivor", 1)]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    stale = pool.entries()[0]
+    assert pool._sync_codex_entry_from_auth_store(stale) is stale
+    write_credential_pool(
+        "openai-codex",
+        [dict(rows[1], priority=0)],
+        removed_ids=["deleted"],
+    )
+
+    pool.mark_exhausted_and_rotate(status_code=429, credential_id="deleted")
+
+    assert [row["id"] for row in read_credential_pool("openai-codex")] == [
+        "survivor"
+    ]
+    assert [entry.id for entry in pool.entries()] == ["survivor"]
+
+
+def test_manual_codex_round_robin_uses_fresh_disk_order_and_membership(
+    tmp_path, monkeypatch
+):
+    rows = [
+        _manual_codex_row("first", 0),
+        _manual_codex_row("deleted", 1),
+        _manual_codex_row("promoted", 2),
+    ]
+    monkeypatch.setattr(
+        "agent.credential_pool.get_pool_strategy", lambda _provider: "round_robin"
+    )
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    write_credential_pool(
+        "openai-codex",
+        [dict(rows[2], priority=0), dict(rows[0], priority=1)],
+        removed_ids=["deleted"],
+    )
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "promoted"
+    assert [row["id"] for row in read_credential_pool("openai-codex")] == [
+        "first",
+        "promoted",
+    ]
+    assert [entry.id for entry in pool.entries()] == ["first", "promoted"]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["reset_statuses", "add_entry", "remove_index", "cooldown_clear", "dead_prune",
+     "acquire_lease"],
+)
+def test_manual_codex_mutations_do_not_restore_externally_deleted_rows(
+    tmp_path, monkeypatch, operation
+):
+    now = time.time()
+    survivor_status = None
+    survivor_status_at = None
+    if operation == "reset_statuses":
+        survivor_status = "exhausted"
+        survivor_status_at = now
+    elif operation == "cooldown_clear":
+        survivor_status = "exhausted"
+        survivor_status_at = now - 7200
+    elif operation == "dead_prune":
+        survivor_status = "dead"
+        survivor_status_at = now - 2 * 24 * 60 * 60
+
+    rows = [
+        _manual_codex_row("deleted", 0),
+        _manual_codex_row(
+            "survivor",
+            1,
+            status=survivor_status,
+            status_at=survivor_status_at,
+        ),
+        _manual_codex_row("third", 2),
+    ]
+    if operation == "dead_prune":
+        rows = rows[:2]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from agent.credential_pool import PooledCredential
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    authoritative = [dict(row) for row in rows if row["id"] != "deleted"]
+    for priority, row in enumerate(authoritative):
+        row["priority"] = priority
+    write_credential_pool(
+        "openai-codex", authoritative, removed_ids=["deleted"]
+    )
+
+    if operation == "reset_statuses":
+        assert pool.reset_statuses() == 1
+    elif operation == "add_entry":
+        pool.add_entry(
+            PooledCredential.from_dict(
+                "openai-codex", _manual_codex_row("added", 99)
+            )
+        )
+    elif operation == "remove_index":
+        removed = pool.remove_index(1)
+        assert removed is not None and removed.id == "survivor"
+    elif operation == "cooldown_clear":
+        selected = pool.select()
+        assert selected is not None and selected.id == "survivor"
+    elif operation == "acquire_lease":
+        assert pool.acquire_lease() == "survivor"
+    else:
+        assert pool.has_available() is False
+
+    persisted = read_credential_pool("openai-codex")
+    assert "deleted" not in {row["id"] for row in persisted}
+    assert "deleted" not in {entry.id for entry in pool.entries()}
+    if operation == "remove_index":
+        assert [row["id"] for row in persisted] == ["third"]
+    elif operation == "add_entry":
+        assert [row["id"] for row in persisted] == ["survivor", "third", "added"]
+    elif operation == "dead_prune":
+        assert persisted == []
+    elif operation in {"reset_statuses", "cooldown_clear"}:
+        survivor = next(row for row in persisted if row["id"] == "survivor")
+        assert survivor["last_status"] in (None, "ok")
+
+
+def test_terminal_invalid_grant_manual_codex_refresh_is_persisted_dead(
+    tmp_path, monkeypatch
+):
+    rows = [_manual_codex_row("dead", 0), _manual_codex_row("healthy", 1)]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from hermes_cli.auth import AuthError, read_credential_pool
+
+    def _invalid_grant(*_args, **_kwargs):
+        raise AuthError(
+            "refresh rejected",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure", _invalid_grant
+    )
+
+    assert pool.try_refresh_matching(credential_id="dead") is None
+    persisted = {
+        row["id"]: row for row in read_credential_pool("openai-codex")
+    }
+    assert persisted["dead"]["last_status"] == "dead"
+    assert persisted["dead"]["last_error_reason"] == "invalid_grant"
+    selected = pool.select()
+    assert selected is not None and selected.id == "healthy"
+
+
+def test_nonterminal_manual_codex_refresh_failure_remains_exhausted(
+    tmp_path, monkeypatch
+):
+    rows = [
+        _manual_codex_row(
+            "target", 0, status="exhausted", status_at=time.time()
+        ),
+        _manual_codex_row("healthy", 1),
+    ]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from hermes_cli.auth import read_credential_pool
+
+    def _temporary_failure(*_args, **_kwargs):
+        raise RuntimeError("temporary token endpoint failure")
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        _temporary_failure,
+    )
+
+    assert pool.try_refresh_matching(credential_id="target") is None
+    persisted = {
+        row["id"]: row for row in read_credential_pool("openai-codex")
+    }
+    assert persisted["target"]["last_status"] == "exhausted"
+    assert persisted["healthy"]["last_status"] is None
+
+
+def test_force_refresh_without_refresh_token_preserves_failure_transition(
+    tmp_path, monkeypatch
+):
+    row = _manual_codex_row("target", 0)
+    row["refresh_token"] = ""
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, [row])
+
+    from hermes_cli.auth import read_credential_pool
+
+    assert pool.try_refresh_matching(credential_id="target") is None
+    persisted = read_credential_pool("openai-codex")
+    assert persisted[0]["last_status"] == "exhausted"
+    assert pool.select() is None
+
+
+def test_manual_codex_profile_materialization_reads_locked_global_snapshot(
+    tmp_path, monkeypatch
+):
+    """Fallback rows must be read under their own lock before profile save."""
+    import threading
+    from contextlib import contextmanager
+
+    from hermes_cli import auth as auth_mod
+
+    profile_path = tmp_path / "profile" / "auth.json"
+    global_path = tmp_path / "global" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    global_path.parent.mkdir(parents=True)
+    profile_path.write_text(json.dumps({"version": 1, "credential_pool": {}}))
+    global_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openai-codex": [
+                        _manual_codex_row("deleted", 0),
+                        _manual_codex_row("survivor", 1),
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_store_cache", None)
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: None)
+
+    from agent.credential_pool import PooledCredential, load_pool
+
+    pool = load_pool("openai-codex")
+    real_lock = auth_mod._auth_store_lock
+    real_load = auth_mod._load_auth_store
+    global_updated = threading.Event()
+    release_global = threading.Event()
+    global_attempted = threading.Event()
+    operation_done = threading.Event()
+    global_read_locked = threading.Event()
+
+    @contextmanager
+    def _tracking_lock(*args, **kwargs):
+        target = kwargs.get("target_path")
+        if (
+            threading.current_thread().name == "profile-operation"
+            and target is not None
+            and auth_mod._same_path(target, global_path)
+        ):
+            global_attempted.set()
+        with real_lock(*args, **kwargs):
+            yield
+
+    def _tracking_load(path=None):
+        if (
+            threading.current_thread().name == "profile-operation"
+            and path is not None
+            and auth_mod._same_path(path, global_path)
+        ):
+            holder = auth_mod._auth_lock_holder_for(global_path)
+            if getattr(holder, "depth", 0) > 0:
+                global_read_locked.set()
+        return real_load(path)
+
+    monkeypatch.setattr(auth_mod, "_auth_store_lock", _tracking_lock)
+    monkeypatch.setattr(auth_mod, "_load_auth_store", _tracking_load)
+
+    def _global_writer():
+        with real_lock(target_path=global_path):
+            store = real_load(global_path)
+            survivor = _manual_codex_row("survivor", 0)
+            survivor["access_token"] = "survivor-current-access"
+            store["credential_pool"]["openai-codex"] = [survivor]
+            auth_mod._save_auth_store(store, target_path=global_path)
+            global_updated.set()
+            assert release_global.wait(timeout=5)
+
+    def _profile_operation():
+        pool.add_entry(
+            PooledCredential.from_dict(
+                "openai-codex", _manual_codex_row("added", 99)
+            )
+        )
+        operation_done.set()
+
+    writer = threading.Thread(target=_global_writer, name="global-writer")
+    writer.start()
+    assert global_updated.wait(timeout=5)
+    operation = threading.Thread(target=_profile_operation, name="profile-operation")
+    operation.start()
+    # Fixed code attempts the source lock; baseline completes without it.
+    while not global_attempted.is_set() and not operation_done.is_set():
+        operation_done.wait(timeout=0.01)
+    release_global.set()
+    writer.join(timeout=5)
+    operation.join(timeout=5)
+    assert not writer.is_alive() and not operation.is_alive()
+
+    profile = json.loads(profile_path.read_text())
+    saved = profile["credential_pool"]["openai-codex"]
+    assert global_read_locked.is_set()
+    assert [row["id"] for row in saved] == ["survivor", "added"]
+    assert saved[0]["access_token"] == "survivor-current-access"
+
+
+def test_manual_codex_transaction_does_not_wait_for_auth_under_pool_lock(
+    tmp_path, monkeypatch
+):
+    """Auth-first and pool-first threads complete without lock inversion."""
+    import threading
+    from contextlib import contextmanager
+
+    from hermes_cli import auth as auth_mod
+
+    rows = [_manual_codex_row("first", 0), _manual_codex_row("second", 1)]
+    monkeypatch.setattr(
+        "agent.credential_pool.get_pool_strategy", lambda _provider: "round_robin"
+    )
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+    real_lock = auth_mod._auth_store_lock
+    auth_held = threading.Event()
+    pool_waiting_for_auth = threading.Event()
+    auth_thread_got_pool = []
+
+    @contextmanager
+    def _tracking_lock(*args, **kwargs):
+        if threading.current_thread().name == "pool-first":
+            pool_waiting_for_auth.set()
+        with real_lock(*args, **kwargs):
+            yield
+
+    monkeypatch.setattr(auth_mod, "_auth_store_lock", _tracking_lock)
+
+    def _auth_first():
+        with real_lock():
+            auth_held.set()
+            assert pool_waiting_for_auth.wait(timeout=5)
+            acquired = pool._lock.acquire(timeout=1)
+            auth_thread_got_pool.append(acquired)
+            if acquired:
+                pool._lock.release()
+
+    def _pool_first():
+        assert auth_held.wait(timeout=5)
+        pool.select()
+
+    auth_thread = threading.Thread(target=_auth_first, name="auth-first")
+    pool_thread = threading.Thread(target=_pool_first, name="pool-first")
+    auth_thread.start()
+    pool_thread.start()
+    auth_thread.join(timeout=5)
+    pool_thread.join(timeout=5)
+
+    assert not auth_thread.is_alive() and not pool_thread.is_alive()
+    assert auth_thread_got_pool == [True]
+
+
+def test_exact_manual_codex_refresh_adopts_external_delete_without_post(
+    tmp_path, monkeypatch
+):
+    rows = [_manual_codex_row("deleted", 0), _manual_codex_row("survivor", 1)]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    write_credential_pool(
+        "openai-codex", [dict(rows[1], priority=0)], removed_ids=["deleted"]
+    )
+
+    def _must_not_refresh(*_args, **_kwargs):
+        raise AssertionError("deleted exact row must not reach token endpoint")
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        _must_not_refresh,
+    )
+
+    assert pool.try_refresh_matching(credential_id="deleted") is None
+    assert [row["id"] for row in read_credential_pool("openai-codex")] == [
+        "survivor"
+    ]
+    assert [entry.id for entry in pool.entries()] == ["survivor"]
+
+
+def test_singleton_sync_does_not_restore_externally_deleted_manual_codex_row(
+    tmp_path, monkeypatch
+):
+    singleton = _manual_codex_row("singleton", 0)
+    singleton["source"] = "device_code"
+    manual = _manual_codex_row("deleted-manual", 1)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": singleton["access_token"],
+                        "refresh_token": singleton["refresh_token"],
+                    }
+                }
+            },
+            "credential_pool": {"openai-codex": [singleton, manual]},
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import (
+        _save_codex_tokens,
+        read_credential_pool,
+        write_credential_pool,
+    )
+
+    pool = load_pool("openai-codex")
+    stale_singleton = next(
+        entry for entry in pool.entries() if entry.source == "device_code"
+    )
+    write_credential_pool(
+        "openai-codex", [singleton], removed_ids=["deleted-manual"]
+    )
+    _save_codex_tokens(
+        {
+            "access_token": "singleton-current-access",
+            "refresh_token": "singleton-current-refresh",
+        }
+    )
+
+    synced = pool._sync_codex_entry_from_auth_store(stale_singleton)
+
+    assert synced.access_token == "singleton-current-access"
+    persisted = read_credential_pool("openai-codex")
+    assert [row["id"] for row in persisted] == ["singleton"]
+    assert [entry.id for entry in pool.entries()] == ["singleton"]
+
+
+def test_provider_and_pool_transactions_lock_profile_global_in_same_order(
+    tmp_path, monkeypatch
+):
+    from contextlib import contextmanager
+
+    from hermes_cli import auth as auth_mod
+
+    profile_path = tmp_path / "z-profile" / "auth.json"
+    global_path = tmp_path / "a-global" / "auth.json"
+    profile_path.parent.mkdir(parents=True)
+    global_path.parent.mkdir(parents=True)
+    profile_path.write_text(json.dumps({"version": 1, "credential_pool": {}}))
+    global_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {"openai-codex": {"tokens": {}}},
+                "credential_pool": {"openai-codex": []},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_store_cache", None)
+
+    acquisitions = []
+
+    @contextmanager
+    def _recording_lock(*_args, **kwargs):
+        acquisitions.append(kwargs.get("target_path") or profile_path)
+        yield
+
+    monkeypatch.setattr(auth_mod, "_auth_store_lock", _recording_lock)
+
+    with auth_mod._provider_state_transaction("openai-codex"):
+        pass
+    provider_order = list(acquisitions)
+    acquisitions.clear()
+    auth_mod.mutate_credential_pool("openai-codex", lambda _rows: None)
+    pool_order = list(acquisitions)
+
+    expected = sorted(
+        [profile_path, global_path],
+        key=lambda path: str(path.resolve(strict=False)),
+    )
+    assert provider_order == expected
+    assert pool_order == expected
+
+
+def test_next_available_at_prunes_authoritative_manual_codex_rows_without_pool_auth_wait(
+    tmp_path, monkeypatch
+):
+    """A stale probe must neither restore a deleted row nor invert locks."""
+    import threading
+    from contextlib import contextmanager
+
+    from hermes_cli import auth as auth_mod
+
+    rows = [
+        _manual_codex_row("deleted", 0),
+        _manual_codex_row(
+            "prunable",
+            1,
+            status="dead",
+            status_at=time.time() - 2 * 24 * 60 * 60,
+        ),
+    ]
+    pool = _load_manual_codex_pool(tmp_path, monkeypatch, rows)
+    auth_mod.mutate_credential_pool(
+        "openai-codex",
+        lambda current: current.__setitem__(
+            slice(None), [row for row in current if row.get("id") != "deleted"]
+        ),
+    )
+
+    real_auth_lock = auth_mod._auth_store_lock
+    operation_thread = threading.get_ident()
+    auth_acquired_under_pool_lock = []
+
+    @contextmanager
+    def _tracking_auth_lock(*args, **kwargs):
+        if threading.get_ident() == operation_thread:
+            auth_acquired_under_pool_lock.append(pool._lock._is_owned())
+        with real_auth_lock(*args, **kwargs):
+            yield
+
+    monkeypatch.setattr(auth_mod, "_auth_store_lock", _tracking_auth_lock)
+
+    assert pool.next_available_at() is None
+
+    assert auth_acquired_under_pool_lock
+    assert not any(auth_acquired_under_pool_lock)
+    assert auth_mod.read_credential_pool("openai-codex") == []
+    assert pool.entries() == []
+
+
+def test_mixed_codex_singleton_mark_uses_authoritative_rows_after_manual_delete(
+    tmp_path, monkeypatch
+):
+    singleton = _manual_codex_row("singleton", 0)
+    singleton["source"] = "device_code"
+    deleted = _manual_codex_row("deleted-manual", 1)
+    survivor = _manual_codex_row("survivor", 2)
+    rows = [singleton, deleted, survivor]
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": singleton["access_token"],
+                        "refresh_token": singleton["refresh_token"],
+                    }
+                }
+            },
+            "credential_pool": {"openai-codex": rows},
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    pool = load_pool("openai-codex")
+    write_credential_pool(
+        "openai-codex",
+        [singleton, survivor],
+        removed_ids=["deleted-manual"],
+    )
+
+    rotated = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id="singleton",
+    )
+
+    assert rotated is not None and rotated.id == "survivor"
+    persisted = read_credential_pool("openai-codex")
+    assert [row["id"] for row in persisted] == ["singleton", "survivor"]
+    assert persisted[0]["last_status"] == "exhausted"
+    assert persisted[1]["last_status"] is None
+    assert [entry.id for entry in pool.entries()] == ["singleton", "survivor"]
+
+
+def test_mixed_codex_singleton_refresh_uses_authoritative_row_after_manual_delete(
+    tmp_path, monkeypatch
+):
+    singleton = _manual_codex_row("singleton", 0, refresh_token="")
+    singleton["source"] = "device_code"
+    deleted = _manual_codex_row("deleted-manual", 1)
+    survivor = _manual_codex_row("survivor", 2)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": singleton["access_token"],
+                        "refresh_token": "",
+                    }
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [singleton, deleted, survivor]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import (
+        _save_codex_tokens,
+        read_credential_pool,
+        write_credential_pool,
+    )
+
+    pool = load_pool("openai-codex")
+    authoritative_singleton = dict(
+        singleton,
+        access_token="singleton-current-access",
+        refresh_token="singleton-current-refresh",
+    )
+    write_credential_pool(
+        "openai-codex",
+        [authoritative_singleton, survivor],
+        removed_ids=["deleted-manual"],
+    )
+    _save_codex_tokens(
+        {
+            "access_token": "singleton-current-access",
+            "refresh_token": "singleton-current-refresh",
+        }
+    )
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "singleton-fresh-access",
+            "refresh_token": "singleton-fresh-refresh",
+            "last_refresh": "fresh-at",
+        }
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure", _refresh
+    )
+
+    refreshed = pool.try_refresh_matching(credential_id="singleton")
+
+    assert refresh_calls == [
+        ("singleton-current-access", "singleton-current-refresh")
+    ]
+    assert refreshed is not None and refreshed.id == "singleton"
+    assert refreshed.access_token == "singleton-fresh-access"
+    persisted = read_credential_pool("openai-codex")
+    assert [row["id"] for row in persisted] == ["singleton", "survivor"]
+    assert persisted[0]["access_token"] == "singleton-fresh-access"
+    assert persisted[0]["refresh_token"] == "singleton-fresh-refresh"
+    assert persisted[1]["access_token"] == survivor["access_token"]
+    assert [entry.id for entry in pool.entries()] == ["singleton", "survivor"]
+    saved_store = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    saved_tokens = saved_store["providers"]["openai-codex"]["tokens"]
+    assert saved_tokens["access_token"] == "singleton-fresh-access"
+    assert saved_tokens["refresh_token"] == "singleton-fresh-refresh"
+
+
+def test_singleton_forced_refresh_does_not_wait_for_auth_under_pool_lock(
+    tmp_path, monkeypatch
+):
+    """An auth-first thread can take the pool lock while refresh waits."""
+    import threading
+    from contextlib import contextmanager
+
+    from hermes_cli import auth as auth_mod
+
+    singleton = _manual_codex_row("singleton", 0)
+    singleton["source"] = "device_code"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": singleton["access_token"],
+                        "refresh_token": singleton["refresh_token"],
+                    }
+                }
+            },
+            "credential_pool": {"openai-codex": [singleton]},
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    real_auth_lock = auth_mod._auth_store_lock
+    real_locked_stores = auth_mod._locked_profile_global_auth_stores
+    auth_held = threading.Event()
+    refresh_waiting_for_auth = threading.Event()
+    auth_thread_pool_acquires = []
+    refreshed_entries = []
+    thread_errors = []
+
+    @contextmanager
+    def _tracking_locked_stores(*args, **kwargs):
+        if threading.current_thread().name == "pool-first":
+            refresh_waiting_for_auth.set()
+        with real_locked_stores(*args, **kwargs) as locked:
+            yield locked
+
+    monkeypatch.setattr(
+        auth_mod, "_locked_profile_global_auth_stores", _tracking_locked_stores
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        lambda *_args: {
+            "access_token": "singleton-fresh-access",
+            "refresh_token": "singleton-fresh-refresh",
+        },
+    )
+
+    def _auth_first():
+        try:
+            with real_auth_lock():
+                auth_held.set()
+                if not refresh_waiting_for_auth.wait(timeout=5):
+                    thread_errors.append("refresh never waited for auth")
+                    return
+                acquired = pool._lock.acquire(timeout=1)
+                auth_thread_pool_acquires.append(acquired)
+                if acquired:
+                    pool._lock.release()
+        except BaseException as exc:
+            thread_errors.append(exc)
+
+    def _pool_first():
+        try:
+            if not auth_held.wait(timeout=5):
+                thread_errors.append("auth lock was never held")
+                return
+            refreshed_entries.append(
+                pool.try_refresh_matching(credential_id="singleton")
+            )
+        except BaseException as exc:
+            thread_errors.append(exc)
+
+    auth_thread = threading.Thread(target=_auth_first, name="auth-first")
+    pool_thread = threading.Thread(target=_pool_first, name="pool-first")
+    auth_thread.start()
+    pool_thread.start()
+    auth_thread.join(timeout=5)
+    pool_thread.join(timeout=5)
+
+    assert not auth_thread.is_alive() and not pool_thread.is_alive()
+    assert thread_errors == []
+    assert auth_thread_pool_acquires == [True]
+    assert len(refreshed_entries) == 1
+    assert refreshed_entries[0] is not None
+    assert refreshed_entries[0].access_token == "singleton-fresh-access"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,300 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def test_manual_codex_account_does_not_adopt_singleton_or_revert_external_order(
+    tmp_path, monkeypatch
+):
+    """Independent Codex OAuth entries must not inherit singleton credentials.
+
+    A long-lived pool can retain an older priority order while another process
+    promotes a manual account. Syncing that independent account from the
+    singleton must neither clobber its identity nor write the stale order back.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "pro-access",
+                        "refresh_token": "pro-refresh",
+                    },
+                    "last_refresh": "2026-08-24T10:00:00Z",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "free",
+                        "label": "codex-free",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "free-access",
+                        "refresh_token": "free-refresh",
+                    },
+                    {
+                        "id": "pro",
+                        "label": "codex-pro",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "device_code",
+                        "access_token": "pro-access",
+                        "refresh_token": "pro-refresh",
+                    },
+                    {
+                        "id": "team",
+                        "label": "codex-team",
+                        "auth_type": "oauth",
+                        "priority": 2,
+                        "source": "manual:device_code",
+                        "access_token": "team-access",
+                        "refresh_token": "team-refresh",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    stale_pool = load_pool("openai-codex")
+    team_entry = next(entry for entry in stale_pool.entries() if entry.id == "team")
+
+    current_entries = read_credential_pool("openai-codex")
+    current: dict[str, dict] = {
+        str(item.get("id")): dict(item)
+        for item in current_entries
+        if isinstance(item, dict)
+    }
+    promoted: list[dict] = [
+        current[entry_id] for entry_id in ("team", "pro", "free")
+    ]
+    for priority, entry in enumerate(promoted):
+        entry["priority"] = priority
+    write_credential_pool("openai-codex", promoted)
+
+    synced = stale_pool._sync_codex_entry_from_auth_store(team_entry)
+
+    assert synced.access_token == "team-access"
+    assert synced.refresh_token == "team-refresh"
+    persisted = read_credential_pool("openai-codex")
+    assert [entry["id"] for entry in persisted] == ["team", "pro", "free"]
+
+
+def test_manual_codex_singleton_alias_adopts_refresh_without_reverting_order(
+    tmp_path, monkeypatch
+):
+    """A true manual singleton alias still adopts a refreshed token pair."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-singleton-access",
+                        "refresh_token": "old-singleton-refresh",
+                    },
+                    "last_refresh": "2026-08-24T10:00:00Z",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "legacy-alias",
+                        "label": "legacy-alias",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "old-singleton-access",
+                        "refresh_token": "old-singleton-refresh",
+                    },
+                    {
+                        "id": "independent",
+                        "label": "independent",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "independent-access",
+                        "refresh_token": "independent-refresh",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import (
+        _save_codex_tokens,
+        read_credential_pool,
+        write_credential_pool,
+    )
+
+    stale_pool = load_pool("openai-codex")
+    alias_entry = next(
+        entry for entry in stale_pool.entries() if entry.id == "legacy-alias"
+    )
+
+    _save_codex_tokens(
+        {
+            "access_token": "fresh-singleton-access",
+            "refresh_token": "fresh-singleton-refresh",
+        },
+        last_refresh="2026-08-24T11:00:00Z",
+    )
+    current_entries = read_credential_pool("openai-codex")
+    current: dict[str, dict] = {
+        str(item.get("id")): dict(item)
+        for item in current_entries
+        if isinstance(item, dict)
+    }
+    singleton_id = next(
+        entry_id
+        for entry_id, item in current.items()
+        if item.get("source") == "device_code"
+    )
+    promoted: list[dict] = [
+        current[entry_id]
+        for entry_id in ("independent", "legacy-alias", singleton_id)
+    ]
+    for priority, entry in enumerate(promoted):
+        entry["priority"] = priority
+    write_credential_pool("openai-codex", promoted)
+
+    synced = stale_pool._sync_codex_entry_from_auth_store(alias_entry)
+
+    assert synced.access_token == "fresh-singleton-access"
+    assert synced.refresh_token == "fresh-singleton-refresh"
+    persisted = read_credential_pool("openai-codex")
+    assert [entry["id"] for entry in persisted] == [
+        "independent",
+        "legacy-alias",
+        singleton_id,
+    ]
+
+
+def test_manual_codex_refresh_adopts_complete_persisted_pool_before_persist(
+    tmp_path, monkeypatch
+):
+    """A manual refresh must not overwrite an external reorder with stale memory."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": entry_id,
+                        "label": entry_id,
+                        "auth_type": "oauth",
+                        "priority": priority,
+                        "source": "manual:device_code",
+                        "access_token": f"{entry_id}-access",
+                        "refresh_token": f"{entry_id}-refresh",
+                    }
+                    for priority, entry_id in enumerate(("free", "other", "team"))
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    pool = load_pool("openai-codex")
+    current = {
+        entry["id"]: dict(entry)
+        for entry in read_credential_pool("openai-codex")
+    }
+    reordered = [current[entry_id] for entry_id in ("team", "other", "free")]
+    for priority, entry in enumerate(reordered):
+        entry["priority"] = priority
+    write_credential_pool("openai-codex", reordered)
+
+    refresh_calls = []
+
+    def _refresh(access_token, refresh_token):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "team-final-access",
+            "refresh_token": "team-final-refresh",
+            "last_refresh": "2026-08-27T02:00:00Z",
+        }
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        _refresh,
+    )
+
+    refreshed = pool.try_refresh_matching(credential_id="team")
+
+    assert refreshed is not None
+    assert refresh_calls == [("team-access", "team-refresh")]
+    persisted = read_credential_pool("openai-codex")
+    assert [entry["id"] for entry in persisted] == ["team", "other", "free"]
+    assert persisted[0]["access_token"] == "team-final-access"
+    assert persisted[0]["refresh_token"] == "team-final-refresh"
+
+
+def test_dead_manual_codex_alias_refreshed_on_disk_is_selectable(
+    tmp_path, monkeypatch
+):
+    """Public selection must recover a DEAD manual alias from its fresh same-ID row."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "legacy-alias",
+                        "label": "legacy-alias",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "stale-access",
+                        "refresh_token": "stale-refresh",
+                        "last_status": "dead",
+                        "last_status_at": time.time(),
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    pool = load_pool("openai-codex")
+    refreshed_alias = dict(read_credential_pool("openai-codex")[0])
+    refreshed_alias.update(
+        access_token="fresh-access",
+        refresh_token="fresh-refresh",
+        last_status=None,
+        last_status_at=None,
+        last_error_code=None,
+        last_error_reason=None,
+    )
+    write_credential_pool("openai-codex", [refreshed_alias])
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "legacy-alias"
+    assert selected.access_token == "fresh-access"
+    assert selected.refresh_token == "fresh-refresh"


### PR DESCRIPTION
## Summary

- keep canonical `device_code` entries synchronized with provider singleton state
- synchronize `manual:device_code` entries only from their exact persisted pool identity
- adopt the complete authoritative persisted Codex pool before later refresh persistence, preserving external order, priority, and status even when tokens are unchanged
- allow a legitimately re-authenticated same-ID legacy manual alias to recover from stale `DEAD` or `EXHAUSTED` in-memory state

## Root cause

The runtime treated all manual Codex entries as singleton aliases. During rate-limit recovery, an independent account could adopt another account's singleton credentials or persist a stale in-memory pool snapshot. That could clear exhaustion, restore an old order, and select the same rate-limited credential repeatedly.

The patch keeps independent account identity isolated while preserving the intended re-auth behavior for true same-ID legacy aliases.

## Regression coverage

The added behavioral tests cover:

- independent manual accounts never adopting singleton identity
- legitimate same-ID aliases receiving write-side refreshed credentials
- real refresh persistence preserving externally reordered pools
- refreshed `DEAD` aliases becoming selectable through the public path
- order-only persisted changes being adopted even when token values are unchanged
- persisted order remaining `codex-pro -> codex-team -> codex-free` across a manual account refresh

## Verification

Run after rebasing onto current `main` (`7a1aafb4e1dac5d2840cd3ab524f6d6bd0658694`):

```bash
HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python \
HERMES_TEST_FILE_RETRIES=0 \
scripts/run_tests.sh \
  tests/agent/test_credential_pool.py \
  tests/hermes_cli/test_auth_codex_provider.py
```

Result: **74 passed, 0 failed**.

```bash
HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python \
HERMES_TEST_FILE_RETRIES=0 \
scripts/run_tests.sh \
  tests/run_agent/test_env_credential_turn_refresh.py \
  tests/run_agent/test_fallback_credential_isolation.py \
  tests/run_agent/test_credential_pool_interrupt.py \
  tests/run_agent/test_credential_rotation_route_settings.py \
  tests/run_agent/test_63425_credential_pool_auto_detect.py
```

Result: **33 passed, 0 failed**.

Additional temporary-state probes verified both order-only changes and `codex-pro -> codex-team -> codex-free` preservation without reading or writing live credentials.

`git diff --check` passes. The patch changes only `agent/credential_pool.py` and `tests/agent/test_credential_pool.py`.
