### PR TITLE
fix(update): add idle timeout to npm ci so a stalled install fails over to npm install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6183,6 +6183,7 @@ def _run_with_idle_timeout(
     idle_timeout_seconds: int = 180,
     indent: str = "    ",
     env: dict[str, str] | None = None,
+    activity: str = "Build",
 ) -> subprocess.CompletedProcess:
     """Run a subprocess that streams output, with an idle-output timeout.
 
@@ -6265,7 +6266,7 @@ def _run_with_idle_timeout(
     combined = "".join(merged_chunks)
     if idle_killed:
         msg = (
-            f"\n  ⚠ Build produced no output for {idle_timeout_seconds}s — terminated.\n"
+            f"\n  ⚠ {activity} produced no output for {idle_timeout_seconds}s — terminated.\n"
             "    Common causes: out-of-memory on a low-RAM host (WSL/container),\n"
             "    a stuck Node process, or an antivirus scan stalling I/O.\n"
         )
@@ -6371,11 +6372,26 @@ def _run_npm_install_deterministic(
     run_env = _npm_lifecycle_env(env)
 
     def _run(cmd: list[str]) -> subprocess.CompletedProcess:
-        return _run_npm_watching_for_engine_failure(
+        if capture_output:
+            return _run_npm_watching_for_engine_failure(
+                cmd,
+                cwd=cwd,
+                env=run_env,
+                capture_output=True,
+            )
+        # Streaming callers (the `hermes update` ui-tui/web install) previously
+        # invoked the bare subprocess with no timeout, so a deadlocked `npm ci`
+        # (Issue #39267: reify stalls silently on some hosts) blocked `hermes
+        # update` forever instead of failing over to `npm install`. Reuse the
+        # same idle-output timeout the `npm run build` path already uses
+        # (#33788): a silent stall is terminated and `_attempt`'s ci->install
+        # fallback can finally fire.
+        return _run_with_idle_timeout(
             cmd,
             cwd=cwd,
             env=run_env,
-            capture_output=capture_output,
+            indent="",
+            activity="npm install",
         )
 
     def _attempt(npm_exe: str) -> subprocess.CompletedProcess:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1151,7 +1151,10 @@ class TestUpdateNodeDependencies:
         class _FakeProc:
             def __init__(self, cmd, **kwargs):
                 calls.append({"cmd": cmd, "kwargs": kwargs})
-                self.stderr = iter(stderr_lines)
+                # _run_with_idle_timeout streams stdout and merges stderr into
+                # it (stderr=STDOUT) via a reader thread, so the tee'd lines
+                # must be surfaced through ``stdout``, not ``stderr``.
+                self.stdout = iter(list(stderr_lines))
 
             def __enter__(self):
                 return self
@@ -1159,7 +1162,7 @@ class TestUpdateNodeDependencies:
             def __exit__(self, *exc_info):
                 return False
 
-            def wait(self):
+            def wait(self, timeout=None):
                 return returncode
 
         return _FakeProc
@@ -1372,3 +1375,100 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestNpmInstallStreamingTimeoutFallback:
+    """A deadlocked ``npm ci`` (Issue #39267) must not block ``hermes update``
+    forever. The streaming (``capture_output=False``) install path reuses the
+    idle-output timeout the ``npm run build`` path already uses (#33788), so a
+    silent reify stall is terminated and ``_attempt``'s ci->install fallback
+    can fire instead of hanging indefinitely.
+    """
+
+    @staticmethod
+    def _make_checkout(tmp_path):
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        (checkout / "package-lock.json").write_text("{}")
+        return checkout
+
+    def test_ci_stall_falls_back_to_install(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+
+        checkout = self._make_checkout(tmp_path)
+        calls = []
+
+        def fake_timeout(cmd, **kwargs):
+            calls.append(("idle", cmd, kwargs))
+            joined = " ".join(cmd)
+            if "ci" in joined:
+                # Simulate the idle-timeout kill: non-zero, no clean return, so
+                # _attempt must fall through to `npm install`.
+                return subprocess.CompletedProcess(cmd, 124, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(hm, "_run_with_idle_timeout", fake_timeout)
+
+        def _fail_if_capture_path(*a, **k):  # pragma: no cover
+            raise AssertionError("capture path used for streaming install")
+
+        monkeypatch.setattr(hm, "_run_npm_watching_for_engine_failure", _fail_if_capture_path)
+
+        result = hm._run_npm_install_deterministic(
+            "/usr/bin/npm", checkout, capture_output=False
+        )
+
+        assert result.returncode == 0
+        # Both ci and install went through the idle-timeout runner (not the
+        # plain capture/stream subprocess runner).
+        assert [c[0] for c in calls] == ["idle", "idle"]
+        assert "ci" in " ".join(calls[0][1])
+        assert "install" in " ".join(calls[1][1])
+
+    def test_ci_success_skips_install(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+
+        checkout = self._make_checkout(tmp_path)
+        calls = []
+
+        def fake_timeout(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(hm, "_run_with_idle_timeout", fake_timeout)
+
+        result = hm._run_npm_install_deterministic(
+            "/usr/bin/npm", checkout, capture_output=False
+        )
+
+        assert result.returncode == 0
+        # ci succeeded -> the install fallback is NOT attempted.
+        assert len(calls) == 1
+        assert "ci" in " ".join(calls[0])
+
+    def test_capture_path_keeps_engine_failure_runner(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+
+        checkout = self._make_checkout(tmp_path)
+        used = {"watching": False, "idle": False}
+
+        def fake_watching(cmd, **kwargs):
+            used["watching"] = True
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        def fake_idle(cmd, **kwargs):
+            used["idle"] = True
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(hm, "_run_with_idle_timeout", fake_idle)
+        monkeypatch.setattr(hm, "_run_npm_watching_for_engine_failure", fake_watching)
+
+        result = hm._run_npm_install_deterministic(
+            "/usr/bin/npm", checkout, capture_output=True
+        )
+
+        assert result.returncode == 0
+        # capture_output=True (desktop/web-silent callers) must keep the
+        # original engine-failure runner; the idle-timeout path is not used.
+        assert used["watching"] is True
+        assert used["idle"] is False


### PR DESCRIPTION
## Problem

`hermes update` can hang **forever** at `→ Updating Node.js dependencies...` when `npm ci` deadlocks.

`_run_npm_install_deterministic` runs `npm ci` (then falls back to `npm install` only when `npm ci` **returns non-zero**). The install subprocess had **no timeout**, so a silent reify deadlock — `npm ci` neither succeeds nor returns cleanly — never triggers the fallback. The update blocks indefinitely.

This is the same symptom as **#39267** ("glacial update with high cpu usage"): stuck at Node.js deps for hours, high CPU + high read I/O, `node_modules` frozen, no progress. I reproduced it on WSL2 (Ubuntu 20.04, Hermes v0.20.5): `npm ci` sat at `Updating Node.js dependencies...`, all workspace `node_modules` frozen, a fresh `npm --version` even blocks on the cache lock; killing the hung `npm ci` and running `npm install` by hand completed in seconds.

## Fix

Reuse the exact idle-output timeout helper the `npm run build` path already uses (**#33788**) for the streaming (`capture_output=False`) install path:

- If `npm ci` produces no output for 180s (the signature of a stalled/deadlocked reify), terminate it and let `_attempt`'s ci→`npm install` fallback fire.
- `capture_output=True` callers (desktop deps, web-silent deps) keep the original `_run_npm_watching_for_engine_failure` runner — no behaviour change for them.
- `_run_with_idle_timeout` gains a keyword-only `activity` label so the terminate message reads accurately (e.g. "npm install produced no output…") while defaulting to "Build" for existing callers.

This is a defensiveness fix: it makes a stalled install *fail over* to the proven-working `npm install` instead of blocking forever, regardless of *why* `npm ci` stalls.

## Tests

Added `TestNpmInstallStreamingTimeoutFallback` (3 tests):
- a stalled `npm ci` (non-zero) falls through to `npm install`
- a successful `npm ci` skips the fallback
- the `capture_output=True` path keeps the original engine-failure runner

Updated the existing node-deps test fixture (`_FakeProc`) to expose `stdout` + `wait(timeout=…)`, matching the streaming idle-timeout runner's contract.

`test_cmd_update.py` node-deps area + new tests: **13 passed**. (A handful of unrelated `cmd_update` full-path tests — migration / skill-sync / branch-flag — fail on the base `github/main` too, in an isolated checkout that lacks a live gateway runtime; not related to this change.)

Closes #39267.
