### PR TITLE
feat(agent): forward chat_id/chat_name/user_name/chat_type to pre_llm_call hook

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -626,6 +626,10 @@ def _collect_pre_llm_call_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            chat_id=getattr(agent, "_chat_id", None) or "",
+            chat_name=getattr(agent, "_chat_name", None) or "",
+            user_name=getattr(agent, "_user_name", None) or "",
+            chat_type=getattr(agent, "_chat_type", None) or "",
         )
         try:
             # Spill oversized per-hook context to disk so a runaway plugin can't inflate every subsequent

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -495,3 +495,73 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
+
+
+# ── pre_llm_call source-metadata kwargs (issue #79214) ───────────────────────
+#
+# The pre_llm_call hook now forwards chat_id / chat_name / user_name /
+# chat_type alongside the long-standing platform / sender_id. Plugins that
+# inject per-channel context (public-safe mode in groups, attribution,
+# presence) depend on these reaching the hook. Assert the forward happens and
+# defaults to "" when the agent carries no source (CLI/local runs).
+
+
+def _captured_pre_llm_call(agent, **overrides):
+    calls = []
+
+    def _fake_invoke_hook(hook_name, **kwargs):
+        if hook_name == "pre_llm_call":
+            calls.append(kwargs)
+        return []
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook", side_effect=_fake_invoke_hook
+    ):
+        _build(agent, **overrides)
+    return calls
+
+
+def test_pre_llm_call_receives_source_metadata_when_present():
+    agent = _FakeAgent()
+    agent._chat_id = "100000001"
+    agent._chat_name = "Test Chat"
+    agent._user_name = "testuser"
+    agent._chat_type = "group"
+
+    calls = _captured_pre_llm_call(agent)
+    assert calls, "pre_llm_call hook was not invoked"
+    kwargs = calls[0]
+    assert kwargs["chat_id"] == "100000001"
+    assert kwargs["chat_name"] == "Test Chat"
+    assert kwargs["user_name"] == "testuser"
+    assert kwargs["chat_type"] == "group"
+    # Existing fields still forwarded unchanged.
+    assert kwargs["sender_id"] == ""
+    assert kwargs["platform"] == "cli"
+
+
+def test_pre_llm_call_source_metadata_defaults_empty():
+    agent = _FakeAgent()
+    # No source attributes set → must not crash, must default to "".
+    calls = _captured_pre_llm_call(agent)
+    assert calls, "pre_llm_call hook was not invoked"
+    kwargs = calls[0]
+    assert kwargs["chat_id"] == ""
+    assert kwargs["chat_name"] == ""
+    assert kwargs["user_name"] == ""
+    assert kwargs["chat_type"] == ""
+
+
+def test_pre_llm_call_source_metadata_distinguishes_dm_vs_group():
+    dm_agent = _FakeAgent()
+    dm_agent._chat_id = "100000001"
+    dm_agent._chat_type = "dm"
+    dm_calls = _captured_pre_llm_call(dm_agent)
+    assert dm_calls[0]["chat_type"] == "dm"
+
+    group_agent = _FakeAgent()
+    group_agent._chat_id = "-100200300"
+    group_agent._chat_type = "group"
+    group_calls = _captured_pre_llm_call(group_agent)
+    assert group_calls[0]["chat_type"] == "group"
+    assert group_calls[0]["chat_id"] == "-100200300"


### PR DESCRIPTION
## What does this PR do?

Forwards four message-source fields — `chat_id`, `chat_name`, `user_name`, `chat_type` — from the inbound message source onto the existing `pre_llm_call` hook's `TurnContext`. This lets plugins/agents know *which chat* and *which user* a turn originated from in multi-user sessions (groups, multi-channel), without re-deriving it from raw event metadata.

This is a continuation of PR #79340, which the original author (`Enough1122`) withdrew for backlog reasons (closed unmerged 2026-08-21 — *"I'd rather withdraw it than leave it half-tended... happy to reopen or resubmit"*). Rebuilt against current `main` as a focused, reviewable slice. Happy to credit the original author if they'd like.

## Related Issue

Fixes #79214

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_context.py`: `build_turn_context()` now reads `chat_id`/`chat_name`/`user_name`/`chat_type` off the agent (when present) and passes them as kwargs into the `pre_llm_call` hook invocation.
- `tests/agent/test_turn_context.py`: added tests asserting the four fields surface on the hook kwargs for DM vs group sources.

## How to Test

1. Configure a `pre_llm_call` plugin that logs `ctx.kwargs`.
2. Send a message from a group and a DM.
3. Confirm `chat_id` / `chat_name` / `user_name` / `chat_type` appear in the hook kwargs for both.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched existing PRs (found #79340, withdrawn — this PR is the continuation)
- [x] PR contains only changes related to this feature
- [x] `pytest tests/agent/test_turn_context.py` passes (22 tests)
- [x] Tests added
- [x] Tested on: Linux (aarch64, Ubuntu 26.04)
- [x] No new config keys / docs needed (N/A)
- [x] Cross-platform: pure-Python, no OS assumptions (N/A)
