### PR TITLE
fix(agent): persist display_metadata for every user message, derived from source

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -454,6 +454,74 @@ class TurnContext:
     preflight_compression_blocked: bool = False
 
 
+# Stable core wrappers the gateway wraps around voice-derived content
+# (gateway/run.py _enrich_message_with_transcription). Origin is classified
+# from these shapes per-row at ingest — no cross-message state anywhere.
+_VOICE_MARKERS = (
+    "[voice message could not be transcribed",
+    "[The user sent a voice message but it came through",
+)
+
+
+def _neutralize_untrusted(value: Any) -> str:
+    """Cap untrusted display strings using the session module's sanitizer.
+
+    Falls back to a length-capped str() when the sanitizer is unavailable so
+    a missing import can never block attribution storage.
+    """
+    try:
+        from gateway.session import neutralize_untrusted_inline_text
+
+        return neutralize_untrusted_inline_text(value)
+    except Exception:
+        return str(value or "")[:200]
+
+
+def _classify_origin(content: Any) -> str:
+    """Per-row origin: 'voice' when the body carries a voice wrapper, else 'text'."""
+    text = content if isinstance(content, str) else ""
+    stripped = text.lstrip()
+    is_voice = (
+        (text.startswith('"') and text.rstrip().endswith('"') and len(text) >= 2)
+        or any(stripped.startswith(m) for m in _VOICE_MARKERS)
+    )
+    return "voice" if is_voice else "text"
+
+
+def _derive_source_annotation(
+    agent: Any, content: Any = None
+) -> Optional[Dict[str, Any]]:
+    """Build the default ``display_metadata`` from the agent's source attributes.
+
+    The agent already resolves these at init (agent_init.py:681-684) from the
+    inbound SessionSource, so no per-caller wiring is required. Returns ``None``
+    when there is nothing worth storing, keeping unannotated rows byte-identical
+    to stock. Untrusted display strings (user_name/chat_name) are neutralized so
+    stored metadata is safe to render anywhere.
+    """
+    try:
+        raw = {
+            "platform": getattr(agent, "platform", None),
+            "chat_id": getattr(agent, "_chat_id", None) or "",
+            "chat_type": getattr(agent, "_chat_type", None) or "",
+            "user_id": getattr(agent, "_user_id", None) or "",
+            "user_name": getattr(agent, "_user_name", None) or "",
+            "chat_name": getattr(agent, "_chat_name", None) or "",
+        }
+        ann: Dict[str, Any] = {}
+        for field, value in raw.items():
+            if value in (None, ""):
+                continue
+            if field in ("user_name", "chat_name"):
+                ann[field] = _neutralize_untrusted(value)
+            else:
+                ann[field] = str(value)
+        ann["origin"] = _classify_origin(content)
+        return ann or None
+    except Exception:
+        return None
+
+
 def build_turn_context(
     agent,
     user_message: Any,
@@ -710,8 +778,19 @@ def build_turn_context(
     # build strips both fields from every outgoing copy.
     if persist_user_display_kind:
         user_msg["display_kind"] = persist_user_display_kind
-        if persist_user_display_metadata:
-            user_msg["display_metadata"] = persist_user_display_metadata
+    # Persist structured origin metadata on EVERY user message, not only
+    # those carrying a display_kind. display_metadata rides the stored
+    # transcript row (api message assembly strips it from outgoing copies),
+    # so it never touches message content and defaults change nothing for
+    # anyone who does not set it. When the caller did not supply one, derive
+    # it from the agent's already-resolved source attributes so attribution
+    # survives compaction / cross-session continuity without per-caller wiring.
+    if persist_user_display_metadata is None:
+        _derived = _derive_source_annotation(agent, user_message)
+        if _derived:
+            persist_user_display_metadata = _derived
+    if persist_user_display_metadata:
+        user_msg["display_metadata"] = persist_user_display_metadata
 
     append_message(messages, user_msg)
     current_turn_user_idx = len(messages) - 1

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -452,3 +452,57 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
+
+
+# ── display_metadata persistence (Task C, issue #79214 sibling) ───────────────
+#
+# Upstream nested `display_metadata` inside the `display_kind` check, so a
+# normal user message (no display_kind) silently dropped its attribution.
+# The fix un-nests: every message persists derived source metadata unless the
+# caller supplied its own. Assert (1) a plain message now carries
+# display_metadata, (2) a CLI message gets minimal platform+origin only,
+# (3) a caller-supplied payload wins over the derivation.
+
+
+def test_display_metadata_derived_for_plain_message():
+    agent = _FakeAgent()
+    agent._chat_id = "100000001"
+    agent._chat_name = "Test Chat"
+    agent._user_name = "testuser"
+    agent._chat_type = "group"
+    agent.platform = "telegram"
+
+    ctx = _build(agent, user_message="hello from the group")
+    row = ctx.messages[-1]
+    assert "display_metadata" in row
+    meta = row["display_metadata"]
+    assert meta["chat_id"] == "100000001"
+    assert meta["chat_name"] == "Test Chat"
+    assert meta["user_name"] == "testuser"
+    assert meta["chat_type"] == "group"
+    assert meta["platform"] == "telegram"
+    assert meta["origin"] in ("text", "voice")
+
+
+def test_display_metadata_minimal_for_cli_without_chat_source():
+    agent = _FakeAgent()  # platform="cli", no chat_id/name/user set
+    ctx = _build(agent, user_message="hi")
+    # platform is always known → minimal annotation, no chat-specific fields.
+    meta = ctx.messages[-1].get("display_metadata", {})
+    assert meta.get("platform") == "cli"
+    assert meta.get("origin") in ("text", "voice")
+    assert "chat_id" not in meta
+    assert "user_name" not in meta
+    assert "chat_name" not in meta
+
+
+def test_display_metadata_caller_payload_wins():
+    agent = _FakeAgent()
+    agent._chat_id = "100000001"
+    custom = {"chat_id": "override", "origin": "voice"}
+    ctx = _build(
+        agent,
+        user_message="hi",
+        persist_user_display_metadata=custom,
+    )
+    assert ctx.messages[-1]["display_metadata"] == custom


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `display_metadata` was silently dropped for every normal user message.

In `agent/turn_context.py`, `display_metadata` was only persisted *inside* the `if display_kind:` block. Normal user messages (role `user`, no `display_kind`) never entered that branch, so their `display_metadata` — attribution like `origin`, `platform`, `chat_id` — was never written to the session store. This breaks downstream consumers that rely on per-message attribution (e.g. session search, annotation rendering, the HUD footer).

The fix un-nests the persistence so it runs for every message, and derives `origin`/`platform` attribution from the message `source` when not explicitly provided (mirroring how the gateway already computes these).

## Related Issue

No open issue exists for this bug. Symptom verified locally: a `[Replying to: ...]` reply-composite row in `state.db` carried no `display_metadata` while a sibling message did.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_context.py`: moved `display_metadata` persistence out of the `display_kind` guard; added `_derive_source_annotation(agent, content)` helper that reads `platform` / `chat_id` / etc. off the source and returns a minimal attribution dict. Every user message now persists attribution.
- `tests/agent/test_turn_context.py`: added tests covering (a) message with explicit `display_metadata`, (b) message with source-derived attribution, (c) CLI message (platform=cli) gets at least `platform` + `origin`.

## How to Test

1. Start a session, send a normal message (no `display_kind`).
2. Inspect the resulting row in `state.db` `messages` — `display_metadata` should be present with `origin`/`platform`.
3. Before the fix: `display_metadata` was absent for that row.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched existing PRs (no duplicate of this fix)
- [x] PR contains only changes related to this fix
- [x] `pytest tests/agent/test_turn_context.py` passes (22 tests)
- [x] Tests added (required for bug fixes)
- [x] Tested on: Linux (aarch64, Ubuntu 26.04)
- [x] No new config keys / docs needed (N/A)
- [x] Cross-platform: pure-Python, no OS assumptions (N/A)

## Companion PR (read path)

This PR is the **write path** — it persists `display_metadata` onto every user message. The **read path** (making `session_search` actually surface that column) is #97523. Merged together, per-message attribution survives compaction end-to-end; either alone is incomplete.