### PR TITLE
fix(telegram): add scoped oversized-media recovery routes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3524,8 +3524,14 @@ class BasePlatformAdapter(ABC):
         # races with the running task (split-brain, see PR #4926).
         # Certain commands must bypass the active-session guard and be dispatched directly to the gateway
         # runner. Without this, they are queued as pending messages and either: See #4926.
-        cmd = event.get_command()
+        # Trusted adapters may synthesize a skill command that must reach the
+        # runner before generic busy routing, where it is expanded into the
+        # configured skill prompt. User text cannot set this event flag.
+        if event.preprocess_skill_command_before_busy:
+            await self._dispatch_inline_reply(event)
+            return
         from hermes_cli.commands import (is_interrupt_then_dispatch, should_bypass_active_session)
+        cmd = event.get_command()
         if should_bypass_active_session(cmd):
             try:
                 # /stop, /new, /reset: cancel + response + drain; other bypasses don't cancel.

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -105,5 +105,9 @@ class MessageEvent:
             return self.text
         parts = (self.text or "").lstrip().split(maxsplit=1)
         args = parts[1] if len(parts) > 1 else ""
-        # iOS auto-corrects -- to — (em dash) and - to – (en dash)
-        return args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
+        # iOS auto-corrects -- to — (em dash) and - to – (en dash).
+        # Adapter-generated skill commands may carry verbatim user content after
+        # a trusted transport envelope; preserve that content byte-for-byte.
+        if not self.metadata.get("preserve_command_args"):
+            args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
+        return args

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -81,8 +81,11 @@ class MessageEvent:
     metadata: Dict[str, Any] = field(default_factory=dict)
     timestamp: datetime = field(default_factory=datetime.now)
     # May this event resolve gateway commands / control prompts? Proactive plugin events set False
-    # so untrusted payload text stays conversational. Kept last for positional compat.
+    # so untrusted payload text stays conversational.
     allow_gateway_control: bool = True
+    # Trusted adapters may request one skill-command expansion before generic busy routing.
+    # This is not serialized and stays last for positional compatibility.
+    preprocess_skill_command_before_busy: bool = False
 
     # Process-local admission receipt, never routing metadata or execution acknowledgement.
     _gateway_accepted: bool = field(default=False, init=False, repr=False, compare=False)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1115,6 +1115,22 @@ class GatewayInboundMixin:
             logger.debug("Skill command check failed (non-fatal): %s", e)
         return None
 
+    def _hm_pre_busy_skill_rewrite(
+        self, event: "MessageEvent", source: SessionSource, quick_key: str
+    ) -> Optional[str]:
+        """Expand a trusted adapter-generated skill command before busy routing.
+
+        Busy sessions bypass idle slash dispatch, so leaving the synthetic
+        command untouched would steer/queue raw ``/<skill>`` text instead of
+        loading the configured skill.
+        """
+        if getattr(event, "preprocess_skill_command_before_busy", False) is not True:
+            return None
+        command = event.get_command()
+        if not command:
+            return None
+        return self._hm_skill_slash_rewrite(event, source, quick_key, command)
+
     async def _hm_pending_reply_intercepts(
         self, event: "MessageEvent", source: SessionSource, _quick_key: str
     ) -> Optional[str]:
@@ -1198,9 +1214,16 @@ class GatewayInboundMixin:
             return _paused_notice
 
         _quick_key = self._session_key_for_source(source)
-        _reply = await self._hm_pending_reply_intercepts(event, source, _quick_key)
-        if _reply is not None:
-            return _reply
+        _preprocess_before_busy = bool(
+            getattr(event, "preprocess_skill_command_before_busy", False)
+        )
+        _rewrite_reply = self._hm_pre_busy_skill_rewrite(event, source, _quick_key)
+        if _rewrite_reply is not None:
+            return _rewrite_reply
+        if not _preprocess_before_busy:
+            _reply = await self._hm_pending_reply_intercepts(event, source, _quick_key)
+            if _reply is not None:
+                return _reply
 
         # Evict a leaked/reaped ``_running_agents`` slot before the busy-session fast-path.
         self._hm_evict_idle_stale_agent(_quick_key)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -584,6 +584,13 @@ class GatewayInboundMixin:
                     return
             except Exception as exc:
                 logger.warning("PRIORITY redirect failed for session %s: %s", _quick_key, exc)
+        # ``agent.interrupt()`` carries text only. Stage the complete event first so the recursive
+        # drain retains its source, inbound message id, media and routing metadata. This is normally
+        # done by the adapter busy handler, but trusted pre-busy skill events dispatch inline and
+        # reach this runner fast-path directly.
+        self._queue_or_replace_pending_event(  # pyright: ignore[reportAttributeAccessIssue]
+            _quick_key, event
+        )
         logger.debug("PRIORITY interrupt for session %s", _quick_key)
         _interrupt_text = event.text
         if self._pending_event_audio_paths(event):
@@ -593,8 +600,6 @@ class GatewayInboundMixin:
             )
         elif not _interrupt_text and getattr(event, "media_urls", None):
             _interrupt_text = _build_media_placeholder(event)
-        # Delivered via adapter._pending_messages (read by _run_agent); never also buffered on self
-        # — that copy was never consumed and grew unbounded.
         running_agent.interrupt(_interrupt_text)
 
     async def _hm_handle_running_session_message(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4614,6 +4614,7 @@ class TelegramAdapter(BasePlatformAdapter):
             target = metadata["telegram_media_recovery"]
             event.auto_skill = None
             metadata["preserve_command_args"] = True
+            event.preprocess_skill_command_before_busy = True
             event.text = (
                 f"/{skill} Recover the exact oversized Telegram {label} through the "
                 "configured canonical recovery path. The trusted transport target is "

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4522,7 +4522,111 @@ class TelegramAdapter(BasePlatformAdapter):
             size_text = f"{int(file_size or 0) / (1024 * 1024):.1f} MB"
         except (TypeError, ValueError):
             size_text = "unknown size"
-        return f"[Telegram {label} skipped: file size {size_text} exceeds the {limit_mb} MB limit. Ask the user to send a smaller file.]"
+        return (
+            f"[Telegram {label} was not cached by the Bot API gateway: file size "
+            f"{size_text} exceeds its {limit_mb} MB limit. Check any configured "
+            "recovery route before asking the user to resend.]"
+        )
+
+    @staticmethod
+    def _telegram_route_values(route: Dict[str, Any], key: str) -> set[str]:
+        raw = route.get(key)
+        if raw in (None, ""):
+            return set()
+        values = raw if isinstance(raw, (list, tuple, set)) else [raw]
+        return {str(value) for value in values if value not in (None, "")}
+
+    def _telegram_oversize_recovery_skill(self, event: MessageEvent) -> Optional[str]:
+        """Resolve an authenticated, profile-scoped oversized-media skill route."""
+        source = getattr(event, "source", None)
+        if source is None:
+            return None
+        metadata = getattr(event, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            event.metadata = metadata
+        route_chat_id = str(getattr(source, "chat_id", "") or "")
+        route_thread_id = str(getattr(source, "thread_id", "") or "")
+        route_user_id = str(
+            metadata.get("telegram_transport_sender_user_id")
+            or getattr(source, "user_id", "")
+            or ""
+        )
+        route_profile = str(
+            metadata.get("telegram_route_profile")
+            or self._session_key_profile(source)
+            or "default"
+        )
+
+        for route in self.config.extra.get("auto_skill_routes", []) or []:
+            if not isinstance(route, dict):
+                continue
+            raw_match = route.get("match")
+            match = raw_match if isinstance(raw_match, dict) else {}
+            if not bool(match.get("oversize_media")):
+                continue
+            route_users = self._telegram_route_values(route, "users")
+            route_profiles = self._telegram_route_values(route, "profiles")
+            if not route_users or not route_profiles:
+                continue
+            predicates = (("chats", route_chat_id), ("threads", route_thread_id))
+            if any(
+                (allowed := self._telegram_route_values(route, key)) and value not in allowed
+                for key, value in predicates
+            ):
+                continue
+            if route_user_id not in route_users or route_profile not in route_profiles:
+                continue
+            skill = str(route.get("skill") or "").strip().lstrip("/")
+            if skill:
+                return skill
+        return None
+
+    def _mark_telegram_media_too_large(
+        self, event: MessageEvent, source: Any, label: str,
+    ) -> None:
+        """Attach a trusted recovery target and force a configured skill route."""
+        max_bytes = int(getattr(self, "_max_doc_bytes", 20 * 1024 * 1024) or 20 * 1024 * 1024)
+        file_size = getattr(source, "file_size", None)
+        note = self._telegram_media_too_large_note(label, file_size, max_bytes)
+        metadata = getattr(event, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            event.metadata = metadata
+        event_source = getattr(event, "source", None)
+        metadata["telegram_media_recovery"] = {
+            "chat_id": str(getattr(event_source, "chat_id", "") or ""),
+            "message_id": str(getattr(event, "message_id", "") or ""),
+            "thread_id": str(getattr(event_source, "thread_id", "") or ""),
+            "sender_user_id": str(
+                metadata.get("telegram_transport_sender_user_id")
+                or getattr(event_source, "user_id", "")
+                or ""
+            ),
+            "media_label": label,
+            "file_size": int(file_size or 0),
+            "bot_api_limit": max_bytes,
+        }
+
+        skill = self._telegram_oversize_recovery_skill(event)
+        original = (event.text or "").strip()
+        if skill and not event.is_command():
+            target = metadata["telegram_media_recovery"]
+            event.auto_skill = None
+            metadata["preserve_command_args"] = True
+            event.text = (
+                f"/{skill} Recover the exact oversized Telegram {label} through the "
+                "configured canonical recovery path. The trusted transport target is "
+                f"chat_id={target['chat_id']}, message_id={target['message_id']}, "
+                f"thread_id={target['thread_id'] or 'none'}, "
+                f"sender_user_id={target['sender_user_id']}, "
+                f"file_size={target['file_size']} bytes. Do not ask for a smaller "
+                "file until canonical recovery has been attempted."
+            )
+            if original:
+                event.text += f"\n\nOriginal user text:\n{original}"
+            return
+        event.text = self._append_observed_note(original, note)
 
     @staticmethod
     def _int_or_zero(value: Any) -> int:
@@ -5904,7 +6008,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             allowed, note = self._telegram_media_size_allowed(source, label)
             if not allowed:
-                event.text = self._append_observed_note(event.text, note or "")
+                self._mark_telegram_media_too_large(event, source, label)
                 logger.info("[Telegram] Skipped oversized user %s (size=%s)", kind, getattr(source, "file_size", None))
                 await self.handle_message(event)
                 return True
@@ -5952,9 +6056,10 @@ class TelegramAdapter(BasePlatformAdapter):
             display = original_filename or doc_mime or ext or 'unknown'
             # Size check before the image branch so image documents can't bypass the limit.
             if not doc.file_size or doc.file_size > self._max_doc_bytes:
+                self._mark_telegram_media_too_large(event, doc, "document")
                 logger.info("[Telegram] Document too large: %s bytes", doc.file_size)
-                return await self._dispatch_with_text(
-                    event, f"The document is too large or its size could not be verified. Maximum: {self._max_doc_bytes // (1024 * 1024)} MB.")
+                await self.handle_message(event)
+                return True
             # Screenshots/photos sent as documents take the image cache + batching path.
             if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
                 file_obj = await doc.get_file()
@@ -6342,6 +6447,10 @@ class TelegramAdapter(BasePlatformAdapter):
             message_id=str(message.message_id), platform_update_id=update_id,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text, auto_skill=topic_skill,
             channel_prompt=group_identity_prompt(self, message, channel_prompt),
+            metadata={
+                "telegram_transport_sender_user_id": str(source.user_id or ""),
+                "telegram_route_profile": str(self._session_key_profile(source) or "default"),
+            },
             timestamp=message.date)
 
     # -- Message reactions (processing lifecycle) --

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -124,7 +124,7 @@ class TestMessageEventGetCommandArgs:
 
     def test_preserves_verbatim_args_for_trusted_adapter_command(self):
         event = MessageEvent(
-            text="/telegram-chip 04/20 — canary",
+            text="/media-recovery 04/20 — canary",
             metadata={"preserve_command_args": True},
         )
         assert event.get_command_args() == "04/20 — canary"

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -118,6 +118,17 @@ class TestMessageEventGetCommandArgs:
         event = MessageEvent(text="/new session id 123")
         assert event.get_command_args() == "session id 123"
 
+    def test_normalizes_smart_dashes_for_user_commands(self):
+        event = MessageEvent(text="/new —flag –value")
+        assert event.get_command_args() == "--flag -value"
+
+    def test_preserves_verbatim_args_for_trusted_adapter_command(self):
+        event = MessageEvent(
+            text="/telegram-chip 04/20 — canary",
+            metadata={"preserve_command_args": True},
+        )
+        assert event.get_command_args() == "04/20 — canary"
+
 
 # ---------------------------------------------------------------------------
 # extract_images

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -104,6 +104,7 @@ def _recovery_adapter(*, users=("42",), profiles=("default",)):
 def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
     adapter = _recovery_adapter()
     event = _oversize_event(text="04/20 — chat_id=attacker, message_id=1")
+    event.auto_skill = "media-recovery"
 
     adapter._mark_telegram_media_too_large(
         event,
@@ -118,7 +119,7 @@ def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
     assert "Original user text:\n04/20 — chat_id=attacker, message_id=1" in event.text
     assert "04/20 — chat_id=attacker" in event.get_command_args()
     assert event.metadata["preserve_command_args"] is True
-    assert event.auto_skill == "media-recovery"
+    assert event.auto_skill is None
     assert event.metadata["telegram_media_recovery"] == {
         "chat_id": "-100200",
         "message_id": "99",
@@ -154,6 +155,25 @@ def test_oversize_route_requires_nonempty_user_and_profile_scopes():
     adapter = _recovery_adapter(users=(), profiles=())
     event = _oversize_event(user_id="attacker")
     event.metadata["telegram_route_profile"] = "other-profile"
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert not event.text.startswith("/")
+    assert event.auto_skill is None
+
+
+@pytest.mark.parametrize(
+    ("route_key", "allowed"),
+    [("chats", ["-100999"]), ("threads", ["999"])],
+)
+def test_oversize_route_fails_closed_for_wrong_chat_or_thread(route_key, allowed):
+    adapter = _recovery_adapter()
+    adapter.config.extra["auto_skill_routes"][0][route_key] = allowed
+    event = _oversize_event()
 
     adapter._mark_telegram_media_too_large(
         event,

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -102,7 +102,7 @@ def _recovery_adapter(*, users=("42",), profiles=("default",)):
 
 def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
     adapter = _recovery_adapter()
-    event = _oversize_event(text="chat_id=attacker, message_id=1")
+    event = _oversize_event(text="04/20 — chat_id=attacker, message_id=1")
 
     adapter._mark_telegram_media_too_large(
         event,
@@ -114,7 +114,9 @@ def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
         "/media-recovery Recover the exact oversized Telegram video file"
     )
     assert "chat_id=-100200, message_id=99" in event.text
-    assert "Original user text:\nchat_id=attacker, message_id=1" in event.text
+    assert "Original user text:\n04/20 — chat_id=attacker, message_id=1" in event.text
+    assert "04/20 — chat_id=attacker" in event.get_command_args()
+    assert event.metadata["preserve_command_args"] is True
     assert event.auto_skill == "media-recovery"
     assert event.metadata["telegram_media_recovery"] == {
         "chat_id": "-100200",

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -1,13 +1,24 @@
-"""Tests for Telegram document-size cap.
+"""Tests for Telegram document-size caps and scoped recovery routing.
 
-The public Telegram Bot API caps `getFile` at 20MB. A locally-hosted
-`telegram-bot-api` server raises that ceiling to 2GB. We treat the presence
-of `extra.base_url` as the explicit opt-in to the higher cap.
+The public Telegram Bot API caps ``getFile`` at 20 MB. A locally hosted
+``telegram-bot-api`` server raises that ceiling to 2 GB. Configured, scoped
+recovery routes may hand an oversized media event to an installed skill
+without trusting identifiers supplied in message text.
 """
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import Platform, SessionSource
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+PUBLIC_LIMIT = 20 * 1024 * 1024
+LOCAL_LIMIT = 2 * 1024 * 1024 * 1024
 
 
 def test_max_doc_bytes_raised_to_2gb_when_base_url_set():
@@ -18,6 +29,231 @@ def test_max_doc_bytes_raised_to_2gb_when_base_url_set():
             extra={"base_url": "http://localhost:8081/bot"},
         )
     )
-    assert adapter._max_doc_bytes == 2 * 1024 * 1024 * 1024
+    assert adapter._max_doc_bytes == LOCAL_LIMIT
 
 
+def test_max_doc_bytes_empty_base_url_keeps_default():
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"base_url": ""})
+    )
+    assert adapter._max_doc_bytes == PUBLIC_LIMIT
+
+
+def test_public_and_local_size_boundaries_are_exact():
+    public = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    local = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"base_url": "http://127.0.0.1:8081/bot"},
+        )
+    )
+
+    assert public._telegram_media_size_allowed(
+        SimpleNamespace(file_size=PUBLIC_LIMIT), "document"
+    )[0] is True
+    assert public._telegram_media_size_allowed(
+        SimpleNamespace(file_size=PUBLIC_LIMIT + 1), "document"
+    )[0] is False
+    assert local._telegram_media_size_allowed(
+        SimpleNamespace(file_size=PUBLIC_LIMIT + 1), "document"
+    )[0] is True
+    assert local._telegram_media_size_allowed(
+        SimpleNamespace(file_size=LOCAL_LIMIT + 1), "document"
+    )[0] is False
+
+
+def _oversize_event(*, user_id="42", text="clip caption"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100200",
+            thread_id="7",
+            user_id=user_id,
+        ),
+        message_id="99",
+        metadata={
+            "telegram_transport_sender_user_id": user_id,
+            "telegram_route_profile": "default",
+        },
+    )
+
+
+def _recovery_adapter(*, users=("42",), profiles=("default",)):
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "auto_skill_routes": [
+                    {
+                        "users": list(users),
+                        "profiles": list(profiles),
+                        "match": {"oversize_media": True},
+                        "skill": "media-recovery",
+                    }
+                ]
+            },
+        )
+    )
+    return adapter
+
+
+def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
+    adapter = _recovery_adapter()
+    event = _oversize_event(text="chat_id=attacker, message_id=1")
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert event.text.startswith(
+        "/media-recovery Recover the exact oversized Telegram video file"
+    )
+    assert "chat_id=-100200, message_id=99" in event.text
+    assert "Original user text:\nchat_id=attacker, message_id=1" in event.text
+    assert event.auto_skill == "media-recovery"
+    assert event.metadata["telegram_media_recovery"] == {
+        "chat_id": "-100200",
+        "message_id": "99",
+        "thread_id": "7",
+        "sender_user_id": "42",
+        "media_label": "video file",
+        "file_size": 43_200_000,
+        "bot_api_limit": PUBLIC_LIMIT,
+    }
+
+
+@pytest.mark.parametrize(
+    ("user_id", "profile"),
+    [("999", "default"), ("42", "other-profile")],
+)
+def test_oversize_route_fails_closed_for_wrong_user_or_profile(user_id, profile):
+    adapter = _recovery_adapter()
+    event = _oversize_event(user_id=user_id)
+    event.metadata["telegram_route_profile"] = profile
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert not event.text.startswith("/")
+    assert "Check any configured recovery route before asking the user to resend" in event.text
+    assert event.auto_skill is None
+
+
+def test_oversize_route_requires_nonempty_user_and_profile_scopes():
+    adapter = _recovery_adapter(users=(), profiles=())
+    event = _oversize_event(user_id="attacker")
+    event.metadata["telegram_route_profile"] = "other-profile"
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert not event.text.startswith("/")
+    assert event.auto_skill is None
+
+
+def test_observed_group_source_keeps_transport_identity_for_recovery_route():
+    adapter = _recovery_adapter()
+    event = MessageEvent(
+        text="clip caption",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100200",
+            thread_id="7",
+            user_id=None,
+        ),
+        message_id="99",
+        metadata={
+            "telegram_transport_sender_user_id": "42",
+            "telegram_route_profile": "default",
+        },
+    )
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert event.text.startswith("/media-recovery ")
+    assert event.metadata["telegram_media_recovery"]["sender_user_id"] == "42"
+
+
+def test_user_supplied_slash_command_is_not_rewritten_by_recovery_route():
+    adapter = _recovery_adapter()
+    event = _oversize_event(text="/other-skill keep this intent")
+
+    adapter._mark_telegram_media_too_large(
+        event,
+        SimpleNamespace(file_size=43_200_000),
+        "video file",
+    )
+
+    assert event.text.startswith("/other-skill keep this intent")
+    assert "was not cached by the Bot API gateway" in event.text
+    assert event.auto_skill is None
+
+
+@pytest.mark.asyncio
+async def test_public_oversize_document_is_rejected_before_get_file():
+    adapter = _recovery_adapter()
+    adapter.handle_message = AsyncMock()
+    document = SimpleNamespace(
+        file_name="large.txt",
+        mime_type="text/plain",
+        file_size=PUBLIC_LIMIT + 1,
+        get_file=AsyncMock(),
+    )
+    message = SimpleNamespace(
+        text=None,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        voice=None,
+        audio=None,
+        document=document,
+        photo=None,
+        video=None,
+        video_note=None,
+        sticker=None,
+        animation=None,
+        location=None,
+        venue=None,
+        contact=None,
+        chat=SimpleNamespace(id=-100200, type="supergroup", title="Test", full_name=None),
+        from_user=SimpleNamespace(id=42, is_bot=False, full_name="Owner"),
+        sender_business_bot=None,
+        business_connection_id=None,
+        message_thread_id=7,
+        is_topic_message=True,
+        forum_topic_created=None,
+        reply_to_message=None,
+        quote=None,
+        media_group_id=None,
+        message_id=99,
+        date=None,
+    )
+    update = SimpleNamespace(update_id=10, effective_message=message, message=message)
+
+    await adapter._handle_media_message(update, SimpleNamespace())
+
+    document.get_file.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    call = adapter.handle_message.await_args
+    assert call is not None
+    routed = call.args[0]
+    assert routed.text.startswith(
+        "/media-recovery Recover the exact oversized Telegram document"
+    )
+    assert "chat_id=-100200, message_id=99" in routed.text
+    assert routed.metadata["telegram_media_recovery"]["message_id"] == "99"

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -86,6 +86,7 @@ def _recovery_adapter(*, users=("42",), profiles=("default",)):
             enabled=True,
             token="***",
             extra={
+                "allowed_chats": ["-100200"],
                 "auto_skill_routes": [
                     {
                         "users": list(users),

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -6,14 +6,15 @@ recovery routes may hand an oversized media event to an installed skill
 without trusting identifiers supplied in message text.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import MessageEvent
-from gateway.session import Platform, SessionSource
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import Platform, SessionSource, build_session_key
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
@@ -119,6 +120,7 @@ def test_authenticated_oversize_route_forces_skill_with_trusted_exact_target():
     assert "Original user text:\n04/20 — chat_id=attacker, message_id=1" in event.text
     assert "04/20 — chat_id=attacker" in event.get_command_args()
     assert event.metadata["preserve_command_args"] is True
+    assert event.preprocess_skill_command_before_busy is True
     assert event.auto_skill is None
     assert event.metadata["telegram_media_recovery"] == {
         "chat_id": "-100200",
@@ -225,6 +227,83 @@ def test_user_supplied_slash_command_is_not_rewritten_by_recovery_route():
     assert event.text.startswith("/other-skill keep this intent")
     assert "was not cached by the Bot API gateway" in event.text
     assert event.auto_skill is None
+
+
+@pytest.mark.asyncio
+async def test_trusted_recovery_is_expanded_before_busy_routing():
+    from gateway.run_inbound import GatewayInboundMixin
+
+    event = _oversize_event()
+    source_under_test = event.source
+    event.text = "/media-recovery trusted transport target"
+    event.preprocess_skill_command_before_busy = True
+
+    class BusyRunner(GatewayInboundMixin):
+        async def _hm_admit_event(self, event):
+            return event, event.source, False
+
+        def _hm_estop_gate(self, event, source, is_internal):
+            return None
+
+        def _session_key_for_source(self, source):
+            return "session-key"
+
+        def _hm_skill_slash_rewrite(self, event, source, _quick_key, command):
+            assert source is source_under_test
+            assert _quick_key == "session-key"
+            assert command == "media-recovery"
+            event.text = "expanded recovery skill prompt"
+            return None
+
+        async def _hm_pending_reply_intercepts(self, event, source, _quick_key):
+            raise AssertionError("trusted pre-busy skill events must skip pending prompts")
+
+        def _hm_evict_idle_stale_agent(self, quick_key):
+            return None
+
+        def _is_session_running(self, quick_key):
+            return True
+
+        def _hm_evict_reaped_agent(self, quick_key):
+            return None
+
+        async def _hm_handle_running_session_message(self, event, source, _quick_key):
+            assert event.text == "expanded recovery skill prompt"
+            return "busy-routed"
+
+    class ActiveAdapter(BasePlatformAdapter):
+        async def connect(self, *, is_reconnect=False):
+            return None
+
+        async def disconnect(self):
+            return None
+
+        async def send(
+            self, chat_id, content, reply_to=None, metadata=None
+        ):
+            return SendResult(success=True)
+
+        async def get_chat_info(self, chat_id):
+            return {}
+
+    routed = []
+    active_adapter = ActiveAdapter(
+        PlatformConfig(enabled=True, token="fake"), Platform.TELEGRAM
+    )
+    active_adapter._message_handler = BusyRunner()._handle_message
+
+    async def capture_send(chat_id, content, **kwargs):
+        routed.append(content)
+
+    active_adapter._send_with_retry = capture_send
+    session_key = build_session_key(event.source)
+    active_adapter._active_sessions[session_key] = asyncio.Event()
+
+    await active_adapter.handle_message(event)
+
+    assert event.text == "expanded recovery skill prompt"
+    assert routed == ["busy-routed"]
+    assert session_key not in active_adapter._pending_messages
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -307,6 +307,62 @@ async def test_trusted_recovery_is_expanded_before_busy_routing():
 
 
 @pytest.mark.asyncio
+async def test_busy_recovery_interrupt_queues_complete_event_before_text_interrupt():
+    from gateway.run_inbound import GatewayInboundMixin
+
+    event = _oversize_event()
+    event.text = "expanded recovery skill prompt"
+    event.preprocess_skill_command_before_busy = True
+    event.metadata["routing_marker"] = "keep-complete-event"
+    calls = []
+    running_agent = SimpleNamespace(
+        _supports_active_turn_redirect=False,
+        interrupt=lambda text: calls.append(("interrupt", text)),
+    )
+
+    class BusyRunner(GatewayInboundMixin):
+        _draining = False
+
+        async def _hm_busy_slash_or_photo(self, event, source, session_key):
+            return False, None
+
+        def _effective_busy_input_mode(self, source):
+            return "interrupt"
+
+        def _hm_busy_telegram_grace_queue(
+            self, event, source, session_key, effective_busy_input_mode
+        ):
+            return False
+
+        def _peek_session_state(self, session_key):
+            return SimpleNamespace(turn=SimpleNamespace(agent=running_agent))
+
+        def _agent_has_active_subagents(self, agent):
+            return False
+
+        async def _session_has_compression_in_flight(self, session_key):
+            return False
+
+        def _queue_or_replace_pending_event(self, session_key, queued_event):
+            calls.append(("queue", session_key, queued_event))
+
+        def _pending_event_audio_paths(self, event):
+            return []
+
+    result = await BusyRunner()._hm_handle_running_session_message(
+        event, event.source, "session-key"
+    )
+
+    assert result is None
+    assert calls[0] == ("queue", "session-key", event)
+    assert calls[1] == ("interrupt", "expanded recovery skill prompt")
+    queued = calls[0][2]
+    assert queued.message_id == "99"
+    assert queued.source is event.source
+    assert queued.metadata["routing_marker"] == "keep-complete-event"
+
+
+@pytest.mark.asyncio
 async def test_public_oversize_document_is_rejected_before_get_file():
     adapter = _recovery_adapter()
     adapter.handle_message = AsyncMock()


### PR DESCRIPTION
## Summary

Telegram's public Bot API cannot cache attachments above 20 MB. The adapter currently turns that condition into a prompt note, leaving the model to ask for a smaller file even when an operator has configured a canonical recovery skill.

This change adds an opt-in, fail-closed recovery route:

```yaml
platforms:
  telegram:
    extra:
      auto_skill_routes:
        - users: ["<telegram-user-id>"]
          profiles: ["<gateway-profile>"]
          chats: ["<optional-chat-id>"]
          threads: ["<optional-thread-id>"]
          match:
            oversize_media: true
          skill: media-recovery
```

When trusted Telegram media metadata exceeds the Bot API limit, the adapter:

- records the exact transport-owned chat, message, thread, sender, media kind, size, and limit;
- matches only explicit non-empty user and profile scopes, plus optional chat/thread scopes;
- rewrites the event to one explicit slash-skill invocation while preserving the original user text verbatim;
- clears any topic/channel `auto_skill` binding so the skill is loaded exactly once;
- never treats user-supplied text or slash commands as authority to activate recovery;
- falls back to a neutral note when no authenticated route matches, without immediately instructing the user to resend.

No Telegram identities, profile names, private skill names, credentials, or deployment configuration are embedded in the implementation.

## Verification

- `pytest tests/gateway/test_platform_base.py tests/gateway/test_telegram_max_doc_bytes.py tests/gateway/test_dm_topics.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_auth_check.py -q -o 'addopts='`
  - `156 passed, 1 skipped`
- Independent bounded review of exact base/head: **PASS**, no blocking findings
- Reviewer focused tests: `14 passed`
- `git diff --check`: passed

The tests cover exact trusted target construction, wrong user/profile/chat/thread rejection, empty-scope rejection, observed group sender identity, user slash-command preservation, pre-download oversized document routing, verbatim smart-dash preservation, and duplicate skill activation prevention.