### PR TITLE
fix(desktop): enable cross-source group chat creation

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -14865,7 +14865,7 @@ function BotsPane() {
                         children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
                       }),
                       jsxs(DropdownMenuItem, {
-                        disabled: activeSourceRoster.length < 2,
+                        disabled: roster.filter(bot => !bot?.ghost).length < 2,
                         onSelect: () => setGroupCreateOpen(true),
                         children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
                       })

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
@@ -15,6 +15,11 @@ test('source contract: header + is a dropdown offering agent and group chat', ()
   assert.match(pluginSource, /'New Group Chat'/)
 })
 
+test('source contract: remote selectable bots count toward enabling New Group Chat', () => {
+  assert.match(pluginSource, /disabled:\s*roster\.filter\(bot => !bot\?\.ghost\)\.length < 2/)
+  assert.doesNotMatch(pluginSource, /disabled:\s*activeSourceRoster\.length < 2/)
+})
+
 test('source contract: create-group modal has search, checkboxes, name, create', () => {
   assert.match(pluginSource, /function CreateGroupChatDialog\(/)
   // An outage placeholder preserves identity, but cannot receive a message.


### PR DESCRIPTION
## Summary

- enable **New Group Chat** when at least two selectable bots exist across the full multi-source roster
- continue excluding unreachable `ghost` placeholders, matching the creation dialog's own selection rules
- add a regression contract for local-plus-remote Bot fleets

## Why

The menu gate counted `activeSourceRoster`, which intentionally excludes `remoteSource` rows. A Desktop with one local Bot and one or more healthy Bots on registered connections therefore disabled **New Group Chat**, even though the dialog already receives the full multi-source `roster` and can route those members to their owning machines.

## Reproduction

1. Run Hermes Desktop with one local profile.
2. Register another reachable gateway that exposes at least one Bot profile.
3. Open **Bots → New…**.
4. Observe **New Group Chat** is disabled even though two selectable Bots exist across the roster.

After this change, the item is enabled whenever the full roster contains at least two non-ghost Bots.

## Tests

- `node --test src/plugins/hermes-bots/tests/create-group-chat.test.mjs` — 5 passed
- `node --test src/plugins/hermes-bots/tests/*.test.mjs` — 605 passed
- `npm run build` in `apps/desktop` — passed
- `git diff --check` — passed

## Manual validation

- macOS 26.5.1 (arm64) Desktop
- one local Bot plus Bots from registered Windows, macOS, and NAS connections
- verified **New Group Chat** enables and the picker can seat cross-machine members

Related to #94726.
