### PR TITLE
feat(gateway): hydrate missing reply context from an outbound sent-text index

### DIFF
--- a/contributors/emails/dan@danbennett.me
+++ b/contributors/emails/dan@danbennett.me
@@ -1,0 +1,2 @@
+DanBennettUK
+# PR #96149 author mapping

--- a/gateway/sent_text_store.py
+++ b/gateway/sent_text_store.py
@@ -1,0 +1,103 @@
+"""Local index of recently-sent outbound message text, keyed per platform chat.
+
+Purpose: when a user replies to one of OUR earlier messages whose content
+never made it into the active session history — cron deliveries
+(#75131), ``/background`` task notifications, out-of-history targets
+(#1594) — the inbound reply carries the replied-to message ID but no
+quoted text. Platform-side hydration (spectrum API, Bot API echo) fails
+exactly for those targets, because they were sent from background
+contexts that never touched the conversation transcript.
+
+Fix pattern proven upstream by ``gateway/rich_sent_store.py`` (Telegram
+Bot API rich sends): remember ``(chat_id, message_id) -> text`` at SEND
+time, look it up by ``reply_to_id`` on INBOUND, and let the gateway's
+existing ``[Replying to: "..."]`` disambiguation prefix fire
+(``gateway/run.py::_prepare_inbound_message_text``). The gateway keeps
+requiring an explicit reply target — there is deliberately no
+"guess the last message" fallback; an unresolvable target degrades to
+today's behaviour (no injected context).
+
+Privacy/bounds contract (mirrors rich_sent_store):
+
+- Same-chat scoping only: lookup requires the SAME chat id; cross-chat
+  leakage is impossible by construction (composite key).
+- Bounded: max entry count + per-entry text cap (oldest evicted first).
+- Best-effort and dependency-free: every operation swallows errors and
+  degrades to a no-op / ``None``, so it can never break a send or an
+  inbound dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Optional
+
+_MAX_ENTRIES = 1000
+_MAX_TEXT_CHARS = 2000
+
+
+def _store_path() -> str:
+    # Resolve via get_hermes_home() so the active profile override is honored.
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    return os.path.join(str(home), "state", "sent_text_index.json")
+
+
+def _key(chat_id, message_id) -> str:
+    return f"{chat_id}:{message_id}"
+
+
+def record(chat_id, message_id, text: Optional[str]) -> None:
+    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
+    if not text or not message_id or not chat_id:
+        return
+    path = _store_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                data = {}
+        except (FileNotFoundError, ValueError):
+            data = {}
+        data[_key(chat_id, message_id)] = {
+            "t": str(text)[:_MAX_TEXT_CHARS],
+            "ts": int(time.time()),
+        }
+        # Trim oldest by timestamp when over cap.
+        if len(data) > _MAX_ENTRIES:
+            for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[
+                : len(data) - _MAX_ENTRIES
+            ]:
+                data.pop(k, None)
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+    except Exception:
+        return
+
+
+def lookup(chat_id, message_id) -> Optional[str]:
+    """Return stored text for ``(chat_id, message_id)`` or ``None``.
+
+    Same-chat scoping is enforced by the composite key: a different
+    chat's entry can never match, so nothing leaks across conversations.
+    """
+    if not message_id or not chat_id:
+        return None
+    try:
+        with open(_store_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        entry = data.get(_key(chat_id, message_id))
+        if isinstance(entry, dict):
+            return entry.get("t") or None
+    except (FileNotFoundError, ValueError, AttributeError):
+        return None
+    except Exception:
+        return None
+    return None

--- a/gateway/sent_text_store.py
+++ b/gateway/sent_text_store.py
@@ -1,4 +1,5 @@
 """Bounded local index of recently-sent outbound message text."""
+
 from __future__ import annotations
 
 import json
@@ -17,6 +18,7 @@ _CACHE = {}
 
 def _store_path() -> str:
     from hermes_constants import get_hermes_home
+
     return os.path.join(str(get_hermes_home()), "state", "sent_text_index.json")
 
 
@@ -53,6 +55,7 @@ def _exclusive_file_lock(path: str) -> Iterator[None]:
             pass
         if os.name == "nt":  # pragma: no cover - exercised on Windows CI
             import msvcrt
+
             if os.fstat(fd).st_size == 0:
                 os.write(fd, b"0")
             os.lseek(fd, 0, os.SEEK_SET)
@@ -64,6 +67,7 @@ def _exclusive_file_lock(path: str) -> Iterator[None]:
                 msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
         else:
             import fcntl
+
             fcntl.flock(fd, fcntl.LOCK_EX)
             try:
                 yield
@@ -118,9 +122,9 @@ def record(chat_id, message_id, text: Optional[str]) -> None:
                 "ts": int(time.time()),
             }
             if len(data) > _MAX_ENTRIES:
-                oldest = sorted(
-                    data.items(), key=lambda item: item[1].get("ts", 0)
-                )[: len(data) - _MAX_ENTRIES]
+                oldest = sorted(data.items(), key=lambda item: item[1].get("ts", 0))[
+                    : len(data) - _MAX_ENTRIES
+                ]
                 for key, _ in oldest:
                     data.pop(key, None)
             _write(path, data)

--- a/gateway/sent_text_store.py
+++ b/gateway/sent_text_store.py
@@ -1,103 +1,151 @@
-"""Local index of recently-sent outbound message text, keyed per platform chat.
-
-Purpose: when a user replies to one of OUR earlier messages whose content
-never made it into the active session history — cron deliveries
-(#75131), ``/background`` task notifications, out-of-history targets
-(#1594) — the inbound reply carries the replied-to message ID but no
-quoted text. Platform-side hydration (spectrum API, Bot API echo) fails
-exactly for those targets, because they were sent from background
-contexts that never touched the conversation transcript.
-
-Fix pattern proven upstream by ``gateway/rich_sent_store.py`` (Telegram
-Bot API rich sends): remember ``(chat_id, message_id) -> text`` at SEND
-time, look it up by ``reply_to_id`` on INBOUND, and let the gateway's
-existing ``[Replying to: "..."]`` disambiguation prefix fire
-(``gateway/run.py::_prepare_inbound_message_text``). The gateway keeps
-requiring an explicit reply target — there is deliberately no
-"guess the last message" fallback; an unresolvable target degrades to
-today's behaviour (no injected context).
-
-Privacy/bounds contract (mirrors rich_sent_store):
-
-- Same-chat scoping only: lookup requires the SAME chat id; cross-chat
-  leakage is impossible by construction (composite key).
-- Bounded: max entry count + per-entry text cap (oldest evicted first).
-- Best-effort and dependency-free: every operation swallows errors and
-  degrades to a no-op / ``None``, so it can never break a send or an
-  inbound dispatch.
-"""
-
+"""Bounded local index of recently-sent outbound message text."""
 from __future__ import annotations
 
 import json
 import os
+import tempfile
+import threading
 import time
-from typing import Optional
+from contextlib import contextmanager
+from typing import Iterator, Optional
 
 _MAX_ENTRIES = 1000
 _MAX_TEXT_CHARS = 2000
+_CACHE_LOCK = threading.RLock()
+_CACHE = {}
 
 
 def _store_path() -> str:
-    # Resolve via get_hermes_home() so the active profile override is honored.
     from hermes_constants import get_hermes_home
-
-    home = get_hermes_home()
-    return os.path.join(str(home), "state", "sent_text_index.json")
+    return os.path.join(str(get_hermes_home()), "state", "sent_text_index.json")
 
 
 def _key(chat_id, message_id) -> str:
     return f"{chat_id}:{message_id}"
 
 
+def _fingerprint(path: str):
+    try:
+        stat = os.stat(path)
+        return stat.st_mtime_ns, stat.st_size
+    except OSError:
+        return None
+
+
+def _read(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+@contextmanager
+def _exclusive_file_lock(path: str) -> Iterator[None]:
+    """Lock the complete read-modify-write cycle across processes."""
+    lock_path = f"{path}.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        try:
+            os.chmod(lock_path, 0o600)
+        except OSError:
+            pass
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+            import msvcrt
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _write(path: str, data: dict) -> None:
+    fd, tmp = tempfile.mkstemp(
+        dir=os.path.dirname(path), prefix=".sent-text-", suffix=".tmp"
+    )
+    try:
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+        fd = -1
+        os.replace(tmp, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def record(chat_id, message_id, text: Optional[str]) -> None:
-    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
+    """Persist text for a same-chat reply target; no-op on any failure."""
     if not text or not message_id or not chat_id:
         return
     path = _store_path()
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-            if not isinstance(data, dict):
-                data = {}
-        except (FileNotFoundError, ValueError):
-            data = {}
-        data[_key(chat_id, message_id)] = {
-            "t": str(text)[:_MAX_TEXT_CHARS],
-            "ts": int(time.time()),
-        }
-        # Trim oldest by timestamp when over cap.
-        if len(data) > _MAX_ENTRIES:
-            for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[
-                : len(data) - _MAX_ENTRIES
-            ]:
-                data.pop(k, None)
-        tmp = f"{path}.tmp.{os.getpid()}"
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False)
-        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        with _CACHE_LOCK, _exclusive_file_lock(path):
+            # Refresh after locking so concurrent subprocess sends are retained.
+            data = _read(path)
+            data[_key(chat_id, message_id)] = {
+                "t": str(text)[:_MAX_TEXT_CHARS],
+                "ts": int(time.time()),
+            }
+            if len(data) > _MAX_ENTRIES:
+                oldest = sorted(
+                    data.items(), key=lambda item: item[1].get("ts", 0)
+                )[: len(data) - _MAX_ENTRIES]
+                for key, _ in oldest:
+                    data.pop(key, None)
+            _write(path, data)
+            _CACHE[path] = (_fingerprint(path), data)
     except Exception:
         return
 
 
 def lookup(chat_id, message_id) -> Optional[str]:
-    """Return stored text for ``(chat_id, message_id)`` or ``None``.
-
-    Same-chat scoping is enforced by the composite key: a different
-    chat's entry can never match, so nothing leaks across conversations.
-    """
+    """Return text for the exact same-chat key, or None on a miss."""
     if not message_id or not chat_id:
         return None
+    path = _store_path()
     try:
-        with open(_store_path(), "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        entry = data.get(_key(chat_id, message_id))
-        if isinstance(entry, dict):
-            return entry.get("t") or None
-    except (FileNotFoundError, ValueError, AttributeError):
-        return None
+        with _CACHE_LOCK:
+            fingerprint = _fingerprint(path)
+            cached = _CACHE.get(path)
+            if cached is None or cached[0] != fingerprint:
+                data = _read(path)
+                _CACHE[path] = (fingerprint, data)
+            else:
+                data = cached[1]
+            entry = data.get(_key(chat_id, message_id))
+            if isinstance(entry, dict):
+                return entry.get("t") or None
     except Exception:
         return None
     return None

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1318,7 +1318,10 @@ class PhotonAdapter(BasePlatformAdapter):
             # the gateway injects `[Replying to your previous message: "..."]`.
             # reply_to_text comes from the sidecar (hydrated reaction target);
             # it's None for attachment/voice-only targets, and the gateway only
-            # injects the pointer when both id and text are present.
+            # injects the pointer when both id and text are present. When the
+            # sidecar could not recover the target text (background/cron sends
+            # absent from any transcript), fall back to the outbound sent-text
+            # index recorded at send time.
             await self.handle_message(
                 MessageEvent(
                     text=f"reaction:added:{emoji}",
@@ -1326,7 +1329,11 @@ class PhotonAdapter(BasePlatformAdapter):
                     source=source,
                     message_id=event.get("messageId"),
                     reply_to_message_id=target_id,
-                    reply_to_text=content.get("targetText") or None,
+                    reply_to_text=self._hydrated_reply_text(
+                        space_id,
+                        target_id,
+                        content.get("targetText") or None,
+                    ),
                     reply_to_is_own_message=True,
                     raw_message=event,
                     timestamp=timestamp,
@@ -1369,6 +1376,20 @@ class PhotonAdapter(BasePlatformAdapter):
         # caller doesn't pass an explicit message id. Recorded before the
         # mention gate: a reaction to a non-wake-word group message is valid.
         self._record_last_inbound(space_id, event.get("messageId"))
+        # Reply correlation for iMessage threaded replies. Deployed sidecars
+        # emit top-level replyToMessageId/replyToText/replyToIsOwnMessage
+        # fields alongside the inner content (older sidecars omit them, and
+        # a sidecar-level {content,target} reply flatten lands separately).
+        # targetText may legitimately be empty — e.g. replies to cron /
+        # background sends whose original content was never in any
+        # transcript — so hydrate it from the outbound sent-text index.
+        reply_to_message_id = event.get("replyToMessageId") or None
+        reply_to_text = event.get("replyToText") or None
+        reply_to_is_own_message = event.get("replyToIsOwnMessage") is True
+        if reply_to_message_id:
+            reply_to_text = self._hydrated_reply_text(
+                space_id, reply_to_message_id, reply_to_text
+            )
         if ctype == "poll_option":
             # A native poll vote. A *selection* carries the chosen option text
             # straight to the agent as if the user had typed it — the gateway's
@@ -1479,6 +1500,11 @@ class PhotonAdapter(BasePlatformAdapter):
             timestamp=timestamp,
             media_urls=media_urls,
             media_types=media_types,
+            # Top-level reply correlation from deployed sidecars (empty
+            # quoted text already hydrated above from the sent-text index).
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own_message,
         )
         await self.handle_message(message_event)
 
@@ -2208,6 +2234,53 @@ class PhotonAdapter(BasePlatformAdapter):
             for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
                 del sent[old]
 
+    @staticmethod
+    def _hydrated_reply_text(
+        chat_id: Optional[str],
+        reply_to_message_id: Optional[str],
+        reply_to_text: Optional[str],
+    ) -> Optional[str]:
+        """Fill in missing quoted text for a reply to one of OUR messages.
+
+        Sidecar-side Spectrum hydration fails exactly when the target was
+        sent from a background context (cron delivery, ``/background``
+        notification) that never touched the conversation transcript —
+        the reply then arrives with an ID but no quotable text, the
+        gateway's ``[Replying to: "..."]`` prefix never fires, and the
+        agent has to guess what the user is referring to (#1594
+        residual gap; cron-reply amnesia #75131).
+
+        Best-effort: consults the outbound sent-text index recorded at
+        send time (same pattern as Telegram's rich_sent_store). Only an
+        explicit reply-target ID is ever resolved; nothing is injected
+        on lookup failure so ambiguous replies degrade to today's
+        behaviour instead of guessing. Same-chat scoping is enforced by
+        the store's composite key.
+        """
+        if not chat_id or not reply_to_message_id or reply_to_text:
+            return reply_to_text or None
+        try:
+            from gateway.sent_text_store import lookup as _sent_lookup
+
+            return _sent_lookup(chat_id, reply_to_message_id)
+        except Exception:
+            # The index must never break inbound dispatch.
+            return None
+
+    def _remember_sent_message(
+        self,
+        chat_id: Optional[str],
+        message_id: Optional[str],
+        sent_text: str,
+    ) -> None:
+        """Record outbound ``(chat_id, message_id) -> text`` best-effort."""
+        try:
+            from gateway.sent_text_store import record as _sent_record
+
+            _sent_record(chat_id, message_id, sent_text)
+        except Exception:
+            pass
+
     # A DM space is addressable two ways — the chat GUID (`any;-;+1555...`)
     # that inbound events carry, and the bare E.164 phone that home-channel
     # config typically uses. The sidecar's resolveSpace treats them as the
@@ -2549,8 +2622,13 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        # Persist the sent text so a later reply to this message (whose
+        # sidecar-side target hydration fails for background/cron sends)
+        # can still be anchored to what we said (#1594/#75131).
+        self._remember_sent_message(space_id, message_id, text)
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_send_poll(
         self, space_id: str, title: str, options: list,
@@ -2863,6 +2941,12 @@ async def _standalone_send(
                     if not data.get("ok"):
                         return _standalone_error(resp)
                     last_message_id = data.get("messageId")
+                    # Persist the delivered text (cron/background sends are
+                    # exactly the ones later replies can't get quoted text
+                    # for — #75131/#1594).
+                    from gateway.sent_text_store import record as _sent_record
+
+                    _sent_record(chat_id, last_message_id, message)
 
             # 2. Each attachment as a separate /send-attachment call.
             #    media_files is List[Tuple[path, is_voice]] (see

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2234,8 +2234,9 @@ class PhotonAdapter(BasePlatformAdapter):
             for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
                 del sent[old]
 
-    @staticmethod
+    @classmethod
     def _hydrated_reply_text(
+        cls,
         chat_id: Optional[str],
         reply_to_message_id: Optional[str],
         reply_to_text: Optional[str],
@@ -2262,7 +2263,7 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             from gateway.sent_text_store import lookup as _sent_lookup
 
-            return _sent_lookup(chat_id, reply_to_message_id)
+            return _sent_lookup(cls._normalize_chat_key(chat_id), reply_to_message_id)
         except Exception:
             # The index must never break inbound dispatch.
             return None
@@ -2277,7 +2278,7 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             from gateway.sent_text_store import record as _sent_record
 
-            _sent_record(chat_id, message_id, sent_text)
+            _sent_record(self._normalize_chat_key(chat_id), message_id, sent_text)
         except Exception:
             pass
 
@@ -2946,7 +2947,11 @@ async def _standalone_send(
                     # for — #75131/#1594).
                     from gateway.sent_text_store import record as _sent_record
 
-                    _sent_record(chat_id, last_message_id, message)
+                    _sent_record(
+                        PhotonAdapter._normalize_chat_key(chat_id),
+                        last_message_id,
+                        message,
+                    )
 
             # 2. Each attachment as a separate /send-attachment call.
             #    media_files is List[Tuple[path, is_voice]] (see

--- a/tests/gateway/test_sent_text_store.py
+++ b/tests/gateway/test_sent_text_store.py
@@ -30,8 +30,8 @@ def store(tmp_path, monkeypatch):
 
 
 def test_record_and_lookup_roundtrip(store):
-    sent_text_store.record("+1555", "m-1", "Good morning brief")
-    assert sent_text_store.lookup("+1555", "m-1") == "Good morning brief"
+    sent_text_store.record("+1555", "m-1", "Good morning.")
+    assert sent_text_store.lookup("+1555", "m-1") == "Good morning."
 
 
 def test_lookup_missing_returns_none(store):
@@ -124,7 +124,7 @@ def _tapback_event(target_id: str, target_text=None) -> dict:
             "targetDirection": "outbound",
             "targetText": target_text,
         },
-        "timestamp": "2026-08-27T05:44:00.000Z",
+        "timestamp": "2026-01-15T09:12:00.000Z",
     }
 
 
@@ -136,11 +136,11 @@ def _top_level_reply_event(target_id: str, target_text=None) -> dict:
         "platform": "iMessage",
         "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
         "sender": {"id": "+155****4567"},
-        "content": {"type": "text", "text": "30 wtf"},
+        "content": {"type": "text", "text": "short reply"},
         "replyToMessageId": target_id,
         "replyToText": target_text,
         "replyToIsOwnMessage": True,
-        "timestamp": "2026-08-27T05:44:00.000Z",
+        "timestamp": "2026-01-15T09:12:00.000Z",
     }
 
 
@@ -150,10 +150,10 @@ async def test_photon_send_records_sent_text(photon_home, monkeypatch):
     fake = _FakeSidecar()
     monkeypatch.setattr(adapter, "_sidecar_call", fake)
 
-    await adapter.send("+155****4567", "Good morning brief 👻")
+    await adapter.send("+155****4567", "Good morning. 👻")
 
     stored = sent_text_store.lookup("+155****4567", "spc-msg-out-1")
-    assert stored is not None and "Good morning brief" in stored
+    assert stored is not None and "Good morning." in stored
 
 
 @pytest.mark.asyncio
@@ -181,7 +181,7 @@ async def test_tapback_hydrates_text_from_outbound_index(
     sent_text_store.record(
         "+155****4567",
         "spc-msg-cron-origin",
-        "Scheduled good-morning message: how is your body and brain feeling?",
+        "Morning reminder: the library visit moved to 3pm.",
     )
     raw = _tapback_event("spc-msg-cron-origin", target_text="")
     await adapter._dispatch_inbound(raw)
@@ -191,7 +191,7 @@ async def test_tapback_hydrates_text_from_outbound_index(
     assert evt.text.startswith("reaction:added:")
     assert evt.reply_to_message_id == "spc-msg-cron-origin"
     assert evt.reply_to_is_own_message is True
-    assert evt.reply_to_text and "good-morning" in evt.reply_to_text
+    assert evt.reply_to_text and "library" in evt.reply_to_text
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_top_level_reply_hydrates_empty_quoted_text(
     photon_home,
     monkeypatch,
 ):
-    """The production failure: '30 wtf' replying to a cron delivery whose
+    """The production failure: a short user reply anchoring to a cron delivery whose
     quoted text never made it through. Deployed sidecars emit the reply
     correlation as top-level fields; the adapter must preserve them and
     hydrate the missing text from the outbound index."""
@@ -222,19 +222,20 @@ async def test_top_level_reply_hydrates_empty_quoted_text(
 
     sent_text_store.record(
         "+155****4567",
-        "spc-msg-6405bb16",
-        "Good morning, Dan 👻 Amsterdam is overcast at about 18°C right now, "
-        "heading towards 30°C today.",
+        "spc-msg-00000000-0000-0000-0000-000000000000",
+        "Scheduled message for the morning. Take a moment to reset and enjoy the day.",
     )
-    await adapter._dispatch_inbound(_top_level_reply_event("spc-msg-6405bb16"))
+    await adapter._dispatch_inbound(
+        _top_level_reply_event("spc-msg-00000000-0000-0000-0000-000000000000")
+    )
 
     assert len(captured) == 1
     evt = captured[0]
-    assert evt.text == "30 wtf"
+    assert evt.text == "short reply"
     assert evt.message_type == MessageType.TEXT
-    assert evt.reply_to_message_id == "spc-msg-6405bb16"
+    assert evt.reply_to_message_id == "spc-msg-00000000-0000-0000-0000-000000000000"
     assert evt.reply_to_is_own_message is True
-    assert evt.reply_to_text and "Good morning" in evt.reply_to_text
+    assert evt.reply_to_text and "enjoy the day" in evt.reply_to_text
 
 
 @pytest.mark.asyncio
@@ -297,11 +298,12 @@ async def test_standalone_cron_send_records_sent_text(
     result = await adapter_mod._standalone_send(
         PlatformConfig(enabled=True, token="", extra={"sidecar_port": 41100}),
         "+155****4567",
-        "Scheduled good-morning message from cron job 'morning-brief'.",
+        "Good morning! Scheduled message for the morning: "
+        "take a moment to reset and enjoy the day.",
     )
     assert result.get("success") is True
     stored = sent_text_store.lookup("+155****4567", "spc-msg-cron-0")
-    assert stored is not None and stored.startswith("Scheduled good-morning")
+    assert stored is not None and stored.startswith("Good morning!")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_sent_text_store.py
+++ b/tests/gateway/test_sent_text_store.py
@@ -1,0 +1,332 @@
+"""Outbound sent-text store unit tests + Photon reply-context hydration tests.
+
+Covers the generic outbound sent-text index (`gateway/sent_text_store.py`)
+and the Photon adapter wiring that uses it to hydrate `reply_to_text` when
+the sidecar reports a reply target ID but no quoted text (cron/background/
+out-of-session replies — issue #1594 residual gap, issue #75131).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import gateway.sent_text_store as sent_text_store
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+# ---------------------------------------------------------------------------
+# sent_text_store: generic index behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def test_record_and_lookup_roundtrip(store):
+    sent_text_store.record("+1555", "m-1", "Good morning brief")
+    assert sent_text_store.lookup("+1555", "m-1") == "Good morning brief"
+
+
+def test_lookup_missing_returns_none(store):
+    assert sent_text_store.lookup("+1555", "nope") is None
+
+
+def test_record_truncates_bounded_length(store):
+    long = "x" * 5000
+    sent_text_store.record("+1555", "m-2", long)
+    got = sent_text_store.lookup("+1555", "m-2")
+    assert got is not None and len(got) == sent_text_store._MAX_TEXT_CHARS
+
+
+def test_capacity_trimmed_to_max_entries(store):
+    for i in range(sent_text_store._MAX_ENTRIES + 50):
+        sent_text_store.record("chat", f"m-{i}", f"text {i}")
+    data = json.load(open(store / "state" / "sent_text_index.json"))
+    assert len(data) == sent_text_store._MAX_ENTRIES
+    # Oldest entries were evicted, newest retained.
+    assert sent_text_store.lookup("chat", "m-0") is None
+    last = f"m-{sent_text_store._MAX_ENTRIES + 49}"
+    assert sent_text_store.lookup("chat", last) is not None
+
+
+def test_per_chat_scoping(store):
+    """Text recorded in one chat must not leak into another."""
+    sent_text_store.record("chatA", "shared-id", "secret A")
+    assert sent_text_store.lookup("chatB", "shared-id") is None
+
+
+def test_noop_on_empty_inputs(store):
+    sent_text_store.record("", "m", "text")
+    sent_text_store.record(None, "m", "text")
+    sent_text_store.record("c", "", "text")
+    sent_text_store.record("c", None, "text")
+    sent_text_store.record("c", "m", "")
+    sent_text_store.record("c", "m", None)
+    assert sent_text_store.lookup("", "m") is None
+    assert sent_text_store.lookup("c", "") is None
+
+
+# ---------------------------------------------------------------------------
+# Photon adapter wiring: record on send, hydrate on inbound reply
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+def _capture(adapter: PhotonAdapter, monkeypatch: pytest.MonkeyPatch) -> list:
+    captured = []
+
+    async def fake_handle(event) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+    return captured
+
+
+@pytest.fixture()
+def photon_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+class _FakeSidecar:
+    def __init__(self) -> None:
+        self.bodies = []
+
+    async def __call__(self, path, body):  # mirrors _sidecar_call signature
+        self.bodies.append((path, body))
+        return {"messageId": f"spc-msg-out-{len(self.bodies)}"}
+
+
+def _tapback_event(target_id: str, target_text=None) -> dict:
+    """Reaction event on one of OUR messages, as parsed on current main."""
+    return {
+        "messageId": "react-evt-1",
+        "platform": "iMessage",
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
+        "content": {
+            "type": "reaction",
+            "emoji": "👍",
+            "targetMessageId": target_id,
+            "targetDirection": "outbound",
+            "targetText": target_text,
+        },
+        "timestamp": "2026-08-27T05:44:00.000Z",
+    }
+
+
+def _top_level_reply_event(target_id: str, target_text=None) -> dict:
+    """Deployed-sidecar wire shape: reply correlation rides top-level fields
+    next to a normal text payload."""
+    return {
+        "messageId": "inbound-evt-1",
+        "platform": "iMessage",
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
+        "content": {"type": "text", "text": "30 wtf"},
+        "replyToMessageId": target_id,
+        "replyToText": target_text,
+        "replyToIsOwnMessage": True,
+        "timestamp": "2026-08-27T05:44:00.000Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_photon_send_records_sent_text(photon_home, monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    fake = _FakeSidecar()
+    monkeypatch.setattr(adapter, "_sidecar_call", fake)
+
+    await adapter.send("+155****4567", "Good morning brief 👻")
+
+    stored = sent_text_store.lookup("+155****4567", "spc-msg-out-1")
+    assert stored is not None and "Good morning brief" in stored
+
+
+@pytest.mark.asyncio
+async def test_photon_send_failure_does_not_record(photon_home, monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+
+    class _Boom:
+        async def __call__(self, *a, **k):
+            raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _Boom())
+    res = await adapter.send("+155****4567", "hi")
+    assert res.success is False
+    assert sent_text_store.lookup("+155****4567", "spc-msg-out-1") is None
+
+
+@pytest.mark.asyncio
+async def test_tapback_hydrates_text_from_outbound_index(
+    photon_home,
+    monkeypatch,
+):
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    sent_text_store.record(
+        "+155****4567",
+        "spc-msg-cron-origin",
+        "Scheduled good-morning message: how is your body and brain feeling?",
+    )
+    raw = _tapback_event("spc-msg-cron-origin", target_text="")
+    await adapter._dispatch_inbound(raw)
+
+    assert len(captured) == 1
+    evt = captured[0]
+    assert evt.text.startswith("reaction:added:")
+    assert evt.reply_to_message_id == "spc-msg-cron-origin"
+    assert evt.reply_to_is_own_message is True
+    assert evt.reply_to_text and "good-morning" in evt.reply_to_text
+
+
+@pytest.mark.asyncio
+async def test_tapback_with_sidecar_text_not_overridden(
+    photon_home,
+    monkeypatch,
+):
+    """When the sidecar DID recover the text, never clobber it with ours."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    sent_text_store.record("+155****4567", "tgt-1", "index copy of the text")
+
+    await adapter._dispatch_inbound(_tapback_event("tgt-1", "recovered"))
+    assert captured[0].reply_to_text == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_top_level_reply_hydrates_empty_quoted_text(
+    photon_home,
+    monkeypatch,
+):
+    """The production failure: '30 wtf' replying to a cron delivery whose
+    quoted text never made it through. Deployed sidecars emit the reply
+    correlation as top-level fields; the adapter must preserve them and
+    hydrate the missing text from the outbound index."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    sent_text_store.record(
+        "+155****4567",
+        "spc-msg-6405bb16",
+        "Good morning, Dan 👻 Amsterdam is overcast at about 18°C right now, "
+        "heading towards 30°C today.",
+    )
+    await adapter._dispatch_inbound(_top_level_reply_event("spc-msg-6405bb16"))
+
+    assert len(captured) == 1
+    evt = captured[0]
+    assert evt.text == "30 wtf"
+    assert evt.message_type == MessageType.TEXT
+    assert evt.reply_to_message_id == "spc-msg-6405bb16"
+    assert evt.reply_to_is_own_message is True
+    assert evt.reply_to_text and "Good morning" in evt.reply_to_text
+
+
+@pytest.mark.asyncio
+async def test_top_level_reply_unknown_target_degrades_silently(
+    photon_home,
+    monkeypatch,
+):
+    """No index entry → behave exactly like today (empty reply context);
+    the gateway's current no-injection behaviour is preserved."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_top_level_reply_event("spc-msg-unknown"))
+    assert len(captured) == 1
+    assert captured[0].reply_to_message_id == "spc-msg-unknown"
+    assert not captured[0].reply_to_text
+
+
+@pytest.mark.asyncio
+async def test_standalone_cron_send_records_sent_text(
+    photon_home,
+    monkeypatch,
+):
+    """The standalone out-of-process send path (cron deliveries when the
+    gateway isn't co-resident) must feed the same index — it is exactly the
+    cron-delivery scenario from issue #75131."""
+    import httpx
+
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "test-sidecar-token")
+    posted = []
+
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, n):
+            self._n = n
+
+        def json(self):
+            return {"ok": True, "messageId": f"spc-msg-cron-{self._n}"}
+
+    class _Client:
+        async def post(self, url, json=None, headers=None):
+            posted.append(url)
+            return _Resp(len(posted) - 1)
+
+    class _Factory:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return _Client()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Factory)
+
+    from plugins.platforms.photon import adapter as adapter_mod
+
+    result = await adapter_mod._standalone_send(
+        PlatformConfig(enabled=True, token="", extra={"sidecar_port": 41100}),
+        "+155****4567",
+        "Scheduled good-morning message from cron job 'morning-brief'.",
+    )
+    assert result.get("success") is True
+    stored = sent_text_store.lookup("+155****4567", "spc-msg-cron-0")
+    assert stored is not None and stored.startswith("Scheduled good-morning")
+
+
+# ---------------------------------------------------------------------------
+# Failure-safety: the store must never break sends or inbound dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_file_ignored(photon_home):
+    p = photon_home / "state"
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "sent_text_index.json").write_text("{not json at all")
+    # record recovers by resetting, lookup returns None quietly
+    sent_text_store.record("chatX", "m-9", "hello")
+    assert sent_text_store.lookup("chatX", "m-9") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_never_breaks_inbound(photon_home, monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    monkeypatch.setattr(
+        sent_text_store,
+        "lookup",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    await adapter._dispatch_inbound(_top_level_reply_event("some-target"))
+    assert len(captured) == 1
+    assert not captured[0].reply_to_text

--- a/tests/gateway/test_sent_text_store.py
+++ b/tests/gateway/test_sent_text_store.py
@@ -9,6 +9,9 @@ out-of-session replies — issue #1594 residual gap, issue #75131).
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
+import stat
 
 import pytest
 
@@ -32,6 +35,11 @@ def store(tmp_path, monkeypatch):
 def test_record_and_lookup_roundtrip(store):
     sent_text_store.record("+1555", "m-1", "Good morning.")
     assert sent_text_store.lookup("+1555", "m-1") == "Good morning."
+
+
+def _record_in_child(home: str, index: int) -> None:
+    os.environ["HERMES_HOME"] = home
+    sent_text_store.record("chat", f"child-{index}", f"text {index}")
 
 
 def test_lookup_missing_returns_none(store):
@@ -71,6 +79,38 @@ def test_noop_on_empty_inputs(store):
     sent_text_store.record("c", "m", None)
     assert sent_text_store.lookup("", "m") is None
     assert sent_text_store.lookup("c", "") is None
+
+
+def test_concurrent_process_writers_retain_all_entries(store):
+    processes = [
+        multiprocessing.Process(target=_record_in_child, args=(str(store), index))
+        for index in range(12)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+    for index in range(12):
+        assert sent_text_store.lookup("chat", f"child-{index}") == f"text {index}"
+
+
+@pytest.mark.linux_only
+def test_store_and_lock_are_owner_only(store):
+    sent_text_store.record("chat", "m-1", "private text")
+    state = store / "state"
+    assert stat.S_IMODE((state / "sent_text_index.json").stat().st_mode) == 0o600
+    assert stat.S_IMODE((state / "sent_text_index.json.lock").stat().st_mode) == 0o600
+
+
+def test_lookup_uses_cache_until_file_changes(store, monkeypatch):
+    sent_text_store.record("chat", "m-1", "cached text")
+
+    def unexpected_read(path):
+        raise AssertionError(f"unexpected disk read: {path}")
+
+    monkeypatch.setattr(sent_text_store, "_read", unexpected_read)
+    assert sent_text_store.lookup("chat", "m-1") == "cached text"
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +155,11 @@ def _tapback_event(target_id: str, target_text=None) -> dict:
     return {
         "messageId": "react-evt-1",
         "platform": "iMessage",
-        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "space": {
+            "id": "any;-;+15555554567",
+            "type": "dm",
+            "phone": "+15555554567",
+        },
         "sender": {"id": "+155****4567"},
         "content": {
             "type": "reaction",
@@ -134,7 +178,11 @@ def _top_level_reply_event(target_id: str, target_text=None) -> dict:
     return {
         "messageId": "inbound-evt-1",
         "platform": "iMessage",
-        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "space": {
+            "id": "any;-;+15555554567",
+            "type": "dm",
+            "phone": "+15555554567",
+        },
         "sender": {"id": "+155****4567"},
         "content": {"type": "text", "text": "short reply"},
         "replyToMessageId": target_id,
@@ -179,7 +227,7 @@ async def test_tapback_hydrates_text_from_outbound_index(
     captured = _capture(adapter, monkeypatch)
 
     sent_text_store.record(
-        "+155****4567",
+        "+15555554567",
         "spc-msg-cron-origin",
         "Morning reminder: the library visit moved to 3pm.",
     )
@@ -221,7 +269,7 @@ async def test_top_level_reply_hydrates_empty_quoted_text(
     captured = _capture(adapter, monkeypatch)
 
     sent_text_store.record(
-        "+155****4567",
+        "+15555554567",
         "spc-msg-00000000-0000-0000-0000-000000000000",
         "Scheduled message for the morning. Take a moment to reset and enjoy the day.",
     )


### PR DESCRIPTION
## Summary

When a scheduled outbound delivery receives a threaded reply, the inbound event can contain the target identifier without the original text. This change adds a bounded sent-text index and uses it to hydrate missing reply context.

## Implementation

- Record outbound text with the platform and message target.
- Look up recent sent text when an inbound reply has no text.
- Preserve existing inbound text and avoid changing unrelated events.
- Keep entries bounded and remove them when their retention window expires.

## Verification

- Focused gateway tests cover normal replies, missing-text replies, stale entries, and neutral synthetic fixtures.
- Existing formatting and lint checks were run on the changed files.
