### PR TITLE
feat(discord): seed create_thread with an optional first message

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -306,6 +306,52 @@ class TestCreateThread:
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
 
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_with_content_seeds_first_message(self, mock_req, monkeypatch):
+        """#96057: content posts into the fresh thread via message-create."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "802", "name": "Decision"},   # thread created
+            {"id": "9001"},                       # seed message sent
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Decision",
+            content="Summary: we chose option B.",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "802"
+        assert result["seeded_message_id"] == "9001"
+        assert mock_req.call_count == 2
+        seed_call = mock_req.call_args_list[1]
+        assert seed_call.args == ("POST", "/channels/802/messages", "test-token")
+        assert seed_call.kwargs["body"] == {"content": "Summary: we chose option B."}
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_seed_failure_is_fail_soft(self, mock_req, monkeypatch):
+        """The thread exists by seed time — a failed send must not fail the action."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "803", "name": "Notes"},
+            DiscordAPIError(403, '{"message": "Missing Access"}'),
+        ]
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Notes", content="hello",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "803"
+        assert "seed_error" in result
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_without_content_makes_one_call(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "804", "name": "Plain"}
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Plain",
+        ))
+        assert result["success"] is True
+        assert mock_req.call_count == 1
+        assert "seed_error" not in result and "seeded_message_id" not in result
+
 
 # ---------------------------------------------------------------------------
 # Error handling

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -587,9 +587,20 @@ def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
     auto_archive_duration: int = 1440,
+    content: Optional[str] = None,
     **_kwargs: Any,
 ) -> str:
-    """Create a thread in a channel."""
+    """Create a thread in a channel, optionally seeding a first message.
+
+    ``content`` (when non-empty) is posted into the freshly created thread
+    via the normal message-create path. Neither thread-creation endpoint
+    (from-message or standalone) carries a message body, so seeding is a
+    second call — without it the thread is born as a named, anchored shell
+    and "create a thread and post the summary into it" workflows can only
+    half-complete (#96057). Seeding is fail-soft: the thread exists by the
+    time the send runs, so a failed send is reported in the payload rather
+    than failing the whole action.
+    """
     if message_id:
         # Create thread from an existing message
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
@@ -606,11 +617,26 @@ def _create_thread(
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
-    return json.dumps({
+    result: Dict[str, Any] = {
         "success": True,
         "thread_id": thread["id"],
         "name": thread.get("name"),
-    })
+    }
+    seed = str(content).strip() if content else ""
+    if seed:
+        try:
+            seeded = _discord_request(
+                "POST",
+                f"/channels/{thread['id']}/messages",
+                token,
+                body={"content": seed},
+            )
+            result["seeded_message_id"] = seeded.get("id")
+        except Exception as exc:
+            # The thread itself was created successfully — surface the seed
+            # failure instead of failing the action over it.
+            result["seed_error"] = str(exc)
+    return json.dumps(result)
 
 
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
@@ -669,7 +695,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
-    ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor and optional content first message"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -871,6 +897,14 @@ def _build_schema(
             "enum": [60, 1440, 4320, 10080],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
+        "content": {
+            "type": "string",
+            "description": (
+                "First message to seed the new thread with (create_thread, "
+                "optional). Without it the thread is created empty; the same "
+                "length limits as a normal message apply."
+            ),
+        },
     }
 
     return {
@@ -998,6 +1032,7 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    content: str = "",
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -1051,6 +1086,7 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            content=content,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)


### PR DESCRIPTION
## What does this PR do?

The `discord` tool's `create_thread` accepted no content parameter, so an agent following a "create a thread and post the decision summary into it" request produced a named, anchored shell with an **empty starter message** — the substantive content had to be delivered to the parent channel and the workflow half-completed (observed in the wild, #96057).

`create_thread` now takes an optional `content` parameter. Neither Discord thread-creation endpoint (from-message or standalone) carries a message body, so seeding is a second call to the normal message-create path against the fresh thread id — the same limits as a normal send apply, and it works for both anchored and standalone threads. Seeding is **fail-soft**: the thread already exists by the time the send runs, so a failed send surfaces as `seed_error` in the payload rather than failing the whole action.

## Related Issue

Fixes #96057

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/discord_tool.py`
  - `_create_thread` accepts `content`; after a successful creation it posts the seed message into the new thread and returns `seeded_message_id` (or `seed_error`, fail-soft).
  - `_run_discord_action` forwards the new `content` kwarg; the tool schema gains the `content` property and the usage hint mentions it.
- `tests/tools/test_discord_tool.py` (+3 in `TestCreateThread`): content seeds the first message into the fresh thread (exact API call pinned); a failed seed is fail-soft; no content keeps today's single-call behavior.

## How to Test

1. `python -m pytest tests/tools/test_discord_tool.py -q` — should pass (50 passed).
2. Red/green: on unpatched `main`, the seed tests fail (`content` is not an accepted kwarg); with this PR they pass. The no-content pin passes on both — the default path is unchanged.
3. Manual: `discord(action="create_thread", channel_id=..., name="Decision", content="Summary: we chose option B.")` — the thread appears with the summary as its first message.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the two-call seeding rationale and the fail-soft contract documented on `_create_thread`)
- [x] New and existing unit tests pass locally (3 new; 50 in the discord tool suites)
- [x] Changes are backward compatible (content is optional; the default single-call behavior is pinned unchanged)
