### PR TITLE
feat: add authoritative execution receipts

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -110,6 +110,28 @@ def run_codex_app_server_turn(
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
 
+    # App-server tools execute outside Hermes' standard executor. Count only
+    # projected calls that have a matching projected tool result; a call-shaped
+    # assistant item alone is merely attempted, not authoritative evidence that
+    # Codex actually ran it.
+    completed_call_ids = {
+        message.get("tool_call_id")
+        for message in turn.projected_messages
+        if isinstance(message, dict) and message.get("role") == "tool"
+    }
+    executed_tool_calls = []
+    for message in turn.projected_messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        for tool_call in message.get("tool_calls") or []:
+            if not isinstance(tool_call, dict) or tool_call.get("id") not in completed_call_ids:
+                continue
+            function = tool_call.get("function") or {}
+            executed_tool_calls.append({
+                "name": function.get("name", ""),
+                "call_id": tool_call.get("id"),
+            })
+
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
     # in the run_conversation() pre-loop block (lines ~11793-11817) so we
@@ -170,6 +192,7 @@ def run_codex_app_server_turn(
         "error": turn.error,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
+        "turn_execution_evidence": {"tool_calls": executed_tool_calls},
     }
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -422,6 +422,10 @@ def run_conversation(
         persist_user_message = _sanitize_surrogates(persist_user_message)
 
     # Store stream callback for _interruptible_api_call to pick up
+    # Stable current-turn evidence survives message-list replacement during
+    # context compression. It is the source of truth for final receipts.
+    turn_execution_evidence: Dict[str, Any] = {"tool_calls": []}
+    agent._turn_execution_evidence = turn_execution_evidence
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
@@ -750,13 +754,15 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
-        return agent._run_codex_app_server_turn(
+        result = agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+        result.setdefault("turn_execution_evidence", turn_execution_evidence)
+        return result
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
@@ -4532,6 +4538,7 @@ def run_conversation(
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
         "session_id": agent.session_id,
+        "turn_execution_evidence": turn_execution_evidence,
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/agent/execution_receipt.py
+++ b/agent/execution_receipt.py
@@ -1,0 +1,100 @@
+"""Authoritative execution state for one completed agent turn."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+def build_execution_receipt(
+    turn_evidence: Mapping[str, Any] | None,
+    process_sessions: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build a receipt from evidence recorded while the turn was executing."""
+    evidence = turn_evidence or {}
+    tool_calls = len(evidence.get("tool_calls") or [])
+    active_processes: list[str] = []
+    exited_processes: list[dict[str, Any]] = []
+    for session in process_sessions:
+        session_id = str(session.get("session_id") or "")
+        if not session_id:
+            continue
+        if session.get("status") == "running":
+            active_processes.append(session_id)
+        elif session.get("status") == "exited":
+            exited_processes.append(
+                {"session_id": session_id, "exit_code": session.get("exit_code")}
+            )
+
+    if active_processes:
+        status = "active"
+    elif exited_processes:
+        status = "exited"
+    elif tool_calls:
+        status = "completed"
+    else:
+        status = "not_started"
+    return {
+        "status": status,
+        "tool_calls": tool_calls,
+        "active_processes": active_processes,
+        "exited_processes": exited_processes,
+    }
+
+
+def render_execution_status(receipt: Mapping[str, Any]) -> dict[str, str]:
+    """Render the structured receipt into deterministic delivery text."""
+    status = str(receipt.get("status") or "not_started")
+    tool_calls = int(receipt.get("tool_calls") or 0)
+    active = list(receipt.get("active_processes") or [])
+    exited = list(receipt.get("exited_processes") or [])
+    if status == "active":
+        detail = f"active; managed process(es) still running: {', '.join(active)}."
+    elif status == "exited":
+        rendered = ", ".join(
+            f"{item['session_id']} (exit {item.get('exit_code')})" for item in exited
+        )
+        detail = f"exited; managed process(es) started this turn finished: {rendered}."
+    elif status == "completed":
+        detail = f"completed; {tool_calls} tool call(s) ran and no managed process remains active."
+    else:
+        detail = "not started; no tools ran and no managed process was started this turn."
+    return {"status": status, "text": f"Execution status: {detail}"}
+
+
+def finalize_execution_result(
+    result: dict[str, Any],
+    *,
+    turn_evidence: Mapping[str, Any] | None,
+    process_sessions: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Attach structured and rendered authoritative status to a turn result."""
+    receipt = build_execution_receipt(turn_evidence, process_sessions)
+    execution_status = render_execution_status(receipt)
+    result["execution_receipt"] = receipt
+    result["execution_status"] = execution_status
+    return result
+
+
+def attach_execution_status_for_delivery(result: dict[str, Any]) -> dict[str, Any]:
+    """Render an attached status into final text at a delivery boundary."""
+    response = result.get("final_response")
+    status = result.get("execution_status") or {}
+    status_text = status.get("text") if isinstance(status, Mapping) else None
+    if (
+        isinstance(response, str)
+        and response
+        and isinstance(status_text, str)
+        and status_text
+        and not result.get("interrupted")
+        and not response.rstrip().endswith(status_text)
+    ):
+        result["final_response"] = response.rstrip() + "\n\n" + status_text
+    return result
+
+
+__all__ = [
+    "attach_execution_status_for_delivery",
+    "build_execution_receipt",
+    "finalize_execution_result",
+    "render_execution_status",
+]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -47,6 +47,13 @@ from tools.tool_result_storage import (
 
 logger = logging.getLogger(__name__)
 
+
+def _record_executed_tool_call(agent, name: str, call_id: str | None) -> None:
+    """Record a call only once execution has passed every blocking gate."""
+    evidence = getattr(agent, "_turn_execution_evidence", None)
+    if isinstance(evidence, dict):
+        evidence.setdefault("tool_calls", []).append({"name": name, "call_id": call_id})
+
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
@@ -300,6 +307,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # ContextVars are propagated by propagate_context_to_thread() at the
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
         start = time.time()
+        _record_executed_tool_call(agent, function_name, getattr(tool_call, "id", None))
         try:
             result = agent._invoke_tool(
                 function_name,
@@ -672,6 +680,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 pass  # never block tool execution
 
         tool_start_time = time.time()
+
+        if not _execution_blocked:
+            _record_executed_tool_call(
+                agent, function_name, getattr(tool_call, "id", None)
+            )
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12036,6 +12036,13 @@ class GatewayRunner:
 
             result = await self._run_in_executor_with_context(run_sync)
 
+            # Background tasks bypass the normal gateway run path, so apply
+            # the same delivery-boundary renderer before extracting content.
+            # The renderer is idempotent and preserves interrupted responses.
+            if result:
+                from agent.execution_receipt import attach_execution_status_for_delivery
+                attach_execution_status_for_delivery(result)
+
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
@@ -17416,6 +17423,12 @@ class GatewayRunner:
                 if observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                # The agent returns an authoritative structured receipt. Render
+                # it only at this delivery boundary so core callers retain the
+                # original model response while gateway streaming/non-streaming
+                # paths share the exact same final text.
+                from agent.execution_receipt import attach_execution_status_for_delivery
+                attach_execution_status_for_delivery(result)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -17469,6 +17482,8 @@ class GatewayRunner:
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "execution_receipt": result.get("execution_receipt"),
+                    "execution_status": result.get("execution_status"),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -17632,6 +17647,8 @@ class GatewayRunner:
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),
+                "execution_receipt": result.get("execution_receipt"),
+                "execution_status": result.get("execution_status"),
             }
         
         # Start progress message sender if enabled
@@ -18127,10 +18144,46 @@ class GatewayRunner:
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     _previewed = bool(result.get("response_previewed"))
+                    _receipt_rendered = bool(result.get("execution_status"))
+                    _receipt_finalized = False
+                    if _receipt_rendered and _sc and getattr(_sc, "message_id", None):
+                        try:
+                            _receipt_edit_result = await _sc.adapter.edit_message(
+                                chat_id=source.chat_id,
+                                message_id=_sc.message_id,
+                                content=result.get("final_response", ""),
+                                finalize=True,
+                            )
+                            _receipt_finalized = bool(
+                                _receipt_edit_result
+                                and getattr(_receipt_edit_result, "success", False)
+                            )
+                            if not _receipt_finalized:
+                                logger.warning(
+                                    "Failed to finalize streamed execution receipt for queued turn %s: %s",
+                                    session_key or "?",
+                                    getattr(
+                                        _receipt_edit_result,
+                                        "error",
+                                        "edit returned no successful delivery result",
+                                    ),
+                                )
+                        except Exception as _receipt_edit_err:
+                            logger.warning(
+                                "Failed to finalize streamed execution receipt for queued turn %s: %s",
+                                session_key or "?",
+                                _receipt_edit_err,
+                            )
                     _already_streamed = bool(
-                        (_sc and getattr(_sc, "final_response_sent", False))
-                        or _previewed
-                        or (_sc and getattr(_sc, "final_content_delivered", False))
+                        _receipt_finalized
+                        or (
+                            not _receipt_rendered
+                            and (
+                                (_sc and getattr(_sc, "final_response_sent", False))
+                                or _previewed
+                                or (_sc and getattr(_sc, "final_content_delivered", False))
+                            )
+                        )
                     )
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
@@ -18316,7 +18369,8 @@ class GatewayRunner:
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
             _transformed = bool(response.get("response_transformed"))
-            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
+            _receipt_rendered = bool(response.get("execution_status"))
+            if not _is_empty_sentinel and not (_transformed or _receipt_rendered) and (_streamed or _previewed or _content_delivered):
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",
@@ -18325,23 +18379,34 @@ class GatewayRunner:
                     _content_delivered,
                 )
                 response["already_sent"] = True
-            elif not _is_empty_sentinel and _transformed and _sc is not None:
+            elif not _is_empty_sentinel and (_transformed or _receipt_rendered) and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
+                        _edit_result = await _sc.adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=response["final_response"],
                             finalize=True,
                         )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
+                        if _edit_result and getattr(_edit_result, "success", False):
+                            response["already_sent"] = True
+                            logger.info(
+                                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                                _sc_msg_id, session_key or "?",
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to edit streamed message for session %s: %s",
+                                session_key or "?",
+                                getattr(
+                                    _edit_result,
+                                    "error",
+                                    "edit returned no successful delivery result",
+                                ),
+                            )
                     except Exception as _edit_err:
                         logger.warning(
                             "Failed to edit streamed message for session %s: %s",

--- a/run_agent.py
+++ b/run_agent.py
@@ -4339,9 +4339,38 @@ class AIAgent:
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        """Run a turn and attach its authoritative execution receipt."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
+        from agent.execution_receipt import finalize_execution_result
+        from tools.process_registry import process_registry
+
+        initial_session_ids = {
+            session.get("session_id")
+            # Snapshot globally so a task id resolved or changed inside the
+            # loop cannot make an older session look newly created.
+            for session in process_registry.list_sessions(task_id=None)
+            if session.get("session_id")
+        }
+        result = run_conversation(
+            self,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+        )
+        effective_task_id = getattr(self, "_current_task_id", None) or task_id
+        new_sessions = [
+            session
+            for session in process_registry.list_sessions(task_id=effective_task_id)
+            if session.get("session_id") not in initial_session_ids
+        ]
+        return finalize_execution_result(
+            result,
+            turn_evidence=result.get("turn_execution_evidence"),
+            process_sessions=new_sessions,
+        )
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,6 +5,8 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import concurrent.futures
+import contextvars
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -44,6 +46,17 @@ def _make_runner():
 
     from gateway.hooks import HookRegistry
     runner.hooks = HookRegistry()
+
+    async def _run_isolated(func, *args):
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return await loop.run_in_executor(executor, ctx.run, func, *args)
+        finally:
+            executor.shutdown(wait=True)
+
+    runner._run_in_executor_with_context = _run_isolated
 
     return runner
 
@@ -266,6 +279,85 @@ class TestRunBackgroundTask:
         assert "Hello from background!" in content
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("final_response", "interrupted", "expected_footer_count"),
+        [
+            ("Background work finished.", False, 1),
+            (
+                "Background work finished.\n\n"
+                "Execution status: completed; 1 tool call(s) ran and no managed "
+                "process remains active.",
+                False,
+                1,
+            ),
+            ("Background work was interrupted.", True, 0),
+        ],
+    )
+    async def test_execution_status_is_rendered_at_background_delivery_boundary(
+        self,
+        monkeypatch,
+        final_response,
+        interrupted,
+        expected_footer_count,
+    ):
+        """Background delivery uses the normal renderer without changing interrupts."""
+        from gateway import run as gateway_run
+
+        status_text = (
+            "Execution status: completed; 1 tool call(s) ran and no managed "
+            "process remains active."
+        )
+        result = {
+            "final_response": final_response,
+            "interrupted": interrupted,
+            "execution_receipt": {
+                "status": "completed",
+                "tool_calls": 1,
+                "active_processes": [],
+                "exited_processes": [],
+            },
+            "execution_status": {"status": "completed", "text": status_text},
+            "messages": [],
+        }
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(return_value=result)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(
+            side_effect=lambda response: ([], response)
+        )
+        mock_adapter.extract_images = MagicMock(
+            side_effect=lambda response: ([], response)
+        )
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        await runner._run_background_task("do work", source, "bg_receipt")
+
+        delivered = mock_adapter.send.call_args.kwargs["content"]
+        assert delivered.count(status_text) == expected_footer_count
 
     @pytest.mark.asyncio
     async def test_telegram_dm_topic_completion_preserves_reply_anchor_metadata(self, monkeypatch):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1,6 +1,8 @@
 """Tests for topic-aware gateway progress updates."""
 
 import asyncio
+import contextvars
+import concurrent.futures
 import importlib
 import sys
 import time
@@ -112,6 +114,21 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
             }
         )
         return SendResult(success=True, message_id=message_id)
+
+
+class FailingMetadataEditProgressCaptureAdapter(MetadataEditProgressCaptureAdapter):
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=False, error="edit rejected")
 
 
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
@@ -242,6 +259,16 @@ def _make_runner(adapter):
         group_sessions_per_user=False,
         stt_enabled=False,
     )
+    async def _run_isolated(func, *args):
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return await loop.run_in_executor(executor, ctx.run, func, *args)
+        finally:
+            executor.shutdown(wait=True)
+
+    runner._run_in_executor_with_context = _run_isolated
     return runner
 
 
@@ -620,6 +647,33 @@ class StreamingRefineAgent:
         }
 
 
+class StreamingReceiptAgent:
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        raw = "I’ll keep working and report back later."
+        if self.stream_delta_callback:
+            self.stream_delta_callback(raw)
+        status_text = (
+            "Execution status: not started; no tools ran and no managed process "
+            "was started this turn."
+        )
+        return {
+            "final_response": raw,
+            "execution_receipt": {
+                "status": "not_started",
+                "tool_calls": 0,
+                "active_processes": [],
+                "exited_processes": [],
+            },
+            "execution_status": {"status": "not_started", "text": status_text},
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedCommentaryAgent:
     calls = 0
 
@@ -916,6 +970,106 @@ async def test_run_agent_previewed_final_marks_already_sent(monkeypatch, tmp_pat
 
     assert result.get("already_sent") is True
     assert [call["content"] for call in adapter.sent] == ["You're welcome."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_nonstreaming_propagates_execution_receipt(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingReceiptAgent,
+        session_id="sess-receipt-nonstreaming",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": False},
+        },
+    )
+
+    assert result["execution_receipt"]["status"] == "not_started"
+    assert result["execution_status"]["status"] == "not_started"
+    assert "Execution status: not started" in result["final_response"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_streaming_finalizes_authoritative_execution_status(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingReceiptAgent,
+        session_id="sess-receipt-streaming",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        adapter_cls=MetadataEditProgressCaptureAdapter,
+    )
+
+    assert result["execution_receipt"]["status"] == "not_started"
+    assert result.get("already_sent") is True
+    assert adapter.edits, "the raw streamed prose must be finalized authoritatively"
+    assert "Execution status: not started" in adapter.edits[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_streaming_failed_receipt_edit_does_not_suppress_fallback(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingReceiptAgent,
+        session_id="sess-receipt-streaming-edit-failed",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        adapter_cls=FailingMetadataEditProgressCaptureAdapter,
+    )
+
+    assert adapter.edits
+    assert result.get("already_sent") is not True
+    assert "Execution status: not started" in result["final_response"]
+
+
+@pytest.mark.asyncio
+async def test_queued_streaming_turn_finalizes_receipt_before_followup(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingReceiptAgent,
+        session_id="sess-receipt-streaming-queued",
+        pending_text="next question",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        adapter_cls=MetadataEditProgressCaptureAdapter,
+    )
+
+    assert result["execution_receipt"]["status"] == "not_started"
+    assert any("Execution status: not started" in edit["content"] for edit in adapter.edits)
+
+
+@pytest.mark.asyncio
+async def test_queued_streaming_failed_receipt_edit_sends_authoritative_fallback(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingReceiptAgent,
+        session_id="sess-receipt-streaming-queued-edit-failed",
+        pending_text="next question",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        adapter_cls=FailingMetadataEditProgressCaptureAdapter,
+    )
+
+    authoritative = result["final_response"]
+    assert "Execution status: not started" in authoritative
+    assert any(call["content"] == authoritative for call in adapter.sent)
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -84,6 +84,19 @@ class TestRunConversationCodexPath:
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
 
+    def test_projected_tool_call_produces_completed_execution_receipt(self, fake_session):
+        """Projected app-server tool results are authoritative execution evidence."""
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("use a tool")
+
+        assert result["turn_execution_evidence"] == {
+            "tool_calls": [{"name": "exec_command", "call_id": "exec_1"}]
+        }
+        assert result["execution_receipt"]["status"] == "completed"
+        assert result["execution_receipt"]["tool_calls"] == 1
+        assert "1 tool call(s) ran" in result["execution_status"]["text"]
+
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()
         with patch.object(agent, "_spawn_background_review", return_value=None):

--- a/tests/run_agent/test_execution_receipt.py
+++ b/tests/run_agent/test_execution_receipt.py
@@ -1,0 +1,106 @@
+"""Integration coverage for authoritative per-turn execution receipts."""
+
+import pytest
+
+from run_agent import AIAgent
+from tools.process_registry import process_registry
+
+
+def _agent_without_init():
+    agent = AIAgent.__new__(AIAgent)
+    agent._current_task_id = None
+    return agent
+
+
+def _result(*, provider="openai", evidence=None, response="I’ll keep working."):
+    return {
+        "provider": provider,
+        "final_response": response,
+        "messages": [{"role": "assistant", "content": response}],
+        "interrupted": False,
+        "turn_execution_evidence": evidence or {"tool_calls": []},
+    }
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "custom"])
+def test_actual_agent_attaches_provider_neutral_structured_status(monkeypatch, provider):
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *args, **kwargs: _result(provider=provider),
+    )
+
+    result = _agent_without_init().run_conversation("inspect", task_id=None)
+
+    assert result["execution_receipt"] == {
+        "status": "not_started",
+        "tool_calls": 0,
+        "active_processes": [],
+        "exited_processes": [],
+    }
+    assert result["execution_status"]["status"] == "not_started"
+    assert result["execution_status"]["text"] == (
+        "Execution status: not started; no tools ran and no managed process was started this turn."
+    )
+    assert result["final_response"] == "I’ll keep working."
+
+
+def test_actual_agent_uses_precompression_turn_evidence(monkeypatch):
+    # The returned transcript intentionally contains no tool messages, as it
+    # would after compression. Stable evidence captured during execution wins.
+    evidence = {"tool_calls": [{"name": "read_file", "call_id": "call-1"}]}
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *args, **kwargs: _result(evidence=evidence, response="Done."),
+    )
+
+    result = _agent_without_init().run_conversation(
+        "inspect", conversation_history=[{"role": "user", "content": "old"}]
+    )
+
+    assert result["execution_receipt"]["tool_calls"] == 1
+    assert result["execution_receipt"]["status"] == "completed"
+
+
+@pytest.mark.parametrize("final_status", ["running", "exited"])
+def test_actual_agent_excludes_preexisting_process_from_turn(monkeypatch, final_status):
+    before = [{"session_id": "old", "status": "running"}]
+    after = [{"session_id": "old", "status": final_status, "exit_code": 0}]
+    snapshots = iter([before, after])
+    monkeypatch.setattr(process_registry, "list_sessions", lambda task_id=None: next(snapshots))
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *args, **kwargs: _result(response="Done."),
+    )
+
+    result = _agent_without_init().run_conversation("inspect", task_id=None)
+
+    assert result["execution_receipt"]["active_processes"] == []
+    assert result["execution_receipt"]["exited_processes"] == []
+
+
+@pytest.mark.parametrize(
+    ("session", "expected_status"),
+    [
+        ({"session_id": "new", "status": "running"}, "active"),
+        ({"session_id": "new", "status": "exited", "exit_code": 0}, "exited"),
+    ],
+)
+def test_actual_agent_attributes_new_managed_process_with_task_id_none(
+    monkeypatch, session, expected_status
+):
+    snapshots = iter([[], [session]])
+    monkeypatch.setattr(process_registry, "list_sessions", lambda task_id=None: next(snapshots))
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *args, **kwargs: _result(response="Done."),
+    )
+
+    result = _agent_without_init().run_conversation("inspect", task_id=None)
+
+    assert result["execution_receipt"]["status"] == expected_status
+    if expected_status == "active":
+        assert result["execution_receipt"]["active_processes"] == ["new"]
+    else:
+        assert result["execution_receipt"]["exited_processes"] == [
+            {"session_id": "new", "exit_code": 0}
+        ]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2920,6 +2920,8 @@ class TestRunConversation:
             result = agent.run_conversation("search something")
         assert result["final_response"] == "Done searching"
         assert result["api_calls"] == 2
+        assert result["execution_receipt"]["status"] == "completed"
+        assert result["execution_receipt"]["tool_calls"] == 1
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -298,6 +298,16 @@ def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_
     assert "stopped retrying" in result["final_response"]
     assert result["guardrail"]["code"] == "repeated_exact_failure_block"
     assert result["guardrail"]["tool_name"] == "web_search"
+    assert result["turn_execution_evidence"] == {
+        "tool_calls": [
+            {"name": "web_search", "call_id": "c1"},
+            {"name": "web_search", "call_id": "c2"},
+        ]
+    }
+    assert result["execution_receipt"]["tool_calls"] == 2
+    assert result["execution_receipt"]["status"] == "completed"
+    assert "2 tool call(s) ran" in result["execution_status"]["text"]
+    assert "3 tool call(s) ran" not in result["execution_status"]["text"]
 
     assistant_tool_calls = [m for m in result["messages"] if m.get("role") == "assistant" and m.get("tool_calls")]
     for assistant_msg in assistant_tool_calls:


### PR DESCRIPTION
## Summary
- attach per-turn execution receipts from executed tool and managed-process evidence
- render deterministic execution status at gateway delivery boundaries, including streaming and background-task paths
- cover normal, guardrail, Codex App Server, managed-process, and delivery fallback cases

## Verification
- `HERMES_HOME=$(mktemp -d) pytest -q tests/gateway/test_run_progress_topics.py tests/gateway/test_background_command.py tests/run_agent/test_execution_receipt.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_run_agent.py`
  - 442 passed

## Notes
- Receipt state is derived from runtime evidence; deterministic delivery status does not rely on model wording.