### PR TITLE
fix(sessions): don't let the empty-session sweep delete an archived transcript

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -491,11 +491,16 @@ async def count_empty_sessions_endpoint(profile: Optional[str] = None):
 
 @manage_router.delete("/api/sessions/empty")
 async def delete_empty_sessions_endpoint(profile: Optional[str] = None):
-    """Delete every empty (``message_count == 0``), ended,
-    non-archived session in a single transaction.
+    """Delete every empty, ended, non-archived session in a single
+    transaction.
 
     Safety contract mirrors :meth:`SessionDB.delete_empty_sessions`:
 
+    * "Empty" means the session owns no rows in ``messages`` at all — not
+      merely ``message_count == 0``. A rewound or in-place-compacted chat
+      keeps its dropped turns as soft-archived (``active = 0``) rows while
+      the counter reads zero, and those rows are the only recoverable copy
+      of the transcript (#95868).
     * Active sessions are skipped (``ended_at IS NULL``) so a live
       agent isn't yanked mid-handshake.
     * Archived sessions are skipped — the user explicitly chose to

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13144,11 +13144,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     #: keeping the dropped turns on disk as ``active = 0``:
     #: :meth:`replace_messages` with ``archive_dropped=True`` (the rewind /
     #: edit / regenerate mode from #82756) and :meth:`archive_and_compact`
-    #: (in-place compaction). A chat rewound to its first turn, or compacted
-    #: with an empty live set, therefore reports ``message_count = 0`` while
-    #: still holding its entire recoverable transcript — and those
-    #: soft-archived rows are the ONLY copy, which is the whole point of
-    #: archiving instead of deleting. Deleting such a row destroys it silently.
+    #: (in-place compaction). ``prompt.submit`` reaches the first with an empty
+    #: prefix on a confirmed ordinal-0 rewind, so a chat whose first user turn
+    #: was regenerated reports ``message_count = 0`` while still holding its
+    #: entire recoverable transcript — and those soft-archived rows are the
+    #: ONLY copy, which is the whole point of archiving instead of deleting
+    #: (#70516 / #80763 / #82756). Deleting such a row destroys it silently.
     #:
     #: So the counter stays as a cheap prefilter and a real ``EXISTS`` probe is
     #: the authority, exactly as every other emptiness test in this module

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13134,16 +13134,51 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._remove_session_files(sessions_dir, sid)
         return count
 
+    #: Selector shared by :meth:`count_empty_sessions` and
+    #: :meth:`delete_empty_sessions` so the button's count and the sweep it
+    #: triggers can never disagree about what "empty" means.
+    #:
+    #: ``message_count`` alone is NOT a safe emptiness test. It is a
+    #: denormalized counter that tracks the LIVE (``active = 1``) row set, and
+    #: two production transcript-rewrite paths deliberately reset it while
+    #: keeping the dropped turns on disk as ``active = 0``:
+    #: :meth:`replace_messages` with ``archive_dropped=True`` (the rewind /
+    #: edit / regenerate mode from #82756) and :meth:`archive_and_compact`
+    #: (in-place compaction). A chat rewound to its first turn, or compacted
+    #: with an empty live set, therefore reports ``message_count = 0`` while
+    #: still holding its entire recoverable transcript — and those
+    #: soft-archived rows are the ONLY copy, which is the whole point of
+    #: archiving instead of deleting. Deleting such a row destroys it silently.
+    #:
+    #: So the counter stays as a cheap prefilter and a real ``EXISTS`` probe is
+    #: the authority, exactly as every other emptiness test in this module
+    #: already does it (:meth:`delete_session_if_empty`,
+    #: :meth:`prune_empty_ghost_sessions`,
+    #: :meth:`list_never_active_keyed_sessions`). (#95868)
+    _EMPTY_SESSION_WHERE = (
+        "message_count = 0 "
+        "AND ended_at IS NOT NULL "
+        "AND archived = 0 "
+        "AND NOT EXISTS ("
+        "SELECT 1 FROM messages WHERE messages.session_id = sessions.id"
+        ")"
+    )
+
     def count_empty_sessions(self) -> int:
         """Return the count of empty, non-active, non-archived sessions.
 
-        "Empty" = ``message_count = 0`` AND the session has ended
+        "Empty" = the session holds no message rows at all AND has ended
         (``ended_at IS NOT NULL``) AND is not archived. The ``ended_at``
         guard matches the safety contract used by :meth:`prune_sessions`:
         only ended sessions are candidates for bulk deletion, so a freshly
         spawned session whose first message hasn't landed yet — or one
         held open by the live agent — is never sniped out from under
         the runtime.
+
+        Emptiness is decided by :data:`_EMPTY_SESSION_WHERE`, which probes the
+        ``messages`` table instead of trusting the ``message_count`` counter —
+        see that constant for why the counter reads zero for rewound and
+        compacted sessions that still hold a full transcript.
 
         Backs the ``GET /api/sessions/empty/count`` endpoint that lets the
         web dashboard hide its "Delete empty" button when there's nothing
@@ -13152,10 +13187,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT COUNT(*) FROM sessions "
-                "WHERE message_count = 0 "
-                "AND ended_at IS NOT NULL "
-                "AND archived = 0"
+                f"SELECT COUNT(*) FROM sessions WHERE {self._EMPTY_SESSION_WHERE}"
             )
             return cursor.fetchone()[0]
 
@@ -13167,9 +13199,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Mirrors :meth:`prune_sessions`' transactional shape:
 
-        * Selects candidate IDs first (``message_count = 0`` AND
-          ``ended_at IS NOT NULL`` AND ``archived = 0``) so we never
-          touch a live session or one the user deliberately archived.
+        * Selects candidate IDs first (:data:`_EMPTY_SESSION_WHERE`: no
+          message rows AND ``ended_at IS NOT NULL`` AND ``archived = 0``)
+          so we never touch a live session, one the user deliberately
+          archived, or one whose transcript survives only as soft-archived
+          (``active = 0``) rows after a rewind or an in-place compaction.
         * Orphans any child whose parent is in the kill list — children
           of an empty parent are kept and re-parented to ``NULL`` rather
           than cascade-deleted, matching ``delete_session`` /
@@ -13192,10 +13226,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             cursor = conn.execute(
-                "SELECT id FROM sessions "
-                "WHERE message_count = 0 "
-                "AND ended_at IS NOT NULL "
-                "AND archived = 0"
+                f"SELECT id FROM sessions WHERE {self._EMPTY_SESSION_WHERE}"
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
 
@@ -13210,10 +13241,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
             for sid in session_ids:
-                # DELETE FROM messages is paranoia — by construction
-                # these rows have ``message_count = 0`` — but if a
-                # bookkeeping bug ever lets the counter drift below the
-                # real row count, we still leave a clean FK state.
+                # DELETE FROM messages is paranoia — the selector's
+                # ``NOT EXISTS`` probe already proved these sessions own no
+                # message rows — but a row inserted between the SELECT and
+                # this statement would otherwise be left dangling, so we
+                # still leave a clean FK state.
                 conn.execute(
                     "DELETE FROM messages WHERE session_id = ?", (sid,)
                 )

--- a/tests/hermes_state/test_empty_sweep_archived_transcript_95868.py
+++ b/tests/hermes_state/test_empty_sweep_archived_transcript_95868.py
@@ -1,0 +1,137 @@
+"""The empty-session sweep must not eat a rewound / compacted transcript (#95868).
+
+``count_empty_sessions`` / ``delete_empty_sessions`` back the dashboard's
+"Delete empty (N)" affordance. They used to define "empty" as
+``sessions.message_count = 0``, which is a denormalized counter over the LIVE
+(``active = 1``) rows only.
+
+Two production transcript-rewrite paths reset that counter on purpose while
+keeping every dropped turn on disk as ``active = 0``:
+
+* ``replace_messages(..., archive_dropped=True)`` — the rewind / edit /
+  regenerate mode added in #82756 precisely so a user can take a turn back
+  without the rows being unrecoverable.
+* ``archive_and_compact`` — in-place compaction, which archives the
+  pre-compaction transcript under the same session id (#38763).
+
+Rewind a chat back to its first turn, or compact it with an empty live set,
+and the row reports ``message_count = 0`` while still holding its entire
+recoverable history. Those soft-archived rows are the ONLY copy.
+
+A gateway reload is what makes such a row *eligible*: every detached session
+gets ``ended_at`` stamped (``end_reason='ws_orphan_reap'``), which satisfies
+the sweep's ``ended_at IS NOT NULL`` gate. The next "Delete empty" click then
+hard-deleted the session row AND ``DELETE FROM messages`` — silently, with no
+log line to trace it by.
+
+These tests pin the counter drift as real, and pin the sweep's refusal to act
+on it.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _seed(db, session_id, turns=4):
+    """A populated, ended desktop chat — the shape #95868 lost."""
+    db.create_session(session_id, source="desktop", model="test-model")
+    for i in range(turns):
+        db.append_message(
+            session_id,
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"turn {i}",
+        )
+    return session_id
+
+
+def _row_counts(db, session_id):
+    """(message_count column, real rows on disk) for *session_id*."""
+    with db._lock:
+        counter = db._conn.execute(
+            "SELECT message_count FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()["message_count"]
+        rows = db._conn.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session_id,)
+        ).fetchone()["n"]
+    return counter, rows
+
+
+def test_rewind_to_empty_drifts_the_counter_to_zero(db):
+    """The premise: an archived-drop rewrite zeroes the counter, keeps the rows."""
+    _seed(db, "rewound")
+    assert _row_counts(db, "rewound") == (4, 4)
+
+    db.replace_messages("rewound", [], archive_dropped=True)
+
+    counter, rows = _row_counts(db, "rewound")
+    assert counter == 0, "message_count tracks the live set only"
+    assert rows == 4, "the dropped turns stay on disk as the recoverable copy"
+    assert len(db.get_messages("rewound", include_inactive=True)) == 4
+
+
+def test_sweep_spares_a_rewound_session(db):
+    """A rewound chat is not empty and must survive the sweep."""
+    _seed(db, "rewound")
+    db.replace_messages("rewound", [], archive_dropped=True)
+    # A gateway reload stamps ended_at on every detached session, which is what
+    # makes the row eligible for the sweep in the first place.
+    db.end_session("rewound", end_reason="ws_orphan_reap")
+
+    assert db.count_empty_sessions() == 0
+    assert db.delete_empty_sessions() == 0
+    assert db.get_session("rewound") is not None
+    assert len(db.get_messages("rewound", include_inactive=True)) == 4
+
+
+def test_sweep_spares_an_in_place_compacted_session(db):
+    """``archive_and_compact`` leaves the same zero-counter/live-rows shape."""
+    _seed(db, "compacted")
+    db.archive_and_compact("compacted", [])
+    assert _row_counts(db, "compacted") == (0, 4)
+
+    db.end_session("compacted", end_reason="ws_orphan_reap")
+
+    assert db.count_empty_sessions() == 0
+    assert db.delete_empty_sessions() == 0
+    assert db.get_session("compacted") is not None
+    assert len(db.get_messages("compacted", include_inactive=True)) == 4
+
+
+def test_genuinely_empty_sessions_are_still_swept(db):
+    """The fix must not neuter the feature: no rows at all is still empty."""
+    db.create_session("ghost", source="desktop")
+    db.end_session("ghost", end_reason="tui_close")
+
+    _seed(db, "populated")
+    db.end_session("populated", end_reason="tui_close")
+
+    assert db.count_empty_sessions() == 1
+    assert db.delete_empty_sessions() == 1
+    assert db.get_session("ghost") is None
+    assert db.get_session("populated") is not None
+
+
+def test_count_and_delete_agree_on_a_mixed_database(db):
+    """The button's N and the sweep it triggers must never disagree.
+
+    They read one shared selector; this pins that they still agree once
+    drifted-counter rows are in the mix.
+    """
+    db.create_session("ghost", source="desktop")
+    db.end_session("ghost", end_reason="tui_close")
+
+    _seed(db, "rewound")
+    db.replace_messages("rewound", [], archive_dropped=True)
+    db.end_session("rewound", end_reason="ws_orphan_reap")
+
+    _seed(db, "live")  # never ended — not a candidate either way
+
+    counted = db.count_empty_sessions()
+    assert counted == 1
+    assert db.delete_empty_sessions() == counted

--- a/tests/hermes_state/test_empty_sweep_archived_transcript_95868.py
+++ b/tests/hermes_state/test_empty_sweep_archived_transcript_95868.py
@@ -10,13 +10,18 @@ keeping every dropped turn on disk as ``active = 0``:
 
 * ``replace_messages(..., archive_dropped=True)`` — the rewind / edit /
   regenerate mode added in #82756 precisely so a user can take a turn back
-  without the rows being unrecoverable.
+  without the rows being unrecoverable. ``prompt.submit`` reaches it with an
+  empty prefix on a confirmed ordinal-0 rewind (regenerating the very first
+  user turn), which is the reachable production shape.
 * ``archive_and_compact`` — in-place compaction, which archives the
-  pre-compaction transcript under the same session id (#38763).
+  pre-compaction transcript under the same session id (#38763). It normally
+  publishes at least a summary row, so it lands on the same shape only when
+  the live set comes back empty; pinned here as defense in depth.
 
-Rewind a chat back to its first turn, or compact it with an empty live set,
-and the row reports ``message_count = 0`` while still holding its entire
-recoverable history. Those soft-archived rows are the ONLY copy.
+Either way the row reports ``message_count = 0`` while still holding its
+entire recoverable history, and those soft-archived rows are the ONLY copy —
+which is the whole point of the archive-instead-of-delete guarantee that
+#70516 / #80763 / #82756 were fixed to provide.
 
 A gateway reload is what makes such a row *eligible*: every detached session
 gets ``ended_at`` stamped (``end_reason='ws_orphan_reap'``), which satisfies


### PR DESCRIPTION
## Summary

Investigating #95868 I could not reproduce a hard delete on the reload path itself — and I want to state that plainly up front, because it changes where the fix belongs.

Driving the real code against a real `state.db`, the gateway-reload sequence the reporter describes (`ws closed … code=1012 … detached_sessions=7` → plugin remount) **preserves every row**. `_close_sessions_for_transport` only re-points detached sessions at the drop sentinel; `_teardown_popped_session` → `_finalize_session` only calls `end_session()`. There is no `DELETE FROM sessions` anywhere on that path. What the reload *does* do is stamp `ended_at` + `end_reason='ws_orphan_reap'` on every detached session — and that stamp is the trigger for the actual defect.

**Root cause: the empty-session sweep decides "empty" from a counter that two production paths deliberately zero on populated sessions.**

`SessionDB.count_empty_sessions()` / `delete_empty_sessions()` — the dashboard's *"Delete empty (N)"* affordance, `GET|DELETE /api/sessions/empty` — selected on `sessions.message_count = 0`. That column is a denormalized counter over the **live** (`active = 1`) row set only. Two transcript-rewrite paths reset it on purpose while keeping every dropped turn on disk as `active = 0`:

| Path | Why it archives instead of deleting | Reaches `message_count = 0` |
|---|---|---|
| `replace_messages(..., archive_dropped=True)` | The rewind / edit / regenerate mode from #82756 — a plain `DELETE` also evicts the rows from FTS, leaving nothing to recover from | **Yes, in production.** `prompt.submit` computes the surviving prefix with `history_before_user_originated_turn`; a confirmed ordinal-0 rewind (regenerating the very first user turn, gated behind `confirm_empty_truncate`) yields `truncated == []` |
| `archive_and_compact` | In-place compaction keeps the pre-compaction transcript under the same session id (#38763) | Only when the live set comes back empty — normally it publishes at least a summary row. Pinned as defense in depth |

So a chat whose first user turn was regenerated reports `message_count = 0` while still holding its **entire recoverable history** — and those soft-archived rows are the only copy that exists. Once the gateway reload stamps `ended_at`, the row satisfies the sweep's `ended_at IS NOT NULL` gate, gets counted in the *"Delete empty (N)"* badge, and is hard-deleted together with `DELETE FROM messages`. Silently, and with no log line — which is exactly the "rows gone, no `delete_session` in the logs" signature reported.

What makes this sting is *whose* guarantee it breaks. The `archive_dropped=True` call site says so in its own comment: *"a rewind overwrites turns the user may not have meant to drop, and this write is the last step before they are gone — three reported incidents ended here with nothing to restore from (#70516, #80763, #82756). Soft-archiving keeps them on disk (active=0) and in the FTS index, so a mis-aimed cut is recoverable instead of terminal."* The empty-session sweep silently deletes exactly the rows those three fixes were written to preserve.

The asymmetry that makes this a clear bug rather than a design call: **every other emptiness test in `hermes_state` already refuses to trust the counter** and pairs it with a real `EXISTS (SELECT 1 FROM messages …)` probe — `delete_session_if_empty`, `prune_empty_ghost_sessions`, `list_never_active_keyed_sessions`, `find_recoverable_session`. This sweep was the single destructive path still trusting it alone. Its own inline comment even anticipated the failure ("*if a bookkeeping bug ever lets the counter drift below the real row count*") without guarding against it.

## The fix

One selector, `SessionDB._EMPTY_SESSION_WHERE`, shared by the count and the delete so the badge's `N` and the sweep it triggers can never disagree about what "empty" means:

```sql
message_count = 0
AND ended_at IS NOT NULL
AND archived = 0
AND NOT EXISTS (SELECT 1 FROM messages WHERE messages.session_id = sessions.id)
```

The counter stays as a cheap prefilter; the `EXISTS` probe is the authority. This is the same shape the four sibling guards already use, so it is an in-style narrowing rather than new machinery. Genuinely message-less rows are still swept — the feature is unchanged for the case it was built for.

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Populated Desktop Chat] -->|"confirmed ordinal-0 rewind"| B["🔥 replace_messages(archive_dropped=True)"]
    A -->|"in-place compaction"| C[🔥 archive_and_compact]
    B --> D["⚰️ Rows kept as active = 0<br/>message_count reset to 0"]
    C --> D
    D -->|"gateway reload<br/>detached_sessions &gt; 0"| E["🕯️ ended_at stamped<br/>end_reason = ws_orphan_reap"]
    E --> F{"⚔️ Empty-Session Sweep"}
    F -->|"BEFORE: message_count = 0 only"| G["💀 Hard Delete<br/>sessions + messages<br/>no log, unrecoverable"]
    F -->|"AFTER: + NOT EXISTS messages"| H["🛡️ Transcript Preserved<br/>row survives, archived rows intact"]

    style G fill:#3b0008,stroke:#ff0038,color:#ffccd5
    style H fill:#062a12,stroke:#28d17c,color:#d6ffe6
```

## Relationship to #95961

Deliberately disjoint — no overlapping files, no overlapping mechanism. #95961 addresses the *soft* half of the report (populated rows should not be stamped `tui_shutdown`/ended by a reload, plus delete-path logging) in `tui_gateway/*`. This PR addresses the *hard* half: the sweep that turns an `ended_at` stamp into an actual `DELETE`. Both can land independently; together they close the loop, since #95961 removes the stamp that makes rows eligible and this PR removes the sweep's ability to act on a populated row even when a stamp is legitimate.

## Verification

Empirical, not inferred. Two harnesses were run against real `SessionDB` instances:

1. **Reload path** — 8 populated `source='desktop'` sessions bound to one transport, then `_close_sessions_for_transport` (`reaped=0 detached=8`, matching the report's shape) → forced `ws_orphan_reap` teardown → `_shutdown_sessions` → next-startup `_run_state_db_auto_maintenance`. Result: **8/8 rows survived**, stamped `ended_at` + `ws_orphan_reap`. No hard-delete path exists there.
2. **Counter drift** — `replace_messages(sid, [], archive_dropped=True)` and `archive_and_compact(sid, [])` both leave `(message_count=0, rows_on_disk=4, rows_active=0)`. On pre-fix code `count_empty_sessions()` reported `2` and `delete_empty_sessions()` destroyed both session rows and all 8 message rows.

The regression tests encode exactly that, and were confirmed **red before / green after** (3 of the 5 fail on unpatched `hermes_state.py`).

## Test plan

- [x] `pytest tests/hermes_state/test_empty_sweep_archived_transcript_95868.py` — 5 passed (3 fail without the fix)
- [x] `pytest tests/test_empty_session_hygiene.py tests/test_session_system_prompt_dedup.py tests/hermes_state` — 202 passed
- [x] `pytest tests/hermes_cli/test_web_server.py::TestDeleteEmptySessionsEndpoint` — 3 passed
- [x] `pytest tests/test_hermes_state.py tests/test_web_server_sessiondb_eventloop.py` — 246 passed, 2 skipped
- [x] `ruff check` on all changed files — clean
- [ ] Dashboard: rewind a chat to its first turn, close it, confirm *"Delete empty"* no longer counts it and the sweep leaves it resumable with history intact
- [ ] Dashboard: a genuinely message-less ended session is still counted and still swept

Fixes #95868

 