### PR TITLE
feat(cron): add per-job fallback boundaries for agent-backed cron jobs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3305,6 +3305,65 @@ _RUNTIME_MAIN_CONTEXT: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("auxiliary_runtime_main", default=None)
 )
 
+# Optional per-run fallback boundary. Cron installs this in the copied worker
+# context so auxiliary calls cannot silently escape the job's provider policy.
+# ``None`` means ordinary interactive behaviour; strict policies carry the
+# already-authorised in-memory chain (never persisted here).
+_AUXILIARY_FALLBACK_BOUNDARY_CONTEXT: contextvars.ContextVar[
+    Optional[Dict[str, Any]]
+] = contextvars.ContextVar("auxiliary_fallback_boundary", default=None)
+
+
+def set_auxiliary_fallback_boundary(
+    policy: str,
+    chain: Optional[List[Dict[str, Any]]] = None,
+) -> contextvars.Token:
+    """Bind one context-local auxiliary fallback boundary."""
+    normalized_policy = str(policy or "").strip().lower()
+    if normalized_policy not in {"inherit", "none", "pinned"}:
+        raise ValueError("invalid auxiliary fallback boundary policy")
+    normalized_chain = [
+        dict(entry) for entry in (chain or []) if isinstance(entry, dict)
+    ]
+    if normalized_policy == "none":
+        normalized_chain = []
+    return _AUXILIARY_FALLBACK_BOUNDARY_CONTEXT.set(
+        {"policy": normalized_policy, "chain": normalized_chain}
+    )
+
+
+def get_auxiliary_fallback_boundary() -> Optional[Dict[str, Any]]:
+    """Return a defensive copy of the active auxiliary fallback boundary."""
+    boundary = _AUXILIARY_FALLBACK_BOUNDARY_CONTEXT.get()
+    if not isinstance(boundary, dict):
+        return None
+    return {
+        "policy": str(boundary.get("policy") or ""),
+        "chain": [
+            dict(entry)
+            for entry in (boundary.get("chain") or [])
+            if isinstance(entry, dict)
+        ],
+    }
+
+
+def reset_auxiliary_fallback_boundary(token: contextvars.Token) -> None:
+    """Restore the auxiliary fallback boundary that preceded one scoped run."""
+    if token is None:
+        return
+    try:
+        _AUXILIARY_FALLBACK_BOUNDARY_CONTEXT.reset(token)
+    except (RuntimeError, ValueError):
+        pass
+
+
+def _strict_auxiliary_fallback_boundary() -> bool:
+    boundary = _AUXILIARY_FALLBACK_BOUNDARY_CONTEXT.get()
+    return isinstance(boundary, dict) and boundary.get("policy") in {
+        "none",
+        "pinned",
+    }
+
 _RELAY_AUX_CALL_CONTEXT: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("auxiliary_relay_call", default=None)
 )
@@ -5465,6 +5524,9 @@ def _try_payment_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
+    if _strict_auxiliary_fallback_boundary():
+        return None, None, ""
+
     # Normalise the failed provider label for matching.
     skip = failed_provider.lower().strip()
     # Also skip Step-1 main-provider path if it maps to the same backend.
@@ -5537,6 +5599,9 @@ def _try_main_agent_model_fallback(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
+    if _strict_auxiliary_fallback_boundary():
+        return None, None, ""
+
     main_provider = (_read_main_provider() or "").strip()
     main_model = (_read_main_model() or "").strip()
     if main_provider.lower() == "moa":
@@ -5705,6 +5770,8 @@ def _try_configured_fallback_chain(
     Returns:
         (client, model, provider_label) or (None, None, "") if no fallback.
     """
+    if _strict_auxiliary_fallback_boundary():
+        return None, None, ""
     if not task:
         return None, None, ""
 
@@ -5863,14 +5930,22 @@ def _try_main_fallback_chain(
     both modern ``fallback_providers`` and legacy ``fallback_model`` entries
     participate in the same order as the main agent.
     """
-    try:
-        from hermes_cli.config import load_config_readonly
-        from hermes_cli.fallback_config import get_fallback_chain
+    boundary = get_auxiliary_fallback_boundary()
+    if boundary and boundary["policy"] in {"none", "pinned"}:
+        chain = boundary["chain"]
+    else:
+        try:
+            from hermes_cli.config import load_config_readonly
+            from hermes_cli.fallback_config import get_fallback_chain
 
-        chain = get_fallback_chain(load_config_readonly())
-    except Exception as exc:
-        logger.debug("Auxiliary %s: could not load main fallback chain: %s", task or "call", exc)
-        return None, None, ""
+            chain = get_fallback_chain(load_config_readonly())
+        except Exception as exc:
+            logger.debug(
+                "Auxiliary %s: could not load main fallback chain: %s",
+                task or "call",
+                exc,
+            )
+            return None, None, ""
 
     if not chain:
         return None, None, ""
@@ -5931,6 +6006,61 @@ def _try_main_fallback_chain(
             task or "call", ", ".join(tried),
         )
     return None, None, ""
+
+
+def _try_explicit_auxiliary_fallback(
+    task: Optional[str],
+    failed_provider: str,
+    *,
+    reason: str,
+    failed_model: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Recover an explicit auxiliary primary without escaping a strict boundary."""
+    task_name = task or ""
+    candidate = _try_configured_fallback_chain(
+        task_name,
+        failed_provider or "auto",
+        reason=reason,
+        failed_model=failed_model,
+    )
+    if candidate[0] is not None:
+        return candidate
+    if _strict_auxiliary_fallback_boundary():
+        return _try_main_fallback_chain(task, failed_provider, reason=reason)
+    return _try_main_agent_model_fallback(
+        failed_provider,
+        task_name,
+        reason=reason,
+        failed_model=failed_model,
+    )
+
+
+def _try_stale_fallback_recovery(
+    failed_provider: str,
+    task: Optional[str],
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Continue within the authorised lane after quarantining a stale rung."""
+    reason = "stale fallback credential"
+    if _strict_auxiliary_fallback_boundary():
+        return _try_main_fallback_chain(task, failed_provider, reason=reason)
+    return _try_payment_fallback(failed_provider, task or "", reason=reason)
+
+
+def _try_unavailable_explicit_auxiliary_fallback(
+    task: Optional[str],
+    failed_provider: str,
+    *,
+    failed_model: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Recover an unavailable explicit primary without escaping strict policy."""
+    if _strict_auxiliary_fallback_boundary():
+        return _try_explicit_auxiliary_fallback(
+            task,
+            failed_provider,
+            reason="provider unavailable before first request",
+            failed_model=failed_model,
+        )
+    return _try_configured_fallback_for_unavailable_client(task, failed_provider)
 
 
 def _resolve_single_provider(
@@ -6125,6 +6255,13 @@ def _resolve_auto_route(
         return fb_client, fb_model, fb_label
 
     # ── Step 3: aggregator / fallback chain ──────────────────────────────
+    if _strict_auxiliary_fallback_boundary():
+        logger.info(
+            "Auxiliary %s: strict fallback boundary exhausted; built-in "
+            "provider discovery disabled",
+            task or "call",
+        )
+        return None, None, ""
     tried = []
     for label, try_fn in _get_provider_chain():
         if _is_provider_unhealthy(label):
@@ -9531,8 +9668,12 @@ def _call_llm_impl(
             # auth (for example openai-codex).
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
-                fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
-                    task, _explicit,
+                fb_client, fb_model, fb_label = (
+                    _try_unavailable_explicit_auxiliary_fallback(
+                        task,
+                        _explicit,
+                        failed_model=resolved_model,
+                    )
                 )
                 if fb_client is not None:
                     client, final_model = fb_client, fb_model
@@ -10116,13 +10257,12 @@ def _call_llm_impl(
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
             else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
+                fb_client, fb_model, fb_label = _try_explicit_auxiliary_fallback(
+                    task,
+                    resolved_provider or "auto",
+                    reason=reason,
+                    failed_model=_chain_failed_model,
+                )
 
             if fb_client is not None:
                 _record_route_info(
@@ -10140,8 +10280,10 @@ def _call_llm_impl(
                 # The candidate had a stale/unrefreshable credential and was
                 # quarantined — walk the discovery chain once more; unhealthy
                 # entries are skipped so the next viable candidate serves.
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason="stale fallback credential")
+                fb_client, fb_model, fb_label = _try_stale_fallback_recovery(
+                    resolved_provider,
+                    task,
+                )
                 if fb_client is not None:
                     _record_route_info(
                         route_info, _fallback_provider_from_label(fb_label), fb_model
@@ -10350,8 +10492,12 @@ async def _async_call_llm_impl(
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
-                fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
-                    task, _explicit,
+                fb_client, fb_model, fb_label = (
+                    _try_unavailable_explicit_auxiliary_fallback(
+                        task,
+                        _explicit,
+                        failed_model=resolved_model,
+                    )
                 )
                 if fb_client is not None:
                     client, final_model = _to_async_client(
@@ -10814,13 +10960,12 @@ async def _async_call_llm_impl(
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
             else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
+                fb_client, fb_model, fb_label = _try_explicit_auxiliary_fallback(
+                    task,
+                    resolved_provider or "auto",
+                    reason=reason,
+                    failed_model=_chain_failed_model,
+                )
 
             if fb_client is not None:
                 # Convert sync fallback client to async
@@ -10843,8 +10988,10 @@ async def _async_call_llm_impl(
                     return fb_resp
                 # Stale/unrefreshable candidate credential — quarantined; walk
                 # the discovery chain once more (unhealthy entries skipped).
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason="stale fallback credential")
+                fb_client, fb_model, fb_label = _try_stale_fallback_recovery(
+                    resolved_provider,
+                    task,
+                )
                 if fb_client is not None:
                     async_fb, async_fb_model = _to_async_client(
                         fb_client, fb_model or "", is_vision=(task == "vision")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -9,6 +9,7 @@ import contextlib
 import copy
 from contextvars import ContextVar
 from dataclasses import dataclass
+import hashlib
 import json
 import logging
 import shutil
@@ -35,6 +36,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -457,7 +459,93 @@ def fire_claim_fence(job_id: str, *, expected_owner: str):
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_IMMUTABLE_JOB_FIELDS = frozenset({"id", "fallback_snapshot"})
+
+_FALLBACK_POLICIES = frozenset({"inherit", "none", "pinned"})
+
+
+def normalize_fallback_policy(value: Any) -> str:
+    """Return one supported cron fallback policy or raise ``ValueError``."""
+    allowed = ", ".join(sorted(_FALLBACK_POLICIES))
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid cron fallback_policy {value!r}; expected one of: {allowed}"
+        )
+    normalized = value.strip().lower()
+    if normalized not in _FALLBACK_POLICIES:
+        raise ValueError(
+            f"Invalid cron fallback_policy {value!r}; expected one of: {allowed}"
+        )
+    return normalized
+
+
+def snapshot_fallback_chain(chain: Any) -> Dict[str, Any]:
+    """Snapshot an ordered fallback route without persisting cleartext secrets."""
+    routes: List[Dict[str, Optional[str]]] = []
+    identity_routes: List[Dict[str, Optional[str]]] = []
+    for raw in chain or []:
+        if not isinstance(raw, dict):
+            continue
+        provider = str(raw.get("provider") or "").strip() or None
+        model = str(raw.get("model") or "").strip() or None
+        base_url = str(raw.get("base_url") or "").strip().rstrip("/") or None
+        if not any((provider, model, base_url)):
+            continue
+
+        safe_base_url = None
+        identity_base_url = None
+        if base_url:
+            try:
+                parsed = urlsplit(base_url)
+                if parsed.scheme and parsed.hostname:
+                    host = parsed.hostname
+                    if ":" in host and not host.startswith("["):
+                        host = f"[{host}]"
+                    try:
+                        port = f":{parsed.port}" if parsed.port is not None else ""
+                    except ValueError:
+                        port = ""
+                    safe_base_url = f"{parsed.scheme.lower()}://{host.lower()}{port}"
+                    identity_base_url = f"{safe_base_url}{parsed.path or ''}"
+                else:
+                    safe_base_url = "<configured endpoint>"
+                    identity_base_url = safe_base_url
+            except (TypeError, ValueError):
+                safe_base_url = "<configured endpoint>"
+                identity_base_url = safe_base_url
+
+        identity_routes.append(
+            {"provider": provider, "model": model, "base_url": identity_base_url}
+        )
+        routes.append(
+            {"provider": provider, "model": model, "base_url": safe_base_url}
+        )
+
+    payload = json.dumps(
+        identity_routes,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return {
+        "fingerprint": hashlib.sha256(payload).hexdigest(),
+        "routes": routes,
+    }
+
+
+def _resolve_current_fallback_chain() -> List[Dict[str, Any]]:
+    """Resolve the active profile's effective global fallback chain."""
+    from hermes_cli.config import _expand_env_vars, load_config
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    cfg = load_config()
+    try:
+        from hermes_cli import managed_scope
+
+        cfg = managed_scope.apply_managed_overlay(cfg)
+    except Exception:
+        pass
+    return get_fallback_chain(_expand_env_vars(cfg))
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -567,6 +655,8 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     ensure consumers never crash while formatting or running those records.
     """
     normalized = _apply_skill_fields(job)
+    normalized.setdefault("fallback_policy", "inherit")
+    normalized.setdefault("fallback_snapshot", None)
     job_id = _coerce_job_text(normalized.get("id"), "unknown")
     prompt = _coerce_job_text(normalized.get("prompt"))
     normalized["id"] = job_id
@@ -1933,6 +2023,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    fallback_policy: str = "inherit",
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2000,6 +2091,10 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        fallback_policy: Per-job cross-provider fallback boundary. ``inherit``
+                follows the active profile chain, ``none`` stops after the
+                primary provider fails, and ``pinned`` snapshots the current
+                route and fails closed if it changes.
 
     Returns:
         The created job dict
@@ -2031,6 +2126,9 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_fallback_policy = normalize_fallback_policy(fallback_policy)
+    if normalized_no_agent:
+        normalized_fallback_policy = "inherit"
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
@@ -2080,6 +2178,16 @@ def create_job(
         base_url=normalized_base_url,
         no_agent=normalized_no_agent,
     )
+    fallback_snapshot = None
+    if normalized_fallback_policy == "pinned":
+        fallback_snapshot = snapshot_fallback_chain(
+            _resolve_current_fallback_chain()
+        )
+        if not fallback_snapshot["routes"]:
+            raise ValueError(
+                "fallback_policy='pinned' requires a configured global "
+                "fallback route to snapshot"
+            )
 
     next_run_at = compute_next_run(parsed_schedule)
     if parsed_schedule.get("kind") == "once" and next_run_at is None:
@@ -2103,6 +2211,8 @@ def create_job(
         "skill": normalized_skills[0] if normalized_skills else None,
         "model": normalized_model,
         "provider": normalized_provider,
+        "fallback_policy": normalized_fallback_policy,
+        "fallback_snapshot": fallback_snapshot,
         # Provider/model resolution captured at creation for unpinned jobs
         # (#44585). None for pinned axes, no_agent jobs, resolution failures, and
         # any pre-existing job written before these fields existed (back-compat).
@@ -2293,6 +2403,32 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     bool(updated.get("no_agent")),
                     _upd_script or None,
                 )
+
+            if {"fallback_policy", "no_agent"}.intersection(updates):
+                raw_fallback_policy = (
+                    updated["fallback_policy"]
+                    if "fallback_policy" in updated
+                    else "inherit"
+                )
+                fallback_policy = normalize_fallback_policy(
+                    raw_fallback_policy
+                )
+                if bool(updated.get("no_agent")):
+                    fallback_policy = "inherit"
+
+                fallback_snapshot = None
+                if fallback_policy == "pinned":
+                    fallback_snapshot = snapshot_fallback_chain(
+                        _resolve_current_fallback_chain()
+                    )
+                    if not fallback_snapshot["routes"]:
+                        raise ValueError(
+                            "fallback_policy='pinned' requires a configured "
+                            "global fallback route to snapshot"
+                        )
+
+                updated["fallback_policy"] = fallback_policy
+                updated["fallback_snapshot"] = fallback_snapshot
 
             if any(k in updates for k in _PAYLOAD_FIELDS):
                 if job_payload_is_empty(updated):
@@ -2578,8 +2714,9 @@ def _set_alert_flag(job_id: str, field: str, value: bool) -> bool:
     job's condition, so the scheduler alerts exactly once and stays silent
     on subsequent ticks until the condition heals (same alert-once shape as
     the dead-pin auto-pause in #73506). Persisted on the job record so the
-    dedup survives gateway restarts. Fields: ``preflight_alerted`` (blocked
-    config, T1-26) and ``drift_alerted`` (#44585 drift-guard skip).
+    dedup survives gateway restarts. Fields include ``preflight_alerted``
+    (blocked config, T1-26), ``drift_alerted`` (#44585 primary-route drift),
+    and ``fallback_drift_alerted`` (the per-job pinned fallback chain).
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -2620,6 +2757,16 @@ def mark_drift_alerted(job_id: str) -> bool:
 def clear_drift_alerted(job_id: str) -> None:
     """Clear the drift alert-dedup marker (resolution matches again)."""
     _set_alert_flag(job_id, "drift_alerted", False)
+
+
+def mark_fallback_drift_alerted(job_id: str) -> bool:
+    """Mark pinned-fallback drift; return True if it was already marked."""
+    return _set_alert_flag(job_id, "fallback_drift_alerted", True)
+
+
+def clear_fallback_drift_alerted(job_id: str) -> None:
+    """Clear pinned-fallback drift once the authorised chain matches again."""
+    _set_alert_flag(job_id, "fallback_drift_alerted", False)
 
 
 def note_fire_forward_failure(job_id: str, detail: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -54,6 +54,7 @@ from hermes_cli.config import (
     resolve_cron_model_drift_defaults,
 )
 from hermes_cli.fallback_config import get_fallback_chain
+from cron.jobs import normalize_fallback_policy, snapshot_fallback_chain
 from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
@@ -121,7 +122,7 @@ def _set_cron_session_title(session_db, session_id, base_title):
         return deduped
 
 
-def _fallback_chain_phrase() -> str:
+def _fallback_chain_phrase(job: Optional[dict] = None) -> str:
     """Wording for the fallback-chain clause of a provider-failure message.
 
     "Fallback chain was exhausted or unavailable." used to fire
@@ -135,6 +136,18 @@ def _fallback_chain_phrase() -> str:
     read (e.g. mid-shutdown, permissions) -- never let a lookup error crash
     failure-message generation itself.
     """
+    raw_policy: Any = "inherit"
+    if isinstance(job, dict) and "fallback_policy" in job:
+        raw_policy = job["fallback_policy"]
+    try:
+        policy = normalize_fallback_policy(raw_policy)
+    except ValueError:
+        return "Cron fallback policy is invalid; no fallback provider was attempted."
+    if policy == "none":
+        return "Cron fallback_policy=none; no fallback provider was attempted."
+    if policy == "pinned":
+        return "Pinned fallback chain was exhausted or unavailable."
+
     try:
         cfg = load_config() or {}
         chain = get_fallback_chain(cfg)
@@ -282,7 +295,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             reason = "quota limit"
         return (
             f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            f"{_fallback_chain_phrase()} "
+            f"{_fallback_chain_phrase(job)} "
             "Full details saved in cron output."
         )
 
@@ -329,7 +342,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            f"{_fallback_chain_phrase()} "
+            f"{_fallback_chain_phrase(job)} "
             "Full details saved in cron output."
         )
 
@@ -4879,6 +4892,56 @@ DRIFT_SKIP_MARKER = "[drift_skip]"
 DRIFT_SKIP_SILENT_MARKER = "[drift_skip:silent]"
 
 
+def _blocked_config_result(
+    job_name: str,
+    job_id: str,
+    reason: str,
+    *,
+    preflight_opt_out: bool = False,
+) -> tuple[bool, str, str, str]:
+    """Build a fail-before-spend result using the existing alert-once lane."""
+    logger.warning(
+        "Job '%s' (ID: %s): BLOCKED by configuration validation — %s "
+        "(no LLM call was made)",
+        job_name,
+        job_id,
+        reason,
+    )
+    already_alerted = False
+    try:
+        from cron.jobs import mark_preflight_alerted
+
+        already_alerted = mark_preflight_alerted(job_id)
+    except Exception:
+        logger.debug(
+            "Job '%s': could not persist preflight alert marker",
+            job_id,
+            exc_info=True,
+        )
+    marker = (
+        BLOCKED_CONFIG_SILENT_MARKER
+        if already_alerted
+        else BLOCKED_CONFIG_MARKER
+    )
+    opt_out = (
+        " Set `cron.preflight: false` in config.yaml to disable ordinary "
+        "pre-dispatch checks."
+        if preflight_opt_out
+        else ""
+    )
+    blocked_doc = (
+        f"# Cron Job: {job_name}\n\n"
+        f"**Job ID:** {job_id}\n"
+        f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        "**Status:** BLOCKED (configuration)\n\n"
+        "Configuration validation found a problem and the agent was NOT run "
+        "(no tokens spent).\n\n"
+        f"**Reason:** {reason}\n\n"
+        "The job will stay blocked without re-alerting until the configuration "
+        f"is fixed; the next healthy run clears this state.{opt_out}"
+    )
+    return False, blocked_doc, "", f"{marker} {reason}"
+
 
 def _is_transient_provider_resolve_error(exc: BaseException) -> bool:
     """True when primary provider resolution failed for a transient network reason.
@@ -4987,7 +5050,15 @@ def _cron_preflight_enabled(cfg: dict) -> bool:
     return cron_cfg.get("preflight", True) is not False
 
 
-def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
+_FALLBACK_CHAIN_UNSET = object()
+
+
+def _preflight_check_provider_key(
+    job: dict,
+    cfg: dict,
+    *,
+    fallback_chain=_FALLBACK_CHAIN_UNSET,
+) -> Optional[str]:
     """READ-ONLY probe: would provider resolution fail for lack of a key?
 
     Mirrors the effective requested-provider computation from run_job's
@@ -4998,7 +5069,12 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     already guaranteed by the fallback resolution being config-local).
     """
     try:
-        if get_fallback_chain(cfg):
+        effective_chain = (
+            get_fallback_chain(cfg)
+            if fallback_chain is _FALLBACK_CHAIN_UNSET
+            else fallback_chain
+        )
+        if effective_chain:
             return None
     except Exception:
         return None  # fail-open: never block on a preflight-internal error
@@ -5150,7 +5226,12 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     return None
 
 
-def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
+def _preflight_job_config(
+    job: dict,
+    cfg: dict,
+    *,
+    fallback_chain=_FALLBACK_CHAIN_UNSET,
+) -> Optional[str]:
     """Pre-dispatch configuration validation (T1-26).
 
     Returns a human-readable reason when the job's configuration cannot
@@ -5167,7 +5248,14 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     alert-once pattern from the dead-pin auto-pause (#73506).
     """
     for name, check in (
-        ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
+        (
+            "provider_key",
+            lambda: _preflight_check_provider_key(
+                job,
+                cfg,
+                fallback_chain=fallback_chain,
+            ),
+        ),
         ("skills", lambda: _preflight_check_skills(job)),
         ("delivery", lambda: _preflight_check_delivery(job)),
     ):
@@ -5790,6 +5878,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _auxiliary_boundary_token = None
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -5982,6 +6071,70 @@ def run_job(
         if _mt is None:
             _mt = _cfg.get("max_turns")
         max_iterations = _resolve_turn_limit(_mt)
+        cfg_dict: dict[str, Any] = _cfg if isinstance(_cfg, dict) else {}
+
+        # Per-job cross-provider fallback boundary. Missing policy means
+        # ``inherit`` for backward compatibility; a present malformed value is
+        # fail-closed so direct jobs.json edits cannot silently widen routing.
+        raw_fallback_policy = (
+            job["fallback_policy"]
+            if "fallback_policy" in job
+            else "inherit"
+        )
+        try:
+            fallback_policy = normalize_fallback_policy(raw_fallback_policy)
+        except ValueError:
+            return _blocked_config_result(
+                job_name,
+                job_id,
+                "stored fallback policy is invalid; update it explicitly to "
+                "inherit, none, or pinned",
+            )
+
+        global_fallback_chain = list(get_fallback_chain(cfg_dict) or [])
+        fallback_chain = global_fallback_chain
+        if fallback_policy == "none":
+            fallback_chain = []
+        elif fallback_policy == "pinned":
+            pinned_snapshot = job.get("fallback_snapshot")
+            pinned_fingerprint = (
+                str(pinned_snapshot.get("fingerprint") or "").strip()
+                if isinstance(pinned_snapshot, dict)
+                else ""
+            )
+            current_fingerprint = snapshot_fallback_chain(global_fallback_chain)[
+                "fingerprint"
+            ]
+            if not pinned_fingerprint or current_fingerprint != pinned_fingerprint:
+                already_alerted = False
+                try:
+                    from cron.jobs import mark_fallback_drift_alerted
+
+                    already_alerted = mark_fallback_drift_alerted(job_id)
+                except Exception:
+                    pass  # fail open: better a duplicate alert than none
+                marker = (
+                    DRIFT_SKIP_SILENT_MARKER
+                    if already_alerted
+                    else DRIFT_SKIP_MARKER
+                )
+                raise RuntimeError(
+                    f"{marker} Pinned fallback route no longer matches the "
+                    "current global configuration. No provider was contacted. "
+                    "Stored and current route details are intentionally omitted. "
+                    "Review the global fallback configuration, then re-pin this "
+                    f"job with `hermes cron edit {job_id} --fallback-policy "
+                    "pinned` to adopt it."
+                )
+            if job.get("fallback_drift_alerted"):
+                try:
+                    from cron.jobs import clear_fallback_drift_alerted
+
+                    clear_fallback_drift_alerted(job_id)
+                except Exception:
+                    pass
+
+        remaining_fallback_chain = list(fallback_chain)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -6017,8 +6170,12 @@ def run_job(
         # ---------------------------------------------------------------
         _pf_reason = None
         try:
-            if _cron_preflight_enabled(_cfg):
-                _pf_reason = _preflight_job_config(job, _cfg)
+            if _cron_preflight_enabled(cfg_dict):
+                _pf_reason = _preflight_job_config(
+                    job,
+                    cfg_dict,
+                    fallback_chain=fallback_chain,
+                )
                 if not _pf_reason and job.get("preflight_alerted"):
                     # Configuration validates again — clear the alert-once
                     # marker so a FUTURE config break re-alerts.
@@ -6124,6 +6281,21 @@ def run_job(
                 str(getattr(resolve_exc, "provider", "") or "").strip().lower()
                 or primary_provider_for_drift
             )
+            if not fallback_chain:
+                if fallback_policy == "none":
+                    logger.warning(
+                        "Job '%s': primary resolve failed and fallback_policy=none; "
+                        "no fallback provider will be attempted",
+                        job_id,
+                    )
+                    raise RuntimeError(
+                        f"{format_runtime_provider_error(resolve_exc)} "
+                        "Cron fallback_policy=none; no fallback provider was "
+                        "attempted."
+                    ) from resolve_exc
+                raise RuntimeError(
+                    format_runtime_provider_error(resolve_exc)
+                ) from resolve_exc
             reason = "auth" if is_auth else "transient network"
             logger.warning(
                 "Job '%s': primary provider resolve failed (%s: %s), trying fallback",
@@ -6131,9 +6303,9 @@ def run_job(
                 reason,
                 resolve_exc,
             )
-            fb_list = get_fallback_chain(_cfg)
+            fb_list = fallback_chain
             runtime = None
-            for entry in fb_list:
+            for fb_index, entry in enumerate(fb_list):
                 if not isinstance(entry, dict):
                     continue
                 fb_provider = str(entry.get("provider") or "").strip()
@@ -6154,6 +6326,7 @@ def run_job(
                         fb_kwargs["explicit_api_key"] = fb_api_key
                     runtime = resolve_runtime_provider(**fb_kwargs)
                     model = fb_model
+                    remaining_fallback_chain = list(fb_list[fb_index + 1 :])
                     logger.info(
                         "Job '%s': fallback resolved to %s model %s",
                         job_id,
@@ -6266,7 +6439,17 @@ def run_job(
                     f"config is pinned or restored. See #44585."
                 )
 
-        fallback_model = get_fallback_chain(_cfg) or None
+        # Re-arm alert-once as soon as every drift guard has passed, not only
+        # after the agent succeeds. A later tool/provider failure is unrelated
+        # to route drift and must not suppress the next genuine drift alert.
+        try:
+            from cron.jobs import clear_drift_alerted
+
+            clear_drift_alerted(job_id)
+        except Exception:
+            pass
+
+        fallback_model = remaining_fallback_chain or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:
@@ -6303,6 +6486,14 @@ def run_job(
             logger.warning(
                 "Job '%s': MCP initialization failed (non-fatal): %s",
                 job_id, _mcp_exc,
+            )
+
+        if fallback_policy in {"none", "pinned"}:
+            from agent.auxiliary_client import set_auxiliary_fallback_boundary
+
+            _auxiliary_boundary_token = set_auxiliary_fallback_boundary(
+                fallback_policy,
+                chain=remaining_fallback_chain,
             )
 
         agent = AIAgent(
@@ -6681,6 +6872,10 @@ def run_job(
             _cron_session_var.reset(_cron_session_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
+        if _auxiliary_boundary_token is not None:
+            from agent.auxiliary_client import reset_auxiliary_fallback_boundary
+
+            reset_auxiliary_fallback_boundary(_auxiliary_boundary_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -185,6 +185,8 @@ def cron_list(show_all: bool = False):
                 print(f"    Changed:   {mon_state['last_changed_at']}")
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
+        else:
+            print(f"    Fallback:  {job.get('fallback_policy') or 'inherit'}")
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
@@ -506,6 +508,7 @@ def cron_create(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        fallback_policy=getattr(args, "fallback_policy", "inherit"),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
@@ -528,6 +531,8 @@ def cron_create(args):
         print(f"  Monitor: {job_data['monitor_url']} (agent runs only on output change)")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    else:
+        print(f"  Fallback: {job_data.get('fallback_policy') or 'inherit'}")
     if job_data.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
@@ -581,6 +586,7 @@ def cron_edit(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", None),
+        fallback_policy=getattr(args, "fallback_policy", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
@@ -606,6 +612,8 @@ def cron_edit(args):
         print(f"  Monitor: {updated['monitor_url']} (agent runs only on output change)")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    else:
+        print(f"  Fallback: {updated.get('fallback_policy') or 'inherit'}")
     if updated.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -71,6 +71,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--fallback-policy",
+        choices=["inherit", "none", "pinned"],
+        default="inherit",
+        help=(
+            "Cross-provider fallback boundary: inherit follows the current "
+            "global chain, none disables it, pinned snapshots the current "
+            "secret-free route and fails closed if it changes."
+        ),
+    )
+    cron_create.add_argument(
         "--monitor-script",
         dest="monitor_script",
         help=(
@@ -191,6 +201,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--fallback-policy",
+        choices=["inherit", "none", "pinned"],
+        default=None,
+        help=(
+            "Set the cross-provider fallback boundary. Choosing pinned "
+            "captures the current global fallback route at edit time."
+        ),
     )
     cron_edit.add_argument(
         "--continuity",

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -386,6 +386,7 @@ class CronJobCreate(BaseModel):
     model: Optional[str] = None
     provider: Optional[str] = None
     base_url: Optional[str] = None
+    fallback_policy: Literal["inherit", "none", "pinned"] = "inherit"
     script: Optional[str] = None
     context_from: Optional[Any] = None
     enabled_toolsets: Optional[List[str]] = None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13005,6 +13005,7 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
 
 def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
     annotated = dict(job)
+    annotated.pop("fallback_snapshot", None)
     annotated["profile"] = profile
     annotated["profile_name"] = profile
     annotated["hermes_home"] = str(home)
@@ -13267,6 +13268,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             model=_cron_optional_text(body.model),
             provider=_cron_optional_text(body.provider),
             base_url=_cron_optional_text(body.base_url, strip_trailing_slash=True),
+            fallback_policy=body.fallback_policy,
             script=script,
             context_from=context_from,
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),

--- a/tests/agent/test_auxiliary_cron_fallback_boundary.py
+++ b/tests/agent/test_auxiliary_cron_fallback_boundary.py
@@ -1,0 +1,312 @@
+"""Cron fallback boundaries must constrain auxiliary provider recovery too."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import auxiliary_client as auxiliary
+
+
+def _install_boundary(policy, chain=None):
+    return auxiliary.set_auxiliary_fallback_boundary(policy, chain or [])
+
+
+def test_boundary_context_is_scoped_and_restored():
+    assert auxiliary.get_auxiliary_fallback_boundary() is None
+
+    token = _install_boundary("none")
+    try:
+        boundary = auxiliary.get_auxiliary_fallback_boundary()
+        assert boundary == {"policy": "none", "chain": []}
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+    assert auxiliary.get_auxiliary_fallback_boundary() is None
+
+
+def test_none_boundary_blocks_every_auxiliary_alternate_lane(monkeypatch):
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError(
+            "strict none boundary must stop before alternate discovery"
+        )
+
+    monkeypatch.setattr(auxiliary, "_get_auxiliary_task_config", unexpected)
+    monkeypatch.setattr(auxiliary, "_get_provider_chain", unexpected)
+    monkeypatch.setattr(auxiliary, "_read_main_provider", lambda: "")
+    monkeypatch.setattr(auxiliary, "_read_main_model", lambda: "")
+
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(config_module, "load_config_readonly", unexpected)
+
+    token = _install_boundary("none")
+    try:
+        assert auxiliary._try_configured_fallback_chain("compression", "primary") == (
+            None,
+            None,
+            "",
+        )
+        assert auxiliary._try_main_fallback_chain("compression", "primary") == (
+            None,
+            None,
+            "",
+        )
+        assert auxiliary._try_payment_fallback("primary", "compression") == (
+            None,
+            None,
+            "",
+        )
+        assert auxiliary._resolve_auto_route(
+            main_runtime={"provider": "", "model": ""},
+            task="compression",
+        ) == (None, None, "")
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+
+def test_pinned_boundary_uses_supplied_chain_without_global_read(monkeypatch):
+    entry = {"provider": "pinned-provider", "model": "pinned-model"}
+    client = MagicMock(name="pinned-client")
+    seen = []
+
+    from hermes_cli import config as config_module
+
+    def unexpected_config_read():
+        raise AssertionError(
+            "pinned auxiliary fallback must not reload the global chain"
+        )
+
+    def resolve(candidate):
+        seen.append(candidate)
+        return client, "pinned-model"
+
+    monkeypatch.setattr(config_module, "load_config_readonly", unexpected_config_read)
+    monkeypatch.setattr(auxiliary, "_resolve_fallback_entry", resolve)
+    monkeypatch.setattr(auxiliary, "_task_minimum_context_length", lambda _task: None)
+    monkeypatch.setattr(auxiliary, "_read_main_provider", lambda: "primary")
+
+    token = _install_boundary("pinned", [entry])
+    try:
+        assert auxiliary._try_main_fallback_chain("compression", "primary") == (
+            client,
+            "pinned-model",
+            "pinned-provider",
+        )
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+    assert seen == [entry]
+
+
+def test_none_boundary_blocks_main_agent_model_safety_net(monkeypatch):
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("none boundary must not inspect the main-agent route")
+
+    monkeypatch.setattr(auxiliary, "_read_main_provider", unexpected)
+    monkeypatch.setattr(auxiliary, "_read_main_model", unexpected)
+
+    token = _install_boundary("none")
+    try:
+        assert auxiliary._try_main_agent_model_fallback(
+            "explicit-aux", "compression"
+        ) == (None, None, "")
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+
+def test_pinned_boundary_routes_explicit_aux_recovery_through_pinned_chain(
+    monkeypatch,
+):
+    client = MagicMock(name="pinned-explicit-recovery")
+
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_main_fallback_chain",
+        lambda *args, **kwargs: (client, "pinned-model", "pinned-provider"),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_main_agent_model_fallback",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pinned boundary must not use main-agent safety net")
+        ),
+    )
+
+    token = _install_boundary(
+        "pinned", [{"provider": "pinned-provider", "model": "pinned-model"}]
+    )
+    try:
+        assert auxiliary._try_explicit_auxiliary_fallback(
+            "compression",
+            "explicit-aux",
+            reason="connection error",
+            failed_model="aux-model",
+        ) == (client, "pinned-model", "pinned-provider")
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+
+def test_pinned_stale_candidate_recovery_reuses_pinned_chain(monkeypatch):
+    client = MagicMock(name="next-pinned-candidate")
+
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_main_fallback_chain",
+        lambda *args, **kwargs: (client, "next-model", "next-provider"),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_payment_fallback",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pinned boundary must not enter built-in discovery")
+        ),
+    )
+
+    token = _install_boundary(
+        "pinned", [{"provider": "next-provider", "model": "next-model"}]
+    )
+    try:
+        assert auxiliary._try_stale_fallback_recovery(
+            "explicit-aux", "compression"
+        ) == (client, "next-model", "next-provider")
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+
+def test_pinned_unavailable_explicit_primary_uses_authorized_chain_sync(monkeypatch):
+    fallback_client = MagicMock(name="pinned-unavailable-sync")
+    fallback_client.base_url = "https://approved.example/v1"
+    fallback_client.chat.completions.create.return_value = object()
+
+    monkeypatch.setattr(
+        auxiliary,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (None, None),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_configured_fallback_for_unavailable_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("strict boundary must not read task-configured fallbacks")
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_main_fallback_chain",
+        lambda *_args, **_kwargs: (
+            fallback_client,
+            "approved-model",
+            "approved-provider",
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_validate_llm_response",
+        lambda _response, *_args, **_kwargs: "approved-result",
+    )
+
+    token = _install_boundary(
+        "pinned", [{"provider": "approved-provider", "model": "approved-model"}]
+    )
+    try:
+        result = auxiliary.call_llm(
+            task="compression",
+            provider="explicit-provider",
+            model="explicit-model",
+            messages=[{"role": "user", "content": "compress"}],
+        )
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+    assert result == "approved-result"
+    fallback_client.chat.completions.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pinned_unavailable_explicit_primary_uses_authorized_chain_async(
+    monkeypatch,
+):
+    fallback_client = MagicMock(name="pinned-unavailable-sync-source")
+    async_client = MagicMock(name="pinned-unavailable-async")
+    async_client.base_url = "https://approved.example/v1"
+    async_client.chat.completions.create = AsyncMock(return_value=object())
+
+    monkeypatch.setattr(
+        auxiliary,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (None, None),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_configured_fallback_for_unavailable_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("strict boundary must not read task-configured fallbacks")
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_try_main_fallback_chain",
+        lambda *_args, **_kwargs: (
+            fallback_client,
+            "approved-model",
+            "approved-provider",
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_to_async_client",
+        lambda *_args, **_kwargs: (async_client, "approved-model"),
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_validate_llm_response",
+        lambda _response, *_args, **_kwargs: "approved-result",
+    )
+
+    token = _install_boundary(
+        "pinned", [{"provider": "approved-provider", "model": "approved-model"}]
+    )
+    try:
+        result = await auxiliary.async_call_llm(
+            task="compression",
+            provider="explicit-provider",
+            model="explicit-model",
+            messages=[{"role": "user", "content": "compress"}],
+        )
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)
+
+    assert result == "approved-result"
+    async_client.chat.completions.create.assert_awaited_once()
+
+
+def test_inherit_boundary_retains_global_main_fallback_behavior(monkeypatch):
+    entry = {"provider": "global-provider", "model": "global-model"}
+    client = MagicMock(name="global-client")
+
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"fallback_providers": [entry]},
+    )
+    monkeypatch.setattr(
+        auxiliary,
+        "_resolve_fallback_entry",
+        lambda candidate: (client, candidate["model"]),
+    )
+    monkeypatch.setattr(auxiliary, "_task_minimum_context_length", lambda _task: None)
+    monkeypatch.setattr(auxiliary, "_read_main_provider", lambda: "primary")
+
+    token = _install_boundary("inherit")
+    try:
+        assert auxiliary._try_main_fallback_chain("compression", "primary") == (
+            client,
+            "global-model",
+            "global-provider",
+        )
+    finally:
+        auxiliary.reset_auxiliary_fallback_boundary(token)

--- a/tests/cron/test_cron_drift_alert_once.py
+++ b/tests/cron/test_cron_drift_alert_once.py
@@ -44,7 +44,7 @@ def _job(**overrides):
     return job
 
 
-def _tick(job, tmp_path, current_provider, deliveries):
+def _tick(job, tmp_path, current_provider, deliveries, *, agent_error=None):
     """Run one run_one_job tick with the provider resolution pinned."""
     fake_db = MagicMock()
 
@@ -68,7 +68,10 @@ def _tick(job, tmp_path, current_provider, deliveries):
          patch.object(sched, "_deliver_result", side_effect=fake_deliver), \
          patch("run_agent.AIAgent") as mock_agent_cls:
         mock_agent = MagicMock()
-        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        if agent_error is None:
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        else:
+            mock_agent.run_conversation.side_effect = agent_error
         mock_agent_cls.return_value = mock_agent
         ok = sched.run_one_job(job)
     return ok, mock_agent_cls.called
@@ -121,6 +124,44 @@ class TestDriftAlertOnce:
             _tick(fresh, tmp_path, "nous", deliveries)
 
         drift_alerts = [d for d in deliveries if "drift" in d.lower()]
+        assert len(drift_alerts) == 2, f"expected re-alert after heal: {deliveries}"
+
+    def test_healed_drift_rearms_even_when_agent_run_then_fails(self, tmp_path):
+        job = _job()
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+
+            fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            _tick(fresh, tmp_path, "nous", deliveries)
+            assert len(
+                [
+                    d
+                    for d in deliveries
+                    if "skipped to prevent unintended spend" in d.lower()
+                ]
+            ) == 1
+
+            fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            _processed, agent_called = _tick(
+                fresh,
+                tmp_path,
+                "openrouter",
+                deliveries,
+                agent_error=RuntimeError("boom unrelated"),
+            )
+            assert agent_called is True
+            stored = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            assert not stored.get("drift_alerted")
+
+            fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            _tick(fresh, tmp_path, "nous", deliveries)
+
+        drift_alerts = [
+            d
+            for d in deliveries
+            if "skipped to prevent unintended spend" in d.lower()
+        ]
         assert len(drift_alerts) == 2, f"expected re-alert after heal: {deliveries}"
 
     def test_non_drift_failures_untouched_by_the_bit(self, tmp_path):

--- a/tests/cron/test_cron_fallback_policy.py
+++ b/tests/cron/test_cron_fallback_policy.py
@@ -1,0 +1,765 @@
+"""Strict per-job cron fallback-boundary contracts."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.scheduler import run_job
+
+
+def _isolated_jobs(monkeypatch):
+    """Return cron.jobs with all persistence confined to memory."""
+    import cron.jobs as jobs
+
+    stored = []
+
+    @contextlib.contextmanager
+    def _noop_lock():
+        yield
+
+    monkeypatch.setattr(jobs, "_jobs_lock", _noop_lock, raising=True)
+    monkeypatch.setattr(jobs, "load_jobs", lambda: list(stored), raising=True)
+
+    def _save(records, **_kwargs):
+        stored[:] = records
+
+    monkeypatch.setattr(jobs, "save_jobs", _save, raising=True)
+    return jobs, stored
+
+
+def test_create_job_persists_explicit_none_policy(monkeypatch):
+    jobs, stored = _isolated_jobs(monkeypatch)
+
+    job = jobs.create_job(
+        prompt="private review",
+        schedule="every 1 hour",
+        provider="openai-codex",
+        model="gpt-5.6-sol",
+        fallback_policy="none",
+    )
+
+    assert job["fallback_policy"] == "none"
+    assert job["fallback_snapshot"] is None
+    assert stored[0]["fallback_policy"] == "none"
+
+
+def test_pinned_snapshot_persists_only_sanitised_route_metadata(monkeypatch):
+    jobs, _stored = _isolated_jobs(monkeypatch)
+    monkeypatch.setattr(
+        jobs,
+        "_resolve_current_fallback_chain",
+        lambda: [
+            {
+                "provider": "custom",
+                "model": "private-model",
+                "base_url": (
+                    "https://alice:supersecret@example.internal:8443/"
+                    "private-token/v1?api_key=query-secret#fragment-secret"
+                ),
+                "api_key": "field-secret",
+            }
+        ],
+        raising=False,
+    )
+
+    job = jobs.create_job(
+        prompt="approved public task",
+        schedule="every 1 hour",
+        fallback_policy="pinned",
+    )
+
+    snapshot = job["fallback_snapshot"]
+    assert snapshot["routes"] == [
+        {
+            "provider": "custom",
+            "model": "private-model",
+            "base_url": "https://example.internal:8443",
+        }
+    ]
+    assert re.fullmatch(r"[0-9a-f]{64}", snapshot["fingerprint"])
+    rendered = json.dumps(snapshot, sort_keys=True)
+    for secret in (
+        "alice",
+        "supersecret",
+        "private-token",
+        "query-secret",
+        "fragment-secret",
+        "field-secret",
+    ):
+        assert secret not in rendered
+
+
+def test_update_to_pinned_atomically_captures_current_route(monkeypatch):
+    jobs, _stored = _isolated_jobs(monkeypatch)
+    job = jobs.create_job(
+        prompt="review",
+        schedule="every 1 hour",
+        fallback_policy="inherit",
+    )
+    monkeypatch.setattr(
+        jobs,
+        "_resolve_current_fallback_chain",
+        lambda: [
+            {
+                "provider": "openrouter",
+                "model": "fallback-model",
+                "base_url": "https://openrouter.ai/api/v1",
+            }
+        ],
+    )
+
+    updated = jobs.update_job(job["id"], {"fallback_policy": "pinned"})
+
+    assert updated["fallback_policy"] == "pinned"
+    assert updated["fallback_snapshot"]["routes"] == [
+        {
+            "provider": "openrouter",
+            "model": "fallback-model",
+            "base_url": "https://openrouter.ai",
+        }
+    ]
+
+
+def test_legacy_job_without_policy_reads_as_inherit():
+    import cron.jobs as jobs
+
+    normalized = jobs._normalize_job_record({
+        "id": "legacy-job",
+        "name": "legacy",
+        "prompt": "run",
+        "schedule": {"kind": "interval", "seconds": 3600},
+    })
+
+    assert normalized["fallback_policy"] == "inherit"
+    assert normalized["fallback_snapshot"] is None
+
+
+def test_legacy_job_no_agent_update_defaults_policy_to_inherit(monkeypatch):
+    jobs, stored = _isolated_jobs(monkeypatch)
+    created = jobs.create_job(
+        prompt="legacy job",
+        schedule="every 1 hour",
+        script="print('ok')",
+    )
+    stored[0].pop("fallback_policy", None)
+    stored[0].pop("fallback_snapshot", None)
+
+    updated = jobs.update_job(created["id"], {"no_agent": True})
+
+    assert updated["no_agent"] is True
+    assert updated["fallback_policy"] == "inherit"
+    assert updated["fallback_snapshot"] is None
+
+
+def test_pinned_fingerprint_is_independent_of_url_secret_components():
+    import cron.jobs as jobs
+
+    first = jobs.snapshot_fallback_chain([
+        {
+            "provider": "custom",
+            "model": "model-a",
+            "base_url": (
+                "https://alice:first-secret@example.internal:8443/"
+                "tenant-route/v1?api_key=first-query#first-fragment"
+            ),
+        }
+    ])
+    second = jobs.snapshot_fallback_chain([
+        {
+            "provider": "custom",
+            "model": "model-a",
+            "base_url": (
+                "https://bob:second-secret@example.internal:8443/"
+                "tenant-route/v1?api_key=second-query#second-fragment"
+            ),
+        }
+    ])
+
+    assert first["routes"] == second["routes"]
+    assert first["fingerprint"] == second["fingerprint"]
+
+
+def test_pinned_fingerprint_changes_when_endpoint_path_changes():
+    import cron.jobs as jobs
+
+    first = jobs.snapshot_fallback_chain([
+        {
+            "provider": "custom",
+            "model": "model-a",
+            "base_url": "https://example.internal:8443/tenant-a/v1?token=secret",
+        }
+    ])
+    second = jobs.snapshot_fallback_chain([
+        {
+            "provider": "custom",
+            "model": "model-a",
+            "base_url": "https://example.internal:8443/tenant-b/v1?token=secret",
+        }
+    ])
+
+    assert first["routes"] == second["routes"]
+    assert "tenant-a" not in repr(first["routes"])
+    assert "tenant-b" not in repr(second["routes"])
+    assert first["fingerprint"] != second["fingerprint"]
+
+
+def _run_job_with_resolver(job, tmp_path, resolver):
+    fake_db = MagicMock()
+    patches = (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=fake_db),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=resolver,
+        ),
+    )
+    with patch("run_agent.AIAgent") as agent_cls, ExitStack() as stack:
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "ok"}
+        agent_cls.return_value = agent
+        for item in patches:
+            stack.enter_context(item)
+        result = run_job(job)
+    return result, agent_cls
+
+
+def test_none_policy_propagates_auxiliary_boundary_into_agent_worker(tmp_path):
+    from agent import auxiliary_client as auxiliary
+
+    (tmp_path / "config.yaml").write_text(
+        "cron:\n  preflight: false\nmodel:\n  default: primary-model\n",
+        encoding="utf-8",
+    )
+    observed = []
+
+    def resolver(**_kwargs):
+        return {
+            "api_key": "test-key",
+            "base_url": "https://primary.invalid/v1",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+
+    def build_agent(*_args, **_kwargs):
+        observed.append(("constructor", auxiliary.get_auxiliary_fallback_boundary()))
+        agent = MagicMock()
+
+        def run_conversation(_prompt):
+            observed.append(("worker", auxiliary.get_auxiliary_fallback_boundary()))
+            return {"final_response": "ok"}
+
+        agent.run_conversation.side_effect = run_conversation
+        return agent
+
+    job = {
+        "id": "none-auxiliary-boundary",
+        "name": "none auxiliary boundary",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "none",
+    }
+    fake_db = MagicMock()
+    patches = (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=fake_db),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=resolver,
+        ),
+        patch("run_agent.AIAgent", side_effect=build_agent),
+    )
+
+    assert auxiliary.get_auxiliary_fallback_boundary() is None
+    with ExitStack() as stack:
+        for item in patches:
+            stack.enter_context(item)
+        success, _output, _final, error = run_job(job)
+
+    assert success is True, error
+    assert observed == [
+        ("constructor", {"policy": "none", "chain": []}),
+        ("worker", {"policy": "none", "chain": []}),
+    ]
+    assert auxiliary.get_auxiliary_fallback_boundary() is None
+
+
+def test_none_policy_stops_after_primary_auth_failure(tmp_path):
+    from hermes_cli.auth import AuthError
+
+    (tmp_path / "config.yaml").write_text(
+        "cron:\n"
+        "  preflight: false\n"
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs.get("requested"))
+        if len(calls) == 1:
+            raise AuthError("primary credential unavailable")
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        }
+
+    job = {
+        "id": "none-runtime",
+        "name": "none runtime",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "none",
+    }
+
+    (success, _output, _final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is False
+    assert calls == ["openai-codex"]
+    assert agent_cls.called is False
+    assert "fallback_policy=none" in (error or "")
+
+
+def test_none_policy_preflight_does_not_use_global_chain_as_rescue(tmp_path):
+    from hermes_cli.auth import AuthError
+
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs.get("requested"))
+        raise AuthError("primary credential unavailable")
+
+    job = {
+        "id": "none-preflight",
+        "name": "none preflight",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "none",
+    }
+
+    (success, _output, _final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is False
+    assert calls == ["openai-codex"]
+    assert agent_cls.called is False
+    assert "[blocked_config]" in (error or "")
+
+
+def test_none_policy_failure_summary_does_not_consult_global_chain(monkeypatch):
+    import cron.scheduler as scheduler
+
+    def unexpected_config_read():
+        raise AssertionError("none-policy summary must not read global fallback config")
+
+    monkeypatch.setattr(scheduler, "load_config", unexpected_config_read)
+    message = scheduler._summarize_cron_failure_for_delivery(
+        {
+            "id": "none-summary",
+            "name": "none summary",
+            "fallback_policy": "none",
+        },
+        "HTTP 429: rate limit exceeded",
+    )
+
+    assert "fallback_policy=none" in message
+    assert "no fallback provider was attempted" in message
+    assert "exhausted" not in message.lower()
+
+
+def test_pinned_route_drift_fails_before_provider_resolution(tmp_path):
+    import cron.jobs as cron_jobs
+
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: current-provider\n"
+        "    model: current-model\n"
+        "    base_url: https://current.example/v1?token=current-secret\n",
+        encoding="utf-8",
+    )
+    expected = cron_jobs.snapshot_fallback_chain([
+        {
+            "provider": "expected-provider",
+            "model": "expected-model",
+            "base_url": "https://expected.example/v1?token=expected-secret",
+        }
+    ])
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs)
+        return {
+            "api_key": "test-key",
+            "base_url": "https://primary.invalid/v1",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+
+    job = {
+        "id": "pinned-drift",
+        "name": "pinned drift",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "pinned",
+        "fallback_snapshot": expected,
+    }
+
+    (success, _output, _final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is False
+    assert calls == []
+    assert agent_cls.called is False
+    assert "[drift_skip]" in (error or "")
+    for private_value in (
+        "expected-provider",
+        "expected-model",
+        "expected-secret",
+        "current-provider",
+        "current-model",
+        "current-secret",
+    ):
+        assert private_value not in (error or "")
+
+
+def test_invalid_stored_policy_is_blocked_without_echoing_value(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "model:\n  default: primary-model\n", encoding="utf-8"
+    )
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("provider resolution must not run")
+
+    job = {
+        "id": "invalid-policy",
+        "name": "invalid policy",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "unknown-policy-with-private-value",
+    }
+
+    (success, _output, _final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is False
+    assert calls == []
+    assert agent_cls.called is False
+    assert "[blocked_config]" in (error or "")
+    assert "unknown-policy-with-private-value" not in (error or "")
+
+
+@pytest.mark.parametrize(
+    "stored_policy",
+    [None, False, 0, [], {}],
+    ids=["null", "false", "zero", "list", "mapping"],
+)
+def test_falsy_malformed_stored_policy_is_blocked(tmp_path, stored_policy):
+    (tmp_path / "config.yaml").write_text(
+        "model:\n  default: primary-model\n", encoding="utf-8"
+    )
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("provider resolution must not run")
+
+    job = {
+        "id": "invalid-falsy-policy",
+        "name": "invalid falsy policy",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": stored_policy,
+    }
+
+    (success, _output, _final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is False
+    assert calls == []
+    assert agent_cls.called is False
+    assert "[blocked_config]" in (error or "")
+
+
+def test_pinned_create_rejects_chain_without_usable_route(monkeypatch):
+    jobs, stored = _isolated_jobs(monkeypatch)
+    monkeypatch.setattr(
+        jobs,
+        "_resolve_current_fallback_chain",
+        lambda: [{"provider": "", "model": "", "api_key": "private-value"}],
+    )
+
+    with pytest.raises(ValueError, match="configured global fallback route"):
+        jobs.create_job(
+            prompt="run",
+            schedule="every 1 hour",
+            fallback_policy="pinned",
+        )
+
+    assert stored == []
+
+
+def test_no_agent_create_ignores_policy_without_resolving_chain(monkeypatch):
+    jobs, _stored = _isolated_jobs(monkeypatch)
+
+    def unexpected_resolution():
+        raise AssertionError("no_agent create must not read fallback config")
+
+    monkeypatch.setattr(jobs, "_resolve_current_fallback_chain", unexpected_resolution)
+    job = jobs.create_job(
+        prompt="",
+        schedule="every 1 hour",
+        script="watchdog.py",
+        no_agent=True,
+        fallback_policy="pinned",
+    )
+
+    assert job["fallback_policy"] == "inherit"
+    assert job["fallback_snapshot"] is None
+
+
+def test_no_agent_update_clears_existing_pinned_policy(monkeypatch):
+    jobs, _stored = _isolated_jobs(monkeypatch)
+    monkeypatch.setattr(
+        jobs,
+        "_resolve_current_fallback_chain",
+        lambda: [{"provider": "openrouter", "model": "fallback-model"}],
+    )
+    job = jobs.create_job(
+        prompt="run",
+        schedule="every 1 hour",
+        script="watchdog.py",
+        fallback_policy="pinned",
+    )
+
+    updated = jobs.update_job(job["id"], {"no_agent": True})
+
+    assert updated["fallback_policy"] == "inherit"
+    assert updated["fallback_snapshot"] is None
+
+
+def test_fallback_snapshot_cannot_be_updated_directly(monkeypatch):
+    import pytest
+
+    jobs, _stored = _isolated_jobs(monkeypatch)
+    job = jobs.create_job(prompt="run", schedule="every 1 hour", fallback_policy="none")
+
+    with pytest.raises(ValueError, match="fallback_snapshot"):
+        jobs.update_job(
+            job["id"],
+            {"fallback_snapshot": {"fingerprint": "forged", "routes": []}},
+        )
+
+
+def test_update_away_from_pinned_clears_snapshot(monkeypatch):
+    jobs, _stored = _isolated_jobs(monkeypatch)
+    monkeypatch.setattr(
+        jobs,
+        "_resolve_current_fallback_chain",
+        lambda: [{"provider": "openrouter", "model": "fallback-model"}],
+    )
+    job = jobs.create_job(
+        prompt="run",
+        schedule="every 1 hour",
+        fallback_policy="pinned",
+    )
+
+    updated = jobs.update_job(job["id"], {"fallback_policy": "none"})
+
+    assert updated["fallback_policy"] == "none"
+    assert updated["fallback_snapshot"] is None
+
+
+def test_none_policy_primary_success_gives_agent_no_cross_provider_chain(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "cron:\n"
+        "  preflight: false\n"
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: fallback-model\n",
+        encoding="utf-8",
+    )
+
+    def resolver(**_kwargs):
+        return {
+            "api_key": "test-key",
+            "base_url": "https://primary.invalid/v1",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+
+    job = {
+        "id": "none-success",
+        "name": "none success",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "none",
+    }
+
+    (success, _output, final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is True
+    assert error is None
+    assert final == "ok"
+    assert agent_cls.call_args.kwargs["fallback_model"] is None
+
+
+def test_pinned_auth_fallback_only_offers_later_routes_to_agent(tmp_path):
+    import cron.jobs as cron_jobs
+    from hermes_cli.auth import AuthError
+
+    chain = [
+        {"provider": "first-fallback", "model": "first-model"},
+        {"provider": "second-fallback", "model": "second-model"},
+    ]
+    (tmp_path / "config.yaml").write_text(
+        "cron:\n"
+        "  preflight: false\n"
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: first-fallback\n"
+        "    model: first-model\n"
+        "  - provider: second-fallback\n"
+        "    model: second-model\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def resolver(**kwargs):
+        calls.append(kwargs.get("requested"))
+        if kwargs.get("requested") == "openai-codex":
+            raise AuthError("primary credential unavailable")
+        return {
+            "api_key": "test-key",
+            "base_url": "https://fallback.invalid/v1",
+            "provider": kwargs.get("requested"),
+            "api_mode": "chat_completions",
+        }
+
+    job = {
+        "id": "pinned-auth",
+        "name": "pinned auth",
+        "prompt": "run",
+        "model": "primary-model",
+        "provider": "openai-codex",
+        "base_url": None,
+        "deliver": "local",
+        "fallback_policy": "pinned",
+        "fallback_snapshot": cron_jobs.snapshot_fallback_chain(chain),
+    }
+
+    (success, _output, final, error), agent_cls = _run_job_with_resolver(
+        job, tmp_path, resolver
+    )
+
+    assert success is True
+    assert error is None
+    assert final == "ok"
+    assert calls == ["openai-codex", "first-fallback"]
+    kwargs = agent_cls.call_args.kwargs
+    assert kwargs["model"] == "first-model"
+    assert kwargs["fallback_model"] == [chain[1]]
+
+
+def test_pinned_drift_marker_becomes_silent_after_first_alert(tmp_path, monkeypatch):
+    import cron.jobs as cron_jobs
+
+    expected_chain = [{"provider": "approved", "model": "approved-model"}]
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: primary-model\n"
+        "fallback_providers:\n"
+        "  - provider: changed\n"
+        "    model: changed-model\n",
+        encoding="utf-8",
+    )
+
+    def resolver(**_kwargs):
+        raise AssertionError("pinned drift must stop before provider resolution")
+
+    with cron_jobs.use_cron_store(tmp_path / "cron-store"):
+        monkeypatch.setattr(
+            cron_jobs,
+            "_resolve_current_fallback_chain",
+            lambda: expected_chain,
+        )
+        job = cron_jobs.create_job(
+            prompt="run",
+            schedule="every 1 hour",
+            provider="openai-codex",
+            model="primary-model",
+            fallback_policy="pinned",
+        )
+
+        first, _agent_cls = _run_job_with_resolver(job, tmp_path, resolver)
+        refreshed = cron_jobs.get_job(job["id"])
+        assert refreshed is not None
+        assert refreshed.get("fallback_drift_alerted") is True
+        assert not refreshed.get("drift_alerted")
+        second, _agent_cls = _run_job_with_resolver(refreshed, tmp_path, resolver)
+
+    assert "[drift_skip]" in (first[3] or "")
+    assert "[drift_skip:silent]" not in (first[3] or "")
+    assert "[drift_skip:silent]" in (second[3] or "")

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,17 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_keeps_user_owned_inference_policy_out_of_model_tool():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    properties = CRONJOB_SCHEMA["parameters"]["properties"]
+    for user_owned_route_field in (
+        "model",
+        "provider",
+        "base_url",
+        "reasoning_effort",
+        "fallback_policy",
+    ):
+        assert user_owned_route_field not in properties
+
+

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -128,6 +128,28 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
 
+    def test_create_forwards_fallback_policy(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Run privately",
+                name="Private job",
+                deliver="local",
+                repeat=None,
+                skill=None,
+                skills=None,
+                script=None,
+                workdir=None,
+                no_agent=False,
+                fallback_policy="none",
+            )
+        )
+
+        jobs = list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["fallback_policy"] == "none"
+        assert "Fallback: none" in capsys.readouterr().out
 
 
 class TestGatewayNotRunningWarning:

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,21 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_fallback_policy_create_default_and_edit_tristate():
+    parser = _build()
+
+    created = parser.parse_args(["cron", "create", "30m", "run"])
+    assert created.fallback_policy == "inherit"
+    assert parser.parse_args(
+        ["cron", "create", "30m", "run", "--fallback-policy", "none"]
+    ).fallback_policy == "none"
+
+    assert parser.parse_args(["cron", "edit", "j"]).fallback_policy is None
+    assert parser.parse_args(
+        ["cron", "edit", "j", "--fallback-policy", "pinned"]
+    ).fallback_policy == "pinned"
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.

--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -206,3 +206,39 @@ class TestCronJobSkills:
         )
         assert resp.status_code == 200
         assert resp.json()["skills"] == []
+
+    def test_create_and_update_fallback_policy(self, client, isolated_profiles):
+        created = client.post(
+            "/api/cron/jobs",
+            json={
+                "prompt": "do private work",
+                "schedule": "every 1h",
+                "fallback_policy": "none",
+            },
+        )
+
+        assert created.status_code == 200
+        job = created.json()
+        assert job["fallback_policy"] == "none"
+        assert "fallback_snapshot" not in job
+
+        fetched = client.get(
+            f"/api/cron/jobs/{job['id']}", params={"profile": "default"}
+        )
+        assert fetched.status_code == 200
+        assert "fallback_snapshot" not in fetched.json()
+
+        listed = client.get("/api/cron/jobs", params={"profile": "default"})
+        assert listed.status_code == 200
+        matching = [item for item in listed.json() if item["id"] == job["id"]]
+        assert len(matching) == 1
+        assert "fallback_snapshot" not in matching[0]
+
+        updated = client.put(
+            f"/api/cron/jobs/{job['id']}",
+            json={"updates": {"fallback_policy": "inherit"}},
+            params={"profile": "default"},
+        )
+        assert updated.status_code == 200
+        assert updated.json()["fallback_policy"] == "inherit"
+        assert "fallback_snapshot" not in updated.json()

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,36 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_round_trips_explicit_none_fallback_policy(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                fallback_policy="none",
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["fallback_policy"] == "none"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["fallback_policy"] == "none"
+
+    def test_create_rejects_explicit_empty_fallback_policy(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                fallback_policy="",
+            )
+        )
+
+        assert created["success"] is False
+        assert "fallback_policy" in created["error"]
+        assert json.loads(cronjob(action="list"))["count"] == 0
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 
@@ -393,24 +423,25 @@ class TestUnifiedCronjobTool:
 # =========================================================================
 
 
-class TestAgentCannotSetModelPin:
-    """Per-job inference pins are user-owned (dashboard / `hermes cron`
-    --model / hand-edited jobs). The agent-facing tool schema must not expose
-    model/provider/base_url, and the registered handler must ignore them even
-    if a model hallucinates the old parameters."""
+class TestAgentCannotSetInferencePolicy:
+    """Per-job inference pins and fallback boundaries are user-owned.
 
-    def test_schema_has_no_inference_pin_params(self):
+    The agent-facing tool schema must not expose model/provider/base_url or
+    fallback_policy, and the registered handler must ignore them even if a
+    model hallucinates the parameters.
+    """
+
+    def test_schema_has_no_user_owned_inference_params(self):
         from tools.cronjob_tools import CRONJOB_SCHEMA
 
         props = CRONJOB_SCHEMA["parameters"]["properties"]
         assert "model" not in props
         assert "provider" not in props
         assert "base_url" not in props
+        assert "fallback_policy" not in props
 
-
-    def test_handler_update_leaves_user_pin_untouched(self):
-        """An update through the agent handler must not clear or change a
-        user-set pin (grandfathered agent-era pins included)."""
+    def test_handler_update_leaves_user_inference_policy_untouched(self):
+        """Agent updates cannot clear or relax user-owned inference policy."""
         from cron.jobs import get_job
         from tools.registry import registry
 
@@ -421,6 +452,7 @@ class TestAgentCannotSetModelPin:
                 schedule="every 1h",
                 model="anthropic/claude-sonnet-4",
                 provider="anthropic",
+                fallback_policy="none",
             )
         )
         job_id = created["job_id"]
@@ -433,6 +465,7 @@ class TestAgentCannotSetModelPin:
                     "job_id": job_id,
                     "name": "renamed",
                     "model": {"model": "openai/gpt-4.1"},
+                    "fallback_policy": "inherit",
                 },
             )
         )
@@ -441,6 +474,7 @@ class TestAgentCannotSetModelPin:
         assert stored is not None
         assert stored["model"] == "anthropic/claude-sonnet-4"
         assert stored["provider"] == "anthropic"
+        assert stored["fallback_policy"] == "none"
         assert stored["name"] == "renamed"
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -763,6 +763,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "fallback_policy": job.get("fallback_policy") or "inherit",
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -1371,6 +1372,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    fallback_policy: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1473,6 +1475,9 @@ def cronjob(
                     model=_normalize_optional_job_value(model),
                     provider=_normalize_optional_job_value(provider),
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                    fallback_policy=(
+                        fallback_policy if fallback_policy is not None else "inherit"
+                    ),
                     script=_normalize_optional_job_value(script),
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
@@ -1693,6 +1698,8 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if fallback_policy is not None:
+                updates["fallback_policy"] = fallback_policy
             if reasoning_effort is not None:
                 # CLI-only lane (see create above): update_job validates
                 # against the canonical grammar; empty string clears the pin.
@@ -1960,11 +1967,12 @@ def _cronjob_handler(args, **kw):
         include_disabled=args.get("include_disabled", True),
         skill=args.get("skill"),
         skills=args.get("skills"),
-        # model / provider / base_url are intentionally NOT read from the
-        # agent's arguments: per-job inference pins are user-owned (dashboard,
-        # `hermes cron create/edit --model`, or hand-edited jobs). The agent
-        # must not be able to point unattended spend at a different model.
-        # Programmatic callers of cronjob() itself retain the parameters.
+        # model / provider / base_url / fallback_policy are intentionally NOT
+        # read from the agent's arguments: per-job inference policy is user-owned
+        # (`hermes cron create/edit --model/--fallback-policy`, dashboard API, or
+        # hand-edited jobs). The agent must not point unattended spend at a
+        # different route or relax its fallback boundary. Programmatic callers
+        # of cronjob() itself retain the parameters.
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -35,6 +35,56 @@ All of this is available to Hermes itself through the `cronjob` tool, so you can
 **Per-job reasoning effort.** A job can pin its own thinking level, independent of the model pin: one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. When set, it overrides both the global `agent.reasoning_effort` and per-model `agent.reasoning_overrides` for that job's runs (`none` disables thinking). Set it via `hermes cron create/edit --reasoning-effort high`; pass an empty string on edit to clear the pin and follow config again. (It is deliberately not exposed on the agent's `cronjob` tool — model configuration stays a user decision.) Levels a model doesn't support are clamped or omitted by the provider at request time — pinning `xhigh` on a model that caps at `high` runs at `high`. The pin has no effect on `no_agent` jobs (there is no LLM call to tune). Use it to run heavy scheduled analyses at `high` while cheap recurring jobs run at `minimal`, without touching your global default.
 :::
 
+## Per-job fallback boundaries
+
+Operators can constrain an agent-backed cron job's cross-provider fallback
+independently of its primary model/provider pin:
+
+| Policy | Behaviour |
+| --- | --- |
+| `inherit` | Default. Use the profile's current ordered `fallback_providers` chain. |
+| `none` | Do not recover through a fallback provider after the primary route fails. The normal same-provider credential pool still applies. |
+| `pinned` | Snapshot the current ordered fallback route and fail closed if that route later changes. |
+
+Set the boundary when creating or editing a job:
+
+```bash
+hermes cron create "every 2h" "Check server status" \
+  --fallback-policy none
+
+hermes cron edit <job_id> --fallback-policy pinned
+```
+
+The web API accepts the same `fallback_policy` field. Like model/provider pins,
+this is deliberately not exposed to the agent-facing `cronjob` tool: unattended
+agent actions cannot relax a user-owned inference boundary.
+
+`pinned` requires at least one configured fallback route. Its stored snapshot
+contains a SHA-256 route fingerprint plus display metadata limited to
+provider/model and the endpoint origin (`scheme://host[:port]`). The fingerprint
+also covers the normalised endpoint path so a same-origin path change is treated
+as drift. Cleartext URL userinfo, path, query, and fragment are not persisted;
+userinfo, query, and fragment are excluded from the fingerprint, while the path
+contributes only inside the SHA-256 digest. If the route drifts, Hermes contacts
+no provider, records `drift_skip`, and alerts once; later identical ticks are
+silent until the route is restored or the job is explicitly re-pinned.
+
+The same authorised route is used by preflight, initial authentication
+recovery, and the agent runtime. Therefore a `none` job cannot be rescued by a
+global fallback during preflight, and a selected auth fallback is not offered
+to the agent a second time. Setting `cron.preflight: false` does **not** disable
+the fallback boundary.
+
+Automatic auxiliary-model recovery follows the same boundary. `none` disables
+task-specific fallback chains, the global main fallback chain, and built-in
+provider discovery for auxiliary calls. `pinned` permits only the already
+authorised pinned chain and likewise disables other discovery. An explicitly
+configured auxiliary task's primary provider, and providers contacted by an
+explicit tool action, are not fallback routes and remain outside this policy.
+
+Script-only (`no_agent`) jobs do not perform inference, so their stored policy
+is canonicalised to `inherit` and no fallback snapshot is retained.
+
 :::warning
 Cron-run sessions cannot recursively create more cron jobs. Hermes disables cron management tools inside cron executions to prevent runaway scheduling loops.
 :::


### PR DESCRIPTION
## Summary

Adds an operator-controlled, per-job fallback boundary for agent-backed cron jobs:

- `inherit` uses the effective global fallback chain;
- `none` allows the primary route but no cross-provider fallback;
- `pinned` captures a secret-free fingerprint of the ordered fallback route and fails closed before inference if that route drifts.

The boundary is enforced through scheduler preflight, primary-route recovery, and synchronous/asynchronous auxiliary calls. CLI and web API callers can create or edit the policy; the model-facing `cronjob` schema deliberately cannot set or relax it.

## Behaviour

| Policy | Contract |
| --- | --- |
| `inherit` | Default for legacy and new jobs. Uses the live effective fallback chain. |
| `none` | Stops after the primary route/same-provider credential pool; no cross-provider fallback is attempted. |
| `pinned` | Stores an internal fingerprint of the current ordered fallback chain and skips before spend if the effective chain changes. |

Additional details:

- `no_agent` jobs canonicalise to `inherit` because they perform no model inference;
- malformed stored policies fail closed;
- pinned drift alerts once per drift episode and re-arms after the route heals;
- changing a pinned job's route inputs explicitly re-pins it;
- auxiliary compression/title/tool-selection recovery remains inside the active job boundary.

## Security and storage

- persisted display metadata contains only provider/model identity and endpoint origin;
- endpoint path contributes only to the SHA-256 fingerprint, so same-origin path changes are detected without persisting the cleartext path;
- URL userinfo, query, and fragment are excluded from both stored metadata and fingerprint input;
- the internal snapshot is immutable through ordinary updates and stripped from public CLI/tool/API output;
- pinned drift is checked before provider resolution or inference spend.

## Scope and relationship to active PRs

This is a **cron-scoped authorisation boundary**, not a new primary router or global fallback policy.

- #63418 owns global fallback-policy and observability work. If it lands first, `inherit` should consume its effective filtered chain; `none` and `pinned` only narrow that chain for one job.
- #95835 owns capability-based primary route selection. If it lands first, this boundary should wrap the chain that routing resolves. A routed result with no fallback must remain authoritative: this patch must never reintroduce fallback where capability routing selected none.

Those PRs overlap textually in fallback/cron surfaces, so merge-order reconciliation may be needed. The intended composition rule is: **primary routing resolves first; global policy filters next; the per-job boundary may only narrow the result**.

A dashboard selector is intentionally out of scope. The backend API field is present for a later UI change.

## Verification

Focused contract suite:

```text
8 files
146 passed
0 failed
```

Entire cron subsystem:

```text
79 files
1,000 passed
10 skipped
0 failed
```

Static checks:

```text
ruff check <touched Python files>     passed
python -m compileall <touched files>  passed
git diff --check                      passed
```

Full local suite, no per-file retries, using the same interpreter and dependency set for candidate and exact base `791e2ae3257e211d14ca77e654dfe10ee1976a1c`:

| Run | Failed tests | Failing files | Collection/import failures |
| --- | ---: | ---: | ---: |
| Candidate | 107 | 31 | 11 |
| Exact base | 108 | 32 | 11 |

The candidate has no candidate-only failing or collection-error files. Its failing-file manifest is a strict subset of exact base; the base-only failure was `tests/agent/lsp/test_client_e2e.py`. The shared failures are existing optional dependency, platform/runtime, external integration, and update-simulation failures in this local environment; no file in the cron/fallback patch surface failed.

## Why draft

The contract and local patch are review-ready, but the draft state makes the active overlap and intended composition with #63418 and #95835 explicit before maintainers choose merge order.
