### PR TITLE
fix(matrix): supervise sync consumer lifecycle

### DIFF
--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -14,6 +14,8 @@ from hermes_constants import get_hermes_home
 
 
 _DISK_DEGRADED_PERCENT = 90.0
+_MAX_PID = (1 << 31) - 1
+_MAX_START_TIME = (1 << 63) - 1
 
 
 def _check(status: str, detail: str | None = None, **extra: Any) -> dict[str, Any]:
@@ -22,6 +24,18 @@ def _check(status: str, detail: str | None = None, **extra: Any) -> dict[str, An
         result["detail"] = detail
     result.update(extra)
     return result
+
+
+def _valid_writer_identity(pid: Any, start_time: Any) -> bool:
+    """Return True only for a complete, non-boolean process fingerprint."""
+    return (
+        isinstance(pid, int)
+        and not isinstance(pid, bool)
+        and 0 < pid <= _MAX_PID
+        and isinstance(start_time, int)
+        and not isinstance(start_time, bool)
+        and 0 < start_time <= _MAX_START_TIME
+    )
 
 
 def _probe_state_db(home: Path) -> dict[str, Any]:
@@ -73,17 +87,64 @@ def _probe_gateway(runtime_status: dict[str, Any]) -> dict[str, Any]:
     platforms = runtime_status.get("platforms")
     connected = 0
     configured = 0
+    unhealthy = 0
     if isinstance(platforms, dict):
-        configured = len(platforms)
-        connected = sum(
-            1
-            for value in platforms.values()
-            if isinstance(value, dict)
-            and str(value.get("state") or value.get("status") or "").lower()
-            in {"connected", "running", "ok"}
+        process_pid = runtime_status.get("pid")
+        process_start = runtime_status.get("start_time")
+        runtime_has_any_identity = process_pid is not None or process_start is not None
+        runtime_has_writer_identity = _valid_writer_identity(
+            process_pid, process_start
         )
-    status = "ok" if state in {"running", "draining"} else "degraded"
-    return _check(status, state=state, connected_platforms=connected, platforms=configured)
+        for value in platforms.values():
+            if not isinstance(value, dict):
+                continue
+            # Runtime files can outlive a process. A provenance stamp is usable
+            # only as the complete, exact writer identity pair. Unstamped
+            # legacy entries retain their historical behavior only when the
+            # enclosing runtime record also lacks a complete identity.
+            writer_pid = value.get("writer_pid")
+            writer_start = value.get("writer_start_time")
+            has_any_writer_provenance = (
+                writer_pid is not None or writer_start is not None
+            )
+            has_complete_writer_provenance = _valid_writer_identity(
+                writer_pid, writer_start
+            )
+            if runtime_has_writer_identity and not (
+                has_complete_writer_provenance
+                and writer_pid is not None
+                and writer_start is not None
+                and writer_pid == process_pid
+                and writer_start == process_start
+            ):
+                continue
+            # Legacy compatibility is available only when BOTH the enclosing
+            # runtime and the platform entry are entirely unstamped. A partial
+            # or malformed enclosing fingerprint cannot prove current ownership.
+            if not runtime_has_writer_identity and (
+                runtime_has_any_identity or has_any_writer_provenance
+            ):
+                continue
+            configured += 1
+            platform_state = str(
+                value.get("state") or value.get("status") or ""
+            ).lower()
+            if platform_state in {"connected", "running", "ok"}:
+                connected += 1
+            elif platform_state in {"retrying", "fatal", "paused"}:
+                unhealthy += 1
+    status = (
+        "ok"
+        if state in {"running", "draining"} and unhealthy == 0
+        else "degraded"
+    )
+    return _check(
+        status,
+        state=state,
+        connected_platforms=connected,
+        unhealthy_platforms=unhealthy,
+        platforms=configured,
+    )
 
 
 def _probe_session_store(

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -62,6 +62,7 @@ import shutil
 import subprocess
 import sys
 import time
+from contextlib import suppress
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
 
@@ -1216,8 +1217,16 @@ class MatrixAdapter(BasePlatformAdapter):
         self._device_id_unverified: bool = False
 
         self._client: Any = None  # mautrix.client.Client
+        self._pending_session: Any = None  # pre-Client HTTP session owner
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
+        self._lifecycle_lock = asyncio.Lock()
+        self._fatal_notification_lock = asyncio.Lock()
+        self._lifecycle_cleanup_task: asyncio.Task | None = None
+        self._lifecycle_generation = 0
+        self._active_generation: int | None = None
+        self._published_sync: tuple[int, asyncio.Task] | None = None
+        self._sync_notification_tasks: set[asyncio.Task] = set()
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
         self._closing = False
         self._startup_ts: float = 0.0
@@ -1712,13 +1721,41 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to the Matrix homeserver and start syncing."""
+        """Connect while exclusively owning adapter lifecycle resources."""
+        current = asyncio.current_task()
+        if current in getattr(self, "_detached_fatal_tasks", set()):
+            raise RuntimeError(
+                "Matrix fatal handler cannot reconnect the same adapter instance"
+            )
+        # Lock order is notification -> lifecycle. A fatal handler holds the
+        # notification lock while it mutates gateway state and may call
+        # disconnect(), so a replacement cannot publish until that mutation is
+        # complete. Public disconnect() takes only the lifecycle lock.
+        async with self._fatal_notification_lock:
+            async with self._lifecycle_lock:
+                if (
+                    self._lifecycle_cleanup_task is not None
+                    or self._active_generation is not None
+                    or self._client is not None
+                ):
+                    await self._disconnect_locked()
+
+                self._lifecycle_generation += 1
+                generation = self._lifecycle_generation
+                self._active_generation = generation
+                self._closing = False
+                try:
+                    connected = await self._connect_locked(generation)
+                except BaseException:
+                    await self._disconnect_locked(generation)
+                    raise
+                if not connected:
+                    await self._disconnect_locked(generation)
+                return connected
+
+    async def _connect_locked(self, generation: int) -> bool:
+        """Create one connection generation with ``_lifecycle_lock`` held."""
         self._device_id_unverified = False
-        if self._client is not None:
-            try:
-                await self.disconnect()
-            except Exception as exc:
-                logger.warning("Matrix: error disconnecting before reconnect: %s", exc)
 
         from mautrix.api import HTTPAPI
         from mautrix.client import Client
@@ -1731,15 +1768,18 @@ class MatrixAdapter(BasePlatformAdapter):
         # Ensure store dir exists for E2EE key persistence.
         _STORE_DIR.mkdir(parents=True, exist_ok=True)
 
-        # Create the HTTP API layer.
+        # Publish the raw HTTP session before constructing the client. If either
+        # synchronous constructor fails, outer generation teardown transfers
+        # this session to the same cancellation-safe cleanup owner used after
+        # publication.
         client_session = _create_matrix_session(self._proxy_url)
+        self._pending_session = client_session
         api = HTTPAPI(
             base_url=self._homeserver,
             token=self._access_token or "",
             client_session=client_session,
         )
 
-        # Create the client.
         state_store = MemoryStateStore()
         sync_store = MemorySyncStore()
         client = Client(
@@ -1751,6 +1791,7 @@ class MatrixAdapter(BasePlatformAdapter):
         )
 
         self._client = client
+        self._pending_session = None
 
         # Authenticate.
         if self._access_token:
@@ -1836,7 +1877,6 @@ class MatrixAdapter(BasePlatformAdapter):
                     exc,
                     exc_info=True,
                 )
-                await api.session.close()
                 return False
         elif self._password and self._user_id:
             try:
@@ -1851,13 +1891,11 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.info("Matrix: logged in as %s", self._user_id)
             except Exception as exc:
                 logger.error("Matrix: login failed — %s", exc)
-                await api.session.close()
                 return False
         else:
             logger.error(
                 "Matrix: need MATRIX_ACCESS_TOKEN or MATRIX_USER_ID + MATRIX_PASSWORD"
             )
-            await api.session.close()
             return False
 
         # Set up E2EE if requested.
@@ -1876,7 +1914,6 @@ class MatrixAdapter(BasePlatformAdapter):
                         "Refusing to connect — encrypted rooms would silently fail.",
                         _E2EE_INSTALL_HINT,
                     )
-                    await api.session.close()
                     return False
             if not self._encryption:
                 pass
@@ -1902,7 +1939,6 @@ class MatrixAdapter(BasePlatformAdapter):
                             exc,
                             _E2EE_INSTALL_HINT,
                         )
-                        await api.session.close()
                         return False
             if self._encryption:
                 try:
@@ -1918,8 +1954,11 @@ class MatrixAdapter(BasePlatformAdapter):
                         f"sqlite:///{_CRYPTO_DB_PATH}",
                         upgrade_table=PgCryptoStore.upgrade_table,
                     )
-                    await crypto_db.start()
+                    # Database.start() can allocate before failing or being
+                    # cancelled. Publish ownership first so generation cleanup
+                    # always has a stop() path.
                     self._crypto_db = crypto_db
+                    await crypto_db.start()
 
                     _acct_id = self._user_id or "hermes"
                     # Use the resolved client.device_id (from whoami or password
@@ -1963,8 +2002,6 @@ class MatrixAdapter(BasePlatformAdapter):
                     await olm.load()
 
                     if not await self._verify_device_keys_on_server(client, olm):
-                        await crypto_db.stop()
-                        await api.session.close()
                         return False
 
                     try:
@@ -1979,8 +2016,6 @@ class MatrixAdapter(BasePlatformAdapter):
                                 "or generate a new access token to get a fresh device ID.",
                                 client.device_id,
                             )
-                            await crypto_db.stop()
-                            await api.session.close()
                             return False
                         logger.warning("Matrix: share_keys() warning during startup: %s", exc)
 
@@ -2061,7 +2096,6 @@ class MatrixAdapter(BasePlatformAdapter):
                             exc,
                             _E2EE_INSTALL_HINT,
                         )
-                        await api.session.close()
                         return False
 
         # Register event handlers.
@@ -2129,8 +2163,10 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: initial sync returned unexpected type %s",
                     type(sync_data).__name__,
                 )
+                return False
         except Exception as exc:
             logger.warning("Matrix: initial sync error: %s", exc)
+            return False
 
         # Share keys after initial sync if E2EE is enabled.
         if self._encryption and getattr(client, "crypto", None):
@@ -2139,53 +2175,144 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
-        # Start the sync loop.
-        self._sync_task = asyncio.create_task(self._sync_loop())
+        # The consumer owns startup until it has loaded its sync token.  It then
+        # waits for connect() to publish connected state before it may poll or
+        # notify the runtime supervisor.  This two-phase handoff avoids both a
+        # false-connected return and a pre-registration fatal notification.
+        loop = asyncio.get_running_loop()
+        consumer_started = loop.create_future()
+        consumer_published = asyncio.Event()
+        sync_task = asyncio.create_task(
+            self._sync_loop(consumer_started, consumer_published)
+        )
+        self._sync_task = sync_task
+        sync_task.add_done_callback(
+            lambda task, owner=generation: self._handle_sync_task_done(task, owner)
+        )
+        try:
+            started = await consumer_started
+        except BaseException:
+            sync_task.cancel()
+            await asyncio.gather(sync_task, return_exceptions=True)
+            raise
+        if not started or sync_task.done():
+            logger.error("Matrix: sync consumer exited during startup")
+            return False
         self._mark_connected()
+        self._published_sync = (generation, sync_task)
+        consumer_published.set()
         return True
 
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
-        self._closing = True
+        async with self._lifecycle_lock:
+            await self._disconnect_locked()
 
-        if self._sync_task and not self._sync_task.done():
-            self._sync_task.cancel()
-            try:
-                await self._sync_task
-            except (asyncio.CancelledError, Exception):
-                pass
+    async def _disconnect_locked(self, generation: int | None = None) -> None:
+        """Transfer one generation to cancellation-safe detached cleanup."""
+        cleanup_task = self._lifecycle_cleanup_task
+        if cleanup_task is not None:
+            # A prior caller may have been cancelled while cleanup continued.
+            # The task owns the captured resources; wait for it rather than
+            # creating a second closer or publishing a replacement too early.
+            await asyncio.shield(cleanup_task)
+            return
 
+        if generation is not None and generation != self._active_generation:
+            return
+
+        owned_generation = self._active_generation
+        sync_task = self._sync_task
         invite_join_tasks = list(self._invite_join_tasks.values())
-        for task in invite_join_tasks:
-            if not task.done():
-                task.cancel()
-        if invite_join_tasks:
-            await asyncio.gather(*invite_join_tasks, return_exceptions=True)
-        self._invite_join_tasks.clear()
-
         redaction_tasks = list(self._reaction_redaction_tasks)
-        for task in redaction_tasks:
-            if not task.done():
-                task.cancel()
-        if redaction_tasks:
-            await asyncio.gather(*redaction_tasks, return_exceptions=True)
+        crypto_db = getattr(self, "_crypto_db", None)
+        client = self._client
+        pending_session = self._pending_session
+        has_resources = any(
+            (
+                owned_generation is not None,
+                sync_task is not None,
+                bool(invite_join_tasks),
+                bool(redaction_tasks),
+                crypto_db is not None,
+                client is not None,
+                pending_session is not None,
+            )
+        )
+        if not has_resources:
+            self._mark_disconnected()
+            return
+
+        self._closing = True
+        self._active_generation = None
+        if (
+            self._published_sync is not None
+            and self._published_sync[0] == owned_generation
+        ):
+            self._published_sync = None
+
+        # Transfer sole ownership to the cleanup task before its first await.
+        # Callers may now be cancelled without losing the only references.
+        if self._sync_task is sync_task:
+            self._sync_task = None
+        self._invite_join_tasks.clear()
         self._reaction_redaction_tasks.clear()
-
-        # Close the SQLite crypto store database.
-        if hasattr(self, "_crypto_db") and self._crypto_db:
-            try:
-                await self._crypto_db.stop()
-            except Exception as exc:
-                logger.debug("Matrix: could not close crypto DB on disconnect: %s", exc)
-
-        if self._client:
-            try:
-                await self._client.api.session.close()
-            except Exception:
-                pass
+        if self._crypto_db is crypto_db:
+            self._crypto_db = None
+        if self._client is client:
             self._client = None
+        if self._pending_session is pending_session:
+            self._pending_session = None
+        self._mark_disconnected()
 
-        logger.info("Matrix: disconnected")
+        async def _cleanup_generation() -> None:
+            try:
+                if sync_task and not sync_task.done():
+                    sync_task.cancel()
+                if sync_task:
+                    await asyncio.gather(sync_task, return_exceptions=True)
+
+                for task in invite_join_tasks:
+                    if not task.done():
+                        task.cancel()
+                if invite_join_tasks:
+                    await asyncio.gather(*invite_join_tasks, return_exceptions=True)
+
+                for task in redaction_tasks:
+                    if not task.done():
+                        task.cancel()
+                if redaction_tasks:
+                    await asyncio.gather(*redaction_tasks, return_exceptions=True)
+
+                if crypto_db:
+                    try:
+                        await crypto_db.stop()
+                    except Exception as exc:
+                        logger.debug(
+                            "Matrix: could not close crypto DB on disconnect: %s",
+                            exc,
+                        )
+
+                if client:
+                    try:
+                        await client.api.session.close()
+                    except Exception:
+                        pass
+                elif pending_session:
+                    try:
+                        close_result = pending_session.close()
+                        if inspect.isawaitable(close_result):
+                            await close_result
+                    except Exception:
+                        pass
+            finally:
+                logger.info("Matrix: disconnected")
+                if self._lifecycle_cleanup_task is asyncio.current_task():
+                    self._lifecycle_cleanup_task = None
+
+        cleanup_task = asyncio.create_task(_cleanup_generation())
+        self._lifecycle_cleanup_task = cleanup_task
+        await asyncio.shield(cleanup_task)
 
     async def send(
         self,
@@ -2263,6 +2390,9 @@ class MatrixAdapter(BasePlatformAdapter):
         token_present = bool(self._access_token)
         user_id = self._user_id or getattr(self._client, "mxid", "") or ""
         device_id = self._device_id or getattr(self._client, "device_id", "") or ""
+        consumer_running = bool(
+            self._sync_task is not None and not self._sync_task.done()
+        )
         return {
             "platform": "matrix",
             "homeserver": self._homeserver,
@@ -2275,7 +2405,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 "device_id_preview": _redact_matrix_value(device_id),
             },
             "sync": {
-                "connected": self._client is not None,
+                "connected": self.is_connected and consumer_running,
+                "consumer_running": consumer_running,
                 "joined_room_count": len(self._joined_rooms),
                 "last_sync_age_seconds": (
                     max(0.0, now - self._last_sync_ts) if self._last_sync_ts else None
@@ -3019,11 +3150,99 @@ class MatrixAdapter(BasePlatformAdapter):
     # Sync loop
     # ------------------------------------------------------------------
 
-    async def _sync_loop(self) -> None:
+    def _handle_sync_task_done(
+        self, task: asyncio.Task, generation: int | None = None
+    ) -> None:
+        """Surface unexpected Matrix consumer exits to the gateway supervisor."""
+        published = self._published_sync
+        # Publication, not ``_running``, owns supervisor notification. Fatal
+        # classifiers intentionally clear ``_running`` before the task exits.
+        if (
+            published is None
+            or published[1] is not task
+            or (generation is not None and published[0] != generation)
+            or published[0] != self._active_generation
+        ):
+            with suppress(asyncio.CancelledError, Exception):
+                task.exception()
+            return
+
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError as cancelled:
+            exc = cancelled
+        except Exception as err:  # pragma: no cover - defensive
+            exc = err
+
+        if exc is None:
+            detail = "exited without an exception"
+        elif isinstance(exc, asyncio.CancelledError):
+            detail = "was cancelled unexpectedly"
+        else:
+            detail = "raised an exception"
+
+        logger.error(
+            "Matrix: sync consumer %s",
+            detail,
+            exc_info=exc if isinstance(exc, Exception) else False,
+        )
+        if not self.has_fatal_error:
+            # Persist a fixed message: exception strings can contain sync URLs
+            # and pagination tokens, which do not belong in runtime status.
+            self._set_fatal_error(
+                "matrix_sync_task_exited",
+                "Matrix sync consumer exited unexpectedly",
+                retryable=True,
+            )
+
+        async def _notify() -> None:
+            try:
+                # Serialize supervisor mutation with same-instance reconnect.
+                # The handler may call disconnect(), which takes only the
+                # lifecycle lock; connect takes these locks in this order.
+                async with self._fatal_notification_lock:
+                    if (
+                        self._published_sync != published
+                        or published[0] != self._active_generation
+                    ):
+                        return
+                    await self._notify_fatal_error()
+            except Exception as notify_exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "Matrix: failed to notify gateway supervisor about sync exit: %s",
+                    notify_exc,
+                    exc_info=True,
+                )
+
+        carrier = asyncio.create_task(_notify())
+        self._sync_notification_tasks.add(carrier)
+        carrier.add_done_callback(self._sync_notification_tasks.discard)
+
+    async def _sync_loop(
+        self,
+        consumer_started: asyncio.Future | None = None,
+        consumer_published: asyncio.Event | None = None,
+    ) -> None:
         """Continuously sync with the homeserver."""
         client = self._client
         # Resume from the token stored during the initial sync.
-        next_batch = await client.sync_store.get_next_batch()
+        try:
+            next_batch = await client.sync_store.get_next_batch()
+        except asyncio.CancelledError:
+            if consumer_started is not None and not consumer_started.done():
+                consumer_started.set_result(False)
+            return
+        except Exception as exc:
+            if consumer_started is not None and not consumer_started.done():
+                consumer_started.set_result(False)
+            if self._closing:
+                return
+            logger.error("Matrix: sync consumer failed before startup: %s", exc)
+            return
+        if consumer_started is not None and not consumer_started.done():
+            consumer_started.set_result(True)
+        if consumer_published is not None:
+            await consumer_published.wait()
         while not self._closing:
             try:
                 # Wrap in asyncio.wait_for to guard against TCP-level hangs

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -320,6 +320,15 @@ def _make_adapter():
     return adapter
 
 
+async def _keep_sync_loop_running(consumer_started=None, consumer_published=None):
+    """Test double for the long-lived Matrix consumer task."""
+    if consumer_started is not None:
+        consumer_started.set_result(True)
+    if consumer_published is not None:
+        await consumer_published.wait()
+    await asyncio.Event().wait()
+
+
 # ---------------------------------------------------------------------------
 # Typing indicator
 # ---------------------------------------------------------------------------
@@ -974,13 +983,148 @@ class TestMatrixAccessTokenAuth:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         assert await adapter.connect() is True
 
         mock_client.whoami.assert_awaited_once()
         assert adapter._user_id == "@bot:example.org"
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_initial_sync_exception_fails_connect_without_false_connected_state(self):
+        """A failed initial sync must not start a nominally connected consumer."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+        # A reconnect failure must clear state published by the prior connection.
+        adapter._mark_connected()
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.sync = AsyncMock(side_effect=RuntimeError("initial sync failed"))
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter.is_connected is False
+        assert adapter._sync_task is None
+
+    @pytest.mark.asyncio
+    async def test_initial_sync_error_object_fails_connect(self):
+        """A non-dict initial sync result must not publish connected state."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_access_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                },
+            )
+        )
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value=types.SimpleNamespace(message="M_UNKNOWN_TOKEN")
+        )
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter.is_connected is False
+        assert adapter._sync_task is None
+
+    @pytest.mark.asyncio
+    async def test_sync_consumer_that_exits_during_handoff_fails_connect(self):
+        """connect() must reject a consumer that dies before connected state."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_access_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                },
+            )
+        )
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.sync_store = MagicMock()
+        mock_client.sync_store.put_next_batch = AsyncMock()
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+
+        with patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+            adapter, "_refresh_dm_cache", AsyncMock()
+        ), patch.object(
+            adapter,
+            "_sync_loop",
+            AsyncMock(
+                side_effect=lambda started, _published: started.set_result(False)
+            ),
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter.is_connected is False
+        assert adapter._sync_task is None
 
 
 class TestDeviceKeyReVerification:
@@ -1052,7 +1196,7 @@ class TestMatrixE2EEHardFail:
         import plugins.platforms.matrix.adapter as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
             with patch.dict("sys.modules", fake_mautrix_mods):
-                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                     result = await adapter.connect()
 
         assert result is False
@@ -1100,7 +1244,7 @@ class TestMatrixE2EEHardFail:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(matrix_mod, "_create_matrix_session", return_value=MagicMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         result = await adapter.connect()
 
         assert result is True
@@ -1191,7 +1335,7 @@ class TestMatrixDeviceId:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         assert await adapter.connect() is True
 
         # The configured device_id is retained on the adapter.
@@ -1241,7 +1385,7 @@ class TestMatrixPasswordLoginDeviceId:
 
         with patch.dict("sys.modules", fake_mautrix_mods):
             with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                     assert await adapter.connect() is True
 
         mock_client.login.assert_awaited_once()
@@ -1413,7 +1557,7 @@ class TestMatrixSyncLoop:
         import plugins.platforms.matrix.adapter as matrix_mod
         with patch.dict("sys.modules", fake_mautrix_mods):
             with patch.object(matrix_mod, "_create_matrix_session", return_value=MagicMock()):
-                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                     assert await adapter.connect() is True
 
         assert len(captured) == 1
@@ -1493,6 +1637,9 @@ class TestMatrixDiagnostics:
         adapter._last_sync_ts = time.time() - 7
         adapter._max_media_bytes = 123
         adapter._client = MagicMock()
+        adapter._sync_task = MagicMock()
+        adapter._sync_task.done.return_value = False
+        adapter._running = True
 
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             diagnostics = adapter.get_diagnostics()
@@ -1503,6 +1650,7 @@ class TestMatrixDiagnostics:
         assert diagnostics["auth"]["device_id_present"] is True
         assert diagnostics["auth"]["device_id_preview"] == "***"
         assert diagnostics["sync"]["connected"] is True
+        assert diagnostics["sync"]["consumer_running"] is True
         assert diagnostics["sync"]["joined_room_count"] == 2
         assert diagnostics["sync"]["last_sync_age_seconds"] >= 0
         assert diagnostics["e2ee"]["recovery_key_configured"] is True
@@ -1572,7 +1720,7 @@ class TestMatrixDiagnostics:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         assert await adapter.connect() is True
 
         mock_olm.generate_recovery_key.assert_not_called()
@@ -1694,7 +1842,7 @@ class TestMatrixEncryptedEventHandler:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         assert await adapter.connect() is True
 
         # Verify inbound event handlers were registered as sync-awaited
@@ -2684,7 +2832,7 @@ class TestDeviceIdNoneResolution:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         result = await adapter.connect()
 
         assert result is True
@@ -2734,17 +2882,15 @@ class TestMatrixReconnectDisconnect:
     """connect() must disconnect existing client before reconnecting."""
 
     @pytest.mark.asyncio
-    async def test_connect_calls_disconnect_when_client_already_set(self):
-        """When self._client is set, connect() should call disconnect() first."""
+    async def test_connect_tears_down_existing_client_before_reconnecting(self):
+        """A reconnect closes the old generation before publishing the new one."""
         adapter = _make_adapter()
 
         adapter._client = MagicMock()
         adapter._client.api = MagicMock()
         adapter._client.api.session = MagicMock()
-        adapter._client.api.session.close = AsyncMock()
+        old_close = adapter._client.api.session.close = AsyncMock()
         adapter._client.whoami = AsyncMock()
-
-        adapter.disconnect = AsyncMock()
 
         fake_mautrix_mods = _make_fake_mautrix()
 
@@ -2769,12 +2915,16 @@ class TestMatrixReconnectDisconnect:
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
         import plugins.platforms.matrix.adapter as matrix_mod
-        with patch.dict("sys.modules", fake_mautrix_mods):
+        with patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+            matrix_mod, "_create_matrix_session", return_value=MagicMock()
+        ):
             with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                     await adapter.connect()
 
-        adapter.disconnect.assert_awaited_once()
+        old_close.assert_awaited_once()
+        assert adapter._client is mock_client
+        await adapter.disconnect()
 
 
 class TestDeviceIdRecoveryOnReconnect:
@@ -2838,7 +2988,7 @@ class TestDeviceIdRecoveryOnReconnect:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         await adapter.connect()
 
         assert adapter._device_id_unverified is True
@@ -2886,7 +3036,7 @@ class TestDeviceIdRecoveryOnReconnect:
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)):
                         result = await adapter.connect()
 
         assert result is True
@@ -3086,7 +3236,7 @@ class TestCryptoStoreResetOnDeviceChange:
         ), patch.dict("sys.modules", fake_mautrix_mods), patch.object(
             adapter, "_refresh_dm_cache", AsyncMock()
         ), patch.object(
-            adapter, "_sync_loop", AsyncMock(return_value=None)
+            adapter, "_sync_loop", AsyncMock(side_effect=_keep_sync_loop_running)
         ), patch.object(
             adapter, "_verify_device_keys_on_server", AsyncMock(return_value=True)
         ):

--- a/tests/gateway/test_matrix_sync_lifecycle.py
+++ b/tests/gateway/test_matrix_sync_lifecycle.py
@@ -1,0 +1,656 @@
+"""Regression tests for Matrix sync-task lifecycle and health propagation."""
+
+import asyncio
+import gc
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.matrix.adapter import MatrixAdapter
+from tests.gateway.test_matrix import _make_fake_mautrix
+
+
+def _fresh_adapter() -> MatrixAdapter:
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@hermes:example.org",
+            },
+        )
+    )
+    adapter._e2ee_mode = "off"
+    adapter._encryption = False
+    return adapter
+
+
+def _make_adapter() -> MatrixAdapter:
+    adapter = _fresh_adapter()
+    adapter._client = MagicMock()
+    adapter._client.sync_store = MagicMock()
+    adapter._client.sync_store.get_next_batch = AsyncMock(return_value=None)
+    adapter._joined_rooms = set()
+    adapter._closing = False
+    adapter._lifecycle_generation = 1
+    adapter._active_generation = 1
+    adapter._mark_connected()
+    return adapter
+
+
+def _publish_task(
+    adapter: MatrixAdapter, task: asyncio.Task, generation: int = 1
+) -> None:
+    adapter._lifecycle_generation = max(adapter._lifecycle_generation, generation)
+    adapter._active_generation = generation
+    adapter._sync_task = task
+    adapter._published_sync = (generation, task)
+
+
+def _connect_client() -> MagicMock:
+    client = MagicMock()
+    client.mxid = "@hermes:example.org"
+    client.device_id = None
+    client.crypto = None
+    client.whoami = AsyncMock(
+        return_value=MagicMock(
+            user_id="@hermes:example.org",
+            device_id="DEVICE",
+        )
+    )
+    client.sync_store = MagicMock()
+    client.sync_store.get_next_batch = AsyncMock(return_value=None)
+    client.sync_store.put_next_batch = AsyncMock()
+    client.add_dispatcher = MagicMock()
+    client.add_event_handler = MagicMock()
+    client.handle_sync = MagicMock(return_value=[])
+    return client
+
+
+def _connect_modules(*clients: MagicMock) -> dict:
+    modules = _make_fake_mautrix()
+    remaining = iter(clients)
+
+    class HTTPAPI:
+        def __init__(self, base_url="", token="", client_session=None, **_kwargs):
+            self.base_url = base_url
+            self.token = token
+            self.session = client_session
+
+    def build_client(**kwargs):
+        client = next(remaining)
+        client.api = kwargs["api"]
+        return client
+
+    modules["mautrix.api"].HTTPAPI = HTTPAPI
+    modules["mautrix.client"].Client = MagicMock(side_effect=build_client)
+    return modules
+
+@pytest.mark.asyncio
+async def test_unexpected_consumer_exit_is_generically_retryable():
+    class SyncError:
+        message = "M_UNKNOWN_TOKEN: expired"
+
+    adapter = _make_adapter()
+    adapter._client.sync = AsyncMock(return_value=SyncError())
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    task = asyncio.create_task(adapter._sync_loop())
+    _publish_task(adapter, task)
+    task.add_done_callback(
+        lambda completed: adapter._handle_sync_task_done(completed, 1)
+    )
+    await task
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert adapter.is_connected is False
+    assert adapter.fatal_error_code == "matrix_sync_task_exited"
+    assert adapter.fatal_error_retryable is True
+    fatal_handler.assert_awaited_once_with(adapter)
+
+
+@pytest.mark.asyncio
+async def test_existing_terminal_reason_survives_consumer_exit():
+    adapter = _make_adapter()
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    task = asyncio.create_task(asyncio.sleep(0))
+    _publish_task(adapter, task)
+    adapter._set_fatal_error("future_classifier", "classified elsewhere", retryable=False)
+    await task
+
+    adapter._handle_sync_task_done(task, 1)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert adapter.fatal_error_code == "future_classifier"
+    assert adapter.fatal_error_retryable is False
+    fatal_handler.assert_awaited_once_with(adapter)
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_returns_to_owner_without_supervisor_notification():
+    adapter = _make_adapter()
+    adapter._running = False
+    adapter._client.sync_store.get_next_batch = AsyncMock(
+        side_effect=RuntimeError("sync store unavailable")
+    )
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    started = asyncio.get_running_loop().create_future()
+    published = asyncio.Event()
+
+    await adapter._sync_loop(started, published)
+
+    assert started.result() is False
+    assert adapter.has_fatal_error is False
+    fatal_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consumer_cannot_poll_before_connect_publishes_state():
+    adapter = _make_adapter()
+    adapter._running = False
+    polled = asyncio.Event()
+
+    async def sync(**_kwargs):
+        assert adapter.is_connected is True
+        polled.set()
+        raise asyncio.CancelledError
+
+    adapter._client.sync = sync
+    started = asyncio.get_running_loop().create_future()
+    published = asyncio.Event()
+
+    task = asyncio.create_task(adapter._sync_loop(started, published))
+    assert await started is True
+    await asyncio.sleep(0)
+    assert polled.is_set() is False
+    adapter._mark_connected()
+    published.set()
+    await task
+
+    assert polled.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_connect_cancellation_during_consumer_start_closes_exact_generation():
+    adapter = _fresh_adapter()
+    client = _connect_client()
+    client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+    get_started = asyncio.Event()
+    never = asyncio.Event()
+
+    async def blocked_get_next_batch():
+        get_started.set()
+        await never.wait()
+
+    client.sync_store.get_next_batch = AsyncMock(
+        side_effect=blocked_get_next_batch
+    )
+    session = MagicMock(close=AsyncMock())
+    modules = _connect_modules(client)
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod, "_create_matrix_session", return_value=session
+    ), patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+        connect_task = asyncio.create_task(adapter.connect())
+        await asyncio.wait_for(get_started.wait(), timeout=1)
+        connect_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(connect_task, timeout=1)
+
+    assert adapter._active_generation is None
+    assert adapter._published_sync is None
+    assert adapter._sync_task is None
+    assert adapter._client is None
+    assert adapter.is_connected is False
+    assert adapter.has_fatal_error is False
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_waits_for_connect_generation_then_tears_it_down():
+    adapter = _fresh_adapter()
+    client = _connect_client()
+    initial_started = asyncio.Event()
+    release_initial = asyncio.Event()
+    consumer_never = asyncio.Event()
+    calls = 0
+
+    async def staged_sync(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            initial_started.set()
+            await release_initial.wait()
+            return {"rooms": {"join": {}}}
+        await consumer_never.wait()
+
+    client.sync = AsyncMock(side_effect=staged_sync)
+    session = MagicMock(close=AsyncMock())
+    modules = _connect_modules(client)
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod, "_create_matrix_session", return_value=session
+    ), patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+        connect_task = asyncio.create_task(adapter.connect())
+        await asyncio.wait_for(initial_started.wait(), timeout=1)
+        disconnect_task = asyncio.create_task(adapter.disconnect())
+        await asyncio.sleep(0)
+        assert disconnect_task.done() is False
+        release_initial.set()
+        assert await asyncio.wait_for(connect_task, timeout=1) is True
+        await asyncio.wait_for(disconnect_task, timeout=1)
+
+    assert adapter.is_connected is False
+    assert adapter._active_generation is None
+    assert adapter._sync_task is None
+    assert adapter._client is None
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_old_disconnect_cannot_close_replacement_generation():
+    adapter = _fresh_adapter()
+    client_one = _connect_client()
+    client_two = _connect_client()
+    first_never = asyncio.Event()
+    second_never = asyncio.Event()
+    first_calls = 0
+    second_calls = 0
+
+    async def first_sync(**_kwargs):
+        nonlocal first_calls
+        first_calls += 1
+        if first_calls == 1:
+            return {"rooms": {"join": {}}}
+        await first_never.wait()
+
+    async def second_sync(**_kwargs):
+        nonlocal second_calls
+        second_calls += 1
+        if second_calls == 1:
+            return {"rooms": {"join": {}}}
+        await second_never.wait()
+
+    client_one.sync = AsyncMock(side_effect=first_sync)
+    client_two.sync = AsyncMock(side_effect=second_sync)
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def blocked_old_close():
+        close_started.set()
+        await release_close.wait()
+
+    session_one = MagicMock(close=AsyncMock(side_effect=blocked_old_close))
+    session_two = MagicMock(close=AsyncMock())
+    modules = _connect_modules(client_one, client_two)
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod,
+        "_create_matrix_session",
+        side_effect=[session_one, session_two],
+    ), patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+        assert await asyncio.wait_for(adapter.connect(), timeout=1) is True
+        disconnect_task = asyncio.create_task(adapter.disconnect())
+        await asyncio.wait_for(close_started.wait(), timeout=1)
+        reconnect_task = asyncio.create_task(adapter.connect(is_reconnect=True))
+        await asyncio.sleep(0)
+        assert reconnect_task.done() is False
+        assert modules["mautrix.client"].Client.call_count == 1
+
+        release_close.set()
+        await asyncio.wait_for(disconnect_task, timeout=1)
+        assert await asyncio.wait_for(reconnect_task, timeout=1) is True
+        assert adapter._client is client_two
+        assert adapter.is_connected is True
+        session_one.close.assert_awaited_once()
+        session_two.close.assert_not_awaited()
+
+        await asyncio.wait_for(adapter.disconnect(), timeout=1)
+
+    session_two.close.assert_awaited_once()
+    assert adapter._client is None
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_reconnect_waits_for_admitted_fatal_handler_to_finish():
+    adapter = _make_adapter()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_handler(_adapter):
+        entered.set()
+        await release.wait()
+
+    adapter.set_fatal_error_handler(blocked_handler)
+    old_task = asyncio.create_task(asyncio.sleep(0))
+    _publish_task(adapter, old_task, generation=1)
+    await old_task
+    adapter._handle_sync_task_done(old_task, 1)
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    replacement_client = _connect_client()
+    replacement_never = asyncio.Event()
+    replacement_calls = 0
+
+    async def replacement_sync(**_kwargs):
+        nonlocal replacement_calls
+        replacement_calls += 1
+        if replacement_calls == 1:
+            return {"rooms": {"join": {}}}
+        await replacement_never.wait()
+
+    replacement_client.sync = AsyncMock(side_effect=replacement_sync)
+    replacement_session = MagicMock(close=AsyncMock())
+    modules = _connect_modules(replacement_client)
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod,
+        "_create_matrix_session",
+        return_value=replacement_session,
+    ), patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+        reconnect_task = asyncio.create_task(adapter.connect(is_reconnect=True))
+        await asyncio.sleep(0)
+        assert reconnect_task.done() is False
+        assert adapter._active_generation == 1
+
+        release.set()
+        assert await asyncio.wait_for(reconnect_task, timeout=1) is True
+        assert adapter._active_generation == 2
+        assert adapter._client is replacement_client
+        assert adapter.is_connected is True
+        await asyncio.wait_for(adapter.disconnect(), timeout=1)
+
+    replacement_session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_resource", ["crypto", "session"])
+async def test_cancelled_disconnect_retains_cleanup_ownership_until_done(
+    blocked_resource
+):
+    adapter = _make_adapter()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_close():
+        entered.set()
+        await release.wait()
+
+    crypto_stop = AsyncMock(
+        side_effect=blocked_close if blocked_resource == "crypto" else None
+    )
+    session_close = AsyncMock(
+        side_effect=blocked_close if blocked_resource == "session" else None
+    )
+    adapter._crypto_db = MagicMock(stop=crypto_stop)
+    adapter._client.api.session.close = session_close
+
+    disconnect_task = asyncio.create_task(adapter.disconnect())
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    cleanup_task = adapter._lifecycle_cleanup_task
+    assert cleanup_task is not None
+    disconnect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await disconnect_task
+
+    assert cleanup_task.done() is False
+    assert adapter._client is None
+    assert adapter._crypto_db is None
+    retry_disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    assert retry_disconnect.done() is False
+
+    release.set()
+    await asyncio.wait_for(cleanup_task, timeout=1)
+    await asyncio.wait_for(retry_disconnect, timeout=1)
+
+    crypto_stop.assert_awaited_once()
+    session_close.assert_awaited_once()
+    assert adapter._lifecycle_cleanup_task is None
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_client_constructor_failure_closes_unpublished_http_session():
+    adapter = _fresh_adapter()
+    session = MagicMock(close=AsyncMock())
+    modules = _make_fake_mautrix()
+    modules["mautrix.client"].Client = MagicMock(
+        side_effect=RuntimeError("client construction failed")
+    )
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod, "_create_matrix_session", return_value=session
+    ):
+        with pytest.raises(RuntimeError, match="client construction failed"):
+            await adapter.connect()
+
+    session.close.assert_awaited_once()
+    assert adapter._active_generation is None
+    assert adapter._client is None
+    assert adapter._pending_session is None
+    assert adapter._lifecycle_cleanup_task is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_constructor_failure_close_keeps_session_owned():
+    adapter = _fresh_adapter()
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def blocked_close():
+        close_started.set()
+        await release_close.wait()
+
+    session = MagicMock(close=AsyncMock(side_effect=blocked_close))
+    modules = _make_fake_mautrix()
+    modules["mautrix.client"].Client = MagicMock(
+        side_effect=RuntimeError("client construction failed")
+    )
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod, "_create_matrix_session", return_value=session
+    ):
+        connect_task = asyncio.create_task(adapter.connect())
+        await asyncio.wait_for(close_started.wait(), timeout=1)
+        cleanup_task = adapter._lifecycle_cleanup_task
+        assert cleanup_task is not None
+        connect_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await connect_task
+
+        assert cleanup_task.done() is False
+        assert adapter._pending_session is None
+        release_close.set()
+        await asyncio.wait_for(cleanup_task, timeout=1)
+
+    session.close.assert_awaited_once()
+    assert adapter._lifecycle_cleanup_task is None
+    assert adapter._active_generation is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_crypto_database_start_still_stops_database():
+    adapter = _fresh_adapter()
+    adapter._e2ee_mode = "required"
+    adapter._encryption = True
+    client = _connect_client()
+    session = MagicMock(close=AsyncMock())
+    start_entered = asyncio.Event()
+    never = asyncio.Event()
+
+    async def blocked_start():
+        start_entered.set()
+        await never.wait()
+
+    crypto_db = MagicMock(
+        start=AsyncMock(side_effect=blocked_start),
+        stop=AsyncMock(),
+    )
+    modules = _connect_modules(client)
+    modules["mautrix.util.async_db"].Database.create = MagicMock(
+        return_value=crypto_db
+    )
+    import plugins.platforms.matrix.adapter as matrix_mod
+
+    with patch.dict("sys.modules", modules), patch.object(
+        matrix_mod, "_create_matrix_session", return_value=session
+    ), patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
+        connect_task = asyncio.create_task(adapter.connect())
+        await asyncio.wait_for(start_entered.wait(), timeout=1)
+        connect_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await connect_task
+
+    crypto_db.stop.assert_awaited_once()
+    session.close.assert_awaited_once()
+    assert adapter._crypto_db is None
+    assert adapter._client is None
+    assert adapter._active_generation is None
+    assert adapter._lifecycle_cleanup_task is None
+
+
+@pytest.mark.asyncio
+async def test_notification_carrier_is_retained_while_handler_is_blocked_and_drains():
+    adapter = _make_adapter()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_handler(_adapter):
+        entered.set()
+        await release.wait()
+
+    adapter.set_fatal_error_handler(blocked_handler)
+    task = asyncio.create_task(asyncio.sleep(0))
+    _publish_task(adapter, task)
+    await task
+    adapter._handle_sync_task_done(task, 1)
+    await entered.wait()
+
+    assert len(adapter._sync_notification_tasks) == 1
+    gc.collect()
+    assert len(adapter._sync_notification_tasks) == 1
+
+    carriers = tuple(adapter._sync_notification_tasks)
+    release.set()
+    await asyncio.gather(*carriers)
+    await asyncio.sleep(0)
+    assert adapter._sync_notification_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_planned_disconnect_task_completion_is_not_fatal():
+    adapter = _make_adapter()
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    task = asyncio.create_task(asyncio.sleep(0))
+    _publish_task(adapter, task)
+    # _disconnect_locked clears publication before a planned cancellation.
+    adapter._closing = True
+    adapter._published_sync = None
+    await task
+
+    adapter._handle_sync_task_done(task, 1)
+    await asyncio.sleep(0)
+
+    assert adapter.has_fatal_error is False
+    fatal_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_is_idempotent_and_closes_resources_once():
+    adapter = _make_adapter()
+    session_close = AsyncMock()
+    adapter._client.api.session.close = session_close
+    crypto_stop = AsyncMock()
+    adapter._crypto_db = MagicMock(stop=crypto_stop)
+    task = asyncio.create_task(asyncio.Event().wait())
+    _publish_task(adapter, task)
+    task.add_done_callback(
+        lambda completed: adapter._handle_sync_task_done(completed, 1)
+    )
+
+    await adapter.disconnect()
+    await adapter.disconnect()
+
+    assert adapter.is_connected is False
+    assert adapter._sync_task is None
+    session_close.assert_awaited_once()
+    crypto_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_completed_task_cannot_poison_none_transition():
+    adapter = _make_adapter()
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    old_task = asyncio.create_task(asyncio.sleep(0))
+    await old_task
+    adapter._sync_task = None
+
+    adapter._handle_sync_task_done(old_task, 1)
+    await asyncio.sleep(0)
+
+    assert adapter.is_connected is True
+    assert adapter.has_fatal_error is False
+    fatal_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stale_completed_task_cannot_fail_replacement_consumer():
+    adapter = _make_adapter()
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    old_task = asyncio.create_task(asyncio.sleep(0))
+    await old_task
+    replacement = asyncio.create_task(asyncio.Event().wait())
+    _publish_task(adapter, replacement, generation=2)
+
+    adapter._handle_sync_task_done(old_task, 1)
+    await asyncio.sleep(0)
+
+    assert adapter.is_connected is True
+    assert adapter.has_fatal_error is False
+    fatal_handler.assert_not_awaited()
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+
+@pytest.mark.asyncio
+async def test_stale_notification_carrier_cannot_fail_replacement_generation():
+    adapter = _make_adapter()
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+    old_task = asyncio.create_task(asyncio.sleep(0))
+    _publish_task(adapter, old_task, generation=1)
+    await old_task
+
+    # Scheduling the carrier does not run it until this coroutine yields.
+    adapter._handle_sync_task_done(old_task, 1)
+    replacement = asyncio.create_task(asyncio.Event().wait())
+    _publish_task(adapter, replacement, generation=2)
+    adapter._mark_connected()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    fatal_handler.assert_not_awaited()
+    assert adapter.is_connected is True
+    assert adapter.has_fatal_error is False
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -5,6 +5,8 @@ import os
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from gateway.readiness import collect_runtime_readiness
 
 
@@ -58,6 +60,269 @@ def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gatewa
     assert result["checks"]["gateway"]["status"] == "degraded"
     # Readiness is diagnostic data, not an exception or a destructive repair.
     assert (home / "config.yaml").read_text(encoding="utf-8") == "model: [unterminated"
+
+
+def test_readiness_degrades_when_current_platform_is_retrying(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 123,
+            "start_time": 456,
+            "platforms": {
+                "telegram": {
+                    "state": "connected",
+                    "writer_pid": 123,
+                    "writer_start_time": 456,
+                },
+                "matrix": {
+                    "state": "retrying",
+                    "writer_pid": 123,
+                    "writer_start_time": 456,
+                },
+            },
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert result["status"] == "degraded"
+    assert gateway["status"] == "degraded"
+    assert gateway["connected_platforms"] == 1
+    assert gateway["unhealthy_platforms"] == 1
+    assert gateway["platforms"] == 2
+
+
+def test_readiness_ignores_platform_entries_from_previous_process(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 200,
+            "start_time": 300,
+            "platforms": {
+                "matrix": {
+                    "state": "fatal",
+                    "writer_pid": 100,
+                    "writer_start_time": 150,
+                }
+            },
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "ok"
+    assert gateway["platforms"] == 0
+    assert gateway["unhealthy_platforms"] == 0
+
+
+@pytest.mark.parametrize("platform_state", ["retrying", "fatal", "paused"])
+def test_readiness_degrades_for_current_unhealthy_platform_state(
+    tmp_path, monkeypatch, platform_state
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 123,
+            "start_time": 456,
+            "platforms": {
+                "matrix": {
+                    "state": platform_state,
+                    "writer_pid": 123,
+                    "writer_start_time": 456,
+                }
+            },
+        },
+    )
+
+    assert result["checks"]["gateway"]["status"] == "degraded"
+    assert result["checks"]["gateway"]["unhealthy_platforms"] == 1
+
+
+def test_readiness_does_not_degrade_for_intentionally_disabled_platform(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 123,
+            "start_time": 456,
+            "platforms": {
+                "matrix": {
+                    "state": "disabled",
+                    "writer_pid": 123,
+                    "writer_start_time": 456,
+                }
+            },
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "ok"
+    assert gateway["platforms"] == 1
+    assert gateway["unhealthy_platforms"] == 0
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"state": "fatal", "writer_pid": 123},
+        {"state": "fatal", "writer_start_time": 456},
+        {"state": "fatal", "writer_pid": "not-a-pid", "writer_start_time": 456},
+    ],
+)
+def test_readiness_ignores_partial_or_malformed_writer_provenance(
+    tmp_path, monkeypatch, entry
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 123,
+            "start_time": 456,
+            "platforms": {"matrix": entry},
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "ok"
+    assert gateway["platforms"] == 0
+
+
+def test_readiness_ignores_unstamped_entry_when_runtime_has_writer_identity(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "pid": 123,
+            "start_time": 456,
+            "platforms": {"matrix": {"state": "retrying"}},
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "ok"
+    assert gateway["platforms"] == 0
+    assert gateway["unhealthy_platforms"] == 0
+
+
+@pytest.mark.parametrize(
+    ("runtime_identity", "entry"),
+    [
+        ({"pid": 123}, {"state": "fatal"}),
+        ({"start_time": 456}, {"state": "fatal"}),
+        (
+            {},
+            {
+                "state": "fatal",
+                "writer_pid": 123,
+                "writer_start_time": 456,
+            },
+        ),
+        (
+            {"pid": True, "start_time": 1},
+            {
+                "state": "fatal",
+                "writer_pid": 1,
+                "writer_start_time": True,
+            },
+        ),
+        (
+            {"pid": "123", "start_time": "456"},
+            {
+                "state": "fatal",
+                "writer_pid": "123",
+                "writer_start_time": "456",
+            },
+        ),
+        (
+            {"pid": 123, "start_time": 456.0},
+            {
+                "state": "fatal",
+                "writer_pid": 123,
+                "writer_start_time": 456.0,
+            },
+        ),
+        (
+            {"pid": 123, "start_time": 10**1000},
+            {
+                "state": "fatal",
+                "writer_pid": 123,
+                "writer_start_time": 10**1000,
+            },
+        ),
+    ],
+)
+def test_readiness_rejects_unverifiable_runtime_or_platform_identity(
+    tmp_path, monkeypatch, runtime_identity, entry
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            **runtime_identity,
+            "platforms": {"matrix": entry},
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "ok"
+    assert gateway["platforms"] == 0
+    assert gateway["unhealthy_platforms"] == 0
+
+
+def test_readiness_keeps_legacy_unstamped_entry_without_runtime_identity(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "platforms": {"matrix": {"state": "retrying"}},
+        },
+    )
+
+    gateway = result["checks"]["gateway"]
+    assert gateway["status"] == "degraded"
+    assert gateway["platforms"] == 1
+    assert gateway["unhealthy_platforms"] == 1
 
 
 def test_readiness_uses_running_session_store_state_over_independent_probe(


### PR DESCRIPTION
## What does this PR do?

Matrix currently owns `_sync_task` as fire-and-forget state. Initial sync failure can still be followed by a connected claim, and a later sync-consumer exit can leave the adapter and gateway reporting healthy while inbound Matrix processing is dead.

This PR gives the consumer an explicit startup handoff, clears connected state on every teardown/failure path, retains fatal-notification carrier tasks, and makes readiness reflect current unhealthy platform state. It deliberately does **not** reimplement Matrix authentication classification; #80532 remains the classifier dependency.

## Related Issue

Related to #80336.

This PR addresses only the sync-task lifecycle/readiness portion of #80336; #80532 owns structured auth-error classification, so the issue should remain open until both parts are resolved.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: fail initial sync cleanly; serialize same-instance connect/disconnect; use a generation-owned two-phase startup handoff; supervise unexpected consumer exit; retain and generation-gate fatal notifications; and transfer task/client/crypto teardown to a cancellation-safe cleanup owner.
- `gateway/readiness.py`: degrade only for current unhealthy configured platform records while preserving intentional disabled and legacy record behavior.
- `tests/gateway/test_matrix.py`, `tests/gateway/test_matrix_sync_lifecycle.py`, `tests/gateway/test_readiness.py`: cover startup failure, reconnect failure, unexpected task exit, cancellation, notification ownership, stale callbacks, cleanup, and readiness identity/state semantics.

## How to Test

1. Focused/canonical Matrix + readiness suite:
   ```bash
   HERMES_PYTHON=/Users/jj/.hermes/venvs/hermes-matrix-dev/bin/python \
     scripts/run_tests.sh tests/gateway/test_matrix*.py tests/gateway/test_readiness.py -q
   ```
   Exact head on current `upstream/main@791e2ae3`: **226 passed, 1 failed, 1 skipped**. The lone failure is the pre-existing `test_collect_runtime_readiness_reports_healthy_local_runtime` disk-capacity assertion; unchanged current main reproduces it because this host reports `disk.used_percent=90.0`. Excluding that baseline case, the three changed suites pass **154/154**. On the preceding base, the same diff recorded **227 passed, 0 failed, 1 skipped**; the 19-test lifecycle file also passed **10 consecutive runs (190/190)**.
2. Temporary current `upstream/main@79b8703d` + #80532 classifier stack, same command: **252 passed, 0 failed, 1 skipped**.
3. Regression sabotage against unchanged current `upstream/main@79b8703d` while retaining the new tests: initial-sync false-connected, unexpected consumer exit, connect cancellation, connect/disconnect serialization, in-flight stale notification, cancellation-safe cleanup (crypto and session cases), immediate and cancelled constructor cleanup, cancellation during crypto database start, and stale readiness provenance all failed as intended (**11 failed**).
4. Repository checks: `ruff check .` passed; Windows-footgun scan passed across **1,019 files**; `py_compile` and `git diff --check` passed. Advisory `ty` diff reported no new production-code diagnostic (new entries are test-mock/module-resolution diagnostics plus a tool panic). A full canonical run on the preceding base `upstream/main@790e1eb6` recorded **124 failures across 39 unrelated files** and no Matrix/readiness failure, so the full-suite checklist remains honestly unchecked and draft CI is the next broad gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and kept #80532's classifier out of this change
- [x] My PR contains only changes related to Matrix sync lifecycle/readiness
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.6.2 with Python 3.11 through `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] Relevant documentation — N/A; this corrects runtime health semantics without adding user configuration
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; no platform-specific APIs added
- [x] Tool descriptions/schemas — N/A

## Risks and exclusions

- Auth-error classification remains owned by #80532. The temporary combined tree is tested separately, but this PR does not duplicate that contributor's classifier.
- This detects consumer termination; it is not a stalled-long-poll watchdog.
- No production gateway, account, token, or service was changed while developing this patch.

## Screenshots / Logs

N/A — lifecycle behavior is covered by automated regression tests.
