### PR TITLE
fix(desktop): don't overscroll-contain an expanded thinking body (wheel dead zone)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -239,7 +239,14 @@ const ThinkingDisclosure: FC<{
             // and inherits the disclosure-level opacity fade defined in
             // styles.css (~0.67 at rest, 1 on hover/focus). overflow-auto so
             // the max-h-40 preview is a real scroller, not a clip.
-            'mt-0.5 w-full min-w-0 max-w-full overflow-auto overscroll-contain wrap-anywhere pb-1',
+            // No overscroll-contain in any state: a body that can't scroll
+            // itself (expanded, or content shorter than the cap) must chain
+            // the wheel to the thread viewport, and a scrollable preview
+            // chains past its own edge once it hits top/bottom — matching
+            // every other scroller in the app (settings, code blocks). A
+            // contain here is a dead zone or a scroll discontinuity, the
+            // same trap #84964 hit in the session list.
+            'mt-0.5 w-full min-w-0 max-w-full overflow-auto wrap-anywhere pb-1',
             isPreview && 'max-h-40'
           )}
           data-slot="aui_thinking-body"

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -643,6 +643,36 @@ describe('assistant-ui streaming renderer', () => {
     expect(settled).not.toMatch(/\boverflow-hidden\b/)
   })
 
+  it('never overscroll-contains the thinking body — preview or expanded', async () => {
+    const { container } = render(<RunningReasoningHarness />)
+    const ui = within(container)
+    const toggle = ui.getByRole('button', { name: /thinking/i })
+
+    // The live preview is height-capped, but it must NOT carry
+    // overscroll-contain: a body that can't scroll itself (expanded, or
+    // content shorter than the cap) would swallow the wheel instead of
+    // chaining it to the thread viewport, and a scrollable preview must
+    // chain past its own edge once it hits top/bottom — matching every
+    // other scroller in the app (#84964-style dead zone otherwise).
+    const preview = container.querySelector('[data-slot="aui_thinking-body"]')?.className ?? ''
+    expect(preview).toContain('max-h-40')
+    expect(preview).toMatch(/\boverflow-auto\b/)
+    expect(preview).not.toMatch(/\boverscroll-contain\b/)
+
+    // Collapse, then expand by hand: the body loses the cap but keeps
+    // chaining — still no contain.
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+
+    const expanded = container.querySelector('[data-slot="aui_thinking-body"]')?.className ?? ''
+    expect(expanded).toMatch(/\boverflow-auto\b/)
+    expect(expanded).not.toContain('max-h-40')
+    expect(expanded).not.toMatch(/\boverscroll-contain\b/)
+  })
+
   it('does not collapse a live thinking preview when the turn settles', async () => {
     const { container, settle } = renderSettlingReasoning()
     const toggle = within(container).getByRole('button', { name: /thinking/i })


### PR DESCRIPTION
## What does this PR do?

Drops `overscroll-contain` from the thinking body (introduced by #95783), which has a dead-zone side effect and breaks scroll chaining.

#95783 changed the thinking body to `overflow-auto overscroll-contain` so the height-capped live preview (`max-h-40`) becomes a real scroller. The class is unconditional, and it misbehaves exactly when the body can't scroll itself:

- **Expanded** (no `max-h`): the body grows to its content and never scrolls, so `contain` has nothing to contain — it eats the wheel entirely, leaving a **dead zone** where neither the body nor the thread viewport scrolls.
- **Preview with short content**: same dead zone when the thought is under `max-h-40`.

`contain` only does its job when the body actually overflows — which is precisely the case where a reader most wants the wheel to keep going.

## Related Issue

Fixes #96094

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/message-parts.tsx` — remove `overscroll-contain` entirely. The body keeps `overflow-auto` + `max-h-40` on the preview, so it consumes the wheel first and, once at top/bottom, chains to the thread viewport like every other block in the app. The `max-h-40` cap and pin-to-bottom live behavior from #95783 are preserved.
- `apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx` — regression test asserting no `overscroll-contain` in **either** state (preview and manually expanded). Verified red against the post-#95783 classes, green after.

## How to Test

1. Open a conversation with reasoning output.
2. **Expanded**: expand the Thinking block, hover over the thought, scroll — the transcript must keep scrolling (was: dead zone).
3. **Preview**: during/after a live stream, hover the capped preview and scroll — the preview scrolls first, then the transcript continues at the boundary.
4. Compare with any other scroller (settings panels, code blocks) — behavior must match.

Playwright repro driving a real wheel over the exact DOM (`aui_thread-viewport` → thinking body → content):

| thinking body classes | wheel over the body |
|---|---|
| `overflow-auto overscroll-contain` (post-#95783) | **dead zone** — neither body nor transcript scrolls |
| `overflow-auto` (this fix) | body scrolls; past its edge the wheel chains to the transcript (verified: body consumes the first ticks, transcript takes over after the boundary) |

Unit tests: `npx vitest run --project ui src/components/assistant-ui/thread/streaming.test.tsx` → 21/21 pass.

## Note on #95783's "don't chain into the transcript" intent

I understand the intent — a long thought shouldn't yank the transcript while you read it — and the `max-h-40` cap solves the underlying problem (a long thought shoving the reply off-screen). Two points on `overscroll-contain` specifically:

1. **Consistency**: this is the *only* scroller in the app that doesn't chain — settings panels, code blocks and tool output all hand the wheel to the transcript at their edges, and chaining is the macOS platform default. The isolation reads as a bug even when it isn't.
2. **Chaining is gentler than it sounds**: the body still consumes the wheel first (verified — several wheel ticks scroll only the body), and the transcript only starts moving once the body hits top/bottom. A long thought won't yank the transcript on the first scroll — it just *eventually* continues, matching every other block.

If keeping the transcript still while reading a thought is a hard requirement, `overscroll-behavior` can't express "contain only when overflowing" — that would need a JS gate. But chain-always is the more consistent and less surprising behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (priorities + search-first confirmed; no CLA/DCO requirement)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS (Apple Silicon)
- [x] I've considered cross-platform impact (Windows, macOS): pure CSS utility classes, platform-neutral

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or architecture changes
