### PR TITLE
fix(agent): local endpoints — gate /api/show probe, keep infinite stale timeout under reasoning floor, exempt local from stale breaker

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -808,7 +808,17 @@ def _touch_stale_kill_activity(agent, elapsed: float) -> None:
 
 def _check_stale_giveup(agent) -> None:
     """Raise immediately when the consecutive-stale streak is past the
-    give-up threshold — no network attempt, no stale-timeout wait."""
+    give-up threshold — no network attempt, no stale-timeout wait.
+
+    Local endpoints are exempt: bouncing your own inference server is
+    routine ops, so a stale streak accumulated against a local server
+    must never permanently wedge the session. Mirrors the
+    local-endpoint infinite-stale-timeout policy in run_agent.py.
+    """
+    base_url = getattr(agent, "_base_url", None) or getattr(agent, "base_url", None) or ""
+    if base_url and is_local_endpoint(base_url):
+        return
+
     _giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
     _streak = _stale_streak(agent)
     if _giveup > 0 and _streak >= _giveup:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2069,10 +2069,11 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
 def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server's native ``/api/show`` for context length.
 
-    Provider-agnostic: works against ANY Ollama-compatible server regardless
-    of hostname — local Ollama, Ollama Cloud (``ollama.com``), custom Ollama
-    hosting behind a reverse proxy, etc.  For non-Ollama servers the POST
-    returns 404/405 quickly; the function handles errors gracefully.
+    Gated on ``detect_local_server_type``: the POST only fires for servers
+    identified as Ollama-compatible (local Ollama, Ollama Cloud (``ollama.com``), custom Ollama
+    hosting behind a reverse proxy, etc.). Non-Ollama servers (mlx-lm, sglang,
+    TabbyAPI, etc.) are skipped to prevent 404 spray — the server-type probe
+    is cached for the process lifetime so no extra round-trips are paid.
 
     Results are cached in ``_LOCAL_CTX_PROBE_CACHE`` (same 30s TTL,
     positive-only — see ``_query_local_context_length``) so back-to-back
@@ -2117,6 +2118,25 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
         server_url = server_url[:-3]
 
     if _endpoint_blackholed(server_url):
+        return None
+
+    # Gate on server type: only POST /api/show to servers that are actually
+    # Ollama-compatible. detect_local_server_type (line 996) runs a probe
+    # waterfall — LM Studio /api/v1/models, Ollama /api/tags, llama.cpp /props,
+    # vLLM /version — and caches the result for the process lifetime. Its
+    # sibling probes (query_ollama_num_ctx, query_ollama_supports_vision,
+    # _query_local_context_length_uncached) all gate on it the same way.
+    #
+    # This prevents 404 spray against non-Ollama local servers (mlx-lm, sglang,
+    # TabbyAPI, etc.) that speak OpenAI-compatible /v1/chat/completions but
+    # don't implement Ollama's native /api/show. The in-memory + disk cache
+    # in detect_local_server_type means the probe waterfall only fires once
+    # per (host:port) per process.
+    try:
+        server_type = detect_local_server_type(base_url, api_key=api_key)
+    except Exception:
+        return None
+    if server_type is not None and server_type != "ollama":
         return None
 
     headers = _auth_headers(api_key)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1469,6 +1469,16 @@ class AIAgent:
         if env_timeout is not None:
             return float(env_timeout), False
 
+        # Local endpoints: never kill for being slow. The stale detector
+        # is designed for cloud gateways that idle-kill connections;
+        # local servers (mlx-lm, llama.cpp, vLLM, etc.) don't have that
+        # problem. Check BEFORE the reasoning-model floor so over-broad
+        # pattern matching (e.g. "qwen3" matching "Qwen3.8-27B-mxfp8")
+        # doesn't disable this protection for local endpoints.
+        base_url = getattr(self, "_base_url", None) or self.base_url or ""
+        if base_url and is_local_endpoint(base_url):
+            return float("inf"), True
+
         # Reasoning-model floor: auto-mitigation for known reasoning models
         # (Nemotron 3 Ultra, OpenAI o1/o3, Anthropic Opus 4.x thinking,
         # DeepSeek R1, Qwen QwQ, xAI Grok reasoning, etc.) whose cloud

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1150,6 +1150,109 @@ class TestGetModelContextLength:
         mock_local_ctx.assert_called_once()
 
 
+# =========================================================================
+# _query_ollama_api_show: non-Ollama server gating (regression)
+# =========================================================================
+
+class TestNonOllamaServerGating:
+    """Regression: _query_ollama_api_show must not POST /api/show to
+    non-Ollama local servers.
+
+    Servers like mlx-lm, sglang, TabbyAPI expose an OpenAI-compatible
+    /v1/chat/completions endpoint but do NOT implement Ollama's native
+    /api/show. Before the fix, the context-length resolver fired
+    POST /api/show at any unrecognized local endpoint, producing a 404
+    on every probe cycle (~30s TTL, never memoized on failure).
+
+    The fix: _query_ollama_api_show_uncached gates on
+    detect_local_server_type() — the same guard its sibling probes
+    (query_ollama_num_ctx, query_ollama_supports_vision) already use.
+    Non-Ollama servers identified by the probe waterfall are skipped;
+    unknown servers (detect_local_server_type returns None) still
+    receive the probe as a fallback (the original conservative behavior).
+    """
+
+    @patch("agent.model_metadata._endpoint_blackholed", return_value=False)
+    @patch("agent.model_metadata.detect_local_server_type", return_value="vllm")
+    @patch("agent.model_metadata._auth_headers", return_value={})
+    def test_non_ollama_server_skips_api_show(self, mock_auth, mock_detect, mock_blackhole):
+        """A server identified as 'vllm' should never receive POST /api/show."""
+        import httpx
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        with patch.object(httpx, "Client", return_value=mock_client):
+            from agent.model_metadata import _query_ollama_api_show_uncached
+            result = _query_ollama_api_show_uncached(
+                "mlx-community/Qwen3.8-27B-mxfp8",
+                "http://127.0.0.1:8080/v1",
+            )
+        assert result is None
+        mock_client.post.assert_not_called()
+
+    @patch("agent.model_metadata._endpoint_blackholed", return_value=False)
+    @patch("agent.model_metadata.detect_local_server_type", return_value="ollama")
+    @patch("agent.model_metadata._auth_headers", return_value={})
+    def test_ollama_server_still_receives_api_show(self, mock_auth, mock_detect, mock_blackhole):
+        """A server identified as 'ollama' must still receive POST /api/show."""
+        import httpx
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "model_info": {"model.context_length": 131072},
+            "parameters": "",
+        }
+        mock_client.post.return_value = mock_response
+        with patch.object(httpx, "Client", return_value=mock_client):
+            from agent.model_metadata import _query_ollama_api_show_uncached
+            result = _query_ollama_api_show_uncached(
+                "my-model",
+                "http://127.0.0.1:11434",
+            )
+        assert result == 131072
+        mock_client.post.assert_called_once()
+
+    @patch("agent.model_metadata._endpoint_blackholed", return_value=False)
+    @patch("agent.model_metadata.detect_local_server_type", return_value=None)
+    @patch("agent.model_metadata._auth_headers", return_value={})
+    def test_unknown_server_falls_through_to_probe(self, mock_auth, mock_detect, mock_blackhole):
+        """Unknown server type (None) preserves original behavior: probe fires."""
+        import httpx
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_client.post.return_value = mock_response
+        with patch.object(httpx, "Client", return_value=mock_client):
+            from agent.model_metadata import _query_ollama_api_show_uncached
+            result = _query_ollama_api_show_uncached(
+                "my-model",
+                "http://127.0.0.1:8080/v1",
+            )
+        assert result is None
+        mock_client.post.assert_called_once()
+
+    @patch("agent.model_metadata._endpoint_blackholed", return_value=False)
+    @patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio")
+    @patch("agent.model_metadata._auth_headers", return_value={})
+    def test_lm_studio_skips_api_show(self, mock_auth, mock_detect, mock_blackhole):
+        """LM Studio identified servers must not receive POST /api/show."""
+        import httpx
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        with patch.object(httpx, "Client", return_value=mock_client):
+            from agent.model_metadata import _query_ollama_api_show_uncached
+            result = _query_ollama_api_show_uncached(
+                "my-model",
+                "http://127.0.0.1:1234/v1",
+            )
+        assert result is None
+        mock_client.post.assert_not_called()
 
 
 # =========================================================================

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -322,3 +322,98 @@ def test_turn_clock_stamped_only_with_budget(monkeypatch, tmp_path):
 
     assert agent_with._run_budget_started_at is not None
     assert agent_with._run_budget_wrapup_injected is False
+
+
+# ── local-endpoint stale-timeout override (Bug 2 regression) ─────────────
+
+
+class TestLocalEndpointStaleTimeout:
+    """Regression: local endpoints must get float("inf") stale timeout
+    regardless of reasoning-model floor matching.
+
+    Bug: Qwen3.8-27B-mxfp8 matches the "qwen3" reasoning floor pattern
+    (regex ^qwen3(?:$|[\-._]) matches "qwen3.8" because "." is in the
+    separator class). This sets uses_implicit_default=False, which disables
+    the local-endpoint float("inf") short-circuit. Result: a healthy local
+    mlx-lm server gets killed after 180s of no output.
+
+    Fix: move the is_local_endpoint check BEFORE the reasoning-model floor
+    in _resolved_api_call_stale_timeout_base, so local endpoints always get
+    float("inf") regardless of reasoning model detection.
+    """
+
+    def test_local_endpoint_with_reasoning_model_gets_inf(self, monkeypatch, tmp_path):
+        """A local endpoint running a Qwen3 model must get inf, not 180s."""
+        import run_agent
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+        agent = _make_agent(
+            tmp_path, monkeypatch,
+            model="mlx-community/Qwen3.8-27B-mxfp8",
+            provider="custom",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == float("inf"), (
+            f"Local endpoint with Qwen3 model should get inf, got {base}"
+        )
+        assert implicit is True
+
+    def test_local_endpoint_with_deepseek_gets_inf(self, monkeypatch, tmp_path):
+        """A local endpoint running deepseek-v4-pro must get inf, not 600s."""
+        import run_agent
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+        agent = _make_agent(
+            tmp_path, monkeypatch,
+            model="deepseek/deepseek-v4-pro",
+            provider="custom",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == float("inf"), (
+            f"Local endpoint with deepseek-v4-pro should get inf, got {base}"
+        )
+        assert implicit is True
+
+    def test_cloud_endpoint_still_gets_reasoning_floor(self, monkeypatch, tmp_path):
+        """A cloud endpoint running deepseek-v4-pro must still get 600s floor."""
+        import run_agent
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+        agent = _make_agent(
+            tmp_path, monkeypatch,
+            model="deepseek/deepseek-v4-pro",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == 600.0, (
+            f"Cloud endpoint with deepseek-v4-pro should get 600s, got {base}"
+        )
+        assert implicit is False
+
+    def test_explicit_config_still_wins_over_local(self, monkeypatch, tmp_path):
+        """Explicit stale_timeout_seconds overrides even local endpoint inf."""
+        import run_agent
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: 300.0)
+        agent = _make_agent(
+            tmp_path, monkeypatch,
+            model="mlx-community/Qwen3.8-27B-mxfp8",
+            provider="custom",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == 300.0
+        assert implicit is False
+
+    def test_local_endpoint_non_reasoning_model_gets_inf(self, monkeypatch, tmp_path):
+        """A local endpoint with a non-reasoning model also gets inf."""
+        import run_agent
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+        agent = _make_agent(
+            tmp_path, monkeypatch,
+            model="llama3.1:8b",
+            provider="custom",
+            base_url="http://127.0.0.1:11434/v1",
+        )
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == float("inf")
+        assert implicit is True

--- a/tests/agent/test_stale_breaker.py
+++ b/tests/agent/test_stale_breaker.py
@@ -1,0 +1,79 @@
+"""Tests for the stale-streak circuit-breaker exemption (Bug 3 Path A).
+
+The local-endpoint exemption lives inside :func:`_check_stale_giveup` in
+``agent/chat_completion_helpers.py``.  Stub agents carry only ``.base_url``
+and ``._consecutive_stale_streams`` — the two attributes the function actually
+reads.
+
+Run with::
+
+    .venv/bin/python -m pytest tests/agent/test_stale_breaker.py -q
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.chat_completion_helpers import _check_stale_giveup
+
+
+def _make_stub(base_url: str | None, streak: int) -> types.SimpleNamespace:
+    """Minimal stub carrying only the attributes _check_stale_giveup reads."""
+    return types.SimpleNamespace(
+        base_url=base_url,
+        _consecutive_stale_streams=streak,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_stale_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the default threshold back to 5 so ambient env cannot skew tests."""
+    monkeypatch.delenv("HERMES_STREAM_STALE_GIVEUP", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Local endpoints — exempt from the give-up breaker
+# ---------------------------------------------------------------------------
+
+def test_local_http_127_0_0_1_streak_5_no_raise() -> None:
+    stub = _make_stub("http://127.0.0.1:8080/v1", 5)
+    _check_stale_giveup(stub)  # should be a no-op
+
+
+def test_local_localhost_11434_streak_10_no_raise() -> None:
+    stub = _make_stub("http://localhost:11434/v1", 10)
+    _check_stale_giveup(stub)  # should be a no-op
+
+
+# ---------------------------------------------------------------------------
+# Cloud endpoints — subject to the breaker
+# ---------------------------------------------------------------------------
+
+def test_cloud_openai_streak_5_raises() -> None:
+    stub = _make_stub("https://api.openai.com/v1", 5)
+    with pytest.raises(RuntimeError, match="consecutive stale attempts"):
+        _check_stale_giveup(stub)
+
+
+def test_cloud_openai_streak_4_no_raise() -> None:
+    stub = _make_stub("https://api.openai.com/v1", 4)
+    _check_stale_giveup(stub)  # below the default threshold of 5
+
+
+# ---------------------------------------------------------------------------
+# Missing base_url — treated as cloud (no exemption)
+# ---------------------------------------------------------------------------
+
+def test_missing_base_url_streak_5_raises() -> None:
+    stub = _make_stub(None, 5)
+    # SimpleNamespace with base_url=None is equivalent to no attribute for the
+    # ``getattr ... or ""`` chain inside the exemption.
+    # Re-create as a real missing-attribute stub:
+    stub = MagicMock(spec=["_consecutive_stale_streams"])
+    stub._consecutive_stale_streams = 5
+    with pytest.raises(RuntimeError, match="consecutive stale attempts"):
+        _check_stale_giveup(stub)


### PR DESCRIPTION
Closes #96054

## Summary

Three compounding defects prevented non-Ollama local inference servers (mlx-lm tested; sglang/TabbyAPI/vLLM same class) from completing a single agent turn when the model name matches a reasoning-model pattern. One branch, one commit per fix, 14 regression tests.

## The three fixes

### 1. `/api/show` probe gated by detected server type

`_query_ollama_api_show_uncached` was the only Ollama probe without a `detect_local_server_type()` gate — it POSTed to any unrecognized endpoint, spraying 404s against mlx-lm every resolution cycle. Now: positively-identified non-Ollama servers skip the probe; unknown servers still fall through (conservative — Ollama behind unusual hostnames/tunnels unaffected). Sibling-probe pattern applied.

### 2. Local endpoints keep infinite stale timeout despite reasoning floor

`mlx-community/Qwen3.8-27B-mxfp8` matches `^qwen3(?:$|[\-._])` (`.` is in the separator class), so `_resolved_api_call_stale_timeout_base` returned `(180.0, False)` and the local-endpoint `float("inf")` short-circuit in `_compute_non_stream_stale_timeout` never fired — healthy inference killed at ~180–226s while waiting on first token from a 27B model.

Fix: `is_local_endpoint` check moved **before** the reasoning floor, returning `(inf, True)`. Explicit user config (`stale_timeout_seconds` / env) still wins untouched. Rationale: the reasoning floor exists because cloud gateways idle-kill connections mid-think; loopback has no middleman that can do that. Cloud behavior byte-identical (verified: `test_cloud_endpoint_still_gets_reasoning_floor`, `test_active_budget_caps_implicit_reasoning_floor` both green).

### 3. Stale-streak breaker exempts local endpoints

The cross-turn breaker (#58962) resets only on a completed call or explicit provider switch — nothing decays it and nothing notices a restarted server. Five stale kills (fed by fix-2's bug plus ordinary local-server restarts during testing) permanently insta-aborted every future attempt in the session.

Fix: `_check_stale_giveup` early-returns for local base URLs before the threshold raise. Design reviewed cross-vendor: Path A (this exemption) preferred over health-probe reset (adds network I/O inside an error handler; probe endpoint assumptions don't hold across providers) and wall-clock decay (weakens #58962's dead-cloud protection). Attribute resolution order matches run_agent.py canonical form (`_base_url` first).

## Testing

- 14 new tests: 4 × server-type gating, 5 × stale-timeout resolution (local/cloud/explicit-config matrix), 5 × breaker exemption (incl. missing-attribute stub raising as before)
- Targeted suites: **160 passed** (test_model_metadata + test_run_budget + test_ollama_num_ctx + new test_stale_breaker)
- Full `tests/agent/`: no new failures vs pristine-base run of same commit pair (177 vs 179 failed — pre-existing suite-order pollution, our diff is net −2)


### Open question

Should streak *bumps* also be gated for local endpoints (currently accumulate-but-never-raise)? Left ungated deliberately — preserves diagnostics; breaker still re-arms if session later switches to a cloud provider.
