### PR TITLE
fix(serve): flush sessions on kill + unset semantics for live compression config

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19770,6 +19770,19 @@ def start_server(
     )
     server = uvicorn.Server(config)
 
+    # Flush-on-kill guard (#94724 item 2): install chaining SIGTERM/SIGINT
+    # handlers that first persist in-memory session transcripts to state.db
+    # (bounded, best-effort) before the normal shutdown story runs. Installed
+    # on the main thread BEFORE uvicorn's capture_signals() so uvicorn saves
+    # these as the "original" handlers and re-raises into them after its own
+    # graceful shutdown — kills outside the serve window are covered too.
+    try:
+        from tui_gateway.server import install_exit_flush_signal_handlers
+
+        install_exit_flush_signal_handlers()
+    except Exception as exc:
+        _log.debug("exit-flush signal handlers not installed: %s", exc)
+
     # ── #93608: machine-readable port-conflict detection ──────────────
     # uvicorn's own bind_socket() would catch the EADDRINUSE and exit 1
     # with a bare ERROR line — indistinguishable from "backend broken".

--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -107,3 +107,129 @@ def test_prompt_submit_calls_compression_sync_after_model_sync():
     assert model_idx != -1
     assert compression_idx != -1
     assert model_idx < compression_idx
+
+
+# ── Unset semantics (#94724 review finding on #95980) ────────────────────
+# ``_apply_live_compression_config`` used to act only on PRESENT keys, so
+# removing tail_mode / context_length / target_ratio / model_thresholds /
+# proactive_prune_* / protect_last_n / min_tail_user_messages / threshold /
+# idle_compact_after_seconds from config.yaml left stale values active in
+# live sessions forever. Absence must restore the normalized default (or the
+# model-derived value) through the same derivation the agent-construction
+# path uses.
+
+
+def _neutral_session(**compression_ctor):
+    """Session on a model with no per-model threshold override in play."""
+    compressor = ContextCompressor(
+        model="unset-test-model",
+        config_context_length=600_000,  # >=512K: no small-context floor
+        quiet_mode=True,
+        **compression_ctor,
+    )
+    agent = SimpleNamespace(
+        model="unset-test-model",
+        provider="",
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+    )
+    return {"agent": agent, "session_key": "session-unset"}, compressor
+
+
+def _sync_with_cfg(monkeypatch, session, cfg):
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    server._sync_agent_compression_with_config("sid-unset", session)
+
+
+def test_removing_tail_mode_restores_lean_default(monkeypatch):
+    session, compressor = _neutral_session(tail_mode="legacy")
+    assert compressor.tail_mode == "legacy"
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.tail_mode == "lean"
+
+
+def test_removing_target_ratio_restores_default(monkeypatch):
+    session, compressor = _neutral_session(summary_target_ratio=0.60)
+    assert compressor.summary_target_ratio == 0.60
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.summary_target_ratio == 0.20
+
+
+def test_removing_protect_last_n_restores_default(monkeypatch):
+    session, compressor = _neutral_session(protect_last_n=5)
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.protect_last_n == 20
+
+
+def test_removing_proactive_prune_keys_restores_defaults(monkeypatch):
+    session, compressor = _neutral_session(
+        proactive_prune_tokens=48_000,
+        proactive_prune_min_result_chars=30_000,
+        proactive_prune_min_reclaim_tokens=1,
+    )
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.proactive_prune_tokens == 0
+    assert compressor.proactive_prune_min_result_chars == 8000
+    assert compressor.proactive_prune_min_reclaim_tokens == 4096
+
+
+def test_removing_min_tail_user_messages_restores_default(monkeypatch):
+    session, compressor = _neutral_session(min_tail_user_messages=4)
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.min_tail_user_messages == 1
+
+
+def test_removing_model_thresholds_restores_empty_map(monkeypatch):
+    session, compressor = _neutral_session(
+        model_thresholds={"unset-test-model": 0.95}
+    )
+    assert compressor.threshold_percent == 0.95
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert compressor.model_thresholds == {}
+    # The stale per-model override must stop steering the live threshold too.
+    assert compressor.threshold_percent == 0.50
+
+
+def test_removing_threshold_restores_derived_default(monkeypatch):
+    session, compressor = _neutral_session(threshold_percent=0.85)
+    assert compressor.threshold_percent == 0.85
+    _sync_with_cfg(
+        monkeypatch,
+        session,
+        {"model": {"context_length": 600_000}, "compression": {}},
+    )
+    assert compressor._config_threshold_percent == 0.50
+    assert compressor.threshold_percent == 0.50
+    assert compressor.threshold_tokens == int(600_000 * 0.50)
+
+
+def test_removing_context_length_reinfers_from_model_metadata(monkeypatch):
+    import agent.context_compressor as cc_mod
+
+    session, compressor = _neutral_session()
+    assert compressor.context_length == 600_000
+
+    monkeypatch.setattr(
+        cc_mod,
+        "get_model_context_length",
+        lambda *a, **k: 1_000_000,
+    )
+    _sync_with_cfg(monkeypatch, session, {"model": {}, "compression": {}})
+    assert compressor._config_context_length is None
+    assert compressor.context_length == 1_000_000
+    assert compressor.threshold_tokens == int(1_000_000 * 0.50)
+
+
+def test_removing_idle_compact_after_seconds_restores_zero(monkeypatch):
+    session, _ = _neutral_session()
+    session["agent"].compression_idle_compact_after_seconds = 1800
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert session["agent"].compression_idle_compact_after_seconds == 0
+
+
+def test_removing_enabled_restores_true(monkeypatch):
+    session, _ = _neutral_session()
+    session["agent"].compression_enabled = False
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert session["agent"].compression_enabled is True

--- a/tests/tui_gateway/test_serve_exit_flush.py
+++ b/tests/tui_gateway/test_serve_exit_flush.py
@@ -1,0 +1,200 @@
+"""A killed ``hermes serve`` must not lose in-memory session transcripts.
+
+Regression for #94724 (item 2, @ruangraung): a serve terminated mid-update
+lost every un-flushed in-memory session — the next RPC failed with
+"session-scoped RPC rejected: not in memory (detached/reaped runtime)" and no
+store held the transcript. #95576 made serves survive *future* updates; this
+covers the kill path itself:
+
+* SIGTERM/SIGINT first flush in-memory sessions to state.db (bounded,
+  best-effort, chained to the previously installed handler so uvicorn's
+  graceful shutdown still runs).
+* The idle-reaper tick piggybacks a periodic incremental flush so even a
+  SIGKILL loses at most one flush interval.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+
+import pytest
+
+from tui_gateway import server
+
+
+class _FlushAgent:
+    """Minimal agent exposing the real ``_persist_session`` flush contract."""
+
+    def __init__(self, messages=None):
+        self.session_id = "flush-agent"
+        self.flush_calls: list[list] = []
+        self._session_messages = (
+            messages
+            if messages is not None
+            else [{"role": "user", "content": "unflushed turn"}]
+        )
+
+    def _persist_session(self, messages, conversation_history=None):
+        self.flush_calls.append(list(messages))
+
+
+@pytest.fixture
+def registered_session():
+    """Register a fake in-memory session; always deregister on exit."""
+    registered: list[str] = []
+
+    def _register(sid: str, agent, **extra):
+        session = {"agent": agent, "session_key": sid, "running": False}
+        session.update(extra)
+        with server._sessions_lock:
+            server._sessions[sid] = session
+        registered.append(sid)
+        return session
+
+    yield _register
+
+    with server._sessions_lock:
+        for sid in registered:
+            server._sessions.pop(sid, None)
+
+
+def _restore_signal_state(prev_handlers):
+    for signum, handler in prev_handlers.items():
+        signal.signal(signum, handler)
+    server._exit_flush_prev_handlers.clear()
+    server._exit_flush_handlers_installed = False
+
+
+def test_sigterm_flushes_populated_session_into_state_db(
+    registered_session, tmp_path, monkeypatch
+):
+    """A populated in-memory session survives a SIGTERM into state.db."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "sess-sigterm-flush"
+    db.create_session(sid, source="tui")
+
+    class _DbAgent(_FlushAgent):
+        def _persist_session(self, messages, conversation_history=None):
+            super()._persist_session(messages, conversation_history)
+            for msg in messages:
+                if msg.get("_db_persisted"):
+                    continue
+                db.append_message(sid, msg["role"], msg["content"])
+                msg["_db_persisted"] = True
+
+    agent = _DbAgent(messages=[{"role": "user", "content": "survive the kill"}])
+    registered_session(sid, agent)
+
+    chained = {"called": False}
+
+    def _prev_handler(signum, frame):
+        chained["called"] = True
+
+    prev = {signal.SIGTERM: signal.signal(signal.SIGTERM, _prev_handler)}
+    try:
+        assert server.install_exit_flush_signal_handlers() is True
+        os.kill(os.getpid(), signal.SIGTERM)
+        # The handler runs synchronously on the main thread at the next
+        # bytecode boundary; poll briefly for robustness.
+        deadline = time.monotonic() + 5.0
+        while not chained["called"] and time.monotonic() < deadline:
+            time.sleep(0.01)
+    finally:
+        _restore_signal_state(prev)
+
+    assert chained["called"], "previous SIGTERM handler must still be chained"
+    assert agent.flush_calls, "SIGTERM must flush in-memory sessions"
+    rows = db.get_messages(sid)
+    assert any("survive the kill" in str(r.get("content", "")) for r in rows)
+
+
+def test_exit_flush_is_bounded(registered_session):
+    """A hung persist must never block exit longer than the budget."""
+
+    class _HangingAgent(_FlushAgent):
+        def _persist_session(self, messages, conversation_history=None):
+            time.sleep(5.0)
+
+    registered_session("sess-hang", _HangingAgent())
+
+    start = time.monotonic()
+    server._flush_sessions_before_exit(budget_s=0.3)
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, f"exit flush blocked {elapsed:.1f}s past its budget"
+
+
+def test_shutdown_sessions_flushes_before_teardown(monkeypatch):
+    """The atexit path persists transcripts BEFORE slow per-session teardown."""
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        server, "_release_gateway_wake_owner", lambda: None, raising=False
+    )
+    monkeypatch.setattr(
+        server,
+        "_flush_sessions_before_exit",
+        lambda budget_s=None: order.append("flush") or 0,
+    )
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, **kw: order.append(f"close:{sid}"),
+    )
+    with server._sessions_lock:
+        server._sessions["sess-order"] = {"agent": None, "session_key": "sess-order"}
+    try:
+        server._shutdown_sessions()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop("sess-order", None)
+
+    assert order and order[0] == "flush"
+    assert "close:sess-order" in order
+
+
+def test_periodic_flush_respects_interval_with_fake_clock(
+    registered_session, monkeypatch
+):
+    monkeypatch.setattr(server, "_INCREMENTAL_FLUSH_INTERVAL_S", 300.0)
+    agent = _FlushAgent()
+    registered_session("sess-interval", agent)
+
+    assert server._flush_dirty_sessions(now=1_000.0) == 1
+    assert len(agent.flush_calls) == 1
+
+    # Within the interval: no re-flush.
+    assert server._flush_dirty_sessions(now=1_000.0 + 299.0) == 0
+    assert len(agent.flush_calls) == 1
+
+    # Past the interval: flushes again — SIGKILL loses at most one interval.
+    assert server._flush_dirty_sessions(now=1_000.0 + 301.0) == 1
+    assert len(agent.flush_calls) == 2
+
+
+def test_periodic_flush_skips_running_sessions(registered_session, monkeypatch):
+    """Mid-turn sessions are the turn thread's to persist — never race them."""
+    monkeypatch.setattr(server, "_INCREMENTAL_FLUSH_INTERVAL_S", 300.0)
+    agent = _FlushAgent()
+    registered_session("sess-running", agent, running=True)
+
+    assert server._flush_dirty_sessions(now=1_000.0) == 0
+    assert agent.flush_calls == []
+
+
+def test_idle_reaper_scan_piggybacks_incremental_flush(monkeypatch):
+    """The existing reaper tick drives the flush — no new timer subsystem."""
+    called = {"flush": 0}
+    monkeypatch.setattr(
+        server,
+        "_flush_dirty_sessions",
+        lambda now=None: called.__setitem__("flush", called["flush"] + 1) or 0,
+    )
+    monkeypatch.setattr(server, "_enforce_session_cap", lambda: None)
+    monkeypatch.setattr(server, "_reclaim_orphaned_leases", lambda: None)
+    server._reap_idle_sessions()
+    assert called["flush"] == 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1441,6 +1441,15 @@ def _close_sessions_for_transport(
 
 
 def _shutdown_sessions() -> None:
+    # Durable-first (#94724 item 2): persist every session's un-flushed
+    # transcript within a bounded budget BEFORE the slow per-session
+    # teardown below (plugin hooks, memory commit, delegation interrupts,
+    # agent.close). A supervisor that SIGKILLs a slow shutdown mid-way can
+    # then no longer lose the transcripts — the flush already landed.
+    try:
+        _flush_sessions_before_exit()
+    except Exception:
+        pass
     try:
         _release_gateway_wake_owner()
     except Exception:
@@ -1460,6 +1469,176 @@ except (TypeError, ValueError):
     _SESSION_TTL_S = float(6 * 3600)
 _SESSION_TTL_S = max(0.0, _SESSION_TTL_S)
 _REAPER_SCAN_S = 300.0
+
+
+# ── Flush-on-kill + periodic incremental flush (#94724 item 2) ───────────
+# A `hermes serve` killed mid-update used to lose every un-flushed in-memory
+# session: the next RPC failed with "session-scoped RPC rejected: not in
+# memory (detached/reaped runtime)" and NO store held the transcript. #95576
+# made serves survive *future* updates; this closes the kill path itself:
+#   (a) SIGTERM/SIGINT run a bounded, best-effort flush of in-memory session
+#       transcripts to state.db BEFORE the normal shutdown path, chained to
+#       whatever handler was installed before (uvicorn's included);
+#   (b) the idle-reaper scan piggybacks a periodic incremental flush so even
+#       a SIGKILL loses at most one flush interval.
+try:
+    _EXIT_FLUSH_BUDGET_S = float(
+        os.environ.get("HERMES_TUI_EXIT_FLUSH_BUDGET_S") or 5.0
+    )
+except (TypeError, ValueError):
+    _EXIT_FLUSH_BUDGET_S = 5.0
+_EXIT_FLUSH_BUDGET_S = max(0.0, _EXIT_FLUSH_BUDGET_S)
+
+try:
+    _INCREMENTAL_FLUSH_INTERVAL_S = float(
+        os.environ.get("HERMES_TUI_SESSION_FLUSH_INTERVAL_S") or _REAPER_SCAN_S
+    )
+except (TypeError, ValueError):
+    _INCREMENTAL_FLUSH_INTERVAL_S = _REAPER_SCAN_S
+_INCREMENTAL_FLUSH_INTERVAL_S = max(0.0, _INCREMENTAL_FLUSH_INTERVAL_S)
+
+
+def _flush_session_messages(session: dict | None) -> bool:
+    """Best-effort durable flush of one session's in-memory transcript.
+
+    Rides ``agent._persist_session`` — the same marker-deduped persist
+    contract ``_finalize_session`` uses (#13121) — so repeated calls only
+    write genuinely-unflushed messages and never duplicate durable rows.
+    """
+    if not session:
+        return False
+    agent = session.get("agent")
+    if agent is None or not hasattr(agent, "_persist_session"):
+        return False
+    snapshot = getattr(agent, "_session_messages", None)
+    if not snapshot:
+        return False
+    try:
+        agent._persist_session(snapshot)
+        return True
+    except Exception:
+        logger.debug("incremental session flush failed", exc_info=True)
+        return False
+
+
+def _flush_dirty_sessions(now: float | None = None) -> int:
+    """Periodic incremental flush, driven by the idle-reaper scan.
+
+    Skips ``running`` sessions: the turn thread owns mid-turn persistence
+    (it already flushes at every persist point) and
+    ``_drop_trailing_empty_response_scaffolding`` mutates the live message
+    list, so racing an in-flight turn from the reaper thread is never safe.
+    Idle/detached sessions — precisely the ones a kill strands — are flushed
+    at most once per ``_INCREMENTAL_FLUSH_INTERVAL_S``. ``now`` is injectable
+    for tests (monotonic clock).
+    """
+    if _INCREMENTAL_FLUSH_INTERVAL_S <= 0:
+        return 0
+    if now is None:
+        now = time.monotonic()
+    with _sessions_lock:
+        sessions = list(_sessions.values())
+    flushed = 0
+    for session in sessions:
+        if not isinstance(session, dict) or session.get("running"):
+            continue
+        last = float(session.get("_last_incremental_flush") or 0.0)
+        if last and (now - last) < _INCREMENTAL_FLUSH_INTERVAL_S:
+            continue
+        if _flush_session_messages(session):
+            flushed += 1
+        session["_last_incremental_flush"] = now
+    return flushed
+
+
+def _flush_sessions_before_exit(budget_s: float | None = None) -> int:
+    """Bounded flush of ALL in-memory sessions on the way out.
+
+    Runs on a daemon worker joined with the budget so a hung SQLite write
+    can never block exit longer than ``HERMES_TUI_EXIT_FLUSH_BUDGET_S``
+    (default 5s). Running sessions are included — the process is dying, so
+    a best-effort partial transcript beats guaranteed loss.
+    """
+    budget = _EXIT_FLUSH_BUDGET_S if budget_s is None else max(0.0, budget_s)
+    if budget <= 0:
+        return 0
+    result = {"flushed": 0}
+
+    def _run() -> None:
+        deadline = time.monotonic() + budget
+        with _sessions_lock:
+            sessions = list(_sessions.values())
+        for session in sessions:
+            if time.monotonic() >= deadline:
+                break
+            if _flush_session_messages(session):
+                result["flushed"] += 1
+
+    worker = threading.Thread(target=_run, daemon=True, name="hermes-exit-flush")
+    worker.start()
+    worker.join(budget)
+    return result["flushed"]
+
+
+_exit_flush_prev_handlers: dict[int, Any] = {}
+_exit_flush_handlers_installed = False
+
+
+def _handle_exit_flush_signal(signum, frame) -> None:
+    """Flush in-memory sessions, then hand off to the prior handler.
+
+    Chaining preserves the pre-existing signal story (uvicorn's graceful
+    shutdown, a supervisor's handler, or the default terminate disposition)
+    — this handler only *prepends* a bounded durable flush.
+    """
+    try:
+        _flush_sessions_before_exit()
+    except Exception:
+        pass
+    import signal as _signal
+
+    prev = _exit_flush_prev_handlers.get(signum)
+    if callable(prev):
+        prev(signum, frame)
+        return
+    if prev is _signal.SIG_IGN:
+        return
+    # Default disposition: restore it and re-raise so the process still dies
+    # with the correct signal (exit status visible to supervisors).
+    try:
+        _signal.signal(signum, _signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+    except Exception:
+        raise SystemExit(128 + int(signum)) from None
+
+
+def install_exit_flush_signal_handlers() -> bool:
+    """Install chaining SIGTERM/SIGINT flush handlers (main thread only).
+
+    Called by ``hermes serve`` / dashboard startup before uvicorn takes over
+    signals: uvicorn's ``capture_signals()`` saves these as the "original"
+    handlers and restores + re-raises into them after its graceful shutdown,
+    so the flush also covers terminations outside uvicorn's serve window.
+    Idempotent; returns False off the main thread or when installation fails.
+    """
+    global _exit_flush_handlers_installed
+    if _exit_flush_handlers_installed:
+        return True
+    if threading.current_thread() is not threading.main_thread():
+        return False
+    import signal as _signal
+
+    installed = False
+    for signum in (_signal.SIGTERM, _signal.SIGINT):
+        try:
+            prev = _signal.getsignal(signum)
+            _signal.signal(signum, _handle_exit_flush_signal)
+            _exit_flush_prev_handlers[signum] = prev
+            installed = True
+        except (ValueError, OSError, RuntimeError):
+            continue
+    _exit_flush_handlers_installed = installed
+    return installed
 
 
 def _transport_is_dead(transport) -> bool:
@@ -1491,6 +1670,13 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
 
 def _reap_idle_sessions() -> None:
     now = time.time()
+    # Piggyback the periodic incremental flush on the existing reaper tick
+    # (#94724 item 2) — no new timer subsystem. Even a SIGKILL then loses at
+    # most one flush interval of un-persisted messages.
+    try:
+        _flush_dirty_sessions()
+    except Exception:
+        logger.debug("periodic incremental session flush failed", exc_info=True)
     with _sessions_lock:
         victims = [sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)]
     for sid in victims:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6093,6 +6093,73 @@ def _tui_compression_config_signature(cfg: dict | None) -> tuple:
     return tuple(sorted(picked.items()))
 
 
+def _compressor_ctor_default(name: str, fallback: Any) -> Any:
+    """Read a normalized default from ContextCompressor's REAL signature.
+
+    Unset restoration must go through the same derivation the construction
+    path uses (#94724 review finding on #95980) — pulling the default off
+    ``ContextCompressor.__init__`` itself instead of hardcoding copies keeps
+    the two from drifting.
+    """
+    try:
+        import inspect
+
+        from agent.context_compressor import ContextCompressor
+
+        default = inspect.signature(ContextCompressor.__init__).parameters[
+            name
+        ].default
+        if default is inspect.Parameter.empty:
+            return fallback
+        return default
+    except Exception:
+        return fallback
+
+
+def _derived_default_threshold_percent(agent: Any, compression: dict) -> float:
+    """Default compaction threshold when ``compression.threshold`` is unset.
+
+    Mirrors agent_init exactly: the ctor's global default, then the per-model
+    resolution (Codex gpt-5.4/5.5 + spark autoraise, Arcee Trinity, etc.)
+    via the SAME ``_resolve_compression_threshold`` helper — so removing the
+    key restores the model-derived value, not a bare constant.
+    """
+    try:
+        pct = float(_compressor_ctor_default("threshold_percent", 0.50))
+    except (TypeError, ValueError):
+        pct = 0.50
+    try:
+        from agent.agent_init import _resolve_compression_threshold
+        from agent.auxiliary_client import (
+            _compression_threshold_for_model,
+            _is_codex_gpt54_or_gpt55,
+            _is_codex_spark,
+        )
+
+        model = getattr(agent, "model", "") or ""
+        provider = getattr(agent, "provider", "") or ""
+        autoraise_enabled = str(
+            compression.get("codex_gpt55_autoraise", True)
+        ).lower() in {"true", "1", "yes"}
+        model_cthresh = _compression_threshold_for_model(
+            model,
+            provider,
+            allow_codex_gpt55_autoraise=autoraise_enabled,
+        )
+        pct, _notice = _resolve_compression_threshold(
+            pct,
+            model_cthresh,
+            model=model,
+            is_codex_autoraise=(
+                _is_codex_gpt54_or_gpt55(model, provider)
+                or _is_codex_spark(model, provider)
+            ),
+        )
+    except Exception:
+        pass
+    return pct
+
+
 def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     """Update a live session's compressor from current config.yaml.
 
@@ -6100,6 +6167,15 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     Recomputes the trigger from the ratio-based threshold and then applies
     ``compression.threshold_tokens`` so raising, lowering, or clearing the
     cap all take effect on the next preflight.
+
+    Every adopted key has UNSET semantics (#94724 review finding on the
+    merged #95980): removing a key from config.yaml restores the normalized
+    default — or the model-derived value — on the next turn, through the
+    same derivation the construction path uses (ContextCompressor ctor
+    defaults read off its real signature, the Codex threshold autoraise via
+    ``_resolve_compression_threshold``, context-length re-inference via the
+    deferred ``get_model_context_length`` resolution). The old behavior
+    acted only on PRESENT keys, leaving stale values active forever.
     """
     cfg = cfg if isinstance(cfg, dict) else {}
     compression = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
@@ -6111,10 +6187,8 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     else:
         agent.compression_enabled = str(enabled_raw).lower() in {"true", "1", "yes"}
 
-    idle_raw = compression.get(
-        "idle_compact_after_seconds",
-        getattr(agent, "compression_idle_compact_after_seconds", 0),
-    )
+    # Absence restores the agent_init/config default (0 = disabled).
+    idle_raw = compression.get("idle_compact_after_seconds", 0)
     try:
         agent.compression_idle_compact_after_seconds = max(0, int(idle_raw or 0))
     except (TypeError, ValueError):
@@ -6124,31 +6198,55 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     if cc is None:
         return
 
-    if "tail_mode" in compression:
-        mode = str(compression.get("tail_mode") or "legacy").strip().lower()
-        cc.tail_mode = mode if mode in ("legacy", "lean") else "legacy"
+    # tail_mode: ctor normalization — unknown/absent values land on "lean",
+    # matching agent_init's default and the compressor's own fallback.
+    default_tail = str(_compressor_ctor_default("tail_mode", "lean"))
+    mode = str(compression.get("tail_mode", default_tail) or default_tail)
+    mode = mode.strip().lower()
+    cc.tail_mode = mode if mode in ("legacy", "lean") else default_tail
 
     def _assign_int(key: str, attr: str, default: int, min_value: int = 0) -> None:
-        if key not in compression:
-            return
+        raw = compression.get(key, default)
         try:
-            raw = compression.get(key)
             value = default if raw is None else int(raw)
-            setattr(cc, attr, max(min_value, value))
         except (TypeError, ValueError):
             return
+        setattr(cc, attr, max(min_value, value))
 
-    _assign_int("proactive_prune_tokens", "proactive_prune_tokens", 0)
-    _assign_int("proactive_prune_min_result_chars", "proactive_prune_min_result_chars", 8000)
-    _assign_int("proactive_prune_min_reclaim_tokens", "proactive_prune_min_reclaim_tokens", 0)
-    _assign_int("protect_last_n", "protect_last_n", 20)
-    _assign_int("min_tail_user_messages", "min_tail_user_messages", 1, min_value=1)
+    _assign_int(
+        "proactive_prune_tokens",
+        "proactive_prune_tokens",
+        int(_compressor_ctor_default("proactive_prune_tokens", 0)),
+    )
+    _assign_int(
+        "proactive_prune_min_result_chars",
+        "proactive_prune_min_result_chars",
+        int(_compressor_ctor_default("proactive_prune_min_result_chars", 8000)),
+    )
+    _assign_int(
+        "proactive_prune_min_reclaim_tokens",
+        "proactive_prune_min_reclaim_tokens",
+        int(_compressor_ctor_default("proactive_prune_min_reclaim_tokens", 4096)),
+    )
+    _assign_int(
+        "protect_last_n",
+        "protect_last_n",
+        int(_compressor_ctor_default("protect_last_n", 20)),
+    )
+    _assign_int(
+        "min_tail_user_messages",
+        "min_tail_user_messages",
+        int(_compressor_ctor_default("min_tail_user_messages", 1)),
+        min_value=1,
+    )
 
-    if "target_ratio" in compression:
-        try:
-            cc.summary_target_ratio = max(0.10, min(float(compression["target_ratio"]), 0.80))
-        except (TypeError, ValueError):
-            pass
+    try:
+        ratio_raw = compression.get(
+            "target_ratio", _compressor_ctor_default("summary_target_ratio", 0.20)
+        )
+        cc.summary_target_ratio = max(0.10, min(float(ratio_raw), 0.80))
+    except (TypeError, ValueError):
+        pass
 
     raw_thresholds = compression.get("model_thresholds")
     if isinstance(raw_thresholds, dict):
@@ -6157,34 +6255,46 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
             for k, v in raw_thresholds.items()
             if isinstance(v, (int, float)) and not isinstance(v, bool)
         }
+    else:
+        # Absent (or invalid shape — agent_init treats both as empty):
+        # stale per-model overrides must stop steering the live threshold.
+        cc.model_thresholds = {}
 
+    # threshold: present value wins; absence derives the default through
+    # the same agent_init resolution (global default + per-model autoraise).
+    pct: float | None = None
     if "threshold" in compression:
         try:
             pct = float(compression["threshold"])
-            cc._config_threshold_percent = pct
-            cc._configured_threshold_percent = pct
-            base = pct
-            model_thresholds = getattr(cc, "model_thresholds", None) or {}
-            if model_thresholds:
-                from agent.context_compressor import resolve_model_threshold
-
-                base = resolve_model_threshold(
-                    getattr(agent, "model", "") or "",
-                    model_thresholds,
-                    pct,
-                )
-            cc._base_threshold_percent = base
-            if hasattr(cc, "_effective_threshold_percent"):
-                try:
-                    cc.threshold_percent = cc._effective_threshold_percent(
-                        cc.context_length, base
-                    )
-                except Exception:
-                    cc.threshold_percent = pct
-            else:
-                cc.threshold_percent = pct
         except (TypeError, ValueError):
-            pass
+            pct = None
+    if pct is None:
+        pct = _derived_default_threshold_percent(agent, compression)
+    try:
+        cc._config_threshold_percent = pct
+        cc._configured_threshold_percent = pct
+        base = pct
+        model_thresholds = getattr(cc, "model_thresholds", None) or {}
+        if model_thresholds:
+            from agent.context_compressor import resolve_model_threshold
+
+            base = resolve_model_threshold(
+                getattr(agent, "model", "") or "",
+                model_thresholds,
+                pct,
+            )
+        cc._base_threshold_percent = base
+        if hasattr(cc, "_effective_threshold_percent"):
+            try:
+                cc.threshold_percent = cc._effective_threshold_percent(
+                    cc.context_length, base
+                )
+            except Exception:
+                cc.threshold_percent = pct
+        else:
+            cc.threshold_percent = pct
+    except (TypeError, ValueError):
+        pass
 
     raw_ctx = model_cfg.get("context_length")
     if raw_ctx is not None:
@@ -6198,6 +6308,14 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
                 cc.context_length = new_ctx
             except Exception:
                 pass
+    elif getattr(cc, "_config_context_length", None) is not None:
+        # model.context_length removed: drop the config override and force
+        # re-inference from model metadata on next access — the same
+        # deferred get_model_context_length resolution agent construction
+        # uses (#32221). The re-resolve also re-applies the small-context
+        # threshold floor for the genuinely re-inferred window.
+        cc._config_context_length = None
+        cc._resolved_context_length = None
 
     coerce_cap = getattr(cc, "_coerce_threshold_tokens_cap", None)
     if callable(coerce_cap):
@@ -6208,6 +6326,8 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
             cc.threshold_tokens_cap = cap if cap > 0 else None
         except (TypeError, ValueError):
             cc.threshold_tokens_cap = None
+    else:
+        cc.threshold_tokens_cap = None
 
     # Invalidate cached trigger so the next preflight re-derives from the
     # current percent/window and then applies the (possibly new) cap.


### PR DESCRIPTION
## Summary

Two fixes for the reopened tracker #94724, one branch:

### 1. `hermes serve` killed mid-update no longer loses in-memory sessions

Reported by @ruangraung (#94724 item 2): a serve terminated mid-update lost every un-flushed in-memory session — the next RPC failed with `session-scoped RPC rejected: not in memory (detached/reaped runtime)` and **no store** held the transcript. #95576 made serves survive *future* updates; this closes the kill path itself.

- **Flush-on-SIGTERM/SIGINT**: `install_exit_flush_signal_handlers()` (called from `hermes serve` / dashboard startup on the main thread, before uvicorn's `capture_signals()`) chains a bounded, best-effort flush of in-memory session transcripts to `state.db` in front of whatever handler was previously installed. uvicorn saves these as the "original" handlers and re-raises into them after its graceful shutdown, so kills outside uvicorn's serve window are covered too.
- **Bounded**: the flush runs on a daemon worker joined with `HERMES_TUI_EXIT_FLUSH_BUDGET_S` (default 5s) — a hung SQLite write can never block exit.
- **Durable-first atexit**: `_shutdown_sessions` runs the same bounded flush *before* the slow per-session teardown (plugin hooks, memory commit, delegation interrupts, `agent.close`) that a supervisor may SIGKILL mid-way.
- **Periodic incremental flush**: piggybacked on the existing idle-reaper tick (no new timer subsystem), marker-deduped via `agent._persist_session`, skipping `running` sessions (the turn thread owns mid-turn persistence). Even a SIGKILL now loses at most one flush interval (`HERMES_TUI_SESSION_FLUSH_INTERVAL_S`, default = the 300s reaper scan).

### 2. Unset semantics for every live-adopted compression/model config key

Independent review finding on the merged #95980: `_apply_live_compression_config` only acted on **present** keys, so removing `tail_mode` / `model.context_length` / `target_ratio` / `model_thresholds` / `proactive_prune_*` / `protect_last_n` / `min_tail_user_messages` / `threshold` / `idle_compact_after_seconds` from config.yaml left stale values active in live sessions forever (probe-verified: all six stale after applying empty mappings).

Absence now restores the normalized default — or the model-derived value — through the **same derivation the construction path uses**:

- ContextCompressor ctor defaults are read off its real `__init__` signature (`_compressor_ctor_default`), not hardcoded copies that can drift.
- `compression.threshold` removal re-derives through agent_init's `_resolve_compression_threshold` (Codex gpt-5.4/5.5 + spark autoraise included), so a Codex session snaps back to its model-derived threshold, not a bare constant.
- `model.context_length` removal drops the config override and forces re-inference through the deferred `get_model_context_length` resolution (#32221 path), which also re-applies the small-context threshold floor.
- `model_thresholds` removal clears stale per-model overrides out of the live threshold; `tail_mode` falls back to the ctor's `lean` (the old present-key path normalized invalid values to `legacy`, diverging from the compressor's own fallback).
- Also fixes `proactive_prune_min_reclaim_tokens`'s present-but-null default (was 0; the real default is 4096).

## Testing (TDD, red pre-fix, sabotage-proven)

- `tests/tui_gateway/test_serve_exit_flush.py` (new, 6 tests): a populated in-memory session survives a SIGTERM-initiated shutdown into a **real** `state.db`; handler chaining; bounded exit flush (hung persist returns within budget); `_shutdown_sessions` flushes before teardown; fake-clock interval gating; running-session skip; reaper-tick piggyback.
- `tests/tui_gateway/test_compression_config_hot_reload.py` (+10 tests): per-key set→remove→assert-default for every adopted key (previously only `threshold_tokens` clearing was covered).
- All 15 new tests were red pre-fix; sabotage runs (signal-handler flush disabled, interval gate inverted, tail_mode back to present-only) each went red on the exact guarding test, then reverted.
- `tests/tui_gateway/` full suite: 653 passed, 1 failed — `test_gui_surface_toolsets.py::test_holds_exactly_the_gui_affordances`, verified **pre-existing** on a clean origin/main tree (same single failure), unrelated to this change.
- ruff clean on all touched files.

## Credits

- **@ruangraung** — reported the serve flush-on-kill data-loss gap (#94724 item 2) with the detached/reaped-runtime reproduction.
- The **independent review of #95980** — surfaced the compression-config unset defect with the six-key stale-value probe.

Refs #94724

## Infographic

![serve-flush-and-config-unset](https://v3b.fal.media/files/b/0aa7fa77/D9UdksmZ365FIJI_knCnh_DCUnW4b8.png)
