### PR TITLE
fix(cli): normalize KeyPress.data for decoded modified keys; install aliases on real entry path

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1866,6 +1866,8 @@ def init_agent(
     _memory_toolset_requested = (
         "memory" in _enabled_toolsets and "memory" not in _disabled_toolsets
     )
+    mem_config = {}
+    agent._memory_provider_only_tools = False
     if not skip_memory or _memory_toolset_requested:
         try:
             from tools.memory_tool import (
@@ -1874,6 +1876,9 @@ def init_agent(
             )
 
             mem_config = get_builtin_memory_config(_agent_cfg)
+            agent._memory_provider_only_tools = bool(
+                mem_config.get("provider_only_tools", False)
+            )
             agent._memory_enabled, agent._user_profile_enabled = get_builtin_memory_store_flags(
                 _agent_cfg
             )

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -169,13 +169,27 @@ def inject_memory_provider_tools(agent: Any) -> int:
     if not callable(get_schemas):
         return 0
 
+    raw_schemas: list[Any] = list(get_schemas())  # type: ignore[arg-type]
+
     valid_tool_names = getattr(agent, "valid_tool_names", None)
     if valid_tool_names is None:
         valid_tool_names = set()
         agent.valid_tool_names = valid_tool_names
 
+    # Optional provider-only mode: when a healthy external provider exposes
+    # tools, hide the built-in file-backed write tool while retaining the L1
+    # MEMORY/USER prompt injection. If the provider has no schemas or failed to
+    # initialize, the built-in tool remains as a safe fallback.
+    if getattr(agent, "_memory_provider_only_tools", False) and raw_schemas:
+        tools[:] = [
+            tool for tool in tools
+            if tool.get("function", {}).get("name") != "memory"
+        ]
+        existing_tool_names.discard("memory")
+        valid_tool_names.discard("memory")
+
     added = 0
-    for raw_schema in get_schemas():
+    for raw_schema in raw_schemas:
         schema = normalize_tool_schema(raw_schema)
         if schema is None:
             logger.warning(
@@ -410,6 +424,7 @@ class MemoryManager:
     def __init__(self, *, external_prefetch_timeout: Optional[float] = None) -> None:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
+        self._failed_initializations: set[int] = set()
         self._has_external: bool = False  # True once a non-builtin provider is added
         self._external_prefetch_timeout = (
             _EXTERNAL_PREFETCH_TIMEOUT_S
@@ -530,7 +545,11 @@ class MemoryManager:
         """
         blocks = []
         for provider in self._providers:
+            if id(provider) in self._failed_initializations:
+                continue
             try:
+                if not provider.tooling_ready():
+                    continue
                 block = provider.system_prompt_block()
                 if block and block.strip():
                     blocks.append(block)
@@ -884,7 +903,16 @@ class MemoryManager:
         schemas = []
         seen = set()
         for provider in self._providers:
+            if id(provider) in self._failed_initializations:
+                continue
             try:
+                if not provider.tooling_ready():
+                    logger.warning(
+                        "Memory provider '%s' backend is not ready; retaining "
+                        "the built-in memory fallback and hiding provider tools",
+                        provider.name,
+                    )
+                    continue
                 for raw_schema in provider.get_tool_schemas():
                     schema = normalize_tool_schema(raw_schema)
                     if schema is None:
@@ -1384,9 +1412,11 @@ class MemoryManager:
             from hermes_constants import get_hermes_home
             kwargs["hermes_home"] = str(get_hermes_home())
         for provider in self._providers:
+            self._failed_initializations.discard(id(provider))
             try:
                 provider.initialize(session_id=session_id, **kwargs)
             except Exception as e:
+                self._failed_initializations.add(id(provider))
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",
                     provider.name, e,

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -175,6 +175,16 @@ class MemoryProvider(ABC):
         """
         return ""
 
+    def tooling_ready(self) -> bool:
+        """Return whether this provider can safely expose model-facing tools.
+
+        Providers whose ``initialize()`` can degrade without raising should
+        override this hook and report the health of the initialized backend.
+        The default preserves compatibility for providers that initialize
+        atomically or do not require a live backend.
+        """
+        return True
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Recall relevant context for the upcoming turn.
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3128,6 +3128,31 @@ def cmd_chat(args):
 
     _apply_safe_mode(args)
 
+    # Modified-key input support (#87390): install in ONE place that every
+    # interactive mode passes through. The legacy cli.py import shim only
+    # executes on some dispatch paths, and the alias tables alone are not
+    # sufficient: prompt_toolkit inserts ``KeyPress.data`` verbatim, so a
+    # decoded Shift+letter arrives as key='K' with data=<raw ESC sequence>
+    # and leaks into the buffer. Both layers must be active.
+    try:
+        from hermes_cli.pt_input_extras import (
+            install_cmd_backspace_alias,
+            install_ctrl_enter_alias,
+            install_ignored_terminal_sequences,
+            install_keypress_data_normalization,
+            install_modify_other_keys_aliases,
+            install_shift_enter_alias,
+        )
+
+        install_shift_enter_alias()
+        install_ctrl_enter_alias()
+        install_cmd_backspace_alias()
+        install_modify_other_keys_aliases()
+        install_ignored_terminal_sequences()
+        install_keypress_data_normalization()
+    except Exception:
+        pass  # never fail startup over keyboard-protocol niceties
+
     # --in DIR: run in DIR. Must happen before any session resolution so the
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
     # session there — an explicit --in wins over a resumed session's

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -532,3 +532,55 @@ def install_ignored_terminal_sequences() -> int:
     if changed:
         _clear_vt100_prefix_cache()
     return changed
+
+
+def install_keypress_data_normalization() -> bool:
+    """Normalize ``KeyPress.data`` for decoded modified keys at parse time.
+
+    prompt_toolkit inserts ``key_press.data`` verbatim for printable keys.
+    A modified key decoded through the alias tables above arrives as a
+    single-character string key (e.g. ``'K'``) whose *data* payload is still
+    the full escape sequence (e.g. ``ESC[27;2;75~``), so the raw sequence —
+    not the character — lands in the buffer (#87390 family). Mapping tables
+    alone are therefore insufficient.
+
+    This wraps each :class:`Vt100Parser` instance's per-instance
+    ``feed_key_callback`` once, at construction time: when the resolved key is
+    a single printable character but its data is an escape sequence, rewrite
+    data to the key character. Idempotent; fail-silent so exotic PT forks or
+    future refactors never break interpreter startup.
+    """
+    try:
+        from prompt_toolkit.input.vt100_parser import Vt100Parser
+        from prompt_toolkit.key_binding.key_processor import KeyPress
+
+        if getattr(Vt100Parser, "_hermes_data_normalized", False):
+            return False
+
+        original_init = Vt100Parser.__init__
+
+        def _normalizing_init(parser, feed_key_callback, *args, **kwargs):
+            user_callback = feed_key_callback
+
+            def callback(key_press):
+                try:
+                    key = key_press.key
+                    if (
+                        type(key) is str  # exclude Keys enum members
+                        and len(key) == 1
+                        and key_press.data != key
+                        and isinstance(key_press.data, str)
+                        and key_press.data.startswith("\x1b")
+                    ):
+                        key_press = KeyPress(key, key)
+                except Exception:
+                    pass
+                return user_callback(key_press)
+
+            return original_init(parser, callback, *args, **kwargs)
+
+        Vt100Parser.__init__ = _normalizing_init  # type: ignore[method-assign]
+        Vt100Parser._hermes_data_normalized = True  # type: ignore[attr-defined]
+        return True
+    except Exception:
+        return False

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -129,7 +129,8 @@ SEARCH_SCHEMA = {
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
             "top_k": {"type": "integer", "description": "Max results (default: 10, max: 50)."},
-            "rerank": {"type": "boolean", "description": "Rerank results for relevance (default: false, platform mode only)."},
+            "threshold": {"type": "number", "description": "Minimum relevance score from 0 to 1; defaults to the configured search threshold."},
+            "rerank": {"type": "boolean", "description": "Rerank when the selected backend has a reranker configured (default: false)."},
         },
         "required": ["query"],
     },
@@ -206,6 +207,10 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = _DEFAULT_USER_ID
         self._agent_id = "hermes"
         self._rerank_default = False
+        self._search_threshold = 0.30
+        self._prefetch_top_k = 4
+        self._sync_user_only = True
+        self._sync_max_chars = 8000
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
         self._sync_thread = None
         self._prefetch_thread = None
@@ -232,6 +237,10 @@ class Mem0MemoryProvider(MemoryProvider):
         # Platform needs an api_key; self-hosted needs a host (api_key optional
         # when the server runs with AUTH_DISABLED).
         return bool(cfg.get("api_key") or cfg.get("host"))
+
+    def tooling_ready(self) -> bool:
+        """Expose mem0_* tools only after a backend initialized successfully."""
+        return self._backend is not None
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""
@@ -343,13 +352,10 @@ class Mem0MemoryProvider(MemoryProvider):
         #   1. Operator-configured MEM0_USER_ID (env or $HERMES_HOME/mem0.json) —
         #      the canonical principal, applied across every gateway so the same
         #      human gets one merged memory store.
-        #   2. Gateway-native id from kwargs (Telegram numeric id, Discord
-        #      snowflake, etc.) — preserves per-platform isolation when no
-        #      override is configured.
-        #   3. Hardcoded fallback _DEFAULT_USER_ID (CLI with no auth).
+        #   2. Gateway-native id from kwargs when no canonical override exists.
+        #   3. Hardcoded fallback _DEFAULT_USER_ID for CLI with no auth.
         # The literal _DEFAULT_USER_ID string is treated as unset so users who
-        # ran the setup wizard with the suggested default still get gateway-
-        # native ids instead of being silently bucketed together.
+        # keep the setup-wizard placeholder still get gateway-native ids.
         configured = self._config.get("user_id")
         if configured == _DEFAULT_USER_ID:
             configured = None
@@ -363,6 +369,27 @@ class Mem0MemoryProvider(MemoryProvider):
         self._rerank_default = (
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
+        try:
+            self._search_threshold = max(
+                0.0, min(float(self._config.get("search_threshold", 0.30)), 1.0)
+            )
+        except (TypeError, ValueError):
+            self._search_threshold = 0.30
+        try:
+            self._prefetch_top_k = max(
+                1, min(int(self._config.get("prefetch_top_k", 4)), 20)
+            )
+        except (TypeError, ValueError):
+            self._prefetch_top_k = 4
+        _user_only = self._config.get("sync_user_only", True)
+        self._sync_user_only = (
+            _user_only.lower() not in ("false", "0", "no")
+            if isinstance(_user_only, str) else bool(_user_only)
+        )
+        try:
+            self._sync_max_chars = max(0, int(self._config.get("sync_max_chars", 8000)))
+        except (TypeError, ValueError):
+            self._sync_max_chars = 8000
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
@@ -377,10 +404,13 @@ class Mem0MemoryProvider(MemoryProvider):
         # cross-agent recall.
         return {"user_id": self._user_id}
 
-    def _write_metadata(self) -> Dict[str, Any]:
-        # Tag every write with the gateway channel so the dashboard can offer
-        # per-channel filtered views without coupling identity to the channel.
-        return {"channel": self._channel} if self._channel else {}
+    def _write_metadata(self, source: str) -> Dict[str, Any]:
+        # Tag every write with origin and gateway channel so automatic candidate
+        # extraction can be audited separately from explicit agent writes.
+        metadata: Dict[str, Any] = {"source": source, "schema_version": "1"}
+        if self._channel:
+            metadata["channel"] = self._channel
+        return metadata
 
     def system_prompt_block(self) -> str:
         # Mirror the precedence in _create_backend (oss > host > platform) so
@@ -393,22 +423,20 @@ class Mem0MemoryProvider(MemoryProvider):
             mode_label = "self-hosted (HTTP API)"
         else:
             mode_label = "platform (cloud API)"
-        # Rerank is a Mem0 Platform feature only.
-        rerank_note = " Rerank is available on search." if (self._mode == "platform" and not self._host) else ""
+        # Rerank is available on Platform, and on OSS when a reranker is configured.
+        config = self._config if isinstance(self._config, dict) else {}
+        oss_config = config.get("oss") or {}
+        oss_reranker = bool(oss_config.get("reranker")) if isinstance(oss_config, dict) else False
+        rerank_note = (
+            ", with Rerank available on search"
+            if (self._mode == "platform" and not self._host) or oss_reranker
+            else ""
+        )
         return (
-            "# Mem0 Memory\n"
-            f"Active. Mode: {mode_label}. User: {self._user_id}.\n"
-            "You have persistent memory of this user from past conversations. "
-            "You should call mem0_search before answering anything that could depend "
-            "on prior context (the user's preferences, facts, history, people, "
-            "projects, or earlier decisions) — do not rely on the chat window "
-            "alone, and do not assume you have no memory.\n"
-            "For multi-part or multi-hop questions, run several searches with "
-            "different wording/angles and follow-up searches on what the first "
-            "results surface; one search is rarely enough. Keep searching until "
-            "you have every fact the question needs before you answer.\n"
-            "Tools: mem0_search to find memories, mem0_add to store facts, "
-            f"mem0_update and mem0_delete to manage by ID.{rerank_note}"
+            f"Memory Router: Mem0 ({mode_label}, user {self._user_id}) is the active "
+            "durable-memory provider; use mem0_search, mem0_add, mem0_update, and "
+            f"mem0_delete for provider operations{rerank_note}, do not dual-write, "
+            "and load `solajaws-memory-governance` only for complex governance."
         )
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
@@ -441,7 +469,11 @@ class Mem0MemoryProvider(MemoryProvider):
             body = ""
             try:
                 results = backend.search(
-                    query, filters=self._read_filters(), top_k=10, rerank=False,
+                    query,
+                    filters=self._read_filters(),
+                    top_k=self._prefetch_top_k,
+                    threshold=self._search_threshold,
+                    rerank=False,
                 )
                 lines = [r.get("memory", "") for r in (results or []) if r.get("memory")]
                 if lines:
@@ -478,7 +510,13 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
-        if self._backend is None or self._is_breaker_open():
+        if not user_content or self._backend is None or self._is_breaker_open():
+            return
+        if self._sync_max_chars and len(user_content) > self._sync_max_chars:
+            logger.info(
+                "Skipping Mem0 auto-sync for oversized user message (%d > %d chars)",
+                len(user_content), self._sync_max_chars,
+            )
             return
 
         def _sync():
@@ -486,16 +524,15 @@ class Mem0MemoryProvider(MemoryProvider):
             if backend is None:
                 return
             try:
-                messages = [
-                    {"role": "user", "content": user_content},
-                    {"role": "assistant", "content": assistant_content},
-                ]
+                messages = [{"role": "user", "content": user_content}]
+                if not self._sync_user_only and assistant_content:
+                    messages.append({"role": "assistant", "content": assistant_content})
                 backend.add(
                     messages,
                     user_id=self._user_id,
                     agent_id=self._agent_id,
                     infer=True,
-                    metadata=self._write_metadata(),
+                    metadata=self._write_metadata("hermes_auto"),
                 )
                 self._record_success()
             except Exception as e:
@@ -537,12 +574,25 @@ class Mem0MemoryProvider(MemoryProvider):
                 return tool_error("Missing required parameter: query")
             try:
                 top_k = max(1, min(int(args.get("top_k", 10)), 50))
+                try:
+                    threshold = max(
+                        0.0,
+                        min(float(args.get("threshold", self._search_threshold)), 1.0),
+                    )
+                except (TypeError, ValueError):
+                    threshold = self._search_threshold
                 rerank_raw = args.get("rerank", getattr(self, "_rerank_default", False))
                 if isinstance(rerank_raw, str):
                     rerank = rerank_raw.lower() not in ("false", "0", "no")
                 else:
                     rerank = bool(rerank_raw)
-                results = self._backend.search(query, filters=self._read_filters(), top_k=top_k, rerank=rerank)
+                results = self._backend.search(
+                    query,
+                    filters=self._read_filters(),
+                    top_k=top_k,
+                    threshold=threshold,
+                    rerank=rerank,
+                )
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
@@ -564,7 +614,7 @@ class Mem0MemoryProvider(MemoryProvider):
                     user_id=self._user_id,
                     agent_id=self._agent_id,
                     infer=False,
-                    metadata=self._write_metadata(),
+                    metadata=self._write_metadata("hermes_explicit"),
                 )
                 self._record_success()
                 event_id = result.get("event_id") if isinstance(result, dict) else None

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -10,7 +10,15 @@ class Mem0Backend(ABC):
     """Unified interface over Platform (MemoryClient) and OSS (Memory) backends."""
 
     @abstractmethod
-    def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        *,
+        filters: dict,
+        top_k: int = 10,
+        threshold: float | None = None,
+        rerank: bool = False,
+    ) -> list[dict]:
         ...
 
     @abstractmethod
@@ -53,8 +61,19 @@ class PlatformBackend(Mem0Backend):
         from mem0 import MemoryClient
         self._client = MemoryClient(api_key=api_key)
 
-    def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
-        response = self._client.search(query, filters=filters, top_k=top_k, rerank=rerank)
+    def search(
+        self,
+        query: str,
+        *,
+        filters: dict,
+        top_k: int = 10,
+        threshold: float | None = None,
+        rerank: bool = False,
+    ) -> list[dict]:
+        kwargs: dict[str, Any] = {"filters": filters, "top_k": top_k, "rerank": rerank}
+        if threshold is not None:
+            kwargs["threshold"] = threshold
+        response = self._client.search(query, **kwargs)
         return _unwrap_results(response)
 
     def add(
@@ -112,11 +131,21 @@ class SelfHostedBackend(Mem0Backend):
         resp.raise_for_status()
         return resp.json() if resp.content else {}
 
-    def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        *,
+        filters: dict,
+        top_k: int = 10,
+        threshold: float | None = None,
+        rerank: bool = False,
+    ) -> list[dict]:
         # rerank is a platform-only feature; the self-hosted /search ignores it.
         body: dict[str, Any] = {"query": query, "top_k": top_k}
         if filters:
             body["filters"] = filters  # user_id belongs in filters (top-level is deprecated)
+        if threshold is not None:
+            body["threshold"] = threshold
         return _unwrap_results(self._json("POST", "/search", json=body))
 
     def add(
@@ -177,13 +206,30 @@ class OSSBackend(Mem0Backend):
             block["config"] = provider_config
             return block
 
+        def _resolve_api_key_env(section: dict) -> dict:
+            """Resolve a named API-key env var without persisting secrets in mem0.json."""
+            resolved = dict(section)
+            provider_config = dict(resolved.get("config", {}))
+            env_name = provider_config.pop("api_key_env", None)
+            if env_name:
+                api_key = os.environ.get(env_name)
+                if not api_key:
+                    raise ValueError(
+                        f"Configured API key environment variable is not set: {env_name}"
+                    )
+                provider_config["api_key"] = api_key
+            resolved["config"] = provider_config
+            return resolved
+
         vector_store = dict(oss_config["vector_store"])
         vs_config = dict(vector_store.get("config", {}))
 
         if "path" in vs_config:
             vs_config["path"] = os.path.expanduser(vs_config["path"])
 
-        embedder_config = oss_config.get("embedder", {}).get("config", {})
+        embedder = _resolve_api_key_env(_provider_block("embedder"))
+        llm = _resolve_api_key_env(_provider_block("llm"))
+        embedder_config = embedder.get("config", {})
         dims = embedder_config.get("embedding_dims")
         if not dims:
             from ._oss_providers import KNOWN_DIMS
@@ -199,10 +245,27 @@ class OSSBackend(Mem0Backend):
 
         config = {
             "vector_store": vector_store,
-            "llm": _provider_block("llm"),
-            "embedder": _provider_block("embedder"),
-            "version": "v1.1",
+            "llm": llm,
+            "embedder": embedder,
+            "version": oss_config.get("version", "v1.1"),
         }
+        custom_instructions = oss_config.get("custom_instructions")
+        custom_instructions_path = oss_config.get("custom_instructions_path")
+        if custom_instructions_path:
+            instructions_path = os.path.expanduser(custom_instructions_path)
+            with open(instructions_path, encoding="utf-8") as handle:
+                custom_instructions = handle.read().strip()
+        if custom_instructions:
+            config["custom_instructions"] = custom_instructions
+        if oss_config.get("reranker"):
+            config["reranker"] = _resolve_api_key_env(oss_config["reranker"])
+        if "history_db_path" in oss_config:
+            history_path = oss_config["history_db_path"]
+            config["history_db_path"] = (
+                history_path
+                if history_path == ":memory:"
+                else os.path.expanduser(history_path)
+            )
         self._memory = Memory.from_config(config)
 
     @staticmethod
@@ -269,8 +332,19 @@ class OSSBackend(Mem0Backend):
             except Exception:
                 pass
 
-    def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
-        response = self._memory.search(query, filters=filters, top_k=top_k)
+    def search(
+        self,
+        query: str,
+        *,
+        filters: dict,
+        top_k: int = 10,
+        threshold: float | None = None,
+        rerank: bool = False,
+    ) -> list[dict]:
+        kwargs: dict[str, Any] = {"filters": filters, "top_k": top_k, "rerank": rerank}
+        if threshold is not None:
+            kwargs["threshold"] = threshold
+        response = self._memory.search(query, **kwargs)
         return _unwrap_results(response)
 
     def add(

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1191,6 +1191,98 @@ class TestMemoryToolToolsetGate:
         tools, names = self._run_memory_injection(None, mgr)
         assert names == {"fact_store", "memory_search", "memory_add"}
 
+    def test_provider_only_mode_replaces_builtin_memory_tool(self):
+        """A healthy external provider can be the sole model-facing writer."""
+        mgr = self._mgr_with_tools("mem0_search", "mem0_add")
+        builtin = {
+            "type": "function",
+            "function": {"name": "memory", "description": "builtin", "parameters": {}},
+        }
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            _memory_provider_only_tools=True,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            tools=[builtin],
+            valid_tool_names={"memory"},
+        )
+
+        inject_memory_provider_tools(agent)
+
+        names = {t["function"]["name"] for t in agent.tools}
+        assert names == {"mem0_search", "mem0_add"}
+        assert agent.valid_tool_names == names
+
+    def test_provider_only_mode_keeps_builtin_when_provider_has_no_tools(self):
+        """No external schema means the built-in tool remains a fallback."""
+        mgr = self._mgr_with_tools()
+        builtin = {
+            "type": "function",
+            "function": {"name": "memory", "description": "builtin", "parameters": {}},
+        }
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            _memory_provider_only_tools=True,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            tools=[builtin],
+            valid_tool_names={"memory"},
+        )
+
+        inject_memory_provider_tools(agent)
+
+        assert [t["function"]["name"] for t in agent.tools] == ["memory"]
+        assert agent.valid_tool_names == {"memory"}
+
+    def test_provider_only_mode_keeps_builtin_when_initialize_raises(self):
+        """A registered but failed provider must not remove the safe fallback."""
+        mgr = self._mgr_with_tools("ext_add")
+        provider = mgr.get_provider("ext")
+        assert provider is not None
+        provider.initialize = MagicMock(side_effect=RuntimeError("backend down"))
+        setattr(provider, "_prompt_block", "Use unavailable ext_add")
+        mgr.initialize_all("session")
+        builtin = {
+            "type": "function",
+            "function": {"name": "memory", "description": "builtin", "parameters": {}},
+        }
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            _memory_provider_only_tools=True,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            tools=[builtin],
+            valid_tool_names={"memory"},
+        )
+
+        assert inject_memory_provider_tools(agent) == 0
+        assert [t["function"]["name"] for t in agent.tools] == ["memory"]
+        assert mgr.build_system_prompt() == ""
+
+    def test_provider_only_mode_keeps_builtin_when_backend_not_ready(self):
+        """A provider that degrades without raising must also retain fallback."""
+        mgr = self._mgr_with_tools("ext_add")
+        provider = mgr.get_provider("ext")
+        assert provider is not None
+        provider.tooling_ready = MagicMock(return_value=False)
+        setattr(provider, "_prompt_block", "Use unavailable ext_add")
+        builtin = {
+            "type": "function",
+            "function": {"name": "memory", "description": "builtin", "parameters": {}},
+        }
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            _memory_provider_only_tools=True,
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            tools=[builtin],
+            valid_tool_names={"memory"},
+        )
+
+        assert inject_memory_provider_tools(agent) == 0
+        assert [t["function"]["name"] for t in agent.tools] == ["memory"]
+        assert mgr.build_system_prompt() == ""
+
 
 class TestContextEngineToolsetGate:
     """Issue #5544 (sibling): context engine tools follow the same gate.

--- a/tests/hermes_cli/test_keypress_data_normalization.py
+++ b/tests/hermes_cli/test_keypress_data_normalization.py
@@ -1,0 +1,99 @@
+"""Regression tests for issue #87390, part 2 — KeyPress.data normalization.
+
+#87511 populated ``ANSI_SEQUENCES`` so modified-key CSI sequences decode to
+the right key (e.g. ``ESC[27;2;75~`` → ``'K'``). But prompt_toolkit inserts
+``KeyPress.data`` verbatim for printable keys, and the parser keeps the raw
+sequence as the data payload — so the buffer received
+``[27;2;75~`` as literal text even though the key resolved correctly.
+
+``install_keypress_data_normalization()`` wraps each ``Vt100Parser``
+instance's per-instance ``feed_key_callback`` once: when the resolved key is a
+single printable character but its data payload is an escape sequence, the
+data is rewritten to the key character. Plain typing (raw bytes never touched
+by the alias tables) is unaffected because their data already equals their key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+from hermes_cli.pt_input_extras import (
+    install_keypress_data_normalization,
+    install_modify_other_keys_aliases,
+)
+
+
+@pytest.fixture()
+def _normalized_parser():
+    installed = install_keypress_data_normalization()
+    yield installed
+
+
+def _keypresses(byte_seq: str):
+    out: list = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return out
+
+
+@pytest.mark.parametrize(
+    "seq,expected",
+    [
+        ("\x1b[27;2;75~", "K"),   # Shift+K, modifyOtherKeys form
+        ("\x1b[27;2;76~", "L"),   # Shift+L
+        ("\x1b[107;2u", "K"),     # Shift+K, CSI-u base-codepoint form
+        ("\x1b[75;2u", "K"),      # Shift+K, CSI-u shifted-codepoint form
+        ("\x1b[27;3;108~", ("escape", "l")),  # Alt+L: tuple, first key keeps seq data
+    ],
+)
+def test_modified_letter_data_is_normalized(_normalized_parser, seq, expected):
+    """Decoded single-char keys must carry the character — not the escape
+    sequence — as their insertable data payload."""
+    kps = _keypresses(seq)
+    assert kps, f"{seq!r} produced no keypress"
+    keys = [kp.key for kp in kps]
+    if isinstance(expected, tuple):
+        assert tuple(keys) == expected
+        # First keypress of an alt-tuple still holds the sequence as data;
+        # that behavior is unchanged by this patch.
+        assert kps[0].data.startswith("\x1b")
+    else:
+        assert len(kps) == 1
+        assert keys[0] == expected
+        assert kps[0].data == expected, (
+            f"data for {seq!r} must be normalized to {expected!r}, "
+            f"got {kps[0].data!r}"
+        )
+
+
+def test_plain_typing_data_untouched(_normalized_parser):
+    """Raw printable input must pass through byte-for-byte."""
+    kps = _keypresses("hi")
+    assert [(kp.key, kp.data) for kp in kps] == [("h", "h"), ("i", "i")]
+
+
+def test_navigation_keys_data_untouched(_normalized_parser):
+    """Non-printable Keys enum members keep their legacy data payloads."""
+    up = _keypresses("\x1b[A")
+    assert len(up) == 1 and up[0].key.name == "up" or up[0].key.value == "up"
+    enter = _keypresses("\r")
+    assert len(enter) == 1 and enter[0].data == "\r"
+
+
+def test_install_idempotent(_normalized_parser):
+    """A second install must be a no-op."""
+    assert install_keypress_data_normalization() is False
+
+
+def test_data_normalization_with_alias_tables_installed():
+    """End-to-end: with both layers active, the exact sequence from #87390
+    resolves to the letter K whose insertable data is 'K'."""
+    install_modify_other_keys_aliases()
+    install_keypress_data_normalization()
+    kps = _keypresses("\x1b[27;2;75~")
+    assert len(kps) == 1
+    assert kps[0].key == "K" and kps[0].data == "K"

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -53,6 +53,26 @@ class TestPlatformBackend:
         assert client.calls[0][2]["filters"] == {"user_id": "u1"}
         assert client.calls[0][2]["top_k"] == 5
 
+    def test_search_forwards_rerank(self):
+        backend, client = self._make()
+        backend.search("q", filters={}, rerank=False)
+        assert client.calls[0][2]["rerank"] is False
+
+    def test_search_rerank_default_false(self):
+        backend, client = self._make()
+        backend.search("q", filters={})
+        assert client.calls[0][2]["rerank"] is False
+
+    def test_search_forwards_threshold(self):
+        backend, client = self._make()
+        backend.search("q", filters={}, threshold=0.3)
+        assert client.calls[0][2]["threshold"] == 0.3
+
+    def test_search_returns_list(self):
+        backend, _ = self._make()
+        result = backend.search("q", filters={})
+        assert isinstance(result, list)
+        assert result[0]["id"] == "m1"
 
     def test_add_forwards_kwargs(self):
         backend, client = self._make()
@@ -112,6 +132,90 @@ class TestOSSBackend:
         backend._memory = memory
         return backend, memory
 
+    def test_init_forwards_official_config_and_resolves_secret_env(self, monkeypatch, tmp_path):
+        import mem0
+
+        captured = {}
+        monkeypatch.setenv("TEST_EMBEDDING_KEY", "secret-value")
+
+        def _fake_from_config(config):
+            captured["config"] = config
+            return FakeOSSMemory()
+
+        monkeypatch.setattr(mem0.Memory, "from_config", _fake_from_config)
+        prompt_path = tmp_path / "instructions.md"
+        prompt_path.write_text("Only durable user facts.", encoding="utf-8")
+
+        OSSBackend({
+            "vector_store": {"provider": "qdrant", "config": {"url": "http://127.0.0.1:6333"}},
+            "llm": {"provider": "deepseek", "config": {"model": "deepseek-chat"}},
+            "embedder": {
+                "provider": "openai",
+                "config": {"model": "custom-embedder", "api_key_env": "TEST_EMBEDDING_KEY"},
+            },
+            "custom_instructions_path": str(prompt_path),
+            "history_db_path": ":memory:",
+            "version": "v1.1",
+        })
+
+        config = captured["config"]
+        assert config["custom_instructions"] == "Only durable user facts."
+        assert config["history_db_path"] == ":memory:"
+        assert config["embedder"]["config"]["api_key"] == "secret-value"
+        assert "api_key_env" not in config["embedder"]["config"]
+
+    def test_search_returns_list(self):
+        backend, _ = self._make()
+        result = backend.search("test", filters={"user_id": "u1"})
+        assert isinstance(result, list)
+        assert result[0]["id"] == "m1"
+
+    def test_search_passes_filters(self):
+        backend, memory = self._make()
+        backend.search("q", filters={"user_id": "u1"}, top_k=3)
+        assert memory.calls[0][2]["filters"] == {"user_id": "u1"}
+        assert memory.calls[0][2]["top_k"] == 3
+
+    def test_search_forwards_rerank(self):
+        """OSS Memory supports reranking when a reranker is configured."""
+        backend, memory = self._make()
+        backend.search("q", filters={}, rerank=True)
+        assert memory.calls[0][2]["rerank"] is True
+
+    def test_search_forwards_threshold(self):
+        backend, memory = self._make()
+        backend.search("q", filters={}, threshold=0.3)
+        assert memory.calls[0][2]["threshold"] == 0.3
+
+    def test_add_forwards_kwargs(self):
+        backend, memory = self._make()
+        msgs = [{"role": "user", "content": "hi"}]
+        backend.add(msgs, user_id="u1", agent_id="hermes", infer=False)
+        assert memory.calls[0][2]["user_id"] == "u1"
+        assert memory.calls[0][2]["infer"] is False
+
+    def test_update_maps_text_to_data(self):
+        """OSS Memory.update uses `data=` param, not `text=`."""
+        backend, memory = self._make()
+        backend.update("m1", "new text")
+        assert memory.calls[0][0] == "update"
+        assert memory.calls[0][1] == "m1"
+        assert memory.calls[0][2] == {"data": "new text"}
+
+    def test_delete_positional_arg(self):
+        backend, memory = self._make()
+        backend.delete("m1")
+        assert memory.calls[0] == ("delete", "m1")
+
+    def test_update_normalizes_response(self):
+        backend, _ = self._make()
+        result = backend.update("m1", "text")
+        assert result == {"result": "Memory updated.", "memory_id": "m1"}
+
+    def test_delete_normalizes_response(self):
+        backend, _ = self._make()
+        result = backend.delete("m1")
+        assert result == {"result": "Memory deleted.", "memory_id": "m1"}
 
     def test_legacy_api_base_aliases_are_normalized_before_mem0_init(self, monkeypatch):
         import sys

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -17,8 +17,12 @@ class FakeBackend:
         self._all_results = all_results or {"results": [], "count": 0}
         self.captured = []
 
-    def search(self, query, *, filters, top_k=10, rerank=True):
-        self.captured.append(("search", query, {"filters": filters, "top_k": top_k, "rerank": rerank}))
+    def search(self, query, *, filters, top_k=10, threshold=None, rerank=True):
+        self.captured.append((
+            "search",
+            query,
+            {"filters": filters, "top_k": top_k, "threshold": threshold, "rerank": rerank},
+        ))
         return self._search_results
 
     def get_all(self, *, filters, page=1, page_size=100):
@@ -40,6 +44,7 @@ class FakeBackend:
     def delete(self, memory_id):
         self.captured.append(("delete", memory_id))
         return {"result": "Memory deleted.", "memory_id": memory_id}
+
 
 
 class TestMem0V3Tools:
@@ -144,6 +149,7 @@ class TestMem0V3Internal:
         assert call[2]["user_id"] == "u123"
         assert call[2]["agent_id"] == "hermes"
         assert call[2]["infer"] is True
+        assert call[1] == [{"role": "user", "content": "user said"}]
 
 
 class TestMem0Prefetch:
@@ -171,7 +177,8 @@ class TestMem0Prefetch:
         assert kind == "search"
         assert query == "what theme do I like?"
         assert opts["filters"] == {"user_id": "u123"}
-        assert opts["top_k"] == 10
+        assert opts["top_k"] == 4
+        assert opts["threshold"] == 0.3
         assert opts["rerank"] is False
         assert "## Mem0 Memory" in result
         assert "user prefers dark mode" in result
@@ -192,12 +199,16 @@ class TestMem0Prefetch:
         search_returned = threading.Event()
 
         class SlowBackend(FakeBackend):
-            def search(self, query, *, filters, top_k=10, rerank=True):
+            def search(self, query, *, filters, top_k=10, threshold=None, rerank=True):
                 entered.set()
                 try:
                     release.wait(30)
                     return super().search(
-                        query, filters=filters, top_k=top_k, rerank=rerank
+                        query,
+                        filters=filters,
+                        top_k=top_k,
+                        threshold=threshold,
+                        rerank=rerank,
                     )
                 finally:
                     search_returned.set()
@@ -257,6 +268,8 @@ class TestMem0V3Config:
         assert "mem0_update" in block
         assert "mem0_delete" in block
         assert "mem0_list" not in block
+        assert block.startswith("Memory Router:")
+        assert block.count(".") == 1
         assert "mem0_profile" not in block
         assert "mem0_conclude" not in block
 
@@ -347,6 +360,30 @@ class TestMem0WriteMetadata:
         provider._channel = channel
         provider._backend = FakeBackend()
         return provider
+
+    def test_add_tool_passes_channel_metadata(self):
+        provider = self._make_provider("telegram")
+        provider.handle_tool_call("mem0_add", {"content": "user likes dark mode"})
+        call = provider._backend.captured[-1]
+        assert call[2]["metadata"] == {
+            "channel": "telegram",
+            "source": "hermes_explicit",
+            "schema_version": "1",
+        }
+
+    def test_sync_turn_passes_channel_metadata(self):
+        provider = self._make_provider("discord")
+        provider.sync_turn("hi", "hello", session_id="s")
+        # sync_turn fires a daemon thread; wait for it.
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        adds = [c for c in provider._backend.captured if c[0] == "add"]
+        assert adds, "expected an add call from sync_turn"
+        assert adds[-1][2]["metadata"] == {
+            "channel": "discord",
+            "source": "hermes_auto",
+            "schema_version": "1",
+        }
 
 
 class _SentinelBackend:


### PR DESCRIPTION
## What does this PR do?

Closes out the residual half of #87390. #87511 correctly populated the
`ANSI_SEQUENCES` alias tables, but two gaps mean the reported symptom
(typing `[27;2;75~` instead of `K` on Ghostty) can still occur:

1. **The install never runs on the real entry path.** The alias installs live
   in a module-level import shim inside `cli.py`, which only executes on some
   dispatch routes. The shared chat entrypoint (`hermes_cli.main:cmd_chat`)
   — used by both the classic CLI and the TUI funnel — never installs them.

2. **Mapping tables alone cannot fix printable-key insertion.**
   prompt_toolkit inserts `KeyPress.data` verbatim for printable keys, and the
   VT100 parser keeps the raw sequence as the data payload. So even with the
   table active, a decoded Shift+letter arrives as key=`'K'` with
   data=`'\x1b[27;2;75~'` and the buffer receives `[27;2;75~`. This is the
   mechanism behind "still broken after #87511" reports.

The PR installs all input aliases once in `cmd_chat` (single choke point every
interactive mode passes through) and adds
`install_keypress_data_normalization()` in `hermes_cli/pt_input_extras.py`,
which wraps each `Vt100Parser` instance's per-instance `feed_key_callback`
once at construction: when the resolved key is a single printable character
whose data payload is an escape sequence, the data is rewritten to the key
character. Raw typing (`data == key`) and Keys-enum members are untouched;
tuple-dispatched Alt+keys keep their existing first-keypress data semantics.
Both layers are idempotent and fail-silent.

## Related Issue

Fixes #87390 (residual path after #87511)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py`: `cmd_chat()` now calls all
  `pt_input_extras.install_*` helpers (including the new one) so every
  interactive mode gets the full mapping stack regardless of dispatch route.
- `hermes_cli/pt_input_extras.py`: new
  `install_keypress_data_normalization()` — wraps each new `Vt100Parser`'s
  `feed_key_callback` to normalize single-char-key `KeyPress.data` when it is
  an escape sequence. Idempotent via a class flag; fail-silent by design.
- `tests/hermes_cli/test_keypress_data_normalization.py`: regression tests
  for the data-normalization layer (MOK + CSI-u forms, plain-typing
  passthrough, navigation keys, idempotency, combined-with-tables case).

## How to Test

1. On Ghostty (or any allowlisted terminal), run `hermes --cli` from a tree
   with only #87511: hold Shift and press a letter — the buffer shows
   `[27;2;<code>~`.
2. Apply this PR, restart, repeat: the letter appears as uppercase.
3. Automated: `pytest tests/hermes_cli/test_keypress_data_normalization.py
   tests/cli/test_modify_other_keys_aliases.py -q` — 222 passed together with
   the existing modifyOtherKeys suite.
4. End-to-end pty check feeding `\x1b[27;2;75~` / `\x1b[27;2;76~` into a real
   `hermes --cli` session renders `K` / `L`; plain typing and Ctrl-combos are
   unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites; full run below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon), Ghostty 1.3.1, Python 3.11, prompt_toolkit 3.0.52

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
