### PR TITLE
fix(tools): restore executor allowlist on message_agent inject success (#96105)

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -86,6 +86,30 @@ def test_injects_only_into_bot_chat_on_managed_install(tmp_path):
     assert len(agent.tools) == 1
 
 
+def test_restores_allowlist_when_schema_survives_surface_refresh(tmp_path):
+    """#96105: success must restore the executor allowlist on the
+    schema-present branch.
+
+    A long-lived Bot Chat whose tool surface is reconstructed can keep the
+    schema while the executor's allowlist is rebuilt empty. The injector then
+    returned True while dispatch would reject every ``message_agent`` call —
+    advertised but non-dispatchable. Restore-on-success contract: whenever
+    ``ensure_message_agent_tool()`` returns True, ``MESSAGE_AGENT_TOOL_NAME``
+    is in ``valid_tool_names`` whenever that attribute is a set.
+    """
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title="Bot Chat")
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert len(agent.tools) == 1
+
+    # capability refresh: schema survives, executor allowlist rebuilt empty
+    agent.valid_tool_names = set()
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert bot_mode_dm.MESSAGE_AGENT_TOOL_NAME in agent.valid_tool_names
+    # byte-stable: no duplicate schema was appended
+    assert len(agent.tools) == 1
+
+
 @pytest.mark.parametrize(
     "title",
     ["", "My research chat", "Group: room-abc123", "handoff-12ab34cd"],

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -146,6 +146,16 @@ def ensure_message_agent_tool(agent: Any) -> bool:
                     isinstance(tool, dict)
                     and tool.get("function", {}).get("name") == MESSAGE_AGENT_TOOL_NAME
                 ):
+                    # Restore-on-success contract: a successful injection
+                    # must leave the executor allowlist consistent even when
+                    # the schema already exists — a long-lived Bot Chat whose
+                    # tool surface was reconstructed can keep the schema while
+                    # valid_tool_names was rebuilt without it, and returning
+                    # True then would advertise a non-dispatchable tool
+                    # (#96105).
+                    valid = getattr(agent, "valid_tool_names", None)
+                    if isinstance(valid, set):
+                        valid.add(MESSAGE_AGENT_TOOL_NAME)
                     return True
         from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
 


### PR DESCRIPTION
## What Problem This Solves

`ensure_message_agent_tool(agent)` could return `True` while `message_agent` was absent from `agent.valid_tool_names`. The schema-present branch returned immediately without re-establishing the executor allowlist, so a long-lived Bot Chat whose tool surface was reconstructed could advertise the schema while the executor rejected every `message_agent` call — advertised but non-dispatchable (#96105).

The fix enforces the restore-on-success contract: whenever injection succeeds, the schema exists in `agent.tools` **and** `MESSAGE_AGENT_TOOL_NAME` is in `valid_tool_names` whenever that attribute is a set. The append path already did this; the schema-present path now does too. Failure paths (non-Bot session, unmanaged install, config-disabled protocol) are unchanged and still return `False` without touching either attribute.

## Evidence

**Regression test** (`tests/tools/test_bot_mode_dm.py::test_restores_allowlist_when_schema_survives_surface_refresh`):

- Pre-fix (origin/main): RED — `AssertionError: assert 'message_agent' in set()` — exactly the reported broken invariant.
- Post-fix: GREEN — schema survives a capability refresh, allowlist is rebuilt empty, the next injection restores the name and stays byte-stable (no duplicate schema).

**Coverage map** (issue's required regression coverage):
1. Schema absent + allowlist absent → appended and allowed — existing `test_injects_only_into_bot_chat_on_managed_install`
2. Schema present + allowlist present → idempotent no-op — existing test's second call
3. Schema present + allowlist absent → name restored — new test
4. Non-Bot session → neither changed — existing `test_never_injects_outside_bot_chat`
5. Config-disabled protocol → neither changed — existing `test_config_toggle_disables_injection`
6. Capability refresh retains executable `message_agent` — new test

**Suites**: `tests/tools/test_bot_mode_dm.py` + `tests/tools/test_bot_relay.py` → 63 passed, 1 skipped, 2 deselected (the 2 deselected are pre-existing POSIX-only `_dm_dir` stat/uid tests that fail identically on pristine `origin/main` under Windows; unrelated to this change).

No duplicate PRs exist for this issue (`gh pr list --search "96105"` and `message_agent injector` variants → empty). Sibling reconstruction paths (`refresh_agent_mcp_tools`, ACP server refresh) publish `(tools, valid_tool_names)` atomically, so the injector is the only place that needs the restore.

Closes #96105
