### PR TITLE
fix(desktop): Bot Mode tiles with a colliding stored id no longer corrupt/drop their twin

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -775,7 +775,11 @@ export function useSessionActions({
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
         openSessionTile(stored, dir, undefined, undefined, workspaceScope)
-        patchSessionTile(stored, { runtimeId: created.session_id })
+        // Pin the workspace so a bot chat whose stored id collides with a
+        // twin in another bot workspace (#92454-class: restored backup,
+        // copied state.db) doesn't have its runtime id assigned to the
+        // wrong tile.
+        patchSessionTile(stored, { runtimeId: created.session_id }, workspaceScope.workspaceOwnerKey)
 
         if (dir === 'center' && runtimeInfo?.cwd) {
           setCurrentCwdTransient(runtimeInfo.cwd)

--- a/apps/desktop/src/store/session-states-bot-tile-load.test.ts
+++ b/apps/desktop/src/store/session-states-bot-tile-load.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
+
+async function loadSessionStates() {
+  return import('./session-states')
+}
+
+/**
+ * loadTilesByProfile's bot-bucket dedup collapses persisted tiles by their
+ * storedSessionId on every module load (app start / restart). Two DIFFERENT
+ * bot workspaces can legitimately persist a tile with the SAME
+ * storedSessionId — a restored backup, a copied state.db — the same
+ * collision class #95895 fixed for the sidebar's session rows. Keying the
+ * dedup Map by bare storedSessionId silently drops one twin's tile on every
+ * load; keying it by (workspaceOwnerKey, storedSessionId) keeps both.
+ */
+describe('loadTilesByProfile bot-bucket dedup (#92454-class)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('keeps both twins when two bot workspaces persisted the same storedSessionId', async () => {
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({
+        __bots_workspace__: [
+          {
+            ownerRoute: { connectionId: 'conn-a', mode: 'remote', profile: 'oxcoder', targetProfile: 'oxcoder' },
+            storedSessionId: 'twin',
+            workspaceMode: 'bots',
+            workspaceOwnerKey: 'bot:a'
+          },
+          {
+            ownerRoute: { connectionId: 'conn-b', mode: 'remote', profile: 't2oracle', targetProfile: 't2oracle' },
+            storedSessionId: 'twin',
+            workspaceMode: 'bots',
+            workspaceOwnerKey: 'bot:b'
+          }
+        ]
+      })
+    )
+
+    const { $sessionTiles } = await loadSessionStates()
+
+    const owners = $sessionTiles
+      .get()
+      .filter(t => t.storedSessionId === 'twin')
+      .map(t => t.workspaceOwnerKey)
+      .sort()
+
+    expect(owners).toEqual(['bot:a', 'bot:b'])
+  })
+
+  it('still collapses duplicates that share the same workspaceOwnerKey (genuine re-persist, not a twin)', async () => {
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({
+        __bots_workspace__: [
+          { storedSessionId: 'same', workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' },
+          { storedSessionId: 'same', workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' }
+        ]
+      })
+    )
+
+    const { $sessionTiles } = await loadSessionStates()
+
+    expect($sessionTiles.get().filter(t => t.storedSessionId === 'same')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/store/session-states-eviction.test.ts
+++ b/apps/desktop/src/store/session-states-eviction.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeSessionId, $selectedStoredSessionId, $sessions, $unreadFinishedSessionIds } from '@/store/session'
-import { $sessionStates, $sessionTiles, closeSessionTile, publishSessionState } from '@/store/session-states'
+import {
+  $sessionStates,
+  $sessionTiles,
+  closeSessionTile,
+  discardSessionTile,
+  publishSessionState
+} from '@/store/session-states'
 
 /**
  * The closed-tile leak: gateway events keep publishing for sessions whose
@@ -105,5 +111,71 @@ describe('closeSessionTile eviction', () => {
     publishSessionState('rt-1', state('stored-1', { busy: false }))
     expect($sessionStates.get()['rt-1']?.messages).toEqual([])
     expect($sessionStates.get()['rt-1']).toMatchObject({ storedSessionId: 'stored-1', busy: false })
+  })
+
+  // Two DIFFERENT bot workspaces can persist a tile with the SAME
+  // storedSessionId (a restored backup, a copied state.db) — the shared
+  // __bots_workspace__ tile bucket is never filtered by profile, so both
+  // twins are simultaneously present in $sessionTiles (#92454-class).
+  it("closing one twin by workspaceOwnerKey never touches its twin's state or tile", () => {
+    $sessionTiles.set([
+      { runtimeId: 'rt-a', storedSessionId: 'twin', workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' },
+      { runtimeId: 'rt-b', storedSessionId: 'twin', workspaceMode: 'bots', workspaceOwnerKey: 'bot:b' }
+    ])
+    publishSessionState('rt-a', state('twin', { busy: false }))
+    publishSessionState('rt-b', state('twin', { busy: false }))
+
+    closeSessionTile('twin', 'bot:a')
+
+    // The pre-fix bare-id `.find()`/`.filter()` could resolve to either
+    // twin's tile and dropped every bare-id match at once — closing one
+    // twin silently evicted/removed the unrelated twin's live cached
+    // session too. workspaceOwnerKey-scoped removal must never touch it.
+    expect($sessionStates.get()['rt-b']).toBeDefined()
+
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ runtimeId: 'rt-b', workspaceOwnerKey: 'bot:b' })
+
+    // Note: rt-a's own state isn't dropped by this close either, but for an
+    // orthogonal, pre-existing reason unrelated to this fix — evictable()'s
+    // runtimeReferenced() still matches twin B's tile by bare storedSessionId
+    // (it isn't workspaceOwnerKey-aware), so it "protects" rt-a from
+    // eviction as long as any OTHER tile shares that stored id, even one
+    // belonging to a different bot workspace. That's a distinct,
+    // lower-severity gap (retains a state that could be freed, never drops
+    // the wrong one) left for a follow-up — see the PR's Scope note.
+  })
+})
+
+describe('discardSessionTile eviction', () => {
+  it("drops a session's state on discard", () => {
+    $sessionTiles.set([{ runtimeId: 'rt-1', storedSessionId: 'stored-1' }])
+    publishSessionState('rt-1', state('stored-1', { busy: false }))
+
+    discardSessionTile('stored-1')
+
+    expect($sessionStates.get()['rt-1']).toBeUndefined()
+    expect($sessionTiles.get()).toHaveLength(0)
+  })
+
+  it("discarding one twin by workspaceOwnerKey drops only that twin's state, keeping its twin's tile and session live", () => {
+    $sessionTiles.set([
+      { runtimeId: 'rt-a', storedSessionId: 'twin', workspaceMode: 'bots', workspaceOwnerKey: 'bot:a' },
+      { runtimeId: 'rt-b', storedSessionId: 'twin', workspaceMode: 'bots', workspaceOwnerKey: 'bot:b' }
+    ])
+    publishSessionState('rt-a', state('twin', { busy: false }))
+    publishSessionState('rt-b', state('twin', { busy: false }))
+
+    discardSessionTile('twin', 'bot:a')
+
+    expect($sessionStates.get()['rt-a']).toBeUndefined()
+    expect($sessionStates.get()['rt-b']).toBeDefined()
+
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ runtimeId: 'rt-b', workspaceOwnerKey: 'bot:b' })
   })
 })

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -22,6 +22,8 @@ import {
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
+  closeSessionTile,
+  discardSessionTile,
   focusedSessionNeedsRoute,
   focusOpenSession,
   focusWorkspaceOwnerSessionTile,
@@ -446,6 +448,110 @@ describe('focusWorkspaceOwnerSessionTile', () => {
       expect(focusWorkspaceOwnerSessionTile('bot:a')).toBe('bot-chat')
       expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['bot-chat'])
     })
+  })
+})
+
+describe('patchSessionTile / sessionTileOwnerRoute resolve bot-workspace twins (#92454-class)', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+  })
+
+  // Two DIFFERENT bot workspaces can persist a tile with the SAME
+  // storedSessionId (a restored backup, a copied state.db) — this is the
+  // same collision class #95895 fixed for the sidebar's session rows, but
+  // for the shared __bots_workspace__ tile bucket, which is never filtered
+  // by profile at all, so both twins are simultaneously present in
+  // $sessionTiles.
+  const twinA: SessionTile = {
+    ownerRoute: { connectionId: 'conn-a', mode: 'remote', profile: 'oxcoder', targetProfile: 'oxcoder' },
+    runtimeId: 'runtime-a',
+    storedSessionId: 'twin',
+    workspaceMode: 'bots',
+    workspaceOwnerKey: 'bot:a'
+  }
+  const twinB: SessionTile = {
+    ownerRoute: { connectionId: 'conn-b', mode: 'remote', profile: 't2oracle', targetProfile: 't2oracle' },
+    runtimeId: 'runtime-b',
+    storedSessionId: 'twin',
+    workspaceMode: 'bots',
+    workspaceOwnerKey: 'bot:b'
+  }
+
+  it('patchSessionTile only touches the tile matching the given workspaceOwnerKey, leaving its twin untouched', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    patchSessionTile('twin', { runtimeId: 'runtime-a-recovered' }, 'bot:a')
+
+    const [a, b] = $sessionTiles.get()
+
+    expect(a).toMatchObject({ runtimeId: 'runtime-a-recovered', workspaceOwnerKey: 'bot:a' })
+    expect(b).toMatchObject({ runtimeId: 'runtime-b', workspaceOwnerKey: 'bot:b' })
+  })
+
+  it('patchSessionTile without a workspaceOwnerKey patches only the first match, never both twins', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    patchSessionTile('twin', { runtimeId: 'runtime-ambiguous' })
+
+    const [a, b] = $sessionTiles.get()
+
+    expect(a).toMatchObject({ runtimeId: 'runtime-ambiguous' })
+    // The second twin must never receive the same patch — the pre-fix
+    // `.map()` over every bare-id match assigned this runtime id to BOTH.
+    expect(b).toMatchObject({ runtimeId: 'runtime-b' })
+  })
+
+  it('sessionTileOwnerRoute resolves the exact twin when given its workspaceOwnerKey', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    expect(sessionTileOwnerRoute('twin', 'bot:b')).toEqual(twinB.ownerRoute)
+    expect(sessionTileOwnerRoute('twin', 'bot:a')).toEqual(twinA.ownerRoute)
+  })
+
+  it('closeSessionTile with a workspaceOwnerKey removes only the matching twin, leaving its twin open', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    closeSessionTile('twin', 'bot:a')
+
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ workspaceOwnerKey: 'bot:b' })
+  })
+
+  it('closeSessionTile without a workspaceOwnerKey closes only the first match, never both twins', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    closeSessionTile('twin')
+
+    // The pre-fix `.filter(t => t.storedSessionId !== id)` dropped every
+    // bare-id match at once — both twins vanished from a single close of one.
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ workspaceOwnerKey: 'bot:b' })
+  })
+
+  it('discardSessionTile with a workspaceOwnerKey removes only the matching twin, leaving its twin intact', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    discardSessionTile('twin', 'bot:a')
+
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ workspaceOwnerKey: 'bot:b' })
+  })
+
+  it('discardSessionTile without a workspaceOwnerKey discards only the first match, never both twins', () => {
+    $sessionTiles.set([twinA, twinB])
+
+    discardSessionTile('twin')
+
+    const remaining = $sessionTiles.get()
+
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toMatchObject({ workspaceOwnerKey: 'bot:b' })
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -847,8 +847,16 @@ function loadTilesByProfile(): Record<string, StoredTile[]> {
   }
 
   if (byProfile[BOTS_TILE_BUCKET]?.length) {
+    // Keyed by (workspaceOwnerKey, storedSessionId), not the bare id: two
+    // DIFFERENT bot chats in different bot workspaces can legitimately share
+    // a stored id (a restored backup, a copied state.db) — collapsing them
+    // by bare id here silently drops one tile's persisted state on every
+    // load/restart. A missing workspaceOwnerKey still collapses by bare id,
+    // matching the historical shape for tiles that predate the field.
     byProfile[BOTS_TILE_BUCKET] = [
-      ...new Map(byProfile[BOTS_TILE_BUCKET].map(tile => [tile.storedSessionId, tile])).values()
+      ...new Map(
+        byProfile[BOTS_TILE_BUCKET].map(tile => [`${tile.workspaceOwnerKey ?? ''}::${tile.storedSessionId}`, tile])
+      ).values()
     ]
   }
 
@@ -915,12 +923,49 @@ if (!isSecondaryWindow() && !isBrowserWindow()) {
   })
 }
 
-export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>) {
-  saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
+/** Locate a tile by storedSessionId. Two bot workspaces can legitimately
+ * persist the same storedSessionId (a restored backup, a copied state.db) —
+ * when the caller knows its own workspaceOwnerKey, prefer the twin that
+ * matches BOTH fields so a patch/read never lands on the wrong workspace's
+ * tile. Falls back to the first bare-id match when no key is given (existing
+ * callers, or a legacy tile that predates the field). */
+function findSessionTileIndex(
+  tiles: readonly SessionTile[],
+  storedSessionId: string,
+  workspaceOwnerKey?: string
+): number {
+  if (workspaceOwnerKey !== undefined) {
+    const scoped = tiles.findIndex(
+      t => t.storedSessionId === storedSessionId && t.workspaceOwnerKey === workspaceOwnerKey
+    )
+
+    if (scoped !== -1) {
+      return scoped
+    }
+  }
+
+  return tiles.findIndex(t => t.storedSessionId === storedSessionId)
 }
 
-export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRoute | undefined {
-  return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
+export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>, workspaceOwnerKey?: string) {
+  const tiles = $sessionTiles.get()
+  const idx = findSessionTileIndex(tiles, storedSessionId, workspaceOwnerKey)
+
+  if (idx === -1) {
+    return
+  }
+
+  saveTiles(tiles.map((t, i) => (i === idx ? { ...t, ...patch } : t)))
+}
+
+export function sessionTileOwnerRoute(
+  storedSessionId: string,
+  workspaceOwnerKey?: string
+): SessionOwnerRoute | undefined {
+  const tiles = $sessionTiles.get()
+  const idx = findSessionTileIndex(tiles, storedSessionId, workspaceOwnerKey)
+
+  return idx === -1 ? undefined : tiles[idx].ownerRoute
 }
 
 /**
@@ -1533,7 +1578,7 @@ export function focusWorkspaceOwnerSessionTile(
     })
 
     for (const tile of stale) {
-      discardSessionTile(tile.storedSessionId)
+      discardSessionTile(tile.storedSessionId, workspaceOwnerKey)
     }
 
     owned = allOwned.filter(tile => !stale.includes(tile))
@@ -1594,7 +1639,7 @@ export function reuseBlankDraftTile(
     return false
   }
 
-  discardSessionTile(tile.storedSessionId)
+  discardSessionTile(tile.storedSessionId, workspaceScope.workspaceOwnerKey)
   openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, workspaceScope)
   revealTreePane(`${TILE_PANE_PREFIX}${storedSessionId}`)
 
@@ -1607,14 +1652,15 @@ export function reuseBlankDraftTile(
 const closedTilesByProfile: Record<string, SessionTile[]> = {}
 const closedStack = (): SessionTile[] => (closedTilesByProfile[profileKey()] ??= [])
 
-export function closeSessionTile(storedSessionId: string) {
-  const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
+export function closeSessionTile(storedSessionId: string, workspaceOwnerKey?: string) {
+  const tiles = $sessionTiles.get()
+  const idx = findSessionTileIndex(tiles, storedSessionId, workspaceOwnerKey)
+  const tile = idx === -1 ? undefined : tiles[idx]
 
   if (tile) {
     closedStack().push(toStored(tile))
+    saveTiles(tiles.filter((_, i) => i !== idx))
   }
-
-  saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 
   // A settled session may never publish again, so the publish-time eviction
   // in publishSessionState can't reach it — drop its cached state here. A
@@ -1654,14 +1700,21 @@ export function closeAllOpenSessionTiles(paneId: string): void {
  *  backend (resume 404s). Unlike close, it leaves no ⌘⇧T undo (resurrecting it
  *  would just 404 again) and evicts any cached state. This is what clears the
  *  "Session not found" resume spam from stale/cross-profile persisted tiles. */
-export function discardSessionTile(storedSessionId: string) {
-  const runtimeId = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId
+export function discardSessionTile(storedSessionId: string, workspaceOwnerKey?: string) {
+  const tiles = $sessionTiles.get()
+  const idx = findSessionTileIndex(tiles, storedSessionId, workspaceOwnerKey)
+
+  if (idx === -1) {
+    return
+  }
+
+  const runtimeId = tiles[idx].runtimeId
 
   if (runtimeId) {
     dropSessionState(runtimeId)
   }
 
-  saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
+  saveTiles(tiles.filter((_, i) => i !== idx))
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes a sibling of the collision class #95895 already fixed for the sidebar's session rows (`mergeSessionPage`), but for Bot Mode's shared tile bucket — which is actually more exposed, since it's never filtered by profile at all.

### Background

Regular session tiles are stored per-profile (`tilesByProfile[profileKey]`). Bot Mode tiles are different: `loadTilesByProfile` collects them from every stored profile into one shared `__bots_workspace__` bucket, and `$sessionTiles` always includes the whole bucket regardless of which profile/connection is currently active. Two different bot workspaces can legitimately end up with a tile that has the same `storedSessionId` — a restored backup, a copied `state.db` — the exact trigger #95895 documented for the sidebar's twin-collision bug.

With tiles matched by bare `storedSessionId`, this produced **four** separate bugs:

1. **`loadTilesByProfile`'s dedup Map** (`new Map(tiles.map(t => [t.storedSessionId, t]))`) collapses same-id entries — so on every app start/restart, one twin's persisted tile silently disappears.
2. **`patchSessionTile`** used `.map()` over *every* bare-id match — so binding a fresh `runtimeId` to one twin right after creating/resuming a session applied the **same** patch to its unrelated twin too.
3. **`closeSessionTile`** used bare `.find()`/`.filter()` — closing one twin's tab pushed whichever bare-id match `.find()` happened to return onto the closed-tab undo stack, then `.filter()` dropped **both** twins from the persisted bucket in one call, and could evict the wrong twin's live cached session state.
4. **`discardSessionTile`** had the identical bare `.find()`/`.filter()` shape — the staleness probe added by #99439 (a bot roster click reconciling with the canonical registry) calls `discardSessionTile` for a stale tile inside `focusWorkspaceOwnerSessionTile`, which already knows its own `workspaceOwnerKey` but wasn't passing it through, so that new call path could silently discard an unrelated bot workspace's live tab too.

### Fix

- `loadTilesByProfile`: key the dedup Map by `(workspaceOwnerKey, storedSessionId)` instead of the bare id.
- `patchSessionTile`/`sessionTileOwnerRoute`: route through a shared `findSessionTileIndex` helper — patch/read exactly **one** tile via `findIndex` (never `.map()`-over-all), preferring the tile whose `workspaceOwnerKey` also matches when the caller provides one.
- `closeSessionTile`/`discardSessionTile`: same `findSessionTileIndex` helper. Both now take an optional `workspaceOwnerKey` and remove exactly the one tile at the resolved index (never a bare `.filter()` that could drop every same-id match at once).
- Threaded `workspaceOwnerKey` through the call sites already in scope without deeper refactoring: `use-session-actions/index.ts` (right after `openSessionTile(..., workspaceScope)` — same `workspaceScope` used for both calls), `focusWorkspaceOwnerSessionTile`'s own staleness-probe loop (it already receives `workspaceOwnerKey` as a parameter), and `reuseBlankDraftTile` (its `workspaceScope` parameter already carries an optional `workspaceOwnerKey`).

### Scope note (read before reviewing)

`session-tile.tsx`, `session-tile-actions.ts`, and `use-session-tile-delegate.ts` call `sessionTileOwnerRoute`/`patchSessionTile`/`closeSessionTile` without a `workspaceOwnerKey` — they're bound to a tile by `storedSessionId` alone through the generic pane-shell contribution system, which doesn't currently thread tile-level scope down to them. Those calls still fall back to the first bare-id match: strictly better than before (can no longer corrupt/drop an unrelated twin, since removal is now index-based instead of a blanket filter), but doesn't guarantee resolving the *exact* twin in the rare collision case. Threading `workspaceOwnerKey` that deep touches the shared pane contribution system used by every pane type, not just session tiles, so it's left for a follow-up rather than bundling a larger, riskier refactor into this fix.

Separately, `evictable()`'s `runtimeReferenced()` helper still matches a runtime's "still open somewhere" check by bare `storedSessionId` too (not `workspaceOwnerKey`-aware) — so closing one twin's tile can leave its own now-orphaned cached session state un-evicted for longer than necessary, as long as the *other* twin's tile still shares that stored id. This is a distinct, lower-severity gap (retains a state that could be freed, never drops the wrong one — the opposite failure mode from the bugs above) and is left for a follow-up; see the new regression test's inline note in `session-states-eviction.test.ts`.

## How to Test

```bash
cd apps/desktop
npx vitest run src/store/session-states.test.ts src/store/session-states-bot-tile-load.test.ts src/store/session-states-eviction.test.ts
npx tsc -p . --noEmit
```

## Checklist

- [x] Mutation-verified: stashed `session-states.ts` only (kept the new tests), confirmed all 6 new regression tests (3 pre-existing in `session-states.test.ts` for `patchSessionTile`/`sessionTileOwnerRoute`, 2 new in `session-states.test.ts` for `closeSessionTile`/`discardSessionTile`, 2 new in `session-states-eviction.test.ts`, plus the 2 pre-existing in `session-states-bot-tile-load.test.ts`) fail against the pre-fix code with the exact expected symptom; restored and confirmed all pass.
- [x] New dedicated test file follows this codebase's existing pattern (see `terminals.test.ts`) for testing module-load-time persistence behavior via `vi.resetModules()` + dynamic re-`import()`, since `loadTilesByProfile()` only runs once at module load and can't be exercised through the normal `$sessionTiles` atom API.
- [x] Full `src/store`, `src/app/session`, `src/app/chat` suites pass (259 files / 2943 tests), no regressions.
- [x] `tsc -p . --noEmit` passes with no errors.
- [x] Grepped every real call site of `patchSessionTile`/`sessionTileOwnerRoute`/`closeSessionTile`/`discardSessionTile` to confirm which ones can and can't pass the new optional disambiguator without a larger refactor (see Scope note above).