### PR TITLE
fix(desktop): remote spawn reservation fails closed on an unparseable lockfile

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { exec as execCallback, spawn } from 'node:child_process'
+import { exec as execCallback, execFileSync, spawn } from 'node:child_process'
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -826,6 +826,167 @@ test('buildSpawnCommand atomically reserves the ownership slot through spawn and
   assert.match(cmd, /trap .*rm -rf/)
   assert.ok(cmd.indexOf('lock_json') > cmd.indexOf('serve --isolated'))
 })
+
+// #95532 taught every OTHER lockfile consumer in this file (connect,
+// disconnect, cleanupStale) to fail closed on a lockfile that exists but
+// isn't in our recognized shape — a state that most likely means a
+// different/modified desktop build shares this remote, not "no owner".
+// buildSpawnCommand's own reservation script re-checks for a lock inside its
+// atomic mkdir-mutex (closing the TOCTOU gap between the TS-side check in
+// connect() and this remote exec), but did its own crude sed-only parse and
+// deleted anything it couldn't read a pid from — silently reaping a foreign
+// build's live lockfile and spawning on top of it.
+//
+// This extracts the exact `if [ -f "$lock" ]; then ...; fi;` block straight
+// out of a real buildSpawnCommand() string (not retyped by hand — this test
+// exists to catch a parsing/quoting bug, and a hand-copy risks reintroducing
+// one) and runs it standalone through a real shell against real lock files,
+// so it proves runtime behavior rather than trusting the source read. It
+// does not go through the surrounding reservation mkdir-mutex: that stage
+// has its own $HOME-expansion plumbing (covered by the string assertions in
+// the "atomically reserves" test above) that is orthogonal to the lock
+// classification logic under test here.
+// buildSpawnCommand's return value is `python3 -c <shq script> <shq mutex>
+// <shq payload>` (withRemoteUpdateMutex) — the actual reservation/lock-check
+// shell source is single-quote-escaped (shq()) as one argv element, not
+// present as directly-executable text. Recover it by having a REAL shell
+// parse the command line (shadowing `python3` to just print its last
+// argument) instead of reimplementing shq's escaping by hand here, which
+// is exactly the kind of quoting mistake this test exists to catch.
+function extractInnerPayload(command: string): string {
+  return execFileSync(
+    'bash',
+    ['-c', 'python3() { printf %s "${@: -1}"; }; eval "$1"', 'extract-inner-payload', command],
+    { encoding: 'utf8' }
+  )
+}
+
+function extractLockCheckFragment(command: string): string {
+  const payload = extractInnerPayload(command)
+  const start = payload.indexOf('if [ -f "$lock" ]; then ')
+
+  assert.ok(start !== -1, 'buildSpawnCommand output must contain the lock-check block')
+
+  // The block contains one nested `if kill -0 ...; then ...; fi;` (inside the
+  // case's non-empty-pid arm) before its own closing `fi;` — skip the inner
+  // one to find the block's actual end.
+  const innerEnd = payload.indexOf('; fi; ', start)
+
+  assert.ok(innerEnd !== -1, 'lock-check block must contain the nested kill -0 check')
+
+  const end = payload.indexOf('; fi; ', innerEnd + '; fi; '.length)
+
+  assert.ok(end !== -1, 'lock-check block must be closed with its own fi;')
+
+  return payload.slice(start, end + '; fi;'.length)
+}
+
+function buildReservationCommand() {
+  return buildSpawnCommand('/x/hermes', 'work', {
+    hermesHome: '~/.hermes',
+    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+    ownershipId: OWNERSHIP_ID,
+    reservationNonce: SPAWN_NONCE,
+    spawnNonce: SPAWN_NONCE,
+    tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
+    lockMetadata: {
+      ownershipId: OWNERSHIP_ID,
+      spawnNonce: SPAWN_NONCE,
+      port: 0,
+      profile: 'work',
+      hermesPath: '/x/hermes',
+      hermesHome: '~/.hermes',
+      logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+      tokenFingerprint: fingerprintToken('stored-token'),
+      protocolVersion: PROTOCOL_VERSION,
+      startedAt: '2026-07-14T00:00:00.000Z'
+    }
+  })
+}
+
+test.skipIf(process.platform === 'win32')(
+  'reservation script refuses to delete a lockfile it cannot parse a pid from',
+  async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-lockfile-skew-'))
+
+    try {
+      const lockPath = path.join(directory, 'backend.lock.json')
+      // A shape our sed extraction can't match (space after the colon) —
+      // e.g. a different JSON serializer/build, not a corrupt/empty file.
+      const foreignLock = '{"pid": 999999, "schemaVersion": 2, "note": "written by another build"}'
+
+      await writeFile(lockPath, foreignLock)
+
+      const fragment = extractLockCheckFragment(buildReservationCommand())
+      const script = `lock=${JSON.stringify(lockPath)}\n${fragment}\n`
+
+      await assert.rejects(
+        () => exec(script, { shell: '/bin/bash' }),
+        'the block must refuse to proceed (nonzero exit), not silently reap the foreign lock and spawn on top of it'
+      )
+
+      const survivingLock = await readFile(lockPath, 'utf8')
+
+      assert.equal(survivingLock, foreignLock, 'a lockfile the script cannot parse must be left completely untouched')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+)
+
+test.skipIf(process.platform === 'win32')(
+  'reservation script reaps a lockfile it CAN parse once that pid is confirmed dead',
+  async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-lockfile-skew-'))
+
+    try {
+      const lockPath = path.join(directory, 'backend.lock.json')
+      // A pid essentially guaranteed not to be alive.
+      const staleLock = '{"pid":999999999,"schemaVersion":2}'
+
+      await writeFile(lockPath, staleLock)
+
+      const fragment = extractLockCheckFragment(buildReservationCommand())
+      const script = `lock=${JSON.stringify(lockPath)}\n${fragment}\n`
+
+      await exec(script, { shell: '/bin/bash' })
+
+      await assert.rejects(() => readFile(lockPath, 'utf8'), 'a genuinely stale (parseable, dead-pid) lock must still be reaped')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+)
+
+test.skipIf(process.platform === 'win32')(
+  'reservation script reports EXISTING and leaves the lockfile alone when the owning pid is alive',
+  async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-lockfile-skew-'))
+
+    try {
+      const lockPath = path.join(directory, 'backend.lock.json')
+      // The current shell's own pid is guaranteed alive for the duration of
+      // this `sh -c` invocation.
+      const liveLock = '{"pid":$$,"schemaVersion":2}'
+
+      const fragment = extractLockCheckFragment(buildReservationCommand())
+      // $$ must expand inside the script (the real owning process's pid is
+      // never known ahead of time either), so the lock is written at runtime
+      // rather than via writeFile with a literal pid.
+      const script = `lock=${JSON.stringify(lockPath)}\nprintf '%s' ${JSON.stringify(liveLock)} > "$lock"\n${fragment}\n`
+
+      const { stdout } = await exec(script, { shell: '/bin/bash' })
+
+      assert.equal(stdout, 'EXISTING')
+
+      const survivingLock = await readFile(lockPath, 'utf8')
+
+      assert.match(survivingLock, /"pid":\d+/, 'the live-owner lock must survive untouched')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+)
 
 test.skipIf(process.platform === 'win32')('detached backend does not inherit the update mutex descriptor', async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-update-mutex-'))

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1093,7 +1093,16 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       `trap 'rm -rf "$reservation"' EXIT; ` +
       `if [ -f "$lock" ]; then ` +
       `existing_pid=$(sed -n 's/.*"pid":\\([0-9][0-9]*\\).*/\\1/p' "$lock" | head -n 1); ` +
-      `case "$existing_pid" in ''|*[!0-9]*) rm -f "$lock";; *) ` +
+      // #95532 fail-closed skew sentinel, mirrored here: a lock this sed
+      // can't extract a pid from is not proof of "no owner" — it can equally
+      // be a foreign/pretty-printed shape from a different (fork) build,
+      // exactly the state the TS-side readLockfile()/isLockfileSkew() check
+      // refuses to reap. Deleting it here on parse failure would close the
+      // TOCTOU window this reservation mutex exists to guard by murdering
+      // that build's live lockfile and spawning on top of it. Fail the
+      // reservation (exit 75, the same sentinel already used above for a
+      // reservation-mutex timeout) instead of guessing.
+      `case "$existing_pid" in ''|*[!0-9]*) exit 75;; *) ` +
       `if kill -0 "$existing_pid" 2>/dev/null; then ${tokenPath ? `rm -f ${tokenPath}; ` : ''}printf EXISTING; exit 0; fi; rm -f "$lock";; esac; fi; ` +
       `${markerClear}; marker_clear || exit 75; mkdir -p "$(dirname ${logPath})" && ` +
       `${detachedSpawn}; ` +


### PR DESCRIPTION
## What does this PR do?

Closes a gap in #95532's fail-closed lockfile-skew protection: the one lockfile consumer that check never reached.

### Background

#95532 taught `connect()`, `disconnect()`, and `cleanupStale()` in `remote-lifecycle.ts` to fail closed on a `backend.lock.json` that exists but doesn't match our exact schema — treating it as "skew" (most likely a different/modified desktop build sharing this remote) rather than "no owner", and refusing to reap or overwrite it. The commit message is explicit: *"reaping here is how live tunnels die."*

`buildSpawnCommand()`'s own reservation script never got the memo. It re-checks for an existing lock **inside its atomic mkdir-mutex** — this is what closes the TOCTOU gap between `connect()`'s earlier TS-side check and the actual remote spawn — but does its own crude parse:

```sh
existing_pid=$(sed -n 's/.*"pid":\([0-9][0-9]*\).*/\1/p' "$lock" | head -n 1)
case "$existing_pid" in
  ''|*[!0-9]*) rm -f "$lock";;   # <- any unparseable shape silently deleted
  *) if kill -0 "$existing_pid" ...; then ...; fi; rm -f "$lock";;
esac
```

Any lockfile that doesn't match our own compact-JSON shape exactly — a pretty-printed serializer (`"pid": 1234` with a space), a different key ordering, a genuinely foreign schema — makes `existing_pid` empty, and the reservation script unconditionally deletes it and spawns on top. That's precisely the destructive fail-open behavior #95532 eliminated everywhere else, left live in the one place designed to close the race it was for.

### Fix

Fail the reservation (`exit 75`, reusing the same sentinel already used a few lines earlier for a reservation-mutex timeout) instead of guessing on an unparseable lock.

### A pre-existing, unrelated bug I ran into while testing this

While writing a real-shell-execution regression test for this, I hit a separate, already-known bug: `reservation`/`lock`/`owner_file` are built via `shq(expandRemotePath(...))` — but `expandRemotePath()` already returns a shell **fragment** (`"$HOME"'/literal/path'`, meant to be spliced in raw so `$HOME` expands), and wrapping that fragment in `shq()` again turns the whole thing into an inert literal string containing literal `"`, `$`, quote characters. This makes the reservation `mkdir` loop spin for its full 30s timeout before failing. This is exactly what PR titles like #96061's "double shell-quoting via `shq(expandRemotePath(...))`" describe — it's already being fixed by one of the several PRs currently active on this same function, so I did not touch it here. My regression tests below avoid depending on that reservation/mkdir stage entirely (see the "Why the tests are structured this way" note in the diff) so they aren't blocked on it landing first.

## Changes Made

- `remote-lifecycle.ts` — one-line fix: `rm -f "$lock"` → `exit 75` in the unparseable-pid branch, with a comment explaining why (mirrors #95532's own reasoning).
- `remote-lifecycle.test.ts` — 3 new regression tests. They extract the exact `if [ -f "$lock" ]; then ...; fi;` block from a **real** `buildSpawnCommand()` return value (via bash's own parser — a shadowed `python3` shell function captures the already-unescaped argv rather than me hand-copying the `shq()`-escaped text, since a hand-copy would risk silently hiding the exact class of quoting bug this test exists to catch) and run it through a real shell against real lock files:
  1. Unparseable lock (pretty-printed `"pid": N`) → the block must exit nonzero and leave the lock file byte-for-byte untouched.
  2. Parseable lock with a confirmed-dead pid → still correctly reaped (this behavior is intentionally unchanged).
  3. Parseable lock with a confirmed-alive pid (the test's own `$$`) → prints `EXISTING`, lock untouched.

## How to Test

```bash
cd apps/desktop
npx vitest run electron/remote-lifecycle.test.ts -t "reservation script"
npx tsc -p tsconfig.electron.json --noEmit
```

## Checklist

- [x] Mutation-verified: stashed the `.ts` fix, confirmed regression test 1 fails with the exact pre-fix symptom (`AssertionError: Missing expected rejection` — the block resolves instead of rejecting, meaning it silently deleted the foreign lock); restored and confirmed all 3 pass.
- [x] Full `remote-lifecycle.test.ts` suite passes (91/92; the 1 remaining failure — `pidIsOurDashboard recognizes an installer wrapper...` — is a pre-existing flake unrelated to this change, confirmed by reproducing it identically on unmodified `main`).
- [x] `tsc -p tsconfig.electron.json --noEmit` passes with no errors.
- [x] Checked all 4 currently-open PRs touching `buildSpawnCommand` (#95998, #96061, #96084, #96103) for overlap with this exact branch — none touch `existing_pid` or this lock-check block.