### PR TITLE
fix(feishu): authorize privileged card clicks by operator, not group policy (#96045)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2768,15 +2768,47 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
-        """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
+    def _is_interactive_operator_authorized(
+        self, open_id: str, user_id: str = "", chat_id: str = "",
+    ) -> bool:
+        """Return whether this card-action operator may answer gated prompts.
+
+        Privileged card clicks (exec approvals, update prompts) answer a
+        different question than ``_allow_group_message``: not "may this person
+        talk to the bot here?" but "may this person authorize a dangerous
+        action?". Both must hold, so the gate is the intersection of:
+
+        1. **Operator identity** — membership of ``admins ∪ allowed_group_users``
+           (or the ``*`` wildcard). ``group_policy`` deliberately has no say
+           here: ``open`` means "anyone may chat", never "anyone may approve a
+           dangerous command".
+        2. **Chat lock** — when the card's chat has an explicit ``group_rules``
+           entry, that rule still applies (a ``disabled`` channel, an
+           ``admin_only`` channel, or a per-chat blacklist must not resolve
+           approvals). Chats without an explicit rule impose no extra lock, so
+           DM cards are never gated by the group default policy.
+
+        Both ``open_id`` and ``user_id`` are matched, because allowlists may be
+        configured with either identifier. With no operator configured at all
+        (no admins, no allowlist — the pairing-mode/single-user default) there
+        is no privilege boundary to escalate across, so only the chat lock
+        applies; that keeps unconfigured installs usable instead of
+        dead-locking every approval.
+        """
+        ids = {v for v in (str(open_id or "").strip(), str(user_id or "").strip()) if v}
+        if not ids:
             return False
-        allowed_ids = set(self._admins) | set(self._allowed_group_users)
-        if not allowed_ids:
+        operators = set(self._admins) | set(self._allowed_group_users)
+        if operators and "*" not in operators and not (ids & operators):
+            return False
+        chat = str(chat_id or "").strip()
+        if not chat or chat not in self._group_rules:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        sender_id = SimpleNamespace(
+            open_id=str(open_id or "").strip() or None,
+            user_id=str(user_id or "").strip() or None,
+        )
+        return self._allow_group_message(sender_id, chat, is_bot=False)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2792,8 +2824,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(
+            open_id, operator_user_id, str(state.get("chat_id", "") or ""),
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2819,6 +2853,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=operator_user_id,
                 chat_id=chat_id,
             ),
         ):
@@ -2852,8 +2887,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(
+            open_id, operator_user_id, str(state.get("chat_id", "") or ""),
+        ):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2876,6 +2913,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 answer,
                 user_name,
                 open_id=open_id,
+                user_id=operator_user_id,
                 chat_id=callback_chat_id,
             ),
         ):
@@ -2898,6 +2936,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2905,7 +2944,9 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        if not self._is_interactive_operator_authorized(
+            open_id, user_id, str(state.get("chat_id", "") or "")
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")
@@ -2952,6 +2993,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Persist an update prompt answer for the detached update process."""
@@ -2959,11 +3001,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
+        if not self._is_interactive_operator_authorized(
+            open_id, user_id, str(state.get("chat_id", "") or "")
+        ):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id or "<unknown>", prompt_id)
+            return
         expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -236,6 +236,51 @@ class TestResolveApproval:
         mock_resolve.assert_not_called()
         assert 5 in adapter._approval_state
 
+    @pytest.mark.asyncio
+    async def test_resolves_when_allowlist_matches_user_id(self):
+        """The resolver must accept the same ids the click handler accepted.
+
+        Allowlists may be configured with ``user_id`` values; if only the
+        handler matched them the click would render an approved card that never
+        unblocks the agent.
+        """
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._approval_state[6] = {
+            "session_key": "sess-6",
+            "message_id": "msg_006",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(
+                6, "once", "Bob", open_id="ou_bob", user_id="u_bob", chat_id="oc_12345",
+            )
+
+        mock_resolve.assert_called_once_with("sess-6", "once")
+        assert 6 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_open_group_policy_does_not_authorize_resolution(self):
+        """Regression for #96045 on the resolver itself (defence in depth)."""
+        adapter = _make_adapter()
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg_007",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._resolve_approval(
+                7, "once", "Mallory", open_id="ou_attacker", chat_id="oc_12345",
+            )
+
+        mock_resolve.assert_not_called()
+        assert 7 in adapter._approval_state
+
 
 # ===========================================================================
 # _handle_card_action_event — non-approval card actions
@@ -402,6 +447,162 @@ class TestCardActionCallbackResponse:
         mock_submit.assert_not_called()
 
 
+    def test_open_group_policy_does_not_authorize_approval_click(self, _patch_callback_card_types):
+        """Regression for #96045 — ``policy=open`` admits chat, never approvals.
+
+        The group admission policy answers "may this person talk to the bot
+        here?". Using it as the approval gate let any group member resolve a
+        dangerous-command card once the policy was ``open``.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._approval_state[9] = {
+            "session_key": "sess-9",
+            "message_id": "msg-9",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 9},
+            open_id="ou_attacker",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 9 in adapter._approval_state
+        mock_submit.assert_not_called()
+
+    def test_open_group_policy_does_not_authorize_update_prompt_click(self, _patch_callback_card_types):
+        """Regression for #96045 — same inversion on the update-prompt card."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._update_prompt_state[9] = {
+            "session_key": "sess-up-9",
+            "message_id": "msg_up_009",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 9},
+            open_id="ou_attacker",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 9 in adapter._update_prompt_state
+        mock_submit.assert_not_called()
+
+    def test_open_group_policy_still_allows_configured_operator(self, _patch_callback_card_types):
+        """Hardening must not deny the operators who are actually allowlisted."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._default_group_policy = "open"
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._approval_state[10] = {
+            "session_key": "sess-10",
+            "message_id": "msg-10",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 10},
+            open_id="ou_allowed",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+
+    def test_authorizes_operator_matched_by_user_id(self, _patch_callback_card_types):
+        """Allowlists may hold ``user_id`` values, so both ids must be matched."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._approval_state[11] = {
+            "session_key": "sess-11",
+            "message_id": "msg-11",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 11},
+            open_id="ou_bob",
+        )
+        data.event.operator.user_id = "u_bob"
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+
+    def test_disabled_chat_rule_blocks_operator_click(self, _patch_callback_card_types):
+        """An explicitly locked channel must not resolve approvals either."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._group_rules = {
+            "oc_locked": feishu_module.FeishuGroupRule(policy="disabled"),
+        }
+        adapter._approval_state[12] = {
+            "session_key": "sess-12",
+            "message_id": "msg-12",
+            "chat_id": "oc_locked",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 12},
+            chat_id="oc_locked",
+            open_id="ou_allowed",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is None
+        assert 12 in adapter._approval_state
+        mock_submit.assert_not_called()
+
+    def test_click_allowed_when_no_operator_boundary_configured(self, _patch_callback_card_types):
+        """No admins and no allowlist is the pairing-mode/single-user default.
+
+        There is no privilege boundary to escalate across, so the click must
+        still resolve — the group *default* policy does not gate cards.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._admins = set()
+        adapter._allowed_group_users = frozenset()
+        adapter._approval_state[13] = {
+            "session_key": "sess-13",
+            "message_id": "msg-13",
+            "chat_id": "oc_dm_1",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 13},
+            chat_id="oc_dm_1",
+            open_id="ou_solo",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+
     def test_update_prompt_chat_mismatch_returns_no_card(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()
@@ -441,9 +642,32 @@ class TestResolveUpdatePrompt:
             "chat_id": "oc_12345",
         }
 
-        await adapter._resolve_update_prompt(1, "y", "Alice")
+        await adapter._resolve_update_prompt(
+            1, "y", "Alice", open_id="ou_alice", chat_id="oc_12345",
+        )
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
+
+    @pytest.mark.asyncio
+    async def test_unattributed_click_does_not_resolve(self, tmp_path, monkeypatch):
+        """An operator-less callback is unattributable and must fail closed.
+
+        ``_resolve_approval`` already refused these; the update-prompt resolver
+        used to skip its authorization check entirely when ``open_id`` was empty.
+        """
+        adapter = _make_adapter()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+        adapter._update_prompt_state[1] = {
+            "session_key": "sess-up-1",
+            "message_id": "msg_up_003",
+            "chat_id": "oc_12345",
+        }
+
+        await adapter._resolve_update_prompt(1, "y", "Nobody", open_id="", chat_id="oc_12345")
+
+        assert not (tmp_path / ".hermes" / ".update_response").exists()
+        assert 1 in adapter._update_prompt_state
 
 


### PR DESCRIPTION
## Summary

Fixes #96045.

Feishu gated interactive **approval-card** and **update-prompt** clicks with `_allow_group_message()` — the group *admission* policy. That policy answers *"may this person talk to the bot in this chat?"*, not *"may this person authorize a dangerous action?"*, and it short-circuits `return True` for **every** sender when the policy is `open`:

```python
if policy == "open":
    return True          # plugins/platforms/feishu/adapter.py:~4431
```

On any deployment running `FEISHU_GROUP_POLICY=open` (or `default_group_policy: open`), **any member of the card's chat could resolve a pending dangerous-command approval or answer a hermes update prompt**, regardless of `FEISHU_ALLOWED_USERS` / `admins`.

The same wrong gate is also the source of the long-reported failures in the *opposite* direction (#40225, #51684, #51583, #79841, #37252): `admin_only` / `disabled` policies and the empty-allowlist DM default silently deny clicks from legitimate operators. One gate, two inverted failure modes — this PR fixes the gate, so both directions are corrected together.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Card Click Callback] --> B{Operator Identity<br/>admins + allowed_group_users + wildcard}
    B -->|Not an operator| D[Reject - log - card stays pending]
    B -->|No operator configured<br/>no privilege boundary| C
    B -->|Operator| C{Explicit group_rules<br/>entry for this chat?}
    C -->|No rule| E[Authorized]
    C -->|Rule: disabled / admin_only / blacklisted| D
    C -->|Rule admits operator| E
    E --> F{Callback chat matches card chat?}
    F -->|Mismatch| D
    F -->|Match| G[Resolve Approval - Unblock Agent]
    G --> H{Resolver re-check<br/>same gate, same ids}
    H -->|Denied| D
    H -->|Allowed| I[Command Executes]
```

## Root cause

Two different questions were answered by one function:

| Question | Correct authority | What the code used |
| --- | --- | --- |
| May this person **chat** here? | `_allow_group_message()` (group policy) | `_allow_group_message()` — correct |
| May this person **approve a dangerous command**? | operator allowlist | `_allow_group_message()` — wrong |

Four privileged call sites were affected — three used the admission policy, and a fourth skipped authorization altogether:

- `_handle_approval_card_action()` — synchronous approval gate
- `_handle_update_prompt_card_action()` — synchronous update-prompt gate
- `_resolve_update_prompt()` — async resolver; additionally guarded by `if open_id:`, so a callback carrying **no operator id was never authorized at all**
- `_resolve_approval()` — already used `_is_interactive_operator_authorized()`, which is why an approval click by an outsider produced a *green "Approved" card* while the agent stayed blocked: the UI reported an approval that never happened.

## The fix

`_is_interactive_operator_authorized()` becomes the single gate for every privileged card path and now expresses the **intersection** of the two questions instead of picking one:

1. **Operator identity** — membership of `admins ∪ allowed_group_users` (or the `*` wildcard). The group policy has no say here: `open` means *"anyone may chat"*, never *"anyone may approve"*.
2. **Chat lock** — when the card's chat has an explicit `group_rules` entry, that rule still applies, so a `disabled` / `admin_only` channel or a per-chat blacklist cannot resolve approvals. Chats *without* an explicit rule impose no extra lock, so DM cards are no longer gated by the group default policy.

**Empty-allowlist semantics — the explicit decision the issue asked for.** With no admins and no allowlist (the pairing-mode / single-user default from `setup`), there is no privilege boundary to escalate across, so only the chat lock applies. Making that case fail-closed would dead-lock every approval on a default single-user install; making the `policy=open` case fail-open is what produced this bug. The two cases are now distinguished instead of being collapsed into one flag.

Two consistency fixes fall out of the shared gate:

- **`user_id` is matched alongside `open_id`.** Allowlists may be configured with either identifier; the async resolvers now receive `user_id` too, so they accept exactly what the click handler accepted (otherwise a `user_id`-allowlisted operator would get an approved card that never unblocks the agent).
- **`_resolve_update_prompt()` no longer skips authorization** when the callback carries no operator id. An unattributable click fails closed, matching `_resolve_approval()`.

## Why not the other open PRs

Several open PRs touch this gate; none fixes the escalation direction correctly:

- **#67955 / #40271 / #44317 / #35042 and similar** swap the call sites to `_is_interactive_operator_authorized()` as-is. That closes the `policy=open` hole but keeps the unconditional `empty allowlist -> everyone` fail-open, drops per-chat channel locks entirely (a `disabled` channel would still resolve approvals), and still matches `open_id` only. #40271 additionally leaves the two update-prompt paths on the old gate.
- **#92865** goes the other way — it keeps `_allow_group_message()` for group chats by design and only special-cases DMs, so a `policy=open` group remains fully escalatable. It also adds a `get_chat_info()` round-trip on the card-send path.

This PR keeps the operator gate authoritative, preserves channel locks, matches both identifiers, and covers all four privileged paths.

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| `policy=open`, non-allowlisted user clicks Allow | Card flips to "Approved"; update prompts fully resolve | Rejected, warning logged, card stays pending |
| `policy=admin_only` / `disabled`, allowlisted operator clicks | Rejected | Rejected only when the chat has an explicit locking rule |
| DM, no allowlist configured (pairing default) | Rejected by group gate | Allowed |
| Operator allowlisted by `user_id` | Rejected | Allowed |
| Callback with empty operator id | Update prompt resolved without any check | Rejected |

`FEISHU_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS` remain conversation-admission switches and are deliberately **not** honoured as approval authority.

## Test plan

- [x] `tests/gateway/test_feishu_approval_buttons.py` — **22 passed** (13 pre-existing + 9 new)
- [x] Same suite under `FEISHU_GROUP_POLICY=open` — **22 passed**. On `main` this environment fails `test_rejects_approval_click_from_unauthorized_user` and `test_update_prompt_unauthorized_operator_returns_no_card`, exactly as the issue reports.
- [x] `test_feishu_bot_admission.py`, `test_feishu_bot_auth_bypass.py`, `test_feishu_channel_prompts.py` under both the default and the `open` policy — **38 passed** combined, no admission-path regressions.
- [x] `ruff check` clean on both changed files.
- [ ] Not run: the pre-existing `test_feishu.py` failures on this machine are Python 3.14 / Windows `pathlib` `RuntimeError` noise — they reproduce identically on unmodified `main` and are unrelated to this change.

New regression coverage:

| Test | Guards |
| --- | --- |
| `test_open_group_policy_does_not_authorize_approval_click` | #96045 core — approval card |
| `test_open_group_policy_does_not_authorize_update_prompt_click` | #96045 — update-prompt card |
| `test_open_group_policy_does_not_authorize_resolution` | #96045 at the resolver (defence in depth) |
| `test_open_group_policy_still_allows_configured_operator` | Hardening does not deny real operators |
| `test_authorizes_operator_matched_by_user_id` | `user_id` allowlists |
| `test_resolves_when_allowlist_matches_user_id` | Handler and resolver accept the same ids |
| `test_disabled_chat_rule_blocks_operator_click` | Explicit channel locks survive |
| `test_click_allowed_when_no_operator_boundary_configured` | Pairing-mode default stays usable |
| `test_unattributed_click_does_not_resolve` | Operator-less callback fails closed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AdbhdsgdzssaGmD7TfKAo
