### PR TITLE
feat(pricing): add Claude 3.7 Sonnet, GPT-4.5, and Gemini 2.0 Flash Lite official pricing & Bedrock limits

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1622,6 +1622,7 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
+    "anthropic.claude-3-7-sonnet":   200_000,
     "anthropic.claude-3-5-sonnet":   200_000,
     "anthropic.claude-3-5-haiku":    200_000,
     "anthropic.claude-3-opus":       200_000,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -466,7 +466,64 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/api/pricing/",
         pricing_version="openai-pricing-2026-03-16",
     ),
+    (
+        "openai",
+        "gpt-4.5-preview-2025-02-27",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("75.00"),
+        output_cost_per_million=Decimal("150.00"),
+        cache_read_cost_per_million=Decimal("37.50"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/api/pricing/",
+        pricing_version="openai-pricing-2026-03-16",
+    ),
+    (
+        "openai",
+        "gpt-4.5-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("75.00"),
+        output_cost_per_million=Decimal("150.00"),
+        cache_read_cost_per_million=Decimal("37.50"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/api/pricing/",
+        pricing_version="openai-pricing-2026-03-16",
+    ),
+    (
+        "openai",
+        "gpt-4.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("75.00"),
+        output_cost_per_million=Decimal("150.00"),
+        cache_read_cost_per_million=Decimal("37.50"),
+        source="official_docs_snapshot",
+        source_url="https://openai.com/api/pricing/",
+        pricing_version="openai-pricing-2026-03-16",
+    ),
     # ── Anthropic older models (pre-4.5 generation) ────────────────────────
+    (
+        "anthropic",
+        "claude-3-7-sonnet-20250219",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-05",
+    ),
+    (
+        "anthropic",
+        "claude-3-7-sonnet",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-05",
+    ),
     (
         "anthropic",
         "claude-3-5-sonnet-20241022",
@@ -681,6 +738,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-07-07",
     ),
+    (
+        "google",
+        "gemini-2.0-flash-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.075"),
+        output_cost_per_million=Decimal("0.30"),
+        cache_read_cost_per_million=Decimal("0.0075"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-07-07",
+    ),
     # AWS Bedrock — pricing per the Bedrock pricing page.
     # Bedrock charges the same per-token rates as the model provider but
     # through AWS billing.  These are the on-demand prices (no commitment).
@@ -771,6 +839,30 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("4.00"),
         cache_read_cost_per_million=Decimal("0.08"),
         cache_write_cost_per_million=Decimal("1.00"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-3-7-sonnet",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-3-5-sonnet",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -867,3 +867,60 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+def test_claude_37_sonnet_pricing_and_cache_rates():
+    entry = get_pricing_entry("claude-3-7-sonnet-20250219", provider="anthropic")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.00")
+    assert entry.output_cost_per_million == Decimal("15.00")
+    assert entry.cache_read_cost_per_million == Decimal("0.30")
+    assert entry.cache_write_cost_per_million == Decimal("3.75")
+
+    result = estimate_usage_cost(
+        "claude-3-7-sonnet",
+        CanonicalUsage(
+            input_tokens=1_000,
+            output_tokens=500,
+            cache_read_tokens=2_000,
+            cache_write_tokens=1_000,
+        ),
+        provider="anthropic",
+    )
+    # (1k * $3.00 + 500 * $15.00 + 2k * $0.30 + 1k * $3.75) / 1M
+    # = (0.003 + 0.0075 + 0.0006 + 0.00375) = 0.01485
+    assert result.amount_usd == Decimal("0.01485")
+
+
+def test_gpt_45_preview_pricing():
+    entry = get_pricing_entry("gpt-4.5-preview", provider="openai")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("75.00")
+    assert entry.output_cost_per_million == Decimal("150.00")
+    assert entry.cache_read_cost_per_million == Decimal("37.50")
+
+    result = estimate_usage_cost(
+        "gpt-4.5-preview-2025-02-27",
+        CanonicalUsage(input_tokens=10_000, output_tokens=2_000, cache_read_tokens=5_000),
+        provider="openai",
+    )
+    # (10k * 75 + 2k * 150 + 5k * 37.5) / 1M = (0.75 + 0.30 + 0.1875) = 1.2375
+    assert result.amount_usd == Decimal("1.2375")
+
+
+def test_gemini_20_flash_lite_pricing():
+    entry = get_pricing_entry("gemini-2.0-flash-lite", provider="google")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.075")
+    assert entry.output_cost_per_million == Decimal("0.30")
+    assert entry.cache_read_cost_per_million == Decimal("0.0075")
+
+
+def test_bedrock_claude_37_sonnet_pricing():
+    entry = get_pricing_entry("anthropic.claude-3-7-sonnet", provider="bedrock")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.00")
+    assert entry.output_cost_per_million == Decimal("15.00")
+    assert entry.cache_read_cost_per_million == Decimal("0.30")
+    assert entry.cache_write_cost_per_million == Decimal("3.75")
+

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -144,3 +144,13 @@ class TestBedrockNormalize:
         assert nr.finish_reason == "stop"
         assert nr.usage is not None
         assert nr.usage.prompt_tokens == 10
+
+
+class TestBedrockContextLimits:
+
+    def test_claude_37_sonnet_context_limit(self):
+        from agent.bedrock_adapter import _static_bedrock_context_length
+        assert _static_bedrock_context_length("anthropic.claude-3-7-sonnet-20250219-v1:0") == 200_000
+        assert _static_bedrock_context_length("anthropic.claude-3-7-sonnet") == 200_000
+        assert _static_bedrock_context_length("anthropic.claude-3-5-sonnet") == 200_000
+


### PR DESCRIPTION
### Summary
Adds official documentation pricing entries and cross-adapter context limits for recent model releases:
- **Anthropic Claude 3.7 Sonnet** (`claude-3-7-sonnet-20250219`, `claude-3-7-sonnet`): Includes base input/output rates and prompt cache read/write rates.
- **OpenAI GPT-4.5 Preview** (`gpt-4.5-preview-2025-02-27`, `gpt-4.5-preview`, `gpt-4.5`): Includes input, output, and cache read rates.
- **Google Gemini 2.0 Flash Lite** (`gemini-2.0-flash-lite`): Base and cache read rates.
- **AWS Bedrock**: Added `anthropic.claude-3-7-sonnet` to `_BEDROCK_CONTEXT_LIMITS` (200k tokens) and pricing entries for `anthropic.claude-3-7-sonnet` / `anthropic.claude-3-5-sonnet`.

### Test Plan
- Ran unit tests verifying `get_pricing_entry` lookup, exact decimal calculation in `estimate_usage_cost`, and Bedrock static context lookup.
- `uv run --with pytest pytest tests/agent/test_usage_pricing.py tests/agent/transports/test_bedrock_transport.py -v` (62 passed).
