### PR TITLE
fix(kanban): clear stale crash diagnostics after unblock

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -673,9 +673,30 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
     in-flight run (no outcome yet) doesn't break the trailing crash scan,
     so a retried card kept showing "crashed Nx" over an active run. The
     banner re-fires if the new attempt also crashes.
+
+    An explicit ``unblocked`` event is also a recovery boundary. It resets
+    the dispatcher's retry counter and records an operator's decision that
+    the prior failure class has been repaired. The old runs remain valuable
+    history, but they must not keep an alert visible while the replacement
+    attempt is pending. A later crash still re-enables the diagnostic.
     """
     if _task_field(task, "status") in ("done", "archived", "running"):
         return []
+    latest_crash_at = max(
+        (
+            int(_task_field(run, "ended_at", 0) or _task_field(run, "started_at", 0) or 0)
+            for run in runs
+            if _task_field(run, "outcome") == "crashed"
+        ),
+        default=0,
+    )
+    if latest_crash_at:
+        latest_unblock_at = max(
+            (_event_ts(event) for event in events if _event_kind(event) == "unblocked"),
+            default=0,
+        )
+        if latest_unblock_at >= latest_crash_at:
+            return []
     failure_threshold = int(cfg.get(
         "failure_threshold",
         cfg.get("spawn_failure_threshold", 3),

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -120,6 +120,32 @@ def test_repeated_crashes_truncates_huge_tracebacks():
     assert d.detail.endswith("…") or len(d.detail) < 700
 
 
+def test_repeated_crashes_clears_after_explicit_unblock():
+    """An explicit recovery clears stale alarms while the retry is pending."""
+    task = _task(status="ready")
+    runs = [
+        {**_run(outcome="crashed", run_id=1), "ended_at": 100},
+        {**_run(outcome="crashed", run_id=2), "ended_at": 200},
+    ]
+    events = [_event("unblocked", ts=300)]
+
+    assert not kd._rule_repeated_crashes(task, events, runs, now=400, cfg={})
+
+
+def test_repeated_crashes_after_unblock_still_alerts():
+    """The recovery boundary does not hide a new crash."""
+    task = _task(status="ready")
+    runs = [
+        {**_run(outcome="crashed", run_id=1), "ended_at": 100},
+        {**_run(outcome="crashed", run_id=2), "ended_at": 400},
+    ]
+    events = [_event("unblocked", ts=300)]
+
+    diagnostics = kd._rule_repeated_crashes(task, events, runs, now=500, cfg={})
+    assert len(diagnostics) == 1
+    assert diagnostics[0].kind == "repeated_crashes"
+
+
 # ---------------------------------------------------------------------------
 # Severity sorting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An explicit unblock resets the dispatcher retry budget but did not break the historic crash diagnostic scan. This produced a false active crash alarm while a recovered task was waiting to retry. The rule now treats a later unblocked event as a recovery boundary. A subsequent crash still alerts.

Verification:
- pre-fix mutation: new recovery test failed (1 failed, 6 passed)
- fixed: 7 passed
- git diff --check passed.