### PR TITLE
fix(desktop): roll back incomplete macOS rebuilds

### DIFF
--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -41,6 +41,12 @@
  * resolve rather than throw — worst case electron-builder hits the original
  * ENOENT, which is no worse than not having this hook at all.
  *
+ * On Windows and macOS, a complete previous package is first renamed to
+ * `<appOutDir>.bak`.  The updater can then restore it if the new package is
+ * incomplete or the build fails; Linux keeps the original clean rebuild
+ * behavior because its packaged relaunch target is not the unpacked build
+ * directory.
+ *
  * 2. Re-stages node-pty's native files for the ACTUAL target platform/arch
  *    of this pack. `npm run build` already staged node-pty once for the
  *    host machine (see scripts/stage-native-deps.mjs), which is correct for
@@ -57,7 +63,7 @@
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
  *   - arch:                 Arch enum (0=ia32, 1=x64, 2=armv7l, 3=arm64, 4=universal)
  */
-import { existsSync, rmSync, renameSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, renameSync } from 'node:fs'
 import path from 'node:path'
 import { Arch } from 'electron-builder'
 import { stageNodePty, stageGetWindows } from './stage-native-deps.mjs'
@@ -77,22 +83,29 @@ export function cleanStaleAppOutDir(appOutDir) {
 }
 
 /**
- * Windows rollback material (#69179): before wiping the previous unpacked
+ * Packaged rollback material (#69179): before wiping the previous unpacked
  * tree, preserve it as `<appOutDir>.bak` — but ONLY when it holds the product
- * exe (i.e. it is a previously-working build, not the corrupted partial state
- * cleanStaleAppOutDir exists to remove). If the fresh pack then produces a
- * Hermes.exe that Windows can't load (truncated PE from a corrupt cached
- * Electron zip, wrong arch), the updater's integrity gate in
- * `hermes desktop --build-only` (hermes_cli/main.py
- * `_ensure_desktop_exe_launchable`) restores this .bak instead of leaving the
- * user with "This app can't run on your computer".
+ * executable (i.e. it is a previously-working build, not the corrupted partial
+ * state cleanStaleAppOutDir exists to remove). If the fresh pack then produces
+ * an incomplete bundle, the platform-specific updater integrity gate restores
+ * this .bak instead of leaving the user with a broken application (Python's
+ * `_ensure_desktop_exe_launchable` on Windows; the POSIX bundle finalizer on
+ * macOS).
  *
  * Returns true when the tree was preserved (appOutDir no longer exists), false
  * when there was nothing worth preserving (caller falls through to the wipe).
  * A rename failure (AV holding a handle) also returns false — the wipe is the
  * safe fallback and matches pre-#69179 behavior exactly.
  */
-export function preserveRollbackBackup(appOutDir, productExeName = 'Hermes.exe') {
+export function macRollbackOutputDir(appOutDir) {
+  return path.join(path.dirname(appOutDir), '.hermes-update-backup', path.basename(appOutDir))
+}
+
+export function preserveRollbackBackup(
+  appOutDir,
+  productExeName = 'Hermes.exe',
+  backupDir = `${appOutDir}.bak`
+) {
   if (!appOutDir || typeof appOutDir !== 'string' || !existsSync(appOutDir)) {
     return false
   }
@@ -100,10 +113,22 @@ export function preserveRollbackBackup(appOutDir, productExeName = 'Hermes.exe')
     // Partial/corrupt tree (interrupted prior pack) — not rollback material.
     return false
   }
-  const backupDir = `${appOutDir}.bak`
+  const staleBackupDir = `${backupDir}.stale`
   try {
-    rmSync(backupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-    renameSync(appOutDir, backupDir)
+    mkdirSync(path.dirname(backupDir), { recursive: true })
+    rmSync(staleBackupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    if (existsSync(backupDir)) {
+      renameSync(backupDir, staleBackupDir)
+    }
+    try {
+      renameSync(appOutDir, backupDir)
+    } catch (error) {
+      if (existsSync(staleBackupDir) && !existsSync(backupDir)) {
+        renameSync(staleBackupDir, backupDir)
+      }
+      throw error
+    }
+    rmSync(staleBackupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
     return true
   } catch {
     return false
@@ -114,13 +139,23 @@ export default async function beforePack(context) {
   const appOutDir = context && context.appOutDir
   const platformName = context && context.electronPlatformName
   try {
-    // Windows: keep the previous working build as rollback material for the
-    // post-build integrity gate (#69179) instead of destroying it. Falls
-    // through to the plain wipe when the old tree is partial/corrupt or the
-    // rename fails.
-    const productExe = `${(context && context.packager?.appInfo?.productFilename) || 'Hermes'}.exe`
-    if (platformName === 'win32' && preserveRollbackBackup(appOutDir, productExe)) {
-      console.log(`[before-pack] preserved previous unpacked dir for rollback: ${appOutDir}.bak`)
+    // Windows/macOS: keep the previous working build as rollback material for
+    // the post-build integrity gate instead of destroying it. This is
+    // especially load-bearing on macOS when the running .app lives inside
+    // appOutDir: an interrupted in-place pack must not destroy the only
+    // launchable bundle. Falls through to the plain wipe when the old tree is
+    // partial/corrupt or the rename fails.
+    const productFilename = (context && context.packager?.appInfo?.productFilename) || 'Hermes'
+    const rollbackExecutable =
+      platformName === 'win32'
+        ? `${productFilename}.exe`
+        : platformName === 'darwin'
+          ? path.join(`${productFilename}.app`, 'Contents', 'MacOS', productFilename)
+          : null
+
+    const backupDir = platformName === 'darwin' ? macRollbackOutputDir(appOutDir) : `${appOutDir}.bak`
+    if (rollbackExecutable && preserveRollbackBackup(appOutDir, rollbackExecutable, backupDir)) {
+      console.log(`[before-pack] preserved previous unpacked dir for rollback: ${backupDir}`)
     } else if (cleanStaleAppOutDir(appOutDir)) {
       console.log(`[before-pack] removed stale unpacked dir before staging: ${appOutDir}`)
     }

--- a/apps/desktop/scripts/before-pack.test.mjs
+++ b/apps/desktop/scripts/before-pack.test.mjs
@@ -4,7 +4,11 @@ import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
 
-import beforePack, { cleanStaleAppOutDir, preserveRollbackBackup } from '../scripts/before-pack.mjs'
+import beforePack, {
+  cleanStaleAppOutDir,
+  macRollbackOutputDir,
+  preserveRollbackBackup
+} from '../scripts/before-pack.mjs'
 
 test('cleanStaleAppOutDir removes a populated unpacked directory', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
@@ -67,10 +71,7 @@ test('preserveRollbackBackup moves a working build to .bak', () => {
     // Original slot vacated so electron-builder stages into a clean tree...
     assert.equal(fs.existsSync(appOutDir), false)
     // ...and the previous working build is intact under .bak for rollback.
-    assert.equal(
-      fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
-      'MZ-old-build'
-    )
+    assert.equal(fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'), 'MZ-old-build')
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
@@ -129,10 +130,37 @@ test('beforePack on win32 preserves the previous build instead of wiping it', as
     await beforePack({ appOutDir, electronPlatformName: 'win32' })
 
     assert.equal(fs.existsSync(appOutDir), false)
+    assert.equal(fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'), 'MZ-working')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('beforePack on darwin preserves the previous app bundle instead of wiping it', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'mac-arm64')
+    const executable = path.join(appOutDir, 'Hermes.app', 'Contents', 'MacOS', 'Hermes')
+    fs.mkdirSync(path.dirname(executable), { recursive: true })
+    fs.writeFileSync(executable, 'working-mac-build', 'utf8')
+
+    // node-pty staging is skipped because arch is not a number here.
+    await beforePack({
+      appOutDir,
+      electronPlatformName: 'darwin',
+      packager: { appInfo: { productFilename: 'Hermes' } }
+    })
+
+    const backupDir = macRollbackOutputDir(appOutDir)
+
+    assert.equal(fs.existsSync(appOutDir), false)
     assert.equal(
-      fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
-      'MZ-working'
+      fs.readFileSync(path.join(backupDir, 'Hermes.app', 'Contents', 'MacOS', 'Hermes'), 'utf8'),
+      'working-mac-build'
     )
+    assert.equal(path.basename(path.dirname(backupDir)), '.hermes-update-backup')
+    assert.equal(path.basename(backupDir), 'mac-arm64')
+    assert.equal(fs.existsSync(`${appOutDir}.bak`), false)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/apps/desktop/scripts/posix-mac-update.test.mjs
+++ b/apps/desktop/scripts/posix-mac-update.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(here, '../../..')
+const updater = path.join(repoRoot, 'scripts', 'desktop-update', 'posix.sh')
+
+function backupOutputDir(outputDir) {
+  return path.join(path.dirname(outputDir), '.hermes-update-backup', path.basename(outputDir))
+}
+
+function writeBundle(bundle, executableText, { includeLazyChunk = true } = {}) {
+  const resources = path.join(bundle, 'Contents', 'Resources')
+  const dist = path.join(resources, 'app.asar.unpacked', 'dist')
+  const assets = path.join(dist, 'assets')
+
+  fs.mkdirSync(path.join(bundle, 'Contents', 'MacOS'), { recursive: true })
+  fs.mkdirSync(assets, { recursive: true })
+  fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'Hermes'), executableText)
+  fs.writeFileSync(path.join(resources, 'app.asar'), 'asar')
+  fs.writeFileSync(
+    path.join(dist, 'index.html'),
+    '<script type="module" src="./assets/index-test.js"></script>',
+    'utf8'
+  )
+  fs.writeFileSync(
+    path.join(assets, 'index-test.js'),
+    'const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/lazy-test.js"])))=>i.map(i=>d[i]);',
+    'utf8'
+  )
+
+  if (includeLazyChunk) {
+    fs.writeFileSync(path.join(assets, 'lazy-test.js'), 'export default {}', 'utf8')
+  }
+}
+
+test.skipIf(process.platform !== 'darwin')(
+  'posix updater restores the last complete mac bundle after a failed in-place build',
+  () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-posix-mac-update-'))
+    try {
+      const installRoot = path.join(home, 'hermes-agent')
+      const outputDir = path.join(installRoot, 'apps', 'desktop', 'release', 'mac-arm64')
+      const bundle = path.join(outputDir, 'Hermes.app')
+      const backupDir = backupOutputDir(outputDir)
+      const backupBundle = path.join(backupDir, 'Hermes.app')
+      const verifierDir = path.join(installRoot, 'apps', 'desktop', 'scripts')
+
+      writeBundle(bundle, 'partial-new', { includeLazyChunk: false })
+      writeBundle(backupBundle, 'previous-working')
+      fs.mkdirSync(verifierDir, { recursive: true })
+      fs.copyFileSync(
+        path.join(repoRoot, 'apps', 'desktop', 'scripts', 'verify-mac-bundle.mjs'),
+        path.join(verifierDir, 'verify-mac-bundle.mjs')
+      )
+
+      const run = spawnSync(
+        '/bin/bash',
+        [
+          updater,
+          '--self-test-mac-finalize',
+          '--self-test-final-code',
+          '6',
+          '--install-root',
+          installRoot,
+          '--relaunch-target',
+          bundle,
+          '--no-ui'
+        ],
+        { encoding: 'utf8' }
+      )
+
+      assert.equal(run.status, 0, run.stderr || run.stdout)
+      assert.equal(
+        fs.readFileSync(path.join(bundle, 'Contents', 'MacOS', 'Hermes'), 'utf8'),
+        'previous-working',
+        run.stderr || run.stdout
+      )
+      assert.equal(fs.existsSync(backupDir), false)
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true })
+    }
+  }
+)
+
+test.skipIf(process.platform !== 'darwin')(
+  'posix updater restores the backup when the failed build produced no new app bundle',
+  () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-posix-mac-update-'))
+    try {
+      const installRoot = path.join(home, 'hermes-agent')
+      const outputDir = path.join(installRoot, 'apps', 'desktop', 'release', 'mac-arm64')
+      const bundle = path.join(outputDir, 'Hermes.app')
+      const backupBundle = path.join(backupOutputDir(outputDir), 'Hermes.app')
+      const verifierDir = path.join(installRoot, 'apps', 'desktop', 'scripts')
+
+      writeBundle(backupBundle, 'previous-working')
+      fs.mkdirSync(verifierDir, { recursive: true })
+      fs.copyFileSync(
+        path.join(repoRoot, 'apps', 'desktop', 'scripts', 'verify-mac-bundle.mjs'),
+        path.join(verifierDir, 'verify-mac-bundle.mjs')
+      )
+
+      const run = spawnSync(
+        '/bin/bash',
+        [
+          updater,
+          '--self-test-mac-finalize',
+          '--self-test-final-code',
+          '6',
+          '--install-root',
+          installRoot,
+          '--relaunch-target',
+          bundle,
+          '--no-ui'
+        ],
+        { encoding: 'utf8' }
+      )
+
+      assert.equal(run.status, 0, run.stderr || run.stdout)
+      assert.equal(
+        fs.readFileSync(path.join(bundle, 'Contents', 'MacOS', 'Hermes'), 'utf8'),
+        'previous-working',
+        run.stderr || run.stdout
+      )
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true })
+    }
+  }
+)

--- a/apps/desktop/scripts/verify-mac-bundle.mjs
+++ b/apps/desktop/scripts/verify-mac-bundle.mjs
@@ -1,0 +1,212 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const TAG_WITH_URL = /<(?:script|link)\b[^>]*\b(?:src|href)=["']([^"']+)["'][^>]*>/gi
+const MODULE_TAG = /\btype=["']module["']|\brel=["']modulepreload["']/i
+const MAP_DEPS_ARRAY = /__vite__mapDeps[^[\]]{0,300}\[([^\]]*)\]/g
+const QUOTED_REF = /["']([^"']+)["']/g
+
+function localRef(value) {
+  if (!value || /^[a-z]+:|^\/\//i.test(value)) {
+    return null
+  }
+
+  return value.replace(/^\.\//, '').split(/[?#]/)[0]
+}
+
+function moduleRefs(html) {
+  const refs = []
+
+  for (const [tag, href] of String(html ?? '').matchAll(TAG_WITH_URL)) {
+    const ref = MODULE_TAG.test(tag) ? localRef(href) : null
+
+    if (ref) {
+      refs.push(ref)
+    }
+  }
+
+  return refs
+}
+
+function lazyRefs(js) {
+  const refs = new Set()
+
+  for (const [, body] of String(js ?? '').matchAll(MAP_DEPS_ARRAY)) {
+    for (const [, value] of body.matchAll(QUOTED_REF)) {
+      const ref = localRef(value)
+
+      if (ref) {
+        refs.add(ref)
+      }
+    }
+  }
+
+  return [...refs]
+}
+
+function readUtf8(file) {
+  try {
+    return fs.readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+export function verifyMacBundle(bundlePath, productFilename = 'Hermes') {
+  const bundle = path.resolve(String(bundlePath || ''))
+  const resources = path.join(bundle, 'Contents', 'Resources')
+  const dist = path.join(resources, 'app.asar.unpacked', 'dist')
+  const indexPath = path.join(dist, 'index.html')
+  const required = [
+    ['Contents/MacOS/' + productFilename, path.join(bundle, 'Contents', 'MacOS', productFilename)],
+    ['Contents/Resources/app.asar', path.join(resources, 'app.asar')],
+    ['Contents/Resources/app.asar.unpacked/dist/index.html', indexPath]
+  ]
+  const missing = required.filter(([, file]) => !fs.existsSync(file)).map(([label]) => label)
+
+  if (missing.length > 0) {
+    return { ok: false, missing }
+  }
+
+  const html = readUtf8(indexPath)
+  const bootRefs = moduleRefs(html)
+
+  if (html === null || bootRefs.length === 0) {
+    return { ok: false, missing: ['renderer module graph'] }
+  }
+
+  const queue = [...bootRefs]
+  const seen = new Set()
+
+  while (queue.length > 0) {
+    const ref = queue.shift()
+
+    if (seen.has(ref)) {
+      continue
+    }
+
+    seen.add(ref)
+    const file = path.join(dist, ref)
+
+    if (!fs.existsSync(file)) {
+      missing.push(ref)
+      continue
+    }
+
+    if (!/\.m?js$/i.test(ref)) {
+      continue
+    }
+
+    const js = readUtf8(file)
+
+    if (js === null) {
+      missing.push(ref)
+      continue
+    }
+
+    for (const lazyRef of lazyRefs(js)) {
+      const chunkRelative = path.join(path.dirname(ref), lazyRef).split(path.sep).join('/')
+
+      if (fs.existsSync(path.join(dist, lazyRef))) {
+        queue.push(lazyRef)
+      } else if (fs.existsSync(path.join(dist, chunkRelative))) {
+        queue.push(chunkRelative)
+      } else {
+        queue.push(lazyRef)
+      }
+    }
+  }
+
+  return { ok: missing.length === 0, missing: [...new Set(missing)] }
+}
+
+export function macRollbackOutputDir(outputDir) {
+  return path.join(path.dirname(outputDir), '.hermes-update-backup', path.basename(outputDir))
+}
+
+export function finalizeMacBundleUpdate(bundlePath, { productFilename = 'Hermes', updateSucceeded = false } = {}) {
+  const bundle = path.resolve(String(bundlePath || ''))
+  const outputDir = path.dirname(bundle)
+  const backupOutputDir = macRollbackOutputDir(outputDir)
+  const backupBundle = path.join(backupOutputDir, path.basename(bundle))
+  const newBundle = verifyMacBundle(bundle, productFilename)
+
+  if (updateSucceeded && newBundle.ok) {
+    return {
+      action: 'kept-new',
+      backupBundle,
+      newBundleMissing: [],
+      usable: true
+    }
+  }
+
+  const backup = verifyMacBundle(backupBundle, productFilename)
+
+  if (!backup.ok) {
+    return {
+      action: 'rollback-unavailable',
+      backupBundle,
+      backupMissing: backup.missing,
+      newBundleMissing: newBundle.missing,
+      usable: newBundle.ok
+    }
+  }
+
+  const failedOutputDir = `${backupOutputDir}.failed`
+
+  try {
+    fs.rmSync(failedOutputDir, { recursive: true, force: true })
+
+    if (fs.existsSync(outputDir)) {
+      fs.renameSync(outputDir, failedOutputDir)
+    }
+
+    try {
+      fs.renameSync(backupOutputDir, outputDir)
+    } catch (error) {
+      if (fs.existsSync(failedOutputDir) && !fs.existsSync(outputDir)) {
+        fs.renameSync(failedOutputDir, outputDir)
+      }
+
+      throw error
+    }
+
+    fs.rmSync(failedOutputDir, { recursive: true, force: true })
+
+    return {
+      action: 'restored-backup',
+      backupBundle,
+      newBundleMissing: newBundle.missing,
+      usable: true
+    }
+  } catch (error) {
+    return {
+      action: 'rollback-failed',
+      backupBundle,
+      error: error instanceof Error ? error.message : String(error),
+      newBundleMissing: newBundle.missing,
+      usable: verifyMacBundle(bundle, productFilename).ok
+    }
+  }
+}
+
+function canonicalPath(file) {
+  try {
+    return fs.realpathSync(file)
+  } catch {
+    return path.resolve(file)
+  }
+}
+
+if (process.argv[1] && canonicalPath(process.argv[1]) === canonicalPath(fileURLToPath(import.meta.url))) {
+  const finalize = process.argv[2] === '--finalize'
+  const result = finalize
+    ? finalizeMacBundleUpdate(process.argv[3], {
+        productFilename: process.argv[4] || 'Hermes',
+        updateSucceeded: process.argv[5] === 'success'
+      })
+    : verifyMacBundle(process.argv[2], process.argv[3] || 'Hermes')
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+  process.exitCode = finalize ? (result.usable ? 0 : 1) : result.ok ? 0 : 1
+}

--- a/apps/desktop/scripts/verify-mac-bundle.test.mjs
+++ b/apps/desktop/scripts/verify-mac-bundle.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import {
+  finalizeMacBundleUpdate,
+  macRollbackOutputDir,
+  verifyMacBundle
+} from '../scripts/verify-mac-bundle.mjs'
+
+function makeBundle() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-mac-bundle-'))
+  const bundle = path.join(root, 'mac-arm64', 'Hermes.app')
+  const resources = path.join(bundle, 'Contents', 'Resources')
+  const dist = path.join(resources, 'app.asar.unpacked', 'dist')
+  const assets = path.join(dist, 'assets')
+
+  fs.mkdirSync(path.join(bundle, 'Contents', 'MacOS'), { recursive: true })
+  fs.mkdirSync(assets, { recursive: true })
+  fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'Hermes'), 'binary')
+  fs.writeFileSync(path.join(resources, 'app.asar'), 'asar')
+  fs.writeFileSync(path.join(dist, 'index.html'), '<script type="module" src="./assets/index-abc.js"></script>', 'utf8')
+  fs.writeFileSync(
+    path.join(assets, 'index-abc.js'),
+    'const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/syntax-diff-def.js"])))=>i.map(i=>d[i]);',
+    'utf8'
+  )
+  fs.writeFileSync(path.join(assets, 'syntax-diff-def.js'), 'export default {}', 'utf8')
+
+  return { assets, bundle, root }
+}
+
+test('verifyMacBundle accepts a complete packaged renderer generation', () => {
+  const fixture = makeBundle()
+  try {
+    assert.deepEqual(verifyMacBundle(fixture.bundle), { ok: true, missing: [] })
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('verifyMacBundle rejects a bundle without its executable', () => {
+  const fixture = makeBundle()
+  try {
+    fs.rmSync(path.join(fixture.bundle, 'Contents', 'MacOS', 'Hermes'))
+
+    const result = verifyMacBundle(fixture.bundle)
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.missing, ['Contents/MacOS/Hermes'])
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('verifyMacBundle rejects a renderer whose boot module is missing', () => {
+  const fixture = makeBundle()
+  try {
+    fs.rmSync(path.join(fixture.assets, 'index-abc.js'))
+
+    const result = verifyMacBundle(fixture.bundle)
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.missing, ['assets/index-abc.js'])
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('verifyMacBundle rejects a renderer whose lazy chunk is missing', () => {
+  const fixture = makeBundle()
+  try {
+    fs.rmSync(path.join(fixture.assets, 'syntax-diff-def.js'))
+
+    const result = verifyMacBundle(fixture.bundle)
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.missing, ['assets/syntax-diff-def.js'])
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+function makeUpdatePair() {
+  const current = makeBundle()
+  const appOutDir = path.dirname(current.bundle)
+  const backupOutDir = macRollbackOutputDir(appOutDir)
+  const backupBundle = path.join(backupOutDir, path.basename(current.bundle))
+
+  fs.cpSync(appOutDir, backupOutDir, { recursive: true })
+  fs.writeFileSync(path.join(backupBundle, 'Contents', 'MacOS', 'Hermes'), 'previous-build')
+
+  return { ...current, appOutDir, backupBundle, backupOutDir }
+}
+
+test('finalizeMacBundleUpdate keeps a complete new bundle and its rollback copy', () => {
+  const fixture = makeUpdatePair()
+  try {
+    const result = finalizeMacBundleUpdate(fixture.bundle, { updateSucceeded: true })
+
+    assert.equal(result.action, 'kept-new')
+    assert.equal(result.usable, true)
+    assert.equal(fs.existsSync(fixture.bundle), true)
+    assert.equal(fs.existsSync(fixture.backupBundle), true)
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('finalizeMacBundleUpdate restores the previous bundle after an update failure', () => {
+  const fixture = makeUpdatePair()
+  try {
+    fs.writeFileSync(path.join(fixture.bundle, 'Contents', 'MacOS', 'Hermes'), 'partial-new-build')
+
+    const result = finalizeMacBundleUpdate(fixture.bundle, { updateSucceeded: false })
+
+    assert.equal(result.action, 'restored-backup')
+    assert.equal(result.usable, true)
+    assert.equal(fs.readFileSync(path.join(fixture.bundle, 'Contents', 'MacOS', 'Hermes'), 'utf8'), 'previous-build')
+    assert.equal(fs.existsSync(fixture.backupOutDir), false)
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('finalizeMacBundleUpdate restores the previous bundle when new lazy chunks are torn', () => {
+  const fixture = makeUpdatePair()
+  try {
+    fs.rmSync(path.join(fixture.assets, 'syntax-diff-def.js'))
+
+    const result = finalizeMacBundleUpdate(fixture.bundle, { updateSucceeded: true })
+
+    assert.equal(result.action, 'restored-backup')
+    assert.equal(result.usable, true)
+    assert.deepEqual(result.newBundleMissing, ['assets/syntax-diff-def.js'])
+    assert.equal(fs.readFileSync(path.join(fixture.bundle, 'Contents', 'MacOS', 'Hermes'), 'utf8'), 'previous-build')
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -39,6 +39,7 @@ ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
 NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+SELF_TEST_MAC_FINALIZE=0 SELF_TEST_FINAL_CODE=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -52,6 +53,8 @@ while [ $# -gt 0 ]; do
     --no-marker-cleanup) NO_MARKER_CLEANUP=1; shift ;;
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
+    --self-test-mac-finalize) SELF_TEST_MAC_FINALIZE=1; shift ;;
+    --self-test-final-code) SELF_TEST_FINAL_CODE="$2"; shift 2 ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
@@ -327,13 +330,39 @@ linux_gate() {
 }
 
 mac_swap() {
-  local rebuilt="" c
-  for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
-           "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
-    [ -d "$c" ] && { rebuilt="$c"; break; }
-  done
+  local rebuilt="" c output_dir backup_dir
+  output_dir="$(dirname "$RELAUNCH_TARGET")"
+  backup_dir="$(dirname "$output_dir")/.hermes-update-backup/$(basename "$output_dir")"
+  case "$RELAUNCH_TARGET" in
+    "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app"|\
+    "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app")
+      if [ -d "$RELAUNCH_TARGET" ] || [ -d "$backup_dir" ]; then
+        rebuilt="$RELAUNCH_TARGET"
+      fi
+      ;;
+  esac
 
-  # Transactional swap: stage a full copy, move the old bundle aside, move
+  if [ -z "$rebuilt" ]; then
+    for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
+             "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
+      [ -d "$c" ] && { rebuilt="$c"; break; }
+    done
+  fi
+
+  # The CLI-managed mac app normally runs directly from the electron-builder
+  # output directory. before-pack.mjs now preserves that whole output as
+  # release/.hermes-update-backup/<appOutDir> before rebuilding in place.
+  # Finalize that transaction here:
+  # a failed update or an incomplete renderer generation restores the previous
+  # bundle before any relaunch is attempted.
+  if [ -n "$rebuilt" ] && [ "$rebuilt" = "$RELAUNCH_TARGET" ] \
+      && [ -d "$backup_dir" ]; then
+    finalize_in_place_mac_bundle "$rebuilt"
+    return
+  fi
+
+  # Transactional swap for a separately installed target: stage a full copy,
+  # move the old bundle aside, move
   # the copy in. Every step checked; a failed final move ROLLS BACK so the
   # user always has a launchable app, and the result file tells the truth.
   if [ "$FINAL_CODE" -eq 0 ] && [ -n "$rebuilt" ] && [ -d "$RELAUNCH_TARGET" ] && [ "$rebuilt" != "$RELAUNCH_TARGET" ]; then
@@ -361,6 +390,47 @@ mac_swap() {
       log "swapped app bundle"
     fi
   fi
+}
+
+finalize_in_place_mac_bundle() {
+  local bundle="$1" verifier node_bin outcome="" update_state="failure"
+  verifier="$INSTALL_ROOT/apps/desktop/scripts/verify-mac-bundle.mjs"
+  node_bin="$(command -v node 2>/dev/null || true)"
+  [ "$FINAL_CODE" -eq 0 ] && update_state="success"
+
+  if [ -z "$node_bin" ] || [ ! -f "$verifier" ]; then
+    if [ "$FINAL_CODE" -eq 0 ]; then
+      FINAL_CODE=7
+      FINAL_MSG="The update built a new macOS app, but its integrity could not be verified; the previous app backup was kept. Reinstall or run the update again."
+    fi
+    log "ERROR: mac bundle verifier unavailable (node=${node_bin:-missing}, verifier=$verifier)"
+    return 1
+  fi
+
+  outcome="$("$node_bin" "$verifier" --finalize "$bundle" Hermes "$update_state" 2>>"$LOG")"
+  if [ $? -ne 0 ]; then
+    if [ "$FINAL_CODE" -eq 0 ]; then
+      FINAL_CODE=7
+      FINAL_MSG="The updated macOS app was incomplete and its previous backup could not be restored automatically. Reinstall Hermes."
+    fi
+    log "ERROR: mac bundle transaction failed: ${outcome:-no result}"
+    return 1
+  fi
+
+  case "$outcome" in
+    *'"action":"restored-backup"'*)
+      log "restored previous macOS app bundle after update/build integrity failure"
+      if [ "$FINAL_CODE" -eq 0 ]; then
+        DONE_NOTE="Code updated, but the new Desktop app was incomplete; the previous working app was restored. Run the update again."
+      fi
+      ;;
+    *'"action":"kept-new"'*)
+      log "verified new macOS app bundle; retained previous build as rollback material"
+      ;;
+    *)
+      log "mac bundle transaction outcome: $outcome"
+      ;;
+  esac
 }
 
 deliver_outcome() { # the truth-determining half: swap bundles / gate the relaunch
@@ -475,6 +545,20 @@ if [ "$SELF_TEST_GATE" -eq 1 ]; then
   linux_gate
   echo "$GATE${GATE_MSG:+:$GATE_MSG}"
   exit 0
+fi
+
+if [ "$SELF_TEST_MAC_FINALIZE" -eq 1 ]; then
+  # Host-native macOS transaction integration test: exercise the same
+  # verifier + rollback path finish() uses, without running an update or
+  # launching an app.
+  trap - EXIT
+  FINAL_CODE="$SELF_TEST_FINAL_CODE"
+  mac_swap
+  node_bin="$(command -v node 2>/dev/null || true)"
+  [ -n "$node_bin" ] || exit 1
+  "$node_bin" "$INSTALL_ROOT/apps/desktop/scripts/verify-mac-bundle.mjs" \
+    "$RELAUNCH_TARGET" Hermes >/dev/null 2>&1
+  exit $?
 fi
 
 if [ "$SELF_TEST_UI" -eq 1 ]; then


### PR DESCRIPTION
## Summary

- preserve a complete macOS electron-builder output before an in-place Desktop rebuild
- verify the rebuilt app executable, ASAR, renderer entry graph, and transitive Vite lazy chunks before relaunch
- restore the previous complete bundle when the update fails, produces no app, or leaves a torn renderer generation
- keep rollback and failed-build holders under a hidden release subdirectory so the existing mac* executable discovery cannot mistake them for current output

## Why

Issue #46883 remains reproducible on macOS source installs: beforePack removes the live release/mac-arm64 directory before electron-builder has produced its replacement. A failed or interrupted pack can therefore delete the only launchable Desktop app.

PR #46914 attempts backup and restore in Python, but its current branch is stale and the sibling mac*.prior holder can match the existing mac* executable-discovery glob. This PR is a focused current-main change and keeps the holder outside that glob.

Merged PR #85887 detects a torn packaged renderer and can choose an intact ASAR/unpacked copy, but it does not preserve the previous application when the entire in-place rebuild fails. The POSIX finalizer here complements that recovery path by validating the new generation before relaunch and restoring the previous bundle when necessary.

## Transaction

1. beforePack renames a complete release/mac-arm64 tree to release/.hermes-update-backup/mac-arm64.
2. electron-builder writes the replacement into a clean release/mac-arm64 directory.
3. The detached POSIX updater verifies the rebuilt bundle before relaunch.
4. A successful complete build is kept together with one rollback copy.
5. A failed or incomplete build is moved aside and the verified backup is renamed back into place.
6. If the backup promotion itself fails, the partial output is moved back instead of leaving the canonical path absent.

## Tests

- macOS beforePack preservation and Linux non-regression
- complete bundle verification
- missing executable, renderer entry, and lazy chunk rejection
- successful finalize keeps the new app and rollback copy
- failed/torn finalize restores the previous app
- host-native POSIX integration for partial output and no-output failures
- 4 focused Vitest files: 37 tests passed
- npm run typecheck
- bash -n scripts/desktop-update/posix.sh
- git diff --check

Fixes #46883.
Related to #85868.
