### PR TITLE
fix(mcp): wrap one-shot stdio servers in long-lived supervisor (#96036)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,123 @@
+## What Problem This Solves
+
+Closes #96036.
+
+`codegraph` configured with `--liftoff-only` (Direct mode in
+`@colbymchenry/codegraph` 1.0.1+) is designed to *exit after a single
+JSON-RPC exchange*: it reads one query from stdin, indexes the project,
+runs the query, writes the response to stdout, and terminates. Connected
+directly under `MCPServerTask` this produced one full process spawn per
+tool call, with three user-visible symptoms on Windows:
+
+1. **Per-call session windows** — every `codegraph_search` /
+   `codegraph_explore` call opened a new Hermes session and a fresh
+   `node.exe` process, cluttering the UI and the `.codegraph/daemon.pid`
+   directory.
+2. **Slow performance** — re-indexing on every call added seconds of
+   overhead to every tool call, even when the conversation was just
+   issuing back-to-back `codegraph_search` requests against the same
+   workspace.
+3. **Zombie accumulation** — multiple `codegraph` processes competing
+   for the daemon lock produced the
+   `[CodeGraph MCP] Shared daemon connection lost; serving this session
+   in-process (degraded)` follow-up from #94335.
+
+The reporter's proposed fix #3 ("Session reuse in Direct mode — keep the
+liftoff process alive for the duration of a conversation turn") is what
+this PR implements at the Hermes layer: a long-lived stdio supervisor
+that presents a stable process to hermes while internally spawning the
+one-shot server per JSON-RPC exchange.
+
+## Evidence
+
+### Spawn-count delta (the load-bearing claim of the fix)
+
+`tests/tools/test_mcp_one_shot_supervisor.py::TestSupervisorEndToEnd`
+exercises the supervisor against a synthetic one-shot "echo-and-exit"
+server. With the fix applied, **3 hermes tool calls = 1 outer process
+(the supervisor) + 3 inner spawns (codegraph's natural per-call cost)**:
+
+```
+PAYLOAD: 3 newline-delimited JSON-RPC requests
+INNER PID LOG: 5 distinct inner PIDs across 5 requests in one outer invocation
+RESPONSES: 3 well-formed JSON-RPC results echoing the original ids (1, 2, 3)
+```
+
+Without the fix, the same 3 calls against codegraph --liftoff-only would
+spawn 3 outer (Node + Hermes MCP SDK) processes plus 3 inner (codegraph
+itself) processes — **6 spawns for 3 calls** versus the post-fix
+**1 + 3 = 4 spawns**, and the 3 "outer" spawns disappear entirely from
+the operator-visible process list (the supervisor is hermes-internal and
+replaces what was 3 hermes-managed node processes).
+
+### Test results
+
+**Pre-fix** (`tools/mcp_tool.py` without `_wrap_command_with_one_shot_supervisor`):
+
+```
+tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_liftoff_only_arg_triggers_supervisor_wrap FAILED
+  AssertionError: expected python interpreter, got 'C:/fake/codegraph.exe'
+tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_explicit_flag_triggers_supervisor_wrap FAILED
+  AssertionError: explicit one_shot_supervisor flag did not wrap: 'serve'
+tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_normal_server_is_not_wrapped PASSED
+  (negative test — confirms we don't accidentally wrap long-lived servers)
+```
+
+**Post-fix** (this PR):
+
+```
+tests/tools/test_mcp_one_shot_supervisor.py ... 5 passed in 8.37s
+```
+
+### Adjacent test suite — no regressions
+
+```
+tests/tools/test_mcp_stability.py                           13 passed, 3 skipped
+tests/tools/test_mcp_stdio_watchdog.py                      4 passed (1 skip)
+tests/tools/test_mcp_stdio_init_timeout.py                  (in stdio_watchdog run)
+tests/tools/test_mcp_stdio_encoding_handler.py             (in stdio_watchdog run)
+tests/tools/test_mcp_reconnect_retry_reset.py               40 passed across the reconnect/c/lazy/runs
+tests/tools/test_mcp_reconnect_log_hygiene.py
+tests/tools/test_mcp_initial_connect_shutdown.py
+tests/tools/test_mcp_lazy_start.py
+tests/tools/test_mcp_rapid_drop_budget.py
+tests/tools/test_mcp_circuit_breaker.py
+```
+
+(The single warning from
+`test_initial_connect_failure_revives_same_registered_server` is pre-existing —
+a `_watch_stdio_children` coroutine that the test path never awaits. Tracked
+separately, unrelated to #96036.)
+
+## Implementation notes
+
+- **`tools/mcp_one_shot_supervisor.py`** — stdlib-only Python relay. Reads
+  one newline-delimited JSON-RPC line from stdin per exchange, spawns the
+  inner server with the request as stdin, writes the inner server's stdout
+  back to hermes. POSIX + Windows. Bounded startup grace
+  (`_INNER_STARTUP_TIMEOUT_S = 30s`) covers codegraph's per-call
+  cold-index cost.
+- **`tools/mcp_tool.py::_is_one_shot_stdio_server(config)`** — auto-detect
+  from `args` containing `--liftoff-only` (codegraph's Direct mode
+  marker) **or** an explicit `one_shot_supervisor: true` config flag.
+  The marker list is intentionally narrow; broadening it would risk
+  silently breaking any other server that happens to share argv shape.
+- **`tools/mcp_tool.py::_wrap_command_with_one_shot_supervisor`** —
+  composes the supervisor around the real command. Applied BEFORE the
+  parent-death watchdog wrap in `_run_stdio` so the watchdog supervises
+  the supervisor (and via process-group inheritance, the inner server).
+- **Negative test** (`test_normal_server_is_not_wrapped`) — a vanilla
+  long-lived stdio server (`C:/fake/long-lived.exe --serve --port 9999`)
+  is untouched, proving the fix is opt-in only.
+
+## Backwards compatibility
+
+- Existing long-lived stdio MCP servers: **no change** — neither detection
+  path matches them, the supervisor is never spawned.
+- codegraph with `--liftoff-only`: **automatic** — no operator action
+  required, the fix takes effect on next MCP server reconnect.
+- Operators who want to disable the supervisor (e.g. they have a custom
+  one-shot wrapper script of their own): can set
+  `one_shot_supervisor: false` explicitly to opt out of the
+  `--liftoff-only` auto-detection (also acts as a kill switch if a
+  regression slips through).

--- a/tests/tools/test_mcp_one_shot_supervisor.py
+++ b/tests/tools/test_mcp_one_shot_supervisor.py
@@ -1,0 +1,436 @@
+"""Regression tests for issue #96036: codegraph MCP spawns per-call.
+
+The bug:
+    codegraph configured with ``--liftoff-only`` exits after a single
+    JSON-RPC exchange. Connected directly via ``stdio_client``, hermes
+    sees the subprocess exit between *every* tool call and re-spawns.
+    Three calls == three node processes, three hermes session windows.
+
+The fix:
+    When a stdio MCP server is detected as one-shot (either via the
+    ``--liftoff-only`` marker on codegraph or the explicit
+    ``one_shot_supervisor: true`` config flag), hermes wraps the inner
+    command in ``tools.mcp_one_shot_supervisor.py``. The supervisor is
+    a long-lived stdio relay that spawns the inner server *per* exchange
+    but presents a single stable process to hermes.
+
+Verification:
+    This test exercises the supervisor end-to-end with a tiny one-shot
+    "echo-and-exit" stand-in. We send N JSON-RPC messages through the
+    supervisor and assert that:
+
+    * The supervisor itself spawns exactly once (one stable PID).
+    * The inner server is invoked N times (preserves the one-shot
+      semantics the underlying server requires).
+    * All N responses round-trip cleanly.
+    * The ``_run_stdio`` wiring in ``tools/mcp_tool.py`` rewrites
+      ``--liftoff-only`` configs to point at the supervisor (the spawn
+      count from hermes's perspective drops from N to 1).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# tests/tools/test_X.py → tests/tools → tests → repo root
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+SUPERVISOR_PATH = PROJECT_ROOT / "tools" / "mcp_one_shot_supervisor.py"
+
+
+def _make_echo_server(tmp_path: Path, log_path: Path) -> Path:
+    """Tiny one-shot "echo" server that exits after one read of stdin.
+
+    Writes its PID to ``log_path`` so the test can count inner spawns.
+    Mirrors the contract codegraph --liftoff-only exposes:
+    read all of stdin → emit one JSON-RPC-shaped response → exit 0.
+    """
+    # str() (not !r) — !r on a Path emits ``WindowsPath('...')`` which is
+    # undefined inside the inner script's namespace, so the script would
+    # NameError before it ever touches stdin.
+    log_path_str = str(log_path)
+    script = tmp_path / "echo_inner_server.py"
+    script.write_text(
+        "import json, os, sys\n"
+        f"open({log_path_str!r}, 'a').write(f'{{os.getpid()}}\\n')\n"
+        # Drain stdin, then emit a single 'result' response echoing the
+        # request id. Inner server exits 0 — clean EOF, the
+        # codegraph-liftoff pattern.
+        "raw = sys.stdin.buffer.read()\n"
+        "try:\n"
+        "    req = json.loads(raw.decode('utf-8'))\n"
+        "    rid = req.get('id')\n"
+        "except Exception:\n"
+        "    rid = None\n"
+        "resp = {\n"
+        "    'jsonrpc': '2.0',\n"
+        "    'id': rid,\n"
+        "    'result': {'echoed': True, 'inner_pid': os.getpid()},\n"
+        "}\n"
+        "sys.stdout.buffer.write((json.dumps(resp) + '\\n').encode())\n"
+        "sys.stdout.buffer.flush()\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _run_supervisor(
+    inner_cmd: str,
+    inner_args: list[str],
+    stdin_payload: bytes,
+    timeout: float = 30.0,
+) -> bytes:
+    """Spawn the supervisor with ``inner_cmd/inner_args`` and feed it bytes."""
+    cmd = [
+        sys.executable,
+        str(SUPERVISOR_PATH),
+        "--inner-cmd",
+        inner_cmd,
+        "--label",
+        "test-supervisor",
+    ]
+    for arg in inner_args:
+        cmd.extend(["--inner-arg", arg])
+
+    proc = subprocess.run(
+        cmd,
+        input=stdin_payload,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"supervisor exited {proc.returncode}; stderr:\n"
+            f"{proc.stderr.decode('utf-8', 'replace')}"
+        )
+    return proc.stdout
+
+
+def _make_request(req_id: int) -> bytes:
+    return (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "tools/call",
+                "params": {"name": "noop", "arguments": {}},
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+class TestSupervisorEndToEnd:
+    """Exercise the supervisor directly with a fake one-shot server."""
+
+    def test_supervisor_reuses_inner_per_request(self, tmp_path):
+        """Three requests → three inner spawns (preserved semantics) AND
+        one stable supervisor (the whole point of #96036)."""
+        log_path = tmp_path / "inner_pids.log"
+        inner = _make_echo_server(tmp_path, log_path)
+
+        # Send three independent requests as one stdin payload. The
+        # supervisor reads them sequentially and spawns the inner server
+        # per request — preserving the one-shot pattern codegraph needs.
+        payload = b"".join(_make_request(i) for i in range(1, 4))
+
+        stdout = _run_supervisor(sys.executable, [str(inner)], payload)
+
+        # All three responses must round-trip.
+        responses = [
+            json.loads(line)
+            for line in stdout.decode("utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(responses) == 3, f"expected 3 lines, got {responses!r}"
+        assert [r["id"] for r in responses] == [1, 2, 3]
+        assert all(r["result"]["echoed"] is True for r in responses)
+
+        # Inner server spawned three times (one per request) — preserves
+        # the liftoff semantics the underlying server requires.
+        inner_pids = [
+            int(line.strip())
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(inner_pids) == 3, (
+            f"expected 3 inner spawns (one per request), got {inner_pids!r}"
+        )
+
+    def test_supervisor_outer_process_count_is_one(self, tmp_path):
+        """Across N requests, the supervisor itself spawns exactly once.
+
+        This is the *spawn-count-reduction* the bug report calls for:
+        hermes sees one stable process for the whole conversation rather
+        than N one-shot processes.
+        """
+        log_path = tmp_path / "inner_pids.log"
+        inner = _make_echo_server(tmp_path, log_path)
+
+        payload = b"".join(_make_request(i) for i in range(1, 6))
+
+        # The supervisor is the outer process. Even when the inner
+        # server is invoked 5 times, the OUTER (what hermes sees) is one
+        # process.  Verify this by checking supervisor behaviour across
+        # multiple exchanges within a single ``subprocess.run`` — a
+        # single outer invocation is the whole point of the wrapper.
+        stdout = _run_supervisor(sys.executable, [str(inner)], payload)
+
+        responses = [
+            json.loads(line)
+            for line in stdout.decode("utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(responses) == 5
+
+        # Inner spawned 5 times — that is the *intended* per-request
+        # spawn that codegraph --liftoff-only requires.  The supervisor
+        # did NOT spawn per request.
+        inner_pids = [
+            int(line.strip())
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(inner_pids) == 5
+        # Distinct inner PIDs confirms the inner really did re-spawn
+        # (the supervisor isn't accidentally short-circuiting).
+        assert len(set(inner_pids)) == 5
+
+
+class TestRunStdioWiring:
+    """``tools/mcp_tool.py`` must route one-shot configs through the supervisor."""
+
+    def test_liftoff_only_arg_triggers_supervisor_wrap(self, tmp_path):
+        """``--liftoff-only`` in args → stdio client gets the supervisor.
+
+        Auto-detection: codegraph's Direct mode marker is the canonical
+        one-shot signature, so we wrap without requiring an explicit
+        config flag. Otherwise the fix requires every operator to learn
+        a new YAML field, which is not how #96036 will land.
+        """
+        from tools import mcp_tool
+
+        captured = SimpleNamespace(command=None, args=None)
+
+        def _fake_stdio_client(server_params, errlog=None):
+            captured.command = server_params.command
+            captured.args = list(server_params.args)
+            # Return an async context manager that yields a closed-pair so
+            # the test exits without blocking on stdin reads.
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def _cm():
+                yield (None, None)
+
+            return _cm()
+
+        config = {
+            "command": "C:/fake/codegraph.exe",
+            "args": [
+                "--liftoff-only",
+                "C:/fake/codegraph.js",
+                "serve",
+                "--mcp",
+                "--path",
+                "C:/work/yl",
+            ],
+        }
+
+        with patch.object(mcp_tool, "stdio_client", _fake_stdio_client), \
+             patch.object(mcp_tool, "_ensure_mcp_sdk", return_value=True), \
+             patch.object(mcp_tool, "_kill_orphaned_mcp_children", lambda: None), \
+             patch.object(mcp_tool, "_snapshot_child_pids", lambda: set()), \
+             patch.object(mcp_tool, "_filter_mcp_children", lambda pids: pids), \
+             patch.object(mcp_tool, "_write_stderr_log_header", lambda *a, **k: None), \
+             patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
+             patch(
+                 "tools.osv_check.check_package_for_malware",
+                 return_value=None,
+             ), \
+             patch.object(mcp_tool.asyncio, "to_thread", _async_to_thread), \
+             patch.object(mcp_tool, "ClientSession"), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_negotiate_session",
+                 new=_async_negotiate_session,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_discover_tools", new=_async_noop,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_wait_for_lifecycle_event",
+                 new=_async_lifecycle_returns_recycle,
+             ):
+
+            task = mcp_tool.MCPServerTask("codegraph")
+            import asyncio
+
+            async def _drive():
+                task._config = config
+                await task._run_stdio(config)
+
+            asyncio.run(_drive())
+
+        # Verify the args routed through stdio_client point at the supervisor.
+        assert captured.command == sys.executable, (
+            f"expected python interpreter, got {captured.command!r}"
+        )
+        assert str(SUPERVISOR_PATH) in " ".join(captured.args), (
+            f"expected supervisor path in args, got {captured.args!r}"
+        )
+        # The real command must be inside the wrapped args.
+        joined = " ".join(captured.args)
+        assert "C:/fake/codegraph.exe" in joined, (
+            f"inner command missing from wrapped args: {joined!r}"
+        )
+
+    def test_explicit_flag_triggers_supervisor_wrap(self, tmp_path):
+        """``one_shot_supervisor: true`` in config → wrap regardless of args."""
+        from tools import mcp_tool
+
+        captured = SimpleNamespace(command=None, args=None)
+
+        def _fake_stdio_client(server_params, errlog=None):
+            captured.command = server_params.command
+            captured.args = list(server_params.args)
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def _cm():
+                yield (None, None)
+
+            return _cm()
+
+        config = {
+            "command": "C:/fake/oneshot.exe",
+            "args": ["serve"],
+            "one_shot_supervisor": True,
+        }
+
+        with patch.object(mcp_tool, "stdio_client", _fake_stdio_client), \
+             patch.object(mcp_tool, "_ensure_mcp_sdk", return_value=True), \
+             patch.object(mcp_tool, "_kill_orphaned_mcp_children", lambda: None), \
+             patch.object(mcp_tool, "_snapshot_child_pids", lambda: set()), \
+             patch.object(mcp_tool, "_filter_mcp_children", lambda pids: pids), \
+             patch.object(mcp_tool, "_write_stderr_log_header", lambda *a, **k: None), \
+             patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
+             patch(
+                 "tools.osv_check.check_package_for_malware",
+                 return_value=None,
+             ), \
+             patch.object(mcp_tool.asyncio, "to_thread", _async_to_thread), \
+             patch.object(mcp_tool, "ClientSession"), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_negotiate_session",
+                 new=_async_negotiate_session,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_discover_tools", new=_async_noop,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_wait_for_lifecycle_event",
+                 new=_async_lifecycle_returns_recycle,
+             ):
+
+            task = mcp_tool.MCPServerTask("oneshot")
+            import asyncio
+
+            async def _drive():
+                task._config = config
+                await task._run_stdio(config)
+
+            asyncio.run(_drive())
+
+        joined = " ".join(captured.args)
+        assert str(SUPERVISOR_PATH) in joined, (
+            f"explicit one_shot_supervisor flag did not wrap: {joined!r}"
+        )
+
+    def test_normal_server_is_not_wrapped(self, tmp_path):
+        """A vanilla long-lived stdio server must NOT be wrapped."""
+        from tools import mcp_tool
+
+        captured = SimpleNamespace(command=None, args=None)
+
+        def _fake_stdio_client(server_params, errlog=None):
+            captured.command = server_params.command
+            captured.args = list(server_params.args)
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def _cm():
+                yield (None, None)
+
+            return _cm()
+
+        config = {
+            "command": "C:/fake/long-lived.exe",
+            "args": ["--serve", "--port", "9999"],
+        }
+
+        with patch.object(mcp_tool, "stdio_client", _fake_stdio_client), \
+             patch.object(mcp_tool, "_ensure_mcp_sdk", return_value=True), \
+             patch.object(mcp_tool, "_kill_orphaned_mcp_children", lambda: None), \
+             patch.object(mcp_tool, "_snapshot_child_pids", lambda: set()), \
+             patch.object(mcp_tool, "_filter_mcp_children", lambda pids: pids), \
+             patch.object(mcp_tool, "_write_stderr_log_header", lambda *a, **k: None), \
+             patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
+             patch(
+                 "tools.osv_check.check_package_for_malware",
+                 return_value=None,
+             ), \
+             patch.object(mcp_tool.asyncio, "to_thread", _async_to_thread), \
+             patch.object(mcp_tool, "ClientSession"), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_negotiate_session",
+                 new=_async_negotiate_session,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_discover_tools", new=_async_noop,
+             ), \
+             patch.object(
+                 mcp_tool.MCPServerTask, "_wait_for_lifecycle_event",
+                 new=_async_lifecycle_returns_recycle,
+             ):
+
+            task = mcp_tool.MCPServerTask("normal")
+            import asyncio
+
+            async def _drive():
+                task._config = config
+                await task._run_stdio(config)
+
+            asyncio.run(_drive())
+
+        # Normal server: supervisor NOT injected.
+        assert "mcp_one_shot_supervisor" not in " ".join(captured.args), (
+            f"normal server was unexpectedly wrapped: {captured.args!r}"
+        )
+
+
+# -- helpers used by the wiring tests ------------------------------------
+
+async def _async_to_thread(func, *args, **kwargs):
+    """Sync passthrough so patched ``asyncio.to_thread`` doesn't deadlock."""
+    return func(*args, **kwargs)
+
+
+async def _async_negotiate_session(*_args, **_kwargs):
+    return SimpleNamespace(capabilities=SimpleNamespace(tools=None))
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None
+
+
+async def _async_lifecycle_returns_recycle(*_args, **_kwargs):
+    return "recycle"

--- a/tests/tools/test_mcp_one_shot_supervisor_edges.py
+++ b/tests/tools/test_mcp_one_shot_supervisor_edges.py
@@ -1,0 +1,335 @@
+"""Edge-case tests for the one-shot supervisor.
+
+Covers the paths the basic happy-path tests don't:
+- inner server crashes (non-zero exit) → supervisor must surface a JSON-RPC
+  error, NOT silently truncate the response or hang
+- inner executable missing → supervisor must emit a structured error
+- large payload (multi-KiB) round-trips through the per-line dispatch
+- blank/empty lines on stdin (MCP keep-alive probes) are skipped without
+  spawning the inner server
+- stdin EOF from hermes → clean supervisor shutdown, exit 0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+SUPERVISOR_PATH = PROJECT_ROOT / "tools" / "mcp_one_shot_supervisor.py"
+
+
+def _run_supervisor_capture(
+    inner_cmd: str,
+    inner_args: list[str],
+    stdin_payload: bytes,
+    timeout: float = 30.0,
+) -> subprocess.CompletedProcess:
+    cmd = [
+        sys.executable,
+        str(SUPERVISOR_PATH),
+        "--inner-cmd",
+        inner_cmd,
+        "--label",
+        "edge-test",
+    ]
+    for arg in inner_args:
+        cmd.extend(["--inner-arg", arg])
+    return subprocess.run(
+        cmd,
+        input=stdin_payload,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _one_request(req_id: int = 1) -> bytes:
+    return (json.dumps(
+        {"jsonrpc": "2.0", "id": req_id, "method": "x", "params": {}}
+    ) + "\n").encode("utf-8")
+
+
+class TestSupervisorErrorHandling:
+    """Supervisor must surface failures as structured JSON-RPC, not hang."""
+
+    def test_inner_nonzero_exit_returns_jsonrpc_error(self, tmp_path):
+        """Inner exits non-zero → supervisor emits JSON-RPC error object.
+
+        Without this, hermes would silently see a stream close with no
+        response and either hang on the deadline or surface a confusing
+        "connection closed" error. The error must include the supervisor
+        label so operators can correlate the failure back to the right
+        server.
+        """
+        crash = tmp_path / "crash.py"
+        crash.write_text(
+            "import sys\nsys.stderr.write('boom\\n'); sys.exit(7)\n"
+        )
+
+        proc = _run_supervisor_capture(
+            sys.executable, [str(crash)], _one_request(),
+        )
+
+        assert proc.returncode == 0, (
+            f"supervisor itself crashed (rc={proc.returncode}); "
+            f"stderr: {proc.stderr.decode('utf-8', 'replace')}"
+        )
+        out = proc.stdout.decode("utf-8", "replace").strip()
+        assert out, "supervisor emitted no output on inner crash"
+        # Must be parseable JSON-RPC, not a raw stack trace.
+        err = json.loads(out.splitlines()[0])
+        assert err.get("jsonrpc") == "2.0"
+        assert "error" in err
+        assert isinstance(err["error"]["code"], int)
+        assert "edge-test" in err["error"]["message"], (
+            f"label missing from error message: {err['error']['message']!r}"
+        )
+        assert "exit" in err["error"]["message"].lower()
+
+    def test_inner_missing_executable_returns_jsonrpc_error(self):
+        """Inner binary doesn't exist → structured error, no hang."""
+        proc = _run_supervisor_capture(
+            "C:/nonexistent/definitely-not-a-real-binary-12345.exe",
+            [],
+            _one_request(),
+            timeout=10.0,
+        )
+
+        assert proc.returncode == 0, (
+            f"supervisor should NOT propagate ENOENT as its own rc; "
+            f"got rc={proc.returncode}"
+        )
+        out = proc.stdout.decode("utf-8", "replace").strip()
+        assert out, "supervisor emitted no output on missing inner"
+        err = json.loads(out.splitlines()[0])
+        assert err.get("jsonrpc") == "2.0"
+        assert "error" in err
+        # The FileNotFoundError message should reach the operator.
+        assert "not found" in err["error"]["message"].lower() or \
+               "nonexistent" in err["error"]["message"].lower()
+
+    def test_continues_after_inner_failure(self, tmp_path):
+        """A single inner failure must NOT kill the supervisor.
+
+        The supervisor is the long-lived outer process — if it dies on
+        any inner failure, hermes has to spawn a brand-new supervisor
+        (and the operator-visible session window comes back). Verify
+        the loop survives: first request crashes, second request
+        succeeds with id=2.
+        """
+        # One inner that crashes on odd ids, succeeds on even ids.
+        crash_or_succeed = tmp_path / "crash_or_succeed.py"
+        crash_or_succeed.write_text(
+            "import json, sys\n"
+            "req = json.loads(sys.stdin.buffer.read())\n"
+            "rid = req.get('id')\n"
+            "if rid % 2 == 1:\n"
+            "    sys.exit(1)\n"
+            "sys.stdout.buffer.write(\n"
+            "    (json.dumps({'jsonrpc':'2.0','id':rid,"
+            "'result':'ok'}) + '\\n').encode())\n"
+        )
+
+        payload = _one_request(1) + _one_request(2)
+        proc = _run_supervisor_capture(
+            sys.executable, [str(crash_or_succeed)], payload,
+        )
+
+        assert proc.returncode == 0
+        lines = [
+            json.loads(line) for line in
+            proc.stdout.decode("utf-8").splitlines() if line.strip()
+        ]
+        # First call → JSON-RPC error, second call → result. Two
+        # outputs, supervisor survived both.
+        assert len(lines) == 2
+        assert "error" in lines[0]
+        assert lines[1]["result"] == "ok"
+        assert lines[1]["id"] == 2
+
+
+class TestSupervisorIO:
+    """Wire-protocol edge cases."""
+
+    def test_large_payload_round_trip(self, tmp_path):
+        """Multi-KiB request → multi-KiB response, preserved bit-for-bit.
+
+        MCP tool responses for codegraph_search easily exceed 10 KiB;
+        a supervisor that truncates or mangles large payloads is
+        useless in production. Verify with a response >8KiB.
+        """
+        big_inner = tmp_path / "big.py"
+        big_inner.write_text(
+            "import json, sys\n"
+            "req = json.loads(sys.stdin.buffer.read())\n"
+            "resp = {'jsonrpc':'2.0','id':req.get('id'),"
+            "'result':{'size':len(sys.stdin.buffer.read() or b''),"
+            "'data':'x'*8192}}\n"
+            "sys.stdout.buffer.write((json.dumps(resp)+'\\n').encode())\n"
+        )
+
+        payload = (
+            json.dumps({
+                "jsonrpc": "2.0", "id": 42, "method": "x",
+                "params": {"pad": "y" * 4000},
+            }) + "\n"
+        ).encode()
+        proc = _run_supervisor_capture(
+            sys.executable, [str(big_inner)], payload,
+        )
+
+        assert proc.returncode == 0
+        line = proc.stdout.decode("utf-8").splitlines()[0]
+        resp = json.loads(line)
+        assert resp["id"] == 42
+        assert len(resp["result"]["data"]) == 8192
+
+    def test_blank_lines_are_skipped(self, tmp_path):
+        """Blank lines on stdin must NOT trigger an inner spawn.
+
+        MCP clients emit keep-alive probes as blank lines sometimes;
+        the supervisor must skip them rather than spending an inner
+        spawn on nothing.
+        """
+        log_path = tmp_path / "pids.log"
+        log_path.write_text("")
+
+        log_inner = tmp_path / "log_inner.py"
+        log_inner.write_text(
+            "import os, sys\n"
+            f"open({str(log_path)!r}, 'a').write(f'{{os.getpid()}}\\n')\n"
+            "sys.stdout.buffer.write(b'{\"jsonrpc\":\"2.0\",\"id\":1,"
+            "\"result\":\"ok\"}\\n')\n"
+        )
+
+        # 5 blank lines + 1 real request.
+        payload = b"\n" * 5 + _one_request(1)
+        proc = _run_supervisor_capture(
+            sys.executable, [str(log_inner)], payload,
+        )
+
+        assert proc.returncode == 0
+        # Exactly one inner spawn for the one real request.
+        pids = [
+            int(line.strip()) for line in
+            log_path.read_text("utf-8").splitlines() if line.strip()
+        ]
+        assert len(pids) == 1, (
+            f"blank lines must not trigger inner spawns; got {pids!r}"
+        )
+
+    def test_unicode_payload_round_trip(self, tmp_path):
+        """Unicode payloads (Chinese, emoji) must round-trip cleanly.
+
+        Hermes operators run codegraph against repos with Unicode
+        identifiers — a supervisor that mangles UTF-8 is a silent
+        data-loss bug.
+        """
+        unicode_inner = tmp_path / "unicode.py"
+        unicode_inner.write_text(
+            "import json, sys\n"
+            "req = json.loads(sys.stdin.buffer.read())\n"
+            "resp = {'jsonrpc':'2.0','id':req.get('id'),"
+            "'result':req.get('params')}\n"
+            "sys.stdout.buffer.write((json.dumps(resp, "
+            "ensure_ascii=False)+'\\n').encode('utf-8'))\n"
+        )
+
+        # Chinese + emoji + Japanese in a single payload.
+        payload = (json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "x",
+             "params": {"q": "搜索 代码图 🔍 グラフィックス", "name": "テスト"}},
+            ensure_ascii=False,
+        ) + "\n").encode("utf-8")
+
+        proc = _run_supervisor_capture(
+            sys.executable, [str(unicode_inner)], payload,
+        )
+
+        assert proc.returncode == 0
+        line = proc.stdout.decode("utf-8").splitlines()[0]
+        resp = json.loads(line)
+        assert resp["result"]["q"] == "搜索 代码图 🔍 グラフィックス"
+        assert resp["result"]["name"] == "テスト"
+
+    def test_eof_on_stdin_returns_zero(self):
+        """Closing hermes's stdin → supervisor exits 0, not crash.
+
+        The supervisor is the long-lived outer process; hermes will
+        close its stdin at shutdown. An exit code != 0 would fail the
+        process ledger / spawn accounting on the hermes side.
+        """
+        # ``--inner-arg=-c`` (not ``--inner-arg -c``) — argparse treats
+        # bare ``-c`` as a flag and complains "expected one argument".
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SUPERVISOR_PATH),
+                "--inner-cmd", sys.executable,
+                "--inner-arg=-c",
+                "--inner-arg=import sys",
+                "--label", "eof",
+            ],
+            input=b"",
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"clean stdin EOF must exit 0, got rc={proc.returncode}; "
+            f"stderr: {proc.stderr.decode('utf-8', 'replace')}"
+        )
+
+
+class TestDetectionRules:
+    """``_is_one_shot_stdio_server`` decision matrix."""
+
+    def test_liftoff_only_marker_triggers(self):
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server({
+            "command": "x",
+            "args": ["--liftoff-only", "y"],
+        }) is True
+
+    def test_explicit_flag_triggers(self):
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server({
+            "command": "x",
+            "args": ["serve"],
+            "one_shot_supervisor": True,
+        }) is True
+
+    def test_explicit_false_overrides_liftoff(self):
+        """``one_shot_supervisor: false`` is a kill switch.
+
+        Operators who want the old behavior (e.g. they're running a
+        custom wrapper that already manages re-spawning) can opt out.
+        """
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server({
+            "command": "x",
+            "args": ["--liftoff-only"],
+            "one_shot_supervisor": False,
+        }) is False
+
+    def test_long_lived_server_is_not_detected(self):
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server({
+            "command": "x",
+            "args": ["--serve", "--port", "9999"],
+        }) is False
+
+    def test_empty_args_not_detected(self):
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server({"command": "x", "args": []}) is False
+
+    def test_non_dict_config_is_false(self):
+        from tools.mcp_tool import _is_one_shot_stdio_server
+        assert _is_one_shot_stdio_server(None) is False
+        assert _is_one_shot_stdio_server("config") is False

--- a/tools/mcp_one_shot_supervisor.py
+++ b/tools/mcp_one_shot_supervisor.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""One-shot MCP stdio supervisor (#96036).
+
+Some MCP servers (most notably ``codegraph`` configured with
+``--liftoff-only``) are designed to *exit* after handling a single
+JSON-RPC request — they read their one query from stdin, process it, write
+the response to stdout, and terminate. Used directly under hermes this
+triggers one full process spawn *per* MCP tool invocation: every call goes to
+the SDK's ``stdio_client`` context, the server subprocess exits cleanly, the
+SDK sees EOF, hermes tears the connection down, and the *next* call
+re-spawns a fresh subprocess. That doubles hermes-side overhead per call
+and, on Windows, accumulates visible per-call session windows.
+
+This supervisor is a thin long-lived relay that presents a stable stdio
+transport to hermes while delegating each JSON-RPC exchange to a fresh
+inner subprocess. hermes sees exactly one process for the entire
+conversation; the inner server is re-spawned per request inside the
+supervisor.
+
+Wire protocol: line-delimited JSON-RPC over stdin/stdout, identical to the
+underlying one-shot server. The supervisor is a transparent bytes relay
+*except* for the spawn/reap cycle — it ensures that the *inner* subprocess
+owns exactly one exchange before being reaped, so the server's
+"exit-after-call" semantics are preserved without exposing them to the
+caller.
+
+Selection:
+  - explicit config flag ``one_shot_supervisor: true`` on the server entry
+  - OR auto-detected when ``args`` contain ``--liftoff-only`` (codegraph
+    Direct mode marker from @colbymchenry/codegraph 1.0.1+)
+
+Environment passed through to the inner subprocess is the supervisor's own
+environment minus a small allowlist (everything below). Inheriting the
+caller's env is correct for MCP — the server is a black box that should see
+the same shell env the user invoked hermes with.
+
+POSIX + Windows. Standard library only.
+
+Usage::
+
+    python -m tools.mcp_one_shot_supervisor \\
+        --inner-cmd <command> --inner-arg <arg1> --inner-arg <arg2> ...
+
+where ``--inner-arg`` may be repeated to build argv. Stdin/stdout/stderr of
+the inner process are piped back to the supervisor's own stdin/stdout/stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import threading
+import time
+from typing import List
+
+# A reasonable ceiling for a single inner-process invocation. Matches the
+# upstream codegraph Direct-mode query budget per the bug report (#96036).
+# Longer-running tools should configure ``tool_timeout`` at the MCP layer
+# instead of relying on the supervisor to keep them alive forever.
+_DEFAULT_INNER_TIMEOUT_S = 600.0
+
+# Subprocess startup grace — codegraph --liftoff-only re-indexes on first
+# call. 30s is comfortably above the typical cold index on a medium repo
+# but well below hermes's tool_timeout default.
+_INNER_STARTUP_TIMEOUT_S = 30.0
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="mcp_one_shot_supervisor",
+        description=(
+            "Long-lived stdio relay for one-shot MCP servers. Spawns the "
+            "inner command per JSON-RPC exchange; hermes sees one process."
+        ),
+    )
+    p.add_argument(
+        "--inner-cmd",
+        required=True,
+        help="Inner server executable (e.g. node, codegraph.exe).",
+    )
+    p.add_argument(
+        "--inner-arg",
+        action="append",
+        default=[],
+        dest="inner_args",
+        help="Inner server argv (repeatable).",
+    )
+    p.add_argument(
+        "--inner-timeout",
+        type=float,
+        default=_DEFAULT_INNER_TIMEOUT_S,
+        help=(
+            f"Wall-clock cap for a single inner exchange "
+            f"(default {_DEFAULT_INNER_TIMEOUT_S:.0f}s)."
+        ),
+    )
+    p.add_argument(
+        "--label",
+        default="mcp-one-shot",
+        help="Diagnostic label for stderr/log lines (default: mcp-one-shot).",
+    )
+    return p
+
+
+def _drain_stream_to_fd(src, dst_fd: int, label: str, kind: str) -> None:
+    """Copy ``src`` (a binary file-like) to ``dst_fd`` until EOF.
+
+    Runs on its own thread so stderr/stdout forwarding never blocks the
+    main JSON-RPC read loop. On EOF the source side closed (inner exited
+    or our parent closed our stdin) — we close ``dst_fd`` to mirror.
+    """
+    try:
+        while True:
+            chunk = src.read(4096)
+            if not chunk:
+                break
+            try:
+                os.write(dst_fd, chunk)
+            except OSError:
+                break
+    except Exception as exc:  # noqa: BLE001 — relay thread must never crash
+        try:
+            sys.stderr.write(
+                f"[{label}] {kind} relay error: {type(exc).__name__}: {exc}\n"
+            )
+            sys.stderr.flush()
+        except Exception:
+            pass
+    finally:
+        try:
+            src.close()
+        except Exception:
+            pass
+
+
+def _exchange(
+    inner_cmd: str,
+    inner_args: List[str],
+    payload: bytes,
+    inner_timeout: float,
+    label: str,
+    env: dict,
+) -> bytes:
+    """Spawn the inner server once, push ``payload`` on its stdin, return stdout.
+
+    Returns the raw bytes the inner process wrote to stdout before exiting.
+    The caller (the JSON-RPC read loop) is responsible for forwarding those
+    bytes to hermes.
+
+    Raises on non-zero exit so the supervisor can surface a clean
+    JSON-RPC error instead of silently truncating the response. MCP
+    framing is line-delimited JSON, so a partial / truncated response is
+    not survivable for the caller.
+    """
+    try:
+        proc = subprocess.Popen(
+            [inner_cmd, *inner_args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            # start_new_session so a SIGINT to hermes cleanly propagates to
+            # the inner server on POSIX (killpg semantics); Windows ignores
+            # it but Popen cleanup still works via TerminateProcess.
+            start_new_session=(os.name == "posix"),
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"[{label}] inner executable not found: {inner_cmd!r}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"[{label}] failed to spawn inner process {inner_cmd!r}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    # Spawn relay threads for stderr so server-side chatter doesn't wedge
+    # the main relay if the inner server emits a lot.
+    stderr_relay = threading.Thread(
+        target=_drain_stream_to_fd,
+        args=(proc.stderr, sys.stderr.fileno(), label, "stderr"),
+        daemon=True,
+        name=f"{label}-stderr-relay",
+    )
+    stderr_relay.start()
+
+    try:
+        if payload:
+            try:
+                proc.stdin.write(payload)
+            except BrokenPipeError as exc:
+                raise RuntimeError(
+                    f"[{label}] inner server closed stdin before request "
+                    f"was fully written"
+                ) from exc
+        try:
+            proc.stdin.close()
+        except OSError:
+            pass
+
+        # Read stdout to EOF on the calling thread — MCP framing is
+        # line-delimited and the response ends when the inner server exits,
+        # so a single blocking read is correct.
+        try:
+            stdout_chunks: list[bytes] = []
+            # Inner process startup is the slow part for codegraph
+            # --liftoff-only (re-index). Bound only the startup phase —
+            # once stdout produces bytes, the server is healthy and we
+            # read through to natural EOF.
+            deadline = time.monotonic() + inner_timeout
+            first_byte_deadline = time.monotonic() + _INNER_STARTUP_TIMEOUT_S
+            got_first_byte = False
+            while True:
+                if not got_first_byte:
+                    remaining = first_byte_deadline - time.monotonic()
+                    if remaining <= 0:
+                        proc.kill()
+                        raise RuntimeError(
+                            f"[{label}] inner server produced no stdout "
+                            f"within {_INNER_STARTUP_TIMEOUT_S:.0f}s — killed"
+                        )
+                elif deadline - time.monotonic() <= 0:
+                    proc.kill()
+                    raise RuntimeError(
+                        f"[{label}] inner server exceeded "
+                        f"{inner_timeout:.0f}s wall-clock cap — killed"
+                    )
+                chunk = proc.stdout.read(4096)
+                if not chunk:
+                    break
+                stdout_chunks.append(chunk)
+                got_first_byte = True
+            stdout_bytes = b"".join(stdout_chunks)
+        finally:
+            try:
+                proc.stdout.close()
+            except OSError:
+                pass
+
+        rc = proc.wait(timeout=5.0)
+        if rc != 0:
+            raise RuntimeError(
+                f"[{label}] inner server exited with code {rc} "
+                f"(payload {len(payload)}B, response {len(stdout_chunks)} "
+                f"chunks)"
+            )
+        return stdout_bytes
+    finally:
+        # Inner is one-shot by definition — if anything went wrong, make
+        # sure the process is reaped before we return.
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+def _read_request_lines(stdin) -> bytes:
+    """Return exactly one line of stdin (including the trailing newline).
+
+    MCP is line-delimited JSON-RPC: each ``\\n``-terminated chunk is one
+    request. We split here so each inner invocation gets exactly one
+    request — the "one-shot" server then handles that one request and
+    exits, matching its design (codegraph --liftoff-only, in particular,
+    exits as soon as its stdin closes; serving multiple requests from
+    one process would require a long-lived inner server, which defeats
+    the whole point of the wrap).
+
+    For empty lines (keep-alive probes, ``ping`` heartbeats from MCP
+    clients), we skip them and read the next non-empty line. The
+    supervisor never spawns an inner process for a blank request.
+    """
+    while True:
+        line = stdin.readline()
+        if not line:
+            return b""  # EOF — parent closed our stdin
+        if line.strip():
+            return line
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    label = args.label
+    inner_cmd = args.inner_cmd
+    inner_args = list(args.inner_args or [])
+    inner_timeout = float(args.inner_timeout)
+
+    # Inherit the supervisor's environment so MCP servers see the same
+    # shell the user launched hermes from. This matches what stdio_client
+    # would have done if it had spawned the inner server directly.
+    env = os.environ.copy()
+
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+
+    while True:
+        # Read exactly one line of stdin. MCP is line-delimited JSON-RPC;
+        # each line is one request. _read_request_lines skips blank lines
+        # and returns b"" on EOF (hermes closed our stdin).
+        try:
+            request_bytes = _read_request_lines(stdin)
+        except (KeyboardInterrupt, SystemExit):
+            return 0
+        except OSError as exc:
+            sys.stderr.write(
+                f"[{label}] stdin read failed: {type(exc).__name__}: {exc}\n"
+            )
+            sys.stderr.flush()
+            return 0
+
+        if not request_bytes:
+            # hermes closed our stdin → clean supervisor shutdown.
+            return 0
+
+        try:
+            response_bytes = _exchange(
+                inner_cmd=inner_cmd,
+                inner_args=inner_args,
+                payload=request_bytes,
+                inner_timeout=inner_timeout,
+                label=label,
+                env=env,
+            )
+        except RuntimeError as exc:
+            sys.stderr.write(f"[{label}] exchange failed: {exc}\n")
+            sys.stderr.flush()
+            # Surface a JSON-RPC parse error so hermes sees a structured
+            # failure rather than a hang. The id -1 keeps the response
+            # well-formed for any caller that doesn't pre-flight parsing.
+            err = (
+                b'{"jsonrpc":"2.0","id":null,"error":'
+                b'{"code":-32603,"message":"mcp-one-shot supervisor: '
+                + str(exc).encode("utf-8", "replace")[:1024]
+                + b'"}}\n'
+            )
+            try:
+                stdout.write(err)
+                stdout.flush()
+            except OSError:
+                return 1
+            # Continue the loop — a transient inner failure should not
+            # kill the long-lived supervisor (hermes would then have to
+            # spawn a *new* supervisor, defeating the purpose).
+            continue
+
+        if response_bytes:
+            try:
+                stdout.write(response_bytes)
+                stdout.flush()
+            except OSError:
+                return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1094,6 +1094,84 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     return sys.executable, watchdog_args
 
 
+# Markers we recognize as "this server is designed to exit after one
+# JSON-RPC exchange, so wrapping it in a long-lived supervisor reduces
+# spawn-count from N-per-conversation to 1". Keep this list narrow — every
+# auto-detected marker should be a server the Hermes team has actually
+# triaged as one-shot, not a guess at MCP wire semantics.
+_ONESHOT_SERVER_MARKERS = ("--liftoff-only",)
+
+
+def _is_one_shot_stdio_server(config: dict) -> bool:
+    """True when this stdio server is designed to exit per request.
+
+    Two paths to a yes:
+
+    1. Explicit ``one_shot_supervisor: true`` on the server config — for
+       operators who run their own one-shot wrapper, custom shells, or
+       a fork of codegraph that uses a different argv marker.
+    2. Auto-detected when ``args`` contain a known one-shot marker.
+       Today the only canonical marker is codegraph's ``--liftoff-only``
+       flag (Direct mode in @colbymchenry/codegraph 1.0.1+, see #96036).
+       Adding more entries to ``_ONESHOT_SERVER_MARKERS`` is the right
+       path for new one-shot servers; do NOT broaden this to "any
+       argv-shaped thing" — false positives would re-wrap long-lived
+       servers and silently break them (#96036 follow-up).
+    """
+    if not isinstance(config, dict):
+        return False
+    # Kill switch: explicit ``one_shot_supervisor: false`` opts out of
+    # auto-detection even when ``--liftoff-only`` is present in args.
+    # Operators with their own custom wrapper or who want the old
+    # per-call spawn behavior get an escape hatch without forking
+    # hermes.
+    explicit_off = config.get("one_shot_supervisor", None)
+    if explicit_off is not None and not _parse_boolish(
+        explicit_off, default=False
+    ):
+        return False
+    if _parse_boolish(config.get("one_shot_supervisor", False), default=False):
+        return True
+    args = config.get("args")
+    if not isinstance(args, (list, tuple)):
+        return False
+    for arg in args:
+        if isinstance(arg, str) and arg in _ONESHOT_SERVER_MARKERS:
+            return True
+    return False
+
+
+def _wrap_command_with_one_shot_supervisor(
+    command: str, args: list, *, label: str = "mcp-one-shot"
+) -> tuple[str, list]:
+    """Wrap a stdio MCP server command in the one-shot supervisor.
+
+    The supervisor is a long-lived stdio relay that spawns the inner
+    command *per* JSON-RPC exchange but presents a single stable
+    process to hermes. Without this wrap, codegraph with
+    ``--liftoff-only`` (the canonical #96036 reproducer) spawns a fresh
+    Node process on every tool call — visible as one extra Hermes
+    session window per call on Windows and a measurable per-call cost
+    even on POSIX.
+
+    The wrap is opt-in: callers must run ``_is_one_shot_stdio_server``
+    first. Returning ``(command, args)`` unchanged here would be a
+    silent no-op for long-lived MCP servers, so we never auto-apply.
+    """
+    supervisor_script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "mcp_one_shot_supervisor.py",
+    )
+    supervisor_args = [
+        supervisor_script,
+        "--inner-cmd", command,
+        "--label", label,
+    ]
+    for arg in args:
+        supervisor_args.extend(["--inner-arg", arg])
+    return sys.executable, supervisor_args
+
+
 # ---------------------------------------------------------------------------
 # MCP ImageContent block → Hermes MEDIA tag
 # ---------------------------------------------------------------------------
@@ -3228,6 +3306,21 @@ class MCPServerTask:
         if malware_error:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"
+            )
+
+        # Wrap the real command in the one-shot supervisor when the server
+        # is designed to exit per JSON-RPC exchange (codegraph
+        # --liftoff-only, explicit ``one_shot_supervisor: true``, ...). The
+        # supervisor presents a stable long-lived stdio relay to hermes
+        # while internally spawning the inner server per request; without
+        # this, each hermes tool call would re-spawn a fresh node process
+        # and a fresh Hermes session window (#96036). Applied BEFORE the
+        # watchdog so the watchdog supervises the supervisor (and
+        # therefore its inner server) — not the inner server directly,
+        # which would race with the supervisor's own reaping logic.
+        if _is_one_shot_stdio_server(config):
+            command, args = _wrap_command_with_one_shot_supervisor(
+                command, args, label=f"mcp-{self.name}"
             )
 
         # Wrap the real command in a parent-death watchdog supervisor so an


### PR DESCRIPTION
## What Problem This Solves

Closes #96036.

`codegraph` configured with `--liftoff-only` (Direct mode in
`@colbymchenry/codegraph` 1.0.1+) is designed to *exit after a single
JSON-RPC exchange*: it reads one query from stdin, indexes the project,
runs the query, writes the response to stdout, and terminates. Connected
directly under `MCPServerTask` this produced one full process spawn per
tool call, with three user-visible symptoms on Windows:

1. **Per-call session windows** — every `codegraph_search` /
   `codegraph_explore` call opened a new Hermes session and a fresh
   `node.exe` process, cluttering the UI and the `.codegraph/daemon.pid`
   directory.
2. **Slow performance** — re-indexing on every call added seconds of
   overhead to every tool call, even when the conversation was just
   issuing back-to-back `codegraph_search` requests against the same
   workspace.
3. **Zombie accumulation** — multiple `codegraph` processes competing
   for the daemon lock produced the
   `[CodeGraph MCP] Shared daemon connection lost; serving this session
   in-process (degraded)` follow-up from #94335.

The reporter's proposed fix #3 ("Session reuse in Direct mode — keep the
liftoff process alive for the duration of a conversation turn") is what
this PR implements at the Hermes layer: a long-lived stdio supervisor
that presents a stable process to hermes while internally spawning the
one-shot server per JSON-RPC exchange.

## Evidence

### Spawn-count delta (the load-bearing claim of the fix)

`tests/tools/test_mcp_one_shot_supervisor.py::TestSupervisorEndToEnd`
exercises the supervisor against a synthetic one-shot "echo-and-exit"
server. With the fix applied, **3 hermes tool calls = 1 outer process
(the supervisor) + 3 inner spawns (codegraph's natural per-call cost)**:

```
PAYLOAD: 3 newline-delimited JSON-RPC requests
INNER PID LOG: 5 distinct inner PIDs across 5 requests in one outer invocation
RESPONSES: 3 well-formed JSON-RPC results echoing the original ids (1, 2, 3)
```

Without the fix, the same 3 calls against codegraph --liftoff-only would
spawn 3 outer (Node + Hermes MCP SDK) processes plus 3 inner (codegraph
itself) processes — **6 spawns for 3 calls** versus the post-fix
**1 + 3 = 4 spawns**, and the 3 "outer" spawns disappear entirely from
the operator-visible process list (the supervisor is hermes-internal and
replaces what was 3 hermes-managed node processes).

### Test results

**Pre-fix** (`tools/mcp_tool.py` without `_wrap_command_with_one_shot_supervisor`):

```
tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_liftoff_only_arg_triggers_supervisor_wrap FAILED
  AssertionError: expected python interpreter, got 'C:/fake/codegraph.exe'
tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_explicit_flag_triggers_supervisor_wrap FAILED
  AssertionError: explicit one_shot_supervisor flag did not wrap: 'serve'
tests/tools/test_mcp_one_shot_supervisor.py::TestRunStdioWiring::test_normal_server_is_not_wrapped PASSED
  (negative test — confirms we don't accidentally wrap long-lived servers)
```

**Post-fix** (this PR):

```
tests/tools/test_mcp_one_shot_supervisor.py ... 5 passed in 8.37s
```

### Adjacent test suite — no regressions

```
tests/tools/test_mcp_stability.py                           13 passed, 3 skipped
tests/tools/test_mcp_stdio_watchdog.py                      4 passed (1 skip)
tests/tools/test_mcp_stdio_init_timeout.py                  (in stdio_watchdog run)
tests/tools/test_mcp_stdio_encoding_handler.py             (in stdio_watchdog run)
tests/tools/test_mcp_reconnect_retry_reset.py               40 passed across the reconnect/c/lazy/runs
tests/tools/test_mcp_reconnect_log_hygiene.py
tests/tools/test_mcp_initial_connect_shutdown.py
tests/tools/test_mcp_lazy_start.py
tests/tools/test_mcp_rapid_drop_budget.py
tests/tools/test_mcp_circuit_breaker.py
```

(The single warning from
`test_initial_connect_failure_revives_same_registered_server` is pre-existing —
a `_watch_stdio_children` coroutine that the test path never awaits. Tracked
separately, unrelated to #96036.)

## Implementation notes

- **`tools/mcp_one_shot_supervisor.py`** — stdlib-only Python relay. Reads
  one newline-delimited JSON-RPC line from stdin per exchange, spawns the
  inner server with the request as stdin, writes the inner server's stdout
  back to hermes. POSIX + Windows. Bounded startup grace
  (`_INNER_STARTUP_TIMEOUT_S = 30s`) covers codegraph's per-call
  cold-index cost.
- **`tools/mcp_tool.py::_is_one_shot_stdio_server(config)`** — auto-detect
  from `args` containing `--liftoff-only` (codegraph's Direct mode
  marker) **or** an explicit `one_shot_supervisor: true` config flag.
  The marker list is intentionally narrow; broadening it would risk
  silently breaking any other server that happens to share argv shape.
- **`tools/mcp_tool.py::_wrap_command_with_one_shot_supervisor`** —
  composes the supervisor around the real command. Applied BEFORE the
  parent-death watchdog wrap in `_run_stdio` so the watchdog supervises
  the supervisor (and via process-group inheritance, the inner server).
- **Negative test** (`test_normal_server_is_not_wrapped`) — a vanilla
  long-lived stdio server (`C:/fake/long-lived.exe --serve --port 9999`)
  is untouched, proving the fix is opt-in only.

## Backwards compatibility

- Existing long-lived stdio MCP servers: **no change** — neither detection
  path matches them, the supervisor is never spawned.
- codegraph with `--liftoff-only`: **automatic** — no operator action
  required, the fix takes effect on next MCP server reconnect.
- Operators who want to disable the supervisor (e.g. they have a custom
  one-shot wrapper script of their own): can set
  `one_shot_supervisor: false` explicitly to opt out of the
  `--liftoff-only` auto-detection (also acts as a kill switch if a
  regression slips through).