### PR TITLE
fix(desktop): evict wedged ControlMaster immediately on exec() timeout

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -437,8 +437,10 @@ test('exec() returns stdout on success and rejects (classified) on failure', asy
 })
 
 test('exec() treats a hung ssh as a timeout (half-open connection)', async () => {
+  // connectTimeoutMs bounds the eviction's own -O exit call below — without it
+  // this falls back to the 15s production default and the test hangs for real.
   const spawnFn = scriptedSpawn([{ hang: true }])
-  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d' })
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d', connectTimeoutMs: 30 })
   await assert.rejects(
     () => conn.exec('uname -s', { timeoutMs: 30 }),
     (err: any) => {
@@ -447,6 +449,49 @@ test('exec() treats a hung ssh as a timeout (half-open connection)', async () =>
       return true
     }
   )
+})
+
+test('exec() evicts a wedged master immediately instead of leaving it for the next open()', async () => {
+  // Mirrors the "open() evicts a wedged master" scenario, but the wedge
+  // develops *mid-attempt* (between two execs on an already-`_opened`
+  // connection), which open()'s dial-time check-then-verify never sees.
+  // Without eviction here, the next attempt's open() would find the same
+  // local master still answering `-O check` (it's a live process talking to
+  // a dead peer) and pay its own full verify-then-evict timeout again.
+  const dir = path.join(os.tmpdir(), `hermes-ssh-exec-evict-${process.pid}-${Date.now()}`)
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+
+  const ops: string[] = []
+
+  const spawnFn = scriptedSpawn(args => {
+    if (args.includes('-O')) {
+      ops.push('evict')
+
+      return { code: 0 }
+    }
+
+    ops.push('exec')
+
+    return { hang: true }
+  })
+
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: dir, connectTimeoutMs: 30 })
+  fs.writeFileSync(conn.controlPath, '') // simulate an already-open master from a prior successful exec
+  conn._opened = true
+
+  await assert.rejects(
+    () => conn.exec('uname -s', { timeoutMs: 30 }),
+    (err: any) => {
+      assert.equal(err.kind, SSH_ERROR.TIMEOUT)
+
+      return true
+    }
+  )
+
+  assert.deepEqual(ops, ['exec', 'evict'], 'a hung exec evicts the wedged master immediately, not on the next open()')
+  assert.equal(conn._opened, false, 'the connection no longer trusts the wedged master')
+  assert.ok(!fs.existsSync(conn.controlPath), 'the stale control socket is removed so the next open() dials fresh')
+  fs.rmSync(dir, { recursive: true, force: true })
 })
 
 test('forward() issues -O forward with a loopback-bound -L spec', async () => {

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -784,7 +784,22 @@ class SshConnection {
         spawnFn: this._spawnFn,
         ...(stdinData != null ? { stdinData } : {})
       })
-    } catch (error) {
+    } catch (error: any) {
+      // A wedge (half-open TCP after sleep, a network change mid-attempt) can
+      // develop *between* two execs on an already-`_opened` mux — open()'s
+      // check-then-verify dance (_verifyMuxChannel/_evictStaleMaster) only
+      // runs at dial time. Left alone, the local master process keeps
+      // answering a future `-O check` (it's a live process talking to a dead
+      // peer), so the *next* attempt's open() re-discovers the same wedge and
+      // pays its own full verify-then-evict timeout before dialing fresh.
+      // Evict now, the moment the wedge is detected, so the next open() sees
+      // a missing control socket and dials fresh immediately instead of
+      // re-paying this cost.
+      if (this._mux && error?.kind === SSH_ERROR.TIMEOUT) {
+        await this._evictStaleMaster()
+        this._opened = false
+      }
+
       throw this._fail(error)
     }
 


### PR DESCRIPTION
## What

`open()` already detects and evicts a wedged ControlMaster at dial time (`-O check` passes, but a real exec through it hangs — the documented macOS sleep/wake case, see the comment above `open()` and the existing `open() evicts a wedged master...` test). `exec()` has no equivalent: if the master wedges **between** two execs on an already-`_opened` connection, the current exec just hangs for the full `DEFAULT_EXEC_TIMEOUT_MS` and the stale local master is left behind — still a live local process, just talking to a dead peer, so it keeps answering `-O check` on the *next* attempt too. That next attempt's `open()` has to rediscover the same wedge and pay its own full verify-then-evict round trip before it can dial fresh.

This PR makes `exec()` evict the master itself the moment it sees a `SSH_ERROR.TIMEOUT`, so the *next* `open()` finds a missing control socket and dials fresh immediately instead of re-paying the discovery cost.

## Why (how I found it)

Desktop SSH remote mode, after the client machine slept. Desktop's own boot log showed a burst of successful `open → several execs → close` cycles (backend version check, locate binary, lock-file probe, etc.), then the detached `hermes serve` spawn command was dispatched — confirmed **server-side** via the remote host's session log, which shows the exact spawn command executing and reaching completion — but it left **no trace at all** on the remote host: no `backend.lock.json`, no spawn log file, no live `hermes serve` process. Desktop then surfaced: `SSH operation to <host> timed out. The connection may be half-open (e.g. after sleep); reconnecting.`

That message comes from exactly one place (`sshErrorMessage`, `SSH_ERROR.TIMEOUT` case), which only fires when `runSsh()`'s hard timeout fires and SIGKILLs the local per-exec `ssh` client. Since a ControlMaster exec is a short-lived client multiplexed through the persistent master process over its Unix socket, killing that per-exec client doesn't touch the master — so the master (and its wedged, half-open TCP connection to the actual remote) survives the failure untouched, and neither `close()` nor any other cleanup runs on this path. Every later exec on the same connection — and, since the master isn't evicted, every later *attempt's* `open()` too — was set up to pay the same cost again.

## Change

- `exec()`: on a `SSH_ERROR.TIMEOUT` from `runSsh()`, when `this._mux` is true, call the existing `_evictStaleMaster()` and set `this._opened = false` before re-throwing the classified error. No new mechanism — this reuses exactly the eviction path `open()` already relies on for the same class of wedge, just triggers it from the other place a wedge can be discovered.

## How to test

- `apps/desktop`: `npx vitest run electron/ssh-connection.test.ts` — extended the existing `exec() treats a hung ssh as a timeout` test with a bounded `connectTimeoutMs` (needed once eviction — which itself races a timeout — runs after the exec timeout), and added `exec() evicts a wedged master immediately instead of leaving it for the next open()`, which asserts the eviction call happens, `_opened` flips to `false`, and the stale control socket file is removed.
- Also ran the full `ssh-connection.test.ts` (68 tests) and `remote-lifecycle.test.ts` (89 tests) suites, plus `tsc --build tsconfig.electron.json` and `prettier --check` on both changed files — all clean.

## What platforms I tested on

Linux only (the host I reproduced the server-side half of this on). I don't have macOS hardware to trigger the actual sleep/wake wedge end-to-end, so this is verified via the unit test harness (which is how the existing `open()` eviction path is tested too) rather than a live repro of the client-side wedge. Flagging that explicitly in case a maintainer wants to sanity-check against a real macOS sleep/wake before merging.