### PR TITLE
fix(discord): stop promising unavailable message actions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18908,13 +18908,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and getattr(source, "platform", None) == Platform.DISCORD
             and getattr(event, "message_id", None)
         ):
-            from gateway.session import _discord_tools_loaded as _disc_tools_loaded
-            if _disc_tools_loaded():
-                message_text = (
-                    f"[Triggering message id: `{event.message_id}` — use as "
-                    f"`message_id` for reply/react/pin via the discord tools.]\n\n"
-                    f"{message_text}"
-                )
+            from gateway.session import _format_discord_message_id_note
+            message_id_note = _format_discord_message_id_note(str(event.message_id))
+            if message_id_note:
+                message_text = f"{message_id_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -445,6 +445,36 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def _discord_message_id_actions() -> tuple[str, ...]:
+    """Return the loaded Discord actions that can consume a message id."""
+    try:
+        from agent.secret_scope import get_secret
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        from tools.discord_tool import get_available_message_id_actions
+
+        if not (get_secret("DISCORD_BOT_TOKEN", "") or "").strip():
+            return ()
+        cfg = load_config()
+        enabled = set(
+            _get_platform_tools(cfg, "discord", include_default_mcp_servers=False)
+        )
+        return get_available_message_id_actions(enabled)
+    except Exception:
+        return ()
+
+
+def _format_discord_message_id_note(message_id: str) -> Optional[str]:
+    """Build the per-turn note without promising unavailable actions."""
+    actions = _discord_message_id_actions()
+    if not actions:
+        return None
+    return (
+        f"[Triggering message id: `{message_id}` — available as `message_id` for "
+        f"these loaded Discord actions: {', '.join(actions)}.]"
+    )
+
+
 _MAX_PROMPT_METADATA_CHARS = 240
 
 
@@ -643,7 +673,8 @@ def build_session_context_prompt(
                 id_lines.append(f"  - Thread: `{src.thread_id}` (use as `channel_id` for fetch_messages etc.)")
             else:
                 id_lines.append(f"  - Channel: `{src.chat_id}`")
-            if src.message_id:
+            message_id_actions = _discord_message_id_actions()
+            if src.message_id and message_id_actions:
                 # The triggering message id is volatile (changes every turn).
                 # Keep it OUT of this cached system-prompt block — including it
                 # here changes build_session_context_prompt() output per turn,
@@ -653,7 +684,8 @@ def build_session_context_prompt(
                 # "Triggering message id" note in run.py).
                 id_lines.append(
                     "  - Triggering message: provided per-turn in the incoming "
-                    "user message (use it as `message_id` for reply/react/pin)"
+                    "user message for these loaded actions: "
+                    f"{', '.join(message_id_actions)}"
                 )
             lines.extend(id_lines)
         else:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -145,8 +145,10 @@ class TestBuildSessionContextPrompt:
             ctx = build_session_context(source, config)
             return build_session_context_prompt(ctx)
 
-        # Force the Discord IDs block on (it only emits when discord tools load).
-        with patch.object(_gs, "_discord_tools_loaded", return_value=True):
+        # Force the Discord IDs block on and expose only the core action that
+        # can consume the volatile id.
+        with patch.object(_gs, "_discord_tools_loaded", return_value=True), \
+             patch.object(_gs, "_discord_message_id_actions", return_value=("create_thread",)):
             p1 = _prompt_for("1001")
             p2 = _prompt_for("2002")
             p3 = _prompt_for("3003")
@@ -155,6 +157,53 @@ class TestBuildSessionContextPrompt:
         assert "1001" not in p1 and "2002" not in p2 and "3003" not in p3
         # Static pointer tells the agent where the volatile id actually lives.
         assert "provided per-turn in the incoming user message" in p1
+        assert "create_thread" in p1
+        assert "reply/react/pin" not in p1
+
+    def test_discord_message_id_actions_match_loaded_toolsets_and_allowlist(self):
+        from unittest.mock import patch
+        from gateway.session import _discord_message_id_actions
+
+        config = {
+            "platform_toolsets": {"discord": ["discord", "discord_admin"]},
+            "discord": {"server_actions": ["fetch_messages", "pin_message", "delete_message"]},
+        }
+        with patch("agent.secret_scope.get_secret", return_value="token"), \
+             patch("hermes_cli.config.load_config", return_value=config):
+            assert _discord_message_id_actions() == ("pin_message", "delete_message")
+
+    def test_discord_core_only_promises_create_thread_for_message_id(self):
+        from unittest.mock import patch
+        from gateway.session import _discord_message_id_actions
+
+        config = {"platform_toolsets": {"discord": ["discord"]}}
+        with patch("agent.secret_scope.get_secret", return_value="token"), \
+             patch("hermes_cli.config.load_config", return_value=config):
+            assert _discord_message_id_actions() == ("create_thread",)
+
+    def test_discord_message_id_note_names_only_available_actions(self):
+        from unittest.mock import patch
+        from gateway.session import _format_discord_message_id_note
+
+        with patch(
+            "gateway.session._discord_message_id_actions",
+            return_value=("create_thread", "pin_message"),
+        ):
+            note = _format_discord_message_id_note("123")
+
+        assert note == (
+            "[Triggering message id: `123` — available as `message_id` for "
+            "these loaded Discord actions: create_thread, pin_message.]"
+        )
+        assert "reply" not in note
+        assert "react" not in note
+
+    def test_discord_message_id_note_omitted_without_compatible_actions(self):
+        from unittest.mock import patch
+        from gateway.session import _format_discord_message_id_note
+
+        with patch("gateway.session._discord_message_id_actions", return_value=()):
+            assert _format_discord_message_id_note("123") is None
 
     def test_slack_prompt_no_tools_shows_disclaimer(self):
         """Without slack toolset loaded, prompt must show the stale-API disclaimer."""

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -25,6 +25,7 @@ returns a 403 at call time and :func:`_enrich_403` maps it to
 actionable guidance the model can relay to the user.
 """
 
+import inspect
 import json
 import logging
 import threading
@@ -652,6 +653,10 @@ _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
 _ADMIN_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _ADMIN_ACTION_NAMES}
+_MESSAGE_ID_ACTION_NAMES = frozenset(
+    name for name, action in _ACTIONS.items()
+    if "message_id" in inspect.signature(action).parameters
+)
 
 # Single-source-of-truth manifest: action → (signature, one-line description).
 # Consumed by :func:`_build_schema` so the schema's top-level description
@@ -759,6 +764,26 @@ def _available_actions(
             continue
         actions.append(name)
     return actions
+
+
+def get_available_message_id_actions(enabled_toolsets: set[str]) -> Tuple[str, ...]:
+    """Return loaded, allowlisted actions that accept ``message_id``.
+
+    The result follows the schema manifest order and intentionally avoids an
+    API capability probe: none of these actions is privileged-intent gated.
+    """
+    allowlist = _load_allowed_actions_config()
+    allowed = set(_available_actions({"has_members_intent": True}, allowlist))
+    return tuple(
+        name
+        for name, _signature, _description in _ACTION_MANIFEST
+        if name in _MESSAGE_ID_ACTION_NAMES
+        and name in allowed
+        and (
+            (name in _CORE_ACTION_NAMES and "discord" in enabled_toolsets)
+            or (name in _ADMIN_ACTION_NAMES and "discord_admin" in enabled_toolsets)
+        )
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Discord turns no longer tell the agent to reply, react, or pin when those actions are absent from the loaded tool schemas. The triggering-message preamble now lists only enabled, allowlisted Discord actions that actually accept `message_id`, preventing prompt/schema contradictions that can derail message handling.

### Symptom

With the core `discord` toolset enabled, every incoming Discord message claimed its ID could be used for reply/react/pin even though those actions were not available to the agent.

### Impact

The model could follow a per-turn instruction that no loaded tool could execute, causing Discord workflows to fail instead of using the actions actually exposed by the current tool configuration.

### Bug Cause

**Trigger:** `gateway/run.py` in the Discord triggering-message preamble branch.

**Causal chain:**
1. A Discord bot token and either Discord toolset made `_discord_tools_loaded()` return true.
2. The gateway injected one fixed reply/react/pin instruction without inspecting the loaded action set or `discord.server_actions` allowlist.
3. The model received capabilities in the prompt that were absent from its tool schemas.

**Why it is wrong:** Toolset presence is only a coarse availability signal. The Discord schemas are filtered by toolset and action allowlist, so a fixed action list can disagree with the callable surface.

**Working sibling / contrast:** The Discord tool schema already derives its visible actions from the enabled tool subset and `discord.server_actions`; only the gateway preamble skipped that resolution.

**Ruled out:** Profile token leakage was not the cause. The existing multiplex token fail-closed test still passes, and the new resolver uses the same scoped secret lookup.

### Fix

Derive message-ID-compatible actions from real handler signatures, filter them through the enabled Discord toolsets and action allowlist, and reuse that exact list in both the cached context pointer and per-turn note. If no loaded action accepts `message_id`, the volatile note is omitted.

## Related Issue

Closes #96056

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/discord_tool.py` - expose the loaded, allowlisted actions whose handlers accept `message_id`.
- `gateway/session.py` - resolve and format an action-accurate message ID capability note.
- `gateway/run.py` - inject the resolved note instead of a fixed reply/react/pin promise.
- `tests/gateway/test_session.py` - cover core-only, admin allowlist, omission, exact wording, and prompt-cache stability.

## How to Test

1. Configure core-only Discord tools and verify the note lists only `create_thread`.
2. Configure admin actions with an allowlist and verify only compatible allowed actions are listed.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_session.py tests/tools/test_discord_tool.py tests/gateway/test_64674_multiplex_primary_token_scope.py -q
```

Result: 120 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the relevant repository tests and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update is N/A; the user-facing behavior is encoded in the runtime prompt.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed.
- [x] Cross-platform impact was considered; the change is platform-independent Python logic.
- [x] Tool descriptions/schemas remain unchanged; the gateway note now follows them.

## Screenshots / Logs

N/A - focused automated tests cover the generated prompt text and action resolution.
