### PR TITLE
fix(gateway): keep raw-session delegation completions recoverable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25845,6 +25845,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "retry"
         return "deliver"
 
+    def _defer_unroutable_durable_raw_completion(self, evt: dict) -> bool:
+        """Leave a durable raw-session wake pending until transport exists."""
+        if evt.get("type") != "async_delegation":
+            return False
+        delegation_id = str(evt.get("delegation_id") or "")
+        raw_sid = _raw_watch_session_id(evt)
+        if (
+            not delegation_id
+            or not raw_sid
+            or self.adapters.get(Platform.API_SERVER) is not None
+        ):
+            return False
+        logger.warning(
+            "Deferring watch notification for raw session %s: no api_server "
+            "adapter is available; durable completion %s remains pending for "
+            "a future gateway start",
+            raw_sid,
+            delegation_id,
+        )
+        return True
+
     async def _deliver_completion_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -25861,23 +25882,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         durable_delegation_id = ""
         if evt.get("type") == "async_delegation":
             durable_delegation_id = str(evt.get("delegation_id") or "")
-            raw_sid = _raw_watch_session_id(evt)
-            if (
-                durable_delegation_id
-                and raw_sid
-                and self.adapters.get(Platform.API_SERVER) is None
-            ):
-                # No transport exists in this gateway lifecycle for this raw
-                # session. Leave the durable row untouched so startup restore
-                # can re-arm it in a future lifecycle without burning the
-                # bounded delivery-failure budget on an attempt never made.
-                logger.warning(
-                    "Deferring watch notification for raw session %s: no "
-                    "api_server adapter is available; durable completion %s "
-                    "remains pending for a future gateway start",
-                    raw_sid,
-                    durable_delegation_id,
-                )
+            if self._defer_unroutable_durable_raw_completion(evt):
                 return None
             if durable_delegation_id:
                 try:
@@ -26300,6 +26305,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             deliverable.append((evt, synth_text))
 
         if not deliverable:
+            return None
+        # Preflight the whole group before claiming any sibling. A missing raw
+        # session transport is shared by the route, so no durable row in this
+        # batch has made a delivery attempt yet.
+        if any(
+            self._defer_unroutable_durable_raw_completion(evt)
+            for evt, _synth_text in deliverable
+        ):
             return None
         if len(deliverable) == 1:
             evt, synth_text = deliverable[0]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3880,6 +3880,17 @@ def _parse_session_key(session_key: str) -> "dict | None":
     return None
 
 
+def _raw_watch_session_id(evt: dict) -> str:
+    """Return an unstructured wake target carried by a watch event."""
+    raw_sid = str(evt.get("origin_session_id") or "").strip()
+    if raw_sid:
+        return raw_sid
+    session_key = str(evt.get("session_key") or "").strip()
+    if session_key and _parse_session_key(session_key) is None:
+        return session_key
+    return ""
+
+
 def _shorten_command_for_display(command: str, limit: int = 80) -> str:
     """Collapse a shell command onto one line and cap its length for display."""
     one_line = " ".join((command or "").split())
@@ -25625,11 +25636,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Recover the raw session id and wake the real session via the API
             # server's own /v1/chat/completions entry point instead of
             # dropping the event.
-            raw_sid = str(evt.get("origin_session_id") or "").strip()
-            if not raw_sid:
-                _sk = str(evt.get("session_key") or "").strip()
-                if _sk and _parse_session_key(_sk) is None:
-                    raw_sid = _sk
+            raw_sid = _raw_watch_session_id(evt)
             if raw_sid:
                 adapter = self.adapters.get(Platform.API_SERVER)
                 from gateway.wake import adapter_supports_push, deliver_wake
@@ -25854,6 +25861,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         durable_delegation_id = ""
         if evt.get("type") == "async_delegation":
             durable_delegation_id = str(evt.get("delegation_id") or "")
+            raw_sid = _raw_watch_session_id(evt)
+            if (
+                durable_delegation_id
+                and raw_sid
+                and self.adapters.get(Platform.API_SERVER) is None
+            ):
+                # No transport exists in this gateway lifecycle for this raw
+                # session. Leave the durable row untouched so startup restore
+                # can re-arm it in a future lifecycle without burning the
+                # bounded delivery-failure budget on an attempt never made.
+                logger.warning(
+                    "Deferring watch notification for raw session %s: no "
+                    "api_server adapter is available; durable completion %s "
+                    "remains pending for a future gateway start",
+                    raw_sid,
+                    durable_delegation_id,
+                )
+                return None
             if durable_delegation_id:
                 try:
                     from tools.async_delegation import claim_completion_delivery

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -9,6 +9,7 @@ state (when available) is acknowledged through its authoritative SQLite API.
 import asyncio
 import json
 import queue
+import time
 from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -130,6 +131,39 @@ def test_unroutable_async_event_is_not_requeued_forever(
 
     adapter.handle_message.assert_not_awaited()
     assert isolated.empty()
+
+
+def test_durable_raw_session_without_api_adapter_waits_for_future_boot(
+    monkeypatch, isolated_registry,
+):
+    """An absent api_server transport must not exhaust durable retries."""
+    from tools import async_delegation
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    event = _async_event("deleg_raw_future_boot")
+    event["session_key"] = "20260711_raw_ui_session"
+    event["dispatched_at"] = time.time() - 1
+    event["completed_at"] = time.time()
+    _persist_pending_completion(event)
+    isolated.put(dict(event))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_not_awaited()
+    assert isolated.empty()
+    row = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert row is not None
+    assert row["delivery_state"] == "pending"
+    assert row["delivery_attempts"] == 0
+
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
 
 
 def test_concurrent_claims_share_the_same_narrow_delivery_seam():

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -166,6 +166,48 @@ def test_durable_raw_session_without_api_adapter_waits_for_future_boot(
     assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
 
 
+def test_durable_raw_session_batch_defers_every_row_before_claiming(
+    monkeypatch, isolated_registry,
+):
+    """A raw-session batch must not spend sibling delivery attempts."""
+    from tools import async_delegation
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    events = [
+        _distinct_async_event(
+            f"deleg_raw_batch_{index}",
+            session_key="20260711_raw_ui_session",
+        )
+        for index in range(2)
+    ]
+    for event in events:
+        event["dispatched_at"] = time.time() - 1
+        event["completed_at"] = time.time()
+        _persist_pending_completion(event)
+        isolated.put(dict(event))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_not_awaited()
+    assert isolated.empty()
+    for event in events:
+        row = async_delegation.get_durable_delegation(event["delegation_id"])
+        assert row is not None
+        assert row["delivery_state"] == "pending"
+        assert row["delivery_attempts"] == 0
+
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 2
+    assert {restored.get_nowait()["delegation_id"] for _ in events} == {
+        event["delegation_id"] for event in events
+    }
+
+
 def test_concurrent_claims_share_the_same_narrow_delivery_seam():
     """Concurrent consumers in one runner cannot both enter the adapter."""
     entered = asyncio.Event()


### PR DESCRIPTION
## What does this PR do?

Async delegations completed for raw sessions could become permanently unrecoverable when a gateway started without an `api_server` adapter. This change keeps those durable completion rows pending without consuming delivery attempts, so a later gateway start can restore and retry the wake instead of exhausting the retry budget across restarts.

### Symptom

The gateway logged `Dropping watch notification for raw session ...: no api_server adapter to self-post through` after the delegated work had completed. No notification reached the originating raw session.

### Impact

Users could lose visibility of completed background delegation work. Repeated gateway starts consumed the bounded delivery-attempt budget even though no delivery transport existed, eventually marking the durable completion as dropped.

### Bug Cause

**Trigger:** `gateway/run.py:_deliver_completion_notification` when an async delegation event has an unstructured raw session id and `Platform.API_SERVER` is absent.

**Causal chain:**
1. Startup restoration re-enqueues the durable pending completion.
2. `_deliver_completion_notification` claims the row before checking whether this gateway has a transport for the raw session, incrementing `delivery_attempts`.
3. `_inject_watch_notification` finds no `api_server` adapter, returns without delivery, and releases the claim. Each restart repeats this until the retry cap marks the row dropped.

**Why it is wrong:** The retry budget represents failed delivery attempts, but no adapter means no delivery attempt was made.

**Working sibling / contrast:** A configured `api_server` adapter self-posts the wake and acknowledges the durable row after acceptance. Transient adapter failures remain retryable and continue consuming the bounded attempt budget.

**Ruled out:** The completion was not missing from persistence. The durable row and startup restore path already existed; the loss came from claiming it before transport availability was known.

### Fix

Detect durable raw-session events before claiming their SQLite delivery row. If this gateway has no `api_server` adapter, leave the row untouched and pending for startup restoration in a future lifecycle. The raw-session id extraction is shared with the existing self-post path to keep both decisions consistent.

## Related Issue

Closes #96070

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - defer durable raw-session completion claims until an `api_server` transport exists.
- `tests/gateway/test_completion_delivery.py` - prove the event remains pending with zero delivery attempts and is restored on a later startup.

## How to Test

1. Persist a completed async delegation whose session key is a raw session id.
2. Drain it through a gateway runner without an `api_server` adapter.
3. Verify the row stays pending with zero attempts and `restore_undelivered_completions` re-enqueues it.
4. Run the related suites:

```bash
scripts/run_tests.sh tests/gateway/test_completion_delivery.py tests/gateway/test_background_process_notifications.py tests/tools/test_async_delegation.py tests/gateway/test_async_delegation_session_binding.py -q
```

Result: 78 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and persistence contracts are covered in code comments and tests
- [x] Config example updates are N/A; no config keys changed
- [x] Contributor guide updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses platform-independent Python and SQLite behavior
- [x] Tool description and schema updates are N/A; no model-tool contract changed

## Screenshots / Logs

N/A; the automated regression test exercises the durable delivery state transition directly.
