### PR TITLE
fix(desktop): surface non-default provider in model pill (#96063)

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,9 +1,12 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { modelOptionsQueryKey } from '@/lib/model-options'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentModel, setCurrentModel, setCurrentModelSource } from '@/store/session'
 
 import { ModelPill } from './model-pill'
@@ -15,8 +18,17 @@ const modelState = (over: Partial<ChatBarState['model']> = {}): ChatBarState['mo
   ...over
 })
 
+// #96063: the pill subscribes to the profile-scoped model-options cache via
+// useQuery (enabled:false) so a config default change re-paints the tag. That
+// hook needs a QueryClient in context; tests that don't care about the cache
+// still wrap with an empty one so the hook doesn't throw.
+function withQueryClient(node: React.ReactNode, queryClient: QueryClient = new QueryClient()) {
+  return <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+}
+
 afterEach(() => {
   cleanup()
+  $activeGatewayProfile.set('default')
   $activeSessionId.set(null)
   setCurrentModel('')
   setCurrentModelSource('')
@@ -30,7 +42,7 @@ describe('ModelPill pinned-override badge', () => {
     setCurrentModelSource('manual')
     $activeSessionId.set(null)
 
-    render(<ModelPill disabled={false} model={modelState({ model: 'deepseek/deepseek-v4-flash' })} />)
+    render(withQueryClient(<ModelPill disabled={false} model={modelState({ model: 'deepseek/deepseek-v4-flash' })} />))
 
     expect(screen.getByTestId('model-pinned-dot')).toBeTruthy()
   })
@@ -40,7 +52,7 @@ describe('ModelPill pinned-override badge', () => {
     setCurrentModelSource('default')
     $activeSessionId.set(null)
 
-    render(<ModelPill disabled={false} model={modelState()} />)
+    render(withQueryClient(<ModelPill disabled={false} model={modelState()} />))
 
     expect(screen.queryByTestId('model-pinned-dot')).toBeNull()
   })
@@ -50,7 +62,7 @@ describe('ModelPill pinned-override badge', () => {
     setCurrentModelSource('manual')
     $activeSessionId.set('live-1')
 
-    render(<ModelPill disabled={false} model={modelState()} />)
+    render(withQueryClient(<ModelPill disabled={false} model={modelState()} />))
 
     expect(screen.queryByTestId('model-pinned-dot')).toBeNull()
   })
@@ -62,7 +74,7 @@ describe('ModelPill pinned-override badge', () => {
 
     // Fallback (no live menu) path.
     const { unmount } = render(
-      <ModelPill disabled={false} model={modelState({ model: 'deepseek/deepseek-v4-flash' })} />
+      withQueryClient(<ModelPill disabled={false} model={modelState({ model: 'deepseek/deepseek-v4-flash' })} />)
     )
 
     expect(screen.getByTestId('model-pinned-dot')).toBeTruthy()
@@ -70,10 +82,12 @@ describe('ModelPill pinned-override badge', () => {
 
     // Live-menu (dropdown) path.
     render(
-      <ModelPill
-        disabled={false}
-        model={modelState({ model: 'deepseek/deepseek-v4-flash', modelMenuContent: <div /> })}
-      />
+      withQueryClient(
+        <ModelPill
+          disabled={false}
+          model={modelState({ model: 'deepseek/deepseek-v4-flash', modelMenuContent: <div /> })}
+        />
+      )
     )
     expect(screen.getByTestId('model-pinned-dot')).toBeTruthy()
     expect($currentModel.get()).toBe('deepseek/deepseek-v4-flash')
@@ -103,15 +117,110 @@ describe('ModelPill per-surface model label', () => {
     }
 
     render(
-      <SessionViewProvider value={tileView}>
-        <ModelPill
-          disabled={false}
-          model={modelState({ model: 'tile/claude-sonnet', provider: 'anthropic', modelMenuContent: <div /> })}
-        />
-      </SessionViewProvider>
+      withQueryClient(
+        <SessionViewProvider value={tileView}>
+          <ModelPill
+            disabled={false}
+            model={modelState({ model: 'tile/claude-sonnet', provider: 'anthropic', modelMenuContent: <div /> })}
+          />
+        </SessionViewProvider>
+      )
     )
 
     expect(screen.getByText('Sonnet · High')).toBeTruthy()
     expect(screen.queryByText(/primary/i)).toBeNull()
+  })
+})
+
+// #96063: a stale persisted provider on a same-named model would silently send
+// API calls to the wrong gateway. The pill must (1) visibly name the live
+// provider when it differs from the Settings → Model default, (2) keep the
+// tooltip / aria-label informative for hover and screen readers, and
+// (3) stay quiet when the live provider IS the default so the pill doesn't
+// grow noise for the common case.
+describe('ModelPill non-default provider tag (#96063)', () => {
+  const renderWithDefaults = (defaultProvider: string, liveProvider: string, model = 'qwen3.7-plus') => {
+    $activeGatewayProfile.set('default')
+    const queryClient = new QueryClient()
+
+    queryClient.setQueryData(modelOptionsQueryKey('default'), {
+      model,
+      provider: defaultProvider,
+      providers: [{ models: [model], name: defaultProvider, slug: defaultProvider }]
+    })
+
+    return render(
+      withQueryClient(
+        <ModelPill
+          disabled={false}
+          model={modelState({
+            canSwitch: false,
+            model,
+            provider: liveProvider,
+            modelMenuContent: <div data-testid="live-menu" />
+          })}
+        />,
+        queryClient
+      )
+    )
+  }
+
+  it('renders the visible provider tag when the live provider differs from the config default', () => {
+    renderWithDefaults('custom:aliyun-coding-plan', 'custom:token-plan-a')
+
+    // The pill text now carries both the model name AND the live provider,
+    // so a same-named model on a different provider can no longer look
+    // identical (#96063).
+    const tag = screen.getByTestId('model-provider-tag')
+
+    expect(tag.textContent).toBe('· custom:token-plan-a')
+    expect(tag.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('keeps the tooltip / aria-label informative when the provider has drifted', () => {
+    renderWithDefaults('custom:aliyun-coding-plan', 'custom:token-plan-a')
+
+    // The button's aria-label is the same string the Tip renders; it must
+    // name BOTH the live provider and the config default so screen readers
+    // and hover both surface the desync.
+    const pill = screen.getByRole('button', { name: /custom:token-plan-a/ })
+
+    expect(pill.getAttribute('aria-label')).toContain('custom:token-plan-a')
+    expect(pill.getAttribute('aria-label')).toContain('custom:aliyun-coding-plan')
+    expect(pill.getAttribute('aria-label')).toContain('not the Settings default')
+  })
+
+  it('stays quiet when the live provider IS the config default', () => {
+    renderWithDefaults('openai', 'openai')
+
+    // Common case: provider matches default → no tag, no extra tooltip noise.
+    expect(screen.queryByTestId('model-provider-tag')).toBeNull()
+
+    const pill = screen.getByRole('button')
+
+    expect(pill.getAttribute('aria-label')).not.toContain('not the Settings default')
+  })
+
+  it('stays quiet when the config default has not loaded yet', () => {
+    $activeGatewayProfile.set('default')
+    const queryClient = new QueryClient()
+
+    // No cache data → defaultProvider resolves to '' → no false-positive tag.
+    render(
+      withQueryClient(
+        <ModelPill
+          disabled={false}
+          model={modelState({
+            canSwitch: false,
+            model: 'qwen3.7-plus',
+            provider: 'custom:token-plan-a',
+            modelMenuContent: <div />
+          })}
+        />,
+        queryClient
+      )
+    )
+
+    expect(screen.queryByTestId('model-provider-tag')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -99,11 +99,12 @@ export function ModelPill({
   // fetcher (model-menu-panel / ComposerControls) owns that.
   const profile = useStore($activeGatewayProfile)
 
-  const defaultProvider = useQuery<ModelOptionsResponse | undefined>({
-    enabled: false,
-    queryFn: () => undefined,
-    queryKey: modelOptionsQueryKey(profile)
-  }).data?.provider?.trim() ?? ''
+  const defaultProvider =
+    useQuery<ModelOptionsResponse | undefined>({
+      enabled: false,
+      queryFn: () => undefined,
+      queryKey: modelOptionsQueryKey(profile)
+    }).data?.provider?.trim() ?? ''
 
   // Two same-named models on two providers (e.g. `qwen3.7-plus` on both
   // `custom:aliyun-coding-plan` and `custom:token-plan-a`) would otherwise look
@@ -123,11 +124,7 @@ export function ModelPill({
         <span className="truncate">
           {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
           {showProviderTag && (
-            <span
-              aria-hidden="true"
-              className="ml-0.5 opacity-70"
-              data-testid="model-provider-tag"
-            >
+            <span aria-hidden="true" className="ml-0.5 opacity-70" data-testid="model-provider-tag">
               {copy.providerTag(liveProvider)}
             </span>
           )}

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
@@ -10,9 +11,12 @@ import { releaseTypingFocus } from '@/components/ui/keyboard-first'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { ChevronDown } from '@/lib/icons'
+import { modelOptionsQueryKey } from '@/lib/model-options'
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $currentModelSource, $defaultReasoningEffort, setModelPickerOpen } from '@/store/session'
+import type { ModelOptionsResponse } from '@/types/hermes'
 
 import { onComposerModelMenuRequest } from './focus'
 import { useComposerScope } from './scope'
@@ -89,9 +93,28 @@ export function ModelPill({
   const pinnedOverride =
     view.kind === 'primary' && !runtimeId && modelSource === 'manual' && Boolean(currentModel.trim())
 
-  // The model resolves a beat after the gateway/session comes up. Rather than
-  // flash a literal "No model", show a quiet loader (inherits the pill text
-  // color at half opacity) until a model lands.
+  // #96063: subscribe to the profile-scoped model-options cache so a config
+  // default change re-paints the pill with the new baseline. `enabled: false`
+  // keeps it a pure cache subscription — no fetch, no spinner; the catalog
+  // fetcher (model-menu-panel / ComposerControls) owns that.
+  const profile = useStore($activeGatewayProfile)
+
+  const defaultProvider = useQuery<ModelOptionsResponse | undefined>({
+    enabled: false,
+    queryFn: () => undefined,
+    queryKey: modelOptionsQueryKey(profile)
+  }).data?.provider?.trim() ?? ''
+
+  // Two same-named models on two providers (e.g. `qwen3.7-plus` on both
+  // `custom:aliyun-coding-plan` and `custom:token-plan-a`) would otherwise look
+  // identical. When the live provider has drifted from the Settings default,
+  // paint a muted tag inside the pill so the desync is visible at a glance
+  // — and extend the tooltip / aria-label so hover + screen readers both name
+  // both providers.
+  const liveProvider = currentProvider.trim()
+  const hasDefaultProvider = defaultProvider.length > 0
+  const showProviderTag = hasDefaultProvider && liveProvider.length > 0 && liveProvider !== defaultProvider
+
   const label = compact ? (
     <ChevronDown className="size-3.5 shrink-0 opacity-70" />
   ) : (
@@ -99,6 +122,15 @@ export function ModelPill({
       {currentModel.trim() ? (
         <span className="truncate">
           {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
+          {showProviderTag && (
+            <span
+              aria-hidden="true"
+              className="ml-0.5 opacity-70"
+              data-testid="model-provider-tag"
+            >
+              {copy.providerTag(liveProvider)}
+            </span>
+          )}
         </span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />
@@ -128,13 +160,22 @@ export function ModelPill({
     ? copy.modelTitle(currentProvider, currentModel || copy.modelNone)
     : copy.switchModel
 
-  const title = pinnedOverride ? `${baseTitle} — ${copy.modelPinned}` : baseTitle
+  // #96063: when the live provider has drifted from the Settings default, name
+  // both so hover + screen readers can tell which provider the session will
+  // actually route to. The visible provider tag inside the label covers the
+  // "glance" path; this carries the same information into the tooltip /
+  // aria-label path so users who do hover (or who use AT) get the full picture.
+  const nonDefaultSuffix = showProviderTag ? ` — ${copy.nonDefaultProvider(liveProvider, defaultProvider)}` : ''
+
+  const title = `${baseTitle}${nonDefaultSuffix}${pinnedOverride ? ` — ${copy.modelPinned}` : ''}`
 
   if (!model.modelMenuContent) {
+    const pickerLabel = `${copy.openModelPicker}${nonDefaultSuffix}${pinnedOverride ? ` — ${copy.modelPinned}` : ''}`
+
     return (
-      <Tip label={pinnedOverride ? `${copy.openModelPicker} — ${copy.modelPinned}` : copy.openModelPicker} side="top">
+      <Tip label={pickerLabel} side="top">
         <Button
-          aria-label={copy.openModelPicker}
+          aria-label={pickerLabel}
           className={pillClass}
           disabled={disabled}
           onClick={() => setModelPickerOpen(true)}

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -612,6 +612,67 @@ describe('useModelControls', () => {
     expect(getCurrentModelSource()).toBe('default')
   })
 
+  // #96063: a stale persisted provider on a same-named model would silently
+  // send API calls to the wrong gateway. The persisted composer state is plain
+  // UI (NOT a manual pick); the profile default is the truth. refreshCurrentModel
+  // must reseed BOTH model and provider from the profile default when the
+  // source isn't 'manual', so the next session.create ships the config default
+  // even if the user never touched the picker.
+  it('reseeds a stale non-manual provider to the profile default (#96063)', async () => {
+    setCurrentModel('qwen3.7-plus')
+    setCurrentProvider('custom:token-plan-a')
+    setCurrentModelSource('default')
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'qwen3.7-plus',
+      provider: 'custom:aliyun-coding-plan'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('qwen3.7-plus')
+    expect($currentProvider.get()).toBe('custom:aliyun-coding-plan')
+    expect(getCurrentModelSource()).toBe('default')
+  })
+
+  // #96063: the converse guard. A manual pick with the same drift (a forgotten
+  // pick from a provider that's no longer the profile default) stays sticky —
+  // wiping it on every refresh would be a worse UX surprise than the visible
+  // pill mismatch. The pill carries the tag so the user can re-pick if needed.
+  it('preserves a manual pick whose provider has drifted from the profile default (#96063)', async () => {
+    setCurrentModel('qwen3.7-plus')
+    setCurrentProvider('custom:token-plan-a')
+    setCurrentModelSource('manual')
+    const queryClient = new QueryClient()
+
+    queryClient.setQueryData(modelOptionsQueryKey('default'), {
+      providers: [
+        { models: ['qwen3.7-plus'], name: 'custom:aliyun-coding-plan', slug: 'custom:aliyun-coding-plan' },
+        { models: ['qwen3.7-plus'], name: 'custom:token-plan-a', slug: 'custom:token-plan-a' }
+      ]
+    })
+
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'qwen3.7-plus',
+      provider: 'custom:aliyun-coding-plan'
+    })
+
+    const { result } = renderHook(() => useModelControls({ queryClient, requestGateway: vi.fn() }))
+
+    await result.current.refreshCurrentModel()
+
+    // Manual pick stays; the pill surfaces the mismatch via a muted provider tag.
+    expect($currentModel.get()).toBe('qwen3.7-plus')
+    expect($currentProvider.get()).toBe('custom:token-plan-a')
+    expect(getCurrentModelSource()).toBe('manual')
+  })
+
   it('targets an explicit tile sessionId without clobbering the primary model', async () => {
     const queryClient = new QueryClient()
     $activeGatewayProfile.set('compass')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -122,6 +122,14 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // 404 every new chat — fall through to reseed from the profile default.
         // Reads the model-options cache the composer already populated; an
         // unknown/not-yet-loaded catalog conservatively preserves the pick.
+        //
+        // #96063: a manual pick's provider can also drift from the config
+        // default (the user picked `custom:token-plan-a` once, then the config
+        // default flipped back to `custom:aliyun-coding-plan`). The pill
+        // surfaces that drift via a muted provider tag so the user can spot
+        // the stale route; we deliberately do NOT auto-reset a manual pick
+        // here — the user made an explicit choice and wiping it on every
+        // refresh would be a worse UX surprise than a visible mismatch.
         const keepManualPick = () => {
           if (force || !$currentModel.get() || getCurrentModelSource() !== 'manual') {
             return false

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2287,7 +2287,10 @@ export const ar = defineLocale({
       openModelPicker: 'فتح اختيار النموذج',
       modelPinned: 'النموذج مثبت',
       modelTitle: (provider, model) => `${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider}: ${model}`
+      providerModelTitle: (provider, model) => `${provider}: ${model}`,
+      providerTag: provider => `· ${provider}`,
+      nonDefaultProvider: (provider, defaultProvider) =>
+        `يتم استخدام ${provider} — ليس الإعداد الافتراضي في الإعدادات (${defaultProvider})`
     }
   },
   rightSidebar: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2950,7 +2950,14 @@ export const en: Translations = {
       openModelPicker: 'Open model picker',
       modelPinned: 'pinned by you; new chats use this instead of the Settings default',
       modelTitle: (provider, model) => `Model · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      // #96063: when two custom providers share a model id (e.g. `qwen3.7-plus`
+      // on both `custom:aliyun-coding-plan` and `custom:token-plan-a`) the pill
+      // would otherwise look identical for both routes. The muted tag makes the
+      // live provider visible without hover, so the user can spot the desync.
+      providerTag: provider => `· ${provider}`,
+      nonDefaultProvider: (provider, defaultProvider) =>
+        `Using ${provider} — not the Settings default (${defaultProvider})`
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2578,7 +2578,10 @@ export const ja = defineLocale({
       openModelPicker: 'モデルピッカーを開く',
       modelPinned: '手動で固定中 — 新しいチャットは設定のデフォルトではなくこのモデルを使用します',
       modelTitle: (provider, model) => `モデル · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      providerTag: provider => `· ${provider}`,
+      nonDefaultProvider: (provider, defaultProvider) =>
+        `${provider} を使用中 — 設定のデフォルト (${defaultProvider}) ではありません`
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2515,6 +2515,14 @@ export interface Translations {
       modelPinned: string
       modelTitle: (provider: string, model: string) => string
       providerModelTitle: (provider: string, model: string) => string
+      /** Short, muted pill tag showing the live provider when it differs from
+       *  the Settings → Model default. Prevents two same-named models on two
+       *  providers from looking identical (#96063). */
+      providerTag: (provider: string) => string
+      /** aria-label / tooltip body when the live provider has drifted from
+       *  the Settings → Model default. Carries both names so screen readers
+       *  and hover see the desync without having to dig into the picker. */
+      nonDefaultProvider: (provider: string, defaultProvider: string) => string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2489,7 +2489,10 @@ export const zhHant = defineLocale({
       openModelPicker: '開啟模型選擇器',
       modelPinned: '已由你固定；新對話將使用此模型而非「設定」中的預設模型',
       modelTitle: (provider, model) => `模型 · ${provider}：${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      providerTag: provider => `· ${provider}`,
+      nonDefaultProvider: (provider, defaultProvider) =>
+        `目前使用 ${provider} — 不是「設定」中的預設提供方 (${defaultProvider})`
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3114,7 +3114,10 @@ export const zh: Translations = {
       openModelPicker: '打开模型选择器',
       modelPinned: '已由你固定；新对话将使用此模型而非“设置”中的默认模型',
       modelTitle: (provider, model) => `模型 · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      providerTag: provider => `· ${provider}`,
+      nonDefaultProvider: (provider, defaultProvider) =>
+        `正在使用 ${provider} — 不是“设置”中的默认提供方 (${defaultProvider})`
     }
   },
 


### PR DESCRIPTION
## What Problem This Solves

Issue #96063 — the Desktop composer's model pill only renders the model name (e.g. "Qwen 3.7 Plus · High"), so two same-named models served by two different gateway providers look identical. The pill then pins the wrong provider in `$currentProvider` and every chat created from that state silently routes to the wrong gateway until they realise their token bucket isn't the one they configured.

The pill now subscribes to the profile-scoped model-options cache and, when the live provider has drifted from the Settings → Model default, renders a muted `· <provider>` tag inside the label plus a "(not the Settings default)" suffix on the tooltip / aria-label. When the live provider IS the default — the common case — the pill stays exactly as quiet as before, no extra noise for users on a stable single-provider setup.

A defensive regression test in `use-model-controls` pins the documented behaviour: a non-manual composer pick (legacy or stale) is reseeded from the profile default on refresh, so a forgotten pinned provider can never again persist as the gateway for a brand-new chat. The converse guard is also pinned — a genuine manual pick is deliberately kept sticky (auto-resetting would be a worse UX surprise than the visible pill mismatch), and the new tag is exactly how the user is told it's time to re-pick.

## Evidence

**Repro path before this fix** (from #96063):
1. Settings → Model = `qwen3.7-plus` on `custom:aliyun-coding-plan`.
2. User picks `qwen3.7-plus` on `custom:token-plan-a` once to compare.
3. Switches back via the picker — but `$currentProvider` is the stale token-plan slug.
4. Every new chat created afterwards sends `session.create` to `custom:token-plan-a`; the composer shows "Qwen 3.7 Plus · High" with no visible cue that the gateway is wrong.

**What changes**
- `apps/desktop/src/app/chat/composer/model-pill.tsx`: imports `useQuery` + `modelOptionsQueryKey` to reactively read the profile default, computes `showProviderTag`, renders `<span data-testid="model-provider-tag" aria-hidden="true">· {provider}</span>` inside the truncating label, and appends a `not the Settings default` suffix to both `title` and the fallback `pickerLabel` so hover and AT both name both providers.
- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: comment-only change — documents why `keepManualPick` does NOT reset on every refresh (deliberate sticky-pick UX), and why the pill is the surface that flags drift instead.
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja,ar}.ts`: adds two new statusbar strings — `providerTag(provider)` for the inline tag and `nonDefaultProvider(provider, default)` for the tooltip / aria-label suffix — with full coverage across all five supported locales.

**Tests**
- `model-pill.test.tsx`: 4 new cases under `ModelPill non-default provider tag (#96063)` — visible tag on drift, informative aria-label, quiet when matched, quiet when default hasn't loaded. The 5 pre-existing pinned-override / per-surface tests are wrapped with a `QueryClientProvider` helper since the pill now subscribes to the cache.
- `use-model-controls.test.tsx`: 2 new regression cases pin the contract — a stale non-manual source is reseeded to the profile default on `refreshCurrentModel`; a manual pick with drift stays sticky.

**Verification**
- `npm run typecheck` (tsc across `tsconfig.json`, `tsconfig.electron.json`, `tsconfig.e2e.json`) — clean.
- `npx vitest run src/app/chat/composer/model-pill.test.tsx --pool=threads` — 9 / 9 pass.
- `npx vitest run src/app/session/hooks/use-model-controls.test.tsx --pool=threads` — 23 / 23 pass.

Closes #96063