### PR TITLE
fix(opencode): route opencode-go vision models natively; pin family endpoint

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -1198,7 +1198,7 @@ def get_model_capabilities(
 
     # If no catalog entry and no override, we can't resolve capabilities.
     if entry is None and override is None:
-        return None
+        return _opencode_vision_fallback(provider, model)
 
     # Start from catalog entry (if found), else use defaults.
     if entry is not None:
@@ -1263,6 +1263,41 @@ def get_model_capabilities(
         context_window=context_window,
         max_output_tokens=max_output_tokens,
         model_family=model_family,
+    )
+
+
+def _opencode_vision_fallback(provider: str, model: str) -> Optional[ModelCapabilities]:
+    """Vision-capable stub for OpenCode-family models absent from models.dev.
+
+    OpenCode Zen/Go resell vendor models, and experimental previews (e.g.
+    ``deepseek-v4-flash-vision-exp``, issue #96066) routinely reach the
+    relay before models.dev picks them up. With an empty or stale registry
+    those models resolve to ``None`` here, so ``image_input_mode: auto``
+    treats them as text-only and routes user-attached images through the
+    lossy ``vision_analyze`` describe path instead of native pixels. A
+    ``-vision`` slug token is an unambiguous vision marker for this family,
+    so fill the catalog gap deterministically rather than depending on
+    registry freshness.
+
+    Only fires on a complete catalog miss (no entry, no override), matching
+    the ``model_overrides._default`` fill-gap semantics. Returns None for
+    non-OpenCode providers and for models without the marker, so unknown
+    models keep their current "unknown" behavior elsewhere.
+    """
+    from hermes_cli.models import opencode_provider_family
+
+    if opencode_provider_family(provider) is None:
+        return None
+    bare = str(model or "").strip().rsplit("/", 1)[-1]
+    if "-vision" not in bare.lower():
+        return None
+    return ModelCapabilities(
+        supports_tools=True,
+        supports_vision=True,
+        supports_reasoning=False,
+        context_window=200000,
+        max_output_tokens=8192,
+        model_family="opencode",
     )
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -41,6 +41,7 @@ rather than parsing the raw JSON themselves.
 
 import json
 import logging
+import re
 import threading
 import time
 from dataclasses import dataclass
@@ -1266,6 +1267,15 @@ def get_model_capabilities(
     )
 
 
+# Anchored slug pattern for the OpenCode vision fill-gap (#96066): the
+# qualified identifier (family prefix + model id, e.g.
+# ``opencode-go/deepseek-v4-flash-vision-exp``) must start with an
+# opencode family slug and carry a ``vision`` marker. Deliberately narrow —
+# the fallback must never fabricate a capability profile, so anything that
+# does not match stays "unknown" for the rest of the pipeline.
+_OPENCODE_VISION_SLUG_RE = re.compile(r"^opencode-(?:go|zen|free).*vision", re.IGNORECASE)
+
+
 def _opencode_vision_fallback(provider: str, model: str) -> Optional[ModelCapabilities]:
     """Vision-capable stub for OpenCode-family models absent from models.dev.
 
@@ -1274,22 +1284,42 @@ def _opencode_vision_fallback(provider: str, model: str) -> Optional[ModelCapabi
     relay before models.dev picks them up. With an empty or stale registry
     those models resolve to ``None`` here, so ``image_input_mode: auto``
     treats them as text-only and routes user-attached images through the
-    lossy ``vision_analyze`` describe path instead of native pixels. A
-    ``-vision`` slug token is an unambiguous vision marker for this family,
-    so fill the catalog gap deterministically rather than depending on
-    registry freshness.
+    lossy ``vision_analyze`` describe path instead of native pixels.
 
-    Only fires on a complete catalog miss (no entry, no override), matching
-    the ``model_overrides._default`` fill-gap semantics. Returns None for
-    non-OpenCode providers and for models without the marker, so unknown
-    models keep their current "unknown" behavior elsewhere.
+    Contract — vision is claimed ONLY when ALL of these hold:
+
+    1. **Complete catalog miss.** The caller invokes this only when the
+       catalog has no entry for the model AND no ``model_overrides`` entry
+       exists (mirroring ``model_overrides._default`` fill-gap semantics).
+       A catalog entry — even one declaring no vision — stays authoritative
+       and the fallback must not fire.
+    2. **OpenCode family membership.** ``opencode_provider_family`` must
+       resolve the provider (built-in slug or name-extended custom family
+       proxy).
+    3. **Anchored slug pattern.** The qualified identifier
+       ``<provider>/<model>`` matches ``^opencode-(go|zen|free).*vision``,
+       with the ``vision`` marker itself living in the model id — never in
+       a provider name that merely extends a family slug (e.g.
+       ``opencode-go-vision-proxy`` must not vouch for a non-vision model).
+
+    Anything else returns None, so unknown models keep their current
+    "unknown" behavior everywhere downstream.
     """
     from hermes_cli.models import opencode_provider_family
 
     if opencode_provider_family(provider) is None:
         return None
-    bare = str(model or "").strip().rsplit("/", 1)[-1]
-    if "-vision" not in bare.lower():
+    bare = str(model or "").strip().lstrip("/")
+    if not bare:
+        return None
+    # The marker must be in the model id itself; a provider name that
+    # happens to contain "vision" must not vouch for a text-only model.
+    if "vision" not in bare.lower():
+        return None
+    # Anchor the family prefix on the qualified identifier so bare ids
+    # under a family provider (deepseek-v4-flash-vision-exp on
+    # opencode-go) and already-qualified ids both match.
+    if _OPENCODE_VISION_SLUG_RE.match(f"{provider}/{bare}") is None:
         return None
     return ModelCapabilities(
         supports_tools=True,

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -79,6 +79,27 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", None) == "native"
 
+    def test_opencode_vision_exp_model_attaches_native_without_catalog(self):
+        """#96066: deepseek-v4-flash-vision-exp on opencode-go must route
+        user-attached images as native pixels (``auto`` mode) even when the
+        models.dev registry has no entry for the exp model — the OpenCode
+        ``*-vision*`` fallback in models_dev fills the gap."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            assert (
+                decide_image_input_mode(
+                    "opencode-go", "deepseek-v4-flash-vision-exp", {}
+                )
+                == "native"
+            )
+
+    def test_opencode_text_model_stays_text_without_catalog(self):
+        """No vision marker → no fallback → unknown model routes to text."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            assert (
+                decide_image_input_mode("opencode-go", "deepseek-v4-flash", {})
+                == "text"
+            )
+
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1365,3 +1365,64 @@ class TestOpencodeVisionFallback:
         assert caps is not None
         assert caps.supports_vision is False
         assert caps.context_window == 1000000
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_catalog_entry_without_attachment_stays_authoritative(self, _mock):
+        """Gap-pin: a models.dev entry that exists but declares no vision —
+        no ``attachment`` field and no image input modality — must keep its
+        authoritative judgment (vision OFF). The fallback must not fire for
+        a catalog-known model, even when the slug carries the vision marker:
+        capability profiles are never fabricated for known models."""
+        registry = {
+            "opencode-go": {
+                "id": "opencode-go",
+                "models": {
+                    "deepseek-v4-flash-vision-exp": {
+                        "id": "deepseek-v4-flash-vision-exp",
+                        "tool_call": True,
+                        "modalities": {"input": ["text"]},
+                        "limit": {"context": 500000, "output": 4096},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("opencode-go", "deepseek-v4-flash-vision-exp")
+        assert caps is not None
+        assert caps.supports_vision is False
+        # Catalog metadata still wins over the fallback stub's defaults.
+        assert caps.supports_tools is True
+        assert caps.context_window == 500000
+        assert caps.max_output_tokens == 4096
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_vision_marker_in_provider_name_does_not_count(self, _mock):
+        """A provider name that merely extends a family slug with ``vision``
+        must not vouch for a text-only model — the marker has to live in the
+        model id itself (anchored slug pattern, #96066)."""
+        caps = get_model_capabilities(
+            "opencode-go-vision-proxy", "deepseek-v4-flash"
+        )
+        assert caps is None
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_qualified_model_id_still_matches(self, _mock):
+        """An already-qualified model id (family prefix in the slug itself)
+        matches the anchored pattern exactly like a bare id does."""
+        caps = get_model_capabilities(
+            "opencode-go", "opencode-go/deepseek-v4-flash-vision-exp"
+        )
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_opencode_free_family_gets_the_same_fallback(self, _mock):
+        caps = get_model_capabilities("opencode-free", "deepseek-v4-flash-vision-exp")
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_empty_model_stays_unknown(self, _mock):
+        """No model id → no capability claim, even under a family provider."""
+        assert get_model_capabilities("opencode-go", "") is None
+        assert get_model_capabilities("opencode-go", None) is None

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1305,3 +1305,63 @@ class TestModelOverrides:
         assert info is not None
         assert "image" in info.input_modalities
         assert info.attachment is True
+
+
+# ---------------------------------------------------------------------------
+# OpenCode-family vision fallback (no models.dev entry) — #96066
+# ---------------------------------------------------------------------------
+
+
+class TestOpencodeVisionFallback:
+    """OpenCode ``*-vision*`` models stay vision-capable without catalog data.
+
+    ``deepseek-v4-flash-vision-exp`` on opencode-go is a VL model, but exp
+    previews routinely reach the OpenCode relay before models.dev picks them
+    up. With an empty/stale registry the catalog lookup misses and
+    ``image_input_mode: auto`` would route images through the text
+    vision_analyze path instead of native pixels (#96066). A ``-vision``
+    slug token is an unambiguous marker for this family, so fill the gap.
+    """
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_opencode_go_vision_exp_model_is_vision_capable(self, _mock):
+        caps = get_model_capabilities("opencode-go", "deepseek-v4-flash-vision-exp")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_tools is True
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_opencode_zen_family_gets_the_same_fallback(self, _mock):
+        caps = get_model_capabilities("opencode-zen", "deepseek-v4-flash-vision-exp")
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_opencode_model_without_vision_marker_stays_unknown(self, _mock):
+        caps = get_model_capabilities("opencode-go", "deepseek-v4-flash")
+        assert caps is None
+
+    @patch("agent.models_dev.fetch_models_dev", return_value={})
+    def test_vision_marker_ignored_for_non_opencode_providers(self, _mock):
+        caps = get_model_capabilities("deepseek", "deepseek-v4-flash-vision-exp")
+        assert caps is None
+
+    def test_catalog_entry_still_authoritative_when_present(self):
+        """The fallback is fill-gap only — a catalog entry (even one that
+        declares no vision) must win over the name heuristic."""
+        registry = {
+            "opencode-go": {
+                "id": "opencode-go",
+                "models": {
+                    "deepseek-v4-flash-vision-exp": {
+                        "id": "deepseek-v4-flash-vision-exp",
+                        "limit": {"context": 1000000, "output": 16384},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("opencode-go", "deepseek-v4-flash-vision-exp")
+        assert caps is not None
+        assert caps.supports_vision is False
+        assert caps.context_window == 1000000

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -262,3 +262,87 @@ def test_make_agent_still_honors_persisted_override_for_non_opencode_provider():
     assert call_kwargs["provider"] == "anthropic"
     assert call_kwargs["api_mode"] == "anthropic_messages"
     assert call_kwargs["base_url"].rstrip("/") == "https://api.anthropic.com"
+
+
+def test_custom_family_name_proxy_gets_model_derived_api_mode_keeps_custom_base_url():
+    """Boundary: a CUSTOM provider whose name extends a family slug (e.g.
+    ``opencode-go-bridge`` at a private relay, #85589) gets the same
+    model-derived api_mode as the built-ins — a stale persisted
+    anthropic_messages must not win — while its own non-opencode.ai
+    endpoint is preserved, not replaced by the opencode.ai default."""
+    fresh_runtime = {
+        "provider": "opencode-go-bridge",
+        "base_url": "https://my-relay.example/v1",
+        "api_key": "sk-bridge-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    stale_override = {
+        "model": "deepseek-v4-flash-vision-exp",
+        "provider": "opencode-go-bridge",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+    }
+    call_kwargs = _make_agent_with_override(stale_override, fresh_runtime)
+
+    # api_mode re-derived from the target model (deepseek on Go = chat).
+    assert call_kwargs["api_mode"] == "chat_completions"
+    # The custom relay endpoint survives untouched (no opencode.ai rewrite).
+    assert call_kwargs["base_url"].rstrip("/") == "https://my-relay.example/v1"
+    assert call_kwargs["api_key"] == "sk-bridge-test"
+
+
+def test_custom_provider_hosted_on_opencode_ai_gets_family_treatment():
+    """Boundary: a custom provider whose NAME is not family-extended but
+    whose resolved endpoint is hosted on opencode.ai gets family treatment
+    through the hostname leg of the dual detection (#85589) — stale
+    persisted anthropic overrides are rejected."""
+    fresh_runtime = {
+        "provider": "my-oc-proxy",
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "api_key": "sk-oc-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    stale_override = {
+        "model": "deepseek-v4-flash-vision-exp",
+        "provider": "my-oc-proxy",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+    }
+    call_kwargs = _make_agent_with_override(stale_override, fresh_runtime)
+
+    assert call_kwargs["api_mode"] == "chat_completions"
+    assert call_kwargs["base_url"].rstrip("/") == "https://opencode.ai/zen/go/v1"
+
+
+def test_custom_provider_with_opencode_hosted_persisted_url_gets_family_treatment():
+    """Boundary: when a custom proxy's opencode.ai endpoint only exists in
+    the PERSISTED override (config base_url empty), the family guard must
+    still fire — otherwise a stale persisted anthropic_messages would be
+    honored verbatim and the anthropic transport would target the
+    opencode.ai endpoint (#96066)."""
+    fresh_runtime = {
+        "provider": "my-oc-proxy",
+        "base_url": "",
+        "api_key": "sk-oc-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    override = {
+        "model": "deepseek-v4-flash-vision-exp",
+        "provider": "my-oc-proxy",
+        "base_url": "https://opencode.ai/zen/go",  # anthropic-stripped
+        "api_mode": "anthropic_messages",          # stale wire
+    }
+    call_kwargs = _make_agent_with_override(override, fresh_runtime)
+
+    assert call_kwargs["api_mode"] == "chat_completions"
+    # opencode.ai endpoint honored, re-normalized to the chat /v1 suffix.
+    assert call_kwargs["base_url"].rstrip("/") == "https://opencode.ai/zen/go/v1"

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -140,3 +140,125 @@ def test_apply_model_switch_does_not_leak_process_env():
     # Sibling session is completely untouched.
     assert sess_a["model_override"] is None
     assert sess_a["agent"].model == "minimax/m3"
+
+
+# ---------------------------------------------------------------------------
+# OpenCode-family session override guard — #96066
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_with_override(model_override, fresh_runtime):
+    """Run _make_agent with a dict-shaped session override and return the
+    AIAgent call kwargs (same patch set as test_make_agent_passes_resolved_provider)."""
+    fake_cfg = {
+        "model": {
+            "default": model_override.get("model", "deepseek-v4-flash-vision-exp"),
+            "provider": model_override.get("provider", "opencode-go"),
+        },
+        "agent": {"system_prompt": "test"},
+    }
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_tool_progress_mode", return_value="compact"),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fresh_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-1", "key-1", model_override=model_override)
+
+    return mock_agent.call_args.kwargs
+
+
+def test_make_agent_rejects_stale_anthropic_override_for_opencode_family():
+    """#96066: a stale persisted anthropic_messages / api.anthropic.com
+    session override must not route opencode-go deepseek-v4-flash-vision-exp
+    to the Anthropic SDK default endpoint.
+
+    The opencode family re-derives api_mode from the target model on every
+    primary runtime path (#16878, #85589); the session-resume override path
+    must honor the same invariant, otherwise a row written while the session
+    used an anthropic-wire model (e.g. minimax on Go) forces the Anthropic
+    transport with an empty/default base_url → api.anthropic.com → the
+    reported "HTTP 401: Invalid Anthropic API Key" with the opencode-go key.
+    """
+    fresh_runtime = {
+        "provider": "opencode-go",
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "api_key": "sk-oc-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    stale_override = {
+        "model": "deepseek-v4-flash-vision-exp",
+        "provider": "opencode-go",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+    }
+    call_kwargs = _make_agent_with_override(stale_override, fresh_runtime)
+
+    assert call_kwargs["provider"] == "opencode-go"
+    assert call_kwargs["api_mode"] == "chat_completions"
+    assert call_kwargs["base_url"].rstrip("/") == "https://opencode.ai/zen/go/v1"
+    # The opencode-go credential is preserved.
+    assert call_kwargs["api_key"] == "sk-oc-test"
+
+
+def test_make_agent_keeps_opencode_persisted_base_url_when_opencode_hosted():
+    """A persisted base_url that IS an opencode.ai endpoint is honored for
+    the family, but still normalized to the model-derived api_mode's /v1
+    suffix (heals a previously anthropic-stripped URL)."""
+    fresh_runtime = {
+        "provider": "opencode-go",
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "api_key": "sk-oc-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    override = {
+        "model": "deepseek-v4-flash-vision-exp",
+        "provider": "opencode-go",
+        "base_url": "https://opencode.ai/zen/go",  # anthropic-stripped
+        "api_mode": "anthropic_messages",          # stale wire
+    }
+    call_kwargs = _make_agent_with_override(override, fresh_runtime)
+
+    assert call_kwargs["api_mode"] == "chat_completions"
+    # chat_completions needs the /v1 suffix back on the opencode host.
+    assert call_kwargs["base_url"].rstrip("/") == "https://opencode.ai/zen/go/v1"
+
+
+def test_make_agent_still_honors_persisted_override_for_non_opencode_provider():
+    """The override guard is scoped to the OpenCode family — ordinary
+    sessions (e.g. anthropic) still restore their persisted endpoint/mode."""
+    fresh_runtime = {
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_key": "sk-ant-test",
+        "api_mode": "anthropic_messages",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    override = {
+        "model": "claude-opus-4-6",
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+    }
+    call_kwargs = _make_agent_with_override(override, fresh_runtime)
+
+    assert call_kwargs["provider"] == "anthropic"
+    assert call_kwargs["api_mode"] == "anthropic_messages"
+    assert call_kwargs["base_url"].rstrip("/") == "https://api.anthropic.com"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7866,6 +7866,40 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _opencode_family_for_runtime(provider: str, base_url: str) -> Optional[str]:
+    """Resolve an OpenCode family for a runtime pair, or None.
+
+    Composes ``hermes_cli.models.opencode_provider_family`` (provider-name
+    membership) with the opencode.ai hostname check, so custom providers
+    whose name does not extend the family slug (e.g. ``my-oc-proxy`` pointed
+    at ``https://opencode.ai/zen/go/v1``) still get family treatment — the
+    same dual detection ``hermes_cli.runtime_provider`` uses for custom
+    family providers (#85589). Family membership decides whether persisted
+    session ``api_mode``/``base_url`` overrides may be honored in
+    ``_make_agent`` (#96066).
+    """
+    from hermes_cli.models import opencode_provider_family
+
+    family = opencode_provider_family(provider)
+    if family is not None:
+        return family
+    if _host_is_opencode_ai(base_url):
+        lower = str(base_url or "").lower()
+        return "opencode-go" if "/zen/go" in lower else "opencode-zen"
+    return None
+
+
+def _host_is_opencode_ai(url: str) -> bool:
+    """True when *url* is hosted on opencode.ai (exact host or subdomain)."""
+    try:
+        from utils import base_url_hostname
+
+        host = (base_url_hostname(url) or "").lower()
+    except Exception:
+        return False
+    return host == "opencode.ai" or host.endswith(".opencode.ai")
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -7983,12 +8017,47 @@ def _make_agent(
             # The switch already resolved concrete credentials/endpoint; honor
             # persisted overrides only while using that original runtime. They
             # must not leak into a different fallback provider/model pair.
+            # Snapshot the freshly-resolved endpoint BEFORE overrides so the
+            # OpenCode family guard below can recover it when a persisted
+            # base_url is stale (#96066).
+            _fresh_base_url = runtime.get("base_url")
             if override_base_url:
                 runtime["base_url"] = override_base_url
             if override_api_key:
                 runtime["api_key"] = override_api_key
             if override_api_mode:
                 runtime["api_mode"] = override_api_mode
+            # OpenCode Zen/Go serve different models behind different API
+            # surfaces, and api_mode is ALWAYS re-derived from the target
+            # model on the primary runtime paths (#16878, #85589). A stale
+            # persisted api_mode/base_url from an earlier anthropic-wire
+            # model (e.g. minimax on Go) must not override the model-derived
+            # route here — with an empty or default base_url the Anthropic
+            # SDK then targets api.anthropic.com with the opencode-go key,
+            # surfacing as "HTTP 401: Invalid Anthropic API Key" (#96066).
+            # Re-derive the family route and keep a persisted base_url only
+            # when it is actually an opencode.ai endpoint.
+            _oc_family = _opencode_family_for_runtime(
+                str(requested_provider or ""),
+                str(_fresh_base_url or ""),
+            )
+            if _oc_family is not None:
+                from hermes_cli.models import (
+                    normalize_opencode_base_url,
+                    opencode_model_api_mode,
+                )
+
+                runtime["api_mode"] = opencode_model_api_mode(_oc_family, model)
+                _oc_base = (
+                    override_base_url
+                    if _host_is_opencode_ai(override_base_url)
+                    else _fresh_base_url
+                )
+                runtime["base_url"] = normalize_opencode_base_url(
+                    _oc_family,
+                    runtime["api_mode"],
+                    str(_oc_base or ""),
+                )
     else:
         model, requested_provider = _resolve_startup_runtime()
         if isinstance(model_override, str) and model_override:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8041,6 +8041,16 @@ def _make_agent(
                 str(requested_provider or ""),
                 str(_fresh_base_url or ""),
             )
+            # A custom family proxy may surface its opencode.ai endpoint only
+            # in the persisted override (config base_url empty or pointing
+            # elsewhere) — probe the override URL too, so the family routing
+            # invariants still apply instead of honoring a stale persisted
+            # api_mode verbatim (#96066).
+            if _oc_family is None and override_base_url:
+                _oc_family = _opencode_family_for_runtime(
+                    str(requested_provider or ""),
+                    str(override_base_url or ""),
+                )
             if _oc_family is not None:
                 from hermes_cli.models import (
                     normalize_opencode_base_url,


### PR DESCRIPTION
## Summary

Fixes #96066: `opencode-go` + `deepseek-v4-flash-vision-exp` mis-routed to `api.anthropic.com` and was not auto-detected as vision-capable.

### 1. Vision auto-detection (agent/models_dev.py)

`deepseek-v4-flash-vision-exp` is a VL model, but exp previews routinely reach the OpenCode relay before models.dev picks them up. With an empty/stale registry, `get_model_capabilities` returned `None`, so `image_input_mode: auto` treated the model as text-only and routed attached images through the lossy `vision_analyze` describe path instead of native pixels.

Add a fill-gap fallback (mirroring `model_overrides._default` semantics): for OpenCode-family providers (`opencode-go`/`opencode-zen`/`opencode-free`), a `*-vision*` slug resolves as vision-capable when the catalog has no entry. Catalog entries remain authoritative.

### 2. Endpoint mis-routing (tui_gateway/server.py `_make_agent`)

The session-resume/override path applied persisted `api_mode`/`base_url` verbatim. OpenCode Zen/Go serve different models behind different API surfaces, and api_mode is always re-derived from the target model on the primary runtime paths (#16878, #85589). A stale persisted `anthropic_messages` mode (e.g. a session row written while using an anthropic-wire model like minimax on Go) forced the Anthropic transport; with an empty/default base_url the Anthropic SDK then targets `api.anthropic.com` with the opencode-go key — the reported `HTTP 401: Invalid Anthropic API Key`.

The override path now re-derives the family route from the target model (`opencode_model_api_mode`) and honors a persisted base_url only when it is actually an opencode.ai endpoint, re-normalizing the `/v1` suffix via `normalize_opencode_base_url`.

## Tests

- `tests/agent/test_models_dev.py` — `TestOpencodeVisionFallback`: empty-registry vision resolution for opencode-go/opencode-zen, no-marker models stay unknown, non-opencode providers unaffected, catalog entries stay authoritative.
- `tests/agent/test_image_routing.py` — end-to-end `decide_image_input_mode` → `native` for the exp model with an empty registry; `text` for a text-only model.
- `tests/tui_gateway/test_make_agent_provider.py` — stale anthropic override rejected for opencode family (endpoint stays `https://opencode.ai/zen/go/v1`), opencode-hosted persisted base_url still honored + re-normalized, non-opencode providers keep honoring persisted overrides.

All new tests sabotage-verified (fail without the fix). Targeted suites: 135 passed; the only failures are 3 pre-existing environment-dependent tests (Windows path fixtures, Nous auth) that also fail on clean main.

Closes #96066