### PR TITLE
fix(matrix): add missing dm_auto_thread config→env bridge

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -5406,6 +5406,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_SESSION_SCOPE"] = str(matrix_cfg["session_scope"]).lower()
     if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
         os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
+    if "dm_auto_thread" in matrix_cfg and not os.getenv("MATRIX_DM_AUTO_THREAD"):
+        os.environ["MATRIX_DM_AUTO_THREAD"] = str(matrix_cfg["dm_auto_thread"]).lower()
     if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):


### PR DESCRIPTION
## Problem

The `dm_auto_thread` feature (added in 1eab5960f0, PR #15399) reads from the `MATRIX_DM_AUTO_THREAD` env var at runtime, but the YAML→env config bridge in `apply_yaml_config()` never sets this env var from `config.yaml`'s `matrix.dm_auto_thread` key.

This means `dm_auto_thread: true` in config.yaml has no effect — users must set `MATRIX_DM_AUTO_THREAD=true` directly in `.env` as a workaround.

The sibling options `auto_thread` and `dm_mention_threads` both have their bridges; `dm_auto_thread` was simply missed.

## Fix

Add the two-line bridge, consistent with existing patterns.

## Testing

Verified locally: setting `matrix.dm_auto_thread: true` in config.yaml now correctly creates threads for DM messages without needing the env var workaround.