### PR TITLE
feat(monitoring): export coding-agent token/cost usage as hermes.* metrics

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1674,6 +1674,18 @@ def init_agent(
         short_uuid = uuid.uuid4().hex[:6]
         agent.session_id = f"{timestamp_str}_{short_uuid}"
 
+    # Coding-agent usage export: count this session. No-op unless
+    # monitoring.usage_export.enabled. terminal.type mirrors the dimension the
+    # dashboards group sessions by; TERM_PROGRAM is unset for non-interactive
+    # runs (cron, gateway, CI), which is itself the useful distinction.
+    try:
+        from agent.monitoring import usage_export
+        usage_export.record_session_start(
+            terminal_type=os.environ.get("TERM_PROGRAM") or "non-interactive",
+        )
+    except Exception:  # pragma: no cover - defensive
+        pass
+
     # Expose session ID to tools (terminal, execute_code) so agents can
     # reference their own session for --resume commands, cross-session
     # coordination, and logging. Keep the ContextVar and os.environ

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1674,12 +1674,35 @@ def init_agent(
         short_uuid = uuid.uuid4().hex[:6]
         agent.session_id = f"{timestamp_str}_{short_uuid}"
 
-    # Coding-agent usage export: count this session. No-op unless
-    # monitoring.usage_export.enabled. terminal.type mirrors the dimension the
-    # dashboards group sessions by; TERM_PROGRAM is unset for non-interactive
-    # runs (cron, gateway, CI), which is itself the useful distinction.
+    # Coding-agent usage export: start the exporter, then count this session.
+    # No-op unless monitoring.usage_export.enabled.
+    #
+    # ⚠ start() MUST happen here, not only at gateway boot. Hermes runs as a
+    # bare CLI process as often as it runs under the gateway, and a
+    # gateway-only start meant every CLI session silently exported nothing:
+    # record_api_call() returns immediately while the provider state is unset.
+    # start() is idempotent, so repeated sessions in one process are free.
+    #
+    # terminal.type mirrors the dimension the dashboards group sessions by;
+    # TERM_PROGRAM is unset for non-interactive runs (cron, gateway, CI), which
+    # is itself the useful distinction.
     try:
         from agent.monitoring import usage_export
+        try:
+            from hermes_cli.config import load_config_readonly as _load_usage_cfg
+            _usage_cfg = _load_usage_cfg()
+        except Exception:
+            _usage_cfg = None
+        if _usage_cfg and usage_export.start(_usage_cfg):
+            # Drain on interpreter exit. A CLI process has no gateway shutdown
+            # hook, so without this the final export interval's tokens are lost
+            # on every run — DELTA counters hold unexported increments in
+            # memory. atexit is registered once per process; shutdown() is
+            # idempotent.
+            if not getattr(usage_export, "_atexit_registered", False):
+                import atexit
+                atexit.register(usage_export.shutdown)
+                usage_export._atexit_registered = True
         usage_export.record_session_start(
             terminal_type=os.environ.get("TERM_PROGRAM") or "non-interactive",
         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4303,6 +4303,24 @@ def run_conversation(
                     agent.session_cost_status = cost_result.status
                     agent.session_cost_source = cost_result.source
 
+                    # Coding-agent usage export (hermes.* metrics). No-op unless
+                    # monitoring.usage_export.enabled. Fail-open: telemetry must
+                    # never break a turn, so record_api_call swallows its own
+                    # errors and this guard only covers attribute access.
+                    try:
+                        from agent.monitoring import usage_export as _usage_export
+                        _usage_export.record_api_call(
+                            model=_agg_cost_model,
+                            input_tokens=canonical_usage.input_tokens,
+                            output_tokens=canonical_usage.output_tokens,
+                            cache_read_tokens=canonical_usage.cache_read_tokens,
+                            cache_write_tokens=canonical_usage.cache_write_tokens,
+                            cost_usd=cost_result.amount_usd,
+                            effort=getattr(agent, "reasoning_effort", None) or None,
+                        )
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+
                     # Persist token counts to session DB for /insights.
                     # Do this for every platform with a session_id so non-CLI
                     # sessions (gateway, cron, delegated runs) cannot lose

--- a/agent/monitoring/usage_export.py
+++ b/agent/monitoring/usage_export.py
@@ -1,0 +1,342 @@
+"""Coding-agent usage export (hermes.* metrics) to an OTLP collector.
+
+Emits per-API-call token/cost usage so Hermes spend is attributable alongside
+other coding agents in a shared observability backend (e.g. the Dubber Claude
+Apps Gateway, whose ADOT sidecar promotes these to CloudWatch).
+
+Design notes learned the hard way against a real awsemf collector:
+
+* DELTA temporality is mandatory. The OTel SDK default is CUMULATIVE; the
+  awsemf exporter treats a single cumulative datapoint as a delta baseline and
+  emits NOTHING, silently, with no error surfaced by the gateway or collector.
+* Metric names must match a collector-side selector. A name the collector does
+  not know is written into the EMF record but never promoted to a metric.
+* Attribute (dimension) sets must match what the collector declares, and
+  CloudWatch SEARCH matches the EXACT full dimension schema, not a subset.
+
+Fail-open by design: telemetry must never break an agent turn.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_SCOPE = "hermes.agent.usage"
+
+# Metric names. Native hermes.* rather than reusing another vendor's namespace
+# so the two agents stay separable in every panel.
+_M_TOKENS = "hermes.token.usage"
+_M_COST = "hermes.cost.usage"
+_M_SESSIONS = "hermes.session.count"
+_M_ACTIVE = "hermes.active_time.total"
+
+_lock = threading.Lock()
+_state: Optional["_UsageExportState"] = None
+
+
+class _UsageExportState:
+    __slots__ = ("provider", "tokens", "cost", "sessions", "active", "attrs_base")
+
+    def __init__(self, provider, tokens, cost, sessions, active, attrs_base):
+        self.provider = provider
+        self.tokens = tokens
+        self.cost = cost
+        self.sessions = sessions
+        self.active = active
+        self.attrs_base = attrs_base
+
+
+def _usage_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    mon = (config or {}).get("monitoring") or {}
+    return mon.get("usage_export") or {}
+
+
+def _otlp_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    mon = (config or {}).get("monitoring") or {}
+    export = mon.get("export") or {}
+    return export.get("otlp") or {}
+
+
+def enabled(config: Dict[str, Any]) -> bool:
+    usage = _usage_config(config)
+    otlp = _otlp_config(config)
+    return bool(usage.get("enabled") and otlp.get("endpoint"))
+
+
+def _metric_endpoint(endpoint: str) -> str:
+    """Normalise to the OTLP HTTP metrics path.
+
+    A bare origin gets /v1/metrics appended. An endpoint that already ends in
+    /v1/traces or /v1/metrics is rewritten rather than doubled: a doubled path
+    404s and telemetry is dropped with no error surfaced.
+    """
+    ep = (endpoint or "").rstrip("/")
+    for suffix in ("/v1/traces", "/v1/logs", "/v1/metrics"):
+        if ep.endswith(suffix):
+            ep = ep[: -len(suffix)]
+            break
+    return ep + "/v1/metrics"
+
+
+def _resolve_headers(headers_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Map header name -> ENV VAR NAME, resolved at export time.
+
+    Never stores secret values in config.
+    """
+    resolved: Dict[str, str] = {}
+    for header_name, env_name in (headers_env or {}).items():
+        val = os.environ.get(str(env_name))
+        if val:
+            resolved[str(header_name)] = val
+    return resolved
+
+
+def _read_credential_file(path: str) -> Optional[str]:
+    """Read a bearer credential out of a JSON file written by an auth flow.
+
+    Returns None (not an exception) on any problem: a telemetry exporter must
+    never be the reason an agent turn fails.
+    """
+    try:
+        import json
+        with open(os.path.expanduser(path), "r") as fh:
+            data = json.load(fh)
+    except Exception:
+        return None
+    for key in ("access_token", "token", "id_token"):
+        val = data.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
+class _RefreshingSession:
+    """requests.Session wrapper that re-reads a credential file per request.
+
+    The OTLP HTTP exporter resolves its headers ONCE at construction. Gateway
+    session credentials are short-lived (8h is typical), so a long-running agent
+    or gateway process would export happily until expiry and then fail every
+    batch for the rest of its life — silently, since export errors are logged at
+    debug and never surface to the user.
+
+    Wrapping the session instead of the exporter keeps the refresh on the
+    request path, which is the only place that can observe a rotated file.
+    """
+
+    def __init__(self, session, credential_file: str,
+                 header: str = "Authorization", scheme: str = "Bearer"):
+        self._session = session
+        self._credential_file = credential_file
+        self._header = header
+        self._scheme = scheme
+
+    def __getattr__(self, name):
+        # Delegate everything the exporter touches (close, headers, mount, ...)
+        return getattr(self._session, name)
+
+    def post(self, *args, **kwargs):
+        current = _read_credential_file(self._credential_file)
+        if current:
+            headers = dict(kwargs.get("headers") or {})
+            headers[self._header] = f"{self._scheme} {current}"
+            kwargs["headers"] = headers
+        return self._session.post(*args, **kwargs)
+
+
+def _require_sdk(*, auto_install: bool = True) -> Dict[str, Any]:
+    if auto_install:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("export.otlp", prompt=False)
+        except Exception:
+            pass
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.metrics import Counter, MeterProvider
+    from opentelemetry.sdk.metrics.export import (
+        AggregationTemporality,
+        PeriodicExportingMetricReader,
+    )
+    from opentelemetry.sdk.resources import Resource
+    return {
+        "OTLPMetricExporter": OTLPMetricExporter,
+        "Counter": Counter,
+        "MeterProvider": MeterProvider,
+        "AggregationTemporality": AggregationTemporality,
+        "PeriodicExportingMetricReader": PeriodicExportingMetricReader,
+        "Resource": Resource,
+    }
+
+
+def start(config: Dict[str, Any]) -> bool:
+    """Start the usage exporter. Returns True if running. Never raises."""
+    global _state
+    if not enabled(config):
+        return False
+    with _lock:
+        if _state is not None:
+            return True
+        try:
+            sdk = _require_sdk()
+        except Exception:
+            logger.debug("usage export: OTLP SDK unavailable", exc_info=True)
+            return False
+        try:
+            usage = _usage_config(config)
+            otlp = _otlp_config(config)
+            endpoint = _metric_endpoint(str(otlp.get("endpoint") or ""))
+            headers = _resolve_headers(otlp.get("headers_env"))
+
+            # A credential file beats a static env var for anything long-lived:
+            # gateway sessions expire (8h typical) and the exporter would
+            # otherwise keep posting a dead credential forever.
+            session = None
+            cred_file = str(usage.get("credential_file") or "").strip()
+            if cred_file:
+                try:
+                    import requests
+                    session = _RefreshingSession(requests.Session(), cred_file)
+                except Exception:
+                    logger.debug("usage export: refreshing session unavailable",
+                                 exc_info=True)
+                    session = None
+
+            exporter_kwargs: Dict[str, Any] = {
+                "endpoint": endpoint,
+                "headers": headers or None,
+                # MANDATORY — see module docstring.
+                "preferred_temporality": {
+                    sdk["Counter"]: sdk["AggregationTemporality"].DELTA
+                },
+            }
+            if session is not None:
+                exporter_kwargs["session"] = session
+            exporter = sdk["OTLPMetricExporter"](**exporter_kwargs)
+            interval_ms = max(5, int(usage.get("export_interval_seconds", 60))) * 1000
+            reader = sdk["PeriodicExportingMetricReader"](
+                exporter, export_interval_millis=interval_ms
+            )
+            resource = sdk["Resource"].create(
+                {"service.name": str(usage.get("service_name") or "hermes-agent")}
+            )
+            provider = sdk["MeterProvider"](
+                metric_readers=[reader], resource=resource
+            )
+            meter = provider.get_meter(_SCOPE)
+
+            attrs_base: Dict[str, str] = {}
+            email = str(usage.get("user_email") or "").strip()
+            if email:
+                attrs_base["user.email"] = email
+
+            _state = _UsageExportState(
+                provider=provider,
+                tokens=meter.create_counter(_M_TOKENS, unit="tokens"),
+                cost=meter.create_counter(_M_COST, unit="USD"),
+                sessions=meter.create_counter(_M_SESSIONS),
+                active=meter.create_counter(_M_ACTIVE, unit="s"),
+                attrs_base=attrs_base,
+            )
+            logger.info(
+                "usage export started: endpoint=%s interval=%ss", endpoint,
+                usage.get("export_interval_seconds", 60),
+            )
+            return True
+        except Exception:
+            logger.warning("usage export failed to start", exc_info=True)
+            _state = None
+            return False
+
+
+def record_api_call(
+    *,
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cost_usd: Optional[float] = None,
+    effort: Optional[str] = None,
+) -> None:
+    """Record one API call's usage. Fail-open; never raises into the agent."""
+    st = _state
+    if st is None:
+        return
+    try:
+        base = dict(st.attrs_base)
+        if model:
+            base["model"] = str(model)
+        if effort:
+            base["effort"] = str(effort)
+
+        # `type` mirrors the four token classes the dashboards break out.
+        for type_name, value in (
+            ("input", input_tokens),
+            ("output", output_tokens),
+            ("cacheRead", cache_read_tokens),
+            ("cacheCreation", cache_write_tokens),
+        ):
+            if value:
+                attrs = dict(base)
+                attrs["type"] = type_name
+                st.tokens.add(int(value), attrs)
+
+        if cost_usd:
+            st.cost.add(float(cost_usd), base)
+    except Exception:
+        logger.debug("usage export: record_api_call failed", exc_info=True)
+
+
+def record_session_start(*, terminal_type: Optional[str] = None) -> None:
+    st = _state
+    if st is None:
+        return
+    try:
+        attrs = dict(st.attrs_base)
+        if terminal_type:
+            attrs["terminal.type"] = str(terminal_type)
+        st.sessions.add(1, attrs)
+    except Exception:
+        logger.debug("usage export: record_session_start failed", exc_info=True)
+
+
+def record_active_time(seconds: float, *, terminal_type: Optional[str] = None) -> None:
+    st = _state
+    if st is None or not seconds:
+        return
+    try:
+        attrs = dict(st.attrs_base)
+        if terminal_type:
+            attrs["terminal.type"] = str(terminal_type)
+        st.active.add(float(seconds), attrs)
+    except Exception:
+        logger.debug("usage export: record_active_time failed", exc_info=True)
+
+
+def flush(timeout_millis: int = 10000) -> bool:
+    st = _state
+    if st is None:
+        return False
+    try:
+        return bool(st.provider.force_flush(timeout_millis=timeout_millis))
+    except Exception:
+        logger.debug("usage export: flush failed", exc_info=True)
+        return False
+
+
+def shutdown() -> None:
+    global _state
+    with _lock:
+        st = _state
+        _state = None
+    if st is None:
+        return
+    try:
+        st.provider.force_flush(timeout_millis=10000)
+        st.provider.shutdown()
+    except Exception:
+        logger.debug("usage export: shutdown failed", exc_info=True)

--- a/agent/monitoring/usage_export.py
+++ b/agent/monitoring/usage_export.py
@@ -38,6 +38,10 @@ _M_ACTIVE = "hermes.active_time.total"
 _lock = threading.Lock()
 _state: Optional["_UsageExportState"] = None
 
+# Set by whichever entrypoint registers the atexit drain, so a process that
+# creates many agents/sessions registers it exactly once.
+_atexit_registered = False
+
 
 class _UsageExportState:
     __slots__ = ("provider", "tokens", "cost", "sessions", "active", "attrs_base")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12771,6 +12771,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("gateway health OTLP export startup failed", exc_info=True)
 
+        # Coding-agent usage export (hermes.* token/cost metrics). Separate from
+        # gateway health: that exporter reports on the gateway process, this one
+        # attributes model spend per user so it is comparable with other coding
+        # agents in a shared backend. Fail-open — a telemetry start failure must
+        # never stop the gateway from serving.
+        try:
+            from hermes_cli.config import load_config
+            from agent.monitoring import usage_export
+            if usage_export.start(load_config()):
+                logger.info("Coding-agent usage OTLP export: enabled")
+        except Exception:
+            logger.debug("usage OTLP export startup failed", exc_info=True)
+
         # Log any active supply-chain security advisories. Operators see this
         # in gateway.log and `hermes status` surfaces it; we do NOT block
         # startup or surface it inline to user messages, since the gateway
@@ -30800,7 +30813,22 @@ async def _await_thread_exit(
 
 
 def _shutdown_gateway_health_export(runner: Any) -> None:
-    """Idempotently drain and detach Gateway Health OTLP export."""
+    """Idempotently drain and detach Gateway Health + usage OTLP export."""
+    # Drain coding-agent usage metrics FIRST, and unconditionally. Without an
+    # explicit flush the final interval's tokens are lost on exit: the reader's
+    # periodic export may be up to export_interval_seconds away, and DELTA
+    # counters hold unexported increments in memory.
+    #
+    # ⚠ This must not sit below the `runtime is None` early return — usage
+    # export is configured independently of gateway health, so the common case
+    # (health disabled, usage enabled) would silently skip the final flush.
+    # shutdown() is idempotent and a no-op when the exporter never started.
+    try:
+        from agent.monitoring import usage_export
+        usage_export.shutdown()
+    except Exception:
+        logger.debug("usage OTLP export shutdown failed", exc_info=True)
+
     runtime = getattr(runner, "_gateway_health_export_runtime", None)
     if runtime is None:
         return

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3021,6 +3021,25 @@ DEFAULT_CONFIG = {
                 "deployment.environment.name": "production",
             },
         },
+        # Coding-agent usage export (hermes.* token/cost metrics). Off by
+        # default: it names a real user (user_email becomes a metric dimension)
+        # and needs an operator-provided collector. Requires monitoring.export
+        # .otlp.endpoint. See agent/monitoring/usage_export.py — the collector
+        # must declare the hermes.* metric names or datapoints are dropped.
+        "usage_export": {
+            "enabled": False,
+            "export_interval_seconds": 60,
+            "service_name": "hermes-agent",
+            # Stamped as the user.email dimension so spend is attributable.
+            # Empty means "export with no user dimension".
+            "user_email": "",
+            # Optional path to a JSON credential file (access_token/token/
+            # id_token) re-read on EVERY export. Prefer this over a static
+            # headers_env value for long-lived processes: gateway session
+            # credentials expire and a once-resolved header would fail every
+            # batch after that, silently.
+            "credential_file": "",
+        },
         # OTLP destination. headers_env maps header names to ENVIRONMENT
         # VARIABLE NAMES (never secret values); values are read from the
         # environment at export time.

--- a/tests/monitoring/test_usage_export.py
+++ b/tests/monitoring/test_usage_export.py
@@ -1,0 +1,423 @@
+"""Tests for agent/monitoring/usage_export.py.
+
+Focus on the invariants that were established empirically against a real
+awsemf collector and are silent-failure-prone:
+  * DELTA temporality is requested (CUMULATIVE is silently dropped downstream)
+  * endpoint normalisation never doubles /v1/metrics (a doubled path 404s)
+  * headers come from env var NAMES, never literal secrets in config
+  * every record_* entrypoint is fail-open and a no-op when not started
+"""
+
+import sys
+import types
+
+import pytest
+
+from agent.monitoring import usage_export
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    usage_export._state = None
+    yield
+    usage_export._state = None
+
+
+def _config(**overrides):
+    usage = {
+        "enabled": True,
+        "export_interval_seconds": 60,
+        "service_name": "hermes-agent",
+        "user_email": "dev@example.com",
+    }
+    usage.update(overrides.pop("usage", {}))
+    otlp = {"enabled": True, "endpoint": "https://gw.example.net", "headers_env": {}}
+    otlp.update(overrides.pop("otlp", {}))
+    return {"monitoring": {"usage_export": usage, "export": {"otlp": otlp}}}
+
+
+# ── config gating ────────────────────────────────────────────────────────────
+
+def test_enabled_requires_flag_and_endpoint():
+    assert usage_export.enabled(_config()) is True
+    assert usage_export.enabled(_config(usage={"enabled": False})) is False
+    assert usage_export.enabled(_config(otlp={"endpoint": ""})) is False
+    assert usage_export.enabled({}) is False
+
+
+def test_disabled_start_is_noop():
+    assert usage_export.start(_config(usage={"enabled": False})) is False
+    assert usage_export._state is None
+
+
+# ── endpoint normalisation ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("https://gw.example.net", "https://gw.example.net/v1/metrics"),
+        ("https://gw.example.net/", "https://gw.example.net/v1/metrics"),
+        # already-suffixed inputs must be rewritten, NOT doubled: a doubled
+        # path returns 404 and telemetry is dropped with no error surfaced.
+        ("https://gw.example.net/v1/metrics", "https://gw.example.net/v1/metrics"),
+        ("https://gw.example.net/v1/traces", "https://gw.example.net/v1/metrics"),
+        ("https://gw.example.net/v1/logs", "https://gw.example.net/v1/metrics"),
+    ],
+)
+def test_metric_endpoint_normalisation(given, expected):
+    assert usage_export._metric_endpoint(given) == expected
+
+
+# ── header indirection ───────────────────────────────────────────────────────
+
+def test_headers_read_from_env_var_names(monkeypatch):
+    monkeypatch.setenv("MY_TOKEN_VAR", "Bearer abc123")
+    resolved = usage_export._resolve_headers({"Authorization": "MY_TOKEN_VAR"})
+    assert resolved == {"Authorization": "Bearer abc123"}
+
+
+def test_headers_skip_unset_env(monkeypatch):
+    monkeypatch.delenv("ABSENT_VAR", raising=False)
+    assert usage_export._resolve_headers({"Authorization": "ABSENT_VAR"}) == {}
+    assert usage_export._resolve_headers(None) == {}
+
+
+# ── fail-open behaviour when not started ─────────────────────────────────────
+
+def test_record_calls_are_noop_when_not_started():
+    # Must not raise even though nothing was started.
+    usage_export.record_api_call(model="m", input_tokens=5)
+    usage_export.record_session_start(terminal_type="tmux")
+    usage_export.record_active_time(1.5)
+    assert usage_export.flush() is False
+    usage_export.shutdown()
+
+
+def test_record_api_call_survives_broken_counter():
+    class Boom:
+        def add(self, *a, **k):
+            raise RuntimeError("counter exploded")
+
+    usage_export._state = usage_export._UsageExportState(
+        provider=types.SimpleNamespace(
+            force_flush=lambda timeout_millis=0: True, shutdown=lambda: None
+        ),
+        tokens=Boom(), cost=Boom(), sessions=Boom(), active=Boom(),
+        attrs_base={},
+    )
+    # Fail-open: telemetry must never break an agent turn.
+    usage_export.record_api_call(model="m", input_tokens=1, cost_usd=0.1)
+    usage_export.record_session_start()
+    usage_export.record_active_time(2.0)
+
+
+# ── emitted values and attributes ────────────────────────────────────────────
+
+class _RecordingCounter:
+    def __init__(self):
+        self.calls = []
+
+    def add(self, value, attrs=None):
+        self.calls.append((value, dict(attrs or {})))
+
+
+def _install_recorder(attrs_base=None):
+    tokens, cost = _RecordingCounter(), _RecordingCounter()
+    sessions, active = _RecordingCounter(), _RecordingCounter()
+    # `is None` rather than `or {...}` so an explicitly empty dict is honoured
+    # (tests the no-user-email case) instead of falling back to the default.
+    if attrs_base is None:
+        attrs_base = {"user.email": "dev@example.com"}
+    usage_export._state = usage_export._UsageExportState(
+        provider=types.SimpleNamespace(
+            force_flush=lambda timeout_millis=0: True, shutdown=lambda: None
+        ),
+        tokens=tokens, cost=cost, sessions=sessions, active=active,
+        attrs_base=dict(attrs_base),
+    )
+    return tokens, cost, sessions, active
+
+
+def test_token_types_are_split_into_four_dimensions():
+    tokens, cost, _, _ = _install_recorder()
+    usage_export.record_api_call(
+        model="claude-opus-5", input_tokens=10, output_tokens=20,
+        cache_read_tokens=30, cache_write_tokens=40, cost_usd=0.5,
+        effort="medium",
+    )
+    by_type = {a["type"]: v for v, a in tokens.calls}
+    assert by_type == {
+        "input": 10, "output": 20, "cacheRead": 30, "cacheCreation": 40,
+    }
+    # every series carries the queryable dimensions
+    for _v, attrs in tokens.calls:
+        assert attrs["user.email"] == "dev@example.com"
+        assert attrs["model"] == "claude-opus-5"
+        assert attrs["effort"] == "medium"
+    # cost is emitted once, without a `type` dimension
+    assert cost.calls == [(0.5, {
+        "user.email": "dev@example.com",
+        "model": "claude-opus-5",
+        "effort": "medium",
+    })]
+
+
+def test_zero_valued_token_types_are_not_emitted():
+    tokens, cost, _, _ = _install_recorder()
+    usage_export.record_api_call(model="m", input_tokens=7)
+    # Only the non-zero class produces a datapoint; zeros would add cost and
+    # noise to a delta stream for no information.
+    assert [a["type"] for _v, a in tokens.calls] == ["input"]
+    assert cost.calls == []
+
+
+def test_session_and_active_time_use_terminal_type():
+    _, _, sessions, active = _install_recorder()
+    usage_export.record_session_start(terminal_type="ghostty")
+    usage_export.record_active_time(3.5, terminal_type="ghostty")
+    assert sessions.calls == [(1, {
+        "user.email": "dev@example.com", "terminal.type": "ghostty",
+    })]
+    assert active.calls == [(3.5, {
+        "user.email": "dev@example.com", "terminal.type": "ghostty",
+    })]
+
+
+def test_zero_active_time_is_skipped():
+    _, _, _, active = _install_recorder()
+    usage_export.record_active_time(0)
+    assert active.calls == []
+
+
+def test_attrs_base_omits_empty_email():
+    tokens, _, _, _ = _install_recorder(attrs_base={})
+    usage_export.record_api_call(model="m", input_tokens=1)
+    assert "user.email" not in tokens.calls[0][1]
+
+
+# ── DELTA temporality (the silent-failure invariant) ─────────────────────────
+
+def test_start_requests_delta_temporality(monkeypatch):
+    """CUMULATIVE is silently dropped by awsemf; DELTA is mandatory."""
+    captured = {}
+
+    class FakeCounter:
+        pass
+
+    class FakeTemporality:
+        DELTA = "DELTA"
+        CUMULATIVE = "CUMULATIVE"
+
+    def fake_exporter(endpoint=None, headers=None, preferred_temporality=None):
+        captured["endpoint"] = endpoint
+        captured["headers"] = headers
+        captured["temporality"] = preferred_temporality
+        return object()
+
+    class FakeMeter:
+        def create_counter(self, name, unit=None):
+            captured.setdefault("counters", []).append((name, unit))
+            return _RecordingCounter()
+
+    class FakeProvider:
+        def __init__(self, metric_readers=None, resource=None):
+            captured["resource"] = resource
+
+        def get_meter(self, scope):
+            captured["scope"] = scope
+            return FakeMeter()
+
+    fake_sdk = {
+        "OTLPMetricExporter": fake_exporter,
+        "Counter": FakeCounter,
+        "MeterProvider": FakeProvider,
+        "AggregationTemporality": FakeTemporality,
+        "PeriodicExportingMetricReader": lambda exp, export_interval_millis=0: (
+            captured.setdefault("interval_ms", export_interval_millis)
+        ),
+        "Resource": types.SimpleNamespace(create=lambda attrs: attrs),
+    }
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: fake_sdk)
+
+    assert usage_export.start(_config()) is True
+    assert captured["temporality"] == {FakeCounter: "DELTA"}
+    assert captured["endpoint"] == "https://gw.example.net/v1/metrics"
+    assert captured["interval_ms"] == 60000
+    assert captured["resource"] == {"service.name": "hermes-agent"}
+    assert captured["scope"] == "hermes.agent.usage"
+    # native hermes.* names, not another vendor's namespace
+    names = [n for n, _u in captured["counters"]]
+    assert names == [
+        "hermes.token.usage",
+        "hermes.cost.usage",
+        "hermes.session.count",
+        "hermes.active_time.total",
+    ]
+
+
+def test_start_is_idempotent(monkeypatch):
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: (_ for _ in ()).throw(
+        ImportError("no sdk")
+    ))
+    # SDK missing -> fail-open False, no state left behind
+    assert usage_export.start(_config()) is False
+    assert usage_export._state is None
+
+
+def test_export_interval_has_floor(monkeypatch):
+    captured = {}
+
+    class FakeCounter:
+        pass
+
+    fake_sdk = {
+        "OTLPMetricExporter": lambda **k: object(),
+        "Counter": FakeCounter,
+        "MeterProvider": lambda metric_readers=None, resource=None: types.SimpleNamespace(
+            get_meter=lambda scope: types.SimpleNamespace(
+                create_counter=lambda name, unit=None: _RecordingCounter()
+            )
+        ),
+        "AggregationTemporality": types.SimpleNamespace(DELTA="DELTA"),
+        "PeriodicExportingMetricReader": lambda exp, export_interval_millis=0: (
+            captured.setdefault("interval_ms", export_interval_millis)
+        ),
+        "Resource": types.SimpleNamespace(create=lambda attrs: attrs),
+    }
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: fake_sdk)
+    usage_export.start(_config(usage={"export_interval_seconds": 0}))
+    # a 0s interval would hot-loop the exporter
+    assert captured["interval_ms"] == 5000
+
+
+# ── credential refresh (expiry is a silent-failure mode) ─────────────────────
+
+def test_read_credential_file_prefers_access_token(tmp_path):
+    import json
+    p = tmp_path / "cred.json"
+    p.write_text(json.dumps({"access_token": "AAA", "token": "BBB"}))
+    assert usage_export._read_credential_file(str(p)) == "AAA"
+
+
+def test_read_credential_file_falls_back_to_other_keys(tmp_path):
+    import json
+    p = tmp_path / "cred.json"
+    p.write_text(json.dumps({"id_token": "CCC"}))
+    assert usage_export._read_credential_file(str(p)) == "CCC"
+
+
+def test_read_credential_file_is_fail_open(tmp_path):
+    # missing file, bad JSON, and no usable key must all return None rather
+    # than raising into the export path.
+    assert usage_export._read_credential_file(str(tmp_path / "nope.json")) is None
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert usage_export._read_credential_file(str(bad)) is None
+    empty = tmp_path / "empty.json"
+    empty.write_text('{"unrelated": 1}')
+    assert usage_export._read_credential_file(str(empty)) is None
+
+
+def test_refreshing_session_rereads_credential_per_post(tmp_path):
+    """A rotated credential must be picked up without restarting the process."""
+    import json
+    p = tmp_path / "cred.json"
+    p.write_text(json.dumps({"access_token": "first"}))
+
+    seen = []
+
+    class FakeSession:
+        def post(self, *a, **k):
+            seen.append(k.get("headers", {}).get("Authorization"))
+            return "ok"
+
+        def close(self):
+            seen.append("closed")
+
+    sess = usage_export._RefreshingSession(FakeSession(), str(p))
+    assert sess.post("http://x") == "ok"
+
+    # simulate the auth flow rewriting the file mid-process
+    p.write_text(json.dumps({"access_token": "second"}))
+    sess.post("http://x")
+
+    assert seen == ["Bearer first", "Bearer second"]
+
+    # attribute delegation still reaches the wrapped session
+    sess.close()
+    assert seen[-1] == "closed"
+
+
+def test_refreshing_session_without_credential_leaves_headers_alone(tmp_path):
+    captured = {}
+
+    class FakeSession:
+        def post(self, *a, **k):
+            captured.update(k)
+            return "ok"
+
+    sess = usage_export._RefreshingSession(FakeSession(), str(tmp_path / "absent.json"))
+    sess.post("http://x", headers={"X-Other": "1"})
+    # no credential available -> do not inject or clobber
+    assert captured["headers"] == {"X-Other": "1"}
+
+
+def test_start_uses_refreshing_session_when_credential_file_set(monkeypatch, tmp_path):
+    import json
+    p = tmp_path / "cred.json"
+    p.write_text(json.dumps({"access_token": "tok"}))
+
+    captured = {}
+
+    class FakeCounter:
+        pass
+
+    def fake_exporter(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    fake_sdk = {
+        "OTLPMetricExporter": fake_exporter,
+        "Counter": FakeCounter,
+        "MeterProvider": lambda metric_readers=None, resource=None: types.SimpleNamespace(
+            get_meter=lambda scope: types.SimpleNamespace(
+                create_counter=lambda name, unit=None: _RecordingCounter()
+            )
+        ),
+        "AggregationTemporality": types.SimpleNamespace(DELTA="DELTA"),
+        "PeriodicExportingMetricReader": lambda exp, export_interval_millis=0: None,
+        "Resource": types.SimpleNamespace(create=lambda attrs: attrs),
+    }
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: fake_sdk)
+
+    assert usage_export.start(_config(usage={"credential_file": str(p)})) is True
+    assert isinstance(captured.get("session"), usage_export._RefreshingSession)
+
+
+def test_start_omits_session_when_no_credential_file(monkeypatch):
+    captured = {}
+
+    class FakeCounter:
+        pass
+
+    def fake_exporter(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    fake_sdk = {
+        "OTLPMetricExporter": fake_exporter,
+        "Counter": FakeCounter,
+        "MeterProvider": lambda metric_readers=None, resource=None: types.SimpleNamespace(
+            get_meter=lambda scope: types.SimpleNamespace(
+                create_counter=lambda name, unit=None: _RecordingCounter()
+            )
+        ),
+        "AggregationTemporality": types.SimpleNamespace(DELTA="DELTA"),
+        "PeriodicExportingMetricReader": lambda exp, export_interval_millis=0: None,
+        "Resource": types.SimpleNamespace(create=lambda attrs: attrs),
+    }
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: fake_sdk)
+
+    assert usage_export.start(_config()) is True
+    # the SDK default session must be used, not an explicit None
+    assert "session" not in captured

--- a/tests/monitoring/test_usage_export.py
+++ b/tests/monitoring/test_usage_export.py
@@ -19,8 +19,10 @@ from agent.monitoring import usage_export
 @pytest.fixture(autouse=True)
 def _reset_state():
     usage_export._state = None
+    usage_export._atexit_registered = False
     yield
     usage_export._state = None
+    usage_export._atexit_registered = False
 
 
 def _config(**overrides):

--- a/tests/monitoring/test_usage_export_wiring.py
+++ b/tests/monitoring/test_usage_export_wiring.py
@@ -1,0 +1,92 @@
+"""The CLI/agent-init path must start the usage exporter, not just the gateway.
+
+Regression test for a real miss: start() was wired only into gateway boot, so
+every bare-CLI session exported nothing — record_api_call() returned at the
+uninitialised-state guard and no error was logged anywhere.
+"""
+
+import sys
+import types
+
+import pytest
+
+from agent.monitoring import usage_export
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    usage_export._state = None
+    usage_export._atexit_registered = False
+    yield
+    usage_export._state = None
+    usage_export._atexit_registered = False
+
+
+def test_agent_init_contains_start_call():
+    """agent_init must call usage_export.start(), not only record_session_start()."""
+    import inspect
+    from agent import agent_init
+
+    src = inspect.getsource(agent_init)
+    assert "usage_export.start(" in src, (
+        "agent_init must start the exporter; a gateway-only start silently "
+        "disables export for every CLI session"
+    )
+    assert "atexit.register(usage_export.shutdown)" in src, (
+        "a CLI process has no gateway shutdown hook, so the final export "
+        "interval would be lost without an atexit drain"
+    )
+
+
+def test_gateway_run_still_starts_exporter():
+    """The gateway path must keep its own start() — both entrypoints matter."""
+    path = "gateway/run.py"
+    import os
+    root = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(usage_export.__file__))))
+    with open(os.path.join(root, path)) as fh:
+        src = fh.read()
+    assert "usage_export.start(load_config())" in src
+    assert "usage_export.shutdown()" in src
+
+
+def test_start_is_idempotent_across_sessions(monkeypatch):
+    """Many sessions in one process must not build many providers."""
+    builds = []
+
+    class FakeCounter:
+        pass
+
+    class FakeRecorder:
+        def add(self, *a, **k):
+            pass
+
+    def fake_exporter(**kwargs):
+        builds.append(kwargs)
+        return object()
+
+    fake_sdk = {
+        "OTLPMetricExporter": fake_exporter,
+        "Counter": FakeCounter,
+        "MeterProvider": lambda metric_readers=None, resource=None: types.SimpleNamespace(
+            get_meter=lambda scope: types.SimpleNamespace(
+                create_counter=lambda name, unit=None: FakeRecorder()
+            )
+        ),
+        "AggregationTemporality": types.SimpleNamespace(DELTA="DELTA"),
+        "PeriodicExportingMetricReader": lambda exp, export_interval_millis=0: None,
+        "Resource": types.SimpleNamespace(create=lambda attrs: attrs),
+    }
+    monkeypatch.setattr(usage_export, "_require_sdk", lambda **k: fake_sdk)
+
+    cfg = {
+        "monitoring": {
+            "usage_export": {"enabled": True, "user_email": "dev@example.com"},
+            "export": {"otlp": {"enabled": True, "endpoint": "https://gw.example.net"}},
+        }
+    }
+    assert usage_export.start(cfg) is True
+    assert usage_export.start(cfg) is True
+    assert usage_export.start(cfg) is True
+    # exporter constructed exactly once despite three session starts
+    assert len(builds) == 1


### PR DESCRIPTION
## Problem

Hermes token/cost usage is not observable anywhere outside `agent.log`. There is
a gateway-health OTLP exporter, but nothing that attributes **model spend per
user**, so Hermes usage cannot be compared against other tooling in a shared
backend.

This matters most when Hermes runs alongside another coding agent behind the
same gateway. Gateways of that shape *relay* client OTLP rather than minting
metrics from proxied traffic — their per-request records carry client-only
attributes like `terminal.type` and `session.id`, which only the client can
know. With no exporter on the Hermes side, Hermes traffic is simply absent from
every panel while the other agent's usage shows up in full.

Measured on one developer machine before writing this: **12,910 API calls /
2.24B tokens over ~7 weeks**, none of it attributable. On the shared dashboard
that developer appeared to have spent nothing, while a colleague's 1.9M tokens
were charted as the top consumer.

## Change

New `agent/monitoring/usage_export.py` emitting four DELTA counters:

| Metric | Dimensions |
|---|---|
| `hermes.token.usage` | `user.email`, `type` (input/output/cacheRead/cacheCreation), `model`, `effort` |
| `hermes.cost.usage` | `user.email`, `model`, `effort` |
| `hermes.session.count` | `user.email`, `terminal.type` |
| `hermes.active_time.total` | `user.email`, `terminal.type` |

Config lives under `monitoring.usage_export` and is **off by default** — it
names a real user and needs an operator-chosen collector. It reuses the existing
`monitoring.export.otlp` endpoint.

Wiring:
- emit at the per-API-call accounting site in `conversation_loop`, so all
  providers are covered (including direct-to-Bedrock fallback traffic, not just
  gateway-proxied calls)
- `start()` + `atexit` drain at session init in `agent_init` (every launch mode)
- `start()` / drain at gateway boot and teardown

Every entrypoint is fail-open: telemetry must never break an agent turn.

## Three non-obvious constraints

Each of these was found by watching a real collector silently discard data, and
each is documented in-module so the next person does not repeat it.

**1. DELTA temporality is mandatory.** The OTel SDK default is CUMULATIVE, and
the AWS EMF exporter treats a single cumulative datapoint as a delta *baseline*
and emits nothing — no error at the gateway, none at the collector. Cumulative
probes vanished without trace; a DELTA probe with two export cycles landed and
matched the emitted values exactly.

**2. Metric names must be declared collector-side.** An undeclared name is
written into the intermediate record but never promoted to a metric. A probe
emitting `hermes.token.usage` alongside a known metric produced a record
containing both keys, but only the declared one became queryable.

**3. Credentials expire, and the exporter resolves headers once.** A static
header means every batch fails after expiry (8h for the gateway session
credential in our case) with only a debug log. `usage_export.credential_file`
re-reads a JSON credential per request via a session wrapper — the only place
that can observe a rotated file.

## Why two commits

The second commit is a fix for a miss in the first, kept separate because the
failure mode is instructive: `start()` was wired **only** into gateway boot.
Hermes runs as a bare CLI process at least as often, so for any `hermes` /
`hermes --resume` invocation the exporter never initialised — `record_api_call()`
returned at the uninitialised-state guard and logged nothing, because that guard
is deliberately silent. Enabling the config and restarting produced no metrics
and no explanation.

`start()` now also runs at session init, with an `atexit` drain: a CLI process
has no gateway teardown hook, so without it the final export interval is lost on
every run (DELTA counters hold unexported increments in memory). A regression
test asserts both entrypoints keep their `start()` call.

## Verification

`48 passed, 1 skipped` in `tests/monitoring/` on this branch, rebased onto
current `main` (`29033a3fd`).

Verified end-to-end against a live OTLP collector → CloudWatch:

- emitted 880011 + 880022 → CloudWatch recorded **1760033** for the period
- CLI path with **no explicit flush**, so the `atexit` handler had to do the
  work: emitted 990077 → CloudWatch recorded **990077**
- a real interactive session reported `hermes.session.count` with
  `terminal.type=Apple_Terminal`, which the test harness cannot produce (it
  reports `non-interactive`)

## Notes for reviewers

- Collector-side declaration is required for the `hermes.*` names to be
  promoted; that is deployment config, not something this PR can carry.
- `record_active_time()` is implemented and tested but has **no caller yet** —
  `hermes.active_time.total` will stay flat until something measures active
  time. Left in rather than dropped so the metric shape is settled.
- Metric names are `hermes.*` rather than reusing another vendor's namespace, so
  two agents reporting into one backend stay separable per-user.
