### PR TITLE
fix(install): expose the installer's python3 to node-gyp during npm install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2423,10 +2423,22 @@ install_node_deps() {
         # installed", hiding the degradation from the user (#77003). Now it
         # fails the install outright instead of burying the warning (#85297).
         # Capture npm output so failures are diagnosable (#87340).
+        #
+        # node-gyp needs a python3 on PATH (node-pty has no prebuild on fresh
+        # Node ABIs, so it always compiles), and minimal images — Docker
+        # builds without a system python3 — fail there with output that
+        # --silent swallows entirely, leaving the captured log empty and the
+        # BuildKit failure undiagnosable (#96072). The installer's own venv
+        # already provides a python3; put it on PATH for this npm step only.
         local npm_log
         npm_log="$(mktemp)"
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent \
-                >"$npm_log" 2>&1; then
+        if ! (
+                _py_bin="$(dirname "${PYTHON_PATH:-}")"
+                if [ -x "$_py_bin/python3" ]; then
+                    PATH="$_py_bin:$PATH"
+                fi
+                run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent
+            ) >"$npm_log" 2>&1; then
             log_error "npm install failed or timed out; Node.js dependencies were not installed"
             if [ -s "$npm_log" ]; then
                 log_error "npm output:"

--- a/tests/test_install_sh_npm_python_path.py
+++ b/tests/test_install_sh_npm_python_path.py
@@ -1,0 +1,38 @@
+"""Regression test: the installer's npm step must expose a python3 to node-gyp.
+
+node-pty has no prebuild on fresh Node ABIs, so `npm install` always compiles
+it via node-gyp — which needs a python3 on PATH. Minimal Docker images ship
+none, and the failure was invisible: ``--silent`` swallowed node-gyp's output
+entirely, the captured mktemp log stayed empty, and the BuildKit failure had
+no diagnostics at all (#96072). The installer's own venv provides a python3;
+the npm step now puts that bin dir on PATH for its duration only.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_npm_install_injects_installer_python_on_path() -> None:
+    text = INSTALL_SH.read_text()
+
+    # The npm step resolves the installer's python bin dir and prepends it to
+    # PATH inside the subshell, scoped to the npm call only.
+    assert '_py_bin="$(dirname "${PYTHON_PATH:-}")"' in text
+    assert 'PATH="$_py_bin:$PATH"' in text
+    # The injection guards on an actual python3 executable there, so a missing
+    # or unset PYTHON_PATH degrades to today's behavior instead of breaking.
+    assert '[ -x "$_py_bin/python3" ]' in text
+    # The failure branch (empty-log cat, #87340) is preserved.
+    assert 'log_error "npm install failed or timed out; Node.js dependencies were not installed"' in text
+
+
+def test_npm_injection_is_scoped_to_the_subshell() -> None:
+    text = INSTALL_SH.read_text()
+
+    # The PATH assignment lives inside the `if ! ( ... ) >"$npm_log"` subshell
+    # that wraps the npm call — it must not leak into the rest of the install
+    # (e.g. shadowing a system python3 for later steps).
+    assert 'if ! (\n                _py_bin=' in text
+    assert 'run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent' in text


### PR DESCRIPTION
## What does this PR do?

`install.sh`'s `npm install --silent` failed **invisibly** on minimal Docker images that ship no system python3: node-pty has no prebuild for fresh Node ABIs, so npm always compiles it via node-gyp — which needs a `python3` on PATH. node-gyp's failure output is swallowed by `--silent` entirely, so even the #87340 captured-log path printed nothing ("the mktemp log is empty"), and the BuildKit failure carried zero diagnostics (the reporter burned hours suspecting flakiness; the same box with xfce4 pulled python3 via apt and built fine, making it look non-deterministic).

Fix (the reporter's suggested option 1): the installer's own venv already provides a python3 — the npm step now puts that bin dir on `PATH` inside its existing `if ! ( ... ) >"$npm_log"` subshell, scoped to the npm call only. A missing/unset `PYTHON_PATH` degrades to today's behavior instead of breaking.

## Related Issue

Fixes #96072

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `scripts/install.sh` — the node-deps `npm install` subshell resolves `$(dirname "$PYTHON_PATH")` and prepends it to `PATH` when a `python3` executable exists there; the timeout wrapper, log capture, and failure branch (#87340/#85297) are unchanged.
- `tests/test_install_sh_npm_python_path.py` (new, 2 tests, source-text convention per the existing install.sh tests): the injection and its `[ -x .../python3 ]` guard are present, and the `PATH` assignment stays scoped inside the npm subshell.

## How to Test

1. `python -m pytest tests/test_install_sh_npm_python_path.py -q` — should pass (2 passed).
2. Red/green: on unpatched `main` both tests fail (the asserted forms do not exist — the npm step runs with the ambient PATH only).
3. Install.sh test family unchanged: `python -m pytest tests/test_install_sh_browser_install.py tests/test_install_sh_install_method_stamp.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_diverged_update.py -q` — should pass (19 passed).
4. Manual (per the issue): on a python3-less ubuntu:24.04 BuildKit image, `bash install.sh --skip-browser` now compiles node-pty through the installer's venv python instead of failing with an empty log.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the node-gyp/ABI/prebuild mechanism and the PATH scoping rationale documented at the call site)
- [x] New and existing unit tests pass locally (2 new; 19 across the install.sh family)
- [x] Changes are backward compatible (PATH injection is additive and guarded; the ambient-PATH path is preserved when PYTHON_PATH is absent)
