### PR TITLE
fix(cli): don't open a browser tab for a headless/non-TTY dashboard invocation

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12021,8 +12021,11 @@ def cmd_dashboard(args):
             print(f"  Managing profile '{_launch_profile}': {url}")
             if not args.no_open:
                 try:
-                    import webbrowser
-                    webbrowser.open(url)
+                    from hermes_cli.auth import _can_open_graphical_browser
+
+                    if _can_open_graphical_browser():
+                        import webbrowser
+                        webbrowser.open(url)
                 except Exception:
                     pass
             sys.exit(0)

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -85,6 +85,76 @@ class TestUnifiedDashboardRouting:
         assert execs == []
 
 
+class TestDashboardAlreadyListeningBrowserOpen:
+    """Regression for issue #96166: a headless/non-TTY invocation (e.g. a
+    launchd-supervised service) hitting the "dashboard already listening"
+    branch must not call webbrowser.open() -- doing so unconditionally
+    turned a KeepAlive-configured supervisor's respawn loop into an
+    infinite tab-spawn loop, since the branch exits 0 on every spawn."""
+
+    def test_headless_does_not_open_a_browser_tab(self, main_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "fiona"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        monkeypatch.setattr(
+            "hermes_cli.auth._can_open_graphical_browser", lambda: False
+        )
+        opens = []
+        monkeypatch.setattr("webbrowser.open", lambda url: opens.append(url))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(no_open=False))
+
+        assert exc.value.code == 0
+        assert opens == []
+
+    def test_graphical_browser_available_still_opens_a_tab(self, main_mod, monkeypatch):
+        """Sanity: the interactive case is unaffected -- a genuinely
+        available GUI browser still opens, matching pre-fix behavior."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "fiona"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        monkeypatch.setattr(
+            "hermes_cli.auth._can_open_graphical_browser", lambda: True
+        )
+        opens = []
+        monkeypatch.setattr("webbrowser.open", lambda url: opens.append(url))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(no_open=False))
+
+        assert exc.value.code == 0
+        assert len(opens) == 1
+        assert "profile=fiona" in opens[0]
+
+    def test_no_open_flag_still_short_circuits_before_any_browser_check(self, main_mod, monkeypatch):
+        """--no-open must still work exactly as before -- the new guard is
+        an additional condition, not a replacement for this one."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "fiona"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        checked = []
+        monkeypatch.setattr(
+            "hermes_cli.auth._can_open_graphical_browser",
+            lambda: checked.append(1) or True,
+        )
+        opens = []
+        monkeypatch.setattr("webbrowser.open", lambda url: opens.append(url))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(no_open=True))
+
+        assert exc.value.code == 0
+        assert opens == []
+        assert checked == []
+
+
 class TestInteractiveDashboardAuthSetup:
 
     def test_loopback_proxy_public_url_offers_auth_setup(


### PR DESCRIPTION
Fixes #96166.

## Root cause

The "dashboard already listening" branch in `cmd_dashboard()` called `webbrowser.open(url)` unconditionally (behind only `--no-open`), with no check for whether a graphical browser is actually available. On a headless launchd/systemd-supervised profile-dashboard invocation, this opened a browser tab and exited 0 on every spawn. A supervisor configured with restart-on-success (e.g. launchd `KeepAlive=true`) interpreted the exit 0 as healthy and immediately respawned -- 71 tabs in ~9 minutes in the reported incident.

## Fix

Gated the browser-open behind `hermes_cli.auth`'s own `_can_open_graphical_browser()`, reusing the exact function every OAuth flow in this codebase already routes through for this same reason (same bug class as #72393). No new detection logic -- this closes the one call site that had never been routed through the existing guard.

## Verification

Verified directly: simulated the exact reported scenario (headless Linux, no DISPLAY/WAYLAND_DISPLAY/SSH_CLIENT/BROWSER) and confirmed `_can_open_graphical_browser()` correctly returns `False`.

Added 3 regression tests following the existing file's established `main_mod.cmd_dashboard()` call pattern. Verified as a genuine regression by reverting just the fix and confirming the headless test fails, opening a tab exactly as described.

14/14 pass across the two related dashboard-launch test files (no regression).

**Scope note**: the issue also raises a secondary, optional concern about exit-code semantics for the "already listening" case. Left out of this fix -- it's explicitly marked "optionally also consider" and is a larger, separate behavioral question from the concrete browser-open bug this fix addresses.