### PR TITLE
fix(desktop): allow CJK bot names

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx
@@ -162,6 +162,41 @@ afterEach(() => {
 })
 
 describe('materializing the draft profile', () => {
+  it.each([
+    ['小助手', 'u5c0f-u52a9-u624b'],
+    ['test机器人', 'test-u673a-u5668-u4eba']
+  ])('creates %s with an ASCII profile id and retains the display name', async (enteredName, profileName) => {
+    await renderDialog(true)
+
+    fireEvent.change(screen.getByPlaceholderText('inbox-triage'), {
+      target: { value: enteredName }
+    })
+
+    const create = screen.getByRole('button', { name: 'Create Bot' })
+
+    expect((create as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(create)
+
+    await waitFor(() => expect(createCalls()).toHaveLength(1))
+    expect(createCalls()[0][1]).toMatchObject({
+      description: enteredName,
+      name: profileName
+    })
+    expect(mocks.saveBotMeta).toHaveBeenCalledWith(profileName, expect.objectContaining({ title: enteredName }))
+    await waitFor(() => expect(mocks.createCanonicalChat).toHaveBeenCalledWith(profileName, { kickoff: true }))
+  })
+
+  it('keeps Create Bot disabled for a symbols-only name', async () => {
+    await renderDialog(true)
+
+    fireEvent.change(screen.getByPlaceholderText('inbox-triage'), {
+      target: { value: '🤖' }
+    })
+
+    expect((screen.getByRole('button', { name: 'Create Bot' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(createCalls()).toHaveLength(0)
+  })
+
   it('creates it once when the Capabilities tab opens, pinned to the new slug', async () => {
     await renderDialog(true)
 

--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -56,7 +56,7 @@ import {
   liveGroupChatNames
 } from './group-membership'
 import { useBots } from './i18n'
-import { displayName, slugify } from './labels'
+import { botProfileIdentity, displayName } from './labels'
 import { McpSetupButton } from './mcp-setup'
 import { ModelPicker } from './model-picker'
 import type {
@@ -209,7 +209,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
   const [capFilter, setCapFilter] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<null | string>(null)
-  const slug = slugify(name)
+  const { slug, title: botTitle } = botProfileIdentity(name, title)
   const valid = slug.length > 0 && NAME_RE.test(slug)
 
   // Once the draft profile is materialized (Capabilities tab / MCP setup) it
@@ -378,7 +378,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
         return null
       }
 
-      const descriptionText = [title, description].filter(Boolean).join(' — ')
+      const descriptionText = [botTitle, description].filter(Boolean).join(' — ')
       await requestForTarget('profiles.create', {
         name: slug,
         description: descriptionText,
@@ -394,7 +394,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
         share_auth: shareAuth,
         soul: composeSoul({
           name: slug,
-          title,
+          title: botTitle,
           description,
           roster,
           customSoul: soul
@@ -449,7 +449,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
           color,
           image,
           imageKind: image ? 'photo' : 'shape',
-          title: title.trim(),
+          title: botTitle,
           created: Date.now()
         }
 
@@ -477,7 +477,7 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
           color: color ?? undefined,
           image,
           imageKind: image ? 'photo' : 'shape',
-          title: title.trim(),
+          title: botTitle,
           created: Date.now()
         })
       }
@@ -515,11 +515,11 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
         message: remoteTarget
           ? `Bot "${displayName({
               name: slug,
-              title
+              title: botTitle
             })}" created on ${targetLabel}`
           : `Bot "${displayName({
               name: slug,
-              title
+              title: botTitle
             })}" created`
       })
       const wasRemote = remoteTarget

--- a/apps/desktop/src/plugins/hermes-bots/labels.profile-name.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/labels.profile-name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { botProfileIdentity, slugifyProfileName } from './labels'
+
+describe('profile-name identity', () => {
+  it('pins the documented ASCII-lookalike collision', () => {
+    const encoded = 'u5c0f-u52a9-u624b'
+
+    expect(slugifyProfileName('小助手')).toBe(encoded)
+    expect(slugifyProfileName(encoded)).toBe(encoded)
+  })
+
+  it('preserves case-only display identity', () => {
+    expect(botProfileIdentity('Test', '')).toEqual({ slug: 'test', title: 'Test' })
+    expect(botProfileIdentity('test', '')).toEqual({ slug: 'test', title: '' })
+  })
+
+  it('stops before a Unicode token that would cross the profile limit', () => {
+    const prefix = 'a'.repeat(60)
+    const slug = slugifyProfileName(`${prefix}助`)
+
+    expect(slug).toBe(prefix)
+    expect(slug).toHaveLength(60)
+  })
+
+  it('rejects symbols-only identity', () => {
+    expect(botProfileIdentity('🤖', '')).toEqual({ slug: '', title: '🤖' })
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/labels.ts
+++ b/apps/desktop/src/plugins/hermes-bots/labels.ts
@@ -11,6 +11,9 @@
 import { aliasIdentityFor } from './routing'
 import type { BotMeta, RosterRow } from './types'
 
+const ASCII_PROFILE_CHAR = /^[a-z0-9_-]$/
+const UNICODE_PROFILE_WORD_CHAR = /^[\p{L}\p{N}]$/u
+
 export function displayName(bot: Partial<RosterRow>, meta?: BotMeta | null): string {
   // A configured alias route claiming this row overrides source-derived
   // identity: the friendly alias name must survive hosted-session
@@ -69,6 +72,59 @@ export function slugify(value: string) {
     .replace(/[^a-z0-9_-]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 64)
+}
+
+export function slugifyProfileName(value: string) {
+  let slug = ''
+  let separatorPending = false
+
+  for (const char of value.normalize('NFKD').toLowerCase()) {
+    if (ASCII_PROFILE_CHAR.test(char)) {
+      if (char === '-') {
+        separatorPending = slug.length > 0
+
+        continue
+      }
+
+      const prefix = separatorPending && slug ? '-' : ''
+
+      if (slug.length + prefix.length + char.length > 64) {
+        break
+      }
+
+      slug += prefix + char
+      separatorPending = false
+    } else if (UNICODE_PROFILE_WORD_CHAR.test(char)) {
+      // This readable u<hex> contract can collide with the same literal ASCII
+      // name; keep it stable, but never truncate one of its tokens in half.
+      const token = `u${char.codePointAt(0)!.toString(16)}`
+      const prefix = slug ? '-' : ''
+
+      if (slug.length + prefix.length + token.length > 64) {
+        break
+      }
+
+      slug += prefix + token
+      separatorPending = true
+    } else {
+      separatorPending = slug.length > 0
+    }
+  }
+
+  return slug
+}
+
+export function botProfileIdentity(name: string, title: string) {
+  const enteredName = name.trim()
+  const slug = slugifyProfileName(enteredName)
+  const enteredTitle = title.trim()
+
+  return {
+    slug,
+    // A case-only difference is display identity too: preserve "Test" even
+    // though its backend profile is the lowercase "test".
+    title: enteredTitle || (enteredName !== slug ? enteredName : '')
+  }
 }
 
 /** Flatten markdown syntax out of a one-line roster preview so rows read


### PR DESCRIPTION
## What does this PR do?

Allows the Desktop New Bot form to accept CJK and mixed-script names without weakening the backend ASCII profile-ID contract. Unicode letters and numbers receive a deterministic ASCII code-point slug, while the original entered name becomes the bot display title when no explicit title is supplied.

On current-main baseline `f7c79efbac19ae18e8dee7c79a4e4c0935299b5f`, the live form maps `小助手` to an empty string and leaves Create Bot disabled; it maps `test机器人` to `test`, silently losing the CJK identity. This head maps them to `u5c0f-u52a9-u624b` and `test-u673a-u5668-u4eba` and retains both entered display names.

## Related Issue

Fixes #96153

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `labels.ts`: add a profile-specific Unicode identity resolver while leaving the shared group-chat slug behavior unchanged.
- `create-dialog.tsx`: use the resolved profile ID and display title consistently for creation, soul text, local/remote metadata, notifications, and canonical chat routing.
- `create-agent-lazy-profile.test.tsx`: exercise the real dialog for pure CJK and mixed ASCII/CJK inputs, including button state, `profiles.create`, retained metadata, and canonical chat creation.

## How to Test

1. On baseline `f7c79efbac19ae18e8dee7c79a4e4c0935299b5f` plus the new dialog regression, run `npm --prefix apps/desktop run test:ui -- src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx -t "creates CJK names"`; the Create Bot button remains disabled (`expected true to be false`).
2. On head `096e3df66a6b6290e92bace857ccc59dc25daa4c`, run `npm --prefix apps/desktop run test:ui -- src/plugins/hermes-bots/create-agent-lazy-profile.test.tsx` (6 passed).
3. Run the associated create/labels/soul suite (44 passed across 4 files).
4. Run `npm --prefix apps/desktop run typecheck` (renderer, Electron, and E2E TypeScript projects passed).
5. Run ESLint, Prettier check, `git diff HEAD^ HEAD --check`, and changed-file TruffleHog scans (0 verified secrets).

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing open and merged PRs; no competing fix was found.
- [x] This PR contains only the CJK profile-identity fix and its regression.
- [ ] I have run `pytest tests/ -q` and all tests pass. N/A: Desktop-only TypeScript change; scoped Desktop gates above pass.
- [x] I have added regression tests.
- [x] I tested on macOS.

### Documentation and Housekeeping

- [x] Documentation update is N/A; the behavior is internal to the New Bot form.
- [x] `cli-config.yaml.example` update is N/A; no config changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` update is N/A; architecture and workflows did not change.
- [x] Cross-platform impact considered; Unicode normalization and code-point encoding are platform-independent.
- [x] Tool descriptions and schemas are N/A; tool behavior did not change.

## Screenshots / Logs

N/A. The regression drives the real New Bot dialog and asserts the created profile and chat contracts.