### PR TITLE
docs(computer-use): remove the deleted typed browser-page route from the skill

### DIFF
--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -115,7 +115,7 @@ Returned fields (present when the driver supports them):
 - `effect`: `"confirmed"` (driver read the result back — done), `"unverifiable"`
   (delivered, but confirm it yourself by re-capturing), or `"suspected_noop"`
   (ran but almost certainly did nothing).
-- `escalation`: `{recommended: "px" | "foreground" | "page", reason}` — present
+- `escalation`: `{recommended: "px" | "foreground", reason}` — present
   only when there's a next rung to try.
 - `code`: a structured refusal like `"background_unavailable"` or
   `"foreground_unsupported"`.
@@ -131,10 +131,7 @@ Walk it in order:
 3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
    refusal recommends `"px"` (or a `degraded` capture has no elements), click
    by `coordinate=[x,y]` instead of `element`.
-4. **Typed page.** When `escalation.recommended == "page"` and the exact
-   browser-page contract below is available, use the namespaced typed route
-   before native foreground. This is not the legacy `page` workflow.
-5. **Foreground.** After `effect:"suspected_noop"`,
+4. **Foreground.** After `effect:"suspected_noop"`,
    `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
@@ -142,7 +139,7 @@ Walk it in order:
    (it's a visible focus change) and is only appropriate when the user isn't
    actively working. Classic cases: Electron/Chromium consent dialogs (e.g.
    tldraw offline's "Run Script"), DirectInput games, raw-input canvases.
-6. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
+5. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
    Some Qt text components (KTextEditor: Kate, KWrite, KDevelop) discard
    SYNTHETIC X keystrokes entirely — foreground `type` reports ok
    ("Typed N characters into the focused widget", `effect:"unverifiable"`)
@@ -170,62 +167,16 @@ NOT conclude "cua-driver can't drive this app" — climb the ladder. If
 action schema lacks that property; choose another verified rung without
 inferring support from the executable's reported version.
 
-## Typed browser page rung
+## Page content is a separate toolset
 
-For page content in a supported GUI browser, the same `computer_use` tool
-exposes namespaced `cua_browser_*` actions. They do not collide with other
-browser tools. The contract is capability-based:
-
-1. Discover the exact native browser `(pid, window_id)` with `list_windows` or
-   native capture, then call `cua_browser_state` with both values.
-2. Continue only when it returns `status:"ok"`, `binding_quality:"exact"`, and
-   `mutation_allowed:true`. Select an opaque `tab_id` from that response.
-3. Call `cua_browser_state` with the `tab_id` for a fresh `semantic_v2`
-   snapshot. Use only refs from that newest snapshot and only for their
-   declared actions.
-4. Use the matching namespaced action (`cua_browser_click`,
-   `cua_browser_type`, `cua_browser_navigate`, or `cua_browser_pointer`).
-   Trusted input is the default. `input_route="dom_event"` is an explicit
-   trust downgrade; never choose it silently after a refusal.
-5. Every mutation invalidates refs. Take a fresh state snapshot before another
-   typed action. Never chain actions from remembered refs.
-
-`cua_browser_prepare` is a separate approved setup action. Driver-owned
-`isolated_new`/`isolated_named` profiles require explicit `allow_launch=true`.
-An `existing_profile` is decided by cua-driver's immutable permission mode.
-Prefer `isolated_new` unless the task genuinely needs the user's signed-in
-session — attaching to an existing profile exposes its live pages, cookies,
-and storage over the browser protocol.
-
-Authorization paths for `existing_profile`:
-
-1. **Config grant (standard and unrestricted modes).** When
-   `computer_use.grant_existing_profile: true` is set, the runtime is
-   launched pre-authorized in standard mode (`--grant existing-profile`) and
-   Hermes applies the same host-side floor in unrestricted mode. If it is not
-   set, both modes fail closed. Tell the user to flip that config key and
-   restart the session if they want this; do not retry or work around it.
-2. **Bounded manifest.** When `computer_use.permission_mode: bounded` is
-   configured with a reviewed `capability_manifest`, prepares inside the
-   manifest's scope succeed without prompts and everything else fails closed.
-
-Explicit Hermes YOLO (`--yolo`, `/yolo`, or `approvals.mode: off`) launches an
-unrestricted runtime with no runtime Cua approval prompts, but it does not
-substitute for `grant_existing_profile: true`.
-
-These settings belong to runtime launch. The agent cannot add or change them
-after the runtime starts. Without the applicable grant or bounded manifest,
-`existing_profile` fails closed. Report the refusal and name the config key;
-do not retry, downgrade trust, or work around it.
-
-Every MCP transport owns a private lifecycle session inside the runtime. The
-public session name only labels cursor identity and session-scoped state. It
-does not select, share, or keep a runtime alive.
-
-Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
-permission UI, OS prompts, native dialogs, extension surfaces, unsupported
-engines, and any typed route that cannot prove exact binding or mutation
-permission. `cua_browser_dialog` covers page JavaScript dialogs only.
+`computer_use` is desktop-only: it does not expose a typed route for browser
+page content (no `cua_browser_*` actions). For reading or acting on a page's
+DOM — navigation, clicking a link by text, typed input into a form field —
+use the separate `browser_navigate`/`browser_click`/`browser_type`/`browser_snapshot`
+tools (or `browser_exec` when the Browser Use CLI backend is active); their
+own schemas document the current contract. Reserve `computer_use` for browser
+*chrome* (the address bar, permission prompts, extension popups, native
+dialogs) and anything else on screen that isn't page content.
 
 ### Key shortcuts vary per platform
 
@@ -331,7 +282,7 @@ in your conversation context.
 | `cua-driver not installed` | Run `hermes computer-use install`, or `hermes tools` and enable Computer Use |
 | Captures consistently return empty / "no on-screen window" | On Linux: DISPLAY may not be set (X11) or you're on pure Wayland — ask the user to run `hermes computer-use doctor`. On Windows: you may be in Session 0 (SSH session) instead of the interactive desktop — see the cua-driver `WINDOWS.md` deep-dive |
 | Element index stale ("Element N not in cache") | SOM indices are only valid until the next `capture`. Re-capture before clicking. The wrapper carries opaque `element_token`s for stale-detection; you'll see an explicit error rather than a wrong click |
-| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
+| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), then foreground. Browser chrome/native prompts remain native; page content is a separate toolset. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -122,11 +122,11 @@ computer_use:
 ```
 
 Hermes then launches the cua-driver runtime with the trusted-launcher grant
-(`--grant existing-profile`), and
-`cua_browser_prepare` with an existing profile succeeds against the exact
-`(pid, window_id)` the agent proves. Leave it `false` (the default) and
-existing-profile attachment fails closed; driver-owned isolated profiles work
-either way and are what the agent prefers.
+(`--grant existing-profile`), and the standard capture/click/type actions
+succeed against the exact `(pid, window_id)` of that signed-in window. Leave
+it `false` (the default) and existing-profile attachment fails closed;
+driver-owned isolated profiles work either way and are what the agent
+prefers.
 
 ### Bounded mode for repeatable automation
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
@@ -1,14 +1,14 @@
 ---
-title: "Computer Use — Drive the desktop in the background without stealing focus"
+title: "Computer Use — Drive the desktop background-first; escalate on signal"
 sidebar_label: "Computer Use"
-description: "Drive the desktop in the background without stealing focus"
+description: "Drive the desktop background-first; escalate on signal"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Computer Use
 
-Drive the desktop in the background without stealing focus.
+Drive the desktop background-first; escalate on signal.
 
 ## Skill metadata
 
@@ -131,7 +131,7 @@ Returned fields (present when the driver supports them):
 - `effect`: `"confirmed"` (driver read the result back — done), `"unverifiable"`
   (delivered, but confirm it yourself by re-capturing), or `"suspected_noop"`
   (ran but almost certainly did nothing).
-- `escalation`: `{recommended: "px" | "foreground" | "page", reason}` — present
+- `escalation`: `{recommended: "px" | "foreground", reason}` — present
   only when there's a next rung to try.
 - `code`: a structured refusal like `"background_unavailable"` or
   `"foreground_unsupported"`.
@@ -147,10 +147,7 @@ Walk it in order:
 3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
    refusal recommends `"px"` (or a `degraded` capture has no elements), click
    by `coordinate=[x,y]` instead of `element`.
-4. **Typed page.** When `escalation.recommended == "page"` and the exact
-   browser-page contract below is available, use the namespaced typed route
-   before native foreground. This is not the legacy `page` workflow.
-5. **Foreground.** After `effect:"suspected_noop"`,
+4. **Foreground.** After `effect:"suspected_noop"`,
    `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
@@ -158,6 +155,17 @@ Walk it in order:
    (it's a visible focus change) and is only appropriate when the user isn't
    actively working. Classic cases: Electron/Chromium consent dialogs (e.g.
    tldraw offline's "Run Script"), DirectInput games, raw-input canvases.
+5. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
+   Some Qt text components (KTextEditor: Kate, KWrite, KDevelop) discard
+   SYNTHETIC X keystrokes entirely — foreground `type` reports ok
+   ("Typed N characters into the focused widget", `effect:"unverifiable"`)
+   but a fresh AX capture shows the text never arrived, and raw XTest fails
+   identically (proven live, Aug 2026 — it is the toolkit, not the driver;
+   the same foreground route works on kcalc/Chrome). After ONE such
+   verified-lost round trip, stop retrying input rungs: write the file with
+   terminal/file tools and let the editor reload it, or drive the app's
+   DBus/CLI interface. Never loop the ladder against a surface that
+   verifiably swallows synthetic input.
 
 ```
 computer_use(action="click", element=7)
@@ -175,62 +183,16 @@ NOT conclude "cua-driver can't drive this app" — climb the ladder. If
 action schema lacks that property; choose another verified rung without
 inferring support from the executable's reported version.
 
-## Typed browser page rung
+## Page content is a separate toolset
 
-For page content in a supported GUI browser, the same `computer_use` tool
-exposes namespaced `cua_browser_*` actions. They do not collide with other
-browser tools. The contract is capability-based:
-
-1. Discover the exact native browser `(pid, window_id)` with `list_windows` or
-   native capture, then call `cua_browser_state` with both values.
-2. Continue only when it returns `status:"ok"`, `binding_quality:"exact"`, and
-   `mutation_allowed:true`. Select an opaque `tab_id` from that response.
-3. Call `cua_browser_state` with the `tab_id` for a fresh `semantic_v2`
-   snapshot. Use only refs from that newest snapshot and only for their
-   declared actions.
-4. Use the matching namespaced action (`cua_browser_click`,
-   `cua_browser_type`, `cua_browser_navigate`, or `cua_browser_pointer`).
-   Trusted input is the default. `input_route="dom_event"` is an explicit
-   trust downgrade; never choose it silently after a refusal.
-5. Every mutation invalidates refs. Take a fresh state snapshot before another
-   typed action. Never chain actions from remembered refs.
-
-`cua_browser_prepare` is a separate approved setup action. Driver-owned
-`isolated_new`/`isolated_named` profiles require explicit `allow_launch=true`.
-An `existing_profile` is decided by cua-driver's immutable permission mode.
-Prefer `isolated_new` unless the task genuinely needs the user's signed-in
-session. Attaching to an existing profile exposes its live pages, cookies,
-and storage over the browser protocol.
-
-Authorization paths for `existing_profile`:
-
-1. **Config grant (standard and unrestricted modes).** When
-   `computer_use.grant_existing_profile: true` is set, the runtime is
-   launched pre-authorized in standard mode (`--grant existing-profile`) and
-   Hermes applies the same host-side floor in unrestricted mode. If it is not
-   set, both modes fail closed. Tell the user to set that config key and
-   restart the session if they want this. Do not retry or work around it.
-2. **Bounded manifest.** When `computer_use.permission_mode: bounded` is
-   configured with a reviewed `capability_manifest`, prepares inside the
-   manifest's scope succeed without prompts and everything else fails closed.
-
-Explicit Hermes YOLO (`--yolo`, `/yolo`, or `approvals.mode: off`) launches an
-unrestricted runtime with no runtime Cua approval prompts, but it does not
-substitute for `grant_existing_profile: true`.
-
-These settings belong to runtime launch. The agent cannot add or change them
-after the runtime starts. Without the applicable grant or bounded manifest,
-`existing_profile` fails closed. Report the refusal and name the config key;
-do not retry, downgrade trust, or work around it.
-
-Every MCP transport owns a private lifecycle session inside the runtime. The
-public session name only labels cursor identity and session-scoped state. It
-does not select, share, or keep a runtime alive.
-
-Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
-permission UI, OS prompts, native dialogs, extension surfaces, unsupported
-engines, and any typed route that cannot prove exact binding or mutation
-permission. `cua_browser_dialog` covers page JavaScript dialogs only.
+`computer_use` is desktop-only: it does not expose a typed route for browser
+page content (no `cua_browser_*` actions). For reading or acting on a page's
+DOM — navigation, clicking a link by text, typed input into a form field —
+use the separate `browser_navigate`/`browser_click`/`browser_type`/`browser_snapshot`
+tools (or `browser_exec` when the Browser Use CLI backend is active); their
+own schemas document the current contract. Reserve `computer_use` for browser
+*chrome* (the address bar, permission prompts, extension popups, native
+dialogs) and anything else on screen that isn't page content.
 
 ### Key shortcuts vary per platform
 
@@ -336,7 +298,7 @@ in your conversation context.
 | `cua-driver not installed` | Run `hermes computer-use install`, or `hermes tools` and enable Computer Use |
 | Captures consistently return empty / "no on-screen window" | On Linux: DISPLAY may not be set (X11) or you're on pure Wayland — ask the user to run `hermes computer-use doctor`. On Windows: you may be in Session 0 (SSH session) instead of the interactive desktop — see the cua-driver `WINDOWS.md` deep-dive |
 | Element index stale ("Element N not in cache") | SOM indices are only valid until the next `capture`. Re-capture before clicking. The wrapper carries opaque `element_token`s for stale-detection; you'll see an explicit error rather than a wrong click |
-| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
+| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), then foreground. Browser chrome/native prompts remain native; page content is a separate toolset. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |


### PR DESCRIPTION
## What does this PR do?

Removes stale guidance from the `computer-use` skill (and its mirrored docs) that teaches the model to call `computer_use` actions which no longer exist.

### Background

#95620 ("computer_use is now desktop-only") deleted `tools/computer_use/browser_route.py` outright and removed every `cua_browser_*` action from the schema's action enum, `tool.py`'s dispatch, and the escalation-hint code — confirmed on current `main`: zero occurrences of `cua_browser` anywhere in `tools/computer_use/schema.py` or `tool.py`.

The skill doc (`skills/autonomous-ai-agents/computer-use/SKILL.md`) was never updated. It still has a full "Typed browser page rung" section instructing the model to call `cua_browser_state`, `cua_browser_prepare`, `cua_browser_click`, etc., and step 4 of the escalation ladder still tells the model to use this route when `escalation.recommended == "page"` — a value `_enrich_escalation` in `tool.py` can no longer produce (its hint text only mentions `'px'` and `'foreground'` now).

### Impact

A model following this skill's documented workflow calls an action name that fails schema validation on the very first attempt — wasted turn, and it has no way to know from the error alone that the *entire route* was intentionally removed rather than misused.

### Fix

- `SKILL.md`: dropped `"page"` from the `escalation.recommended` union and the ladder step referencing it; replaced the whole "Typed browser page rung" section — including the `existing_profile`/`isolated_new` authorization walkthrough, which described a *model-facing action parameter* that doesn't exist anywhere in `schema.py`/`tool.py` anymore — with a short pointer to the current, separate browser toolset (`browser_navigate`/`browser_click`/`browser_type`/`browser_snapshot`, or `browser_exec` under the Browser Use CLI backend).
- `website/docs/user-guide/features/computer-use.md`: `computer_use.grant_existing_profile` and the rest of the permission-mode config are **not** stale — `cua_backend.py` still reads them to build the cua-driver runtime launch grant. Only reworded the one sentence that named `cua_browser_prepare` as the mechanism consuming that grant; driving a signed-in browser window now goes through the standard capture/click/type actions instead.
- Regenerated the mirrored skill page (`website/docs/user-guide/skills/bundled/.../autonomous-ai-agents-computer-use.md`) via `website/scripts/generate-skill-docs.py`, per that file's own "edit the source SKILL.md, not this page" notice, rather than hand-editing it. The generator also picked up a small amount of pre-existing, unrelated drift already present in `SKILL.md` since #95384 (a title/description sync and a KDE/Qt keystroke-loss item) that had never been regenerated into this page — included as a side effect of a correct regen, kept the diff otherwise scoped to computer-use.

## How to Test

```bash
uv run --frozen pytest tests/website/test_generate_skill_docs.py tests/tools/test_computer_use.py tests/skills -q
```

## Checklist

- [x] Verified via `git show upstream/main:tools/computer_use/schema.py` / `tool.py` (not a possibly-stale local checkout) that `cua_browser` has zero remaining occurrences in the tool implementation.
- [x] Verified `grant_existing_profile`/`capability_manifest`/`permission_mode: bounded` are still live, current config read by `cua_backend.py` before reworking (not removing) that guidance.
- [x] `tests/website/test_generate_skill_docs.py` (7/7), `tests/tools/test_computer_use.py` + `tests/skills` (1688/1688) pass.
- [x] Diff scoped to the three computer-use files; reverted unrelated pre-existing drift the generator surfaced in ~55 other skill doc pages / the sidebar / catalogs.