### PR TITLE
fix(desktop): finish POSIX SSH spawn publication

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { exec as execCallback, spawn } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -33,6 +33,7 @@ import {
   remotePidAlive,
   remoteSupportsSshOwnership,
   scrapeReadyPort,
+  shq,
   spawnLogPath,
   spawnRemoteDashboard,
   spawnTokenPath,
@@ -788,6 +789,90 @@ test('buildSpawnCommand always uses serve (legacy dashboard path removed)', () =
   assert.match(cmd, /setsid/)
 })
 
+test('buildSpawnCommand passes the expanded update mutex path as a shell fragment', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+
+  const mutexPath = expandRemotePath('~/.hermes/.hermes-update-in-progress.mutex')
+
+  assert.ok(cmd.includes(` ${mutexPath} `), 'the already-expanded mutex path must not be quoted again')
+})
+
+test('buildSpawnCommand captures only the live backend PID', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'work', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
+
+  assert.doesNotMatch(cmd, /hermes-update-child "\$1" & echo \$!\)/)
+})
+
+test.skipIf(process.platform === 'win32')('buildSpawnCommand publishes one live backend PID under POSIX sh', async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), 'hermes-posix-spawn-'))
+  const hermesPath = path.join(home, 'hermes')
+  const reportPath = path.join(home, 'backend-pid')
+  const logPath = spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  const lockPath = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, 'backend.lock.json')
+  const reservationPath = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, '.connect.lock')
+  const mutexPath = path.join(home, '.hermes-posix-spawn', '.hermes-update-in-progress.mutex')
+  let spawnedPid = 0
+
+  try {
+    await writeFile(hermesPath, `#!/bin/sh\nprintf '%s' "$$" > ${shq(reportPath)}\nexec sleep 30\n`, { mode: 0o700 })
+
+    const command = buildSpawnCommand(hermesPath, '', {
+      hermesHome: '~/.hermes-posix-spawn',
+      logPath,
+      ownershipId: OWNERSHIP_ID,
+      reservationNonce: SPAWN_NONCE,
+      spawnNonce: SPAWN_NONCE,
+      lockMetadata: {
+        ownershipId: OWNERSHIP_ID,
+        spawnNonce: SPAWN_NONCE,
+        port: 0,
+        profile: '',
+        hermesPath: '/x/__PID__/hermes',
+        hermesHome: '~/.hermes-posix-spawn',
+        logPath,
+        tokenFingerprint: fingerprintToken('stored-token'),
+        protocolVersion: PROTOCOL_VERSION,
+        startedAt: '2026-07-14T00:00:00.000Z'
+      }
+    })
+
+    const result = await exec(command, { shell: '/bin/sh', env: { ...process.env, HOME: home } })
+
+    const returnedPids = result.stdout
+      .trim()
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+
+    assert.equal(returnedPids.length, 1)
+    assert.match(returnedPids[0], /^\d+$/)
+    spawnedPid = Number(returnedPids[0])
+
+    const backendPid = await readFile(reportPath, 'utf8')
+    const published = JSON.parse(await readFile(lockPath, 'utf8'))
+
+    assert.equal(backendPid, returnedPids[0])
+    assert.equal(String(published.pid), returnedPids[0])
+    assert.equal(published.hermesPath, `/x/${returnedPids[0]}/hermes`)
+    process.kill(spawnedPid, 0)
+    await access(mutexPath)
+    await assert.rejects(access(reservationPath), (error: any) => error?.code === 'ENOENT')
+  } finally {
+    if (spawnedPid > 0) {
+      try {
+        process.kill(spawnedPid, 'SIGTERM')
+      } catch {
+        void 0
+      }
+    }
+
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
 test('buildSpawnCommand atomically reserves the ownership slot through spawn and lock publication', () => {
   const cmd = buildSpawnCommand('/x/hermes', 'work', {
     hermesHome: '~/.hermes',
@@ -1496,14 +1581,14 @@ test('buildSpawnCommand lockfile publication is POSIX sh (no bash substitution)'
     reservationNonce: SPAWN_NONCE,
     spawnNonce: SPAWN_NONCE,
     tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
-    lockMetadata: { ownershipId: OWNERSHIP_ID, pid: '__PID__' }
+    lockMetadata: { ownershipId: OWNERSHIP_ID, hermesPath: '/x/__PID__/hermes', pid: '__PID__' }
   })
 
   // ${var//pat/rep} is bash-only; dash aborts the payload on it AFTER the
   // serve was spawned, so the client sees an unknown failure, deletes the
   // token file, and orphans the backend.
   assert.doesNotMatch(cmd, /\$\{lock_json\/\//, 'must not use ${var//} substitution under sh')
-  assert.ok(cmd.includes('sed "s/__PID__/${child}/"'), 'pid substitution must use sed')
+  assert.ok(cmd.includes('sed "s/__PID__/${child}/g"'), 'pid substitution must preserve global replacement')
 })
 
 test('spawnRemoteDashboard removes a token file when upload reporting fails', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -913,7 +913,7 @@ finally:
 sys.exit(result.returncode if result is not None else 1)
 `.trim()
 
-  return `python3 -c ${shq(script)} ${shq(mutexPath)} ${shq(command)}`
+  return `python3 -c ${shq(script)} ${mutexPath} ${shq(command)}`
 }
 
 /**
@@ -1065,7 +1065,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
     `exec env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
 
   const detachedShell = `eval "exec $1>&-"; ${dashCmd} </dev/null >> ${logPath} 2>&1 & echo $!`
-  const detachedSpawn = `child=$("$(command -v setsid || echo nohup)" sh -c ${shq(detachedShell)} hermes-update-child "$1" & echo $!)`
+  const detachedSpawn = `child=$("$(command -v setsid || echo nohup)" sh -c ${shq(detachedShell)} hermes-update-child "$1")`
 
   if (!opts.ownershipId || !opts.lockMetadata) {
     return withRemoteUpdateMutex(
@@ -1109,7 +1109,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       // on Ubuntu), which aborts the whole script on it with "Bad
       // substitution" AFTER the child was spawned, orphaning the backend and
       // skipping the lockfile publication. Substitute with sed instead.
-      `lock_json=$(printf '%s' ${shq(metadata)} | sed "s/__PID__/\${child}/"); ` +
+      `lock_json=$(printf '%s' ${shq(metadata)} | sed "s/__PID__/\${child}/g"); ` +
       `temporary_lock="\${lock}.${reservationNonce}.tmp"; ` +
       `printf '%s' "$lock_json" > "$temporary_lock" && mv -f "$temporary_lock" "$lock" || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
       `echo "$child"`,


### PR DESCRIPTION
## Summary

Follow-up to #96084, targeting its `salv/96061-spawn-fixes` branch rather than `main` so @SmelterLabs' salvaged commit and authorship remain intact.

This closes three remaining gaps in the same managed-SSH spawn path:

- pass the already-expanded update-mutex path directly to Python instead of shell-quoting it a second time;
- capture only the live backend PID instead of combining the short-lived `setsid` wrapper PID with the backend PID;
- preserve the old global PID-placeholder semantics by using `sed .../g`.

Related issue: #96024. This PR deliberately does not duplicate #96084's ownership-variable or stale-reaper changes.

## Root Cause

`expandRemotePath()` returns a complete shell word. `withRemoteUpdateMutex()` still wrapped that word in `shq()`, so Python could receive literal quote characters instead of the expanded mutex path.

The detached launch also emitted `$!` twice: the outer `setsid ... & echo $!` reported a wrapper that had already exited, while the inner shell reported the live backend. In 20/20 WSL probes, `child` contained both PID lines. That breaks signal handling and lockfile publication.

Finally, #96084's POSIX replacement used first-match `sed`. Because lock metadata precedes the final `pid` field, an earlier `__PID__` occurrence could be replaced while leaving `pid: "__PID__"`. `/g` preserves the previous Bash global-replacement behavior.

## Fix

- remove only the second `shq(mutexPath)`;
- remove only the outer `& echo $!`, retaining the inner backend `echo $!`, `setsid`/`nohup`, redirections, and mutex-FD close;
- add the `g` flag to PID substitution;
- add structural regressions plus a POSIX full-spawn test that verifies mutex creation, one live PID, matching lockfile PID, global placeholder replacement, and reservation cleanup.

## How to Verify

```bash
cd apps/desktop
npx vitest run --config vitest.config.ts electron/remote-lifecycle.test.ts
npm run typecheck
npx eslint electron/remote-lifecycle.ts electron/remote-lifecycle.test.ts
```

The three focused tests failed against parent `542736a891` and pass at `994746f5d2`.

## Test Plan

- [x] Parent RED: all three A/D/C-global regressions fail on #96084 head
- [x] `remote-lifecycle.test.ts`: 91 passed, 3 platform-skipped
- [x] Desktop TypeScript checks: all three projects passed
- [x] Changed-file ESLint passed
- [x] `git diff --check` and static secret/debug/conflict scan passed
- [x] WSL2 Ubuntu `/bin/sh` (dash) full ownership payload passed:
  - one live `FULL_PID`
  - `FULL_LOCK_PID` matched it
  - expected `serve --isolated` argv
  - mutex created at the expanded `$HOME` path
  - reservation released

Platforms tested: Windows 11/Git Bash and WSL2 Ubuntu/dash. I did not independently repeat #96084's external macOS-to-Ubuntu SSH round trip.

## Risk Assessment

Medium-low — this touches process lifecycle and shell construction, but the production diff is three narrow lines. Mutex/flock ownership, descriptor closure, reservation protocol, atomic lock publication, token handling, authentication, timeout, and stale-reaper behavior are unchanged.
