### PR TITLE
fix(title): reject truncated structured output

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -172,6 +172,23 @@ def _strip_title_prefix(text: str) -> str:
     return text[6:].strip() if text.lower().startswith("title:") else text
 
 
+def _is_truncated_structured_output(raw: str) -> bool:
+    """Return whether *raw* is truncated structured output rather than prose.
+
+    This is called only after strict JSON parsing and the loose ``"title"``
+    scan fail. Structural signatures avoid rejecting legitimate Markdown
+    emphasis or quoted prose titles.
+    """
+    if not raw:
+        return False
+    # An odd fence count means a Markdown code block was never closed.
+    if raw.count("```") % 2:
+        return True
+    # A leading object or array after failed parsing is incomplete structured
+    # output, including unquoted-key variants the loose scan cannot extract.
+    return raw.lstrip().startswith(("{", "["))
+
+
 def _first_line(text: str) -> str:
     return next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
 
@@ -194,8 +211,12 @@ def _extract_title_text(content: str) -> str:
     if match:
         with suppress(ValueError):
             return json.loads(f'"{match.group(1)}"').strip()
-        return match.group(1).strip()
-    # Prose fallback: scrub <think> blocks so reasoning can't leak into a title.
+    # A low output-token cap can cut structured output before the closing
+    # quote, brace, or fence. Do not persist that fragment as a title.
+    if _is_truncated_structured_output(raw):
+        return ""
+    # Prose fallback. Reuse the canonical scrubber so reasoning-model output
+    # (</think>…) can't leak into a title, then keep the first real line.
     try:
         from agent.agent_runtime_helpers import strip_think_blocks
         raw = strip_think_blocks(None, raw).strip()

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -79,6 +79,46 @@ class TestGenerateTitle:
             # leaving nothing → None.
             assert title is None
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "```json",
+            '```json\n{"title": "Broken title',
+            '{"title"',
+            '{"title": "Broken title',
+            '{title: "Broken title"',
+            "[truncated structured output",
+        ],
+    )
+    def test_rejects_truncated_structured_output(self, content):
+        """Incomplete JSON and fences must not become Markdown-breaking titles."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = content
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("hello") is None
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ('```json\n{"title": "Readable session"}\n```', "Readable session"),
+            ('```JSON\n{"title": "Uppercase fence"}\n```', "Uppercase fence"),
+            ('{"title": "Embedded title"} and chatter {step', "Embedded title"),
+            ("*Fix the login flow*", "*Fix the login flow*"),
+            ("'Quoted phrase'", "Quoted phrase"),
+            ("Use dict {key: value} carefully", "Use dict {key: value} carefully"),
+        ],
+    )
+    def test_preserves_valid_structured_and_prose_titles(self, content, expected):
+        """Structural rejection must not discard valid JSON or ordinary prose."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = content
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("hello") == expected
+
 
     def test_truncates_long_titles(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Prevents truncated structured output from being persisted as a session title. A low output-token cap can cut a provider response mid-JSON or before a closing Markdown fence; the existing prose fallback then stores fragments such as `{"title"` or an opening code fence. In gateway `/status` output, an unterminated fence can corrupt the formatting of the rest of the message.

The parser now rejects structural truncation signatures only after strict JSON parsing and the loose `"title"` scan have both failed:

- unclosed Markdown fences
- incomplete objects beginning with `{`
- incomplete arrays beginning with `[` 

Valid fenced JSON, embedded complete title objects, Markdown-emphasized prose, quoted prose, and prose containing braces remain accepted.

## Related issues and prior work

Fixes #83903.

This supersedes the implementation in draft PR #83985, whose branch no longer shares history with current `main` and is reported as conflicting. The structural approach and original test cases were developed by @olympusbuildz with review from @thatssoheil and @asperger514. This replacement is rebuilt on current `main`; the commit credits @olympusbuildz as co-author.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor

## Verification

```text
PYTHONPATH=/tmp/hermes-title-test-venv/lib/python3.11/site-packages ./venv/bin/python \
  -m pytest tests/agent/test_title_generator.py tests/gateway/test_status_command.py \
  -q -o 'addopts='
# 59 passed

./venv/bin/python -m py_compile \
  agent/title_generator.py tests/agent/test_title_generator.py
# passed

git diff --check origin/main...HEAD
# passed
```

## Checklist

- [x] Rebased onto current upstream `main`
- [x] Conventional commit message
- [x] Focused change limited to title parsing and regression tests
- [x] Tests cover truncated objects, arrays, and fences
- [x] Tests protect valid structured and prose output from false positives
- [x] Tested on Linux
- [ ] Full repository test suite run
