### PR TITLE
fix(telegram): command_menu.enabled=false stops overwriting BotFather commands

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -791,11 +791,25 @@ def _telegram_command_menu_config() -> dict[str, Any]:
     else:
         priority = []
 
+    # Master opt-out for the automatic command-menu registration (#96025).
+    # set_my_commands overwrites whatever the user customized via BotFather
+    # on every gateway restart; ``enabled: false`` keeps Hermes from touching
+    # the menu at all so manual (e.g. localized) customizations survive.
+    enabled = menu_cfg.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = str(enabled).strip().lower() not in {"false", "0", "no", "off"}
+
     return {
+        "enabled": enabled,
         "max_commands": max_commands,
         "priority_mode": priority_mode,
         "priority": priority,
     }
+
+
+def telegram_menu_enabled() -> bool:
+    """True unless ``platforms.telegram.extra.command_menu.enabled`` is false."""
+    return bool(_telegram_command_menu_config()["enabled"])
 
 
 def telegram_menu_max_commands() -> int:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4090,8 +4090,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommandScopeAllGroupChats,
                     BotCommandScopeDefault,
                 )
-                from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
+                from hermes_cli.commands import (
+                    telegram_menu_commands,
+                    telegram_menu_enabled,
+                    telegram_menu_max_commands,
+                )
                 if not self._bot:
+                    return
+                # command_menu.enabled: false opts out entirely — the
+                # automatic registration overwrites BotFather customizations
+                # (e.g. localized descriptions) on every restart (#96025).
+                if not telegram_menu_enabled():
+                    logger.info(
+                        "[%s] Telegram command menu disabled via config; "
+                        "keeping existing (BotFather) commands",
+                        self.name,
+                    )
                     return
                 # Telegram allows up to 100 commands but has an undocumented
                 # payload size limit (~4KB total).  Hermes defaults to 60 to
@@ -9639,7 +9653,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 if chat_id in self._forum_command_registered:
                     return
                 from telegram import BotCommand, BotCommandScopeChat
-                from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
+                from hermes_cli.commands import (
+                    telegram_menu_commands,
+                    telegram_menu_enabled,
+                    telegram_menu_max_commands,
+                )
+                if not telegram_menu_enabled():
+                    # Same opt-out as the startup registration: never
+                    # overwrite menu customizations the user owns (#96025).
+                    self._forum_command_registered.add(chat_id)
+                    return
                 menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))

--- a/tests/gateway/test_telegram_forum_commands.py
+++ b/tests/gateway/test_telegram_forum_commands.py
@@ -83,3 +83,24 @@ async def test_ensure_forum_commands_race_safety():
 
     # The lock should make this exactly 1 call, not 2.
     assert adapter._bot.set_my_commands.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_forum_commands_respects_menu_opt_out():
+    """#96025: command_menu.enabled=false must skip lazy forum registration.
+
+    The automatic set_my_commands overwrites BotFather customizations (e.g.
+    localized descriptions) on every registration; the opt-out keeps Hermes
+    from touching the menu at all.
+    """
+    adapter = _make_test_adapter()
+    msg = _forum_message(chat_id=-456, is_forum=True)
+
+    with patch("hermes_cli.commands.telegram_menu_enabled", return_value=False):
+        with patch("hermes_cli.commands.telegram_menu_commands") as mock_menu:
+            await adapter._ensure_forum_commands(msg)
+
+    adapter._bot.set_my_commands.assert_not_awaited()
+    mock_menu.assert_not_called()
+    # Marked handled so the check short-circuits on later messages too.
+    assert -456 in adapter._forum_command_registered

--- a/tests/hermes_cli/test_telegram_menu_enabled.py
+++ b/tests/hermes_cli/test_telegram_menu_enabled.py
@@ -1,0 +1,48 @@
+"""Tests for the Telegram command-menu opt-out (#96025).
+
+``platforms.telegram.extra.command_menu.enabled: false`` stops Hermes from
+calling ``set_my_commands`` — every gateway restart otherwise overwrites the
+user's BotFather customizations (e.g. localized command descriptions) with
+the built-in English menu.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.commands import telegram_menu_enabled
+
+
+def _config_with(menu_cfg):
+    def _read_raw_config():
+        return {"platforms": {"telegram": {"extra": {"command_menu": menu_cfg}}}}
+
+    return _read_raw_config
+
+
+class TestTelegramMenuEnabled:
+    def test_defaults_to_enabled(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={},
+        ):
+            assert telegram_menu_enabled() is True
+
+    def test_explicit_false_opts_out(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            side_effect=_config_with({"enabled": False}),
+        ):
+            assert telegram_menu_enabled() is False
+
+    def test_string_false_opts_out(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            side_effect=_config_with({"enabled": "false"}),
+        ):
+            assert telegram_menu_enabled() is False
+
+    def test_other_menu_keys_do_not_disable(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            side_effect=_config_with({"max_commands": 30, "priority": ["new"]}),
+        ):
+            assert telegram_menu_enabled() is True


### PR DESCRIPTION
## What does this PR do?

Every gateway restart re-registers the Telegram bot command menu with the built-in English list (`set_my_commands` for Default/Private/Group scopes, plus the lazy per-forum-topic registration), **overwriting whatever the user customized via BotFather** — including localized command descriptions. Non-English users who customized the menu lose it on every restart, and the reporter's attempted opt-out (`platforms.telegram.extra.command_menu.enabled`) was a key that simply did not exist.

This adds the opt-out: `command_menu.enabled: false` (default `true`) gates both registration sites — the post-connect housekeeping and the lazy forum registration — so Hermes never touches the command menu and manual (e.g. localized) customizations survive restarts. String forms (`false`/`0`/`no`/`off`) are accepted like the rest of the config surface.

The full localization direction from the issue (following each user's `language_code`, per-language `getMyCommands`/`setMyCommands`) is deliberately out of scope here: it needs localized description assets and is a feature build. The opt-out is the escape hatch that makes the overwrite stop today.

## Related Issue

Fixes #96025

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/commands.py` — `_telegram_command_menu_config()` parses an `enabled` key (bool or string truthiness, default true) and exposes `telegram_menu_enabled()`.
- `plugins/platforms/telegram/adapter.py` — `_run_post_connect_housekeeping` skips the `set_my_commands` block when disabled (logs that existing commands are kept); `_ensure_forum_commands` marks the chat handled and returns without registering under the same opt-out.
- `tests/hermes_cli/test_telegram_menu_enabled.py` (new, 4 tests): default enabled, explicit false, string false, other menu keys don't disable.
- `tests/gateway/test_telegram_forum_commands.py` (+1): the lazy forum registration is skipped and the chat marked handled under the opt-out.

## How to Test

1. `python -m pytest tests/hermes_cli/test_telegram_menu_enabled.py tests/gateway/test_telegram_forum_commands.py -q` — should pass (7 passed).
2. Red/green: on unpatched `main`, `telegram_menu_enabled` does not exist (collection error) and the forum opt-out test fails; with this PR all pass.
3. Adjacent suites unchanged: `python -m pytest tests/hermes_cli/test_commands.py -q` — should pass (53 passed).
4. Manual (per the issue): set `platforms: {telegram: {extra: {command_menu: {enabled: false}}}}`, customize commands in BotFather, restart the gateway — the custom menu survives.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the overwrite mechanism and opt-out semantics documented at both registration sites)
- [x] New and existing unit tests pass locally (5 new; 53 adjacent)
- [x] Changes are backward compatible (default behavior unchanged; pure opt-out)
