### PR TITLE
feat(plugins): let a pre_llm_call hook route a turn to another model

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1514,7 +1514,28 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
-    if not agent._fallback_activated:
+    # ── Per-turn routing-override revert (dedicated, scoped) ──
+    # A routed turn (see agent/routing_override.py) swaps model/provider via a
+    # DEDICATED flag, keeping _primary_runtime == the routed runtime during the
+    # turn so in-turn recovery paths do not jump tiers. This block reverts it
+    # FIRST — before the _fallback_activated gate, the rate-limit cooldown gate,
+    # and the reset-aware pool gate below — so a routed turn ALWAYS reverts to the
+    # configured primary next turn. It must not be gated on _fallback_activated
+    # (the override never sets it) or on any cooldown a 429 from the routed model
+    # may have armed; either would leak the routed model past its turn.
+    # Falls through to the shared rebuild body below.
+    _override_revert = bool(getattr(agent, "_routing_override_active", False))
+    if _override_revert:
+        _saved = getattr(agent, "_routing_override_saved_primary", None)
+        if isinstance(_saved, dict):
+            agent._primary_runtime = _saved
+        # Clear the scoping state so this runs exactly once.
+        agent._routing_override_active = False
+        agent._routing_override_saved_primary = None
+        # Do NOT return here — proceed to rebuild the runtime from the restored
+        # _primary_runtime via the shared body below.
+
+    if not _override_revert and not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was
         # called but returned False (chain exhausted or provider not
@@ -1525,7 +1546,7 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
+    if not _override_revert and getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
     # ── Reset-aware gate ──
@@ -1584,7 +1605,7 @@ def restore_primary_runtime(agent) -> bool:
                 prefetched_primary_pool = None
                 pool = None
         next_at = getattr(pool, "next_available_at", lambda: None)()
-        if next_at is not None and next_at > time.time():
+        if not _override_revert and next_at is not None and next_at > time.time():
             if not getattr(agent, "_restore_wait_logged", False):
                 agent._restore_wait_logged = True
                 logger.info(

--- a/agent/routing_override.py
+++ b/agent/routing_override.py
@@ -1,0 +1,214 @@
+"""Per-turn routing override: actuate a plugin's routing decision.
+
+The ``pre_llm_call`` plugin hook can inject context into a turn, but it cannot
+change *which model answers it* — by the time the hook fires, the turn's model
+and client are already fixed (``restore_primary_runtime`` has run at the top of
+the loop). A plugin can therefore decide "this turn is cheap" and have no way to
+act on it.
+
+This module is the small interface extension that closes that gap. A
+``pre_llm_call`` hook result may carry a ``route`` key::
+
+    {"context": "...optional injected text...",
+     "route": {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}}
+
+``model`` is required. ``provider`` and the optional ``base_url`` / ``api_key`` /
+``api_mode`` fields are forwarded to the agent's existing ``switch_model``.
+``turn_context`` extracts the first well-formed override and applies it right
+after the hook fires, before the turn's first API call is assembled.
+
+Nothing here decides *when* to route. That policy belongs entirely to a plugin;
+core only provides the actuation path.
+
+── Turn scoping (the load-bearing detail) ──
+A proactive route is a PER-TURN decision, exactly like reactive fallback — it
+must not pin the session to the routed model. We reuse the agent's existing,
+tested ``switch_model`` (atomic client rebuild with rollback), which persists the
+swap into ``_primary_runtime``. We then scope it with a DEDICATED flag rather
+than by overloading reactive-fallback state:
+
+  1. Stash the pre-swap ``_primary_runtime`` in ``_routing_override_saved_primary``.
+  2. Set ``_routing_override_active = True``.
+  3. Leave ``_primary_runtime`` pointing at the ROUTED runtime for the turn, and
+     do not touch ``_fallback_activated``.
+
+``restore_primary_runtime`` reverts the swap at the top of the next turn, in a
+dedicated block that runs BEFORE the ``_fallback_activated`` and rate-limit
+cooldown gates, so a routed turn always reverts regardless of cooldown state.
+
+The dedicated flag is not incidental — reusing the reactive-fallback fields for
+scoping produced three distinct defects during review:
+
+  - Scoping via ``_rate_limited_until`` / ``_fallback_activated`` let a routed
+    turn LEAK past its turn whenever a cooldown gate skipped restoration.
+  - Pointing ``_primary_runtime`` at the pre-route model made in-turn transient
+    recovery rebuild the *pre-route* client mid-routed-turn, jumping tiers.
+  - Pre-arming ``_fallback_activated`` corrupted reactive cooldown accounting, so
+    a 429 from the routed model armed no cooldown.
+
+Keeping ``_primary_runtime`` == the routed runtime and using a dedicated flag
+fixes all three: reactive fallback continues to work normally UNDERNEATH a routed
+turn, treating the routed runtime as its "primary".
+
+── Known limitation: the system prompt's identity line ──
+The cached system prompt (including its ``Model:`` / ``Provider:`` identity
+lines) is assembled earlier in ``build_turn_context`` than the ``pre_llm_call``
+hook fires, and the turn's effective prompt is captured into a local before the
+hook runs. A routed turn therefore ships the *pre-route* identity line, so the
+routed model will misreport which model it is if asked during that turn. Reactive
+failover solves the equivalent problem with ``rewrite_prompt_model_identity`` plus
+``_sync_failover_system_message``, which run inside the call-block retry loop.
+Wiring the same reconciliation into the proactive path means reaching into the
+turn's prompt/compression bookkeeping, which is deliberately out of scope for this
+interface addition. Everything else about the turn — client, credentials, endpoint,
+wire format, reasoning config — is the routed model's.
+
+── Fail-safe ──
+Any error (malformed override, ``switch_model`` raising on a bad key or network
+fault) leaves the agent untouched and returns ``False``. A routing miss must
+degrade to "answer on the configured primary", never break the turn.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Optional endpoint/credential fields forwarded into switch_model alongside
+# model/provider.
+_PASSTHROUGH_FIELDS = ("base_url", "api_key", "api_mode")
+
+
+def extract_routing_override(results: Iterable[Any]) -> Optional[dict]:
+    """Return the first well-formed ``route`` override from hook results, or None.
+
+    A well-formed override is a dict with a non-empty ``model``. First match wins
+    (deterministic, and consistent with how ``pre_llm_call`` context parts are
+    consumed in plugin registration order).
+    """
+    if not results:
+        return None
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        route = r.get("route")
+        if isinstance(route, dict) and str(route.get("model") or "").strip():
+            return route
+    return None
+
+
+def apply_routing_override(agent: Any, override: Optional[dict]) -> bool:
+    """Actuate a routing override for THIS turn. Return True iff a swap happened.
+
+    Turn-scoped and fail-safe (see the module docstring). No-op (returns False)
+    when the override is empty or already matches the live model/provider.
+    """
+    if not override or not isinstance(override, dict):
+        return False
+
+    target_model = str(override.get("model") or "").strip()
+    if not target_model:
+        return False
+    target_provider = str(override.get("provider") or "").strip()
+
+    cur_model = str(getattr(agent, "model", "") or "").strip()
+    cur_provider = str(getattr(agent, "provider", "") or "").strip()
+    # Avoid churn: nothing to do if we are already on the target.
+    if target_model == cur_model and (
+        not target_provider or target_provider == cur_provider
+    ):
+        return False
+
+    # Stash the configured-primary runtime so restore_primary_runtime can revert
+    # the swap next turn. switch_model overwrites _primary_runtime with the routed
+    # runtime — we deliberately KEEP that (so in-turn recovery paths stay on the
+    # routed model) and use the stash plus a dedicated flag for the revert, NOT
+    # the reactive-fallback state.
+    primary_snapshot = getattr(agent, "_primary_runtime", None)
+
+    kwargs = {k: override[k] for k in _PASSTHROUGH_FIELDS if override.get(k)}
+
+    # When the route switches provider but carries no explicit base_url, resolve
+    # the new provider's canonical endpoint up front.
+    #
+    # ``switch_model`` deliberately REFUSES a cross-provider switch that carries
+    # no resolved base_url — it raises rather than keep the previous provider's
+    # endpoint (agent/agent_runtime_helpers.py, the ``elif old_norm_provider !=
+    # new_norm_provider: raise ValueError`` branch; see #47828). Its existing
+    # callers go through ``model_switch.switch_model()``, which resolves the URL
+    # first. A plugin route does not, and the natural override a plugin writes is
+    # ``{"model": ..., "provider": ...}`` with no base_url. Without this
+    # pre-resolution such a route would never take effect: the ValueError is
+    # caught by the fail-safe below and the turn silently stays on the configured
+    # primary.
+    #
+    # Fail-safe: a resolver error must not break the turn. We fall through and
+    # let switch_model decide — a same-provider route still switches; a
+    # cross-provider one is refused and the turn keeps its configured primary.
+    if (
+        "base_url" not in kwargs
+        and target_provider
+        and target_provider.strip().lower() != cur_provider.strip().lower()
+    ):
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+
+            _client, _ = resolve_provider_client(target_provider, model=target_model)
+            if _client is not None:
+                _resolved_base = str(getattr(_client, "base_url", "") or "").strip()
+                if _resolved_base:
+                    kwargs["base_url"] = _resolved_base
+                if "api_key" not in kwargs:
+                    _resolved_key = getattr(_client, "api_key", None)
+                    if _resolved_key:
+                        kwargs["api_key"] = _resolved_key
+        except Exception:  # noqa: BLE001 — never break the turn on a resolve miss
+            logger.debug(
+                "routing override: could not pre-resolve endpoint for %s; "
+                "switch_model will fall back to provider defaults",
+                target_provider,
+                exc_info=True,
+            )
+
+    try:
+        agent.switch_model(target_model, target_provider, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — a routing miss must never break the turn
+        logger.warning(
+            "routing override: switch to %s/%s failed (%s); staying on %s/%s",
+            target_model,
+            target_provider or "?",
+            exc,
+            cur_model,
+            cur_provider,
+        )
+        return False
+
+    # Mark the override turn-scoped with a DEDICATED flag. Do NOT restore the
+    # pre-route snapshot into _primary_runtime (keep it == the routed runtime) and
+    # do NOT arm _fallback_activated (that would corrupt reactive cooldown
+    # accounting).
+    try:
+        # Only the FIRST apply of a turn snapshots. A second apply without an
+        # intervening restore would otherwise stash the first route's own runtime
+        # as the "pristine" pre-turn state, so the route would survive the revert.
+        # The single in-tree call site applies once per turn, but the snapshot is
+        # the whole safety property.
+        #
+        # ``is not True`` deliberately, not falsiness: the flag is set to exactly
+        # True here and cleared to False by the revert, so anything else means "no
+        # snapshot has been taken" rather than "a routed turn is live".
+        if getattr(agent, "_routing_override_active", False) is not True:
+            agent._routing_override_saved_primary = primary_snapshot
+        agent._routing_override_active = True
+    except Exception:  # noqa: BLE001 — best-effort scoping; swap already applied
+        logger.debug("routing override: could not scope override to turn", exc_info=True)
+
+    logger.info(
+        "routing override: routed this turn to %s/%s (was %s/%s)",
+        target_model,
+        target_provider or "?",
+        cur_model,
+        cur_provider,
+    )
+    return True

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1322,6 +1322,24 @@ def build_turn_context(
             _ctx_parts.append(_piece)
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+
+        # Routing override: a pre_llm_call result may carry a ``route`` dict that
+        # proactively swaps model/provider for THIS turn, before the first API
+        # call is assembled. The hook can already inject context; this lets it
+        # also act on a routing decision. Turn-scoped and fail-safe — see
+        # agent/routing_override.py. Core provides only the actuation path; the
+        # policy that produces the decision lives entirely in the plugin.
+        try:
+            from agent.routing_override import (
+                apply_routing_override,
+                extract_routing_override,
+            )
+
+            _override = extract_routing_override(_pre_results)
+            if _override:
+                apply_routing_override(agent, _override)
+        except Exception as _route_exc:
+            logger.warning("pre_llm_call routing override failed: %s", _route_exc)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 

--- a/tests/agent/test_routing_override.py
+++ b/tests/agent/test_routing_override.py
@@ -1,0 +1,307 @@
+"""Unit tests for the per-turn routing-override interface extension.
+
+A ``pre_llm_call`` hook result may carry a
+``{"route": {"model": ..., "provider": ...}}`` override that the runtime applies
+BEFORE the turn's client is built, turning a plugin routing DECISION into an
+actual model swap.
+
+Design (see agent/routing_override.py):
+  - ``extract_routing_override(results)`` pulls the first well-formed override
+    out of the list of pre_llm_call hook results.
+  - ``apply_routing_override(agent, override)`` actuates the swap by delegating
+    to the agent's existing, tested ``switch_model`` machinery, then makes the
+    swap TURN-SCOPED via a dedicated flag plus a snapshot of the pre-swap
+    ``_primary_runtime`` (reverted next turn by ``restore_primary_runtime``).
+    Reactive-fallback state is deliberately left untouched. Fail-safe: any error
+    leaves the agent untouched.
+"""
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.routing_override import (
+    apply_routing_override,
+    extract_routing_override,
+)
+
+
+def _stub_resolver(monkeypatch, fn):
+    """Inject a fake ``agent.auxiliary_client`` so the lazy
+    ``from agent.auxiliary_client import resolve_provider_client`` in
+    apply_routing_override picks up ``fn`` without importing the heavy real
+    module (and its runtime deps) at unit-test time."""
+    mod = types.ModuleType("agent.auxiliary_client")
+    mod.resolve_provider_client = fn
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", mod)
+
+
+@pytest.fixture(autouse=True)
+def _inert_resolver(monkeypatch):
+    """Default every test to a resolver that resolves nothing, so a cross-provider
+    route never reaches the real provider registry. Tests that care about
+    resolution install their own stub over this one."""
+    _stub_resolver(monkeypatch, lambda *a, **k: (None, None))
+
+
+# ------------------------------------------------ extract_routing_override ----
+
+def test_extract_none_when_no_results():
+    assert extract_routing_override([]) is None
+
+
+def test_extract_none_when_only_context():
+    results = [{"context": "[Current model: x]"}, "some string"]
+    assert extract_routing_override(results) is None
+
+
+def test_extract_pulls_route_dict():
+    results = [{"context": "line", "route": {"model": "deepseek/deepseek-v3.2",
+                                             "provider": "openrouter"}}]
+    ov = extract_routing_override(results)
+    assert ov == {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+
+
+def test_extract_requires_model_key():
+    # A route dict with no model is not actionable.
+    assert extract_routing_override([{"route": {"provider": "openrouter"}}]) is None
+
+
+def test_extract_first_wins():
+    results = [
+        {"route": {"model": "a", "provider": "p1"}},
+        {"route": {"model": "b", "provider": "p2"}},
+    ]
+    assert extract_routing_override(results)["model"] == "a"
+
+
+# ------------------------------------------------- apply_routing_override -----
+
+def _fake_agent():
+    agent = MagicMock()
+    agent.model = "claude-sonnet-5"
+    agent.provider = "anthropic"
+    agent._primary_runtime = {"model": "claude-sonnet-5", "provider": "anthropic"}
+    agent._fallback_activated = False
+    # Set explicitly: a MagicMock would otherwise auto-create these on read and
+    # make "was it scoped?" assertions vacuously truthy.
+    agent._routing_override_active = False
+    agent._routing_override_saved_primary = None
+
+    # switch_model mutates model/provider like the real one, and (like the real
+    # one) persists _primary_runtime — we assert the override code re-scopes.
+    def _switch(new_model, new_provider, **kw):
+        agent.model = new_model
+        agent.provider = new_provider
+        agent._primary_runtime = {"model": new_model, "provider": new_provider}
+        return {"ok": True}
+
+    agent.switch_model.side_effect = _switch
+    return agent
+
+
+def test_apply_actuates_the_swap():
+    agent = _fake_agent()
+    ok = apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                        "provider": "openrouter"})
+    assert ok is True
+    assert agent.model == "deepseek/deepseek-v3.2"
+    assert agent.provider == "openrouter"
+    agent.switch_model.assert_called_once()
+
+
+def test_apply_is_turn_scoped_with_dedicated_flag():
+    """Scoping uses a DEDICATED flag, NOT reactive-fallback state.
+
+    _primary_runtime stays == the routed runtime (so in-turn recovery paths do
+    not jump tiers), the pre-route snapshot is stashed for the revert,
+    _routing_override_active is set, and _fallback_activated is left untouched
+    (arming it would corrupt reactive cooldown accounting).
+    """
+    agent = _fake_agent()
+    apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                   "provider": "openrouter"})
+    # _primary_runtime is the ROUTED runtime during the routed turn.
+    assert agent._primary_runtime == {"model": "deepseek/deepseek-v3.2",
+                                      "provider": "openrouter"}
+    # The pre-route snapshot is stashed for restore_primary_runtime to revert.
+    assert agent._routing_override_saved_primary == {"model": "claude-sonnet-5",
+                                                     "provider": "anthropic"}
+    assert agent._routing_override_active is True
+    # Reactive-fallback state is NOT touched.
+    assert agent._fallback_activated is False
+
+
+def test_second_apply_in_one_turn_keeps_the_pristine_snapshot():
+    """A second apply before any revert must not overwrite the snapshot with the
+    first route's own runtime — that would make the revert a no-op."""
+    agent = _fake_agent()
+    apply_routing_override(agent, {"model": "a", "provider": "p1"})
+    apply_routing_override(agent, {"model": "b", "provider": "p2"})
+    assert agent._routing_override_saved_primary == {"model": "claude-sonnet-5",
+                                                     "provider": "anthropic"}
+
+
+def test_apply_noop_when_target_equals_current():
+    """No swap when the override already matches the live model (avoid churn)."""
+    agent = _fake_agent()
+    ok = apply_routing_override(agent, {"model": "claude-sonnet-5",
+                                        "provider": "anthropic"})
+    assert ok is False
+    agent.switch_model.assert_not_called()
+    # _fallback_activated untouched — nothing was swapped.
+    assert agent._fallback_activated is False
+
+
+def test_apply_fail_safe_on_switch_error():
+    """If switch_model raises, the agent is left untouched and we return False."""
+    agent = _fake_agent()
+    agent.switch_model.side_effect = RuntimeError("bad key")
+    ok = apply_routing_override(agent, {"model": "deepseek/deepseek-v3.2",
+                                        "provider": "openrouter"})
+    assert ok is False
+    # Original model/provider preserved (switch_model itself rolls back; the
+    # applier must not leave a half-state or re-raise into the turn loop).
+    assert agent.model == "claude-sonnet-5"
+    assert getattr(agent, "_routing_override_active", False) is False
+
+
+def test_apply_ignores_empty_override():
+    agent = _fake_agent()
+    assert apply_routing_override(agent, {}) is False
+    assert apply_routing_override(agent, None) is False
+    agent.switch_model.assert_not_called()
+
+
+# ---------------- base_url resolution on cross-provider routes ----------------
+#
+# A plugin typically emits {"model": ..., "provider": ...} with NO base_url.
+# switch_model REFUSES a cross-provider switch with no resolved base_url — it
+# raises rather than keep the previous provider's endpoint (#47828). Its normal
+# callers resolve the URL before calling it; a plugin route does not. So without
+# pre-resolution the route never takes effect at all: the ValueError is caught by
+# apply_routing_override's fail-safe and the turn stays on the configured
+# primary. apply_routing_override must therefore resolve the new provider's
+# canonical endpoint up front when the override omits it AND the provider
+# changes. test_real_switch_model_refuses_cross_provider_without_base_url below
+# pins that upstream behavior against the real function.
+
+
+class _FakeClient:
+    def __init__(self, base_url, api_key):
+        self.base_url = base_url
+        self.api_key = api_key
+
+
+def test_apply_resolves_base_url_when_provider_changes(monkeypatch):
+    agent = _fake_agent()  # primary: anthropic
+    seen = {}
+
+    def _resolve(provider, model=None, **kw):
+        seen["provider"] = provider
+        seen["model"] = model
+        return _FakeClient("https://openrouter.ai/api/v1/", "sk-or-test"), model
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+    )
+    assert ok is True
+    assert seen["provider"] == "openrouter"
+    _, kwargs = agent.switch_model.call_args
+    # The resolved endpoint (and key) must be forwarded so switch_model does NOT
+    # inherit the Anthropic primary's base_url.
+    assert kwargs.get("base_url") == "https://openrouter.ai/api/v1/"
+    assert kwargs.get("api_key") == "sk-or-test"
+
+
+def test_apply_does_not_resolve_when_provider_unchanged(monkeypatch):
+    """Same-provider route (e.g. anthropic sonnet → anthropic haiku) must not
+    inject base_url — switch_model correctly keeps the same-provider base_url
+    and re-derives api_mode. Forcing a resolve here is needless and risky."""
+    agent = _fake_agent()  # primary: anthropic
+
+    def _resolve(*a, **k):
+        raise AssertionError("resolve_provider_client should not be called")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "claude-haiku-4-5-20251001", "provider": "anthropic"}
+    )
+    assert ok is True
+    _, kwargs = agent.switch_model.call_args
+    assert "base_url" not in kwargs
+
+
+def test_apply_preserves_explicit_base_url(monkeypatch):
+    """An override that DOES carry base_url wins — no resolve, no overwrite."""
+    agent = _fake_agent()
+
+    def _resolve(*a, **k):
+        raise AssertionError("resolve_provider_client should not be called")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    apply_routing_override(
+        agent,
+        {
+            "model": "deepseek/deepseek-v3.2",
+            "provider": "openrouter",
+            "base_url": "https://custom.example/v1",
+        },
+    )
+    _, kwargs = agent.switch_model.call_args
+    assert kwargs["base_url"] == "https://custom.example/v1"
+
+
+def test_apply_resolve_failure_is_fail_safe(monkeypatch):
+    """A resolver error is swallowed, not propagated.
+
+    apply_routing_override falls through to switch_model without a base_url and
+    lets it decide. (With the real switch_model a cross-provider call in that
+    state raises, and the except below turns it into "stay on the configured
+    primary" — never an exception out of the turn.)"""
+    agent = _fake_agent()
+
+    def _resolve(*a, **k):
+        raise RuntimeError("registry down")
+
+    _stub_resolver(monkeypatch, _resolve)
+
+    ok = apply_routing_override(
+        agent, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+    )
+    assert ok is True
+    agent.switch_model.assert_called_once()
+
+
+# ---------------- premise check against the real switch_model ----------------
+
+
+def test_real_switch_model_refuses_cross_provider_without_base_url():
+    """Pin the upstream behavior the pre-resolution above exists for.
+
+    Uses the REAL ``switch_model``, not a fake: a provider change with no
+    base_url must raise, and must roll the agent back untouched.
+    """
+    from agent import agent_runtime_helpers
+
+    class _BareAgent:
+        def _read_reasoning_echo_from_config(self):
+            return False
+
+    a = _BareAgent()
+    a.model = "gpt-5"
+    a.provider = "openai"
+    a.base_url = "https://api.openai.com/v1"
+
+    with pytest.raises(ValueError, match="no base_url resolved"):
+        agent_runtime_helpers.switch_model(a, "deepseek/deepseek-v3.2", "openrouter")
+
+    # Atomic rollback: nothing about the agent changed.
+    assert a.model == "gpt-5"
+    assert a.provider == "openai"
+    assert a.base_url == "https://api.openai.com/v1"

--- a/tests/agent/test_routing_override_revert.py
+++ b/tests/agent/test_routing_override_revert.py
@@ -1,0 +1,188 @@
+"""Regression tests driving the REAL ``restore_primary_runtime`` after a routing
+override — the error-adjacent paths a fake-agent unit test cannot reach.
+
+Covers the three defects found while reviewing an earlier version of this
+interface, which scoped the override by overloading reactive-fallback state:
+
+  1. LEAK — the routed model must not survive past its turn when the primary is
+     in rate-limit cooldown (restore_primary_runtime's cooldown early-return
+     gate must NOT skip an override revert).
+  2. TIER JUMP — during the routed turn, _primary_runtime must point at the
+     ROUTED runtime, so in-turn transient-transport recovery rebuilds the routed
+     client, not the pre-route one.
+  3. COOLDOWN ACCOUNTING — the override must NOT pre-arm _fallback_activated, so
+     a 429 from the routed model arms its own cooldown correctly.
+
+These drive the real ``restore_primary_runtime`` (not a fake) so they prove the
+revert actually happens, not merely that preconditions were set.
+"""
+import time
+
+from agent.agent_runtime_helpers import restore_primary_runtime
+from agent.routing_override import apply_routing_override
+
+
+class _Comp:
+    model = "x"
+    base_url = ""
+    api_key = ""
+    provider = "openai"
+    context_length = 200000
+    api_mode = ""
+    threshold_tokens = 0
+
+    def update_model(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _primary_runtime():
+    return {
+        "model": "gpt-5", "provider": "openai", "base_url": "https://api.openai.com/v1",
+        "api_mode": "chat_completions", "api_key": "pk", "client_kwargs": {"api_key": "pk"},
+        "use_prompt_caching": True, "use_native_cache_layout": False,
+        "compressor_model": "gpt-5", "compressor_base_url": "https://api.openai.com/v1",
+        "compressor_api_key": "pk", "compressor_provider": "openai",
+        "compressor_context_length": 200000, "compressor_api_mode": "chat_completions",
+        "compressor_threshold_tokens": 0,
+    }
+
+
+def _make_agent():
+    class A:
+        pass
+
+    a = A()
+    a.model = "gpt-5"
+    a.provider = "openai"
+    a.requested_provider = "openai"
+    a.base_url = "https://api.openai.com/v1"
+    a.api_mode = "chat_completions"
+    a.api_key = "pk"
+    a.client = "PRIMARY"
+    a._anthropic_client = None
+    a._is_anthropic_oauth = False
+    a._client_kwargs = {"api_key": "pk"}
+    a._use_prompt_caching = True
+    a._use_native_cache_layout = False
+    a._transport_cache = {}
+    a._fallback_activated = False
+    a._fallback_index = 0
+    a._fallback_chain = []
+    a._rate_limited_until = 0
+    a._rate_limit_backoff_count = 0
+    a._credential_pool = None
+    a._credential_pool_entry_id = None
+    a.reasoning_config = {}
+    a.context_compressor = _Comp()
+    a._primary_runtime = _primary_runtime()
+
+    def switch(nm, np, **kw):
+        a.model = nm
+        a.provider = np
+        a.api_mode = "chat_completions"
+        a.base_url = "https://routed.example/v1"
+        a.api_key = "ck"
+        a.client = "ROUTED"
+        a._client_kwargs = {"api_key": "ck", "base_url": a.base_url}
+        a._use_prompt_caching = False
+        a._use_native_cache_layout = False
+        # switch_model persists the routed runtime into _primary_runtime.
+        a._primary_runtime = {
+            "model": nm, "provider": np, "base_url": a.base_url, "api_mode": a.api_mode,
+            "api_key": "ck", "client_kwargs": dict(a._client_kwargs),
+            "use_prompt_caching": False, "use_native_cache_layout": False,
+            "compressor_model": nm, "compressor_base_url": a.base_url,
+            "compressor_api_key": "ck", "compressor_provider": np,
+            "compressor_context_length": 128000, "compressor_api_mode": a.api_mode,
+            "compressor_threshold_tokens": 0,
+        }
+        a._fallback_activated = False
+        a._fallback_index = 0
+
+    a.switch_model = switch
+    a._create_openai_client = lambda kw, reason="", shared=True: "REBUILT"
+    return a
+
+
+# ───────────────────────────── 1: the leak repro ─────────────────────────────
+
+def test_routed_model_reverts_even_when_primary_in_cooldown():
+    """A routed turn must revert to the configured primary next turn even if a
+    rate-limit cooldown is armed."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    assert a.model == "deepseek/deepseek-v3.2"
+
+    # The routed model 429'd this turn, arming a primary cooldown:
+    a._rate_limited_until = time.monotonic() + 60
+
+    # Next turn's top-of-loop restore MUST revert despite the cooldown gate.
+    restore_primary_runtime(a)
+    assert a.model == "gpt-5", f"LEAK: next turn answered by {a.model}"
+    assert a.provider == "openai"
+    # _primary_runtime is back to the configured primary, flag cleared.
+    assert a._primary_runtime["model"] == "gpt-5"
+    assert getattr(a, "_routing_override_active", False) is False
+
+
+def test_revert_happens_with_no_cooldown_too():
+    """Baseline: revert also works on the ordinary (no-cooldown) path."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    restore_primary_runtime(a)
+    assert a.model == "gpt-5"
+    assert getattr(a, "_routing_override_active", False) is False
+
+
+def test_unrouted_turn_is_unaffected():
+    """No override, no fallback → restore_primary_runtime keeps its existing
+    early-return behavior (reset the chain index, return False)."""
+    a = _make_agent()
+    a._fallback_index = 3
+    assert restore_primary_runtime(a) is False
+    assert a._fallback_index == 0
+    assert a.model == "gpt-5"
+
+
+# ───────────────── 2: _primary_runtime == routed runtime in-turn ─────────────
+
+def test_primary_runtime_points_at_routed_model_during_the_turn():
+    """During the routed turn, _primary_runtime must be the ROUTED runtime so
+    in-turn transient-transport recovery (which rebuilds from _primary_runtime)
+    stays on the routed model and does not jump tiers."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    # Mid-turn, before the next-turn restore:
+    assert a._primary_runtime["model"] == "deepseek/deepseek-v3.2"
+    assert a._primary_runtime["provider"] == "openrouter"
+    # The pre-route snapshot is stashed separately for the revert.
+    assert a._routing_override_saved_primary["model"] == "gpt-5"
+
+
+# ───────────────── 3: _fallback_activated is NOT pre-armed ───────────────────
+
+def test_override_does_not_prearm_fallback_activated():
+    """The override must not set _fallback_activated — that flag carries reactive
+    cooldown-accounting semantics in chat_completion_helpers."""
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    assert a._fallback_activated is False
+    assert a._routing_override_active is True
+
+
+def test_reactive_fallback_engages_under_a_routed_turn():
+    """Reactive fallback must still work UNDERNEATH a routed turn: if the routed
+    model fails mid-turn, try_activate_fallback treats it as the current
+    'primary' (since _primary_runtime == routed and _fallback_activated is False)
+    and arms the cooldown correctly."""
+    from agent.chat_completion_helpers import try_activate_fallback
+    from agent.error_classifier import FailoverReason
+
+    a = _make_agent()
+    apply_routing_override(a, {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"})
+    # Empty chain → exhausted, but the rate_limit branch must still arm cooldown
+    # because _fallback_activated is False and the current provider matches the
+    # (routed) _primary_runtime provider.
+    before = getattr(a, "_rate_limited_until", 0)
+    try_activate_fallback(a, reason=FailoverReason.rate_limit)
+    assert a._rate_limited_until > before, "a 429 on the routed model must arm a cooldown"

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -927,7 +927,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection), [routing override](#per-turn-routing-override) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | `pre_api_request` | Before each raw provider API request (several per turn when the model calls tools) | `session_id: str, model: str, provider: str, base_url: str, api_mode: str, api_call_count: int, message_count: int, tool_count: int, approx_input_tokens: int, max_tokens: int, request: dict` | ignored |
 | `post_api_request` | After each raw provider API request returns | `pre_api_request` fields plus `api_duration: float, finish_reason: str, response_model: str \| None, usage: dict, response: dict, assistant_content_chars: int, assistant_tool_call_count: int` | ignored |
@@ -941,7 +941,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation and optionally [override the model for the turn](#per-turn-routing-override), and `pre_tool_call`, which can return a block/approve directive.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
@@ -1059,6 +1059,88 @@ def register(ctx):
 #### Multiple plugins returning context
 
 When multiple plugins return context from `pre_llm_call`, their outputs are joined with double newlines and appended to the user message together. The order follows plugin discovery order (alphabetical by plugin directory name).
+
+#### Per-turn routing override
+
+Context injection tells the model more. A **routing override** changes *which model answers the turn*. Alongside `"context"`, a `pre_llm_call` result may carry a `"route"` key:
+
+```python
+def route_turn(user_message, model, **kwargs):
+    if is_mechanical(user_message):
+        return {"route": {"model": "deepseek/deepseek-v3.2",
+                          "provider": "openrouter"}}
+    return None  # no route -> the configured model answers
+
+def register(ctx):
+    ctx.register_hook("pre_llm_call", route_turn)
+```
+
+| Key | Required | Meaning |
+| --- | --- | --- |
+| `model` | yes | Model slug to run this turn |
+| `provider` | no | Provider to run it on; omit to stay on the current provider |
+| `base_url` | no | Explicit endpoint. When omitted and the route changes provider, the new provider's canonical endpoint is resolved for you |
+| `api_key` | no | Explicit credential |
+| `api_mode` | no | Wire format override; normally derived from the provider |
+
+Semantics:
+
+- **Turn-scoped.** The swap is reverted at the top of the next turn, exactly like reactive fallback. A routing override can never pin the session to another model.
+- **First match wins.** If several plugins return a `route`, the first well-formed one (in plugin discovery order) is used. Context from *all* plugins is still injected as usual.
+- **Fail-safe.** A malformed override, an unknown model, or a failed client rebuild leaves the agent on its configured model and logs a warning. A routing miss never breaks the turn.
+- **Reactive fallback still applies.** If the routed model errors mid-turn, the normal failover chain engages underneath it.
+- **Policy lives in the plugin.** Core provides only the actuation path; deciding *when* to route is entirely the plugin's business.
+
+Returning both keys at once is valid:
+
+```python
+return {"context": "[routing: mechanical task]",
+        "route": {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}}
+```
+
+##### Example: an opt-in cheap-turn router
+
+A complete plugin. Drop it in `~/.hermes/plugins/cheap-turn-router/`. It is
+inert until you install it, and it ships no defaults into core.
+
+`plugin.yaml`:
+
+```yaml
+name: cheap-turn-router
+version: 0.1.0
+description: Route short mechanical turns to a cheaper model.
+```
+
+`__init__.py`:
+
+```python
+import re
+
+# Keep the policy in the plugin — this is the part core deliberately does not own.
+CHEAP = {"model": "deepseek/deepseek-v3.2", "provider": "openrouter"}
+MECHANICAL = re.compile(
+    r"^\s*(ls|cat|grep|status|what time|rename|list|show me)\b", re.I
+)
+
+
+def route_turn(user_message="", **kwargs):
+    text = (user_message or "").strip()
+    if len(text) < 200 and MECHANICAL.match(text):
+        return {"route": dict(CHEAP)}
+    return None  # everything else answers on the configured model
+
+
+def register(ctx):
+    ctx.register_hook("pre_llm_call", route_turn)
+```
+
+Classification here is a deliberately dumb regex. Swap in whatever you like — a
+local classifier, a token-count threshold, a per-user policy — without touching
+core.
+
+:::note Identity line
+The cached system prompt is assembled before `pre_llm_call` fires, so a routed turn still carries the **pre-route** `Model:` / `Provider:` identity lines. The routed model will misreport which model it is if asked during that turn. Everything else about the turn — client, credentials, endpoint, wire format, reasoning config — belongs to the routed model.
+:::
 
 ### Middleware: change what happens
 


### PR DESCRIPTION
## What does this PR do?

It lets a `pre_llm_call` plugin **return a routing decision that the runtime actually carries out**.

Today that hook can change the *text* of a turn (context injection) but not *which model answers it*. By the time it fires, `restore_primary_runtime` has already fixed the turn's model and rebuilt the client. So a plugin can decide "this turn should run somewhere cheaper/faster" and then has no way to act on the decision.

A hook result may now carry a `route` key alongside the existing `context` key:

```python
def route_turn(user_message, model, **kwargs):
    if is_mechanical(user_message):
        return {"route": {"model": "deepseek/deepseek-v3.2",
                          "provider": "openrouter"}}
    return None  # no route -> the configured model answers

def register(ctx):
    ctx.register_hook("pre_llm_call", route_turn)
```

`model` is required; `provider`, `base_url`, `api_key`, and `api_mode` are optional and forwarded to the agent's existing `switch_model`.

**No router, classifier, tiers, or heuristics land in core.** There are no new config keys and no default-on behavior. Core gains one thing: the ability to *carry out* a decision a plugin already made. A complete opt-in example plugin is included in the docs — it lives in `~/.hermes/plugins/`, not in this tree.

### Why this shape, and not a router

`#43534` proposed a router in core and was closed by @teknium1 with:

> If you do want it, please create a plugin. Happy to support adding to the plugin interface to make this work as one.

This PR is that plugin-interface addition and nothing else. The decision stays in plugin territory, which is where `#43534` concluded it belongs.

I want to be upfront about the tension: `#61371` was closed `not_planned` under a standing `delegation-model-routing` policy — *"Hermes does not accept per-task model/provider routing, model tiers, or complexity-based automatic model selection"* — and `424e9f36b0` deliberately removed the old `smart_model_routing` feature. Nothing here re-adds any of that to core. If the intent is that the policy covers the *plugin interface* too, not just core behavior, then this should be closed and I'd rather hear that than have you carry the review.

### Extend, don't duplicate — what I checked first

- `ctx.llm` (`agent/plugin_llm.py`) is the host-owned LLM facade for a plugin's **own out-of-band** calls. It cannot change the model of the agent's turn.
- `_resolve_turn_agent_config` (`hermes_cli/cli_agent_setup_mixin.py:291`) still has a route-shaped return, but its docstring and body are explicit that it "always uses the session's primary model/provider" — it only attaches `/fast` `request_overrides`. No plugin input reaches it.
- `pre_llm_call`'s documented return contract covers context only.

This hook is not speculative infrastructure: it has a real, concrete consumer (the example plugin below), even though that consumer ships separately.

## Related Issue

Refs #43534 — closed, and the maintainer steer quoted above is what this implements.
Refs #61371 — closed `not_planned` under the `delegation-model-routing` policy; see the note above.

No issue is fixed by this PR, so there is no `Fixes #`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`agent/routing_override.py`** (new, 214 lines; ~80 are executable, the rest docstring/comments) — `extract_routing_override()` reads the first well-formed `route` out of the hook results; `apply_routing_override()` actuates it by delegating to the existing, tested `switch_model`, then scopes it to the turn.
- **`agent/turn_context.py`** (+18) — the single call site, immediately after the existing `pre_llm_call` result loop, before the turn's first API call is assembled.
- **`agent/agent_runtime_helpers.py`** (+24/-3) — a 21-line revert block at the top of `restore_primary_runtime`, plus three one-line gate guards.
- **`tests/agent/test_routing_override.py`** (new, 16 tests), **`tests/agent/test_routing_override_revert.py`** (new, 6 tests).
- **`website/docs/developer-guide/plugins/index.md`** (+84/-2) — a `Per-turn routing override` section next to the existing context-injection docs, including the complete opt-in example plugin.

### How it is scoped

**Turn-scoped, like reactive fallback.** A proactive route is a per-turn decision and must never pin the session. `switch_model` persists into `_primary_runtime`, so the override snapshots the pre-route runtime and sets a dedicated `_routing_override_active` flag; `restore_primary_runtime` reverts it at the top of the next turn.

**The revert runs before all three early-return gates** — deliberately not gated on `_fallback_activated`, on `_rate_limited_until`, or on the reset-aware credential-pool gate. Any of those skipping the revert would leak the routed model past its turn, which is exactly the bug the first version of this patch had.

**A dedicated flag, not reuse of reactive-fallback state.** Scoping the override via `_fallback_activated` / `_rate_limited_until` produced three distinct defects, all now regression-tested:

1. The routed model survived past its turn whenever a cooldown gate skipped restoration.
2. Pointing `_primary_runtime` at the *pre-route* model made in-turn transient-transport recovery rebuild the pre-route client mid-routed-turn, silently jumping tiers.
3. Pre-arming `_fallback_activated` corrupted reactive cooldown accounting, so a 429 from the routed model armed no cooldown.

Keeping `_primary_runtime` pointed at the *routed* runtime and using a separate flag fixes all three, and lets reactive fallback keep working normally underneath a routed turn.

**Cross-provider routes resolve their endpoint first.** `switch_model` refuses a provider change that carries no resolved `base_url` — it raises rather than keep the previous provider's endpoint (`agent/agent_runtime_helpers.py`, the `elif old_norm_provider != new_norm_provider: raise ValueError` branch, whose comment cites #47828). Its existing callers go through `model_switch.switch_model()`, which resolves the URL first; a plugin route does not, and the natural override a plugin writes is `{"model": ..., "provider": ...}` with no `base_url`. Without pre-resolution such a route would never take effect — the `ValueError` is swallowed by the fail-safe and the turn silently stays on the configured primary. So when the provider changes and the override omits `base_url`, `resolve_provider_client` supplies the new provider's canonical endpoint up front. A resolve miss falls through and lets `switch_model` decide.

**Fail-safe everywhere.** A malformed override, an unknown model, a failed client rebuild, or a resolver error all leave the agent on its configured model, log a warning, and return `False`. A routing miss degrades to "answer on the configured primary"; it never breaks the turn.

**Inert unless a plugin opts in.** With no plugin returning `route`, `extract_routing_override` returns `None` on the first pass and nothing else executes.

### Deliberately not in this PR

- **No router, classifier, tiers, or heuristics in core.** Per #43534.
- **No `extra_body` passthrough on the route.** An earlier draft let a route carry provider-specific request-body params. It needs three-state save/restore around `request_overrides` to be safe, which is a lot of surface for a second concept. Left out to keep this reviewable as one idea.
- **Reconciling the system prompt's identity line.** The cached system prompt is assembled earlier in `build_turn_context` than `pre_llm_call` fires, so a routed turn still ships the *pre-route* `Model:` / `Provider:` lines, and the routed model will misreport which model it is if asked during that turn. Reactive failover handles the equivalent case with `rewrite_prompt_model_identity` plus `_sync_failover_system_message` inside the call-block retry loop; wiring the proactive path into that means reaching into the turn's prompt/compression bookkeeping. Documented as a known limitation in the module docstring and the plugin docs — happy to add it here if you'd rather it ship together.
- **A plugin directory in this tree.** The example is documentation; the plugin itself belongs in `~/.hermes/plugins/`.

## How to Test

Against `791e2ae325`:

1. `pytest tests/agent/test_routing_override.py tests/agent/test_routing_override_revert.py -q` → 22 passed.
2. Adjacent existing suites, unchanged: `pytest tests/agent/test_restore_primary_pool_reselect.py tests/agent/test_turn_context.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_reset_aware_primary_restore.py tests/run_agent/test_24996_fallback_exhaustion_cooldown.py tests/run_agent/test_fallback_reasoning_override.py tests/run_agent/test_stream_stale_breaker_reset.py tests/run_agent/test_switch_model_reasoning_override.py -q` → 86 passed.
3. End to end: drop the example plugin from the docs into `~/.hermes/plugins/cheap-turn-router/`, start a session on your normal model, and send `ls the repo`. The log line `routing override: routed this turn to <model>/<provider>` appears and the turn is answered by the routed model. Send a normal message next and the turn is back on the configured primary.

What the tests cover:

- `test_routing_override.py` — extraction, actuation, turn-scoping, the no-op and fail-safe paths, second-apply snapshot integrity, and the four endpoint-resolution cases. One test drives the **real** `switch_model` to pin the cross-provider refusal that the endpoint pre-resolution exists for, rather than asserting it against a fake.
- `test_routing_override_revert.py` — drives the **real** `restore_primary_runtime` rather than a fake, so it proves the revert actually happens: the leak repro (routed model must revert with a cooldown armed), the `_primary_runtime`-points-at-routed invariant, the untouched-`_fallback_activated` invariant, and reactive fallback still engaging underneath a routed turn.

Also: `ruff check` clean on every touched file; tests pass under both fixed and randomized ordering; the diff applies cleanly to a pristine `791e2ae325` checkout.

## Risk

Low, but it touches model selection, so it's worth a careful read.

- For an install with no routing plugin, the only behavior change is one extra dict lookup per turn (`extract_routing_override` over the existing hook results, returning `None`).
- The riskiest surface is the `restore_primary_runtime` revert block. It is first in the function and falls through to the existing shared rebuild body — it adds a path, it does not reorder or alter the existing one. The three gate guards are `not _override_revert and <existing condition>`, so they are no-ops when no route is active.
- A plugin that returns a `route` on every turn effectively changes the session's model. That is the plugin author's and the operator's choice, and it is still reverted every turn.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed in full, and I'd rather be precise than tick this.** I ran `tests/agent tests/run_agent` twice in matched environments on `791e2ae325`: once pristine, once with this patch applied. Pristine: 253 failed, 7006 passed. Patched: 253 failed, 7027 passed. The 253 failing node ids are **identical** in both runs (byte-for-byte), so nothing that passed before this patch fails after it; the only difference is +21 passes, which are this patch's tests. Those 253 are pre-existing failures on `main` in my environment (largely env-dependent — network, provider credentials, local services) that this patch neither causes nor fixes. One further test (the real-`switch_model` premise check) was added after that comparison run, which is why the targeted count above is 22 rather than 21. I have not run the whole `tests/` tree.
- [x] I've tested on my platform: macOS (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (plugin developer guide + module docstrings)
- [x] `cli-config.yaml.example` — N/A, no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, no platform-specific code
- [x] Tool descriptions/schemas — N/A, no tool changes
