### PR TITLE
feat(kanban): enforce routing, accounting, and quality gates

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21570,6 +21570,31 @@ def main(
                         ):
                             cli.session_id = cli.agent.session_id
                         response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                        # A dispatched Kanban worker has one durable run id. Persist
+                        # the finalizer's absolute session totals against that exact
+                        # row before process exit; an unavailable usage report remains
+                        # explicit rather than being fabricated as zero.
+                        if isinstance(result, dict) and os.environ.get("HERMES_KANBAN_TASK") and os.environ.get("HERMES_KANBAN_RUN_ID"):
+                            try:
+                                from hermes_cli.kanban_db import RunAccounting, connect_closing, record_run_accounting
+                                with connect_closing() as _kanban_conn:
+                                    record_run_accounting(
+                                        _kanban_conn,
+                                        task_id=os.environ["HERMES_KANBAN_TASK"],
+                                        run_id=int(os.environ["HERMES_KANBAN_RUN_ID"]),
+                                        accounting=RunAccounting(
+                                            provider=result.get("provider"), model=result.get("model"),
+                                            service_tier=result.get("service_tier"),
+                                            input_tokens=result.get("input_tokens"), output_tokens=result.get("output_tokens"),
+                                            cache_read_tokens=result.get("cache_read_tokens"),
+                                            cache_write_tokens=result.get("cache_write_tokens"),
+                                            reasoning_tokens=result.get("reasoning_tokens"),
+                                            actual_cost_usd=result.get("actual_cost_usd"),
+                                            usage_status="reported" if result.get("total_tokens") is not None else "unavailable",
+                                        ),
+                                    )
+                            except Exception:
+                                logger.exception("failed to persist Kanban run accounting")
                         # Surface backend errors that produced no visible output
                         # (e.g. invalid model slug → provider 4xx). Mirrors the
                         # interactive CLI path. Write to stderr so piped stdout

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -77,6 +77,7 @@ import os
 import re
 import random
 import secrets
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -101,6 +102,8 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "escalation_required", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+QUALITY_GATE_MAX_OUTPUT = 4_000
+QUALITY_GATE_MAX_TIMEOUT_SECONDS = 300
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -3955,7 +3958,7 @@ def _quality_policy_required(row: sqlite3.Row) -> bool:
         policy = json.loads(raw) if raw else {}
     except (KeyError, TypeError, json.JSONDecodeError):
         return False
-    return isinstance(policy, dict) and bool(policy.get("enabled")) and bool(policy.get("required"))
+    return isinstance(policy, dict) and policy.get("enabled") is True and policy.get("required") is True
 
 
 def set_reasoning_effort(
@@ -6988,7 +6991,104 @@ def request_review(
     return _ret(True)
 
 
-def record_quality_gate(
+def _quality_gate_command(gate: Any) -> tuple[list[str], int]:
+    """Validate an operator-configured, shell-free quality command."""
+    if not isinstance(gate, Mapping):
+        raise ValueError("quality gate must be an object")
+    command = gate.get("command")
+    if isinstance(command, str):
+        argv = shlex.split(command)
+    elif isinstance(command, list) and all(isinstance(part, str) for part in command):
+        argv = list(command)
+    else:
+        raise ValueError("quality gate command must be a string or string array")
+    if not argv or any(not part or "\x00" in part for part in argv):
+        raise ValueError("quality gate command must not be empty")
+    timeout = gate.get("timeout_seconds", 60)
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise ValueError("quality gate timeout_seconds must be a number")
+    if not 0 < timeout <= QUALITY_GATE_MAX_TIMEOUT_SECONDS:
+        raise ValueError(f"quality gate timeout_seconds must be 1..{QUALITY_GATE_MAX_TIMEOUT_SECONDS}")
+    return argv, int(timeout)
+
+
+def _bounded_quality_output(value: Any) -> str:
+    return str(redact_review_value(value or ""))[:QUALITY_GATE_MAX_OUTPUT]
+
+
+def execute_quality_gates(
+    conn: sqlite3.Connection, *, task_id: str, run_id: int,
+) -> bool:
+    """Execute persisted operator gates outside a SQLite write transaction.
+
+    The caller supplies no command. Every validation, workspace, spawn,
+    timeout, and non-zero failure is durably escalated by the same review run.
+    """
+    task = conn.execute(
+        "SELECT status, current_run_id, quality_policy_json, workspace_path "
+        "FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if task is None or not _quality_policy_required(task):
+        return False
+    if task["status"] != "running" or task["current_run_id"] != int(run_id):
+        return _persist_executed_quality_gate(
+            conn, task_id=task_id, run_id=run_id, passed=False,
+            reason="quality gate result was stale", result={"gates": [], "status": "stale"},
+        )
+    try:
+        policy = json.loads(task["quality_policy_json"])
+        gates = policy["gates"]
+        if not isinstance(gates, list) or not gates:
+            raise ValueError("quality policy requires one or more gates")
+        commands = [_quality_gate_command(gate) for gate in gates]
+        if not task["workspace_path"] or not Path(task["workspace_path"]).is_dir():
+            raise ValueError("quality gate workspace is missing or not a directory")
+    except (TypeError, KeyError, json.JSONDecodeError, ValueError) as exc:
+        return _persist_executed_quality_gate(
+            conn, task_id=task_id, run_id=run_id, passed=False,
+            reason=f"quality gate configuration failure: {exc}",
+            result={"gates": [], "status": "configuration_failed"},
+        )
+
+    results: list[dict[str, Any]] = []
+    workspace = str(Path(task["workspace_path"]))
+    for argv, timeout in commands:
+        try:
+            completed = subprocess.run(
+                argv, cwd=workspace, stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                errors="replace", timeout=timeout, check=False,
+            )
+            entry: dict[str, Any] = {
+                "command": argv,
+                "status": "passed" if completed.returncode == 0 else "nonzero",
+                "output": _bounded_quality_output(completed.stdout),
+            }
+            results.append(entry)
+            if completed.returncode:
+                entry["exit_code"] = completed.returncode
+                return _persist_executed_quality_gate(
+                    conn, task_id=task_id, run_id=run_id, passed=False,
+                    reason=f"quality gate exited {completed.returncode}", result={"gates": results},
+                )
+        except subprocess.TimeoutExpired as exc:
+            results.append({"command": argv, "status": "timeout", "output": _bounded_quality_output(exc.stdout)})
+            return _persist_executed_quality_gate(
+                conn, task_id=task_id, run_id=run_id, passed=False,
+                reason="quality gate timed out", result={"gates": results},
+            )
+        except OSError as exc:
+            results.append({"command": argv, "status": "spawn_error", "output": _bounded_quality_output(str(exc))})
+            return _persist_executed_quality_gate(
+                conn, task_id=task_id, run_id=run_id, passed=False,
+                reason="quality gate could not be started", result={"gates": results},
+            )
+    return _persist_executed_quality_gate(
+        conn, task_id=task_id, run_id=run_id, passed=True, result={"gates": results},
+    )
+
+
+def _persist_executed_quality_gate(
     conn: sqlite3.Connection,
     *,
     task_id: str,
@@ -6997,13 +7097,13 @@ def record_quality_gate(
     reason: Optional[str] = None,
     result: Optional[Mapping[str, Any]] = None,
 ) -> bool:
-    """Persist the review-owned quality result for an opt-in task.
+    """Persist an executor-owned quality result for an opt-in task.
 
-    The gate intentionally executes no subprocess and never changes model
-    overrides. A pass merely permits a later explicit completion; a failure
-    closes the review run, records ``quality_failed`` before
-    ``escalation_required``, and asks the router for a fresh auditable policy
-    decision using the prior route, evidence, and retry count.
+    Only :func:`execute_quality_gates` calls this private helper after running
+    the persisted operator command(s) outside the SQLite transaction. A pass
+    merely permits a later explicit completion; a failure closes the review
+    run, records ``quality_failed`` before ``escalation_required``, and asks
+    the router for a fresh auditable policy decision.
     """
     reason = str(redact_review_value(reason or "")).strip()
     safe_result = redact_review_value(dict(result or {}))
@@ -7019,6 +7119,25 @@ def record_quality_gate(
         if task is None or not _quality_policy_required(task):
             return False
         if task["status"] != "running" or task["current_run_id"] != int(run_id):
+            # A command result that arrives after its review lease changed can
+            # never authorize completion. Escalate the live task rather than
+            # silently leaving an ambiguous running review behind.
+            active_run_id = task["current_run_id"]
+            if task["status"] == "running" and active_run_id is not None:
+                conn.execute(
+                    "UPDATE tasks SET status = 'escalation_required', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL WHERE id = ? AND current_run_id = ?",
+                    (task_id, int(active_run_id)),
+                )
+                closed_run_id = _end_run(
+                    conn, task_id, outcome="quality_failed", status="quality_failed",
+                    error="quality gate result was stale",
+                )
+                stale = {"requested_run_id": int(run_id), "active_run_id": int(active_run_id)}
+                _append_event(conn, task_id, "quality_failed", {"reason": "quality gate result was stale", "result": stale}, run_id=closed_run_id)
+                _append_event(conn, task_id, "escalation_required", {"prior_run_id": int(run_id), "failure_reason": "quality gate result was stale", "quality_result": stale, "decision": {"action": "human_escalation_required"}}, run_id=closed_run_id)
+            else:
+                _append_event(conn, task_id, "quality_gate_stale", {"run_id": int(run_id)}, run_id=int(run_id))
             return False
         claimed = conn.execute(
             "SELECT payload FROM task_events WHERE task_id = ? AND run_id = ? "
@@ -7092,6 +7211,19 @@ def record_quality_gate(
             run_id=closed_run_id,
         )
     return True
+
+
+def record_quality_gate(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    passed: bool,
+    reason: Optional[str] = None,
+    result: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    """Deprecated compatibility API; workers cannot self-certify a pass."""
+    return False
 
 
 def request_changes(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,7 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "escalation_required", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -1419,6 +1419,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     routing_priority     TEXT,
     routing_tier         TEXT,
     route_snapshot       TEXT,
+    -- Opt-in durable quality-gate policy. NULL means disabled/not required,
+    -- preserving the historic completion path for existing tasks.
+    quality_policy_json  TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -2711,6 +2714,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if _name not in cols:
             _add_column_if_missing(conn, "tasks", _name, _definition)
 
+    if "quality_policy_json" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "quality_policy_json", "quality_policy_json TEXT"
+        )
+
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
         # default) = classic single-shot worker, preserving the behaviour
@@ -3907,6 +3915,47 @@ def set_model_override(
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
     notify_task_updated(conn, task_id, ("model_override", "provider_override"))
     return True
+
+
+def set_quality_policy(
+    conn: sqlite3.Connection,
+    task_id: str,
+    policy: Optional[Mapping[str, Any]],
+) -> bool:
+    """Set an explicit per-task quality policy; ``None`` disables the gate.
+
+    This is an operator/configuration API, not a worker routing mechanism.
+    The default remains disabled/not-required for compatibility. We retain
+    only JSON-object policies so the stored value is durable and auditable.
+    """
+    if policy is not None and not isinstance(policy, Mapping):
+        raise ValueError("quality policy must be an object or None")
+    normalized = dict(policy) if policy is not None else None
+    if normalized is not None and any(
+        key in normalized and not isinstance(normalized[key], bool)
+        for key in ("enabled", "required")
+    ):
+        raise ValueError("quality policy enabled/required values must be booleans")
+    encoded = json.dumps(normalized, sort_keys=True, separators=(",", ":")) if normalized else None
+    with write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if row is None:
+            return False
+        if row["status"] == "archived":
+            raise RuntimeError(f"cannot set quality policy on archived task {task_id}")
+        conn.execute("UPDATE tasks SET quality_policy_json = ? WHERE id = ?", (encoded, task_id))
+        _append_event(conn, task_id, "quality_policy_set", {"policy": normalized})
+    return True
+
+
+def _quality_policy_required(row: sqlite3.Row) -> bool:
+    """Return true only for the explicit, opt-in required gate policy."""
+    try:
+        raw = row["quality_policy_json"]
+        policy = json.loads(raw) if raw else {}
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return False
+    return isinstance(policy, dict) and bool(policy.get("enabled")) and bool(policy.get("required"))
 
 
 def set_reasoning_effort(
@@ -5675,10 +5724,49 @@ def complete_task(
         if not _parents_satisfied(conn, task_id):
             return False
         prior = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, current_run_id, quality_policy_json FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        # Opt-in quality policies are fail-closed: only a review-owned,
+        # run-correlated quality_passed event permits this completion. The
+        # default NULL policy intentionally preserves legacy completion.
+        if prior is not None and _quality_policy_required(prior):
+            gate_run_id = expected_run_id if expected_run_id is not None else prior["current_run_id"]
+            gate = (
+                conn.execute(
+                    "SELECT 1 FROM task_events WHERE task_id = ? AND run_id = ? "
+                    "AND kind = 'quality_passed' ORDER BY id DESC LIMIT 1",
+                    (task_id, int(gate_run_id)),
+                ).fetchone()
+                if gate_run_id is not None
+                else None
+            )
+            if gate is None:
+                _append_event(
+                    conn, task_id, "quality_required",
+                    {"run_id": gate_run_id, "source_status": prior_status},
+                    run_id=int(gate_run_id) if gate_run_id is not None else None,
+                )
+                return False
+        # A quality pass was stored on the active review run before the
+        # explicit approval/completion call. Preserve that durable evidence
+        # when ``_end_run`` writes the final run metadata.
+        if prior is not None and prior["current_run_id"] is not None:
+            existing_run = conn.execute(
+                "SELECT metadata FROM task_runs WHERE id = ?",
+                (int(prior["current_run_id"]),),
+            ).fetchone()
+            try:
+                existing_metadata = (
+                    json.loads(existing_run["metadata"])
+                    if existing_run and existing_run["metadata"]
+                    else {}
+                )
+            except (TypeError, json.JSONDecodeError):
+                existing_metadata = {}
+            if isinstance(existing_metadata, dict) and existing_metadata.get("quality_gate"):
+                metadata = {**existing_metadata, **(metadata or {})}
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -6886,7 +6974,124 @@ def request_review(
             },
             run_id=run_id,
         )
+        policy_row = conn.execute(
+            "SELECT quality_policy_json FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if policy_row is not None and _quality_policy_required(policy_row):
+            _append_event(
+                conn,
+                task_id,
+                "quality_gate_required",
+                {"source_run_id": run_id, "human_approval_required": True},
+                run_id=run_id,
+            )
     return _ret(True)
+
+
+def record_quality_gate(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    passed: bool,
+    reason: Optional[str] = None,
+    result: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    """Persist the review-owned quality result for an opt-in task.
+
+    The gate intentionally executes no subprocess and never changes model
+    overrides. A pass merely permits a later explicit completion; a failure
+    closes the review run, records ``quality_failed`` before
+    ``escalation_required``, and asks the router for a fresh auditable policy
+    decision using the prior route, evidence, and retry count.
+    """
+    reason = str(redact_review_value(reason or "")).strip()
+    safe_result = redact_review_value(dict(result or {}))
+    if not isinstance(safe_result, dict):
+        return False
+    if not passed and not reason:
+        return False
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT status, current_run_id, quality_policy_json, routing_priority "
+            "FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if task is None or not _quality_policy_required(task):
+            return False
+        if task["status"] != "running" or task["current_run_id"] != int(run_id):
+            return False
+        claimed = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND run_id = ? "
+            "AND kind = 'claimed' ORDER BY id DESC LIMIT 1", (task_id, int(run_id)),
+        ).fetchone()
+        try:
+            claim_payload = json.loads(claimed["payload"]) if claimed and claimed["payload"] else {}
+        except (TypeError, json.JSONDecodeError):
+            claim_payload = {}
+        if not isinstance(claim_payload, dict) or claim_payload.get("source_status") != "review":
+            return False
+        run = conn.execute(
+            "SELECT route_snapshot, attempt_number, metadata FROM task_runs "
+            "WHERE id = ? AND task_id = ? AND ended_at IS NULL", (int(run_id), task_id),
+        ).fetchone()
+        if run is None:
+            return False
+        try:
+            route = json.loads(run["route_snapshot"]) if run["route_snapshot"] else {}
+        except (TypeError, json.JSONDecodeError):
+            route = {}
+        prior_model = route.get("model") if isinstance(route, dict) else None
+        try:
+            metadata = json.loads(run["metadata"]) if run["metadata"] else {}
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        gate = {"passed": bool(passed), **safe_result}
+        metadata["quality_gate"] = gate
+        if passed:
+            conn.execute(
+                "UPDATE task_runs SET metadata = ? WHERE id = ?",
+                (json.dumps(metadata, ensure_ascii=False), int(run_id)),
+            )
+            _append_event(conn, task_id, "quality_passed", gate, run_id=int(run_id))
+            return True
+
+        try:
+            from hermes_cli.kanban_model_policy import ModelRoutingPolicy
+            decision = ModelRoutingPolicy.load().reevaluate_quality_failure(
+                priority=task["routing_priority"], prior_model=prior_model,
+                failure_reason=reason, quality_result=safe_result,
+                retry_count=int(run["attempt_number"] or 1),
+            )
+        except Exception as exc:
+            decision = {"action": "human_escalation_required", "router_error": str(exc)}
+        conn.execute(
+            "UPDATE tasks SET status = 'escalation_required', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL WHERE id = ? AND current_run_id = ?",
+            (task_id, int(run_id)),
+        )
+        closed_run_id = _end_run(
+            conn, task_id, outcome="quality_failed", status="quality_failed",
+            error=reason, metadata=metadata,
+        )
+        payload = {"reason": reason, "result": safe_result}
+        _append_event(conn, task_id, "quality_failed", payload, run_id=closed_run_id)
+        _append_event(
+            conn,
+            task_id,
+            "escalation_required",
+            {
+                "prior_run_id": int(run_id),
+                "prior_model": prior_model,
+                "failure_reason": reason,
+                "quality_result": safe_result,
+                "retry_count": int(run["attempt_number"] or 1),
+                "decision": decision,
+            },
+            run_id=closed_run_id,
+        )
+    return True
 
 
 def request_changes(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1335,6 +1335,22 @@ class Event:
     run_id: Optional[int] = None
 
 
+@dataclass(frozen=True)
+class RunAccounting:
+    """Canonical per-attempt usage supplied by the worker finalizer."""
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    service_tier: Optional[str] = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    cache_write_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    api_call_count: Optional[int] = None
+    actual_cost_usd: Optional[Any] = None
+    usage_status: str = "reported"
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1498,7 +1514,27 @@ CREATE TABLE IF NOT EXISTS task_runs (
     route_snapshot      TEXT,
     input_tokens        INTEGER,
     output_tokens       INTEGER,
-    cost_usd            REAL
+    cost_usd            REAL,
+    attempt_number      INTEGER NOT NULL DEFAULT 1,
+    run_kind            TEXT NOT NULL DEFAULT 'initial',
+    retry_of_run_id     INTEGER,
+    escalation_of_run_id INTEGER,
+    provider            TEXT,
+    model               TEXT,
+    service_tier        TEXT,
+    routing_complexity  TEXT,
+    cache_read_tokens   INTEGER,
+    cache_write_tokens  INTEGER,
+    reasoning_tokens    INTEGER,
+    api_call_count      INTEGER,
+    estimated_cost_usd  REAL,
+    actual_cost_usd     REAL,
+    usage_status        TEXT,
+    cost_status         TEXT,
+    cost_source         TEXT,
+    policy_version      TEXT,
+    registry_version    TEXT,
+    duration_ms         INTEGER
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2818,6 +2854,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             ("input_tokens", "input_tokens INTEGER"),
             ("output_tokens", "output_tokens INTEGER"),
             ("cost_usd", "cost_usd REAL"),
+            ("attempt_number", "attempt_number INTEGER NOT NULL DEFAULT 1"),
+            ("run_kind", "run_kind TEXT NOT NULL DEFAULT 'initial'"),
+            ("retry_of_run_id", "retry_of_run_id INTEGER"),
+            ("escalation_of_run_id", "escalation_of_run_id INTEGER"),
+            ("provider", "provider TEXT"), ("model", "model TEXT"),
+            ("service_tier", "service_tier TEXT"), ("routing_complexity", "routing_complexity TEXT"),
+            ("cache_read_tokens", "cache_read_tokens INTEGER"), ("cache_write_tokens", "cache_write_tokens INTEGER"),
+            ("reasoning_tokens", "reasoning_tokens INTEGER"), ("api_call_count", "api_call_count INTEGER"),
+            ("estimated_cost_usd", "estimated_cost_usd REAL"), ("actual_cost_usd", "actual_cost_usd REAL"),
+            ("usage_status", "usage_status TEXT"), ("cost_status", "cost_status TEXT"),
+            ("cost_source", "cost_source TEXT"), ("policy_version", "policy_version TEXT"),
+            ("registry_version", "registry_version TEXT"), ("duration_ms", "duration_ms INTEGER"),
         ):
             if _name not in run_cols:
                 _add_column_if_missing(conn, "task_runs", _name, _definition)
@@ -4737,6 +4785,41 @@ def _snapshot_claim_route(conn: sqlite3.Connection, task_id: str, status: str) -
     return route
 
 
+def record_run_accounting(
+    conn: sqlite3.Connection, *, task_id: str, run_id: int, accounting: RunAccounting,
+) -> bool:
+    """Persist one run's absolute usage totals and registry-derived estimate."""
+    row = conn.execute("SELECT id FROM task_runs WHERE id=? AND task_id=?", (run_id, task_id)).fetchone()
+    if row is None:
+        return False
+    estimate = None
+    source = status = version = None
+    if accounting.usage_status != "unavailable" and accounting.model:
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+        usage = CanonicalUsage(
+            input_tokens=accounting.input_tokens or 0, output_tokens=accounting.output_tokens or 0,
+            cache_read_tokens=accounting.cache_read_tokens or 0,
+            cache_write_tokens=accounting.cache_write_tokens or 0,
+            reasoning_tokens=accounting.reasoning_tokens or 0,
+            request_count=accounting.api_call_count or 1,
+        )
+        priced = estimate_usage_cost(accounting.model, usage, provider=accounting.provider)
+        estimate = float(priced.amount_usd) if priced.amount_usd is not None else None
+        status, source, version = priced.status, priced.source, priced.pricing_version
+    conn.execute(
+        """UPDATE task_runs SET provider=?, model=?, service_tier=?, input_tokens=?, output_tokens=?,
+        cache_read_tokens=?, cache_write_tokens=?, reasoning_tokens=?, api_call_count=?,
+        estimated_cost_usd=?, actual_cost_usd=?, usage_status=?, cost_status=?, cost_source=?, registry_version=?
+        WHERE id=? AND task_id=?""",
+        (accounting.provider, accounting.model, accounting.service_tier, accounting.input_tokens,
+         accounting.output_tokens, accounting.cache_read_tokens, accounting.cache_write_tokens,
+         accounting.reasoning_tokens, accounting.api_call_count, estimate,
+         float(accounting.actual_cost_usd) if accounting.actual_cost_usd is not None else None,
+         accounting.usage_status, status, source, version, run_id, task_id),
+    )
+    return True
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4847,6 +4930,16 @@ def claim_task(
             ),
         )
         run_id = run_cur.lastrowid
+        prior = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id=? AND id<>? ORDER BY id DESC LIMIT 1",
+            (task_id, run_id),
+        ).fetchone()
+        if prior is not None:
+            conn.execute(
+                "UPDATE task_runs SET attempt_number=(SELECT COUNT(*) FROM task_runs WHERE task_id=?), "
+                "run_kind='retry', retry_of_run_id=? WHERE id=?",
+                (task_id, prior["id"], run_id),
+            )
         conn.execute(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),
@@ -4951,6 +5044,16 @@ def claim_review_task(
             ),
         )
         run_id = run_cur.lastrowid
+        prior = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id=? AND id<>? ORDER BY id DESC LIMIT 1",
+            (task_id, run_id),
+        ).fetchone()
+        if prior is not None:
+            conn.execute(
+                "UPDATE task_runs SET attempt_number=(SELECT COUNT(*) FROM task_runs WHERE task_id=?), "
+                "run_kind='retry', retry_of_run_id=? WHERE id=?",
+                (task_id, prior["id"], run_id),
+            )
         conn.execute(
             "UPDATE tasks SET current_run_id = ? WHERE id = ?",
             (run_id, task_id),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3796,7 +3796,8 @@ def set_model_override(
             pass
         else:
             conn.execute(
-                "UPDATE tasks SET model_override = ?, provider_override = ? WHERE id = ?",
+                "UPDATE tasks SET model_override = ?, provider_override = ?, "
+                "routing_tier = NULL, route_snapshot = NULL WHERE id = ?",
                 (model, provider, task_id),
             )
             _append_event(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1398,6 +1398,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- passes --reasoning <level> so the worker runs at that depth regardless
     -- of the profile's agent.reasoning_effort. NULL = profile setting.
     reasoning_effort     TEXT,
+    -- Durable model-policy decision. This is generated at claim time and
+    -- checked again immediately before a worker is spawned.
+    routing_priority     TEXT,
+    routing_tier         TEXT,
+    route_snapshot       TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -1484,7 +1489,16 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Copied from the task's approved claim-time policy decision. The token
+    -- and aggregate cost columns are Phase-A storage placeholders; Phase B
+    -- owns metering and the richer per-run accounting migration.
+    routing_priority    TEXT,
+    routing_tier        TEXT,
+    route_snapshot      TEXT,
+    input_tokens        INTEGER,
+    output_tokens       INTEGER,
+    cost_usd            REAL
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2650,6 +2664,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "reasoning_effort", "reasoning_effort TEXT"
         )
 
+    # Policy-route fields are additive so both fresh and legacy boards can
+    # pass through the fail-closed claim/spawn boundary. Do not synthesize a
+    # snapshot here: normal dispatch must obtain it from the policy resolver.
+    for _name, _definition in (
+        ("routing_priority", "routing_priority TEXT"),
+        ("routing_tier", "routing_tier TEXT"),
+        ("route_snapshot", "route_snapshot TEXT"),
+    ):
+        if _name not in cols:
+            _add_column_if_missing(conn, "tasks", _name, _definition)
+
     if "goal_mode" not in cols:
         # Ralph-style goal loop toggle for the dispatched worker. 0 (the
         # default) = classic single-shot worker, preserving the behaviour
@@ -2785,6 +2810,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
+        run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        for _name, _definition in (
+            ("routing_priority", "routing_priority TEXT"),
+            ("routing_tier", "routing_tier TEXT"),
+            ("route_snapshot", "route_snapshot TEXT"),
+            ("input_tokens", "input_tokens INTEGER"),
+            ("output_tokens", "output_tokens INTEGER"),
+            ("cost_usd", "cost_usd REAL"),
+        ):
+            if _name not in run_cols:
+                _add_column_if_missing(conn, "task_runs", _name, _definition)
         with write_txn(conn):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3238,6 +3238,20 @@ def create_task(
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
+    if model_override:
+        # Creation is a write surface too.  Do not wait until claim/spawn to
+        # discover that a caller persisted an unapproved model pair.
+        try:
+            from hermes_cli.kanban_model_policy import PolicyError, ModelRoutingPolicy
+            ModelRoutingPolicy.load().validate_override(provider_override, model_override)
+        except (PolicyError, ValueError) as exc:
+            _log.warning(
+                "model_override_rejected at task creation: provider=%r model=%r reason=%s",
+                provider_override,
+                model_override,
+                exc,
+            )
+            raise ValueError(f"routing policy rejected model override: {exc}") from exc
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -4656,6 +4670,8 @@ def _snapshot_claim_route(conn: sqlite3.Connection, task_id: str, status: str) -
     try:
         from hermes_cli.kanban_model_policy import PolicyError, policy_for_task
         policy, route = policy_for_task(task)
+        if route["priority"] == "P0" and task.model_override:
+            raise PolicyError("P0 deterministic tasks cannot use model overrides")
         if task.model_override:
             approved = policy.validate_override(task.provider_override, task.model_override)
             route = {**route, **approved}
@@ -10819,9 +10835,13 @@ def _default_spawn(
     try:
         from hermes_cli.kanban_model_policy import policy_for_task
         policy, resolved_route = policy_for_task(task)
+        if resolved_route["priority"] == "P0":
+            raise ValueError("routing policy rejects P0 deterministic task spawn")
         if task.model_override:
             resolved_route = {**resolved_route, **policy.validate_override(task.provider_override, task.model_override)}
-        persisted_route = json.loads(task.route_snapshot or "")
+        if not task.route_snapshot:
+            raise ValueError("routing policy requires a persisted route snapshot")
+        persisted_route = json.loads(task.route_snapshot)
         if persisted_route != resolved_route:
             raise ValueError("persisted route snapshot does not match routing policy")
     except Exception as exc:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5719,6 +5719,28 @@ def complete_task(
     else:
         verified_cards = []
 
+    # The domain completion boundary owns quality execution.  Run the persisted
+    # command before entering the completion write transaction; holding SQLite's
+    # write lock across a subprocess would block every board writer.  A pass is
+    # then re-checked by the CAS-protected event query below.
+    quality_row = conn.execute(
+        "SELECT current_run_id, quality_policy_json FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if quality_row is not None and _quality_policy_required(quality_row):
+        gate_run_id = expected_run_id if expected_run_id is not None else quality_row["current_run_id"]
+        already_passed = (
+            conn.execute(
+                "SELECT 1 FROM task_events WHERE task_id=? AND run_id=? AND kind='quality_passed' LIMIT 1",
+                (task_id, int(gate_run_id)),
+            ).fetchone()
+            if gate_run_id is not None else None
+        )
+        if already_passed is None:
+            if gate_run_id is None or not execute_quality_gates(
+                conn, task_id=task_id, run_id=int(gate_run_id),
+            ):
+                return False
+
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1107,6 +1107,11 @@ class Task:
     # worker runs at that depth regardless of the profile's
     # ``agent.reasoning_effort``. NULL = the worker profile's own setting.
     reasoning_effort: Optional[str] = None
+    # Persisted model-policy decision. ``route_snapshot`` is canonical JSON
+    # (generated at claim time) and is verified again before spawning.
+    routing_priority: Optional[str] = None
+    routing_tier: Optional[str] = None
+    route_snapshot: Optional[str] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -1215,6 +1220,11 @@ class Task:
                 if "reasoning_effort" in keys and row["reasoning_effort"]
                 else None
             ),
+            routing_priority=(
+                row["routing_priority"] if "routing_priority" in keys else None
+            ),
+            routing_tier=(row["routing_tier"] if "routing_tier" in keys else None),
+            route_snapshot=(row["route_snapshot"] if "route_snapshot" in keys else None),
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
@@ -3761,6 +3771,7 @@ def set_model_override(
         raise ValueError("provider_override requires a model_override")
     if not model:
         provider = None
+    rejection: Optional[str] = None
     with write_txn(conn):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,)
@@ -3769,14 +3780,31 @@ def set_model_override(
             return False
         if row["status"] == "archived":
             raise RuntimeError(f"cannot set model override on archived task {task_id}")
-        conn.execute(
-            "UPDATE tasks SET model_override = ?, provider_override = ? WHERE id = ?",
-            (model, provider, task_id),
-        )
-        _append_event(
-            conn, task_id, "model_override_set",
-            {"model": model, "provider": provider},
-        )
+        if model:
+            try:
+                from hermes_cli.kanban_model_policy import PolicyError, ModelRoutingPolicy
+                ModelRoutingPolicy.load().validate_override(provider, model)
+            except (PolicyError, ValueError) as exc:
+                rejection = str(exc)
+                _append_event(
+                    conn, task_id, "model_override_rejected",
+                    {"model": model, "provider": provider, "reason": rejection},
+                )
+        if rejection is not None:
+            # Commit the audit event before rejecting the caller; raising in this
+            # transaction would roll the event back and erase the evidence.
+            pass
+        else:
+            conn.execute(
+                "UPDATE tasks SET model_override = ?, provider_override = ? WHERE id = ?",
+                (model, provider, task_id),
+            )
+            _append_event(
+                conn, task_id, "model_override_set",
+                {"model": model, "provider": provider},
+            )
+    if rejection is not None:
+        raise ValueError(f"routing policy rejected model override: {rejection}")
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
     notify_task_updated(conn, task_id, ("model_override", "provider_override"))
     return True
@@ -4614,6 +4642,48 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+def _snapshot_claim_route(conn: sqlite3.Connection, task_id: str, status: str) -> Optional[dict[str, str]]:
+    """Resolve and durably snapshot an approved route, or block fail-closed.
+
+    Called inside a claim transaction before its ready/review -> running CAS.
+    No policy (or an invalid persisted override) is a routing block, never an
+    implicit fall-back to a profile default.
+    """
+    task = get_task(conn, task_id)
+    if task is None:
+        return None
+    try:
+        from hermes_cli.kanban_model_policy import PolicyError, policy_for_task
+        policy, route = policy_for_task(task)
+        if task.model_override:
+            approved = policy.validate_override(task.provider_override, task.model_override)
+            route = {**route, **approved}
+    except (PolicyError, ValueError) as exc:
+        conn.execute(
+            "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL "
+            "WHERE id=? AND status=? AND claim_lock IS NULL",
+            (task_id, status),
+        )
+        event = "model_resource_blocked" if (task.routing_priority or "").upper() == "P4" else "routing_blocked"
+        _append_event(conn, task_id, event, {"reason": str(exc), "source_status": status})
+        return None
+    if route["priority"] == "P0":
+        conn.execute(
+            "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL, "
+            "routing_priority=?, routing_tier=?, route_snapshot=? "
+            "WHERE id=? AND status=? AND claim_lock IS NULL",
+            ("P0", "deterministic", json.dumps(route, sort_keys=True), task_id, status),
+        )
+        _append_event(conn, task_id, "deterministic_routed", {"route": route, "source_status": status})
+        return None
+    snapshot = json.dumps(route, sort_keys=True, separators=(",", ":"))
+    conn.execute(
+        "UPDATE tasks SET routing_priority=?, routing_tier=?, route_snapshot=? WHERE id=?",
+        (route["priority"], route["tier"], snapshot, task_id),
+    )
+    return route
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4655,6 +4725,10 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        # Policy routing is an admission gate, not a post-claim spawn hint.
+        # This fail-closed path records its own routing event and leaves no run.
+        if _snapshot_claim_route(conn, task_id, "ready") is None:
+            return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4693,7 +4767,8 @@ def claim_task(
         # Look up the current task row so we can populate the run with
         # its assignee / step / runtime cap.
         trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key "
+            "SELECT assignee, max_runtime_seconds, current_step_key, "
+            "routing_priority, routing_tier, route_snapshot "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -4702,8 +4777,8 @@ def claim_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                routing_priority, routing_tier, route_snapshot, started_at
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4712,6 +4787,9 @@ def claim_task(
                 lock,
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
+                trow["routing_priority"] if trow else None,
+                trow["routing_tier"] if trow else None,
+                trow["route_snapshot"] if trow else None,
                 now,
             ),
         )
@@ -4775,6 +4853,8 @@ def claim_review_task(
                     },
                 )
             return None
+        if _snapshot_claim_route(conn, task_id, "review") is None:
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4791,7 +4871,8 @@ def claim_review_task(
         if cur.rowcount != 1:
             return None
         trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key "
+            "SELECT assignee, max_runtime_seconds, current_step_key, "
+            "routing_priority, routing_tier, route_snapshot "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -4800,8 +4881,8 @@ def claim_review_task(
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                routing_priority, routing_tier, route_snapshot, started_at
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4810,6 +4891,9 @@ def claim_review_task(
                 lock,
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
+                trow["routing_priority"] if trow else None,
+                trow["routing_tier"] if trow else None,
+                trow["route_snapshot"] if trow else None,
                 now,
             ),
         )
@@ -10727,6 +10811,22 @@ def _default_spawn(
     import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
+
+    # Defense in depth: dispatch may be called with a Task reconstructed from
+    # hostile/direct DB writes. Only the route snapshot produced by claim is
+    # allowed to reach subprocess creation.
+    try:
+        from hermes_cli.kanban_model_policy import policy_for_task
+        policy, resolved_route = policy_for_task(task)
+        if task.model_override:
+            resolved_route = {**resolved_route, **policy.validate_override(task.provider_override, task.model_override)}
+        persisted_route = json.loads(task.route_snapshot or "")
+        if persisted_route != resolved_route:
+            raise ValueError("persisted route snapshot does not match routing policy")
+    except Exception as exc:
+        if isinstance(exc, ValueError) and "routing policy" in str(exc):
+            raise
+        raise ValueError(f"routing policy rejected task {task.id}: {exc}") from exc
 
     from hermes_cli.profiles import normalize_profile_name
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4535,6 +4535,7 @@ def _end_run(
                error         = ?,
                metadata      = ?,
                ended_at      = ?,
+               duration_ms   = MAX(0, (? - started_at) * 1000),
                claim_lock    = NULL,
                claim_expires = NULL,
                worker_pid    = NULL
@@ -4547,6 +4548,7 @@ def _end_run(
             summary,
             error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
+            now,
             now,
             run_id,
         ),

--- a/hermes_cli/kanban_model_policy.py
+++ b/hermes_cli/kanban_model_policy.py
@@ -98,6 +98,33 @@ class ModelRoutingPolicy:
                 return {"tier": tier, "provider": provider, "model": model}
         raise PolicyError(f"override {provider}/{model} is not an approved candidate")
 
+    def reevaluate_quality_failure(
+        self,
+        *,
+        priority: str | None,
+        prior_model: str | None,
+        failure_reason: str,
+        quality_result: Mapping[str, Any],
+        retry_count: int,
+    ) -> dict[str, Any]:
+        """Make the router-owned decision after a failed quality gate.
+
+        Quality workers supply evidence, never a replacement model.  The
+        policy is reloaded by the caller and resolves the current approved
+        route for auditability, but the default decision remains a human
+        escalation: no worker can self-upgrade, merge, deploy, or activate a
+        result merely because its own quality check failed.
+        """
+        route = self.resolve(priority=priority)
+        return {
+            "action": "human_escalation_required",
+            "route": route,
+            "prior_model": prior_model,
+            "failure_reason": failure_reason,
+            "quality_result": dict(quality_result),
+            "retry_count": int(retry_count),
+        }
+
 
 def policy_for_task(task: Any) -> tuple[ModelRoutingPolicy, dict[str, str]]:
     policy = ModelRoutingPolicy.load()

--- a/hermes_cli/kanban_model_policy.py
+++ b/hermes_cli/kanban_model_policy.py
@@ -1,0 +1,106 @@
+"""Fail-closed in-process model routing for Kanban dispatch.
+
+This module deliberately has no subprocess or model-catalog dependency: the
+persisted config is the policy authority and every route is reproducible from
+its snapshot.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+from typing import Any, Mapping
+
+import yaml
+
+
+class PolicyError(ValueError):
+    """The configured routing policy cannot approve a requested action."""
+
+
+@dataclass(frozen=True)
+class ModelRoutingPolicy:
+    enabled: bool
+    tiers: Mapping[str, tuple[dict[str, str], ...]]
+    classification: Mapping[str, Mapping[str, Any]]
+
+    @classmethod
+    def load(cls, config_path: Path | None = None) -> "ModelRoutingPolicy":
+        path = config_path or Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "config.yaml"
+        try:
+            raw = yaml.safe_load(path.read_text()) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            raise PolicyError(f"model_routing config unavailable: {exc}") from exc
+        value = raw.get("model_routing")
+        if not isinstance(value, dict) or value.get("enabled") is not True:
+            raise PolicyError("model_routing is not enabled")
+        raw_tiers = value.get("tiers")
+        if not isinstance(raw_tiers, dict):
+            raise PolicyError("model_routing.tiers is required")
+        tiers: dict[str, tuple[dict[str, str], ...]] = {}
+        for tier, candidates in raw_tiers.items():
+            name = str(tier).strip().upper()
+            if not name or not isinstance(candidates, list):
+                raise PolicyError(f"invalid candidates for tier {tier!r}")
+            approved: list[dict[str, str]] = []
+            for item in candidates:
+                if not isinstance(item, dict):
+                    continue
+                provider = str(item.get("provider") or "").strip()
+                model = str(item.get("model") or "").strip()
+                if provider and model:
+                    approved.append({"provider": provider, "model": model})
+            tiers[name] = tuple(approved)
+        raw_classification = value.get("classification", {})
+        if not isinstance(raw_classification, dict):
+            raise PolicyError("model_routing.classification must be a mapping")
+        classification = {
+            str(priority).strip().upper(): spec
+            for priority, spec in raw_classification.items()
+            if isinstance(spec, dict)
+        }
+        return cls(True, tiers, classification)
+
+    def classify(self, *, priority: str | None = None, tags: list[str] | None = None) -> str:
+        explicit = (priority or "").strip().upper()
+        if explicit:
+            if explicit not in {"P0", "P1", "P2", "P3", "P4"}:
+                raise PolicyError(f"unknown routing priority {priority!r}")
+            return explicit
+        tag_set = {str(tag).strip().casefold() for tag in (tags or [])}
+        for candidate, spec in self.classification.items():
+            configured = {str(tag).strip().casefold() for tag in spec.get("tags", [])}
+            if configured and configured & tag_set:
+                return candidate
+        return "P1"
+
+    def resolve(self, *, priority: str | None = None, tags: list[str] | None = None) -> dict[str, str]:
+        resolved_priority = self.classify(priority=priority, tags=tags)
+        if resolved_priority == "P0":
+            return {"priority": "P0", "tier": "deterministic", "provider": "", "model": ""}
+        spec = self.classification.get(resolved_priority)
+        if not spec:
+            raise PolicyError(f"no routing rule for {resolved_priority}")
+        tier = str(spec.get("tier") or "").strip().upper()
+        candidates = self.tiers.get(tier, ())
+        if not candidates:
+            raise PolicyError(f"no approved model resource for {resolved_priority}/{tier or 'unset'}")
+        candidate = candidates[0]
+        return {"priority": resolved_priority, "tier": tier, **candidate}
+
+    def validate_override(self, provider: str | None, model: str | None) -> dict[str, str]:
+        provider = (provider or "").strip()
+        model = (model or "").strip()
+        if not provider or not model:
+            raise PolicyError("override requires provider and model")
+        for tier, candidates in self.tiers.items():
+            if any(c["provider"] == provider and c["model"] == model for c in candidates):
+                return {"tier": tier, "provider": provider, "model": model}
+        raise PolicyError(f"override {provider}/{model} is not an approved candidate")
+
+
+def policy_for_task(task: Any) -> tuple[ModelRoutingPolicy, dict[str, str]]:
+    policy = ModelRoutingPolicy.load()
+    tags = list(getattr(task, "skills", None) or [])
+    route = policy.resolve(priority=getattr(task, "routing_priority", None), tags=tags)
+    return policy, route

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -149,7 +149,7 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "escalation_required", "done",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1747,3 +1747,109 @@ def _moa_caches_isolated():
     yield
     moa._preset_cache.clear()
     moa._runtime_cache.clear()
+
+
+# ── Kanban model-routing test admission helpers ────────────────────────────
+#
+# Kanban claims intentionally fail closed unless a persisted routing policy
+# authorizes them. These fixtures use production create/claim/reclaim paths;
+# callers must not hand-write route snapshots or suppress the admission gate.
+_VALID_MODEL_ROUTING_CONFIG = """\
+model_routing:
+  enabled: true
+  tiers:
+    T1:
+      - {provider: nous, model: small}
+    T4:
+      - {provider: openai, model: large}
+  classification:
+    P0: {tags: [deterministic]}
+    P1: {tier: T1}
+    P2: {tier: T1}
+    P3: {tier: T1}
+    P4: {tier: T4}
+"""
+
+
+@pytest.fixture
+def valid_model_routing_config() -> Path:
+    """Persist the minimal valid production routing policy for this test home."""
+    home = Path(os.environ["HERMES_HOME"])
+    home.mkdir(parents=True, exist_ok=True)
+    path = home / "config.yaml"
+    path.write_text(_VALID_MODEL_ROUTING_CONFIG, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def routable_task(valid_model_routing_config):
+    """Create a task which can pass the production routing admission gate."""
+    from hermes_cli import kanban_db as kb
+
+    def create(conn, *, title="routable task", assignee="worker", **kwargs):
+        return kb.create_task(conn, title=title, assignee=assignee, **kwargs)
+
+    return create
+
+
+@pytest.fixture
+def routed_task(routable_task):
+    """Create then claim a P1 task through the real routing gate."""
+    from hermes_cli import kanban_db as kb
+
+    def create_and_claim(conn, *, title="routed task", assignee="worker", claimer=None, **kwargs):
+        task_id = routable_task(conn, title=title, assignee=assignee, **kwargs)
+        task = kb.claim_task(conn, task_id, claimer=claimer)
+        assert task is not None, "valid routed task must be claimable"
+        assert task.status == "running"
+        assert task.route_snapshot is not None
+        return task_id, task
+
+    return create_and_claim
+
+
+@pytest.fixture
+def routed_ready_task(routed_task):
+    """Return a production-reclaimed ready task, never a synthetic snapshot."""
+    from hermes_cli import kanban_db as kb
+
+    def create_claim_and_reclaim(conn, *, title="routed ready task", assignee="worker", **kwargs):
+        task_id, _ = routed_task(conn, title=title, assignee=assignee, **kwargs)
+        assert kb.reclaim_task(conn, task_id, reason="test lifecycle setup")
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "ready"
+        return task_id, task
+
+    return create_claim_and_reclaim
+
+
+@pytest.fixture
+def p0_task(routable_task):
+    """Create a deterministic P0 task through normal skill classification."""
+    def create(conn, *, title="deterministic task", assignee="worker", **kwargs):
+        return routable_task(conn, title=title, assignee=assignee, skills=["deterministic"], **kwargs)
+
+    return create
+
+
+@pytest.fixture
+def p4_blocked_task(routable_task, valid_model_routing_config):
+    """Let production claim admission block P4 when its configured T4 is absent."""
+    from hermes_cli import kanban_db as kb
+
+    def create_and_block(conn, *, title="P4 task", assignee="worker", **kwargs):
+        valid_model_routing_config.write_text(
+            _VALID_MODEL_ROUTING_CONFIG.replace(
+                "    T4:\n      - {provider: openai, model: large}\n", ""
+            ),
+            encoding="utf-8",
+        )
+        task_id = routable_task(conn, title=title, assignee=assignee, **kwargs)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET routing_priority='P4' WHERE id=?", (task_id,))
+        assert kb.claim_task(conn, task_id) is None
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"
+        return task_id, task
+
+    return create_and_block

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1771,14 +1771,18 @@ model_routing:
 """
 
 
-@pytest.fixture
-def valid_model_routing_config() -> Path:
-    """Persist the minimal valid production routing policy for this test home."""
-    home = Path(os.environ["HERMES_HOME"])
+def write_valid_model_routing_config(home: Path) -> Path:
+    """Persist the minimal valid production routing policy at ``home``."""
     home.mkdir(parents=True, exist_ok=True)
     path = home / "config.yaml"
     path.write_text(_VALID_MODEL_ROUTING_CONFIG, encoding="utf-8")
     return path
+
+
+@pytest.fixture
+def valid_model_routing_config() -> Path:
+    """Persist the minimal valid production routing policy for this test home."""
+    return write_valid_model_routing_config(Path(os.environ["HERMES_HOME"]))
 
 
 @pytest.fixture

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -34,6 +34,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
     monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -29,6 +29,8 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -43,6 +43,8 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -61,6 +61,8 @@ def fresh_home(tmp_path, monkeypatch):
         pass
     # Kanban module-level init cache must not leak between tests.
     kb._INITIALIZED_PATHS.clear()
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     return home
 
 
@@ -257,29 +259,16 @@ class TestWorkerSpawnEnv:
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
         kb.create_board("spawntest")
 
-        task = kb.Task(
-            id="t_abc",
-            title="worker test",
-            body=None,
-            assignee="teknium",
-            status="ready",
-            priority=0,
-            created_by="user",
-            created_at=0,
-            started_at=None,
-            completed_at=None,
-            workspace_kind="scratch",
-            workspace_path=None,
-            claim_lock=None,
-            claim_expires=None,
-            tenant=None,
-        )
+        with kb.connect(board="spawntest") as conn:
+            task_id = kb.create_task(conn, title="worker test", assignee="teknium")
+            task = kb.claim_task(conn, task_id, claimer="teknium:1")
+            assert task is not None
 
         kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
 
         env = captured["env"]
         assert env["HERMES_KANBAN_BOARD"] == "spawntest"
-        assert env["HERMES_KANBAN_TASK"] == "t_abc"
+        assert env["HERMES_KANBAN_TASK"] == task.id
         # DB path should match the per-board DB, not the legacy default.
         expected_db = fresh_home / "kanban" / "boards" / "spawntest" / "kanban.db"
         assert env["HERMES_KANBAN_DB"] == str(expected_db)

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -23,9 +22,11 @@ def isolated_kanban_home(monkeypatch):
     test_home = tempfile.mkdtemp(prefix="kanban_cli_passthrough_")
     os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    # Do not purge project modules from sys.modules. Other collected test
+    # modules retain references to them at import time, so deleting and
+    # re-importing creates split-brain singleton/caches for later tests in a
+    # direct multi-file pytest invocation. Kanban path resolution is dynamic
+    # from HERMES_HOME, and monkeypatch restores the environment on teardown.
     yield test_home
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -34,6 +34,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     # Existing crash-detection tests pre-date the grace window; pin to 0
     # so they keep their immediate-reclaim semantics.
     monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
@@ -721,7 +723,8 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     try:
         tid = kb.create_task(conn, title="skill-loading test",
                              assignee="some-profile")
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid, claimer="some-profile:1")
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         pid = kb._default_spawn(task, str(workspace))
         assert pid == 99999

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -38,18 +38,8 @@ def routed_task(kanban_home):
     but their real claims must still carry the authorized snapshot a dispatcher
     worker receives. This prevents hand-written route snapshots in test setup.
     """
-    (kanban_home / "config.yaml").write_text(
-        """
-model_routing:
-  enabled: true
-  tiers:
-    T1:
-      - {provider: nous, model: small}
-  classification:
-    P1: {tier: T1}
-""".strip(),
-        encoding="utf-8",
-    )
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(kanban_home)
 
     def create_and_claim(conn, *, title: str, assignee: str, **kwargs):
         claimer = kwargs.pop("claimer", None)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -27,6 +28,44 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
+
+
+@pytest.fixture
+def routed_task(kanban_home):
+    """Create and claim a task through the production routing admission gate.
+
+    Broader DB tests exercise worker lifecycle behavior, not routing policy,
+    but their real claims must still carry the authorized snapshot a dispatcher
+    worker receives. This prevents hand-written route snapshots in test setup.
+    """
+    (kanban_home / "config.yaml").write_text(
+        """
+model_routing:
+  enabled: true
+  tiers:
+    T1:
+      - {provider: nous, model: small}
+  classification:
+    P1: {tier: T1}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    def create_and_claim(conn, *, title: str, assignee: str, **kwargs):
+        claimer = kwargs.pop("claimer", None)
+        task_id = kb.create_task(conn, title=title, assignee=assignee, **kwargs)
+        claimed = kb.claim_task(conn, task_id, claimer=claimer)
+        assert claimed is not None
+        assert claimed.route_snapshot is not None
+        assert json.loads(claimed.route_snapshot) == {
+            "priority": "P1",
+            "tier": "T1",
+            "provider": "nous",
+            "model": "small",
+        }
+        return task_id, claimed
+
+    return create_and_claim
 
 
 def _init_git_repo(repo: Path) -> None:
@@ -207,7 +246,7 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
 
 
 def test_stale_claim_reclaim_event_records_diagnostic_payload(
-    kanban_home, monkeypatch,
+    routed_task, monkeypatch,
 ):
     """``reclaimed`` events should carry claim_expires, last_heartbeat_at,
     and worker_pid so operators can diagnose why a claim went stale
@@ -217,9 +256,10 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
     import hermes_cli.kanban_db as _kb
 
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
-        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        t, _claimed = routed_task(
+            conn, title="x", assignee="a", claimer=f"{host}:worker"
+        )
         kb._set_worker_pid(conn, t, 12345)
         old_expires = int(time.time()) - 3600
         hb_at = int(time.time()) - 1800
@@ -265,7 +305,7 @@ def _exited_status(code: int) -> int:
 
 
 def test_rate_limit_exit_requeues_without_counting_failure(
-    kanban_home, monkeypatch,
+    routed_task, monkeypatch,
 ):
     """A rate-limit sentinel exit releases the task to ``ready`` and leaves
     ``consecutive_failures`` untouched — the breaker must never trip on a
@@ -277,16 +317,18 @@ def test_rate_limit_exit_requeues_without_counting_failure(
 
     with kb.connect() as conn:
         host = _kb._claimer_id().split(":", 1)[0]
-        tid = kb.create_task(conn, title="rl", assignee="a")
+        tid, claimed = routed_task(conn, title="rl", assignee="a", claimer=f"{host}:w0")
 
         # Simulate FAR more quota-wall hits than DEFAULT_FAILURE_LIMIT (2).
         # If any of these counted as a failure the task would be blocked.
         for i in range(6):
             pid = 70000 + i
-            # Claim to open a real run (so detect_crashed_workers can close
-            # it with a rate_limited outcome), then point the claim at this
-            # host + a dead pid so the crash path acts on it.
-            kb.claim_task(conn, tid, claimer=f"{host}:w{i}")
+            # The helper supplies the first production claim; every requeue
+            # must be re-claimed through the same routing admission gate.
+            if i:
+                claimed = kb.claim_task(conn, tid, claimer=f"{host}:w{i}")
+                assert claimed is not None
+            route_snapshot = claimed.route_snapshot
             conn.execute(
                 "UPDATE tasks SET worker_pid=?, consecutive_failures=? "
                 "WHERE id=?",
@@ -311,6 +353,15 @@ def test_rate_limit_exit_requeues_without_counting_failure(
                 f"hit {i}: rate-limit must not count a failure, "
                 f"got {task.consecutive_failures}"
             )
+            # Rate-limit requeue preserves the real admission snapshot on both
+            # the task and the run; it must not create an un-routed retry.
+            assert task.route_snapshot == route_snapshot
+            run = conn.execute(
+                "SELECT route_snapshot FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+                (tid,),
+            ).fetchone()
+            assert run is not None
+            assert run["route_snapshot"] == route_snapshot
 
         # Last failure error stamped so the respawn guard recognizes the
         # quota wall.
@@ -329,7 +380,7 @@ def test_rate_limit_exit_requeues_without_counting_failure(
 
 
 def test_respawn_guard_defers_rate_limited_within_cooldown(
-    kanban_home, monkeypatch,
+    routed_task, monkeypatch,
 ):
     """Within the cooldown after a rate-limit requeue, the guard defers the
     respawn; after the cooldown it allows a probe — and crucially does NOT
@@ -340,9 +391,8 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
     now = 5_000_000
 
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="rl-guard", assignee="a")
+        tid, claimed = routed_task(conn, title="rl-guard", assignee="a")
         # Seed a rate_limited run that just ended + the stamped error.
-        kb.claim_task(conn, tid)
         run_id = kb.get_task(conn, tid).current_run_id
         conn.execute(
             "UPDATE task_runs SET outcome='rate_limited', status='rate_limited', "
@@ -356,6 +406,9 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
             ("pid 1 exited rate-limited (quota wall) — requeued", tid),
         )
         conn.commit()
+        task_after_requeue = kb.get_task(conn, tid)
+        assert task_after_requeue is not None
+        assert task_after_requeue.route_snapshot == claimed.route_snapshot
 
         # Inside cooldown → defer with the rate-limit-specific reason.
         monkeypatch.setattr(_kb.time, "time", lambda: now + 100)
@@ -796,7 +849,7 @@ class TestSharedBoardPaths:
 
 
     def test_dispatcher_spawn_injects_kanban_paths_without_stale_session(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, routed_task
     ):
         # The dispatcher must pin board paths while stripping any unrelated
         # HERMES_SESSION_* identity inherited from the long-lived gateway.
@@ -804,7 +857,6 @@ class TestSharedBoardPaths:
         # re-sets to its own `kanban` tag AFTER the strip — a value it owns,
         # never one inherited from whatever the gateway last routed.
         default_home = tmp_path / ".hermes"
-        default_home.mkdir()
         self._set_home(monkeypatch, tmp_path, default_home)
 
         from gateway import session_context as sc
@@ -825,24 +877,15 @@ class TestSharedBoardPaths:
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
 
-        task = kb.Task(
-            id="t_dispatch_env",
-            title="x",
-            body=None,
-            assignee="coder",
-            status="ready",
-            priority=0,
-            created_by=None,
-            created_at=0,
-            started_at=None,
-            completed_at=None,
-            workspace_kind="worktree",
-            workspace_path=str(tmp_path / "ws"),
-            claim_lock=None,
-            claim_expires=None,
-            tenant=None,
-            branch_name="wt/t_dispatch_env",
-        )
+        with kb.connect() as conn:
+            task_id, task = routed_task(
+                conn,
+                title="x",
+                assignee="coder",
+                workspace_kind="worktree",
+                workspace_path=str(tmp_path / "ws"),
+                branch_name="wt/t_dispatch_env",
+            )
         kb._default_spawn(task, str(tmp_path / "ws"))
 
         env = captured["env"]
@@ -850,7 +893,7 @@ class TestSharedBoardPaths:
         assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(
             default_home / "kanban" / "workspaces"
         )
-        assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_KANBAN_TASK"] == task_id
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
         for key in sc._VAR_MAP:
             if key == "HERMES_SESSION_SOURCE":
@@ -1247,7 +1290,7 @@ def _make_task(**overrides) -> "kb.Task":
 
 
 def test_dispatch_max_in_progress_blocks_review_when_at_limit(
-    kanban_home, all_assignees_spawnable,
+    routed_task, all_assignees_spawnable,
 ):
     """Review-only backlog must still respect max_in_progress."""
     spawns = []
@@ -1257,8 +1300,7 @@ def test_dispatch_max_in_progress_blocks_review_when_at_limit(
         return 42
 
     with kb.connect() as conn:
-        running = kb.create_task(conn, title="running", assignee="alice")
-        kb.claim_task(conn, running)
+        running, _claimed = routed_task(conn, title="running", assignee="alice")
         review = kb.create_task(conn, title="review", assignee="bob")
         _set_task_status(conn, review, "review")
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=1)

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -7,8 +7,6 @@ the task is skipped (existing behavior preserved).
 from __future__ import annotations
 
 import json
-import os
-import sys
 import tempfile
 
 import pytest
@@ -19,11 +17,16 @@ def isolated_kanban_home(monkeypatch):
     """Spin up a fresh HERMES_HOME with a clean kanban DB."""
     test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
     monkeypatch.setenv("HERMES_HOME", test_home)
-    # Force-reimport so the fresh HERMES_HOME is picked up.
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    from pathlib import Path
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(Path(test_home))
+    # ``kanban_db`` resolves HERMES_HOME when opening a connection; do not
+    # purge package modules from ``sys.modules`` here.  Doing so leaves other
+    # collected test modules holding stale imports (notably plugin hook
+    # helpers), while lifecycle code imports a second ``hermes_cli.plugins``
+    # module. Hooks then register on the old singleton and never fire.
     from hermes_cli import kanban_db
+    kanban_db._INITIALIZED_PATHS.clear()
     yield kanban_db, test_home
     # Cleanup is best-effort; tempfile dir survives but pytest isolation
     # gives each test its own monkeypatched HERMES_HOME so no cross-test

--- a/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
+++ b/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
@@ -25,6 +25,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -30,6 +30,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -21,6 +21,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_memory_guard.py
+++ b/tests/hermes_cli/test_kanban_memory_guard.py
@@ -30,6 +30,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_model_policy_phase_a.py
+++ b/tests/hermes_cli/test_kanban_model_policy_phase_a.py
@@ -85,9 +85,42 @@ def test_override_is_validated_and_audited(routed_conn):
     assert any(kind == "model_override_rejected" for kind, _ in events)
 
 
+def test_create_task_rejects_unauthorized_override_before_persisting(routed_conn, caplog):
+    with pytest.raises(ValueError, match="routing policy rejected model override"):
+        kb.create_task(
+            routed_conn,
+            title="unauthorized",
+            assignee="worker",
+            model_override="unapproved",
+            provider_override="evil",
+        )
+    assert routed_conn.execute("SELECT COUNT(*) FROM tasks WHERE title='unauthorized'").fetchone()[0] == 0
+    assert "model_override_rejected at task creation" in caplog.text
+
+
+def test_create_task_override_rejects_when_registry_is_missing(routed_conn, monkeypatch, tmp_path):
+    missing_home = tmp_path / "no-registry"
+    missing_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(missing_home))
+    with pytest.raises(ValueError, match="model_routing config unavailable"):
+        kb.create_task(
+            routed_conn,
+            title="missing registry",
+            assignee="worker",
+            model_override="small",
+            provider_override="nous",
+        )
+
+
 def test_override_invalidates_prior_route_snapshot(routed_conn):
     task_id = kb.create_task(routed_conn, title="t", assignee="worker")
-    assert kb.claim_task(routed_conn, task_id) is not None
+    claimed = kb.claim_task(routed_conn, task_id)
+    assert claimed is not None
+    assert claimed.route_snapshot is not None
+    run = routed_conn.execute(
+        "SELECT route_snapshot FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1", (task_id,)
+    ).fetchone()
+    assert run["route_snapshot"] == claimed.route_snapshot
     # Pretend the first worker completed; the next route must be freshly
     # authorized, rather than reusing a snapshot from before the override.
     routed_conn.execute("UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?", (task_id,))
@@ -102,4 +135,27 @@ def test_spawn_rejects_malicious_persisted_override(routed_conn, monkeypatch, tm
     task = kb.get_task(routed_conn, task_id)
     monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_kw: pytest.fail("must not spawn"))
     with pytest.raises(ValueError, match="routing policy"):
+        kb._default_spawn(task, str(tmp_path))
+
+
+def test_spawn_requires_a_claim_snapshot(routed_conn, monkeypatch, tmp_path):
+    task_id = kb.create_task(routed_conn, title="unclaimed", assignee="worker")
+    task = kb.get_task(routed_conn, task_id)
+    assert task is not None
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_kw: pytest.fail("must not spawn"))
+    with pytest.raises(ValueError, match="persisted route snapshot"):
+        kb._default_spawn(task, str(tmp_path))
+
+
+def test_p0_cannot_spawn_an_approved_persisted_model(routed_conn, monkeypatch, tmp_path):
+    task_id = kb.create_task(routed_conn, title="cleanup", assignee="worker", skills=["deterministic"])
+    routed_conn.execute(
+        "UPDATE tasks SET model_override='small', provider_override='nous', "
+        "route_snapshot=? WHERE id=?",
+        (json.dumps({"priority": "P0", "tier": "T1", "provider": "nous", "model": "small"}, sort_keys=True), task_id),
+    )
+    task = kb.get_task(routed_conn, task_id)
+    assert task is not None
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_kw: pytest.fail("must not spawn"))
+    with pytest.raises(ValueError, match="P0"):
         kb._default_spawn(task, str(tmp_path))

--- a/tests/hermes_cli/test_kanban_model_policy_phase_a.py
+++ b/tests/hermes_cli/test_kanban_model_policy_phase_a.py
@@ -1,0 +1,105 @@
+"""Focused Phase A model-routing policy contracts (written before implementation)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_model_policy import ModelRoutingPolicy, PolicyError
+
+
+@pytest.fixture
+def routed_conn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (home / "config.yaml").write_text(
+        """
+model_routing:
+  enabled: true
+  tiers:
+    T1:
+      - {provider: nous, model: small}
+    T4:
+      - {provider: openai, model: large}
+  classification:
+    P0: {tags: [deterministic]}
+    P1: {tier: T1}
+    P4: {tier: T4}
+""".strip()
+    )
+    kb.init_db()
+    conn = kb.connect()
+    yield conn
+    conn.close()
+
+
+def _events(conn, task_id):
+    return [(e.kind, e.payload) for e in kb.list_events(conn, task_id)]
+
+
+def test_policy_fails_closed_and_resolves_only_approved_candidates(routed_conn):
+    policy = ModelRoutingPolicy.load()
+    assert policy.resolve(priority="P1") == {"priority": "P1", "tier": "T1", "provider": "nous", "model": "small"}
+    with pytest.raises(PolicyError):
+        policy.validate_override("evil", "unapproved")
+
+
+def test_schema_has_route_snapshot_and_future_accounting_fields(routed_conn):
+    task_cols = {r["name"] for r in routed_conn.execute("PRAGMA table_info(tasks)")}
+    run_cols = {r["name"] for r in routed_conn.execute("PRAGMA table_info(task_runs)")}
+    assert {"routing_priority", "routing_tier", "route_snapshot"} <= task_cols
+    assert {"routing_priority", "routing_tier", "route_snapshot", "input_tokens", "output_tokens", "cost_usd"} <= run_cols
+
+
+def test_p0_is_deterministically_routed_without_llm_claim(routed_conn):
+    task_id = kb.create_task(routed_conn, title="cleanup", assignee="worker", skills=["deterministic"])
+    assert kb.claim_task(routed_conn, task_id) is None
+    task = kb.get_task(routed_conn, task_id)
+    assert task.status == "blocked"
+    assert any(kind == "deterministic_routed" for kind, _ in _events(routed_conn, task_id))
+
+
+def test_p4_without_t4_blocks_without_lower_tier_fallback(routed_conn):
+    # Persist a valid policy but remove T4 to simulate unavailable resource.
+    Path(__import__("os").environ["HERMES_HOME"], "config.yaml").write_text(
+        "model_routing:\n  enabled: true\n  tiers: {T1: [{provider: nous, model: small}]}\n  classification: {P4: {tier: T4}}\n"
+    )
+    task_id = kb.create_task(routed_conn, title="hard", assignee="worker")
+    routed_conn.execute("UPDATE tasks SET routing_priority='P4' WHERE id=?", (task_id,))
+    assert kb.claim_task(routed_conn, task_id) is None
+    assert kb.get_task(routed_conn, task_id).status == "blocked"
+    assert any(kind == "model_resource_blocked" for kind, _ in _events(routed_conn, task_id))
+
+
+def test_override_is_validated_and_audited(routed_conn):
+    task_id = kb.create_task(routed_conn, title="t", assignee="worker")
+    assert kb.set_model_override(routed_conn, task_id, "small", provider="nous")
+    with pytest.raises(ValueError):
+        kb.set_model_override(routed_conn, task_id, "large", provider="nous")
+    events = _events(routed_conn, task_id)
+    assert any(kind == "model_override_set" for kind, _ in events)
+    assert any(kind == "model_override_rejected" for kind, _ in events)
+
+
+def test_override_invalidates_prior_route_snapshot(routed_conn):
+    task_id = kb.create_task(routed_conn, title="t", assignee="worker")
+    assert kb.claim_task(routed_conn, task_id) is not None
+    # Pretend the first worker completed; the next route must be freshly
+    # authorized, rather than reusing a snapshot from before the override.
+    routed_conn.execute("UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?", (task_id,))
+    assert kb.set_model_override(routed_conn, task_id, "small", provider="nous")
+    row = routed_conn.execute("SELECT route_snapshot FROM tasks WHERE id=?", (task_id,)).fetchone()
+    assert row["route_snapshot"] is None
+
+
+def test_spawn_rejects_malicious_persisted_override(routed_conn, monkeypatch, tmp_path):
+    task_id = kb.create_task(routed_conn, title="t", assignee="worker")
+    routed_conn.execute("UPDATE tasks SET model_override='malicious', provider_override='evil' WHERE id=?", (task_id,))
+    task = kb.get_task(routed_conn, task_id)
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_a, **_kw: pytest.fail("must not spawn"))
+    with pytest.raises(ValueError, match="routing policy"):
+        kb._default_spawn(task, str(tmp_path))

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -16,6 +16,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     # Allow the kanban notifier path-validator to upload artifacts the
     # tests write under ``tmp_path``. Without this, every artifact-delivery

--- a/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
+++ b/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
@@ -25,7 +25,7 @@ from hermes_cli import kanban_db as kb
 
 
 @pytest.fixture
-def conn(tmp_path: Path):
+def conn(tmp_path: Path, valid_model_routing_config):
     db = kb.connect(tmp_path / "kanban.db")
     try:
         yield db

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -8,7 +8,6 @@ model / API quota / browser pool from being overwhelmed by a fan-out.
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 
 import pytest
@@ -21,10 +20,14 @@ def isolated_kanban_home_with_profiles(monkeypatch):
     for prof in ("alpha", "beta", "default"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    from pathlib import Path
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(Path(test_home))
+    # ``kanban_db`` resolves HERMES_HOME when opening a connection.  Keeping
+    # the canonical package modules avoids splitting plugin hooks between
+    # stale imports held by other collected tests and newly re-imported ones.
     from hermes_cli import kanban_db
+    kanban_db._INITIALIZED_PATHS.clear()
     yield kanban_db
 
 

--- a/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
+++ b/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
@@ -1,0 +1,137 @@
+"""Phase C durable quality-gate contracts at the existing review boundary."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tests.conftest import write_valid_model_routing_config
+
+
+@pytest.fixture
+def routed_conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    write_valid_model_routing_config(home)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    yield conn
+    conn.close()
+
+
+def _review_run(conn, *, quality_enabled: bool = True):
+    task_id = kb.create_task(conn, title="quality-gated change", assignee="builder")
+    if quality_enabled:
+        assert kb.set_quality_policy(conn, task_id, {"enabled": True, "required": True})
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None and implementation.current_run_id is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="implementation complete",
+        reviewer="reviewer",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None and review.current_run_id is not None
+    return task_id, implementation.current_run_id, review.current_run_id
+
+
+def test_quality_enabled_task_requires_review_quality_before_completion(routed_conn):
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+
+    assert not kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
+    assert kb.get_task(routed_conn, task_id).status == "running"
+    assert kb.record_quality_gate(
+        routed_conn,
+        task_id=task_id,
+        run_id=review_run_id,
+        passed=True,
+        result={"checks": ["focused tests"], "approval": "human"},
+    )
+    # Passing quality permits, but does not perform merge/deploy/public activation.
+    assert kb.get_task(routed_conn, task_id).status == "running"
+    assert kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
+
+    task = kb.get_task(routed_conn, task_id)
+    assert task is not None and task.status == "done"
+    review_run = kb.get_run(routed_conn, review_run_id)
+    assert review_run is not None and review_run.outcome == "completed"
+    assert review_run.metadata == {
+        "quality_gate": {"passed": True, "checks": ["focused tests"], "approval": "human"}
+    }
+    events = kb.list_events(routed_conn, task_id)
+    quality = [event for event in events if event.kind == "quality_passed"]
+    completed = [event for event in events if event.kind == "completed"]
+    assert quality[-1].run_id == review_run_id
+    assert quality[-1].payload == {"passed": True, "checks": ["focused tests"], "approval": "human"}
+    assert completed[-1].run_id == review_run_id
+
+
+def test_quality_failure_is_durable_then_requires_router_escalation_without_self_upgrade(routed_conn):
+    task_id, implementation_run_id, review_run_id = _review_run(routed_conn)
+    prior = routed_conn.execute(
+        "SELECT route_snapshot, attempt_number FROM task_runs WHERE id = ?",
+        (review_run_id,),
+    ).fetchone()
+    prior_route = json.loads(prior["route_snapshot"])
+
+    assert kb.record_quality_gate(
+        routed_conn,
+        task_id=task_id,
+        run_id=review_run_id,
+        passed=False,
+        reason="missing regression coverage",
+        result={"checks": ["focused tests"], "score": 0.4},
+    )
+
+    task = kb.get_task(routed_conn, task_id)
+    assert task is not None and task.status == "escalation_required"
+    run = kb.get_run(routed_conn, review_run_id)
+    assert run is not None and run.outcome == "quality_failed"
+    assert run.error == "missing regression coverage"
+    events = kb.list_events(routed_conn, task_id)
+    failure = [event for event in events if event.kind == "quality_failed"][-1]
+    escalation = [event for event in events if event.kind == "escalation_required"][-1]
+    assert failure.run_id == review_run_id
+    assert failure.payload == {
+        "reason": "missing regression coverage",
+        "result": {"checks": ["focused tests"], "score": 0.4},
+    }
+    assert escalation.run_id == review_run_id
+    assert escalation.payload["prior_run_id"] == review_run_id
+    assert escalation.payload["prior_model"] == prior_route["model"]
+    assert escalation.payload["failure_reason"] == "missing regression coverage"
+    assert escalation.payload["quality_result"] == {"checks": ["focused tests"], "score": 0.4}
+    assert escalation.payload["retry_count"] == prior["attempt_number"]
+    # Router owns the decision and merely escalates; the worker cannot mutate routes.
+    assert escalation.payload["decision"]["action"] == "human_escalation_required"
+    assert task.model_override is None
+    assert task.provider_override is None
+    assert implementation_run_id != review_run_id
+
+
+def test_quality_gate_rejects_stale_or_non_review_worker(routed_conn):
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+
+    assert not kb.record_quality_gate(
+        routed_conn, task_id=task_id, run_id=review_run_id + 100, passed=True,
+    )
+    assert kb.get_task(routed_conn, task_id).status == "running"
+    assert not kb.record_quality_gate(
+        routed_conn, task_id=task_id, run_id=review_run_id, passed=False,
+        reason="   ",
+    )
+    assert kb.get_task(routed_conn, task_id).status == "running"
+
+
+def test_quality_policy_is_opt_in_and_default_completion_remains_compatible(routed_conn):
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn, quality_enabled=False)
+
+    assert kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
+    assert kb.get_task(routed_conn, task_id).status == "done"

--- a/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
+++ b/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
@@ -46,7 +46,7 @@ def test_workers_cannot_self_certify_quality_pass(routed_conn):
     task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
 
     assert not kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
-    assert kb.get_task(routed_conn, task_id).status == "running"
+    assert kb.get_task(routed_conn, task_id).status == "escalation_required"
     assert not kb.record_quality_gate(
         routed_conn,
         task_id=task_id,
@@ -74,7 +74,6 @@ def test_operator_configured_gate_executes_in_task_workspace_and_records_same_ru
         },
     )
 
-    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
     assert kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
 
     run = kb.get_run(routed_conn, review_run_id)

--- a/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
+++ b/tests/hermes_cli/test_kanban_quality_gate_phase_c.py
@@ -42,72 +42,86 @@ def _review_run(conn, *, quality_enabled: bool = True):
     return task_id, implementation.current_run_id, review.current_run_id
 
 
-def test_quality_enabled_task_requires_review_quality_before_completion(routed_conn):
+def test_workers_cannot_self_certify_quality_pass(routed_conn):
     task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
 
     assert not kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
     assert kb.get_task(routed_conn, task_id).status == "running"
-    assert kb.record_quality_gate(
+    assert not kb.record_quality_gate(
         routed_conn,
         task_id=task_id,
         run_id=review_run_id,
         passed=True,
         result={"checks": ["focused tests"], "approval": "human"},
     )
-    # Passing quality permits, but does not perform merge/deploy/public activation.
-    assert kb.get_task(routed_conn, task_id).status == "running"
+    assert not kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
+
+
+def test_operator_configured_gate_executes_in_task_workspace_and_records_same_run_pass(
+    routed_conn, tmp_path: Path,
+):
+    workspace = tmp_path / "quality-workspace"
+    workspace.mkdir()
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+    kb.set_workspace_path(routed_conn, task_id, str(workspace))
+    assert kb.set_quality_policy(
+        routed_conn,
+        task_id,
+        {
+            "enabled": True,
+            "required": True,
+            "gates": [{"command": ["/bin/sh", "-c", "printf gate-ok"], "timeout_seconds": 5}],
+        },
+    )
+
+    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
     assert kb.complete_task(routed_conn, task_id, expected_run_id=review_run_id)
 
-    task = kb.get_task(routed_conn, task_id)
-    assert task is not None and task.status == "done"
-    review_run = kb.get_run(routed_conn, review_run_id)
-    assert review_run is not None and review_run.outcome == "completed"
-    assert review_run.metadata == {
-        "quality_gate": {"passed": True, "checks": ["focused tests"], "approval": "human"}
+    run = kb.get_run(routed_conn, review_run_id)
+    assert run is not None
+    assert run.metadata["quality_gate"] == {
+        "passed": True,
+        "gates": [{"command": ["/bin/sh", "-c", "printf gate-ok"], "status": "passed", "output": "gate-ok"}],
     }
-    events = kb.list_events(routed_conn, task_id)
-    quality = [event for event in events if event.kind == "quality_passed"]
-    completed = [event for event in events if event.kind == "completed"]
-    assert quality[-1].run_id == review_run_id
-    assert quality[-1].payload == {"passed": True, "checks": ["focused tests"], "approval": "human"}
-    assert completed[-1].run_id == review_run_id
 
 
-def test_quality_failure_is_durable_then_requires_router_escalation_without_self_upgrade(routed_conn):
+def test_quality_failure_is_durable_then_requires_router_escalation_without_self_upgrade(
+    routed_conn, tmp_path: Path,
+):
     task_id, implementation_run_id, review_run_id = _review_run(routed_conn)
+    workspace = tmp_path / "quality-failure"
+    workspace.mkdir()
+    kb.set_workspace_path(routed_conn, task_id, str(workspace))
+    assert kb.set_quality_policy(routed_conn, task_id, {
+        "enabled": True, "required": True,
+        "gates": [{"command": ["/bin/sh", "-c", "printf broken; exit 7"]}],
+    })
     prior = routed_conn.execute(
         "SELECT route_snapshot, attempt_number FROM task_runs WHERE id = ?",
         (review_run_id,),
     ).fetchone()
     prior_route = json.loads(prior["route_snapshot"])
 
-    assert kb.record_quality_gate(
-        routed_conn,
-        task_id=task_id,
-        run_id=review_run_id,
-        passed=False,
-        reason="missing regression coverage",
-        result={"checks": ["focused tests"], "score": 0.4},
-    )
+    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
 
     task = kb.get_task(routed_conn, task_id)
     assert task is not None and task.status == "escalation_required"
     run = kb.get_run(routed_conn, review_run_id)
     assert run is not None and run.outcome == "quality_failed"
-    assert run.error == "missing regression coverage"
+    assert run.error == "quality gate exited 7"
     events = kb.list_events(routed_conn, task_id)
     failure = [event for event in events if event.kind == "quality_failed"][-1]
     escalation = [event for event in events if event.kind == "escalation_required"][-1]
     assert failure.run_id == review_run_id
     assert failure.payload == {
-        "reason": "missing regression coverage",
-        "result": {"checks": ["focused tests"], "score": 0.4},
+        "reason": "quality gate exited 7",
+        "result": {"gates": [{"command": ["/bin/sh", "-c", "printf broken; exit 7"], "status": "nonzero", "output": "broken", "exit_code": 7}]},
     }
     assert escalation.run_id == review_run_id
     assert escalation.payload["prior_run_id"] == review_run_id
     assert escalation.payload["prior_model"] == prior_route["model"]
-    assert escalation.payload["failure_reason"] == "missing regression coverage"
-    assert escalation.payload["quality_result"] == {"checks": ["focused tests"], "score": 0.4}
+    assert escalation.payload["failure_reason"] == "quality gate exited 7"
+    assert escalation.payload["quality_result"] == failure.payload["result"]
     assert escalation.payload["retry_count"] == prior["attempt_number"]
     # Router owns the decision and merely escalates; the worker cannot mutate routes.
     assert escalation.payload["decision"]["action"] == "human_escalation_required"
@@ -116,7 +130,66 @@ def test_quality_failure_is_durable_then_requires_router_escalation_without_self
     assert implementation_run_id != review_run_id
 
 
+def test_missing_operator_gate_config_fails_closed_and_escalates(routed_conn):
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+
+    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
+
+    task = kb.get_task(routed_conn, task_id)
+    run = kb.get_run(routed_conn, review_run_id)
+    assert task is not None and task.status == "escalation_required"
+    assert run is not None and run.outcome == "quality_failed"
+    assert run.metadata["quality_gate"] == {
+        "passed": False, "gates": [], "status": "configuration_failed",
+    }
+
+
+def test_quality_gate_spawn_error_is_durable_and_bounded(routed_conn, tmp_path: Path):
+    workspace = tmp_path / "quality-workspace"
+    workspace.mkdir()
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+    kb.set_workspace_path(routed_conn, task_id, str(workspace))
+    assert kb.set_quality_policy(routed_conn, task_id, {
+        "enabled": True, "required": True,
+        "gates": [{"command": ["/definitely/not/a/quality-command"]}],
+    })
+
+    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
+
+    run = kb.get_run(routed_conn, review_run_id)
+    assert run is not None and run.outcome == "quality_failed"
+    gate = run.metadata["quality_gate"]["gates"][0]
+    assert gate["status"] == "spawn_error"
+    assert len(gate["output"]) <= kb.QUALITY_GATE_MAX_OUTPUT
+
+
+def test_quality_gate_timeout_fails_closed(routed_conn, tmp_path: Path):
+    workspace = tmp_path / "quality-workspace"
+    workspace.mkdir()
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+    kb.set_workspace_path(routed_conn, task_id, str(workspace))
+    assert kb.set_quality_policy(routed_conn, task_id, {
+        "enabled": True, "required": True,
+        "gates": [{"command": ["/bin/sh", "-c", "sleep 2"], "timeout_seconds": 1}],
+    })
+
+    assert kb.execute_quality_gates(routed_conn, task_id=task_id, run_id=review_run_id)
+
+    run = kb.get_run(routed_conn, review_run_id)
+    assert run is not None and run.outcome == "quality_failed"
+    assert run.metadata["quality_gate"]["gates"][0]["status"] == "timeout"
+
+
 def test_quality_gate_rejects_stale_or_non_review_worker(routed_conn):
+    task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
+
+    assert not kb.execute_quality_gates(
+        routed_conn, task_id=task_id, run_id=review_run_id + 100,
+    )
+    assert kb.get_task(routed_conn, task_id).status == "escalation_required"
+
+
+def test_self_certification_rejects_stale_or_non_review_worker(routed_conn):
     task_id, _implementation_run_id, review_run_id = _review_run(routed_conn)
 
     assert not kb.record_quality_gate(

--- a/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
@@ -28,6 +28,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
     monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -34,6 +34,8 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -21,7 +21,7 @@ from hermes_cli import kanban_diagnostics as kd
 
 
 @pytest.fixture
-def conn(tmp_path: Path):
+def conn(tmp_path: Path, valid_model_routing_config):
     db = kb.connect(tmp_path / "kanban.db")
     try:
         yield db

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -9,12 +9,14 @@ import pytest
 
 from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
+from tests.conftest import write_valid_model_routing_config
 
 
 @pytest.fixture
 def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_PROFILE", "builder")
@@ -119,6 +121,7 @@ def test_review_cli_round_trip_preserves_handoff(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb._INITIALIZED_PATHS.clear()
@@ -165,6 +168,7 @@ def test_domain_and_cli_review_handoffs_redact_before_persistence(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     secret = "ghp_" + "R" * 40
 
@@ -254,6 +258,7 @@ def test_cli_reopen_review_is_transition_first_and_redacts_reason(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     secret = "ghp_" + "Q" * 40
     with kb.connect() as conn:
@@ -288,6 +293,7 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb._INITIALIZED_PATHS.clear()
@@ -391,6 +397,7 @@ def test_cli_and_dashboard_receive_graph_aware_deadlock_diagnostic(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb._INITIALIZED_PATHS.clear()

--- a/tests/hermes_cli/test_kanban_run_accounting.py
+++ b/tests/hermes_cli/test_kanban_run_accounting.py
@@ -1,0 +1,125 @@
+"""Phase B contracts for per-run Kanban token and cost accounting."""
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from agent.usage_pricing import CostResult
+from hermes_cli import kanban_db as kb
+from tests.conftest import write_valid_model_routing_config
+
+
+@pytest.fixture
+def routed_conn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    write_valid_model_routing_config(home)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    yield conn
+    conn.close()
+
+
+def _claimed_run(conn):
+    task_id = kb.create_task(conn, title="account this", assignee="worker")
+    task = kb.claim_task(conn, task_id)
+    assert task is not None and task.current_run_id is not None
+    return task_id, task.current_run_id
+
+
+def test_schema_exposes_complete_per_run_accounting(routed_conn):
+    cols = {r["name"] for r in routed_conn.execute("PRAGMA table_info(task_runs)")}
+    assert {
+        "attempt_number", "run_kind", "retry_of_run_id", "escalation_of_run_id",
+        "provider", "model", "service_tier", "routing_complexity",
+        "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+        "reasoning_tokens", "api_call_count", "estimated_cost_usd", "actual_cost_usd",
+        "usage_status", "cost_status", "cost_source", "policy_version",
+        "registry_version", "duration_ms",
+    } <= cols
+
+
+def test_record_accounting_uses_pricing_registry_and_is_idempotent(routed_conn, monkeypatch):
+    task_id, run_id = _claimed_run(routed_conn)
+    calls = []
+
+    def estimate(model, usage, *, provider=None, **_kwargs):
+        calls.append((model, provider, usage))
+        return CostResult(
+            amount_usd=Decimal("0.0125"), status="estimated", source="test-registry",
+            label="$0.0125", pricing_version="registry-v1",
+        )
+
+    monkeypatch.setattr("agent.usage_pricing.estimate_usage_cost", estimate)
+    accounting = kb.RunAccounting(
+        provider="nous", model="nemotron", service_tier="T1",
+        input_tokens=1000, output_tokens=500, cache_read_tokens=50,
+        cache_write_tokens=25, reasoning_tokens=100, api_call_count=2,
+    )
+    assert kb.record_run_accounting(routed_conn, task_id=task_id, run_id=run_id, accounting=accounting)
+    assert kb.record_run_accounting(routed_conn, task_id=task_id, run_id=run_id, accounting=accounting)
+    row = routed_conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert len(calls) == 2
+    assert row["input_tokens"] == 1000
+    assert row["output_tokens"] == 500
+    assert row["cache_read_tokens"] == 50
+    assert row["cache_write_tokens"] == 25
+    assert row["estimated_cost_usd"] == pytest.approx(0.0125)
+    assert row["actual_cost_usd"] is None
+    assert row["usage_status"] == "reported"
+    assert row["cost_status"] == "estimated"
+    assert row["cost_source"] == "test-registry"
+    assert row["registry_version"] == "registry-v1"
+
+
+def test_missing_usage_is_explicit_and_never_fabricates_zero(routed_conn):
+    task_id, run_id = _claimed_run(routed_conn)
+    assert kb.record_run_accounting(
+        routed_conn, task_id=task_id, run_id=run_id,
+        accounting=kb.RunAccounting(provider="nous", model="unknown", usage_status="unavailable"),
+    )
+    row = routed_conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert row["usage_status"] == "unavailable"
+    assert row["input_tokens"] is None
+    assert row["output_tokens"] is None
+    assert row["estimated_cost_usd"] is None
+    assert row["actual_cost_usd"] is None
+
+
+def test_actual_cost_is_stored_separately_and_wrong_run_is_rejected(routed_conn, monkeypatch):
+    task_id, run_id = _claimed_run(routed_conn)
+    monkeypatch.setattr(
+        "agent.usage_pricing.estimate_usage_cost",
+        lambda *_a, **_kw: CostResult(Decimal("0.5"), "estimated", "registry", "$0.5"),
+    )
+    accounting = kb.RunAccounting(
+        provider="nous", model="nemotron", input_tokens=1, output_tokens=2,
+        actual_cost_usd=Decimal("0.7"),
+    )
+    assert not kb.record_run_accounting(routed_conn, task_id="wrong", run_id=run_id, accounting=accounting)
+    assert kb.record_run_accounting(routed_conn, task_id=task_id, run_id=run_id, accounting=accounting)
+    row = routed_conn.execute("SELECT estimated_cost_usd, actual_cost_usd FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert row["estimated_cost_usd"] == pytest.approx(0.5)
+    assert row["actual_cost_usd"] == pytest.approx(0.7)
+
+
+def test_retry_is_a_separate_linked_attempt(routed_conn):
+    task_id, first_run = _claimed_run(routed_conn)
+    assert kb.block_task(routed_conn, task_id, reason="retry later", kind="transient", expected_run_id=first_run)
+    assert kb.unblock_task(routed_conn, task_id)
+    task = kb.claim_task(routed_conn, task_id)
+    assert task is not None and task.current_run_id is not None
+    rows = routed_conn.execute(
+        "SELECT id, attempt_number, run_kind, retry_of_run_id FROM task_runs WHERE task_id=? ORDER BY id",
+        (task_id,),
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["attempt_number"] == 1
+    assert rows[1]["attempt_number"] == 2
+    assert rows[1]["run_kind"] == "retry"
+    assert rows[1]["retry_of_run_id"] == first_run

--- a/tests/hermes_cli/test_kanban_run_accounting.py
+++ b/tests/hermes_cli/test_kanban_run_accounting.py
@@ -108,6 +108,15 @@ def test_actual_cost_is_stored_separately_and_wrong_run_is_rejected(routed_conn,
     assert row["actual_cost_usd"] == pytest.approx(0.7)
 
 
+def test_completion_records_nonnegative_duration_for_the_exact_run(routed_conn):
+    task_id, run_id = _claimed_run(routed_conn)
+    routed_conn.execute("UPDATE task_runs SET started_at = started_at - 2 WHERE id=?", (run_id,))
+    assert kb.complete_task(routed_conn, task_id, expected_run_id=run_id)
+    row = routed_conn.execute("SELECT duration_ms FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert row["duration_ms"] is not None
+    assert row["duration_ms"] >= 2000
+
+
 def test_retry_is_a_separate_linked_attempt(routed_conn):
     task_id, first_run = _claimed_run(routed_conn)
     assert kb.block_task(routed_conn, task_id, reason="retry later", kind="transient", expected_run_id=first_run)

--- a/tests/hermes_cli/test_kanban_task_updated_hook.py
+++ b/tests/hermes_cli/test_kanban_task_updated_hook.py
@@ -22,6 +22,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -33,6 +33,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     # Crash detection acts immediately in these tests (no launch grace).
     monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/tests/hermes_cli/test_kanban_worker_session_source.py
+++ b/tests/hermes_cli/test_kanban_worker_session_source.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from hermes_state import SessionDB
+from tests.conftest import write_valid_model_routing_config
 
 
 @pytest.fixture()
@@ -24,6 +25,9 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
     """The dispatcher tags the worker's env so its session is a `kanban` row."""
     from hermes_cli import kanban_db as kb
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    write_valid_model_routing_config(tmp_path)
+
     captured = {}
 
     class _Proc:
@@ -37,29 +41,17 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
     monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
     monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
 
-    task = kb.Task(
-        id="t_b21733fb",
-        title="ship it",
-        body=None,
-        assignee="default",
-        status="in_progress",
-        priority=0,
-        created_by=None,
-        created_at=0,
-        started_at=None,
-        completed_at=None,
-        workspace_kind="scratch",
-        workspace_path=None,
-        claim_lock=None,
-        claim_expires=None,
-        tenant=None,
-    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ship it", assignee="default")
+        task = kb.claim_task(conn, task_id, claimer="default:1")
+        assert task is not None
     workspace = str(tmp_path / "ws")
     os.makedirs(workspace, exist_ok=True)
 
     kb._default_spawn(task, workspace)
 
     assert captured["env"]["HERMES_SESSION_SOURCE"] == "kanban"
+    assert captured["env"]["HERMES_KANBAN_TASK"] == task_id
 
 
 def test_kanban_rows_stay_out_of_the_session_list(db):

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,26 +2,15 @@ from __future__ import annotations
 
 import subprocess
 
+from tests.conftest import write_valid_model_routing_config
+
 
 def _make_task(kb, *, assignee: str):
-    return kb.Task(
-        id="t_spawn_tools",
-        title="spawn tools",
-        body=None,
-        assignee=assignee,
-        status="running",
-        priority=0,
-        created_by="test",
-        created_at=1,
-        started_at=None,
-        completed_at=None,
-        workspace_kind="dir",
-        workspace_path=None,
-        claim_lock="lock",
-        claim_expires=None,
-        tenant=None,
-        current_run_id=7,
-    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="spawn tools", assignee=assignee, workspace_kind="dir")
+        task = kb.claim_task(conn, task_id, claimer=f"{assignee}:1")
+        assert task is not None
+        return task
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):
@@ -56,7 +45,7 @@ agent:
 """.lstrip(),
         encoding="utf-8",
     )
-    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    write_valid_model_routing_config(root)
     monkeypatch.setenv("HERMES_HOME", str(root))
 
     from hermes_cli import kanban_db as kb
@@ -78,11 +67,12 @@ agent:
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    task = _make_task(kb, assignee="elias")
+    pid = kb._default_spawn(task, str(workspace))
 
     assert pid == 4242
     assert captured["env"]["HERMES_HOME"] == str(profile)
-    assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
+    assert captured["env"]["HERMES_KANBAN_TASK"] == task.id
     assert "--toolsets" in captured["cmd"]
     pinned = captured["cmd"][captured["cmd"].index("--toolsets") + 1].split(",")
     for required in ("terminal", "web", "file", "skills", "code_execution", "delegation"):
@@ -98,7 +88,7 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     """
     root = tmp_path / ".hermes"
     (root / "profiles" / "elias").mkdir(parents=True)
-    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    write_valid_model_routing_config(root)
     monkeypatch.setenv("HERMES_HOME", str(root))
 
     from hermes_cli import kanban_db as kb
@@ -118,8 +108,17 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    task = _make_task(kb, assignee="elias")
-    task.model_override = "gpt-5.6-sol"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="spawn tools",
+            assignee="elias",
+            workspace_kind="dir",
+            provider_override="openai",
+            model_override="large",
+        )
+        task = kb.claim_task(conn, task_id, claimer="elias:1")
+        assert task is not None
     kb._default_spawn(task, str(workspace))
 
     parser, _subparsers, _chat_parser = build_top_level_parser()
@@ -130,8 +129,8 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     args = parser.parse_args(captured["cmd"][3:])
 
     assert args.command == "chat"
-    assert args.model == "gpt-5.6-sol"
-    assert args.query == "work kanban task t_spawn_tools"
+    assert args.model == "large"
+    assert args.query == f"work kanban task {task_id}"
 
 
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -15,26 +15,15 @@ from __future__ import annotations
 
 import subprocess
 
+from tests.conftest import write_valid_model_routing_config
+
 
 def _make_task(kb, *, assignee: str = "w"):
-    return kb.Task(
-        id="t_cwd",
-        title="cwd pin",
-        body=None,
-        assignee=assignee,
-        status="running",
-        priority=0,
-        created_by="test",
-        created_at=1,
-        started_at=None,
-        completed_at=None,
-        workspace_kind="dir",
-        workspace_path=None,
-        claim_lock="lock",
-        claim_expires=None,
-        tenant=None,
-        current_run_id=1,
-    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="cwd pin", assignee=assignee, workspace_kind="dir")
+        task = kb.claim_task(conn, task_id, claimer=f"{assignee}:1")
+        assert task is not None
+        return task
 
 
 def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict:
@@ -61,7 +50,7 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     (root / "profiles" / "w").mkdir(parents=True)
     (root / "profiles" / "w" / "config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
-    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    write_valid_model_routing_config(root)
     monkeypatch.setenv("HERMES_HOME", str(root))
 
     from hermes_cli import kanban_db as kb

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -43,6 +43,8 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from tests.conftest import write_valid_model_routing_config
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +49,7 @@ def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
@@ -543,6 +545,7 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     compare)."""
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()

--- a/tests/plugins/test_kanban_dashboard_task_updated_hook.py
+++ b/tests/plugins/test_kanban_dashboard_task_updated_hook.py
@@ -40,6 +40,8 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/plugins/test_kanban_model_override.py
+++ b/tests/plugins/test_kanban_model_override.py
@@ -31,6 +31,20 @@ def kanban_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (home / "config.yaml").write_text(
+        """
+model_routing:
+  enabled: true
+  tiers:
+    T1:
+      - {provider: openai, model: gpt-5.6-sol}
+      - {provider: openrouter, model: qwen-max}
+      - {provider: openrouter, model: glm-5}
+      - {provider: nous, model: fallback-model}
+  classification:
+    P1: {tier: T1}
+""".strip()
+    )
     kb.init_db()
     return home
 
@@ -135,12 +149,19 @@ def _spawn_and_capture(monkeypatch, tmp_path, task):
     return captured["cmd"]
 
 
+def _claim_for_spawn(conn, task_id):
+    task = kb.claim_task(conn, task_id)
+    assert task is not None
+    assert task.route_snapshot is not None
+    return task
+
+
 def test_spawn_passes_model_and_provider(monkeypatch, tmp_path, conn):
     tid = kb.create_task(
         conn, title="t", assignee="elias",
         model_override="glm-5", provider_override="openrouter",
     )
-    task = kb.get_task(conn, tid)
+    task = _claim_for_spawn(conn, tid)
     cmd = _spawn_and_capture(monkeypatch, tmp_path, task)
     i = cmd.index("-m")
     assert cmd[i + 1] == "glm-5"
@@ -253,7 +274,7 @@ def test_reasoning_effort_without_a_model_override(conn):
 
 def test_spawn_passes_reasoning_without_a_model(monkeypatch, tmp_path, conn):
     tid = kb.create_task(conn, title="t", assignee="elias", reasoning_effort="high")
-    task = kb.get_task(conn, tid)
+    task = _claim_for_spawn(conn, tid)
     cmd = _spawn_and_capture(monkeypatch, tmp_path, task)
     assert "-m" not in cmd
     i = cmd.index("--reasoning")
@@ -262,7 +283,7 @@ def test_spawn_passes_reasoning_without_a_model(monkeypatch, tmp_path, conn):
 
 def test_spawn_omits_reasoning_when_unset(monkeypatch, tmp_path, conn):
     tid = kb.create_task(conn, title="t", assignee="elias")
-    task = kb.get_task(conn, tid)
+    task = _claim_for_spawn(conn, tid)
     cmd = _spawn_and_capture(monkeypatch, tmp_path, task)
     assert "--reasoning" not in cmd
 

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import write_valid_model_routing_config
+
 # The subprocess-boundary tests below spawn ``sys.executable -c`` with a tmp
 # cwd. Without an explicit PYTHONPATH the child resolves ``hermes_cli`` /
 # ``agent`` through whatever install is on sys.path (in a worktree that is the
@@ -28,6 +30,7 @@ def _python_with_repo_path(code: str) -> str:
 def _make_running_kanban_task(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     attachments_root = tmp_path / "attachments"
     workspace = tmp_path / "parent-workspace"
     workspace.mkdir()

--- a/tests/tools/test_kanban_redaction.py
+++ b/tests/tools/test_kanban_redaction.py
@@ -22,6 +22,8 @@ def worker_env(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    from tests.conftest import write_valid_model_routing_config
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     from pathlib import Path as _Path

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -14,6 +14,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from tests.conftest import write_valid_model_routing_config
+
 
 # ---------------------------------------------------------------------------
 # Gating
@@ -25,6 +27,7 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
     import tools.kanban_tools  # ensure registered
@@ -50,6 +53,7 @@ def worker_env(monkeypatch, tmp_path):
     after we've created the task."""
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
@@ -62,10 +66,12 @@ def worker_env(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
-        kb.claim_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
     return tid
 
 
@@ -170,6 +176,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Set up isolated HERMES_HOME
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
@@ -236,6 +243,7 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
 
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
@@ -457,6 +465,7 @@ def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
     from pathlib import Path as _Path
@@ -694,6 +703,7 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     from pathlib import Path as _P
     monkeypatch.setattr(_P, "home", lambda: tmp_path)
@@ -738,6 +748,7 @@ def multi_board_env(monkeypatch, tmp_path):
     """
     home = tmp_path / ".hermes"
     home.mkdir()
+    write_valid_model_routing_config(home)
     monkeypatch.setenv("HERMES_HOME", str(home))
     # Make sure neither HERMES_KANBAN_DB nor HERMES_KANBAN_BOARD pin a
     # board — the test is specifically about the per-call override.


### PR DESCRIPTION
## Summary
- enforce fail-closed model routing at Kanban claim/spawn boundaries
- add per-run token, cost, retry, and duration accounting
- execute persisted quality gates at completion; fail closed to escalation

## Verification
- 266 passed, 1 skipped
- git diff --check passed

No merge/deploy/public activation behavior added.