### PR TITLE
fix(gateway): stop Telegram flood recovery from duplicating streamed finals

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1592,11 +1592,13 @@ class GatewayStreamConsumer:
                 self._already_sent = True
                 self._fallback_prefix = ""
                 self._fallback_preserve_partial_messages = False
-                if delivery == "ambiguous":
+                if delivery in {"ambiguous", "preview"}:
                     # A timeout may mean Telegram accepted the send but the
-                    # client never received the response. Preserve duplicate
-                    # suppression for that one uncertain outcome.
+                    # client never received the response. A flood rejection
+                    # leaves the complete, ACKed preview as the authoritative
+                    # delivery. Preserve duplicate suppression in both cases.
                     self._final_content_delivered = True
+                    self._record_turn_final_payload(final_text)
                 else:
                     # A confirmed failure leaves the gateway free to perform
                     # its normal final send.
@@ -1761,8 +1763,9 @@ class GatewayStreamConsumer:
         """Commit a completed answer after Telegram finalization fails.
 
         Returns ``delivered`` on confirmed success, ``failed`` when the
-        gateway can safely retry, and ``ambiguous`` when a timeout may have
-        reached the platform already.
+        gateway can safely retry, ``ambiguous`` when a timeout may have
+        reached the platform already, and ``preview`` when flood control
+        leaves the complete streamed preview as the authoritative delivery.
         """
         # Tool/segment boundaries intentionally preserve the run-wide preview
         # IDs for normal fresh-final cleanup.  This recovery replaces only the
@@ -1797,6 +1800,8 @@ class GatewayStreamConsumer:
                 )
                 await asyncio.sleep(retry_delay)
                 continue
+            if self._is_flood_error(result):
+                return "preview"
             return (
                 "ambiguous"
                 if self._send_failure_may_have_delivered(result)

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -123,6 +123,33 @@ async def test_empty_tail_commit_honors_retry_after(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_complete_preview_survives_long_flood_fallback_failure(monkeypatch):
+    """A complete ACKed preview must not trigger a duplicate normal final."""
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(
+        success=False,
+        error="flood_control:20.0",
+        retry_after=20.0,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.send.assert_awaited_once()
+    sleep.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is True
+    assert consumer.delivered_final_matches("Final answer") is True
+
+
+@pytest.mark.asyncio
 async def test_telegram_long_flood_result_keeps_retry_after():
     """The real adapter contract preserves the server delay for consumers."""
     class FloodError(Exception):


### PR DESCRIPTION
## What does this PR do?

Telegram users can receive an identical second final message when a complete streamed preview is already visible and the fresh-final recovery send is rejected by flood control. This change keeps that exact, ACKed preview authoritative instead of clearing delivery confirmation and falling through to the normal final send. Partial previews still use the existing missing-tail recovery, so incomplete responses are not suppressed.

### Symptom

A long Telegram reply appears through streaming, then the same completed reply appears again after flood-control backoff.

### Impact

Affected Telegram turns show duplicate full responses. The measured blast radius is unknown; the reported trigger is a long streamed response under flood control.

### Bug Cause

**Trigger:** `gateway/stream_consumer.py:1563` / `_send_fallback_final()` when the visible prefix equals the completed response and `_send_empty_fallback_final()` is rejected by flood control.

**Causal chain:**
1. Progressive streaming successfully ACKs the complete reply as a visible preview.
2. The turn-final fresh-send recovery receives a Telegram flood-control result whose retry delay exceeds the bounded fallback wait.
3. The consumer clears `final_content_delivered`, so `gateway/run.py` cannot suppress the normal final send and posts the same completed reply again.

**Why it is wrong:** A flood rejection confirms only that the replacement send did not land. It does not invalidate the complete preview that was already ACKed and matched the final response.

**Working sibling / contrast:** A successful fresh fallback and an ambiguous timeout already preserve duplicate suppression. A partial preview remains distinct and still sends its missing tail.

**Ruled out:** Treating every `already_sent` stream as final was rejected because partial commentary or an incomplete preview must not suppress the real answer.

### Fix

Return a dedicated `preview` recovery outcome for flood-control rejection. The caller preserves `final_content_delivered` and records the exact final payload, allowing the existing gateway reconciliation guard to suppress only an exact duplicate. Add a regression test for a 20-second Telegram flood result and retain the existing missing-tail coverage.

## Related Issue

Closes #96078

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py` - preserve exact streamed-final delivery state when the replacement send is flood-controlled.
- `tests/gateway/test_telegram_final_delivery.py` - reproduce the long flood fallback state transition and assert exact-payload reconciliation.

## How to Test

1. Model a complete ACKed Telegram preview followed by a fresh-final send returning `flood_control:20.0`.
2. Verify the consumer does not sleep through the long retry, keeps final delivery confirmed, and matches the recorded final payload.
3. Run the related gateway suites:

```bash
scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_telegram_final_delivery.py -q
```

Result: 90 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A, behavior is covered by code comments and regression tests
- [x] `cli-config.yaml.example`: N/A, no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A, no architecture or workflow changes
- [x] Cross-platform impact considered: the change is platform-result state handling with no OS-specific behavior
- [x] Tool descriptions/schemas: N/A, no tool changes

## Screenshots / Logs

N/A - automated regression coverage exercises the failing state transition.
