### PR TITLE
fix(zai): add glm-5.3 and glm-5.3-flash to preset model lists

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -801,8 +801,8 @@ ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -102,7 +102,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite-preview",
         "google/gemini-2.5-pro", "google/gemini-2.5-flash",
     ],
-    "zai": ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -153,6 +153,8 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
+        "glm-5.3-flash",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",


### PR DESCRIPTION
Zhipu shipped **glm-5.3** (Aug 14, now the chat-completions default) and **glm-5.3-flash** (flagship multimodal, 1/40 the price of Claude Opus 4.8) — but the ZAI/GLM provider preset lists still stop at glm-5.2, so neither model shows up in `hermes model` / setup for direct ZAI API keys.

Adds both (newest first) to:

1. `plugins/model-providers/zai/__init__.py` — `fallback_models` (picker-visible presets)
2. `hermes_cli/setup.py` — `_DEFAULT_PROVIDER_MODELS["zai"]`
3. `hermes_cli/auth.py` — `ZAI_ENDPOINTS` coding-plan probe lists (was missing 5.3-flash)

OpenRouter-side slugs (`z-ai/glm-5.3`, `z-ai/glm-5.3-flash`) were already present in the catalog — this closes the gap for direct ZAI/Zhipu API keys.

Verified: `zai.fallback_models` loads with both models; `tests/hermes_cli/test_api_key_providers.py` 105 passed.