### PR TITLE
fix(desktop): recover cloud auth through portal

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -146,6 +146,51 @@ describe('BootFailureOverlay', () => {
     }
   })
 
+  it('recovers a cloud connection through the portal cascade instead of native OAuth', async () => {
+    const gatewayUrl = 'https://agent-1.agents.nousresearch.com'
+    const logout = vi.fn().mockResolvedValue({ ok: true, connected: false })
+    const nativeLogin = vi.fn().mockResolvedValue({ ok: true, connected: false })
+    const cloudStatus = vi.fn().mockResolvedValue({ portalBaseUrl: 'https://portal.nousresearch.com', signedIn: false })
+
+    const cloudLogin = vi.fn().mockResolvedValue({
+      ok: true,
+      portalBaseUrl: 'https://portal.nousresearch.com',
+      signedIn: true
+    })
+
+    const cloudAgentSignIn = vi.fn().mockResolvedValue({ baseUrl: gatewayUrl, connected: false })
+
+    const restore = stubDesktop(
+      {
+        ...remoteToken,
+        mode: 'cloud',
+        remoteAuthMode: 'oauth',
+        remoteOauthConnected: false,
+        remoteTokenSet: false,
+        remoteUrl: gatewayUrl
+      },
+      {
+        cloud: { status: cloudStatus, login: cloudLogin, agentSignIn: cloudAgentSignIn },
+        oauthLoginConnectionConfig: nativeLogin,
+        oauthLogoutConnectionConfig: logout,
+        probeConnectionConfig: vi.fn().mockResolvedValue({ providers: [{ id: 'nous', type: 'oauth' }] })
+      }
+    )
+
+    try {
+      render(<BootFailureOverlay />)
+      fireEvent.click(await screen.findByRole('button', { name: /sign in/i }))
+
+      await waitFor(() => expect(cloudAgentSignIn).toHaveBeenCalledWith(gatewayUrl))
+      expect(logout).toHaveBeenCalledWith(gatewayUrl)
+      expect(cloudStatus).toHaveBeenCalledTimes(1)
+      expect(cloudLogin).toHaveBeenCalledTimes(1)
+      expect(nativeLogin).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
   it('shows the Nous Cloud down recovery when the backend flags isCloudBackendDown', async () => {
     const restore = stubDesktop(remoteToken)
     $desktopBoot.set({

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -163,10 +163,10 @@ export function BootFailureOverlay() {
     setBusy(null)
   }
 
-  // Clear this gateway's stale auth first, then open its login window
-  // (username/password form or OAuth redirect — the desktop drives both). On a
-  // successful sign-in the cookie is re-established; reload so boot mints a fresh
-  // ticket against a live session without disturbing other saved gateways.
+  // Clear this gateway's stale auth first, then re-establish it through the
+  // connection's owning login flow. Hermes Cloud must reuse its portal session
+  // and per-agent cascade; generic remote gateways use native/embedded OAuth.
+  // Reload after success so boot mints a fresh ticket against the new session.
   const signInRemote = async () => {
     if (!remoteReauth) {
       return
@@ -175,10 +175,39 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
-      const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
+      const desktop = window.hermesDesktop
+
+      await desktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
+
+      let result: { connected?: boolean } | undefined
+
+      if (connectionConfig?.mode === 'cloud' && desktop?.cloud) {
+        const status = await desktop.cloud.status()
+
+        if (!status.signedIn) {
+          const login = await desktop.cloud.login()
+
+          if (!login.signedIn) {
+            notify({
+              kind: 'warning',
+              title: t.boot.failure.signInIncompleteTitle,
+              message: t.boot.failure.signInIncompleteMessage
+            })
+
+            return
+          }
+        }
+
+        result = await desktop.cloud.agentSignIn(remoteReauth.url)
+      } else {
+        result = await desktop?.oauthLoginConnectionConfig(remoteReauth.url)
+      }
 
       if (result?.connected) {
+        if (connectionConfig?.mode === 'cloud') {
+          await desktop?.resetBootstrap().catch(() => undefined)
+        }
+
         notify({ kind: 'success', title: t.boot.failure.signedInTitle, message: t.boot.failure.signedInMessage })
         window.location.reload()
 


### PR DESCRIPTION
## What does this PR do?

Cloud connections that reached the boot-failure reauthentication overlay were sent through the generic remote OAuth flow. That opens a localhost callback even though Nous Cloud already has a portal-owned sign-in cascade for reconnecting an agent.

This change routes `mode: cloud` recovery through the existing portal status, portal login, and per-agent sign-in APIs. Generic remote connections keep their existing OAuth path. A successful Cloud sign-in also resets the boot latch before reloading.

Overlap checked: #95677 improves visibility when generic OAuth falls back, #72128 changes generic remote recovery behavior, and #95716 addresses the reauthentication overlay latch. None route Cloud-mode recovery through the portal cascade.

## Related Issue

No public issue. Support-derived Desktop authentication recovery defect.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route Cloud-mode boot recovery through `desktop.cloud.status()`, `desktop.cloud.login()`, and `desktop.cloud.agentSignIn()`.
- Preserve the generic OAuth recovery path for ordinary remote connections.
- Add a component regression proving Cloud recovery does not invoke native OAuth.

## How to Test

1. Run `vitest run --project ui src/components/boot-failure-overlay.test.tsx` from `apps/desktop`.
2. Run `npm run typecheck` from `apps/desktop`.
3. Configure a Cloud connection that requires reauthentication, open the recovery overlay, and confirm Sign in uses the portal flow before retrying boot.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused UI regression: 7 tests passed. Desktop typecheck, ESLint, Prettier, and `git diff --check` also pass.
