### PR TITLE
fix(weixin): initialize is_rate_limited before use in _send_text_chunk

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1822,6 +1822,7 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> None:
         """Send a text chunk while holding the adapter-wide outbound text gate."""
         last_error: Optional[Exception] = None
+        is_rate_limited = False
         retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
             if self._rate_limit_cooldown_remaining() > 0:


### PR DESCRIPTION
## Summary

`is_rate_limited` in `WeixinAdapter._send_text_chunk()` is assigned inside the retry loop (line 1862) but referenced earlier in the cooldown check (line 1866). When the first attempt raises an exception before reaching the assignment, `UnboundLocalError` crashes the entire send path.

This breaks **cron delivery** and any outbound message that hits a transient error on the first `_send_message` call.

## Fix

Initialize `is_rate_limited = False` alongside the other loop-state variables (`last_error`, `retried_without_token`) before the retry loop.

## Reproduction

1. Set up a Weixin gateway with cron jobs
2. When a cron job fires and `_send_message` raises on the first attempt (e.g. network error), `_send_text_chunk` crashes with:
   ```
   UnboundLocalError: cannot access local variable 'is_rate_limited' where it is not associated with a value
   ```
3. The cron output is silently lost

## Related

- #94423 addresses rate-limiting observability but does not fix this initialization bug