### PR TITLE
fix(cli): normalize KeyPress.data for decoded modified keys; install aliases on real entry path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3128,6 +3128,31 @@ def cmd_chat(args):
 
     _apply_safe_mode(args)
 
+    # Modified-key input support (#87390): install in ONE place that every
+    # interactive mode passes through. The legacy cli.py import shim only
+    # executes on some dispatch paths, and the alias tables alone are not
+    # sufficient: prompt_toolkit inserts ``KeyPress.data`` verbatim, so a
+    # decoded Shift+letter arrives as key='K' with data=<raw ESC sequence>
+    # and leaks into the buffer. Both layers must be active.
+    try:
+        from hermes_cli.pt_input_extras import (
+            install_cmd_backspace_alias,
+            install_ctrl_enter_alias,
+            install_ignored_terminal_sequences,
+            install_keypress_data_normalization,
+            install_modify_other_keys_aliases,
+            install_shift_enter_alias,
+        )
+
+        install_shift_enter_alias()
+        install_ctrl_enter_alias()
+        install_cmd_backspace_alias()
+        install_modify_other_keys_aliases()
+        install_ignored_terminal_sequences()
+        install_keypress_data_normalization()
+    except Exception:
+        pass  # never fail startup over keyboard-protocol niceties
+
     # --in DIR: run in DIR. Must happen before any session resolution so the
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
     # session there — an explicit --in wins over a resumed session's

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -532,3 +532,55 @@ def install_ignored_terminal_sequences() -> int:
     if changed:
         _clear_vt100_prefix_cache()
     return changed
+
+
+def install_keypress_data_normalization() -> bool:
+    """Normalize ``KeyPress.data`` for decoded modified keys at parse time.
+
+    prompt_toolkit inserts ``key_press.data`` verbatim for printable keys.
+    A modified key decoded through the alias tables above arrives as a
+    single-character string key (e.g. ``'K'``) whose *data* payload is still
+    the full escape sequence (e.g. ``ESC[27;2;75~``), so the raw sequence —
+    not the character — lands in the buffer (#87390 family). Mapping tables
+    alone are therefore insufficient.
+
+    This wraps each :class:`Vt100Parser` instance's per-instance
+    ``feed_key_callback`` once, at construction time: when the resolved key is
+    a single printable character but its data is an escape sequence, rewrite
+    data to the key character. Idempotent; fail-silent so exotic PT forks or
+    future refactors never break interpreter startup.
+    """
+    try:
+        from prompt_toolkit.input.vt100_parser import Vt100Parser
+        from prompt_toolkit.key_binding.key_processor import KeyPress
+
+        if getattr(Vt100Parser, "_hermes_data_normalized", False):
+            return False
+
+        original_init = Vt100Parser.__init__
+
+        def _normalizing_init(parser, feed_key_callback, *args, **kwargs):
+            user_callback = feed_key_callback
+
+            def callback(key_press):
+                try:
+                    key = key_press.key
+                    if (
+                        type(key) is str  # exclude Keys enum members
+                        and len(key) == 1
+                        and key_press.data != key
+                        and isinstance(key_press.data, str)
+                        and key_press.data.startswith("\x1b")
+                    ):
+                        key_press = KeyPress(key, key)
+                except Exception:
+                    pass
+                return user_callback(key_press)
+
+            return original_init(parser, callback, *args, **kwargs)
+
+        Vt100Parser.__init__ = _normalizing_init  # type: ignore[method-assign]
+        Vt100Parser._hermes_data_normalized = True  # type: ignore[attr-defined]
+        return True
+    except Exception:
+        return False

--- a/tests/hermes_cli/test_keypress_data_normalization.py
+++ b/tests/hermes_cli/test_keypress_data_normalization.py
@@ -1,0 +1,99 @@
+"""Regression tests for issue #87390, part 2 — KeyPress.data normalization.
+
+#87511 populated ``ANSI_SEQUENCES`` so modified-key CSI sequences decode to
+the right key (e.g. ``ESC[27;2;75~`` → ``'K'``). But prompt_toolkit inserts
+``KeyPress.data`` verbatim for printable keys, and the parser keeps the raw
+sequence as the data payload — so the buffer received
+``[27;2;75~`` as literal text even though the key resolved correctly.
+
+``install_keypress_data_normalization()`` wraps each ``Vt100Parser``
+instance's per-instance ``feed_key_callback`` once: when the resolved key is a
+single printable character but its data payload is an escape sequence, the
+data is rewritten to the key character. Plain typing (raw bytes never touched
+by the alias tables) is unaffected because their data already equals their key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+from hermes_cli.pt_input_extras import (
+    install_keypress_data_normalization,
+    install_modify_other_keys_aliases,
+)
+
+
+@pytest.fixture()
+def _normalized_parser():
+    installed = install_keypress_data_normalization()
+    yield installed
+
+
+def _keypresses(byte_seq: str):
+    out: list = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return out
+
+
+@pytest.mark.parametrize(
+    "seq,expected",
+    [
+        ("\x1b[27;2;75~", "K"),   # Shift+K, modifyOtherKeys form
+        ("\x1b[27;2;76~", "L"),   # Shift+L
+        ("\x1b[107;2u", "K"),     # Shift+K, CSI-u base-codepoint form
+        ("\x1b[75;2u", "K"),      # Shift+K, CSI-u shifted-codepoint form
+        ("\x1b[27;3;108~", ("escape", "l")),  # Alt+L: tuple, first key keeps seq data
+    ],
+)
+def test_modified_letter_data_is_normalized(_normalized_parser, seq, expected):
+    """Decoded single-char keys must carry the character — not the escape
+    sequence — as their insertable data payload."""
+    kps = _keypresses(seq)
+    assert kps, f"{seq!r} produced no keypress"
+    keys = [kp.key for kp in kps]
+    if isinstance(expected, tuple):
+        assert tuple(keys) == expected
+        # First keypress of an alt-tuple still holds the sequence as data;
+        # that behavior is unchanged by this patch.
+        assert kps[0].data.startswith("\x1b")
+    else:
+        assert len(kps) == 1
+        assert keys[0] == expected
+        assert kps[0].data == expected, (
+            f"data for {seq!r} must be normalized to {expected!r}, "
+            f"got {kps[0].data!r}"
+        )
+
+
+def test_plain_typing_data_untouched(_normalized_parser):
+    """Raw printable input must pass through byte-for-byte."""
+    kps = _keypresses("hi")
+    assert [(kp.key, kp.data) for kp in kps] == [("h", "h"), ("i", "i")]
+
+
+def test_navigation_keys_data_untouched(_normalized_parser):
+    """Non-printable Keys enum members keep their legacy data payloads."""
+    up = _keypresses("\x1b[A")
+    assert len(up) == 1 and up[0].key.name == "up" or up[0].key.value == "up"
+    enter = _keypresses("\r")
+    assert len(enter) == 1 and enter[0].data == "\r"
+
+
+def test_install_idempotent(_normalized_parser):
+    """A second install must be a no-op."""
+    assert install_keypress_data_normalization() is False
+
+
+def test_data_normalization_with_alias_tables_installed():
+    """End-to-end: with both layers active, the exact sequence from #87390
+    resolves to the letter K whose insertable data is 'K'."""
+    install_modify_other_keys_aliases()
+    install_keypress_data_normalization()
+    kps = _keypresses("\x1b[27;2;75~")
+    assert len(kps) == 1
+    assert kps[0].key == "K" and kps[0].data == "K"


### PR DESCRIPTION
## What does this PR do?

Closes out the residual half of #87390. #87511 correctly populated the
`ANSI_SEQUENCES` alias tables, but two gaps mean the reported symptom
(typing `[27;2;75~` instead of `K` on Ghostty) can still occur:

1. **The install never runs on the real entry path.** The alias installs live
   in a module-level import shim inside `cli.py`, which only executes on some
   dispatch routes. The shared chat entrypoint (`hermes_cli.main:cmd_chat`)
   — used by both the classic CLI and the TUI funnel — never installs them.

2. **Mapping tables alone cannot fix printable-key insertion.**
   prompt_toolkit inserts `KeyPress.data` verbatim for printable keys, and the
   VT100 parser keeps the raw sequence as the data payload. So even with the
   table active, a decoded Shift+letter arrives as key=`'K'` with
   data=`'\x1b[27;2;75~'` and the buffer receives `[27;2;75~`. This is the
   mechanism behind "still broken after #87511" reports.

The PR installs all input aliases once in `cmd_chat` (single choke point every
interactive mode passes through) and adds
`install_keypress_data_normalization()` in `hermes_cli/pt_input_extras.py`,
which wraps each `Vt100Parser` instance's per-instance `feed_key_callback`
once at construction: when the resolved key is a single printable character
whose data payload is an escape sequence, the data is rewritten to the key
character. Raw typing (`data == key`) and Keys-enum members are untouched;
tuple-dispatched Alt+keys keep their existing first-keypress data semantics.
Both layers are idempotent and fail-silent.

## Related Issue

Fixes #87390 (residual path after #87511)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py`: `cmd_chat()` now calls all
  `pt_input_extras.install_*` helpers (including the new one) so every
  interactive mode gets the full mapping stack regardless of dispatch route.
- `hermes_cli/pt_input_extras.py`: new
  `install_keypress_data_normalization()` — wraps each new `Vt100Parser`'s
  `feed_key_callback` to normalize single-char-key `KeyPress.data` when it is
  an escape sequence. Idempotent via a class flag; fail-silent by design.
- `tests/hermes_cli/test_keypress_data_normalization.py`: regression tests
  for the data-normalization layer (MOK + CSI-u forms, plain-typing
  passthrough, navigation keys, idempotency, combined-with-tables case).

## How to Test

1. On Ghostty (or any allowlisted terminal), run `hermes --cli` from a tree
   with only #87511: hold Shift and press a letter — the buffer shows
   `[27;2;<code>~`.
2. Apply this PR, restart, repeat: the letter appears as uppercase.
3. Automated: `pytest tests/hermes_cli/test_keypress_data_normalization.py
   tests/cli/test_modify_other_keys_aliases.py -q` — 222 passed together with
   the existing modifyOtherKeys suite.
4. End-to-end pty check feeding `\x1b[27;2;75~` / `\x1b[27;2;76~` into a real
   `hermes --cli` session renders `K` / `L`; plain typing and Ctrl-combos are
   unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: 222 passed; full suite green locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon), Ghostty 1.3.1, Python 3.11, prompt_toolkit 3.0.52

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
