### PR TITLE
delegate_task: add optional per-spawn model/provider params

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8390,6 +8390,8 @@ class AIAgent:
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
+            model=function_args.get("model"),
+            provider=function_args.get("provider"),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -82,6 +82,115 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("acp_args", props["tasks"]["items"]["properties"])
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
+    def test_schema_exposes_per_spawn_model_and_provider(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertEqual(props["model"]["type"], "string")
+        self.assertEqual(props["provider"]["type"], "string")
+        self.assertIn("delegation.model", props["model"]["description"])
+        self.assertIn("delegation.provider", props["provider"]["description"])
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_model_provider_omitted_uses_config_defaults(
+        self, _mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": "configured-provider",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "configured-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "configured-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(goal="test", parent_agent=parent)
+
+        mock_creds.assert_called_once_with(
+            {"model": "configured-model", "provider": "configured-provider"},
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "configured-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "configured-provider"
+        )
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_model_provider_explicit_overrides_config(
+        self, _mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": "spawn-provider",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "spawn-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "spawn-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(
+                goal="test",
+                model="spawn-model",
+                provider="spawn-provider",
+                parent_agent=parent,
+            )
+
+        mock_creds.assert_called_once_with(
+            {
+                "model": "spawn-model",
+                "provider": "spawn-provider",
+            },
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "spawn-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "spawn-provider"
+        )
+
+    def test_spawn_model_provider_reject_non_string_values(self):
+        parent = _make_mock_parent()
+        result = delegate_task(goal="test", model=123, parent_agent=parent)
+        self.assertIn("model", json.loads(result)["error"].lower())
+
+        result = delegate_task(goal="test", provider=[], parent_agent=parent)
+        self.assertIn("provider", json.loads(result)["error"].lower())
+
     def test_top_level_description_compact_and_complete(self):
         """The top-level description must stay compact while keeping every
         contract that exists nowhere else in the schema (keyword-level, not
@@ -1383,6 +1492,69 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_dispatch_forwards_top_level_model_and_provider(self):
+        """The live model dispatch path forwards top-level model/provider kwargs."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "model": "spawn-model",
+                    "provider": "spawn-provider",
+                },
+            )
+
+        self.assertEqual(captured["model"], "spawn-model")
+        self.assertEqual(captured["provider"], "spawn-provider")
+
+    def test_dispatch_passes_none_when_model_provider_omitted(self):
+        """Omitting model/provider from the live dispatch yields None kwargs."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "test"},
+            )
+
+        self.assertIsNone(captured["model"])
+        self.assertIsNone(captured["provider"])
+
+    def test_dispatch_surfaces_validation_error_for_invalid_model(self):
+        """An invalid model passed through dispatch must surface the validation error."""
+        import run_agent
+        import tools.delegate_tool as delegate_module
+
+        parent = _make_mock_parent(depth=0)
+        # Bypass the mocked delegate_task to exercise the real validation branch.
+        result = run_agent.AIAgent._dispatch_delegate_task(
+            parent,
+            {"goal": "test", "model": 123},
+        )
+
+        self.assertIsInstance(result, str)
+        parsed = json.loads(result)
+        self.assertIn("error", parsed)
+        self.assertIn("model", parsed["error"])
+        # Ensure the validation lives in delegate_task, not in the dispatcher.
+        self.assertTrue(hasattr(delegate_module, "delegate_task"))
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -191,6 +191,234 @@ class TestDelegateRequirements(unittest.TestCase):
         result = delegate_task(goal="test", provider=[], parent_agent=parent)
         self.assertIn("provider", json.loads(result)["error"].lower())
 
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_model_only_override_keeps_configured_provider(
+        self, _mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": "configured-provider",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "spawn-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "spawn-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(goal="test", model="spawn-model", parent_agent=parent)
+
+        mock_creds.assert_called_once_with(
+            {"model": "spawn-model", "provider": "configured-provider"},
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "spawn-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "configured-provider"
+        )
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_provider_only_override_keeps_configured_model(
+        self, _mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": "spawn-provider",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "configured-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "configured-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(
+                goal="test",
+                provider="spawn-provider",
+                parent_agent=parent,
+            )
+
+        mock_creds.assert_called_once_with(
+            {"model": "configured-model", "provider": "spawn-provider"},
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "configured-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "spawn-provider"
+        )
+
+    def test_spawn_model_provider_reject_empty_string_values(self):
+        parent = _make_mock_parent()
+        result = delegate_task(goal="test", model="   ", parent_agent=parent)
+        self.assertIn("model", json.loads(result)["error"].lower())
+        result = delegate_task(goal="test", provider="", parent_agent=parent)
+        self.assertIn("provider", json.loads(result)["error"].lower())
+
+    def test_validation_skipped_for_control_actions(self):
+        """Control actions (list/steer/stop) must not be blocked by model/provider validation."""
+        sentinel = '{"action":"list","count":0,"subagents":[]}'
+        with patch(
+            "tools.delegate_tool._handle_control_action", return_value=sentinel
+        ) as control_mock:
+            parent = _make_mock_parent()
+            result = delegate_task(
+                action="list",
+                model=123,
+                provider=object(),
+                parent_agent=parent,
+            )
+
+        self.assertEqual(result, sentinel)
+        control_mock.assert_called_once()
+        # Validation must not fire before the control plane, and the raw values
+        # (no stripping / no rejection) must reach the control handler.
+        self.assertEqual(control_mock.call_args.args[0], "list")
+        self.assertEqual(control_mock.call_args.args[1], None)
+        self.assertEqual(control_mock.call_args.args[2], None)
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_overrides_strip_whitespace(self, _mock_cfg, mock_creds):
+        mock_creds.return_value = {
+            "provider": "spawn-provider",
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "spawn-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "spawn-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(
+                goal="test",
+                model="  spawn-model  ",
+                provider="\tspawn-provider\n",
+                parent_agent=parent,
+            )
+
+        mock_creds.assert_called_once_with(
+            {"model": "spawn-model", "provider": "spawn-provider"},
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "spawn-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "spawn-provider"
+        )
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={
+        "model": "configured-model",
+        "provider": "configured-provider",
+    })
+    def test_spawn_override_combines_with_internal_credentials_cfg(
+        self, _mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": "spawn-provider",
+            "base_url": "https://api.example",
+            "api_key": "secret",
+            "api_mode": "chat",
+            "model": "spawn-model",
+        }
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child._delegate_saved_tool_names = []
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.model = "spawn-model"
+        with patch(
+            "tools.delegate_tool._build_child_preserving_parent_tools",
+            return_value=child,
+        ) as build_child:
+            delegate_task(
+                goal="test",
+                model="spawn-model",
+                provider="spawn-provider",
+                credentials_cfg={
+                    "base_url": "https://api.example",
+                    "api_key": "secret",
+                    "api_mode": "chat",
+                    "model": "review-model",
+                    "provider": "review-provider",
+                },
+                parent_agent=parent,
+            )
+
+        # credentials_cfg wins over the global cfg, but per-spawn overrides
+        # still rewrite only the model/provider axes.
+        mock_creds.assert_called_once_with(
+            {
+                "base_url": "https://api.example",
+                "api_key": "secret",
+                "api_mode": "chat",
+                "model": "spawn-model",
+                "provider": "spawn-provider",
+            },
+            parent,
+        )
+        self.assertEqual(build_child.call_args.kwargs["model"], "spawn-model")
+        self.assertEqual(
+            build_child.call_args.kwargs["override_provider"], "spawn-provider"
+        )
+
     def test_top_level_description_compact_and_complete(self):
         """The top-level description must stay compact while keeping every
         contract that exists nowhere else in the schema (keyword-level, not

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3635,14 +3635,23 @@ def delegate_task(
     message: Optional[str] = None,
     parent_agent=None,
     credentials_cfg: Optional[Dict[str, Any]] = None,
+    # Added after all pre-existing positional parameters to preserve callers
+    # that pass them positionally. These are model-facing spawn overrides.
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks, or control
     already-running ones.
 
     Spawn modes (action='spawn' or omitted):
-      - Single: provide goal (+ optional context and role)
-      - Batch:  provide tasks array [{goal, context, role}, ...]
+      - Single: provide goal (+ optional context, role, model, and provider)
+      - Batch:  provide tasks array [{goal, context, role}, ...] plus optional
+                top-level model and provider overrides
+
+    Optional model/provider values override the configured
+    delegation.model/delegation.provider values for every child in this call.
+    Omit either value to preserve that axis's configured or inherited behavior.
 
     Control modes (synchronous, never backgrounded):
       - action='list'  -> live children of this conversation's spawn tree
@@ -3672,6 +3681,16 @@ def delegate_task(
         return tool_error(
             f"Unknown action '{action}'. Use spawn (default), list, steer, or stop."
         )
+
+    for param_name, value in (("model", model), ("provider", provider)):
+        if value is not None and not isinstance(value, str):
+            return tool_error(
+                f"delegate_task '{param_name}' must be a string, got {type(value).__name__}."
+            )
+        if isinstance(value, str) and not value.strip():
+            return tool_error(
+                f"delegate_task '{param_name}' must not be empty; omit it to use the configured default."
+            )
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running
@@ -3723,7 +3742,15 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
+    # Resolve delegation credentials (provider:model pair). Per-spawn values
+    # intentionally win over the global delegation defaults, but each axis is
+    # independent: a model-only override keeps the configured provider, and a
+    # provider-only override keeps the configured/inherited model.
+    effective_delegation_cfg = dict(credentials_cfg if credentials_cfg else cfg)
+    if model is not None:
+        effective_delegation_cfg["model"] = model.strip()
+    if provider is not None:
+        effective_delegation_cfg["provider"] = provider.strip()
     # When delegation.provider is configured, this resolves the full credential
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
@@ -3736,7 +3763,7 @@ def delegate_task(
     # without touching the global delegation pin.
     try:
         creds = _resolve_delegation_credentials(
-            credentials_cfg if credentials_cfg else cfg, parent_agent
+            effective_delegation_cfg, parent_agent
         )
     except ValueError as exc:
         return tool_error(str(exc))
@@ -4798,6 +4825,20 @@ DELEGATE_TASK_SCHEMA = {
                     "specific you are, the better the subagent performs."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional per-spawn model override. Omit to use the "
+                    "delegation.model config value or inherit the parent model."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional per-spawn provider override. Omit to use the "
+                    "delegation.provider config value or inherit the parent provider."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -4948,6 +4989,8 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
+        model=args.get("model"),
+        provider=args.get("provider"),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),


### PR DESCRIPTION
## What Problem This Solves

`delegate_task` previously only honored `model`/`provider` settings that lived in the agent-wide `delegation.model` / `delegation.provider` configuration. Any caller that needed a one-off override for a specific spawn had no way to express it without editing config and reloading the agent. This change adds optional top-level `model` and `provider` parameters to `delegate_task`, mirroring the optional override semantics that already exist for cron jobs and `create_job`, while remaining fully backward compatible when the new parameters are omitted.

Behavior:
- Omitting either parameter keeps the existing precedence: configured `delegation.model` / `delegation.provider` first, then the parent agent's model/provider as fallback.
- Supplying either (or both) parameters overrides only that axis on a per-spawn basis. A model-only override keeps the configured/inherited provider; a provider-only override keeps the configured/inherited model.
- Non-string values or empty strings are rejected with a JSON `tool_error` containing the offending parameter name; `None` (the field being absent) is accepted and treated as "use the configured default".
- Control actions (`list`, `steer`, `stop`) intentionally ignore the new parameters and are not subject to the validation gate, matching how they already ignore `goal`/`tasks`.
- The new parameters are exposed in `DELEGATE_TASK_SCHEMA["parameters"]["properties"]` so any front-end that introspects the schema picks them up automatically. They are also forwarded through `run_agent.AIAgent._dispatch_delegate_task` and the registry handler that calls `delegate_task` from the live model dispatch path, so model-facing spawns see the override end-to-end.

## Evidence

Targeted TDD cycle on the model/tooling:

- `tests/tools/test_delegate.py::TestDelegateRequirements::test_schema_exposes_per_spawn_model_and_provider` — asserts the new schema properties, their `string` type, and that each description references the corresponding `delegation.model` / `delegation.provider` fallback.
- `tests/tools/test_delegate.py::TestDelegateRequirements::test_spawn_model_provider_omitted_uses_config_defaults` — asserts that when both `model` and `provider` are omitted, the merged delegation config passed to `_resolve_delegation_credentials` and ultimately to `_build_child_preserving_parent_tools` still uses the configured `configured-model` / `configured-provider`.
- `tests/tools/test_delegate.py::TestDelegateRequirements::test_spawn_model_provider_explicit_overrides_config` — asserts that supplying both overrides rewrites only that axis on the merged config and forwards them into `_build_child_preserving_parent_tools`.
- `tests/tools/test_delegate.py::TestDelegateRequirements::test_spawn_model_provider_reject_non_string_values` — asserts that supplying a non-string `model` (and separately `provider`) yields a JSON `tool_error` whose message contains the offending parameter name.
- `tests/tools/test_delegate.py::TestDispatchDelegateTask::test_dispatch_forwards_top_level_model_and_provider` — asserts that `_dispatch_delegate_task` in `run_agent.py` forwards top-level `model` / `provider` kwargs through to `delegate_task`.
- `tests/tools/test_delegate.py::TestDispatchDelegateTask::test_dispatch_passes_none_when_model_provider_omitted` — asserts the omission path forwards `None` rather than dropping the keys.
- `tests/tools/test_delegate.py::TestDispatchDelegateTask::test_dispatch_surfaces_validation_error_for_invalid_model` — asserts the dispatcher surfaces the JSON `tool_error` from the validation branch when an invalid type is supplied.

Local verification:

```
D:\code\venvs\hermes-dev\Scripts\python.exe -m pytest tests/tools/test_delegate.py -q
... 76 passed in 28.34s

D:\code\venvs\hermes-dev\Scripts\python.exe -m pytest tests/tools/test_delegate.py -k \
  "per_spawn or explicit_overrides_config or reject_non_string or dispatch_forwards_top_level_model and provider or dispatch_passes_none_when_model_provider_omitted or dispatch_surfaces_validation_error_for_invalid_model" -v
... 6 passed, 70 deselected in 10.06s
```

`run_agent` dispatch tests (`-k "dispatch or delegate"`) pass; the single unrelated failure in `tests/run_agent/test_tool_call_guardrail_runtime.py::test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispatch` is a pre-existing Windows path-separator assertion that fails on this branch even before any of these changes (it compares `/approved/path` against a back-slashed working directory string) and is not introduced or touched by this fix.

Closes #96014