### PR TITLE
fix(desktop): stabilize contribution registry snapshots (workspace pane 'Maximum update depth exceeded')

### DIFF
--- a/apps/desktop/src/contrib/registry.stability.test.ts
+++ b/apps/desktop/src/contrib/registry.stability.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+
+import { registry } from './registry'
+import type { Contribution } from './types'
+
+const entry = (area: string, id: string, extra: Partial<Contribution> = {}): Contribution =>
+  ({ area, id, ...extra }) as Contribution
+
+describe('registry snapshot stability (getSnapshot contract)', () => {
+  test('re-resolving an unchanged area returns the SAME reference', () => {
+    const a = entry('stability.a', 'one')
+    registry.register(a)
+
+    const first = registry.getArea('stability.a')
+
+    // Invalidation drops the cached snapshot. Re-resolving to the SAME entries
+    // must reuse the previous array: `useSyncExternalStore` compares with
+    // `Object.is`, so a fresh-but-identical array reads as a change and can
+    // loop the workspace pane into "Maximum update depth exceeded".
+    registry.register(a) // re-register the same contribution
+
+    const second = registry.getArea('stability.a')
+
+    expect(second).toBe(first)
+  })
+
+  test('an actual change still produces a new reference', () => {
+    const a = entry('stability.b', 'one')
+    registry.register(a)
+
+    const first = registry.getArea('stability.b')
+
+    const dispose = registry.register(entry('stability.b', 'two'))
+    const second = registry.getArea('stability.b')
+
+    expect(second).not.toBe(first)
+    expect(second).toHaveLength(2)
+
+    // ...and removing it returns to a stable, correct snapshot.
+    dispose()
+    const third = registry.getArea('stability.b')
+    expect(third).toHaveLength(1)
+    expect(registry.getArea('stability.b')).toBe(third)
+  })
+
+  test('empty areas stay referentially stable', () => {
+    const first = registry.getArea('stability.empty')
+    expect(registry.getArea('stability.empty')).toBe(first)
+  })
+})

--- a/apps/desktop/src/contrib/registry.ts
+++ b/apps/desktop/src/contrib/registry.ts
@@ -31,9 +31,16 @@ const EMPTY: readonly Contribution[] = Object.freeze([])
  * the current surfaces (no dynamic `when` is in use); revisit if we need
  * reactive `when`.
  */
+/** Shallow reference equality over two resolved area lists. */
+const sameEntries = (a: readonly Contribution[], b: readonly Contribution[]): boolean =>
+  a.length === b.length && a.every((entry, i) => entry === b[i])
+
 class ContributionRegistry {
   private byArea = new Map<string, Contribution[]>()
   private snapshot = new Map<string, readonly Contribution[]>()
+  /** Last resolved list per area, kept across invalidation so an area that
+   *  re-resolves to the SAME entries hands back the SAME reference. */
+  private previous = new Map<string, readonly Contribution[]>()
   private areaListeners = new Map<string, Set<Listener>>()
   private globalListeners = new Set<Listener>()
 
@@ -59,13 +66,26 @@ class ContributionRegistry {
 
     const raw = this.byArea.get(area)
 
-    const resolved: readonly Contribution[] =
+    let resolved: readonly Contribution[] =
       !raw || raw.length === 0
         ? EMPTY
         : raw
             .filter(c => c.enabled !== false && (c.when ? c.when() : true))
             .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 
+    // Invalidation drops the snapshot, so a mutation that leaves an area's
+    // resolved entries unchanged would otherwise mint a fresh array here.
+    // `useSyncExternalStore` compares with `Object.is`, so that new reference
+    // reads as a change and re-renders — and any consumer whose render touches
+    // the registry closes the loop into "Maximum update depth exceeded".
+    // Reuse the previous array whenever the entries are identical.
+    const prev = this.previous.get(area)
+
+    if (prev && sameEntries(prev, resolved)) {
+      resolved = prev
+    }
+
+    this.previous.set(area, resolved)
     this.snapshot.set(area, resolved)
 
     return resolved


### PR DESCRIPTION
## Summary

The desktop **workspace pane crashes behind its error boundary** with:

```
[error-boundary:contrib:workspace] Maximum update depth exceeded.
The result of getSnapshot should be cached to avoid an infinite loop.
```

Root cause is in the contribution registry: `getArea()` mints a **fresh array on every re-resolve after invalidation**, even when the resolved entries are byte-for-byte identical.

`invalidate()` *deletes* the cached snapshot rather than recomputing it, so the next `getSnapshot()` rebuilds the list and returns a new reference. `useSyncExternalStore` compares with `Object.is`, so an identical-but-new array reads as a change and re-renders. The workspace pane registers/unregisters pane contributions as it renders (`app/contrib/wiring.tsx` registers a pane closer on mount), which closes the loop:

```
render → invalidate → new array → notify → render → … → update-depth guard kills the pane
```

This contradicts the registry's own docstring, which already promises the property that is missing:

> Snapshots are cached per area and only invalidated on mutation so the value
> is referentially stable for `useSyncExternalStore` (no render loops).

…and the desktop guide's stated invariant:

> **Preserve reference identity on no-ops.** Handing React a fresh array that contains the same data re-renders expensive trees for nothing.

`workspace` is the surface that dies because it is the heaviest registry consumer, but the bug is in the shared primitive — any area whose consumers touch the registry during render can loop.

## The fix

Keep the last resolved list per area and reuse that reference when the newly resolved entries are identical (shallow, per-entry reference comparison). Real changes still produce a new reference, so subscribers update exactly as before.

This fixes the whole bug class at the primitive rather than patching the one pane that happened to surface it.

## Test plan

Added `src/contrib/registry.stability.test.ts` (3 tests):

- **`re-resolving an unchanged area returns the SAME reference`** — the regression guard. **Fails on unfixed `main`** with `AssertionError: Compared values have no visual difference` (identical contents, different reference — the exact `getSnapshot` violation).
- **`an actual change still produces a new reference`** — proves the fix does not over-cache: adding a contribution yields a new ref, and removing it settles back to a stable, correct snapshot.
- **`empty areas stay referentially stable`** — pins the `EMPTY` path.

Verification performed:

- Regression test confirmed **red before / green after** (stashing only `registry.ts` reproduces the failure).
- `npx vitest run src/contrib src/components/pane-shell` → **182 passed**.
- `tsc --build tsconfig.json` → clean.
- Rebuilt and repackaged the desktop app; ran it against the previously crashing workspace pane.

Note: `src/contrib/runtime-loader.test.ts` fails on pristine `main` in my environment with `Failed to resolve import "blobatar/blob"` — pre-existing and unrelated to this change (verified on `origin/main` without this commit).
