### PR TITLE
fix(desktop): persist unread on unfocused finish for Focus sync

### DIFF
--- a/apps/desktop/src/store/session-unread-remote.test.ts
+++ b/apps/desktop/src/store/session-unread-remote.test.ts
@@ -14,7 +14,13 @@ vi.mock('@/hermes', () => ({
 
 import { $sessions } from '@/store/session'
 
-import { $unreadWriteGuard, clearUnreadOnOpen, markSessionUnread, watchUnreadWriteGuard } from './session-unread-remote'
+import {
+  $unreadWriteGuard,
+  clearUnreadOnOpen,
+  markSessionUnread,
+  persistUnreadOnBackgroundFinish,
+  watchUnreadWriteGuard
+} from './session-unread-remote'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -109,5 +115,37 @@ describe('watchUnreadWriteGuard', () => {
     $sessions.set([row('a', { unread: false })])
 
     expect($unreadWriteGuard.get().has('a')).toBe(true)
+  })
+})
+
+describe('persistUnreadOnBackgroundFinish', () => {
+  it('PATCHes unread=true so Focus can paint the same green dot', async () => {
+    $sessions.set([row('a', { profile: 'work', unread: false })])
+
+    await persistUnreadOnBackgroundFinish('a')
+
+    expect(patch).toHaveBeenCalledWith('a', true, 'work')
+    expect($sessions.get().find(s => s.id === 'a')?.unread).toBe(true)
+  })
+
+  it('no-ops when the row is already persisted unread', async () => {
+    $sessions.set([row('a', { unread: true })])
+
+    await persistUnreadOnBackgroundFinish('a')
+
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('no-ops for a runtime-only session with no persisted row', async () => {
+    await persistUnreadOnBackgroundFinish('ghost')
+
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('swallows a failed PATCH so the local marker still paints', async () => {
+    $sessions.set([row('a', { unread: false })])
+    patch.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+
+    await expect(persistUnreadOnBackgroundFinish('a')).resolves.toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/session-unread-remote.ts
+++ b/apps/desktop/src/store/session-unread-remote.ts
@@ -7,8 +7,11 @@
  * transient) and the backend's derived `unread` key (last_read_at watermark
  * vs last_active — survives restarts and is visible to every surface). This
  * module owns the WRITE side of the persisted flag: the row-level
- * "Mark as unread"/"Mark as read" toggle and the automatic clear when a
- * session is opened. The read side lives in session-dot-state.ts.
+ * "Mark as unread"/"Mark as read" toggle, the automatic clear when a
+ * session is opened, and persistUnreadOnBackgroundFinish so an unfocused
+ * busy→idle edge writes last_read_at (Focus reads only that, not the
+ * local $unreadFinishedSessionIds marker). The read side lives in
+ * session-dot-state.ts.
  *
  * Optimistic, then honest (AGENTS.md): paint the row immediately, PATCH the
  * backend, roll back visibly on failure. A list page already in flight when
@@ -59,6 +62,25 @@ export async function markSessionUnread(storedId: string, unread: boolean): Prom
     $unreadWriteGuard.set(guard2)
     setSessions(rows => rows.map(r => (r.id === storedId ? { ...r, unread: !unread } : r)))
     throw err
+  }
+}
+
+/** Unfocused busy→idle (and any locally-green row that is not yet
+ *  server-unread) must PATCH unread=true. Focus paints only `row.unread`
+ *  from last_read_at; the local finish marker is invisible on the phone.
+ *  No-op when already persisted or when there is no stored row. Best-effort:
+ *  a failed PATCH leaves the local marker painting until the next retry. */
+export async function persistUnreadOnBackgroundFinish(storedId: string): Promise<void> {
+  const row = rowFor(storedId)
+
+  if (!row || row.unread === true) {
+    return
+  }
+
+  try {
+    await markSessionUnread(storedId, true)
+  } catch {
+    // Ignore: Desktop still greens from $unreadFinishedSessionIds.
   }
 }
 

--- a/apps/desktop/src/store/session-unread.test.ts
+++ b/apps/desktop/src/store/session-unread.test.ts
@@ -1,8 +1,13 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
 import { makeSessionInfo } from '../test/session-info'
+
+vi.mock('@/hermes', () => ({
+  setApiRequestProfile: () => {},
+  setSessionUnreadRemote: () => Promise.resolve({ ok: true })
+}))
 
 import { $activeGatewayProfile } from './profile'
 import {
@@ -71,6 +76,13 @@ describe('persisted unread (session-unread)', () => {
     setSessions([session({ id: 's1', message_count: 4 })])
 
     expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+  })
+
+  it('marks the row unread on a live-edge finish so Focus can share the green dot', () => {
+    setSessions([session({ id: 's1', message_count: 4, unread: false })])
+    markSessionUnreadFinished('s1')
+
+    expect($sessions.get().find(s => s.id === 's1')?.unread).toBe(true)
   })
 
   it('acks watermark + marker when the user opens the session', () => {

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -13,6 +13,7 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from './session'
+import { persistUnreadOnBackgroundFinish } from './session-unread-remote'
 import { isBrowserWindow, isSecondaryWindow } from './windows'
 
 /**
@@ -212,13 +213,16 @@ export function markSessionUnreadFinished(storedSessionId: string): void {
   const durableId = row ? sessionPinId(row) : storedSessionId
   const bucket = $unreadFinishedMarkers.get()[profile] ?? []
 
-  if (bucket.includes(durableId)) {
-    return
+  if (!bucket.includes(durableId)) {
+    const next = [...bucket, durableId]
+
+    setMarkerBucket(profile, next.length > MARKERS_CAP ? next.slice(next.length - MARKERS_CAP) : next)
   }
 
-  const next = [...bucket, durableId]
-
-  setMarkerBucket(profile, next.length > MARKERS_CAP ? next.slice(next.length - MARKERS_CAP) : next)
+  // After the local marker is durable: persist() → setSessions would otherwise
+  // recompute unread and drop this id before isMarked could see it. Always
+  // PATCH, even when the marker already existed — Focus never saw the local one.
+  void persistUnreadOnBackgroundFinish(storedSessionId)
 }
 
 /** ACK — the user opened (or is looking at) this session: watermark := its
@@ -545,6 +549,12 @@ function onListChange(): void {
   rehydrateFromDiskOnce()
   ingestRows(rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]))
   recomputeUnread()
+
+  // Replay local greens onto last_read_at so Focus matches Desktop without
+  // waiting for another busy→idle edge (existing-marker heal).
+  for (const id of $unreadFinishedSessionIds.get()) {
+    void persistUnreadOnBackgroundFinish(id)
+  }
 }
 
 // Wiring: module-scope listeners, same pattern as session-states.ts's


### PR DESCRIPTION
## Result

Hermes Focus no longer stays Idle/Done 0 while Desktop shows a row of green unread dots for the same chats. An unfocused turn that finishes in Desktop now writes the shared `last_read_at` watermark (`PATCH /api/sessions/{id}` `{unread: true}`), which is the only unread field Focus paints.

Desktop still greens immediately from the local busy→idle marker. That marker is now followed by the same persist path the sidebar "Mark as unread" toggle already used, and a list refresh heals any locally-green row that is not yet server-unread so existing dots catch up without waiting for another finish.

## Root Cause

Unread has two sources on Desktop (`session-dot-state.ts`): `$unreadFinishedSessionIds` (local, `markSessionUnreadFinished` on unfocused busy→idle) **or** `row.unread` from `SessionDB.session_unread` (`last_read_at` vs `last_active`).

Focus Chats Done/green is **only** `session.unread` from the dashboard list. `session_unread` treats `last_read_at IS NULL` as read (history-flood guard). Live probe of Andrew's `state.db`: 59/60 open sessions NULL, **0** derived unread — matching Focus Done 0 — while Desktop was green from local markers that never PATCHed.

`persistUnreadOnBackgroundFinish` was specified and never implemented. `clearUnreadOnOpen` also no-ops unless `row.unread === true`, so the watermark never armed.

Not this bug: Focus decode of `unread` (already covered), sticky seen overrides (v401), gateway `api_server` stripping unread (Focus uses `hermes serve` `:9119`).

## How to Verify

1. Finish a turn in Desktop on a session you are not looking at. Desktop greens. `sessions.last_read_at` for that id becomes `0`. Focus Chats shows the same row green / Done increments within the ~8s poll.
2. Open the chat on either surface: both clear (PATCH unread=false).
3. Existing Desktop-only greens: next Desktop list refresh PATCHes them; Focus catches up without another turn.

## Test Plan

- [x] Added regression tests for `persistUnreadOnBackgroundFinish` (PATCH, already-unread no-op, no row, failed PATCH swallowed)
- [x] Wiring test: `markSessionUnreadFinished` sets `row.unread === true`
- [x] Existing `session-unread` / `session-unread-remote` tests still pass (27)
- [ ] Manual: Desktop rebuild, then compare Focus Done vs Desktop green after an unfocused finish

## Risks

- If this is wrong: extra PATCHes on list refresh for locally-green rows until the server echoes `unread: true`. Already-unread rows no-op. Failed PATCH is swallowed so Desktop paint does not regress.
- Who / surface: Desktop writer; Focus reader of `last_read_at`. Does not change the watermark formula or flood NULL history to unread.
- How we would know: Focus Done still 0 after an unfocused Desktop finish, with `last_read_at` still NULL.
- Residual: packaged Desktop must pick up this renderer change; Focus needs no app change. Cron-only rows not present in `$sessions` still no-op `rowFor` (same as the existing mark-unread toggle).
