### PR TITLE
fix(mem0): resolve api_key_env references for OSS provider configs

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -177,13 +177,29 @@ class OSSBackend(Mem0Backend):
             block["config"] = provider_config
             return block
 
-        vector_store = dict(oss_config["vector_store"])
+        def _resolve_api_key_env(section: dict) -> dict:
+            """Resolve a named API-key env var without persisting secrets in mem0.json."""
+            resolved = dict(section)
+            provider_config = dict(resolved.get("config", {}))
+            env_name = provider_config.pop("api_key_env", None)
+            if env_name:
+                api_key = os.environ.get(env_name)
+                if not api_key:
+                    raise ValueError(
+                        f"Configured API key environment variable is not set: {env_name}"
+                    )
+                provider_config["api_key"] = api_key
+            resolved["config"] = provider_config
+            return resolved
+
+        vector_store = _resolve_api_key_env(dict(oss_config["vector_store"]))
         vs_config = dict(vector_store.get("config", {}))
 
         if "path" in vs_config:
             vs_config["path"] = os.path.expanduser(vs_config["path"])
 
-        embedder_config = oss_config.get("embedder", {}).get("config", {})
+        embedder = _resolve_api_key_env(_provider_block("embedder"))
+        embedder_config = embedder.get("config", {})
         dims = embedder_config.get("embedding_dims")
         if not dims:
             from ._oss_providers import KNOWN_DIMS
@@ -199,8 +215,8 @@ class OSSBackend(Mem0Backend):
 
         config = {
             "vector_store": vector_store,
-            "llm": _provider_block("llm"),
-            "embedder": _provider_block("embedder"),
+            "llm": _resolve_api_key_env(_provider_block("llm")),
+            "embedder": embedder,
             "version": "v1.1",
         }
         self._memory = Memory.from_config(config)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -152,6 +152,122 @@ class TestOSSBackend:
         assert "api_base" not in captured["embedder"]["config"]
         assert raw == before
 
+    def test_api_key_env_is_resolved_for_all_provider_sections_before_mem0_init(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        # mem0 is a lazy optional dep absent from CI's env; stub it like the
+        # api_base normalization test above does.
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        monkeypatch.setenv("TEST_MEM0_LLM_API_KEY", "llm-key-from-env")
+        monkeypatch.setenv("TEST_MEM0_EMBEDDER_API_KEY", "embedder-key-from-env")
+        monkeypatch.setenv("TEST_MEM0_VECTOR_STORE_API_KEY", "qdrant-key-from-env")
+
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": "gpt-5-mini",
+                    "api_key_env": "TEST_MEM0_LLM_API_KEY",
+                },
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": "text-embedding-3-small",
+                    "api_key_env": "TEST_MEM0_EMBEDDER_API_KEY",
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {"url": "http://qdrant:6333", "api_key_env": "TEST_MEM0_VECTOR_STORE_API_KEY"},
+            },
+        }
+        before = copy.deepcopy(raw)
+
+        OSSBackend(raw)
+
+        assert captured["llm"]["config"]["api_key"] == "llm-key-from-env"
+        assert captured["embedder"]["config"]["api_key"] == "embedder-key-from-env"
+        assert captured["vector_store"]["config"]["api_key"] == "qdrant-key-from-env"
+        for section in ("llm", "embedder", "vector_store"):
+            assert "api_key_env" not in captured[section]["config"]
+        # The caller's config dict must not be mutated.
+        assert raw == before
+
+    def test_api_key_env_missing_variable_raises_actionable_error(self, monkeypatch):
+        import sys
+        import types
+
+        class Memory:
+            @staticmethod
+            def from_config(config):  # pragma: no cover - must never be reached
+                raise AssertionError("Memory.from_config should not run")
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        monkeypatch.delenv("TEST_MEM0_MISSING_API_KEY", raising=False)
+
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "gpt-5-mini"},
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {"model": "text-embedding-3-small", "api_key_env": "TEST_MEM0_MISSING_API_KEY"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+        with pytest.raises(ValueError, match="TEST_MEM0_MISSING_API_KEY"):
+            OSSBackend(raw)
+
+    def test_sections_without_api_key_env_pass_through_unchanged(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "gpt-5-mini", "api_key": "direct-key"},
+            },
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+        OSSBackend(raw)
+
+        assert captured["llm"]["config"]["api_key"] == "direct-key"
+        assert "api_key" not in captured["embedder"]["config"]
+
 
 httpx = pytest.importorskip("httpx")
 


### PR DESCRIPTION
## What does this PR do?

The Mem0 OSS adapter forwards each provider section (`llm`, `embedder`, `vector_store`) to `Memory.from_config()` mostly verbatim. Some setups reference their API key indirectly: the config names an environment variable via `api_key_env`, and the actual secret stays out of `mem0.json` entirely.

Today such configs crash at backend initialization, because the literal string under `api_key_env` reaches the Mem0 SDK's dataclasses:

```
Mem0 backend failed to initialize (oss mode): BaseEmbedderConfig.__init__() got an unexpected keyword argument 'api_key_env'
```

This PR resolves `api_key_env` to `api_key` for the three sections before handing config to the SDK:

- reads the named variable from the environment and substitutes it as `api_key`;
- raises an actionable `ValueError` when the variable is unset (instead of the SDK's confusing unknown-kwarg error);
- leaves sections without the reference completely untouched, so existing direct-`api_key` and keyless (e.g. Ollama) configs behave exactly as before;
- never mutates caller-owned dicts.

Secret hygiene is the point of the feature: users can keep every key in `.env` and name it from `mem0.json`, consistent with how Hermes treats other credentials.

## Related Issue

No existing issue found; the failure signature above reproduces on current `main` whenever any OSS section uses `api_key_env`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py`: add `_resolve_api_key_env()` inside `OSSBackend.__init__()` and apply it to the `llm`, `embedder`, and `vector_store` sections before building the `Memory.from_config()` payload. Resolution composes cleanly with the existing `_provider_block()` alias normalization (`_provider_block("llm")` runs first, then env resolution).
- `tests/plugins/memory/test_mem0_backend.py`: three regression tests alongside the existing `api_base` normalization test:
  - resolution across all three sections, including asserting `api_key_env` never leaks into what reaches the SDK and the input dict is not mutated;
  - missing environment variable raises a `ValueError` naming the variable, without reaching `Memory.from_config()`;
  - sections without `api_key_env` (direct `api_key` or none) pass through unchanged.

## How was this tested?

- New tests follow the established pattern in this file (stubbing the lazily-imported `mem0` module) — no network, no real SDK, no secrets.
- Focused suite `pytest tests/plugins/memory/test_mem0_backend.py`: **10 passed**.
- Full memory plugin suite run locally shows only pre-existing failures unrelated to mem0 (hindsight provider tests fail identically on clean `main`).
