### PR TITLE
fix(matrix): avoid pinning synthetic home threads

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -101,21 +101,21 @@ def _model_switch_skew_guard() -> Optional[str]:
 def _home_thread_from_source(source) -> Optional[str]:
     """The thread id /sethome should persist on the home target, or None.
 
-    Slack thread-per-message session keying stamps a top-level message's own
-    id as ``source.thread_id`` (a session KEY, not a durable location).
+    Slack and Matrix thread-per-message session keying stamp a top-level
+    message's own id as ``source.thread_id`` (a session KEY, not a durable
+    location).
     Persisting it would pin the HOME target itself to the ephemeral thread
     spawned around the /sethome message — every bare-platform delivery
-    (``deliver="slack"``) would then land in that thread forever. Same
-    recognition as cron origin capture: a Slack thread id equal to the
-    message's own id is synthetic. A /sethome run inside a genuine thread
-    (thread id = the parent's id, not this message's own) keeps that thread
-    as the home target.
+    would then land in that thread forever. Same recognition as cron origin
+    capture: on these platforms, a thread id equal to the message's own id is
+    synthetic. A /sethome run inside a genuine thread (thread id = the
+    parent's id, not this message's own) keeps that thread as the home target.
     """
     thread_id = getattr(source, "thread_id", None)
     if not thread_id:
         return None
     if (
-        getattr(source, "platform", None) == Platform.SLACK
+        getattr(source, "platform", None) in (Platform.SLACK, Platform.MATRIX)
         and getattr(source, "message_id", None)
         and str(thread_id) == str(source.message_id)
     ):

--- a/tests/gateway/test_sethome_synthetic_thread.py
+++ b/tests/gateway/test_sethome_synthetic_thread.py
@@ -1,4 +1,4 @@
-"""/sethome must not persist Slack's synthetic per-message session thread.
+"""/sethome must not persist synthetic per-message session threads.
 
 Live repro (relay-fronted Slack staging, 2026-08-13): /sethome run as a
 top-level DM message captured source.thread_id — which the relay adapter had
@@ -7,8 +7,9 @@ persisted HomeChannel. Every bare-platform delivery (deliver="slack") then
 resolved home chat + home thread and landed inside the ephemeral thread
 spawned around the old /sethome message.
 
-Same contract as cron origin capture: a Slack thread id equal to the
-message's own id is a synthetic session key, never a durable location.
+Same contract as cron origin capture: on platforms with per-message session
+keying, a thread id equal to the message's own id is a synthetic session key,
+never a durable location.
 """
 
 from types import SimpleNamespace
@@ -34,6 +35,24 @@ class TestHomeThreadFromSource:
         src = _source(thread_id="1755040000.000100", message_id="1755043010.123456")
         assert _home_thread_from_source(src) == "1755040000.000100"
 
+    def test_synthetic_matrix_thread_dropped(self):
+        """Matrix auto-thread roots equal to the event id are not durable."""
+        src = _source(
+            platform=Platform.MATRIX,
+            thread_id="$sethome-event:example.org",
+            message_id="$sethome-event:example.org",
+        )
+        assert _home_thread_from_source(src) is None
+
+    def test_genuine_matrix_thread_kept(self):
+        """/sethome inside an existing Matrix thread keeps its root."""
+        src = _source(
+            platform=Platform.MATRIX,
+            thread_id="$thread-root:example.org",
+            message_id="$sethome-event:example.org",
+        )
+        assert _home_thread_from_source(src) == "$thread-root:example.org"
+
     def test_no_thread_returns_none(self):
         assert _home_thread_from_source(_source()) is None
 
@@ -42,7 +61,7 @@ class TestHomeThreadFromSource:
         src = _source(thread_id="1755040000.000100", message_id=None)
         assert _home_thread_from_source(src) == "1755040000.000100"
 
-    def test_non_slack_platform_untouched(self):
-        """Telegram forum topics legitimately reuse ids; rule is Slack-scoped."""
+    def test_other_platform_untouched(self):
+        """Telegram forum topics legitimately reuse ids; keep their thread."""
         src = _source(platform=Platform.TELEGRAM, thread_id="2203", message_id="2203")
         assert _home_thread_from_source(src) == "2203"


### PR DESCRIPTION
## Summary

- treat Matrix per-message auto-thread roots as synthetic home targets when the thread id equals the source event id
- preserve genuine Matrix thread roots and existing behavior for other platforms
- add focused regression coverage for synthetic and genuine Matrix thread cases

## Testing

- `scripts/run_tests.sh tests/gateway/test_sethome_synthetic_thread.py tests/gateway/test_restart_notification.py -q` (19 passed)

## Related Issue

Closes #96021
