### PR TITLE
fix(stt): make the managed tool gateway the default STT backend

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -111,18 +111,95 @@ class TestAutodetectPrefersManagedGatewayOverInstallingLocal:
             "must NOT lazy-install faster-whisper when the managed gateway is ready"
         )
 
-    def test_installed_local_still_wins_for_entitled_self_hosted_users(
-        self, monkeypatch
-    ):
-        """Don't take local away from someone who already has it — free,
-        private and offline beats a metered gateway call."""
+    def test_managed_gateway_beats_an_installed_local_model(self, monkeypatch):
+        """When the gateway is entitled it is the DEFAULT — even if
+        faster-whisper happens to be importable.
+
+        Package presence is not a user preference. On a hosted instance a
+        local model is usually RESIDUE from the old lazy-install path, not a
+        deliberate choice, and preferring it is what kept staging broken:
+        faster_whisper sat in /opt/data/lazy-packages (on the data volume, not
+        the venv), so the gateway resolved "local" at rung 1 and never reached
+        the managed branch — every voice note died on a full disk.
+
+        Opting out is explicit: set stt.provider (see the tests below).
+        """
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
             "tools.transcription_tools._has_openai_audio_backend", return_value=True
         ), patch(
             "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
             return_value=True,
         ):
-            assert self._autodetect(monkeypatch)() == "local"
+            assert self._autodetect(monkeypatch)() == "openai"
+
+    def test_managed_gateway_beats_a_local_command(self, monkeypatch):
+        """Same precedence for HERMES_LOCAL_STT_COMMAND: the gateway is the
+        default, and the command is honoured via explicit config."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=True
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ):
+            assert self._autodetect(monkeypatch)() == "openai"
+
+    def test_explicit_local_provider_opts_out_of_the_gateway(self, monkeypatch):
+        """The documented opt-out: stt.provider: local is honoured verbatim,
+        gateway entitlement notwithstanding.
+
+        Asserted via the EXPLICIT branch specifically: _has_local_command is
+        False and the lazy-install is stubbed to fail, so "local" can only be
+        returned by the explicit `provider == "local"` handler. Without that,
+        this test would pass off the unentitled fallthrough ladder and would
+        not actually pin the opt-out (caught by mutation testing).
+
+        read_selection returns "local" because that is what a REAL opt-out
+        looks like: it reads the raw config.yaml, so a hand-written or
+        picker-written stt.provider surfaces here. (None means "never
+        configured" — the legacy DEFAULT_CONFIG seed — which correctly falls
+        through to autodetect and therefore to the gateway.)
+        """
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.read_selection", lambda _k: "local"
+        )
+        from tools.transcription_tools import _get_provider
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._has_local_command", return_value=False
+        ), patch(
+            "tools.transcription_tools._try_lazy_install_stt", return_value=False
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ):
+            assert _get_provider({"enabled": True, "provider": "local"}) == "local"
+
+    def test_explicit_local_command_provider_opts_out_of_the_gateway(
+        self, monkeypatch
+    ):
+        """Opt-out via an explicit local_command provider."""
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.read_selection", lambda _k: "local_command"
+        )
+        from tools.transcription_tools import _get_provider
+
+        with patch("tools.transcription_tools._has_local_command", return_value=True), \
+             patch(
+                 "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+                 return_value=True,
+             ):
+            resolved = _get_provider({"enabled": True, "provider": "local_command"})
+        assert resolved == "local_command"
 
     def test_no_gateway_still_lazy_installs_local(self, monkeypatch):
         """Unentitled/self-hosted with no local backend keeps today's
@@ -223,16 +300,79 @@ class TestAutodetectPrefersManagedGatewayOverInstallingLocal:
 
         return _cap()
 
-    def test_local_command_still_beats_the_gateway(self, monkeypatch):
-        """A user-provided HERMES_LOCAL_STT_COMMAND is an explicit local
-        investment — it is already installed, so it wins like local does."""
-        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
-            "tools.transcription_tools._has_local_command", return_value=True
+    def test_unentitled_box_with_a_direct_key_still_prefers_local(
+        self, monkeypatch
+    ):
+        """Entitlement is what unlocks the gateway-first precedence.
+
+        A self-hosted user with OPENAI_API_KEY set but NO Nous entitlement has
+        an openai audio backend available — but no managed gateway. They must
+        keep the original local-first ladder, not be pushed onto their own
+        metered OpenAI key. (Mutation testing caught that removing the
+        _managed_stt_ready condition changed nothing without this test.)
+        """
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=False,
+        ):
+            assert self._autodetect(monkeypatch)() == "local"
+
+    def test_regression_staging_lazy_installed_whisper_on_full_disk(
+        self, monkeypatch
+    ):
+        """Regression for the exact staging failure (2026-08-27).
+
+        hermes-agent-stg-test-6698: faster_whisper had been lazy-installed into
+        /opt/data/lazy-packages (the data volume — absent from the venv, so
+        `pip show` reported nothing). The gateway process put that directory on
+        sys.path, imported it, and resolved "local" at rung 1. Every voice note
+        then failed inside the model download:
+
+            Local transcription failed: Task error: File reconstruction error:
+            IO Error: No space left on device (os error 28)
+
+        ...while an entitled managed gateway sat idle, and the agent fell back
+        to shelling out to ffmpeg. Package presence must NOT outrank an
+        entitled gateway.
+        """
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._has_local_command", return_value=False
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
         ), patch(
             "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
             return_value=True,
         ):
+            resolved = self._autodetect(monkeypatch)()
+
+        assert resolved == "openai", (
+            "lazy-installed faster-whisper must not outrank an entitled "
+            "managed gateway — this is what kept staging broken"
+        )
+
+    def test_local_command_wins_when_no_gateway_is_available(self, monkeypatch):
+        """Without entitlement nothing changes: local_command still wins."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=False,
+        ):
             assert self._autodetect(monkeypatch)() == "local_command"
+
+    def test_installed_local_wins_when_no_gateway_is_available(self, monkeypatch):
+        """Self-hosted, unentitled, faster-whisper present -> local, as today."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=False,
+        ):
+            assert self._autodetect(monkeypatch)() == "local"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -146,6 +146,83 @@ class TestAutodetectPrefersManagedGatewayOverInstallingLocal:
         assert installs == [True], "unentitled boxes must still be able to install"
         assert resolved == "local"
 
+    def test_managed_branch_does_not_claim_the_gateway_when_a_direct_key_wins(
+        self, monkeypatch
+    ):
+        """Don't log "using the managed gateway" when the request won't go there.
+
+        _resolve_openai_audio_client_config's legacy ladder (no stored stt
+        selection) prefers a DIRECT OPENAI_API_KEY over the managed gateway.
+        So on an entitled box that also has a direct key, resolving to
+        "openai" is still correct — but it is NOT a managed-gateway decision,
+        and the branch must not announce one. Suppressing the install is the
+        part that matters, and it must still hold.
+        """
+        import logging
+
+        installs: list[bool] = []
+
+        def _fake_install():
+            installs.append(True)
+            return True
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=False
+        ), patch(
+            "tools.transcription_tools._try_lazy_install_stt", _fake_install
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            return_value="sk-user-direct",
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ), patch(
+            "tools.tool_backend_helpers.read_selection", return_value=None
+        ):
+            from tools.transcription_tools import _get_provider
+
+            with self._capture_logs() as records:
+                resolved = _get_provider({"enabled": True})
+
+        assert resolved == "openai"
+        assert installs == [], "the install must still be suppressed"
+        managed_claims = [
+            r for r in records if "managed Nous Tool Gateway" in r.getMessage()
+        ]
+        assert not managed_claims, (
+            "logged a managed-gateway claim while a direct key will actually "
+            f"serve the request: {[r.getMessage() for r in managed_claims]}"
+        )
+
+    def _capture_logs(self):
+        import contextlib
+        import logging
+
+        @contextlib.contextmanager
+        def _cap():
+            records: list[logging.LogRecord] = []
+
+            class _H(logging.Handler):
+                def emit(self, record):
+                    records.append(record)
+
+            logger = logging.getLogger("tools.transcription_tools")
+            h = _H()
+            logger.addHandler(h)
+            prev = logger.level
+            logger.setLevel(logging.INFO)
+            try:
+                yield records
+            finally:
+                logger.removeHandler(h)
+                logger.setLevel(prev)
+
+        return _cap()
+
     def test_local_command_still_beats_the_gateway(self, monkeypatch):
         """A user-provided HERMES_LOCAL_STT_COMMAND is an explicit local
         investment — it is already installed, so it wins like local does."""

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -54,6 +54,110 @@ class TestGetProvider:
         assert _get_provider({"enabled": False, "provider": "openai"}) == "none"
 
 
+class TestAutodetectPrefersManagedGatewayOverInstallingLocal:
+    """Autodetect must never PROVISION on-host STT when the managed Nous Tool
+    Gateway is available.
+
+    Hermes Cloud instances ship no faster-whisper and set no stt.provider, so
+    autodetect used to hit ``_try_lazy_install_stt()`` and download a model
+    onto a small instance volume. Live failure (staging 2026-08-26,
+    hermes-agent-stg-test-6698): faster-whisper's 145 MB Systran model could
+    not be fetched onto a 98%-full disk, so every voice note fell back to a
+    "transcribe it yourself" note and the agent hand-rolled a pipeline.
+
+    The narrow contract deliberately does NOT take local away from anyone who
+    already has it: an entitled self-hosted user with faster-whisper installed
+    keeps their free, private, local model. Only the INSTALL is suppressed,
+    and only when a managed backend is actually ready.
+    """
+
+    def _autodetect(self, monkeypatch):
+        """Autodetect config: no explicit provider anywhere."""
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.read_selection", lambda _k: None
+        )
+        from tools.transcription_tools import _get_provider
+
+        return lambda: _get_provider({"enabled": True})
+
+    def test_no_local_installed_and_gateway_ready_uses_managed_not_install(
+        self, monkeypatch
+    ):
+        """The Hermes Cloud shape: nothing local, gateway entitled."""
+        installs: list[bool] = []
+
+        def _fake_install():
+            installs.append(True)
+            return True
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=False
+        ), patch(
+            "tools.transcription_tools._try_lazy_install_stt", _fake_install
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ):
+            resolved = self._autodetect(monkeypatch)()
+
+        assert resolved == "openai", (
+            "an entitled instance with no local STT must use the managed gateway"
+        )
+        assert installs == [], (
+            "must NOT lazy-install faster-whisper when the managed gateway is ready"
+        )
+
+    def test_installed_local_still_wins_for_entitled_self_hosted_users(
+        self, monkeypatch
+    ):
+        """Don't take local away from someone who already has it — free,
+        private and offline beats a metered gateway call."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._has_openai_audio_backend", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ):
+            assert self._autodetect(monkeypatch)() == "local"
+
+    def test_no_gateway_still_lazy_installs_local(self, monkeypatch):
+        """Unentitled/self-hosted with no local backend keeps today's
+        behaviour exactly — the install is the only way they get STT."""
+        installs: list[bool] = []
+
+        def _fake_install():
+            installs.append(True)
+            return True
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=False
+        ), patch(
+            "tools.transcription_tools._try_lazy_install_stt", _fake_install
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=False,
+        ):
+            resolved = self._autodetect(monkeypatch)()
+
+        assert installs == [True], "unentitled boxes must still be able to install"
+        assert resolved == "local"
+
+    def test_local_command_still_beats_the_gateway(self, monkeypatch):
+        """A user-provided HERMES_LOCAL_STT_COMMAND is an explicit local
+        investment — it is already installed, so it wins like local does."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), patch(
+            "tools.transcription_tools._has_local_command", return_value=True
+        ), patch(
+            "tools.managed_tool_gateway.is_managed_tool_gateway_ready",
+            return_value=True,
+        ):
+            assert self._autodetect(monkeypatch)() == "local_command"
+
+
 # ---------------------------------------------------------------------------
 # File validation
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1037,8 +1037,17 @@ def _get_provider(stt_config: dict) -> str:
         # ``read_selection`` reads the raw config.yaml: when the raw file
         # holds an stt selection (picker- or hand-written ``local``) it is
         # honored; when the merged "local" came only from a legacy default
-        # merge, take the autodetect branch (which prefers local first
-        # anyway, so a genuine local user is unaffected when it's available).
+        # merge, take the autodetect branch.
+        #
+        # NOTE: this guard used to justify itself with "autodetect prefers
+        # local first anyway, so a genuine local user is unaffected". That is
+        # no longer true — autodetect now prefers an entitled managed gateway
+        # over an on-host model. So before downgrading, check the RAW config
+        # file directly: a hand-written ``stt.provider`` there is an explicit
+        # opt-out and must survive, even when read_selection (which only sees
+        # the picker's own selection store) knows nothing about it. Without
+        # this, a user who wrote ``stt.provider: local`` by hand would be
+        # silently moved onto the metered gateway.
         try:
             from tools.tool_backend_helpers import read_selection
 
@@ -1149,23 +1158,27 @@ def _get_provider(stt_config: dict) -> str:
     # intentionally skipped while `mistralai` is quarantined on PyPI (malicious
     # 2.4.6 release on 2026-05-12).
 
-    if _HAS_FASTER_WHISPER:
-        return "local"
-    if _has_local_command():
-        return "local_command"
-    # No local backend is PRESENT. Before provisioning one, check whether a
-    # managed Nous Tool Gateway is available — on a hosted instance it always
-    # is, and installing on-host STT there is actively harmful: faster-whisper
-    # pulls a model onto a small instance volume (145 MB for `base`), burns CPU
-    # on a shared VM, and adds a cold-start download to the first voice note.
-    # Live failure this prevents (staging 2026-08-26): the model download hit
-    # `No space left on device` on a 98%-full volume, so every relayed voice
-    # note silently degraded to "transcribe it yourself".
+    # When the managed Nous Tool Gateway is entitled it is the DEFAULT STT
+    # backend, ahead of any on-host model. Opting out is explicit: set
+    # `stt.provider` (local, local_command, groq, openai, ...) and the block
+    # above honours it verbatim.
     #
-    # Deliberately narrow: this only suppresses the INSTALL. A user who ALREADY
-    # has faster-whisper or a local STT command keeps it (both branches above
-    # return first) — free, private and offline beats a metered gateway call,
-    # and we don't move an entitled self-hosted user's STT without them asking.
+    # Precedence deliberately puts the gateway FIRST rather than deferring to
+    # an installed local model, because package presence is not a user
+    # preference. On a hosted instance a local model is usually RESIDUE from
+    # the old lazy-install path, and preferring it is what kept staging broken
+    # (2026-08-27, hermes-agent-stg-test-6698): faster_whisper had been
+    # lazy-installed into /opt/data/lazy-packages — on the data volume, absent
+    # from the venv — so the gateway imported it, resolved "local" at rung 1,
+    # and never reached the managed branch. Every voice note then died in the
+    # model download with `No space left on device` on a 99%-full disk while
+    # an entitled gateway sat idle. Config is the only reliable signal of
+    # intent; an import is not.
+    #
+    # This also removes the reason to lazy-install on an entitled box at all:
+    # on-host STT there consumes the data volume, burns CPU on a shared VM,
+    # adds a cold-start download to the first voice note, and transcribes
+    # worse than whisper-1.
     _managed_stt_ready = False
     try:
         from tools.managed_tool_gateway import is_managed_tool_gateway_ready
@@ -1177,8 +1190,7 @@ def _get_provider(stt_config: dict) -> str:
         # Resolve honestly: with no stored stt selection,
         # _resolve_openai_audio_client_config's legacy ladder prefers a DIRECT
         # OPENAI_API_KEY over the gateway, so "openai" here does not always
-        # mean "managed". Suppressing the install is correct either way; only
-        # claim the gateway when it is what will actually serve the request.
+        # mean "managed". Only claim the gateway when it will actually serve.
         _direct_key = ""
         try:
             _direct_key = resolve_openai_audio_api_key() or ""
@@ -1186,15 +1198,22 @@ def _get_provider(stt_config: dict) -> str:
             logger.debug("direct openai-audio key probe failed", exc_info=True)
         if _direct_key:
             logger.info(
-                "No local STT installed; using the configured OpenAI audio "
-                "credentials (skipping the on-host faster-whisper install)"
+                "Using the configured OpenAI audio credentials for STT "
+                "(managed gateway entitled; set stt.provider to override)"
             )
         else:
             logger.info(
-                "No local STT installed; using the managed Nous Tool Gateway "
-                "(skipping the on-host faster-whisper install)"
+                "Using the managed Nous Tool Gateway for STT "
+                "(set stt.provider to override, e.g. 'local')"
             )
         return "openai"
+    # No managed gateway (self-hosted / unentitled): the original local-first
+    # ladder applies unchanged — an on-host model is the only STT these boxes
+    # get, so presence is a good enough signal there.
+    if _HAS_FASTER_WHISPER:
+        return "local"
+    if _has_local_command():
+        return "local_command"
     # Try lazy-install before falling through to cloud providers
     if _try_lazy_install_stt():
         return "local"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1174,10 +1174,26 @@ def _get_provider(stt_config: dict) -> str:
     except Exception:  # noqa: BLE001 - availability probing must never break STT
         logger.debug("managed STT availability probe failed", exc_info=True)
     if _managed_stt_ready and _HAS_OPENAI and _has_openai_audio_backend():
-        logger.info(
-            "No local STT installed; using the managed Nous Tool Gateway "
-            "(skipping the on-host faster-whisper install)"
-        )
+        # Resolve honestly: with no stored stt selection,
+        # _resolve_openai_audio_client_config's legacy ladder prefers a DIRECT
+        # OPENAI_API_KEY over the gateway, so "openai" here does not always
+        # mean "managed". Suppressing the install is correct either way; only
+        # claim the gateway when it is what will actually serve the request.
+        _direct_key = ""
+        try:
+            _direct_key = resolve_openai_audio_api_key() or ""
+        except Exception:  # noqa: BLE001 - never let a credential probe break STT
+            logger.debug("direct openai-audio key probe failed", exc_info=True)
+        if _direct_key:
+            logger.info(
+                "No local STT installed; using the configured OpenAI audio "
+                "credentials (skipping the on-host faster-whisper install)"
+            )
+        else:
+            logger.info(
+                "No local STT installed; using the managed Nous Tool Gateway "
+                "(skipping the on-host faster-whisper install)"
+            )
         return "openai"
     # Try lazy-install before falling through to cloud providers
     if _try_lazy_install_stt():

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1153,6 +1153,32 @@ def _get_provider(stt_config: dict) -> str:
         return "local"
     if _has_local_command():
         return "local_command"
+    # No local backend is PRESENT. Before provisioning one, check whether a
+    # managed Nous Tool Gateway is available — on a hosted instance it always
+    # is, and installing on-host STT there is actively harmful: faster-whisper
+    # pulls a model onto a small instance volume (145 MB for `base`), burns CPU
+    # on a shared VM, and adds a cold-start download to the first voice note.
+    # Live failure this prevents (staging 2026-08-26): the model download hit
+    # `No space left on device` on a 98%-full volume, so every relayed voice
+    # note silently degraded to "transcribe it yourself".
+    #
+    # Deliberately narrow: this only suppresses the INSTALL. A user who ALREADY
+    # has faster-whisper or a local STT command keeps it (both branches above
+    # return first) — free, private and offline beats a metered gateway call,
+    # and we don't move an entitled self-hosted user's STT without them asking.
+    _managed_stt_ready = False
+    try:
+        from tools.managed_tool_gateway import is_managed_tool_gateway_ready
+
+        _managed_stt_ready = is_managed_tool_gateway_ready("openai-audio")
+    except Exception:  # noqa: BLE001 - availability probing must never break STT
+        logger.debug("managed STT availability probe failed", exc_info=True)
+    if _managed_stt_ready and _HAS_OPENAI and _has_openai_audio_backend():
+        logger.info(
+            "No local STT installed; using the managed Nous Tool Gateway "
+            "(skipping the on-host faster-whisper install)"
+        )
+        return "openai"
     # Try lazy-install before falling through to cloud providers
     if _try_lazy_install_stt():
         return "local"


### PR DESCRIPTION
## The problem

Hermes Cloud instances get **on-host Whisper** instead of the managed Nous Tool Gateway. `_get_provider`'s autodetect ladder preferred a local model, so an entitled instance downloaded a model onto its data volume, burned CPU on a shared VM, added a cold-start download to the first voice note, and transcribed worse than `whisper-1` — with the gateway sitting idle.

**Live failure** (`hermes-agent-stg-test-6698`): every relayed voice note died inside the model download and the agent shelled out to `ffmpeg` to transcribe by hand.

```
Local transcription failed: Task error: File reconstruction error:
  IO Error: No space left on device (os error 28)
```

## The change

**When the managed gateway is entitled it is the default. Opting out is explicit.**

| | precedence |
|---|---|
| 1 | explicit `stt.provider` — honoured verbatim (**the opt-out**) |
| 2 | entitled managed gateway — **the default** |
| 3 | `local` / `local_command` / lazy-install — unentitled boxes, unchanged |

Self-hosted and unentitled users see **no behaviour change**, including those with a direct `OPENAI_API_KEY`: entitlement — not the mere availability of an openai audio backend — is what unlocks step 2. The log line names whichever credential will actually serve, since the resolver's legacy ladder prefers a direct key over the gateway.

## Why the first cut of this PR was wrong

The original patch only suppressed the *install*, deferring to an already-installed faster-whisper on the theory that presence implies a deliberate free/private choice. **Staging disproved that.**

`faster_whisper` had been lazy-installed by the old bug into `/opt/data/lazy-packages` — the data volume, not the venv. So `pip show faster-whisper` reported NOT_INSTALLED and a plain `find_spec` returned False, while the gateway process (which puts that directory on `sys.path`) imported it fine:

```
=== WITHOUT lazy-packages on sys.path (what my probes saw) ===
  faster_whisper importable: False
=== WITH lazy-packages on sys.path (what the gateway sees) ===
  faster_whisper importable: True
  origin: /opt/data/lazy-packages/faster_whisper/__init__.py
  RESOLVED with local present: local        <-- never reached the managed branch
```

A lazy-installed package is **residue from the very bug this PR fixes**, not a user preference. Config is the only reliable signal of intent; an import is not.

This also invalidated a comment in the legacy-merge guard which justified itself with *"autodetect prefers local first anyway, so a genuine local user is unaffected"* — no longer true, so it's now documented. (`read_selection` reads the raw `config.yaml`, so a hand-written `stt.provider` is still a real opt-out.)

## Verification

27 tests pass. New: a named regression test for the staging shape (whisper importable + entitled + no raw selection → gateway), both opt-out paths, and unentitled-with-a-direct-key.

Verified against the **real resolver** (mocks only for the two facts describing the box):

```
STAGING SHAPE (whisper importable + entitled + no selection)
  provider  : openai
  endpoint  : https://openai-audio-gateway.staging-nousresearch.com/v1
  credential: NOUS-TOKEN
OPT-OUT (stt.provider: local) -> local
```

Earlier, on the instance itself, both of Ben's real voice notes transcribed through the managed gateway via the gateway's own call signature `transcribe_audio(path, None, "gateway")` — `200 OK`, provider `openai` (whisper-1).

**Mutation-verified, 5/5 caught:** revert-to-local-first (2 fail), break either opt-out (1 each), drop the unentitled ladder (3), ignore entitlement (1). The last two only fail because of tests added *after* mutation testing showed they survived — the opt-out test originally passed off a fallthrough rather than the branch it claimed to pin.

⚠️ `TestTranscribeLocalExtended::test_config_device_and_compute_type_passed_to_whisper` fails locally on clean `main` too (`int8` vs `float32`, machine-dependent) and passes in CI. Not touched here.

## Not in this PR

- **Silent degradation**: STT failure surfaces to the user as a strange reply while the real cause is only in `gateway.log`. That masking is why this took several rounds to diagnose.
- **`lazy-packages` residue**: instances that already lazy-installed faster-whisper keep the files (and the disk usage). This PR stops *using* them; it does not clean them up.
- **NAS stamping `stt.provider: nous` at provision** so the choice is visible in `config.yaml` rather than implicit in resolution order.