### PR TITLE
fix(desktop): Close Others / Close to Right persist-close Bot Mode tiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { openSession } from '@/app/open-session'
 import {
+  closeableTreeSiblings,
   closeAllTreeTabs,
   closeOtherTreeTabs,
   closeTreeTabsToRight,
@@ -44,7 +45,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
+import { $sessionTiles, closeAllOpenSessionTiles, closeOpenSessionTilesForPanes } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
 
@@ -397,6 +398,10 @@ function useSessionActions({
                   label: t.zones.closeOthers,
                   onSelect: () => {
                     triggerHaptic('selection')
+                    // Persist-close session tiles before dismissing the
+                    // other tree panes, or Bot Mode rehydrates them from the
+                    // shared tile bucket — the same gap Close All had (#94137).
+                    closeOpenSessionTilesForPanes(closeableTreeSiblings(tabPaneId).others)
                     closeOtherTreeTabs(tabPaneId)
                   }
                 }),
@@ -406,6 +411,10 @@ function useSessionActions({
                   label: t.zones.closeToRight,
                   onSelect: () => {
                     triggerHaptic('selection')
+                    // Persist-close session tiles before dismissing the tree
+                    // panes to the right, or Bot Mode rehydrates them from the
+                    // shared tile bucket — the same gap Close All had (#94137).
+                    closeOpenSessionTilesForPanes(closeableTreeSiblings(tabPaneId).right)
                     closeTreeTabsToRight(tabPaneId)
                   }
                 }),

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -30,7 +30,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
-import { closeAllOpenSessionTiles } from '@/store/session-states'
+import { closeAllOpenSessionTiles, closeOpenSessionTilesForPanes } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
 import { useWindowControlsOverlap } from '../../geometry'
@@ -54,6 +54,7 @@ import {
   $treeDragging,
   $treePaneEpochs,
   activateTreePane,
+  closeableTreeSiblings,
   closeAllTreeTabs,
   closeOtherTreeTabs,
   closeTabPane,
@@ -156,8 +157,18 @@ function ZoneMenu({
             closeAllOpenSessionTiles(targetId)
             closeAllTreeTabs(targetId)
           },
-          onCloseOthers: () => closeOtherTreeTabs(targetId),
-          onCloseToRight: () => closeTreeTabsToRight(targetId)
+          onCloseOthers: () => {
+            // Same persist-close as onCloseAll — otherwise Bot Mode
+            // rehydrates the "closed" others from the shared tile bucket.
+            closeOpenSessionTilesForPanes(closeableTreeSiblings(targetId).others)
+            closeOtherTreeTabs(targetId)
+          },
+          onCloseToRight: () => {
+            // Same persist-close as onCloseAll — otherwise Bot Mode
+            // rehydrates the "closed" tabs from the shared tile bucket.
+            closeOpenSessionTilesForPanes(closeableTreeSiblings(targetId).right)
+            closeTreeTabsToRight(targetId)
+          }
         })}
         {(() => {
           // Show/hide rows for the zone's hide-only chrome tabs (sessions /

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -576,8 +576,10 @@ export function closeFocusedToolTab(): boolean {
 }
 
 /** Closeable siblings of `paneId` within its group, split by position — powers
- *  the tab menu's Close-others / Close-to-the-right verbs (and their enablement). */
-function closeableTreeSiblings(paneId: string): { others: string[]; right: string[] } {
+ *  the tab menu's Close-others / Close-to-the-right verbs (and their enablement).
+ *  Exported so callers can persist-close a matching set of Bot Mode session
+ *  tiles (see closeOpenSessionTilesForPanes) before dismissing the tree panes. */
+export function closeableTreeSiblings(paneId: string): { others: string[]; right: string[] } {
   const tree = $layoutTree.get()
   const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
   const idx = panes.indexOf(paneId)

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
-import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
+import { $layoutTree, closeableTreeSiblings, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
 import {
   $workspaceMode,
   forgetActivePane,
@@ -22,6 +22,7 @@ import {
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
+  closeOpenSessionTilesForPanes,
   focusedSessionNeedsRoute,
   focusOpenSession,
   focusWorkspaceOwnerSessionTile,
@@ -693,6 +694,56 @@ describe('dropTilesForProfile', () => {
       /route without profile/
     )
     expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-remote'])
+  })
+})
+
+describe('closeOpenSessionTilesForPanes persists Bot Mode Close Others / Close to Right (sibling of #94137)', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('Close Others drops the persisted twins so a profile rehydrate cannot restore them, keeping the anchor tile', () => {
+    openSessionTile('chat-a', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' })
+    openSessionTile('chat-b', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:b' })
+    openSessionTile('chat-c', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:c' })
+    $layoutTree.set(
+      group(['workspace', tilePane('chat-a'), tilePane('chat-b'), tilePane('chat-c')], {
+        active: 'workspace',
+        id: 'main'
+      })
+    )
+
+    // Mirrors the menu handler: gather the sibling ids before dismissing the
+    // tree panes, exactly like the already-fixed Close All does.
+    closeOpenSessionTilesForPanes(closeableTreeSiblings(tilePane('chat-b')).others)
+
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['chat-b'])
+
+    // Profile swap re-reads the shared Bot bucket. A tree-only dismiss would
+    // leave chat-a/chat-c registered there and rehydrate them.
+    $activeGatewayProfile.set('other-profile')
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['chat-b'])
+  })
+
+  it('Close to Right drops only the persisted tiles positioned after the anchor', () => {
+    openSessionTile('chat-a', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' })
+    openSessionTile('chat-b', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:b' })
+    openSessionTile('chat-c', 'center', 'workspace', undefined, { workspaceMode: 'bots', workspaceOwnerKey: 'bot:c' })
+    $layoutTree.set(
+      group(['workspace', tilePane('chat-a'), tilePane('chat-b'), tilePane('chat-c')], {
+        active: 'workspace',
+        id: 'main'
+      })
+    )
+
+    closeOpenSessionTilesForPanes(closeableTreeSiblings(tilePane('chat-a')).right)
+
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['chat-a'])
+
+    $activeGatewayProfile.set('other-profile')
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['chat-a'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1553,25 +1553,30 @@ export function closeSessionTile(storedSessionId: string) {
   }
 }
 
-/** Persist-close every session tile whose pane lives in `paneId`'s group.
- *
- * Close All used to only dismiss layout-tree panes. Bot Mode tiles are
- * stored in the shared `__bots_workspace__` bucket, so a later roster
- * click or profile swap rehydrated `$sessionTiles` and the closed tabs
- * came back (#94137). Routing through {@link closeSessionTile} writes that
- * bucket, so the closed set survives those rehydrations and a restart.
+/** Persist-close the session tile behind each pane id in `paneIds` that is a
+ * tile pane. Bot Mode tiles live in the shared `__bots_workspace__` bucket
+ * (see loadTilesByProfile), so dismissing only the layout-tree pane leaves
+ * the tile itself registered — a later roster click or profile swap
+ * rehydrates `$sessionTiles` and the "closed" tab comes back (#94137).
+ * Routing through {@link closeSessionTile} writes that bucket, so the
+ * closed set survives those rehydrations and a restart.
  */
-export function closeAllOpenSessionTiles(paneId: string): void {
-  const tree = $layoutTree.get()
-  // Copy the live group list. closeSessionTile can rewrite the layout
-  // tree; iterating the original array would skip every other pane.
-  const panes = [...((tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? [])]
-
-  for (const id of panes) {
+export function closeOpenSessionTilesForPanes(paneIds: readonly string[]): void {
+  // Copy the input. closeSessionTile can rewrite the layout tree, but that
+  // never touches this already-captured id list.
+  for (const id of [...paneIds]) {
     if (id.startsWith(TILE_PANE_PREFIX)) {
       closeSessionTile(id.slice(TILE_PANE_PREFIX.length))
     }
   }
+}
+
+/** Persist-close every session tile whose pane lives in `paneId`'s group. */
+export function closeAllOpenSessionTiles(paneId: string): void {
+  const tree = $layoutTree.get()
+  const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
+
+  closeOpenSessionTilesForPanes(panes)
 }
 
 /** Drop a DEAD tile — a persisted tile whose session no longer exists on the


### PR DESCRIPTION
## What does this PR do?

Fixes the same "closed" tab resurrecting bug that #94137/#94213 already fixed for Close All, but for the two sibling verbs — Close Others and Close to Right — which had the identical gap in both places they're implemented (the sidebar tab menu and the zone right-click menu).

### Background

Bot Mode session tiles are stored in a shared `__bots_workspace__` bucket (`session-states.ts`), separate from the layout tree. Dismissing a layout-tree pane alone doesn't remove the tile from that bucket, so a later Bots roster click or profile swap rehydrates `$sessionTiles` from it and the "closed" tab comes back. Close All was fixed for this in #94213/salvage #95648, adding an explicit persist-close (`closeAllOpenSessionTiles`) before dismissing the tree panes.

Close Others and Close to Right, right next to Close All in both menus, never got the same treatment — they only call `closeOtherTreeTabs`/`closeTreeTabsToRight`, which touch the layout tree only.

### Repro

1. Open several Bot Mode tabs.
2. Right-click a tab → **Close Others** (or **Close to Right**).
3. The tabs disappear, but clicking another bot in the roster (or switching profiles) brings the "closed" tabs back.

### Fix

- `session-states.ts` — extracted the persist-close loop out of `closeAllOpenSessionTiles` into `closeOpenSessionTilesForPanes(paneIds)`, which takes an explicit pane id list instead of always sweeping the whole group. `closeAllOpenSessionTiles` keeps its existing behavior by calling the new function with the full group's panes — no behavior change for Close All.
- `tree/store.ts` — exported the existing (previously module-private) `closeableTreeSiblings()`, which already computes the exact "others"/"right" pane sets that power the menu's enablement counts, so callers can compute and persist-close the matching tile subset.
- `session-actions-menu.tsx` (sidebar tab menu) and `tree-group.tsx` (zone right-click menu) — both Close Others / Close to Right handlers now call `closeOpenSessionTilesForPanes(closeableTreeSiblings(id).others / .right)` before dismissing the tree panes, mirroring exactly what Close All already does.

## How to Test

```bash
cd apps/desktop
npx vitest run src/store/session-states.test.ts
npx tsc -p . --noEmit
```

## Checklist

- [x] Mutation-verified: temporarily stubbed `closeOpenSessionTilesForPanes` as a no-op (simulating the pre-fix behavior) and confirmed both new regression tests fail; restored and confirmed they pass.
- [x] Full `session-states.test.ts` suite passes (52/52), plus the full `session-actions-menu` and `pane-shell` test suites (173/173) with no regressions.
- [x] `tsc -p . --noEmit` passes with no errors.
- [x] Grepped all real call sites of `closeOtherTreeTabs`/`closeTreeTabsToRight` in `apps/desktop/src` to confirm both are covered (there are exactly two, both fixed here).