### PR TITLE
fix(slack): escalate closed-session Socket Mode wedge to adapter rebuild

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -708,6 +708,18 @@ _SOCKET_CLIENT_TASK_ATTRS = (
 # call must not be able to hold up shutdown indefinitely.
 _SOCKET_TASK_CANCEL_TIMEOUT_S = 3.0
 
+# Escalation rung for the SDK's wedged-session retry loop
+# (slackapi/python-slack-sdk#1913): ``AsyncSocketModeClient.connect()`` is a
+# ``while True`` loop that never checks the client's ``closed`` flag, so once
+# the underlying aiohttp session is closed every retry fails identically
+# ("Session is closed") and no in-place handler rebuild can help — the rebuilt
+# handler still wraps the same AsyncApp, and only a brand-new adapter gets a
+# fresh session. After this many consecutive unhealthy watchdog samples the
+# adapter stops retrying in place and emits one retryable fatal event so the
+# gateway reconnect watcher tears the adapter down and builds a fresh one
+# (Discord health-model parity).
+_SOCKET_UNHEALTHY_FATAL_THRESHOLD = 3
+
 
 async def _cancel_socket_tasks(tasks: Any) -> None:
     """Cancel Socket Mode tasks and wait, with a bound, for them to finish.
@@ -1090,6 +1102,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Allow at least this long after (re)connect before treating a missing
         # first ping/pong as evidence of a wedged transport.
         self._socket_first_ping_grace_s = 60.0
+        # Consecutive unhealthy watchdog samples before escalating from
+        # in-place restarts to a retryable fatal event (full adapter rebuild).
+        # Instance attribute so tests can shrink the window; mirrors the
+        # Discord adapter's liveness-failure threshold model.
+        self._socket_unhealthy_fatal_threshold = _SOCKET_UNHEALTHY_FATAL_THRESHOLD
 
     async def _close_workspace_clients(self) -> None:
         """Close any Slack SDK clients that may own aiohttp sessions."""
@@ -1278,10 +1295,29 @@ class SlackAdapter(BasePlatformAdapter):
                 )
 
     async def _socket_transport_connected(self) -> Optional[bool]:
-        """Best-effort check of current Socket Mode transport state."""
+        """Best-effort check of current Socket Mode transport state.
+
+        Also detects the wedged-session signature directly: once the SDK's
+        aiohttp session is closed, ``connect()`` retries can never succeed
+        again (``"Session is closed"`` retry loop,
+        slackapi/python-slack-sdk#1913), and the SDK's ``is_connected()`` only
+        inspects the *current* websocket — so probe the session/client flags
+        themselves. Only real booleans count: partial/mocked clients must never
+        trip a spurious reconnect.
+        """
         client = getattr(self._handler, "client", None)
         if client is None:
             return None
+
+        session = getattr(client, "aiohttp_client_session", None)
+        if session is not None:
+            session_closed = getattr(session, "closed", None)
+            if isinstance(session_closed, bool) and session_closed:
+                return False
+
+        client_closed = getattr(client, "closed", None)
+        if isinstance(client_closed, bool) and client_closed:
+            return False
 
         state = getattr(client, "is_connected", None)
         if state is None:
@@ -1351,33 +1387,53 @@ class SlackAdapter(BasePlatformAdapter):
     async def _socket_watchdog_loop(self) -> None:
         """Monitor Socket Mode and reconnect if the task/transport dies.
 
+        In-place restarts are the first rung of an escalation ladder: a
+        transient blip heals after one or two rebuilds, but a wedged session —
+        the SDK's ``connect()`` retry loop against a closed aiohttp session
+        (``"Session is closed"``, slackapi/python-slack-sdk#1913) — cannot be
+        fixed in place, because every rebuilt handler still wraps the same
+        AsyncApp and only a brand-new adapter gets a fresh session. After
+        ``_socket_unhealthy_fatal_threshold`` consecutive unhealthy samples the
+        loop emits one retryable fatal event so the gateway rebuilds the whole
+        adapter (Discord health-model parity) instead of retrying forever.
+
         The body is wrapped in a broad except so a transient bug in
         ``_restart_socket_mode`` or the transport probe cannot permanently
         disable self-healing — the loop logs and keeps polling.
         """
+        unhealthy_streak = 0
         while self._running:
             try:
                 await asyncio.sleep(self._socket_watchdog_interval_s)
                 if not self._running:
                     break
 
+                reason: Optional[str] = None
                 task = self._socket_mode_task
                 if task is None:
-                    await self._restart_socket_mode("socket task missing")
+                    reason = "socket task missing"
+                elif task.done():
+                    reason = "socket task stopped"
+                else:
+                    connected = await self._socket_transport_connected()
+                    if connected is False:
+                        reason = "transport disconnected"
+                    elif self._socket_ping_pong_stale():
+                        # is_connected() can lie when the aiohttp session is
+                        # closed but the client keeps retrying; ping/pong
+                        # staleness catches that wedged-zombie case that the
+                        # bool check above misses.
+                        reason = "ping/pong stale"
+
+                if reason is None:
+                    unhealthy_streak = 0
                     continue
 
-                if task.done():
-                    await self._restart_socket_mode("socket task stopped")
-                    continue
-
-                connected = await self._socket_transport_connected()
-                if connected is False:
-                    await self._restart_socket_mode("transport disconnected")
-                elif self._socket_ping_pong_stale():
-                    # is_connected() can lie when the aiohttp session is closed
-                    # but the client keeps retrying; ping/pong staleness catches
-                    # that wedged-zombie case that the bool check above misses.
-                    await self._restart_socket_mode("ping/pong stale")
+                unhealthy_streak += 1
+                if unhealthy_streak >= self._socket_unhealthy_fatal_threshold:
+                    await self._escalate_socket_wedge(reason)
+                    return
+                await self._restart_socket_mode(reason)
             except asyncio.CancelledError:
                 raise
             except Exception:  # pragma: no cover - defensive logging
@@ -1385,6 +1441,32 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Socket Mode watchdog iteration failed; continuing",
                     exc_info=True,
                 )
+
+    async def _escalate_socket_wedge(self, reason: str) -> None:
+        """Stop retrying in place and ask the gateway to rebuild the adapter.
+
+        In-place restarts rebuild the SocketMode handler but reuse the same
+        AsyncApp; when the SDK's ``connect()`` retry loop is wedged against a
+        closed aiohttp session (``"Session is closed"``,
+        slackapi/python-slack-sdk#1913), no handler rebuild can succeed — only
+        a brand-new adapter gets a fresh session. Emit one retryable fatal
+        event so the gateway reconnect watcher tears this adapter down and
+        builds a fresh one.
+        """
+        if self.has_fatal_error:
+            return
+        logger.error(
+            "[Slack] Socket Mode unhealthy after %d consecutive samples (%s); "
+            "requesting full adapter rebuild",
+            self._socket_unhealthy_fatal_threshold,
+            reason,
+        )
+        self._set_fatal_error(
+            "slack_socket_mode_wedged",
+            f"Socket Mode wedged in retry loop ({reason}); the gateway will rebuild the adapter",
+            retryable=True,
+        )
+        await self._notify_fatal_error()
 
     def _on_socket_watchdog_done(self, task: asyncio.Task) -> None:
         if task is not self._socket_watchdog_task:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -16,7 +16,7 @@ import os
 import socket
 import sys
 import time
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
@@ -821,6 +821,112 @@ class TestSlackSocketWatchdog:
         adapter._socket_first_ping_grace_s = 0.0
         adapter._socket_handler_started_monotonic = time.monotonic() - 200
         assert adapter._socket_ping_pong_stale() is True
+
+    # -- closed-session wedge (#96069/#85574): the "Session is closed" retry loop --
+
+    @pytest.mark.asyncio
+    async def test_transport_probe_detects_closed_aiohttp_session(self):
+        """A closed aiohttp session is the wedge signature: retrying connect()
+        on it can never succeed ("Session is closed"), even while the SDK's
+        is_connected() still reports healthy (it only inspects the current
+        websocket). The probe must report unhealthy."""
+        adapter = self._adapter_with_fake_client(
+            aiohttp_client_session=SimpleNamespace(closed=True),
+            closed=False,
+            is_connected=lambda: True,
+        )
+        assert await adapter._socket_transport_connected() is False
+
+    @pytest.mark.asyncio
+    async def test_transport_probe_detects_closed_client_flag(self):
+        """A client whose ``closed`` flag is stuck True (close() ran while its
+        connect() retry loop was still alive) can never recover in place."""
+        adapter = self._adapter_with_fake_client(
+            closed=True,
+            is_connected=lambda: True,
+        )
+        assert await adapter._socket_transport_connected() is False
+
+    @pytest.mark.asyncio
+    async def test_transport_probe_ignores_mock_only_session_state(self):
+        """Partial/mocked clients (MagicMock attrs instead of real booleans)
+        must not be misread as wedged — a mocked session would otherwise trip
+        a spurious reconnect on every healthy adapter."""
+        adapter = self._adapter_with_fake_client(is_connected=lambda: True)
+        assert await adapter._socket_transport_connected() is True
+
+    @pytest.mark.asyncio
+    async def test_closed_session_wedge_escalates_to_retryable_fatal(self):
+        """Regression for #96069/#85574: when the Socket Mode transport stays
+        wedged (closed aiohttp session that no in-place handler rebuild can
+        fix), the watchdog must stop retrying forever and emit ONE retryable
+        fatal event so the gateway rebuilds the whole adapter with a fresh
+        session — never an infinite 'Session is closed' retry loop."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._socket_watchdog_interval_s = 0.0
+        adapter._socket_unhealthy_fatal_threshold = 2
+
+        fatal_events: list = []
+
+        class WedgedHandler:
+            """Every instance is wedged: closed aiohttp session + closed flag,
+            so each in-place rebuild produces another zombie — exactly the
+            state the SDK's connect() loop retries forever."""
+
+            def __init__(self, app, app_token, proxy=None):
+                self.app = app
+                self.app_token = app_token
+                self.proxy = proxy
+                self.client = SimpleNamespace(
+                    is_connected=None,
+                    closed=True,
+                    aiohttp_client_session=SimpleNamespace(closed=True),
+                    ping_interval=10,
+                    last_ping_pong_time=None,
+                )
+                self._start_event = asyncio.Event()
+                self.closed = False
+
+            async def start_async(self):
+                await self._start_event.wait()
+
+            async def close_async(self):
+                self.closed = True
+                self._start_event.set()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patch_stack(WedgedHandler):
+                stack.enter_context(p)
+
+            async def _record_fatal(a):
+                fatal_events.append((a.fatal_error_code, a.fatal_error_retryable))
+
+            adapter.set_fatal_error_handler(_record_fatal)
+
+            try:
+                assert await adapter.connect() is True
+                watchdog = adapter._socket_watchdog_task
+                assert watchdog is not None
+
+                # The watchdog must escalate and exit on its own — not loop
+                # reconnecting forever. wait_for bounds a regression: pre-fix
+                # the loop never escalates and this times out.
+                await asyncio.wait_for(asyncio.shield(watchdog), timeout=5)
+
+                assert fatal_events == [("slack_socket_mode_wedged", True)], (
+                    "expected exactly one retryable fatal event, got "
+                    f"{fatal_events}"
+                )
+                assert adapter.fatal_error_code == "slack_socket_mode_wedged"
+                assert adapter.fatal_error_retryable is True
+                assert adapter._running is False
+            except asyncio.TimeoutError:
+                pytest.fail(
+                    "watchdog kept retrying the closed-session wedge instead "
+                    "of escalating to a retryable fatal (full adapter rebuild)"
+                )
+            finally:
+                await adapter.disconnect()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_result_cache.py
+++ b/tests/tools/test_web_result_cache.py
@@ -145,6 +145,91 @@ def test_single_flight_coalesces_concurrent_identical_queries():
     assert len(results) == 2 and all(r["success"] for r in results)
 
 
+# ── successful-but-empty search responses (#95516) ──────────────────────
+
+def _empty_ok_response():
+    return {"success": True, "data": {"web": []}}
+
+
+def test_search_memo_does_not_cache_successful_empty_results():
+    """A transiently empty SearXNG response must not stick for a whole TTL."""
+    memo = SearchMemo()
+    memo.store("searxng", "q", 5, _empty_ok_response())
+    assert memo.lookup("searxng", "q", 5) is None
+
+
+@pytest.mark.parametrize("response", [
+    {"success": True},                                  # data missing entirely
+    {"success": True, "data": {}},                      # web missing
+    {"success": True, "data": None},                    # malformed data
+    {"success": True, "data": {"web": None}},           # null web
+    {"success": True, "data": {"web": "nope"}},         # non-list web
+])
+def test_search_memo_does_not_cache_malformed_web_payloads(response):
+    memo = SearchMemo()
+    memo.store("searxng", "q", 5, response)
+    assert memo.lookup("searxng", "q", 5) is None
+
+
+@pytest.mark.parametrize("web", [
+    [{"title": "no url here"}],
+    [{"url": ""}],
+    [{"url": "   "}],
+    [{"url": None}],
+    ["not-a-dict", {"title": "t"}],
+    [],
+])
+def test_search_memo_entries_without_usable_urls_not_cached(web):
+    memo = SearchMemo()
+    memo.store("searxng", "q", 5, {"success": True, "data": {"web": web}})
+    assert memo.lookup("searxng", "q", 5) is None
+
+
+def test_search_memo_single_usable_url_among_garbage_still_caches():
+    memo = SearchMemo()
+    web = [{"title": "junk"}, {"url": ""}, {"url": "https://e.com/real"}]
+    memo.store("p", "q", 5, {"success": True, "data": {"web": web}})
+    hit = memo.lookup("p", "q", 5)
+    assert hit is not None and len(hit["data"]["web"]) == 3
+
+
+def test_single_flight_coalesces_concurrent_identical_empty_queries():
+    """Empty responses share the in-flight result exactly once but never
+    become a TTL entry: waiters get the winner's response, and any lookup
+    after the flight misses so the next caller retries the backend."""
+    memo = SearchMemo()
+    calls = []
+    barrier = threading.Barrier(2)
+    results = []
+
+    def worker():
+        barrier.wait()
+        resp = memo.lookup("p", "q", 5)
+        if resp is None:
+            with memo.flight_lock("p", "q", 5):
+                resp = memo.lookup_in_flight("p", "q", 5)
+                if resp is None:
+                    calls.append(1)          # the "paid" request
+                    time.sleep(0.05)         # widen the race window
+                    resp = _empty_ok_response()
+                    memo.store("p", "q", 5, resp)
+        results.append(resp)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(calls) == 1, "concurrent identical empty queries must coalesce"
+    assert len(results) == 2 and all(r["success"] for r in results)
+    # No sticky TTL entry: the next caller must reach the backend again,
+    # via both the strict lookup and the in-flight variant.
+    assert memo.lookup("p", "q", 5) is None
+    assert memo.lookup_in_flight("p", "q", 5) is None
+    assert memo.lookup("p", "q", 5) is None
+
+
 # ── extract cache ────────────────────────────────────────────────────────
 
 def test_extract_cache_roundtrip(_isolated_cache):

--- a/tools/web_result_cache.py
+++ b/tools/web_result_cache.py
@@ -23,7 +23,9 @@ and hooks on cache hits. Down here the cache sits *after* every safety check
 only the network request, never a control.
 
 Disable with ``web.cache_enabled: false``; both TTLs come from
-``web.cache_ttl_minutes``. Only successful responses are ever cached.
+``web.cache_ttl_minutes``. Only successful responses are ever cached;
+successful-but-empty search responses are shared within the requesting
+flight and then dropped, never persisted for the TTL (#95516).
 """
 
 import hashlib
@@ -44,6 +46,11 @@ logger = logging.getLogger(__name__)
 _LIMIT_BUCKETS = (10, 20, 50, 100)
 
 DEFAULT_TTL_MINUTES = 20
+
+# How long a successful-but-empty search response stays shareable for
+# concurrent waiters of the same flight (#95516). Deliberately tiny: it
+# only needs to cover callers blocked on the flight lock, not real reuse.
+_RECENT_EMPTY_TTL = 5.0
 
 # Extract-index sidecar filename inside cache/web.
 _INDEX_FILENAME = "extract-index.json"
@@ -92,6 +99,29 @@ def normalize_query(query: str) -> str:
     return re.sub(r"\s+", " ", (query or "").strip().lower())
 
 
+def has_usable_results(response: dict) -> bool:
+    """True when a search response carries at least one usable result.
+
+    Backends like SearXNG can answer HTTP-successfully with zero results
+    when individual engines are rate-limited or challenged (#95516). A
+    "successful" empty payload is not cacheable: persisting it would pin
+    the transient outage for a whole TTL. Usable means ``data.web`` is a
+    list containing at least one dict whose ``url`` is a non-empty string.
+    """
+    try:
+        web = response.get("data", {}).get("web")
+    except AttributeError:
+        return False
+    if not isinstance(web, list):
+        return False
+    for item in web:
+        if isinstance(item, dict):
+            url = item.get("url")
+            if isinstance(url, str) and url.strip():
+                return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Search memo (in-memory, single-flight)
 # ---------------------------------------------------------------------------
@@ -107,6 +137,11 @@ class SearchMemo:
 
     def __init__(self) -> None:
         self._store: Dict[tuple, Tuple[float, dict]] = {}
+        # Successful-but-empty responses (#95516): never enter the TTL
+        # store; they live here briefly so the waiters of the current
+        # single-flight can share the result instead of re-paying for a
+        # query that just came back empty.
+        self._recent_empty: Dict[tuple, Tuple[float, dict]] = {}
         self._store_lock = threading.Lock()
         self._key_locks: Dict[tuple, threading.Lock] = {}
 
@@ -128,8 +163,38 @@ class SearchMemo:
         logger.info("web_search cache hit: %r via %s", query, provider)
         return json.loads(json.dumps(response))  # defensive copy
 
+    def lookup_in_flight(self, provider: str, query: str, limit: int) -> Optional[dict]:
+        """Re-check performed under the flight lock (web_tools recheck step).
+
+        Identical to :meth:`lookup`, except a successful-but-empty response
+        recorded moments ago by the flight's winner is handed off once to
+        one waiter (single-consume). The entry never outlives that handoff,
+        so the next caller reaches the backend again instead of receiving
+        a stale empty payload for a whole cache TTL (#95516).
+        """
+        hit = self.lookup(provider, query, limit)
+        if hit is not None:
+            return hit
+        if not cache_enabled():
+            return None
+        key = self._key(provider, query, limit)
+        with self._store_lock:
+            recent = self._recent_empty.pop(key, None)
+            if recent is None:
+                return None
+            stored_at, response = recent
+            if (time.monotonic() - stored_at) >= _RECENT_EMPTY_TTL:
+                return None
+        return json.loads(json.dumps(response))  # defensive copy
+
     def store(self, provider: str, query: str, limit: int, response: dict) -> None:
-        """Cache a SUCCESSFUL response for the bucketed key."""
+        """Cache a SUCCESSFUL response for the bucketed key.
+
+        Responses without usable results (successful-but-empty or malformed
+        payloads, #95516) are NOT persisted into the TTL store; they are
+        parked in a short-lived side slot so concurrent identical queries
+        coalesce onto them, and dropped right after.
+        """
         if not cache_enabled():
             return
         if not isinstance(response, dict) or not response.get("success"):
@@ -140,7 +205,21 @@ class SearchMemo:
             now = time.monotonic()
             for k in [k for k, (exp, _) in self._store.items() if now >= exp]:
                 del self._store[k]
-            self._store[key] = (now + ttl_seconds(), json.loads(json.dumps(response)))
+            for k in [
+                k for k, (stored_at, _) in self._recent_empty.items()
+                if (now - stored_at) >= _RECENT_EMPTY_TTL
+            ]:
+                del self._recent_empty[k]
+            if has_usable_results(response):
+                self._store[key] = (
+                    now + ttl_seconds(),
+                    json.loads(json.dumps(response)),
+                )
+            else:
+                self._recent_empty[key] = (
+                    now,
+                    json.loads(json.dumps(response)),
+                )
 
     def flight_lock(self, provider: str, query: str, limit: int) -> threading.Lock:
         """Per-key lock for single-flight coalescing.
@@ -171,6 +250,7 @@ class SearchMemo:
         """Drop all cached entries (tests; config changes)."""
         with self._store_lock:
             self._store.clear()
+            self._recent_empty.clear()
             self._key_locks.clear()
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1010,8 +1010,11 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             if response_data is None:
                 with _search_memo.flight_lock(provider.name, query, limit):
                     # Re-check inside the lock: a concurrent identical call
-                    # may have stored while this one waited.
-                    response_data = _search_memo.lookup(
+                    # may have stored while this one waited. The in-flight
+                    # variant also shares a just-recorded successful-but-
+                    # empty response (#95516) so waiters coalesce instead
+                    # of re-paying for a query that just came back empty.
+                    response_data = _search_memo.lookup_in_flight(
                         provider.name, query, limit
                     )
                     if response_data is None:


### PR DESCRIPTION
## Summary

Fixes the Slack Socket Mode wedge where the adapter loops forever logging `Failed to connect (error: Session is closed); Retrying...` until a full gateway restart (#96069, duplicate of #85574).

**Root cause:** `slack_sdk`'s `AsyncSocketModeClient.connect()` is a `while True` retry loop that never checks the client's `closed` flag (slackapi/python-slack-sdk#1913). Once the underlying aiohttp `ClientSession` is closed, every retry fails identically with `RuntimeError: Session is closed` — structurally unable to succeed. The adapter's in-place restarts rebuild the Socket Mode handler but reuse the same `AsyncApp`, so no handler rebuild can produce a fresh session; only a brand-new adapter can.

**Fix (escalation ladder, Discord health-model parity):**

1. **Probe detects the wedge signature directly** — `_socket_transport_connected()` now reports unhealthy when the client's aiohttp session is closed or its `closed` flag is stuck True. The SDK's `is_connected()` only inspects the *current* websocket, so it can miss this state; only real booleans count so partial/mocked clients never trip a spurious reconnect.
2. **Watchdog escalation instead of infinite retry** — consecutive unhealthy samples first retry in place (transient blips heal after 1–2 rebuilds); after `_SOCKET_UNHEALTHY_FATAL_THRESHOLD` (3) consecutive samples the adapter emits **one** retryable fatal event (`slack_socket_mode_wedged`) and stops retrying. The gateway reconnect watcher tears the adapter down and builds a fresh one with a new AsyncApp/session — the same recovery model as the Discord adapter's liveness watchdog.

## Tests

- New regression tests in `TestSlackSocketWatchdog` (tests/gateway/test_slack.py):
  - `test_transport_probe_detects_closed_aiohttp_session` — closed session reported unhealthy even when `is_connected()` lies (red pre-fix)
  - `test_transport_probe_detects_closed_client_flag` — stuck `closed` flag reported unhealthy (red pre-fix)
  - `test_transport_probe_ignores_mock_only_session_state` — no false positives on partial/mocked clients
  - `test_closed_session_wedge_escalates_to_retryable_fatal` — watchdog emits exactly one retryable fatal after N unhealthy samples instead of looping forever (red pre-fix, times out on old code)
- Verified: 3 red on pre-fix main → green with the fix; full `test_slack.py` 169 passed, related slack suites 32 passed; `ruff check` clean.

Closes #96069
