### PR TITLE
desktop: fix two managed-SSH-spawn bugs that break every fresh remote backend spawn

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1467,6 +1467,45 @@ test('buildSpawnCommand raises the SSH child file limit before execing Hermes', 
   assert.ok(cmd.indexOf('ulimit -n 65536') < cmd.indexOf('serve --isolated'))
 })
 
+test('buildSpawnCommand payload variables keep $HOME expandable (no double quoting)', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    ownershipId: OWNERSHIP_ID,
+    reservationNonce: SPAWN_NONCE,
+    spawnNonce: SPAWN_NONCE,
+    tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
+    lockMetadata: { ownershipId: OWNERSHIP_ID, spawnNonce: SPAWN_NONCE }
+  })
+
+  // expandRemotePath() emits "$HOME"'/…' — a fragment the shell expands at
+  // assignment. Wrapping it in shq() again stores the quote characters in
+  // the variable, so mkdir "$reservation" creates (or fails on) a literal
+  // "$HOME" path and the reservation loop spins forever holding the mutex.
+  for (const name of ['reservation', 'lock', 'owner_file']) {
+    assert.match(cmd, new RegExp(`${name}="\\$HOME"`), `${name}= must start with an expandable "$HOME"`)
+    assert.doesNotMatch(cmd, new RegExp(`${name}='`), `${name}= must not be re-quoted`)
+  }
+})
+
+test('buildSpawnCommand lockfile publication is POSIX sh (no bash substitution)', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    ownershipId: OWNERSHIP_ID,
+    reservationNonce: SPAWN_NONCE,
+    spawnNonce: SPAWN_NONCE,
+    tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
+    lockMetadata: { ownershipId: OWNERSHIP_ID, pid: '__PID__' }
+  })
+
+  // ${var//pat/rep} is bash-only; dash aborts the payload on it AFTER the
+  // serve was spawned, so the client sees an unknown failure, deletes the
+  // token file, and orphans the backend.
+  assert.doesNotMatch(cmd, /\$\{lock_json\/\//, 'must not use ${var//} substitution under sh')
+  assert.ok(cmd.includes('sed "s/__PID__/${child}/"'), 'pid substitution must use sed')
+})
+
 test('spawnRemoteDashboard removes a token file when upload reporting fails', async () => {
   const failure = new Error('channel closed')
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -735,9 +735,12 @@ async function disconnect(ssh, ownershipId) {
 
 function buildOwnedStaleTerminationCommand(lock, ownershipId) {
   const pid = Number(lock.pid)
-  const expectedPath = shq(expandRemotePath(lock.hermesPath))
-  const expectedHome = lock.hermesHome ? shq(expandRemotePath(lock.hermesHome)) : "''"
-  const expectedToken = shq(expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce)))
+  // expandRemotePath() output is already a shell-quoted fragment; embed it
+  // raw so $HOME expands at assignment. Double-quoting stores the quote
+  // characters in the variable and every identity match below REFUSEs.
+  const expectedPath = expandRemotePath(lock.hermesPath)
+  const expectedHome = lock.hermesHome ? expandRemotePath(lock.hermesHome) : "''"
+  const expectedToken = expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce))
   const nonce = shq(lock.spawnNonce)
   const profile = shq(lock.profile || '')
   const command = `$(ps -ww -o command= -p ${pid} 2>/dev/null || true)`
@@ -1083,7 +1086,11 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   return withRemoteUpdateMutex(
     `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
-      `reservation=${shq(reservation)}; lock=${shq(lockPath)}; owner_file=${shq(ownerPath)}; ` +
+      // reservation/lockPath/ownerPath are expandRemotePath() output — already
+      // shell-quoted fragments ("$HOME"'/…'). Embed raw so the assignment
+      // expands $HOME; shq() here would store the quote characters literally
+      // and every mkdir/cat against the variable fails forever.
+      `reservation=${reservation}; lock=${lockPath}; owner_file=${ownerPath}; ` +
       `reservation_nonce=${shq(reservationNonce)}; ` +
       `i=0; while ! mkdir "$reservation" 2>/dev/null; do ` +
       `owner_data=$(cat "$owner_file" 2>/dev/null || true); owner_pid=${'${owner_data%%:*}'}; ` +
@@ -1098,7 +1105,11 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       `${markerClear}; marker_clear || exit 75; mkdir -p "$(dirname ${logPath})" && ` +
       `${detachedSpawn}; ` +
       `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; ` +
-      `lock_json=${shq(metadata)}; lock_json=\${lock_json//__PID__/$child}; ` +
+      // ${var//pat/rep} is a bashism — this payload runs under plain sh (dash
+      // on Ubuntu), which aborts the whole script on it with "Bad
+      // substitution" AFTER the child was spawned, orphaning the backend and
+      // skipping the lockfile publication. Substitute with sed instead.
+      `lock_json=$(printf '%s' ${shq(metadata)} | sed "s/__PID__/\${child}/"); ` +
       `temporary_lock="\${lock}.${reservationNonce}.tmp"; ` +
       `printf '%s' "$lock_json" > "$temporary_lock" && mv -f "$temporary_lock" "$lock" || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
       `echo "$child"`,


### PR DESCRIPTION
## What

Two bugs in the managed SSH spawn engine (`apps/desktop/electron/remote-lifecycle.ts`) that together break every **fresh** remote backend spawn on a stock Ubuntu host. Found while running the current tip against a real remote (Ubuntu Server 24.04, dash as /bin/sh); the lockfile-reuse path masks both bugs for already-running backends, which is likely why they went unnoticed.

### Bug 1 — double shell-quoting in the spawn payload (and the stale reaper)

`expandRemotePath()` already returns a shell-quoted fragment like `"$HOME"'/.hermes/...'`. `buildSpawnCommand()` wrapped that output in `shq()` again, so the payload's `reservation` / `lock` / `owner_file` variables store the quote characters **literally**. Every `mkdir "$reservation"` then fails forever, and the reservation loop spins ~5 minutes per attempt while holding the box-global update mutex — with parallel spawn attempts queueing behind it on the flock. Observed live: 20+ payloads stacked on the mutex, every desktop connect timing out at 20s while the abandoned remote payloads kept spinning.

The same double-quoting sits in `buildOwnedStaleTerminationCommand()`'s identity guards, so every stale-backend reap REFUSEs on path mismatch.

Fix: embed `expandRemotePath()` output raw (it is already quoted), with comments marking the contract.

### Bug 2 — bashism in lockfile publication

The payload runs under plain `sh` (dash on Ubuntu), but published the lockfile via `${var//__PID__/$child}` — bash-only substitution. dash aborts the whole script on it **after** the serve child was spawned; the client sees an unknown failure, runs its error cleanup which deletes the session token file, and the just-booting serve dies on the missing token — orphaning one serve process per attempt.

Fix: POSIX `sed` substitution.

## Tests

Two regression tests added to `remote-lifecycle.test.ts`:
- payload variables must keep `$HOME` expandable (no re-quoting after `expandRemotePath()`)
- lockfile publication must be POSIX sh (no `${var//}`; pid substituted via sed)

Both fail against the previous code; all 89 remote-lifecycle tests pass with the fix. Live-verified end to end against an Ubuntu 24.04 remote: fresh backend spawn in ~3s with correct `backend.lock.json` publication, and kill-recovery (dispatch probe -> retire -> respawn) in 12s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)