### PR TITLE
fix(feishu): render markdown tables as native card table components

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -66,6 +66,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
+
+from plugins.platforms.feishu.feishu_table_card import build_table_card_payload
 from typing import Any, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
@@ -270,6 +272,18 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_CARD_CONTENT_INVALID_RE = re.compile(
+# Card payload rejected by the API (invalid schema/component) — triggers the
+# interactive → post downgrade in ``send``/``edit_message``.
+
+    r"invalid card|card.*invalid|invalid.*card|schema|element"
+    r"|content format of the (post|card|interactive) type is incorrect"
+    r"|unable to parse card",
+    re.IGNORECASE,
+)
+# msg types the interactive→post→text downgrade ladder walks through.
+_CARD_DOWNGRADE_NEXT = {"interactive": "post", "post": "text"}
+
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -1982,29 +1996,64 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    # Payload-format downgrade ladder: interactive (card
+                    # table) → post → text. Each rung is only climbed when
+                    # the API rejected the payload format itself; other
+                    # errors keep the normal retry path.
+                    next_type = _CARD_DOWNGRADE_NEXT.get(msg_type)
+                    invalid_re = (
+                        _CARD_CONTENT_INVALID_RE
+                        if msg_type == "interactive"
+                        else _POST_CONTENT_INVALID_RE
+                    )
+                    if next_type is None or not invalid_re.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning(
+                        "[Feishu] Invalid %s payload rejected by API; downgrading to %s",
+                        msg_type, next_type,
+                    )
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=next_type,
+                        payload=(
+                            _build_markdown_post_payload(chunk)
+                            if next_type == "post"
+                            else json.dumps(
+                                {"text": _strip_markdown_to_plain_text(chunk)},
+                                ensure_ascii=False,
+                            )
+                        ),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
+                    msg_type = next_type
                 if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    not self._response_succeeded(response)
+                    and (
+                        (msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or "")))
+                        or (msg_type == "interactive" and _CARD_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or "")))
+                    )
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    downgrade_to = _CARD_DOWNGRADE_NEXT[msg_type]
+                    logger.warning(
+                        "[Feishu] %s payload rejected by API response; downgrading to %s",
+                        msg_type, downgrade_to,
+                    )
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=downgrade_to,
+                        payload=(
+                            _build_markdown_post_payload(chunk)
+                            if downgrade_to == "post"
+                            else json.dumps(
+                                {"text": _strip_markdown_to_plain_text(chunk)},
+                                ensure_ascii=False,
+                            )
+                        ),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
+                    msg_type = downgrade_to
                 last_response = response
 
             return self._finalize_send_result(last_response, "send failed")
@@ -4640,7 +4689,23 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _build_outbound_payload(
         self, content: str, *, prefer_post: bool = False,
+        allow_card_table: bool = True,
     ) -> tuple[str, str]:
+        # Markdown pipe tables: Feishu's post/md table renderer squeezes
+        # columns to content width, wrapping long CJK/Latin cells into
+        # unreadable strips with no width control. Route table-containing
+        # content through an interactive card whose native ``table``
+        # component supports ``width: "auto"`` columns and ``row_height:
+        # "auto"`` rows instead. Non-convertible content (no table, or over
+        # card component limits) returns ``None`` and keeps the post path.
+        #
+        # ``allow_card_table`` is False on the edit path: Feishu's
+        # message-update API cannot change a message's msg_type, so editing
+        # an existing text/post message must not suddenly become a card.
+        if allow_card_table:
+            card_payload = build_table_card_payload(content)
+            if card_payload is not None:
+                return "interactive", card_payload
         # Empirically (issue #52786), current Feishu clients render markdown
         # tables inside ``post``-type ``md`` elements natively. The previous
         # table-downgrade branch forced any table-containing message to

--- a/plugins/platforms/feishu/feishu_table_card.py
+++ b/plugins/platforms/feishu/feishu_table_card.py
@@ -1,0 +1,323 @@
+"""Markdown table → Feishu card table-component converter.
+
+Why this module exists
+----------------------
+Feishu renders markdown tables inside ``post``-type ``md`` elements with
+columns squeezed to content width; long CJK/Latin cells wrap into unreadable
+narrow strips and the column widths are not controllable. Feishu's
+interactive-card ``table`` component (schema 2.0) solves this: columns accept
+``width: "auto"`` (size-to-content) and rows accept ``row_height: "auto"``
+(expand to fit).
+
+This module converts the pipe tables in an outbound markdown chunk into a
+single JSON 2.0 interactive-card payload:
+
+    prose segment  ->  {"tag": "markdown", "content": ...}
+    table block    ->  {"tag": "table", "columns": [...], "rows": [...]}
+
+Interleaved order is preserved. When the content exceeds card component
+limits (>5 tables, >50 columns, >100 rows per table) or contains no
+convertible table, ``build_table_card_payload`` returns ``None`` and the
+caller falls back to the historical post path.
+
+Docs: https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-json-v2-components/content-components/table
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Limits (Feishu card component constraints + defensive caps)
+# ---------------------------------------------------------------------------
+
+_MAX_TABLES_PER_CARD = 5          # Feishu hard limit per card
+_MAX_COLUMNS_PER_TABLE = 50       # Feishu hard limit per table
+_MAX_ROWS_PER_TABLE = 100         # Defensive: longer tables are unreadable in chat
+_MAX_PAGE_SIZE = 10               # Feishu max rows per page
+_ROW_MAX_HEIGHT = "999px"         # row_height auto cap; avoids clipping tall cells
+
+# A table row line: starts (after optional indent) with a pipe.
+_TABLE_ROW_LINE_RE = re.compile(r"^\s*\|")
+# The separator line under the header: cells of colons/dashes/spaces only.
+_TABLE_SEP_CELL_RE = re.compile(r"^:?-+:?$")
+# Escaped pipe inside a cell.
+_ESCAPED_PIPE = "\\|"
+
+
+def _split_table_row(line: str) -> List[str]:
+    """Split a markdown table line into raw cell strings.
+
+    Handles optional leading/trailing pipes and escaped pipes (``\\|``).
+    """
+    text = line.strip()
+    if text.startswith("|"):
+        text = text[1:]
+    if text.endswith("|") and not text.endswith(_ESCAPED_PIPE):
+        text = text[:-1]
+
+    cells: List[str] = []
+    buf: List[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text) and text[i + 1] == "|":
+            buf.append("\\|")  # keep escape for now; unescape below
+            i += 2
+            continue
+        if ch == "|":
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    cells.append("".join(buf))
+    return [c.strip().replace(_ESCAPED_PIPE, "|") for c in cells]
+
+
+def _is_separator_row(cells: List[str]) -> bool:
+    if not cells:
+        return False
+    return all(_TABLE_SEP_CELL_RE.match(c) for c in cells if c != "") and any(
+        c for c in cells
+    )
+
+
+def _alignment_for(sep_cell: str) -> str:
+    stripped = sep_cell.strip()
+    if stripped.startswith(":") and stripped.endswith(":"):
+        return "center"
+    if stripped.endswith(":"):
+        return "right"
+    return "left"
+
+
+def _clean_cell(text: str) -> str:
+    """Normalize a cell for lark_md rendering."""
+    # Internal newlines cannot occur in GFM tables; collapse stray whitespace.
+    text = re.sub(r"\s*\n\s*", " ", text)
+    # lark_md escapes: backslashes before markdown punctuation are literal.
+    return text.strip()
+
+
+def _extract_table_blocks(lines: List[str]) -> List[Dict[str, Any]]:
+    """Extract contiguous markdown table blocks from a line list.
+
+    Returns a list of blocks, each ``{"start": i, "end": j (exclusive),
+    "header": [...], "aligns": [...], "rows": [[...], ...]}``.
+    """
+    blocks: List[Dict[str, Any]] = []
+    i = 0
+    n = len(lines)
+    while i < n - 1:
+        if not _TABLE_ROW_LINE_RE.match(lines[i]):
+            i += 1
+            continue
+        header = _split_table_row(lines[i])
+        sep = _split_table_row(lines[i + 1]) if i + 1 < n else []
+        if not header or not _is_separator_row(sep):
+            i += 1
+            continue
+        # Valid table start: header + separator.
+        aligns = [_alignment_for(c) for c in sep]
+        rows: List[List[str]] = []
+        j = i + 2
+        while j < n and _TABLE_ROW_LINE_RE.match(lines[j]):
+            cells = _split_table_row(lines[j])
+            rows.append(cells)
+            j += 1
+        blocks.append(
+            {"start": i, "end": j, "header": header, "aligns": aligns, "rows": rows}
+        )
+        i = j
+    return blocks
+
+
+# Feishu column width bounds (docs): custom width is [80, 600] px.
+_MIN_COL_PX = 80
+_MAX_COL_PX = 600
+# Approximate rendered character widths at 14px body font.
+_CJK_CHAR_PX = 14.0
+_ASCII_CHAR_PX = 7.5
+# Padding/borders allowance per cell.
+_CELL_PADDING_PX = 24
+# Columns estimated no wider than this are pinned in px; wider columns stay
+# "auto" and share the remaining card width. Pinning only applies when the
+# table has at least one wide (auto) column to absorb the leftover space —
+# an all-pinned table would total far less than the card width and Feishu
+# would re-stretch it anyway.
+_PINNED_COL_MAX_PX = 220
+
+
+def _display_width(text: str) -> float:
+    """Estimated rendered width of *text* in pixels at 14px font.
+
+    CJK/fullwidth characters count double the ASCII width. Markdown markers
+    (**, `, links) are discounted since they render as styling, not glyphs.
+    """
+    # Strip markdown markers that do not render as visible characters.
+    visible = re.sub(r"\*\*|`", "", text)
+    visible = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", visible)  # [label](url) -> label
+    width = 0.0
+    for ch in visible:
+        width += _CJK_CHAR_PX if unicodedata.east_asian_width(ch) in ("W", "F") else _ASCII_CHAR_PX
+    return width
+
+
+def _column_width_px(header: str, rows: List[List[str]], idx: int) -> int:
+    """Estimate the content-driven width for column *idx* in pixels."""
+    widths = [_display_width(header[idx])]
+    for row in rows:
+        cell = row[idx] if idx < len(row) else ""
+        # Only measure the longest line of a multi-line cell.
+        widths.append(max((_display_width(part) for part in cell.split("\n")), default=0.0))
+    content_px = max(widths, default=0.0) + _CELL_PADDING_PX
+    return max(_MIN_COL_PX, min(_MAX_COL_PX, int(content_px)))
+
+
+def _build_table_element(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a Feishu table component from one parsed table block."""
+    header = block["header"]
+    aligns = block["aligns"]
+    rows = block["rows"]
+
+    n_cols = len(header)
+    if n_cols == 0 or n_cols > _MAX_COLUMNS_PER_TABLE:
+        return None
+    if len(rows) > _MAX_ROWS_PER_TABLE:
+        return None
+
+    columns: List[Dict[str, str]] = []
+    # Two-pass: estimate every column's content width first, then pin only
+    # narrow columns to px so wide "auto" columns absorb the remaining card
+    # width. All-narrow tables keep everything "auto" (Feishu stretches the
+    # table to full card width regardless, so pinning gains nothing there).
+    estimated = [_column_width_px(header, rows, i) for i in range(n_cols)]
+    n_pinned = sum(1 for w in estimated if w <= _PINNED_COL_MAX_PX)
+    pin_narrow = 0 < n_pinned < n_cols
+    for idx in range(n_cols):
+        if pin_narrow and estimated[idx] <= _PINNED_COL_MAX_PX:
+            width = f"{estimated[idx]}px"
+        else:
+            width = "auto"
+        col: Dict[str, Any] = {
+            "name": f"c{idx}",
+            "display_name": _clean_cell(header[idx]),
+            "data_type": "lark_md",
+            "width": width,
+            "horizontal_align": aligns[idx] if idx < len(aligns) else "left",
+            "vertical_align": "top",
+        }
+        columns.append(col)
+
+    row_dicts: List[Dict[str, str]] = []
+    for row in rows:
+        row_obj: Dict[str, str] = {}
+        for idx in range(n_cols):
+            cell = _clean_cell(row[idx]) if idx < len(row) else ""
+            row_obj[f"c{idx}"] = cell
+        row_dicts.append(row_obj)
+
+    return {
+        "tag": "table",
+        "page_size": _MAX_PAGE_SIZE,
+        "row_height": "auto",
+        "row_max_height": _ROW_MAX_HEIGHT,
+        "freeze_first_column": False,
+        "header_style": {
+            "text_align": "left",
+            "text_size": "normal",
+            "background_style": "grey",
+            "text_color": "default",
+            "bold": True,
+            "lines": 1,
+        },
+        "columns": columns,
+        "rows": row_dicts,
+    }
+
+
+_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
+_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+
+
+def _prose_elements(segment: str) -> List[Dict[str, str]]:
+    """Build markdown elements for a prose segment, splitting at code fences.
+
+    Splitting mirrors the post-path fence isolation: a fenced block gets its
+    own markdown element so a renderer quirk in one element cannot swallow the
+    content that follows it.
+    """
+    if not segment.strip():
+        return []
+    elements: List[Dict[str, str]] = []
+    current: List[str] = []
+    in_code = False
+
+    def _flush() -> None:
+        text = "\n".join(current).strip("\n")
+        if text.strip():
+            elements.append({"tag": "markdown", "content": text})
+        current.clear()
+
+    for line in segment.splitlines():
+        stripped = line.strip()
+        is_fence = bool(
+            _FENCE_CLOSE_RE.match(stripped) if in_code else _FENCE_OPEN_RE.match(stripped)
+        )
+        if is_fence:
+            if not in_code:
+                _flush()
+            current.append(line)
+            in_code = not in_code
+            if not in_code:
+                _flush()
+            continue
+        current.append(line)
+    _flush()
+    return elements
+
+
+def build_table_card_payload(content: str) -> Optional[str]:
+    """Convert a markdown chunk containing pipe tables into a card JSON string.
+
+    Returns ``None`` when the content has no convertible table or exceeds the
+    Feishu card component limits — the caller then uses the historical post
+    path unchanged.
+    """
+    if not content or "|" not in content:
+        return None
+
+    lines = content.replace("\r\n", "\n").split("\n")
+    blocks = _extract_table_blocks(lines)
+    if not blocks:
+        return None
+    if len(blocks) > _MAX_TABLES_PER_CARD:
+        return None
+
+    table_payloads: List[Optional[Dict[str, Any]]] = [
+        _build_table_element(b) for b in blocks
+    ]
+    if any(t is None for t in table_payloads):
+        return None
+
+    elements: List[Dict[str, Any]] = []
+    cursor = 0
+    for block, table in zip(blocks, table_payloads):
+        prose = "\n".join(lines[cursor : block["start"]])
+        elements.extend(_prose_elements(prose))
+        assert table is not None
+        elements.append(table)
+        cursor = block["end"]
+    elements.extend(_prose_elements("\n".join(lines[cursor:])))
+
+    card = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {"elements": elements},
+    }
+    return json.dumps(card, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Markdown tables in outbound Feishu messages (agent replies and cron deliveries) render inside `post`-type `md` elements with **zero column-width control**: Feishu squeezes each column to content width, so long CJK/latin cells wrap into unreadable one-or-two-character vertical strips. This PR routes table-containing chunks through Feishu's interactive-card native `table` component (JSON 2.0), which supports real width control:

- **content-aware column widths** — narrow columns get an estimated fixed px width (CJK-aware via `unicodedata.east_asian_width`, clamped to the documented [80, 600] px range), wide columns stay `"auto"` to absorb the remaining card width
- `row_height: "auto"` so rows expand instead of clipping
- cells use `lark_md` data type, keeping bold/code/links rendering inside cells

Before / after (same table):

| | |
|---|---|
| post/md path | columns ~100px, text wrapping every few characters |
| card table component | columns sized to content, rows expand to fit |

## Changes

- **`plugins/platforms/feishu/feishu_table_card.py`** (new): pipe-table → JSON 2.0 card converter. Preserves prose/table interleaving order, isolates fenced code blocks into their own markdown elements, handles alignment syntax (`:--` / `:-:` / `--:`) and escaped pipes (`\|`). Returns `None` when content has no convertible table or exceeds Feishu card limits (>5 tables/card, >50 cols/table, >100 rows/table), so callers keep the existing post path unchanged.
- **`plugins/platforms/feishu/adapter.py`**:
  - `_build_outbound_payload` gains an `allow_card_table` flag; convertible tables return an `interactive` payload
  - `send()` walks a payload downgrade ladder **interactive → post → text** when the API rejects the format (raised exception or non-success `msg`), preserving the existing post→text fallback semantics
  - `edit_message()` passes `allow_card_table=False`: Feishu's message-update API cannot change a message's `msg_type`, so edits of existing text/post messages must not become cards

Out of scope deliberately: no config knob — tables are strictly more readable in card form and all failure paths degrade to today's behavior.

## Testing

- New module unit-tested: CJK/basic tables, alignment parsing, escaped pipes, fence isolation (pipe lines inside code fences are not converted), limit returns (`>5` tables → `None`, `>50` cols → `None`), ragged rows, table-at-message-start, lark_md markup preservation
- `pytest tests/gateway/test_feishu.py` — 76 passed (no behavior change for table-free traffic: prose still goes text/post as before)
- Live end-to-end on a self-hosted instance: interactive payloads accepted by the API (`code 0`), client renders column widths as estimated; verified the downgrade ladder by forcing rejections

Note: two pre-existing failures in `tests/gateway/test_feishu_approval_buttons.py` (unauthorized approval click accepted under policy=open) reproduce on clean `main` and are tracked in #96045 — unrelated to this change; this PR leaves that test file untouched.

Related: #96045
