### PR TITLE
feat(whatsapp): add emergency outbound send lock

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1218,6 +1218,11 @@ platform_toolsets:
 #       # Omit either key to preserve Slack's default for that preview type.
 #       unfurl_links: false
 #       unfurl_media: false
+#   whatsapp:
+#     extra:
+#       # Suppress Hermes messages and typing while leaving inbound collection
+#       # running. Defaults to true. See the WhatsApp docs for the hard lock.
+#       outbound_enabled: true
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -57,6 +57,27 @@ def _wenv(name: str, default: str = "") -> str:
 
 logger = logging.getLogger(__name__)
 
+
+_FALSE_LIKE = {"0", "false", "no", "off", "disabled"}
+
+
+def whatsapp_outbound_block_reason(extra: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Return the active WhatsApp outbound hard-lock reason, if any."""
+    hermes_home = Path(
+        os.environ.get("HERMES_HOME") or Path.home() / ".hermes"
+    ).expanduser()
+    lock_path = hermes_home / "locks/whatsapp-outbound.lock"
+    if lock_path.exists():
+        return f"WhatsApp outbound hard-blocked by lock file: {lock_path}"
+
+    values = extra or {}
+    if "outbound_enabled" in values:
+        configured = str(values.get("outbound_enabled", "")).strip().lower()
+        if configured in _FALSE_LIKE:
+            return "WhatsApp outbound hard-blocked by configuration"
+
+    return None
+
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
@@ -935,6 +956,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
         """
+        if reason := whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return SendResult(success=False, error=reason)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1001,6 +1024,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent message via the WhatsApp bridge."""
+        if reason := whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return SendResult(success=False, error=reason)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1034,6 +1059,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> SendResult:
         """Send any media file via bridge /send-media endpoint."""
+        if reason := whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return SendResult(success=False, error=reason)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1088,6 +1115,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         remain gateway-owned and add text fallback plus explicit confirmation
         semantics before approval prompts are ever mapped onto polls.
         """
+        if reason := whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return SendResult(success=False, error=reason)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1172,6 +1201,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a native WhatsApp location pin via the Baileys bridge."""
+        if reason := whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return SendResult(success=False, error=reason)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1277,6 +1308,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
+        if whatsapp_outbound_block_reason(getattr(self.config, "extra", None)):
+            return
         if not self._running or not self._http_session:
             return
         if await self._check_managed_bridge_exit():
@@ -1714,6 +1747,8 @@ async def _standalone_send(
     ``/send`` message beforehand.
     """
     extra = getattr(pconfig, "extra", {}) or {}
+    if reason := whatsapp_outbound_block_reason(extra):
+        return {"error": reason}
     try:
         import aiohttp
     except ImportError:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -113,6 +113,8 @@ const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const HERMES_HOME = process.env.HERMES_HOME || path.join(process.env.HOME || '~', '.hermes');
+const OUTBOUND_LOCK_PATH = path.join(HERMES_HOME, 'locks', 'whatsapp-outbound.lock');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -810,6 +812,29 @@ app.use((req, res, next) => {
       error: 'Invalid Host header. Bridge accepts loopback hosts only.',
     });
   }
+  next();
+});
+
+// Deployment hard lock: protect every message-sending and typing endpoint.
+const _OUTBOUND_ENDPOINTS = [
+  '/send',
+  '/edit',
+  '/send-media',
+  '/send-poll',
+  '/send-location',
+  '/typing',
+];
+
+function outboundBlockReason() {
+  if (existsSync(OUTBOUND_LOCK_PATH)) {
+    return `WhatsApp outbound hard-blocked by lock file: ${OUTBOUND_LOCK_PATH}`;
+  }
+  return null;
+}
+
+app.use(_OUTBOUND_ENDPOINTS, (req, res, next) => {
+  const reason = outboundBlockReason();
+  if (reason) return res.status(403).json({ error: reason });
   next();
 });
 

--- a/tests/gateway/test_whatsapp_outbound_policy.py
+++ b/tests/gateway/test_whatsapp_outbound_policy.py
@@ -1,0 +1,39 @@
+import asyncio
+from types import SimpleNamespace
+
+from plugins.platforms.whatsapp import adapter
+
+
+def test_physical_lock_blocks(tmp_path, monkeypatch):
+    lock = tmp_path / "locks/whatsapp-outbound.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("locked\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert str(lock) in adapter.whatsapp_outbound_block_reason()
+
+
+def test_explicit_false_config_blocks_without_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert "configuration" in adapter.whatsapp_outbound_block_reason(
+        {"outbound_enabled": False}
+    )
+
+
+def test_missing_policy_preserves_upstream_behavior(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert adapter.whatsapp_outbound_block_reason() is None
+
+
+def test_standalone_sender_fails_before_transport_import(tmp_path, monkeypatch):
+    lock = tmp_path / "locks/whatsapp-outbound.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("locked\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    result = asyncio.run(
+        adapter._standalone_send(
+            SimpleNamespace(extra={}),
+            "0000000000000@s.whatsapp.net",
+            "must not send",
+        )
+    )
+    assert "hard-blocked" in result["error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -427,6 +427,13 @@ def _handle_send(args):
         else:
             return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
 
+    # Deployment hard lock: keep CLI/tool egress aligned with the live adapter.
+    if platform == Platform.WHATSAPP:
+        from plugins.platforms.whatsapp.adapter import whatsapp_outbound_block_reason
+
+        if reason := whatsapp_outbound_block_reason(getattr(pconfig, "extra", None)):
+            return tool_error(reason)
+
     from gateway.platforms.base import BasePlatformAdapter
 
     # Capture [[as_document]] directive before extract_media strips it.

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -222,6 +222,33 @@ The Baileys-bridge adapter (bot mode) supports several native WhatsApp message t
 
 All of this works out of the box in bot (Baileys) mode; no configuration needed.
 
+### Emergency Send Lock
+
+To keep receiving WhatsApp messages while suppressing Hermes replies and typing
+indicators, disable outbound activity in `~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        outbound_enabled: false
+```
+
+This blocks text, media, edits, polls, locations, typing indicators, and scheduled
+or tool-driven sends through Hermes. Inbound collection remains active.
+
+For an immediate bridge-wide send lock that also rejects direct send requests to the
+local bridge, create this file:
+
+```bash
+mkdir -p ~/.hermes/locks
+touch ~/.hermes/locks/whatsapp-outbound.lock
+```
+
+Remove `~/.hermes/locks/whatsapp-outbound.lock` to restore the configured behavior.
+The lock file takes precedence over configuration.
+
 ### Message Batching (Debounce)
 
 WhatsApp delivers each message individually, so a rapid burst (forwarded batches, paste-splits, multi-line text) would otherwise trigger a separate agent invocation per fragment — wasting tokens and producing several disjointed replies. The adapter buffers successive text messages from the same chat and dispatches them as one combined request after a short quiet period (default **5s**, extended to **10s** for very long fragments). Tune via `config.yaml`:


### PR DESCRIPTION
## Summary

- Add an opt-in WhatsApp send gate through `gateway.platforms.whatsapp.extra.outbound_enabled`.
- Add a `$HERMES_HOME/locks/whatsapp-outbound.lock` sentinel enforced by the adapter, standalone sender, direct send tool, and every Baileys message/typing endpoint.
- Keep inbound polling and ingestion unchanged while the lock is active.
- Document both the configuration gate and the bridge-wide operational lock.

## Scope

This packages a strict no-send safety mechanism already used in a live deployment. It does not implement the selective mention override proposed in #33912; when locked, Hermes sends nothing through this WhatsApp adapter.

Relates to #33912.

## Verification

- `scripts/run_tests.sh tests/gateway/test_whatsapp_*.py tests/tools/test_whatsapp_*.py tests/hermes_cli/test_whatsapp_*.py tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py tests/tools/test_send_message_tool.py -q`
  - 158 passed, 4 skipped, 0 failed across 24 files
- `ruff check plugins/platforms/whatsapp/adapter.py tools/send_message_tool.py tests/gateway/test_whatsapp_outbound_policy.py`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `git diff --check`

The full repository test suite was not run locally.
