### PR TITLE
feat(desktop): browser_exec tool rows titled by their leading # step comment (parity with CLI/TUI)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -92,6 +92,44 @@ describe('buildToolView terminal exit-code status', () => {
   })
 })
 
+describe('buildToolView browser_exec step label', () => {
+  const bexec = (code: string) =>
+    buildToolView(part({ args: { code }, result: undefined, toolName: 'browser_exec' }), '')
+
+  it('uses the leading # comment as the title', () => {
+    expect(bexec('# Searching Amazon for paper towels\nnew_tab("https://amazon.com")').title).toBe(
+      'Searching Amazon for paper towels'
+    )
+  })
+
+  it('falls back to the generic title when code has no leading comment', () => {
+    const view = bexec('new_tab("https://amazon.com")')
+
+    expect(view.title).not.toBe('')
+    expect(view.title).not.toContain('new_tab')
+  })
+
+  it('truncates long labels and keeps the ellipsis', () => {
+    const long = `# ${'x'.repeat(120)}`
+
+    expect(bexec(long).title.length).toBeLessThanOrEqual(80)
+    expect(bexec(long).title.endsWith('…')).toBe(true)
+  })
+
+  it('keeps the label after the result arrives', () => {
+    const view = buildToolView(
+      part({
+        args: { code: '# Checking workspace persistence\nprint(1)' },
+        result: { output: 'ok', success: true },
+        toolName: 'browser_exec'
+      }),
+      ''
+    )
+
+    expect(view.title).toBe('Checking workspace persistence')
+  })
+})
+
 describe('buildToolView web-search query', () => {
   it('keeps the query separate from structured search results', () => {
     const view = buildToolView(

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -2,6 +2,27 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
+/**
+ * User-friendly step label from browser_exec code's leading `# …` comment.
+ * Mirrors agent/display.py:_browser_exec_step_label (CLI/TUI) so every
+ * surface derives the same label from the same convention.
+ */
+export function browserExecStepLabel(code: string, maxChars = 80): null | string {
+  const first = code.trim().split('\n', 1)[0]?.trim() ?? ''
+
+  if (!first.startsWith('#')) {
+    return null
+  }
+
+  const label = first.replace(/^#+/, '').trim()
+
+  if (!label) {
+    return null
+  }
+
+  return label.length > maxChars ? `${label.slice(0, maxChars - 1)}…` : label
+}
+
 export function compactPreview(value: unknown, max = 72): string {
   let raw: unknown
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -6,6 +6,7 @@ import { isCardTool, isFileEditTool, isSilentTool } from '@/lib/tool-render-clas
 import { extractToolErrorMessage, formatToolResultSummary } from '@/lib/tool-result-summary'
 
 import {
+  browserExecStepLabel,
   compactPreview,
   contextValue,
   formatDurationSeconds,
@@ -1380,6 +1381,19 @@ function dynamicTitle(
           compactPreview(summarizeShellCommand(command), 160)
         )
       )
+    }
+  }
+
+  if (part.toolName === 'browser_exec') {
+    // The browser_exec schema asks the model to open `code` with a one-line
+    // `# …` comment describing the step in plain language; the CLI/TUI
+    // already surface it (agent/display.py). Mirror that here so desktop
+    // rows read "Searching Amazon for paper towels" instead of the generic
+    // "Browser Exec".
+    const label = browserExecStepLabel(firstStringField(args, ['code']))
+
+    if (label) {
+      return { title: label }
     }
   }
 


### PR DESCRIPTION
Maintainer-reported gap: the browser_exec schema instructs the model to open `code` with a one-line `# …` comment "— the UI displays it as the step label", and the CLI/TUI honor that (`agent/display.py:_browser_exec_step_label`), but **desktop rows just said "Browser Exec"** (screenshot in the campaign discussion, #95681-adjacent). The convention was paid for in every session's schema and then dropped on the floor by the desktop renderer.

## Change
- `browserExecStepLabel()` in `fallback-model/format.ts` — a TS mirror of the Python labeler (first line, must start with `#`, strip, 80-char cap with ellipsis), documented as such so the two stay in sync.
- `dynamicTitle()` gains a `browser_exec` branch: when the leading comment exists, the row title becomes e.g. **"Searching Amazon for paper towels"** instead of the generic "Browser Exec"; no comment → existing generic title (unchanged fallback).
- Applies both while running and after completion (title survives result arrival).

## Verification
- 4 new vitest cases (label extraction, no-comment fallback, 80-char truncation + ellipsis, post-result persistence); full `fallback-model.test.ts` suite **35/35 green**.
- `tsc -p tsconfig.json --noEmit` clean.
- Same convention source as the CLI/TUI labeler, so all three surfaces derive identical labels from identical input.