### PR TITLE
Add memobase memory provider to community plugin index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "memobase",
+      "description": "Memobase memory provider — automatic per-turn recall backed by a self-hosted user-profile + event-timeline server.",
+      "author": "fred0m",
+      "tags": ["memory", "provider", "memobase", "recall"],
+      "repo": "fred0m/hermes-memobase-provider",
+      "ref": "3ae63360acb582528ad5f2367da09c42e89399af",
+      "homepage": "https://github.com/fred0m/hermes-memobase-provider",
+      "capabilities": ["tools"],
+      "api_version": 1,
+      "added_at": "2026-08-27"
     }
   ]
 }


### PR DESCRIPTION
Add the `memobase` memory provider plugin to the community plugin index so it is discoverable via `hermes plugins search memobase` and installable by index name.

## What it is

[hermes-memobase-provider](https://github.com/fred0m/hermes-memobase-provider) implements the `MemoryProvider` ABC and connects Hermes's per-turn recall lifecycle (`prefetch` / `sync_turn` / tools) to a self-hosted [Memobase](https://github.com/memodb-io/memobase) server (user-profile + event-timeline memory backend).

- Automatic per-turn recall: `prefetch` injects the user profile + recent events; `sync_turn` writes the completed turn back for background LLM profile extraction.
- On-demand backstop tools: `memobase_search` / `memobase_profile`.
- Fail-open + circuit breaker (5 consecutive failures → 60s pause).
- Writes are skipped for non-primary agents (subagent/cron/flush) to protect the user profile.
- Ships with 23 unit tests (stdlib `unittest` + `httpx.MockTransport`, no extra dependencies).

## Index entry

Ref is pinned to commit `3ae6336` of `fred0m/hermes-memobase-provider` (main).