### PR TITLE
fix(config): fail-closed write guard — refuse unparseable/non-mapping config.yaml instead of wiping it (salvage #71385)

### DIFF
--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -52,8 +52,9 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
         )
 
     # set_config_value is the canonical managed-scope/write-safety chokepoint.
-    # It reports managed policy through stderr + SystemExit, so capture that for
-    # slash-command output instead of terminating the interactive worker.
+    # It reports managed policy through stderr + SystemExit, and the fail-closed
+    # write guard raises RuntimeError on an unparseable config.yaml; capture both
+    # for slash-command output instead of terminating the interactive worker.
     from hermes_cli.config import set_config_value
 
     output = StringIO()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3408,14 +3408,33 @@ def read_raw_config_readonly() -> Dict[str, Any]:
         return cached_copy
 
 
-def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
-    """Refuse to replace an existing config.yaml that cannot be read."""
+def require_readable_config_before_write(
+    config_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Refuse to replace an existing config.yaml that cannot be read or parsed.
+
+    Guards two collapse-to-empty failure modes that would otherwise let a
+    read-then-write caller silently wipe user overrides:
+
+    1. **Unreadable** (permissions / broken mount) - byte open fails.
+    2. **Unparseable or non-mapping** - YAML load raises, or the root is a
+       list/scalar. ``read_user_config_raw()`` / bare ``except`` loaders treat
+       both as ``{}``, so a subsequent write would replace the recoverable
+       file with only the caller's partial dict.
+
+    Returns the loaded mapping (or ``{}`` for a missing / empty / null
+    document) so mutation callers can skip a second parse. A valid empty
+    mapping (``{}``) is allowed through so first-time installs and
+    intentional empty configs still work. On parse failure this also
+    snapshots a ``.corrupt.*.bak`` via :func:`_warn_config_parse_failure`
+    before raising.
+    """
     if config_path is None:
         config_path = get_config_path()
     try:
         config_path.stat()
     except FileNotFoundError:
-        return
+        return {}
     except OSError as exc:
         raise RuntimeError(
             f"Refusing to overwrite {config_path}: existing config.yaml cannot be accessed "
@@ -3431,6 +3450,47 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
             f"({exc}). Fix the file permissions or move it aside first."
         ) from exc
 
+    return _load_user_config_for_mutation(config_path)
+
+
+def _load_user_config_for_mutation(config_path: Path) -> Dict[str, Any]:
+    """Load raw user config for a fail-closed mutation path.
+
+    Fail closed on parse / non-mapping (no bare-except to ``{}`` collapse).
+    Used by :func:`require_readable_config_before_write` and any caller that
+    must re-validate after other work. Distinct from
+    :func:`read_user_config_raw`, which collapses non-dict roots to ``{}``.
+    """
+    if not config_path.exists():
+        return {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            loaded = fast_safe_load(f)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: existing config.yaml cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    except Exception as exc:
+        _warn_config_parse_failure(config_path, exc, fallback="refuse-write")
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: existing config.yaml is not valid YAML "
+            f"({exc}). Fix the file or restore from a .corrupt.*.bak backup first."
+        ) from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        exc = TypeError(
+            f"top-level YAML must be a mapping, got {type(loaded).__name__}"
+        )
+        _warn_config_parse_failure(config_path, exc, fallback="refuse-write")
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: top-level YAML must be a mapping, "
+            f"got {type(loaded).__name__}. Fix the file or restore from a "
+            f".corrupt.*.bak backup first."
+        ) from exc
+    return loaded
+
 
 def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     """Fail-closed atomic write for ``config.yaml``.
@@ -3440,12 +3500,13 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     :func:`require_readable_config_before_write` first, so a full-file
     replacement can never silently clobber an existing ``config.yaml`` that
     degraded to an empty dict on read (permission error, broken mount,
-    transient I/O). New-file creation still works when the path is absent.
+    transient I/O, unparseable YAML, or a non-mapping root). New-file
+    creation still works when the path is absent.
 
-    Root cause this guards: ``read_raw_config()`` returns ``{}`` for BOTH an
-    absent file and an unreadable-but-present file. Callers that read then
-    overwrite can't tell the two apart, so an unreadable config would be
-    replaced with only defaults or the single edited section. Routing every
+    Root cause this guards: ``read_user_config_raw()`` returns ``{}`` for an
+    absent file / unreadable path edge cases and collapses non-dict roots.
+    Callers that read then overwrite can't tell these apart, so a broken
+    config would be replaced with only defaults or the single edited section. Routing every
     write through this helper enforces the invariant in one place rather than
     relying on each of ~15 independent write sites to remember the guard.
 
@@ -5528,21 +5589,9 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
     config_path = get_config_path()
-    require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception as exc:
-            print(
-                f"✗ Cannot parse {config_path}: {exc}\n"
-                f"  The file contains a YAML syntax error. Fix the error\n"
-                f"  in your config file first, then retry.\n"
-                f"  (hermes config edit will open it in your editor.)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    # Fail-closed parse via require_readable (unparseable / non-mapping
+    # refuse-write); returns the mapping so we do not re-parse / collapse.
+    user_config = require_readable_config_before_write(config_path)
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -5786,21 +5835,9 @@ def unset_config_value(key: str):
         return
 
     config_path = get_config_path()
-    require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception as exc:
-            print(
-                f"✗ Cannot parse {config_path}: {exc}\n"
-                f"  The file contains a YAML syntax error. Fix the error\n"
-                f"  in your config file first, then retry.\n"
-                f"  (hermes config edit will open it in your editor.)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    # Fail-closed parse via require_readable (unparseable / non-mapping
+    # refuse-write); returns the mapping so we do not re-parse / collapse.
+    user_config = require_readable_config_before_write(config_path)
 
     removed = _unset_nested(user_config, key)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -141,6 +141,12 @@ def _warn_config_parse_failure(
             f"Keeping the previously loaded config for this process — "
             f"edits to config.yaml are being IGNORED until the YAML is fixed."
         )
+    elif fallback == "refuse-write":
+        msg = (
+            f"Failed to parse {config_path}: {exc}. "
+            f"REFUSING to write config.yaml so the existing file is preserved. "
+            f"Fix the YAML (hermes config edit) and retry."
+        )
     else:
         msg = (
             f"Failed to parse {config_path}: {exc}. "
@@ -5897,7 +5903,13 @@ def config_command(args):
             print("  --force: skip the unknown-key notice for unrecognized keys,")
             print("           and allow a scalar to replace a whole mapping section")
             sys.exit(1)
-        set_config_value(key, value, force=force)
+        try:
+            set_config_value(key, value, force=force)
+        except RuntimeError as exc:
+            # Fail-closed write guard (unparseable / non-mapping / unreadable
+            # config.yaml). Surface a clean CLI error instead of a traceback.
+            print(f"✗ {exc}", file=sys.stderr)
+            sys.exit(1)
 
     elif subcmd == "unset":
         key = getattr(args, 'key', None)
@@ -5909,7 +5921,12 @@ def config_command(args):
             print("  hermes config unset terminal.backend")
             print("  hermes config unset OPENROUTER_API_KEY")
             sys.exit(1)
-        unset_config_value(key)
+        try:
+            unset_config_value(key)
+        except RuntimeError as exc:
+            # Same fail-closed guard surface as `config set` above.
+            print(f"✗ {exc}", file=sys.stderr)
+            sys.exit(1)
     
     elif subcmd == "path":
         print(get_config_path())

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -72,6 +72,15 @@ def _capture_output(fn: Callable[[], object]) -> str:
                 code = 1
             else:
                 code = int(exc.code or 0)
+        except ConsoleCommandError:
+            raise
+        except RuntimeError as exc:
+            # Fail-closed config write guards raise RuntimeError (e.g.
+            # require_readable_config_before_write refusing an unparseable
+            # config.yaml). Convert to a console error instead of letting it
+            # escape execute() and kill the REPL / websocket session.
+            message = str(exc)
+            code = 1
     text = stdout.getvalue() + stderr.getvalue()
     if code:
         raise ConsoleCommandError(message.strip() or text.strip() or f"Command exited with status {code}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5892,7 +5892,16 @@ def cmd_config(args):
     """Configuration management."""
     from hermes_cli.config import config_command
 
-    config_command(args)
+    try:
+        config_command(args)
+    except RuntimeError as exc:
+        # Safety net for the fail-closed config write guard (unparseable /
+        # non-mapping / unreadable config.yaml raises RuntimeError from
+        # require_readable_config_before_write). set/unset already surface
+        # this per-branch; this covers migrate and future write subcommands
+        # so no path ends in a raw traceback.
+        print(f"✗ {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def cmd_skin(args):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -26,6 +26,7 @@ from hermes_cli.config import (
     save_env_value_secure,
     sanitize_env_file,
     set_config_value,
+    unset_config_value,
     write_platform_config_field,
     _sanitize_env_lines,
 )
@@ -245,6 +246,106 @@ class TestSaveAndLoadRoundtrip:
 
 
 
+
+
+    def test_config_set_refuses_to_overwrite_unparseable_existing_config(self, tmp_path):
+        """Unparseable YAML must not be replaced with a single-key document.
+
+        Regression for the set/unset wipe class: a bare except around YAML
+        load used to treat parse failure as {}, then atomic-write only the
+        new key — destroying every prior override with no .corrupt backup.
+        """
+        config_path = tmp_path / "config.yaml"
+        original = (
+            "model:\n"
+            "  default: claude-opus\n"
+            "  provider: anthropic\n"
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      enabled: true\n"
+            "broken: [unterminated\n"
+        )
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                set_config_value("model.default", "gpt-4o")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "parse-failure path should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_unset_refuses_to_overwrite_unparseable_existing_config(self, tmp_path):
+        """Unset must refuse the same way — env-sync paths used to write {}."""
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  default: keep-me\nbroken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+        (tmp_path / ".env").write_text("TERMINAL_TIMEOUT=30\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                unset_config_value("terminal.timeout")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert (tmp_path / ".env").read_text(encoding="utf-8") == "TERMINAL_TIMEOUT=30\n"
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "unset parse-failure path should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_set_refuses_non_mapping_root(self, tmp_path):
+        """A list/scalar root parses without raising but would still wipe."""
+        config_path = tmp_path / "config.yaml"
+        original = "- just\n- a\n- list\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="must be a mapping"):
+                set_config_value("model.default", "gpt-4o")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "non-mapping root should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_unset_refuses_non_mapping_root(self, tmp_path):
+        """Unset shares the same non-mapping refuse path as set."""
+        config_path = tmp_path / "config.yaml"
+        original = "- just\n- a\n- list\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="must be a mapping"):
+                unset_config_value("model.default")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
+    def test_config_set_allows_valid_empty_mapping(self, tmp_path):
+        """A genuine empty {} config must still be writable (not a false refuse)."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            set_config_value("model.default", "gpt-4o")
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved == {"model": {"default": "gpt-4o"}}
+
+    def test_atomic_config_write_refuses_unparseable_existing_config(self, tmp_path):
+        """Shared chokepoint must refuse unparseable YAML, not only unreadable."""
+        from hermes_cli.config import atomic_config_write
+
+        config_path = tmp_path / "config.yaml"
+        original = "broken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="not valid YAML"):
+            atomic_config_write(config_path, {"model": {"provider": "openai"}})
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
 
 class TestSaveEnvValueSecure:
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1691,3 +1691,50 @@ def test_default_config_has_no_duplicate_top_level_keys():
             if "model" in keys and "kanban" in keys:  # the DEFAULT_CONFIG literal
                 dupes = {k for k in keys if keys.count(k) > 1}
                 assert not dupes, f"duplicate DEFAULT_CONFIG keys: {sorted(dupes)}"
+
+
+class TestConfigCommandFailClosedSurface:
+    """`hermes config set/unset` must exit cleanly (no traceback) when the
+    fail-closed write guard refuses an unparseable config.yaml."""
+
+    def _args(self, **kw):
+        import argparse
+
+        ns = argparse.Namespace()
+        for k, v in kw.items():
+            setattr(ns, k, v)
+        return ns
+
+    def test_config_command_set_exits_cleanly_on_broken_yaml(self, tmp_path, capsys):
+        from hermes_cli.config import config_command
+
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  default: keep\nbroken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(SystemExit) as excinfo:
+                config_command(
+                    self._args(config_command="set", key="model.default",
+                               value="gpt-4o", force=False)
+                )
+
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "not valid YAML" in err
+        assert config_path.read_text(encoding="utf-8") == original
+
+    def test_config_command_unset_exits_cleanly_on_broken_yaml(self, tmp_path, capsys):
+        from hermes_cli.config import config_command
+
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  default: keep\nbroken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(SystemExit) as excinfo:
+                config_command(self._args(config_command="unset", key="model.default"))
+
+        assert excinfo.value.code == 1
+        assert "not valid YAML" in capsys.readouterr().err
+        assert config_path.read_text(encoding="utf-8") == original

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -586,3 +586,22 @@ def test_console_checkpoints_prune_succeeds_without_a_tty(
     assert "Aborted." not in result.output
     assert len(prune_calls) == 1
     assert prune_calls[0]["orphan_allowlist"] is None
+
+
+def test_config_set_on_unparseable_yaml_reports_error_not_crash(tmp_path, monkeypatch):
+    """The fail-closed config write guard raises RuntimeError; the console must
+    surface it as a command error, not let it escape execute() and kill the
+    REPL / dashboard websocket session (regression for PR #71385 follow-up)."""
+    config_path = tmp_path / "config.yaml"
+    original = "model:\n  default: keep\nbroken: [unterminated\n"
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = HermesConsoleEngine().execute(
+        "config set model.default gpt-4o", confirmed=True
+    )
+
+    assert result.status == "error"
+    assert "not valid YAML" in (result.output or "") or "Failed to parse" in (result.output or "")
+    # The broken-but-recoverable file must survive untouched.
+    assert config_path.read_text(encoding="utf-8") == original

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -749,28 +749,30 @@ class TestMalformedYAMLConfigPreservation:
         (home / "config.yaml").write_text(self.BROKEN_CONFIG)
 
     def test_set_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
-        """set_config_value must exit with error, not overwrite the broken config."""
+        """set_config_value must raise, not overwrite the broken config."""
         self._write_broken_config(_isolated_hermes_home)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(RuntimeError, match="not valid YAML"):
             set_config_value("agent.max_turns", "50")
 
         captured = capsys.readouterr()
-        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        combined = captured.out + captured.err
+        assert "Failed to parse" in combined or "not valid YAML" in combined
         # Original config must remain intact
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG, f"Config was overwritten:\n{raw}"
 
     def test_unset_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
-        """unset_config_value must exit with error, not overwrite the broken config."""
+        """unset_config_value must raise, not overwrite the broken config."""
         from hermes_cli.config import unset_config_value
 
         self._write_broken_config(_isolated_hermes_home)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(RuntimeError, match="not valid YAML"):
             unset_config_value("model")
 
         captured = capsys.readouterr()
-        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        combined = captured.out + captured.err
+        assert "Failed to parse" in combined or "not valid YAML" in combined
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG


### PR DESCRIPTION
## Summary

Config-write paths now fail closed on an unparseable or non-mapping `config.yaml` — the shared write guard parses the file before any full-document rewrite, refuses with a `.corrupt.*.bak` snapshot instead of collapsing to `{}`, and every user-facing surface (CLI, `hermes console`, dashboard console) reports the refusal cleanly.

Salvage of #71385 by @fangliquanflq (cherry-picked onto current main with authorship preserved) plus one follow-up commit fixing the error-surface regressions found in review.

## What was still broken on main

Main already refuses unparseable YAML in `config set`/`unset` (df09a90cd6), but verified live:
- a **non-mapping root** (`[]` / list / scalar) still silently wiped the file (`[]` → single-key doc) or crashed (`AttributeError` on a list root)
- `save_config()` and the other guard callers (auth provider writers, tui-gateway `_save_cfg`, xai retirement) silently rewrote a corrupt-but-recoverable config with defaults
- no `.corrupt.*.bak` was snapshotted on any write path

## Changes

**Contributor commits (@fangliquanflq, authorship preserved):**
- `hermes_cli/config.py`: `require_readable_config_before_write` now parses with `fast_safe_load`, refuses unparseable / non-mapping roots (RuntimeError + corrupt backup via `_warn_config_parse_failure(fallback="refuse-write")`), and returns the loaded mapping; `set_config_value` / `unset_config_value` consume the returned mapping (no bare-except collapse, no double parse)
- regression tests for set/unset/atomic refuse paths, non-mapping roots, valid empty `{}`, corrupt-backup assertions

**Follow-up commit (ours):**
- `config_command` set/unset + `cmd_config` safety net: catch the guard's RuntimeError → clean `✗ ...` + exit 1 (previously the new raise surfaced as a raw traceback on the primary `hermes config set/unset` path; the `cmd_config` net also covers `config migrate`)
- `console_engine._capture_output`: convert an escaping RuntimeError into `ConsoleCommandError` (previously the new raise **crashed the `hermes console` REPL**; `except ConsoleCommandError: raise` first, since it subclasses RuntimeError)
- `_warn_config_parse_failure`: dedicated `refuse-write` wording branch — the old fallthrough claimed "falling back to default config … every override IGNORED" even though the write was refused and the file preserved
- stale comment fix in `approval_mode.py`; regression tests for the console path and both `config_command` paths

Silent scope widening (intended): all pre-existing guard callers — `save_config`, auth provider writers, `xai_retirement`, `utils.atomic_roundtrip_yaml_save` → tui-gateway `_save_cfg` — now also refuse corrupt YAML instead of rewriting it.

## Validation

| Check | Result |
|---|---|
| Targeted suites (test_config, test_set_config_value, test_console_engine, test_approvals_command) | 211 passed |
| Full `tests/hermes_cli/` vs origin/main baseline | 0 new failures (68 identical pre-existing env failures on both) |
| E2E (real imports, temp HERMES_HOME): refuse+preserve+backup for set/unset/atomic/roundtrip paths, `.env` untouched on unset env-sync, `{}` still writable, fresh-file creation, healthy-config sibling preservation | 9/9 |
| Live CLI: `hermes config set` on broken YAML | clean `✗` + exit 1, no traceback |
| Live console engine: `config set` on broken YAML | `status=error`, REPL survives |
| Mutation check (prod reverted, new tests kept) | all 3 new follow-up tests fail → restored pass |
| ruff on touched files | clean |

## Credit

Original fix and tests by @fangliquanflq in #71385 — commits cherry-picked with authorship preserved. Closes #71385.

Related: #65975 (save_config/auth side — covered transitively by the widened guard here), #29897, #14276 (older takes on the same class). Out-of-scope sibling noted for follow-up: `profiles.py` meta.yaml has the same collapse-to-`{}` write pattern.
