### PR TITLE
fix(memory): forward new_text alias in tool_executor so single-op memory writes work

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2162,6 +2162,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     action=next_args.get("action"),
                     target=target,
                     content=next_args.get("content"),
+                    new_text=next_args.get("new_text"),
                     old_text=next_args.get("old_text"),
                     operations=operations,
                     store=agent._memory_store,


### PR DESCRIPTION
## Summary
`memory_tool` declares `new_text` as an accepted alias for `content` in both its schema (tools/memory_tool.py) and implementation (the single-op path coalesces `new_text` into `content` at line 1116). But `agent/tool_executor.py` forwards only `action/target/content/old_text/operations` to the memory tool — `new_text` is dropped in the middle layer. As a result, a top-level single-op call using `new_text` (the natural `old_text`/\`new_text\` pairing, mirroring the patch tool shape) fails with `content is required for 'replace' action.`

## Fix
One line: forward `new_text` in tool_executor so the alias actually reaches the function, connecting to the existing coalescing at memory_tool.py:1116.

## Verification
- `tests/tools/test_memory_tool.py` alias tests (new_text on replace / add / batch, content-wins) — 10 passed.
- Batch shape + `content` already works today (bypasses the middle layer); this fix makes the documented top-level `new_text` alias work as documented.