### PR TITLE
feat(memory): add PLUR as first-class memory provider (v0.18.1)

### DIFF
--- a/plugins/memory/plur/README.md
+++ b/plugins/memory/plur/README.md
@@ -1,0 +1,87 @@
+# PLUR Memory Provider
+
+Persistent memory for Hermes Agent — local engram store with BM25 + embedding search, feedback-trained retrieval, episodic timeline, and cross-device sync. Zero cloud, works offline.
+
+## Requirements
+
+- `pip install plur-hermes>=0.18.1`
+- Node.js 18+ (for the PLUR CLI — auto-resolved via `npx` on first use if not installed globally)
+
+## Setup
+
+```bash
+pip install plur-hermes
+hermes memory setup    # select "plur"
+```
+
+Or manually:
+
+```bash
+pip install plur-hermes
+hermes config set memory.provider plur
+```
+
+The `plur-hermes` package is auto-discovered by Hermes as a plugin even without
+the `memory.provider` key — installing it activates the standalone hook path
+(auto-inject, auto-learn) automatically. Setting `memory.provider: plur` adds
+the first-class MemoryProvider path on top, making PLUR visible in
+`hermes plugins --memory` and selectable in the desktop Settings panel.
+
+## What PLUR provides
+
+Once active, PLUR runs in the background on every session:
+
+- **Every turn**: relevant memories are injected into context (`prefetch`)
+- **Every response**: corrections and insights are captured automatically (`sync_turn`)
+- **Every session**: episodes are recorded to the timeline (`on_session_end`)
+
+The agent also gains 22 explicit tools:
+
+| Tool | What it does |
+|------|-------------|
+| `plur_learn` | Store a correction, preference, or pattern |
+| `plur_recall` | Search memories by topic |
+| `plur_inject` | Get relevant context for a task |
+| `plur_list` | List all stored engrams |
+| `plur_forget` | Retire outdated knowledge |
+| `plur_feedback` | Rate a memory (trains what surfaces next time) |
+| `plur_capture` | Record an episode |
+| `plur_timeline` | Query past episodes |
+| `plur_status` | Health check |
+| `plur_sync` | Cross-device sync via git |
+| `plur_packs_list` | List installed knowledge packs |
+| `plur_packs_install` | Install a community knowledge pack |
+| `plur_packs_export` | Export a pack to a shareable file |
+| `plur_extract_meta` | Distill cross-domain principles from memories |
+| `plur_meta_engrams` | List extracted meta-engrams |
+| `plur_meta_submit_analysis` | Continue multi-turn extraction |
+| `plur_validate_meta` | Test a principle against a new domain |
+| `plur_ingest` | Extract engrams from text, logs, or conversations |
+| `plur_promote` | Promote an engram to higher confidence |
+| `plur_similarity_search` | Embedding-based similarity search |
+| `plur_stores_add` | Register an additional engram store |
+| `plur_stores_list` | List configured stores |
+
+## How it works
+
+Knowledge is stored as **engrams** — small assertions that strengthen with use and decay when irrelevant, modeled on human memory (ACT-R activation). Storage is plain YAML on disk at `~/.plur/`. Search is fully local (BM25 + BGE embeddings + Reciprocal Rank Fusion). The plugin calls the PLUR CLI via subprocess; if the CLI is not installed globally, it auto-resolves via `npx @plur-ai/cli` on first use.
+
+## Configuration
+
+The plugin works with zero configuration. Optional environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLUR_PATH` | `~/.plur` | Storage directory |
+| `PLUR_INJECT_MODE` | `fast` | `hybrid` for embedding-based injection (slower, more accurate) |
+| `PLUR_INJECTION_FEEDBACK` | `true` | Set to `false` to disable automatic injection feedback |
+
+## Links
+
+- [PyPI: plur-hermes](https://pypi.org/project/plur-hermes/)
+- [GitHub: plur-ai/plur](https://github.com/plur-ai/plur)
+- [npm: @plur-ai/cli](https://www.npmjs.com/package/@plur-ai/cli)
+
+## License
+
+Apache-2.0

--- a/plugins/memory/plur/__init__.py
+++ b/plugins/memory/plur/__init__.py
@@ -1,0 +1,48 @@
+"""PLUR memory provider plugin for Hermes Agent.
+
+Thin registration shim — all implementation lives in the ``plur-hermes``
+PyPI package (``pip install plur-hermes``).
+
+This plugin activates PLUR as a first-class Hermes memory provider so it
+appears in ``hermes plugins --memory`` and can be selected via::
+
+    memory.provider: plur
+
+in config.yaml (or via ``hermes memory setup``).
+
+The ``plur-hermes`` package already auto-registers itself through the
+``hermes_agent.plugins`` entry-point group when installed, so the standalone
+hook path (pre_llm_call / post_llm_call auto-inject + auto-learn) is always
+active.  This plugin adds the MemoryProvider ABC path on top, which makes
+PLUR a *selectable*, *named* memory provider visible to MemoryManager — the
+two paths share a single PlurBridge instance so CLI subprocess spawns are
+deduplicated.
+
+Requirements
+------------
+* ``pip install plur-hermes>=0.18.1``
+* ``plur`` CLI reachable on PATH (ships with the npm package ``@plur-ai/cli``
+  or via ``npx -y @plur-ai/cli``)
+"""
+
+from __future__ import annotations
+
+
+def register(ctx) -> None:
+    """Register PLUR as a Hermes memory provider.
+
+    Called by Hermes on startup when this plugin directory is discovered.
+    Delegates entirely to ``PlurMemoryProvider`` from ``plur-hermes``.
+    """
+    try:
+        from plur_hermes.memory_provider import PlurMemoryProvider
+    except ImportError as exc:
+        import logging
+        logging.getLogger(__name__).error(
+            "plur-hermes is not installed — run `pip install plur-hermes>=0.18.1`. "
+            "Error: %s",
+            exc,
+        )
+        return
+
+    ctx.register_memory_provider(PlurMemoryProvider())

--- a/plugins/memory/plur/plugin.yaml
+++ b/plugins/memory/plur/plugin.yaml
@@ -1,0 +1,5 @@
+name: plur
+version: 0.18.1
+description: "PLUR persistent memory — local engram store with BM25 + embedding search, episodic timeline, cross-device sync, and 22 explicit tools. Zero cloud, works offline."
+pip_dependencies:
+  - plur-hermes>=0.18.1


### PR DESCRIPTION
## Summary

- Adds `plugins/memory/plur/` — a thin registration shim that wraps the `plur-hermes` PyPI package (`>=0.18.1`) as a named Hermes `MemoryProvider`.
- With `memory.provider: plur` in `config.yaml` (or via `hermes memory setup`), PLUR becomes selectable in the desktop Settings panel and visible in `hermes plugins --memory`.
- The `plur-hermes` package already auto-registers itself through the `hermes_agent.plugins` entry-point group; this plugin adds the `MemoryProvider` ABC path on top so both paths coexist. They share a single `PlurBridge` instance to deduplicate PLUR CLI subprocess spawns.

## What PLUR provides

- Local engram store (YAML, BM25 + BGE embeddings + RRF) — zero cloud, fully offline
- Feedback-trained retrieval (positive/negative signals adjust activation weights)
- Episodic timeline and cross-device git-based sync
- 22 explicit tools exposed to the model (`plur_learn`, `plur_recall`, `plur_inject`, `plur_feedback`, `plur_timeline`, and more)
- Meta-engram extraction for cross-domain principle distillation
- Knowledge packs for shareable curated memory sets

## Usage

```bash
pip install plur-hermes
hermes memory setup    # select "plur"
# or
hermes config set memory.provider plur
```

## Files changed

| File | Description |
|------|-------------|
| `plugins/memory/plur/__init__.py` | Registration shim — calls `ctx.register_memory_provider(PlurMemoryProvider())` |
| `plugins/memory/plur/README.md` | Install and usage docs |
| `plugins/memory/plur/plugin.yaml` | Plugin manifest |

## Notes

- No changes to core agent code — purely additive plugin
- Degrades gracefully when `plur-hermes` is not installed (logs a helpful error, returns early)
- `plur-hermes>=0.18.1` is required; it ships `PlurMemoryProvider` implementing the full `MemoryProvider` ABC
- PyPI release `plur-hermes==0.18.1` is pending explicit human approval per ENG-2026-0714-066 before publishing

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)