### PR TITLE
fix(utils): canonicalize Windows junction temp paths in atomic_json_write

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -27,6 +27,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+import utils
 from utils import (
     atomic_json_write,
     atomic_replace,
@@ -106,6 +107,59 @@ def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     assert link.is_symlink()
     loaded = json.loads(real.read_text(encoding="utf-8"))
     assert loaded == {"hello": "world"}
+
+
+def test_atomic_json_write_uses_physical_parent_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows, mkstemp must receive the parent's physical directory, not a
+    junction spelling of it (#95559).
+
+    A Windows filesystem filter can report a false EEXIST for a random
+    mkstemp name when the call traverses a directory junction. CPython treats
+    every EEXIST as a real name collision and retries up to TMP_MAX, so that
+    single false result turns into an effectively unbounded retry loop that
+    pins a worker thread. The fix resolves the parent through
+    ``os.path.realpath`` before handing it to ``mkstemp`` when running on
+    Windows.
+
+    A junction can't be created on this platform, so a plain symlinked
+    directory stands in for it here: the code path under test only calls
+    ``os.path.realpath()`` on the parent, which resolves either kind of
+    reparse point identically, and ``_IS_WINDOWS`` is monkeypatched directly
+    rather than mocking ``sys.platform`` so the real POSIX filesystem calls
+    still run underneath.
+    """
+    if os.name != "posix":
+        pytest.skip("uses a POSIX symlink to stand in for a Windows junction")
+
+    physical_dir = tmp_path / "physical"
+    physical_dir.mkdir()
+    junction_dir = tmp_path / "junction"
+    junction_dir.symlink_to(physical_dir, target_is_directory=True)
+
+    target = junction_dir / "cache.json"
+
+    mkstemp_dirs: list[str] = []
+    real_mkstemp = utils.tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        mkstemp_dirs.append(kwargs.get("dir"))
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(utils, "_IS_WINDOWS", True)
+    monkeypatch.setattr(utils.tempfile, "mkstemp", tracking_mkstemp)
+
+    atomic_json_write(target, {"hello": "world"})
+
+    assert mkstemp_dirs == [str(physical_dir)], (
+        f"mkstemp must be called with the physical parent, got {mkstemp_dirs}"
+    )
+    loaded = json.loads((physical_dir / "cache.json").read_text(encoding="utf-8"))
+    assert loaded == {"hello": "world"}
+    # The caller-visible path stays a junction/symlink — publication targets
+    # the caller's own spelling, only the temp file's parent is resolved.
+    assert junction_dir.is_symlink()
 
 
 @pytest.mark.require_symlinks

--- a/utils.py
+++ b/utils.py
@@ -373,8 +373,15 @@ def atomic_json_write(
     original_mode = None if mode is not None else _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
 
+    # Windows filesystem filters can report false name collisions when
+    # ``mkstemp`` traverses a junction spelling. CPython treats EEXIST as a
+    # random-name collision and retries up to TMP_MAX, turning that false
+    # result into an effectively unbounded CPU loop. Create the sibling temp
+    # through the physical parent spelling instead; the published target keeps
+    # its caller-visible path and final-component symlink semantics.
+    temp_parent = Path(os.path.realpath(path.parent)) if _IS_WINDOWS else path.parent
     fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent),
+        dir=str(temp_parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",
     )


### PR DESCRIPTION
## What does this PR do?

Prevents `atomic_json_write()` from driving `tempfile.mkstemp()` into an effectively unbounded retry loop when the target's parent directory is reached through a Windows directory junction.

### Symptom

On Windows, a Desktop backend can remain alive while routes that dispatch through the executor stop responding (`/api/status`, `/api/profiles`, `/api/tools/toolsets` time out; `/api/health` keeps responding), showing "Runtime not ready" on new tabs. A full restart clears it, but the underlying cause returns.

### Root cause

`atomic_json_write()` (e.g. via `_save_provider_models_cache`) passes the caller's parent-directory spelling straight into `tempfile.mkstemp(dir=...)`. When that parent is reached through a Windows directory junction, filesystem filters can report a false `EEXIST` for a randomly-generated temp filename. CPython's `mkstemp` treats every `EEXIST` as a real name collision and retries up to `tempfile.TMP_MAX`, so a single false result turns into a CPU-pinned worker thread that never returns.

### Fix

On Windows only, resolve the parent directory to its physical path (`os.path.realpath`) before it's handed to `mkstemp`. The published target still uses the caller-visible path, so junction/symlink semantics on the final path component are unaffected. Non-Windows behavior is unchanged (`_IS_WINDOWS` gates the new branch).

## Changes Made

- `utils.py` — canonicalize the `mkstemp` parent on Windows in `atomic_json_write()`.
- `tests/test_atomic_replace_symlinks.py` — new regression test. A real Windows junction can't be created on this sandbox, so the test monkeypatches `utils._IS_WINDOWS` and uses a POSIX symlinked directory as a stand-in (the code path under test only calls `os.path.realpath()` on the parent, which resolves either reparse-point kind identically); it tracks the `dir=` argument actually passed to `mkstemp` and asserts it's the physical path, not the symlink/junction spelling.

## How to Test

```bash
uv run --frozen pytest tests/test_atomic_replace_symlinks.py -q
uv run --frozen ruff check utils.py tests/test_atomic_replace_symlinks.py
```

## Checklist

- [x] Mutation-verified: the new regression test fails against the pre-fix code (confirmed by stashing the `utils.py` change and re-running) and passes with the fix applied.
- [x] Full existing `tests/test_atomic_replace_symlinks.py` suite passes (21 passed, 5 skipped — skips are pre-existing platform-gated symlink tests, unrelated to this change).
- [x] `tests/hermes_cli/test_atomic_json_write.py` passes unchanged.
- [x] `ruff check` passes on both changed files.