### PR TITLE
fix(computer-use): update cua-driver signing team

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3678,7 +3678,7 @@ DEFAULT_CONFIG = {
         # macOS only: allow launching an UNSIGNED (ad-hoc / TeamIdentifier
         # not set) CuaDriver.app for the private-session daemon. The default
         # (false) fails closed unless the bundle is signed with the official
-        # cua-driver identity (com.trycua.driver / team 4YEC26S9KF). Enable
+        # cua-driver identity (com.trycua.driver / team YCK386LBJ7). Enable
         # only when developing the driver locally from source.
         "allow_unsigned_driver": False,
         # Pre-authorize existing-profile browser attachment in standard mode

--- a/tests/tools/test_computer_use_cua_signature.py
+++ b/tests/tools/test_computer_use_cua_signature.py
@@ -1,0 +1,65 @@
+"""Regression coverage for the macOS CuaDriver.app identity gate."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tools.computer_use import cua_backend
+
+
+def _patch_codesign(monkeypatch, *, identifier: str, team_id: str) -> None:
+    monkeypatch.setattr(
+        cua_backend.shutil,
+        "which",
+        lambda name: "/usr/bin/codesign" if name == "codesign" else None,
+    )
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout="",
+            stderr=f"Identifier={identifier}\nTeamIdentifier={team_id}\n",
+        ),
+    )
+
+
+def test_driver_signature_accepts_official_release_identity(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        identifier="com.trycua.driver",
+        team_id="YCK386LBJ7",
+    )
+
+    cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_rejects_stale_team_id(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        identifier="com.trycua.driver",
+        team_id="4YEC26S9KF",
+    )
+
+    with pytest.raises(RuntimeError, match="expected 'YCK386LBJ7'"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+@pytest.mark.parametrize(
+    ("identifier", "team_id", "message"),
+    [
+        ("com.trycua.driver.evil", "YCK386LBJ7", "identifier"),
+        ("com.trycua.driver", "not set", "team"),
+    ],
+)
+def test_driver_signature_keeps_fail_closed_rejections(
+    monkeypatch, identifier, team_id, message
+):
+    _patch_codesign(monkeypatch, identifier=identifier, team_id=team_id)
+
+    with pytest.raises(RuntimeError, match=message):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -617,7 +617,7 @@ def _resolve_cua_driver_app_path(driver_cmd: str) -> Optional[str]:
 # suffixed identifier ("com.trycua.driver.evil") or a different non-empty
 # team is an impostor bundle, not a variant.
 _CUA_DRIVER_BUNDLE_ID = "com.trycua.driver"
-_CUA_DRIVER_TEAM_ID = "4YEC26S9KF"
+_CUA_DRIVER_TEAM_ID = "YCK386LBJ7"
 
 
 def _validate_cua_driver_app_signature(app_path: str) -> None:


### PR DESCRIPTION
## Summary
- update the pinned macOS cua-driver Team ID from the stale Hermes value to the signer used by official trycua driver releases
- keep exact bundle identifier and non-ad-hoc signature validation fail-closed
- add focused regression coverage for the official identity, stale Team ID, wrong bundle ID, and missing Team ID

## Root cause
Hermes pinned Team ID `4YEC26S9KF`, while the official `com.trycua.driver` 0.22.1 release is signed by Team ID `YCK386LBJ7`. The valid official driver was therefore rejected before macOS permissions could be requested. The trycua release workflow also pins `YCK386LBJ7` for signed release verification.

## Tests
- `scripts/run_tests.sh tests/tools/test_computer_use_cua_signature.py -q` (4 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_install_cua_driver.py tests/hermes_cli/test_computer_use_cli.py tests/tools/test_computer_use_cua_backend_linux.py tests/test_install_scripts_computer_use.py -q` (87 passed, 14 platform-specific skipped on Linux)

No signature checks or unsigned-driver safeguards are bypassed.