### PR TITLE
fix(gateway): break clarify loops after consecutive unanswered timeouts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -982,9 +982,42 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     timeout = clarify_mod.get_clarify_timeout()
     response = clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
     if response is None or response == "":
-        # Timeout or session-boundary cancellation
+        # Timeout or session-boundary cancellation. Count it toward the
+        # consecutive-timeout breaker (#96050): a clarify loop where the user
+        # never answers traps every follow-up text as the next prompt's
+        # intercept response.
+        _record_clarify_timeout(session_key)
         return f"[user did not respond within {int(timeout / 60)}m]"
+    _reset_clarify_timeout_streak(session_key)
     return response
+
+
+# Consecutive clarify-timeout breaker (#96050). When a session's clarifies
+# keep timing out, each NEW prompt still arms the text intercept — so the
+# user's imperative follow-ups ("stop", "restart") are consumed as clarify
+# answers and never reach the agent as real turns, and the model re-clarifies
+# in a loop (live report: ~4 hours of 10-minute clarify→timeout cycles).
+# After this many consecutive timeouts, the gateway stops posting new
+# prompts for the session and tells the agent to answer as plain text; any
+# successfully answered clarify resets the streak.
+_CLARIFY_TIMEOUT_BREAKER_LIMIT = 2
+_CLARIFY_TIMEOUT_STREAKS: Dict[str, int] = {}
+
+
+def _record_clarify_timeout(session_key: str) -> None:
+    key = str(session_key or "")
+    if not key:
+        return
+    _CLARIFY_TIMEOUT_STREAKS[key] = _CLARIFY_TIMEOUT_STREAKS.get(key, 0) + 1
+
+
+def _reset_clarify_timeout_streak(session_key: str) -> None:
+    _CLARIFY_TIMEOUT_STREAKS.pop(str(session_key or ""), None)
+
+
+def _clarify_breaker_open(session_key: str) -> bool:
+    key = str(session_key or "")
+    return bool(key) and _CLARIFY_TIMEOUT_STREAKS.get(key, 0) >= _CLARIFY_TIMEOUT_BREAKER_LIMIT
 
 
 def _resolve_progress_thread_id(
@@ -5961,6 +5994,22 @@ class TurnRunner:
 
             if not ctx._status_adapter:
                 return ""
+
+            if _clarify_breaker_open(ctx.session_key or ""):
+                # Consecutive-timeout breaker (#96050): previous prompts in
+                # this session timed out unanswered, and each new prompt
+                # traps the user's follow-up text in the intercept loop.
+                # Post nothing; tell the agent to answer as plain text.
+                logger.info(
+                    "[clarify] breaker open for %s — skipping prompt, "
+                    "agent answers as text",
+                    ctx.session_key or "<unknown>",
+                )
+                return (
+                    "[clarify unavailable: earlier prompts in this session "
+                    "timed out with no answer. Do not ask again — answer "
+                    "directly as normal text using your best judgement.]"
+                )
 
             clarify_id = _uuid.uuid4().hex[:10]
             _clarify_mod.register(

--- a/tests/gateway/test_clarify_timeout_breaker.py
+++ b/tests/gateway/test_clarify_timeout_breaker.py
@@ -1,0 +1,72 @@
+"""Regression tests for the consecutive clarify-timeout breaker (#96050).
+
+When a session's clarifies keep timing out, each NEW prompt still arms the
+text intercept — the user's imperative follow-ups ("stop", "restart") are
+consumed as clarify answers and never reach the agent as real turns, and the
+model re-clarifies in a loop (live report: ~4 hours of 10-minute
+clarify→timeout cycles). After two consecutive timeouts the gateway stops
+posting new prompts for the session and tells the agent to answer as text;
+any successfully answered clarify resets the streak.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway import run as gateway_run
+
+
+@pytest.fixture(autouse=True)
+def _clean_streaks():
+    gateway_run._CLARIFY_TIMEOUT_STREAKS.clear()
+    yield
+    gateway_run._CLARIFY_TIMEOUT_STREAKS.clear()
+
+
+def _timed_out_wait(clarify_mod):
+    """Drive one clarify through the sent-disposition → timeout path."""
+    fut = MagicMock()
+    result = MagicMock()
+    result.success = True
+    fut.result.return_value = result
+    clarify_mod.get_clarify_timeout.return_value = 600.0
+    clarify_mod.wait_for_response.return_value = None  # timeout
+    return gateway_run._clarify_send_then_wait(
+        fut, clarify_id="c1", session_key="sk", clarify_mod=clarify_mod
+    )
+
+
+class TestClarifyTimeoutBreaker:
+    def test_two_consecutive_timeouts_open_the_breaker(self):
+        clarify_mod = MagicMock()
+        for _ in range(2):
+            out = _timed_out_wait(clarify_mod)
+            assert "did not respond" in out
+
+        assert gateway_run._clarify_breaker_open("sk") is True
+        assert gateway_run._clarify_breaker_open("other-session") is False
+
+    def test_answered_clarify_resets_the_streak(self):
+        clarify_mod = MagicMock()
+        _timed_out_wait(clarify_mod)
+        assert gateway_run._clarify_breaker_open("sk") is False
+
+        fut = MagicMock()
+        result = MagicMock()
+        result.success = True
+        fut.result.return_value = result
+        clarify_mod.wait_for_response.return_value = "the user's answer"
+        out = gateway_run._clarify_send_then_wait(
+            fut, clarify_id="c2", session_key="sk", clarify_mod=clarify_mod
+        )
+        assert out == "the user's answer"
+        assert gateway_run._clarify_breaker_open("sk") is False
+
+        # One timeout alone no longer opens it.
+        _timed_out_wait(clarify_mod)
+        assert gateway_run._clarify_breaker_open("sk") is False
+
+    def test_empty_session_key_never_opens(self):
+        for _ in range(5):
+            gateway_run._record_clarify_timeout("")
+        assert gateway_run._clarify_breaker_open("") is False


### PR DESCRIPTION
## What does this PR do?

When a session's clarify prompts keep timing out unanswered, each NEW prompt still arms the session text intercept — so the user's imperative follow-ups ("stop", "restart", "do it") are consumed as the next prompt's clarify response and never reach the agent as a real turn. The model then re-clarifies, and the cycle repeats: the issue's live report shows ~4 hours of 10-minute clarify→timeout loops with every user message swallowed, until the twice-compacted context produced degenerate placeholder prompts.

This adds a consecutive-timeout breaker (the reporter's suggested fix, threshold 2):

- `_clarify_send_then_wait` counts a timeout toward the session's streak; any successfully answered clarify resets it.
- After two consecutive timeouts the breaker opens: `_clarify_callback_sync` stops posing new prompts (nothing is rendered, so the intercept never re-arms) and returns a sentinel telling the agent to answer directly as normal text using its best judgement.

The wait-for-response registration itself is unchanged — timeouts already tear it down correctly; the loop is model behavior re-issuing prompts, and the breaker removes its fuel.

## Related Issue

Fixes #96050

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/run.py`
  - New `_CLARIFY_TIMEOUT_STREAKS`/`_record_clarify_timeout`/`_reset_clarify_timeout_streak`/`_clarify_breaker_open` helpers (module-level, session-key scoped, limit 2).
  - `_clarify_send_then_wait`: timeout path records the streak; answered path resets it.
  - `_clarify_callback_sync`: when the breaker is open, no prompt is posted and a text-answer sentinel is returned (with an info log).
- `tests/gateway/test_clarify_timeout_breaker.py` (new, 3 tests): two consecutive timeouts open the breaker for that session only; an answered clarify resets the streak (one later timeout alone does not re-open); an empty session key never opens it.

## How to Test

1. `python -m pytest tests/gateway/test_clarify_timeout_breaker.py -q` — should pass (3 passed).
2. Red/green: on unpatched `main` the breaker helpers do not exist (collection error) — the sentinel-streak behavior is absent.
3. Sibling seam unchanged: `python -m pytest tests/gateway/test_clarify_send_timeout_ambiguity.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py -q` — should pass (17 passed).
4. Manual (per the issue): let two clarifies time out in one session, then call `clarify` again — no card is posted and the agent answers as text; answer a clarify normally at any point and the streak resets.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the intercept-trap mechanism and breaker rationale documented on the streak state)
- [x] New and existing unit tests pass locally (3 new; 17 across the clarify seams)
- [x] Changes are backward compatible (normal answered clarifies behave identically; the breaker only engages after two unanswered timeouts)
