### PR TITLE
feat(skills): add grimdall-guard skill

### DIFF
--- a/optional-skills/security/grimdall-guard/SKILL.md
+++ b/optional-skills/security/grimdall-guard/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: grimdall-guard
+description: Install and configure Grimdall policy checkpoint plugin.
+version: 1.0.0
+author: grimdalltech
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [security, policy, guardrails, checkpoint, egress, secrets]
+    category: security
+    related_skills: [security-guidance]
+---
+
+# Grimdall Guard
+
+Grimdall is a deterministic policy checkpoint that hooks the `pre_tool_call`
+lifecycle to block or log destructive shell commands, secret reads, and
+non-allowlisted egress before they execute. It ships as a standalone plugin
+(`github.com/grimdalltech/hermes-grimdall`); this skill walks through
+installing and configuring it.
+
+## When to Use
+
+- The operator wants destructive shell (`rm -rf` of absolute/home/glob paths,
+  `DROP TABLE`, fork bombs) blocked before execution.
+- The operator wants secret reads (`~/.ssh`, `~/.aws`, `.env`, `*.pem`)
+  blocked or logged.
+- The operator wants a network egress allowlist enforced on `curl`, `wget`,
+  `ssh`, `scp`, `git`, and the `web_extract` / `web_search` tools.
+- The operator wants a signed audit receipt for every policy hit.
+
+## Prerequisites
+
+- The plugin is installed either as a pip package (`hermes-grimdall`) or as a
+  drop-in directory under `~/.hermes/plugins/grimdall/`.
+- The plugin is enabled (`hermes plugins enable grimdall`).
+- For enforce-mode enforcement, the operator has configured the egress
+  allowlist, since an empty allowlist blocks all non-local network egress.
+
+## How to Run
+
+1. Install the plugin (pip entry point or directory).
+2. Enable it: `hermes plugins enable grimdall`.
+3. Choose a mode in `~/.hermes/config.yaml`.
+4. Restart the Hermes session so the hook loads.
+
+## Quick Reference
+
+| Setting (`plugins.entries.grimdall.settings`) | Purpose | Default |
+|---|---|---|
+| `mode` | `shadow` (log + pass through) or `enforce` (block) | `shadow` |
+| `egress_allowlist` | Hosts (and subdomains) allowed to receive egress | `[]` (loopback always allowed) |
+| `signing_key` | Path to the Ed25519 signing key | auto-generated |
+| `receipt_log` | JSONL path for signed receipts | `~/.hermes/grimdall/receipts.jsonl` |
+
+Environment overrides (testing): `GRIMDALL_MODE`, `GRIMDALL_ALLOWLIST` (CSV),
+`GRIMDALL_SIGNING_KEY`, `GRIMDALL_RECEIPT_LOG`.
+
+## Procedure
+
+### 1. Install
+
+```bash
+pip install hermes-grimdall
+hermes plugins enable grimdall
+```
+
+Or, directory install:
+
+```bash
+mkdir -p ~/.hermes/plugins/grimdall
+cp -r plugin.yaml hermes_grimdall ~/.hermes/plugins/grimdall/
+```
+
+### 2. Configure mode
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  entries:
+    grimdall:
+      settings:
+        mode: shadow          # or enforce
+        egress_allowlist:
+          - github.com
+          - pypi.org
+```
+
+Start with `shadow` to observe what would be blocked before switching to
+`enforce`.
+
+### 3. Verify enforcement
+
+Run `hermes plugins show grimdall` to confirm the `pre_tool_call` hook is
+registered, then review `receipts.jsonl` for signed hit records.
+
+## Pitfalls
+
+- **Heuristic, not a boundary.** Grimdall scans command strings; it is not an
+  OS sandbox. A determined model can evade string matching. Pair it with a
+  terminal backend or whole-process sandbox for a real boundary.
+- **`enforce` blocks before the approval gate.** Grimdall's block fires at the
+  `pre_tool_call` hook regardless of `--yolo` / `approvals.mode: off`.
+- **Empty allowlist blocks all egress.** In `enforce` mode, an empty
+  `egress_allowlist` denies every external host; configure it before enabling
+  enforce, or tooling that needs the network will fail.
+- **Shadow mode passes through.** Receipts are logged but nothing is stopped;
+  do not read "logged" as "blocked".
+
+## Verification
+
+- `hermes plugins list` shows `grimdall` with `pre_tool_call` hook.
+- A destructive command in `enforce` mode returns a `grimdall-receipt` block
+  message instead of executing.
+- `~/.hermes/grimdall/receipts.jsonl` contains one signed JSON record per hit
+  with a non-empty `sig` field.

--- a/optional-skills/security/grimdall-guard/SKILL.md
+++ b/optional-skills/security/grimdall-guard/SKILL.md
@@ -2,14 +2,13 @@
 name: grimdall-guard
 description: Install and configure Grimdall policy checkpoint plugin.
 version: 1.0.0
-author: grimdalltech
+author: Aniket (@grimdalltech, Grimdall Tech)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [security, policy, guardrails, checkpoint, egress, secrets]
     category: security
-    related_skills: [security-guidance]
 ---
 
 # Grimdall Guard

--- a/tests/skills/test_grimdall_guard_skill.py
+++ b/tests/skills/test_grimdall_guard_skill.py
@@ -1,0 +1,54 @@
+"""Discoverability contract for the optional grimdall-guard security skill.
+
+The plugin's enforcement behavior is tested in its own repo
+(github.com/grimdalltech/hermes-grimdall). This in-tree test guards only the
+skill's discoverability contract — frontmatter parses, the description stays
+within the authoring limit, the skill is classified under ``security``, and the
+CLI command / config path the skill documents are actually present — so the
+skill remains loadable without duplicating the plugin's behavioral tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.skill_utils import parse_frontmatter
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "security" / "grimdall-guard"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    parsed, _ = parse_frontmatter(skill_text)
+    return parsed
+
+
+def test_frontmatter_parses_and_names_the_skill(frontmatter: dict) -> None:
+    assert frontmatter.get("name") == "grimdall-guard"
+
+
+def test_description_is_within_authoring_limit(frontmatter: dict) -> None:
+    description = frontmatter.get("description")
+    assert isinstance(description, str) and description.strip()
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_skill_loads_under_security_category(frontmatter: dict) -> None:
+    assert frontmatter["metadata"]["hermes"]["category"] == "security"
+
+
+def test_enable_command_is_documented(skill_text: str) -> None:
+    assert "hermes plugins enable" in skill_text
+
+
+def test_config_path_is_documented(skill_text: str) -> None:
+    assert "plugins.entries.grimdall.settings" in skill_text


### PR DESCRIPTION
## What & Why

Adds `optional-skills/security/grimdall-guard/SKILL.md` — a security skill that
documents the standalone [Grimdall](https://github.com/grimdalltech/grimdall-os)
policy-checkpoint plugin and its Hermes distribution
([hermes-grimdall](https://github.com/grimdalltech/hermes-grimdall)).

Grimdall is an MIT-licensed deterministic policy checkpoint that hooks
`pre_tool_call` to block or log destructive shell, secret reads, and
non-allowlisted egress, with signed Ed25519 receipts. It ships as a standalone
plugin repo (per the third-party-plugin policy); this skill is the in-tree
discovery surface that tells Hermes how to install, enable, and configure it.

## How to test

1. Install the standalone plugin: `pip install hermes-grimdall`.
2. Enable it: `hermes plugins enable grimdall`.
3. Confirm the skill is discoverable under the security category
   (`optional-skills/security/grimdall-guard/`).

The plugin's own behavior is covered by its test suite (`pytest` in
https://github.com/grimdalltech/hermes-grimdall) — enforce mode blocks
destructive shell / secret reads / non-allowlisted egress even under
`--yolo`, and shadow mode logs signed receipts and passes through.

## Platforms tested

- [ ] Linux (not run)
- [ ] macOS (not run)
- [x] Windows — frontmatter validated against the existing optional-skills
  security schema and authoring standards (description <=60 chars, human
  author, modern section order)

## Notes

- One file, zero core changes.
- Standalone plugin repo: https://github.com/grimdalltech/hermes-grimdall
