### PR TITLE
feat(plugins): report gateway dispatch outcomes

### DIFF
--- a/gateway/plugin_injection.py
+++ b/gateway/plugin_injection.py
@@ -1,0 +1,223 @@
+"""Gateway-side dispatch of plugin-triggered session wakes.
+
+``GatewayRunner`` owns the loop, the session store, the authorization check, and
+the adapter table; this module owns what to *do* with them when a plugin asks to
+wake one exact stored session. ``gateway/run.py`` keeps only a two-line
+delegation seam per entry point so injection authority does not regrow inside
+the runner (`sharded, never reverted`).
+
+The typed outcome vocabulary lives in :mod:`hermes_cli.plugin_injection`, which
+is also what plugins import -- one result algebra, not two.
+
+Scope
+-----
+This is the *exact-session wake* path: the caller already holds a stored
+``session_key`` and the route is read from the session, never from the caller.
+It reports on the ``ctx.inject_message(session_key=...)`` seam introduced by
+#84929 (preserving the earlier #64436 lineage) and adds nothing to addressing.
+Profile/platform/chat *routing* injection, durable cross-gateway relay, and
+qualified-identity control-plane work are deliberately out of scope here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import dataclasses
+import logging
+from typing import Any, Optional, Union
+
+from agent.async_utils import safe_schedule_threadsafe
+from hermes_cli.plugin_injection import (
+    GatewayInjectionHandle,
+    GatewayInjectionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def schedule_injection(
+    runner: Any,
+    *,
+    session_key: str,
+    content: str,
+    plugin_id: str,
+    await_dispatch: bool = False,
+    correlation_id: Optional[str] = None,
+) -> Union[bool, GatewayInjectionHandle]:
+    """Schedule a plugin-triggered turn on the live gateway loop.
+
+    Returns ``True``/``False`` for the scheduling outcome by default. With
+    ``await_dispatch=True`` it returns a :class:`GatewayInjectionHandle` that
+    resolves to what dispatch itself decided, so a caller can tell adoption apart
+    from a silent drop.
+    """
+
+    def _refused(reason: str) -> Union[bool, GatewayInjectionHandle]:
+        if not await_dispatch:
+            return False
+        return GatewayInjectionHandle.resolved(
+            GatewayInjectionResult(
+                False,
+                reason,
+                session_key=session_key,
+                correlation_id=correlation_id,
+            )
+        )
+
+    loop = getattr(runner, "_gateway_loop", None)
+    if not getattr(runner, "_running", False) or loop is None or loop.is_closed():
+        return _refused("gateway_draining")
+
+    # Through the runner's seam, not straight at ``dispatch_injection``: the
+    # runner stays the single entry point that owns this coroutine.
+    coro = runner._dispatch_plugin_message_injection(
+        session_key=session_key,
+        content=content,
+        plugin_id=plugin_id,
+        correlation_id=correlation_id,
+    )
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+
+    if current_loop is loop:
+        try:
+            future = loop.create_task(coro)
+        except Exception:
+            coro.close()
+            logger.warning("Plugin message injection scheduling failed", exc_info=True)
+            return _refused("not_scheduled")
+        runner._background_tasks.add(future)
+        future.add_done_callback(runner._background_tasks.discard)
+    else:
+        future = safe_schedule_threadsafe(
+            coro,
+            loop,
+            logger=logger,
+            log_message="Plugin message injection scheduling failed",
+            log_level=logging.WARNING,
+        )
+        if future is None:
+            return _refused("not_scheduled")
+
+    def _log_result(completed) -> None:
+        try:
+            result = completed.result()
+        except (asyncio.CancelledError, concurrent.futures.CancelledError):
+            return
+        except Exception:
+            logger.warning(
+                "Plugin message injection failed: plugin=%s session=%s",
+                plugin_id,
+                session_key,
+                exc_info=True,
+            )
+            return
+        if not result:
+            logger.warning(
+                "Plugin message injection was not routed: plugin=%s session=%s "
+                "reason=%s",
+                plugin_id,
+                session_key,
+                getattr(result, "reason", "unknown"),
+            )
+
+    future.add_done_callback(_log_result)
+    if await_dispatch:
+        return GatewayInjectionHandle(
+            future,
+            correlation_id=correlation_id,
+            session_key=session_key,
+        )
+    return True
+
+
+async def dispatch_injection(
+    runner: Any,
+    *,
+    session_key: str,
+    content: str,
+    plugin_id: str,
+    correlation_id: Optional[str] = None,
+) -> GatewayInjectionResult:
+    """Route a plugin-triggered turn through the session's live adapter.
+
+    Returns a :class:`GatewayInjectionResult`. It is falsy for every refusal, so
+    callers that only cared about the boolean still read correctly.
+    """
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    def _refused(reason: str) -> GatewayInjectionResult:
+        return GatewayInjectionResult(
+            False,
+            reason,
+            session_key=session_key,
+            correlation_id=correlation_id,
+        )
+
+    if not getattr(runner, "_running", False) or getattr(runner, "_draining", False):
+        return _refused("gateway_draining")
+
+    entry = await runner.async_session_store.lookup_by_session_key(session_key)
+    if entry is None or entry.origin is None:
+        return _refused("unknown_session")
+    if not getattr(runner, "_running", False) or getattr(runner, "_draining", False):
+        return _refused("gateway_draining")
+
+    source = dataclasses.replace(entry.origin)
+    try:
+        if not runner._is_user_authorized(source, allow_adapter_delegation=False):
+            logger.warning(
+                "Plugin message injection denied by current gateway authorization: "
+                "plugin=%s session=%s",
+                plugin_id,
+                session_key,
+            )
+            return _refused("unauthorized")
+    except Exception:
+        logger.warning(
+            "Plugin message injection authorization check failed: plugin=%s session=%s",
+            plugin_id,
+            session_key,
+            exc_info=True,
+        )
+        return _refused("unauthorized")
+
+    adapter = runner._adapter_for_source(source)
+    if adapter is None:
+        return _refused("no_adapter")
+
+    metadata = {
+        "hermes_plugin_id": plugin_id,
+        "hermes_plugin_injection": True,
+        "gateway_session_key": session_key,
+        "gateway_session_id": entry.session_id,
+        "gateway_session_strict": True,
+    }
+    if correlation_id is not None:
+        metadata["hermes_plugin_injection_id"] = correlation_id
+
+    event = MessageEvent(
+        text=content,
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        allow_gateway_control=False,
+        metadata=metadata,
+    )
+    await adapter.handle_message(event)
+    logger.info(
+        "Plugin message injection dispatched: plugin=%s session=%s session_id=%s",
+        plugin_id,
+        session_key,
+        entry.session_id,
+    )
+    return GatewayInjectionResult(
+        True,
+        "adopted",
+        session_id=entry.session_id,
+        session_key=session_key,
+        correlation_id=correlation_id,
+    )

--- a/gateway/plugin_injection.py
+++ b/gateway/plugin_injection.py
@@ -31,6 +31,7 @@ from agent.async_utils import safe_schedule_threadsafe
 from hermes_cli.plugin_injection import (
     GatewayInjectionHandle,
     GatewayInjectionResult,
+    InjectionDelivery,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,10 @@ def schedule_injection(
     if not getattr(runner, "_running", False) or loop is None or loop.is_closed():
         return _refused("gateway_draining")
 
+    # Shared with the handle so a cancellation or crash can be told apart from a
+    # provable refusal once the adapter holds the event.
+    delivery = InjectionDelivery()
+
     # Through the runner's seam, not straight at ``dispatch_injection``: the
     # runner stays the single entry point that owns this coroutine.
     coro = runner._dispatch_plugin_message_injection(
@@ -76,6 +81,7 @@ def schedule_injection(
         content=content,
         plugin_id=plugin_id,
         correlation_id=correlation_id,
+        delivery=delivery,
     )
     try:
         current_loop = asyncio.get_running_loop()
@@ -130,6 +136,7 @@ def schedule_injection(
             future,
             correlation_id=correlation_id,
             session_key=session_key,
+            delivery=delivery,
         )
     return True
 
@@ -141,11 +148,16 @@ async def dispatch_injection(
     content: str,
     plugin_id: str,
     correlation_id: Optional[str] = None,
+    delivery: Optional[InjectionDelivery] = None,
 ) -> GatewayInjectionResult:
     """Route a plugin-triggered turn through the session's live adapter.
 
     Returns a :class:`GatewayInjectionResult`. It is falsy for every refusal, so
     callers that only cared about the boolean still read correctly.
+
+    ``delivery`` is the arbiter between this coroutine and a caller holding the
+    handle: everything up to the adapter call is disprovable delivery, the
+    adapter call itself is not.
     """
     from gateway.platforms.base import MessageEvent, MessageType
 
@@ -207,6 +219,9 @@ async def dispatch_injection(
         allow_gateway_control=False,
         metadata=metadata,
     )
+    if delivery is not None and not delivery.enter_adapter():
+        # A cancel reserved the outcome first, so non-delivery is still provable.
+        return _refused("cancelled")
     await adapter.handle_message(event)
     logger.info(
         "Plugin message injection dispatched: plugin=%s session=%s session_id=%s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19346,95 +19346,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         await_dispatch: bool = False,
         correlation_id: str | None = None,
     ):
-        """Schedule a plugin-triggered turn on the live gateway loop.
+        """Delegate to :mod:`gateway.plugin_injection`."""
+        from gateway.plugin_injection import schedule_injection
 
-        Returns ``True``/``False`` for the scheduling outcome by default. With
-        ``await_dispatch=True`` it returns a ``GatewayInjectionHandle`` that
-        resolves to what dispatch itself decided, so a caller can tell adoption
-        apart from a silent drop.
-        """
-        from hermes_cli.plugins import GatewayInjectionHandle, GatewayInjectionResult
-
-        def _refused(reason: str):
-            if not await_dispatch:
-                return False
-            return GatewayInjectionHandle.resolved(
-                GatewayInjectionResult(
-                    False,
-                    reason,
-                    session_key=session_key,
-                    correlation_id=correlation_id,
-                )
-            )
-
-        loop = getattr(self, "_gateway_loop", None)
-        if not getattr(self, "_running", False) or loop is None or loop.is_closed():
-            return _refused("gateway_draining")
-
-        coro = self._dispatch_plugin_message_injection(
+        return schedule_injection(
+            self,
             session_key=session_key,
             content=content,
             plugin_id=plugin_id,
+            await_dispatch=await_dispatch,
             correlation_id=correlation_id,
         )
-        try:
-            current_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            current_loop = None
-
-        if current_loop is loop:
-            try:
-                future = loop.create_task(coro)
-            except Exception:
-                coro.close()
-                logger.warning(
-                    "Plugin message injection scheduling failed",
-                    exc_info=True,
-                )
-                return _refused("not_scheduled")
-            self._background_tasks.add(future)
-            future.add_done_callback(self._background_tasks.discard)
-        else:
-            future = safe_schedule_threadsafe(
-                coro,
-                loop,
-                logger=logger,
-                log_message="Plugin message injection scheduling failed",
-                log_level=logging.WARNING,
-            )
-            if future is None:
-                return _refused("not_scheduled")
-
-        def _log_result(completed) -> None:
-            try:
-                result = completed.result()
-            except (asyncio.CancelledError, concurrent.futures.CancelledError):
-                return
-            except Exception:
-                logger.warning(
-                    "Plugin message injection failed: plugin=%s session=%s",
-                    plugin_id,
-                    session_key,
-                    exc_info=True,
-                )
-                return
-            if not result:
-                logger.warning(
-                    "Plugin message injection was not routed: plugin=%s session=%s "
-                    "reason=%s",
-                    plugin_id,
-                    session_key,
-                    getattr(result, "reason", "unknown"),
-                )
-
-        future.add_done_callback(_log_result)
-        if await_dispatch:
-            return GatewayInjectionHandle(
-                future,
-                correlation_id=correlation_id,
-                session_key=session_key,
-            )
-        return True
 
     async def _dispatch_plugin_message_injection(
         self,
@@ -19444,87 +19366,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         plugin_id: str,
         correlation_id: str | None = None,
     ):
-        """Route a plugin-triggered turn through the session's live adapter.
+        """Delegate to :mod:`gateway.plugin_injection`."""
+        from gateway.plugin_injection import dispatch_injection
 
-        Returns a ``GatewayInjectionResult``. It is falsy for every refusal, so
-        callers that only cared about the boolean still read correctly.
-        """
-        from hermes_cli.plugins import GatewayInjectionResult
-
-        def _refused(reason: str) -> "GatewayInjectionResult":
-            return GatewayInjectionResult(
-                False,
-                reason,
-                session_key=session_key,
-                correlation_id=correlation_id,
-            )
-
-        if not getattr(self, "_running", False) or getattr(self, "_draining", False):
-            return _refused("gateway_draining")
-
-        entry = await self.async_session_store.lookup_by_session_key(session_key)
-        if entry is None or entry.origin is None:
-            return _refused("unknown_session")
-        if not getattr(self, "_running", False) or getattr(self, "_draining", False):
-            return _refused("gateway_draining")
-
-        source = dataclasses.replace(entry.origin)
-        try:
-            if not self._is_user_authorized(
-                source,
-                allow_adapter_delegation=False,
-            ):
-                logger.warning(
-                    "Plugin message injection denied by current gateway authorization: "
-                    "plugin=%s session=%s",
-                    plugin_id,
-                    session_key,
-                )
-                return _refused("unauthorized")
-        except Exception:
-            logger.warning(
-                "Plugin message injection authorization check failed: "
-                "plugin=%s session=%s",
-                plugin_id,
-                session_key,
-                exc_info=True,
-            )
-            return _refused("unauthorized")
-
-        adapter = self._adapter_for_source(source)
-        if adapter is None:
-            return _refused("no_adapter")
-
-        metadata = {
-            "hermes_plugin_id": plugin_id,
-            "hermes_plugin_injection": True,
-            "gateway_session_key": session_key,
-            "gateway_session_id": entry.session_id,
-            "gateway_session_strict": True,
-        }
-        if correlation_id is not None:
-            metadata["hermes_plugin_injection_id"] = correlation_id
-
-        event = MessageEvent(
-            text=content,
-            message_type=MessageType.TEXT,
-            source=source,
-            internal=True,
-            allow_gateway_control=False,
-            metadata=metadata,
-        )
-        await adapter.handle_message(event)
-        logger.info(
-            "Plugin message injection dispatched: plugin=%s session=%s session_id=%s",
-            plugin_id,
-            session_key,
-            entry.session_id,
-        )
-        return GatewayInjectionResult(
-            True,
-            "adopted",
-            session_id=entry.session_id,
+        return await dispatch_injection(
+            self,
             session_key=session_key,
+            content=content,
+            plugin_id=plugin_id,
             correlation_id=correlation_id,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19343,16 +19343,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
         content: str,
         plugin_id: str,
-    ) -> bool:
-        """Schedule a plugin-triggered turn on the live gateway loop."""
+        await_dispatch: bool = False,
+        correlation_id: str | None = None,
+    ):
+        """Schedule a plugin-triggered turn on the live gateway loop.
+
+        Returns ``True``/``False`` for the scheduling outcome by default. With
+        ``await_dispatch=True`` it returns a ``GatewayInjectionHandle`` that
+        resolves to what dispatch itself decided, so a caller can tell adoption
+        apart from a silent drop.
+        """
+        from hermes_cli.plugins import GatewayInjectionHandle, GatewayInjectionResult
+
+        def _refused(reason: str):
+            if not await_dispatch:
+                return False
+            return GatewayInjectionHandle.resolved(
+                GatewayInjectionResult(
+                    False,
+                    reason,
+                    session_key=session_key,
+                    correlation_id=correlation_id,
+                )
+            )
+
         loop = getattr(self, "_gateway_loop", None)
         if not getattr(self, "_running", False) or loop is None or loop.is_closed():
-            return False
+            return _refused("gateway_draining")
 
         coro = self._dispatch_plugin_message_injection(
             session_key=session_key,
             content=content,
             plugin_id=plugin_id,
+            correlation_id=correlation_id,
         )
         try:
             current_loop = asyncio.get_running_loop()
@@ -19368,7 +19391,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Plugin message injection scheduling failed",
                     exc_info=True,
                 )
-                return False
+                return _refused("not_scheduled")
             self._background_tasks.add(future)
             future.add_done_callback(self._background_tasks.discard)
         else:
@@ -19380,11 +19403,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 log_level=logging.WARNING,
             )
             if future is None:
-                return False
+                return _refused("not_scheduled")
 
         def _log_result(completed) -> None:
             try:
-                accepted = completed.result()
+                result = completed.result()
             except (asyncio.CancelledError, concurrent.futures.CancelledError):
                 return
             except Exception:
@@ -19395,14 +19418,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc_info=True,
                 )
                 return
-            if not accepted:
+            if not result:
                 logger.warning(
-                    "Plugin message injection was not routed: plugin=%s session=%s",
+                    "Plugin message injection was not routed: plugin=%s session=%s "
+                    "reason=%s",
                     plugin_id,
                     session_key,
+                    getattr(result, "reason", "unknown"),
                 )
 
         future.add_done_callback(_log_result)
+        if await_dispatch:
+            return GatewayInjectionHandle(
+                future,
+                correlation_id=correlation_id,
+                session_key=session_key,
+            )
         return True
 
     async def _dispatch_plugin_message_injection(
@@ -19411,16 +19442,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
         content: str,
         plugin_id: str,
-    ) -> bool:
-        """Route a plugin-triggered turn through the session's live adapter."""
+        correlation_id: str | None = None,
+    ):
+        """Route a plugin-triggered turn through the session's live adapter.
+
+        Returns a ``GatewayInjectionResult``. It is falsy for every refusal, so
+        callers that only cared about the boolean still read correctly.
+        """
+        from hermes_cli.plugins import GatewayInjectionResult
+
+        def _refused(reason: str) -> "GatewayInjectionResult":
+            return GatewayInjectionResult(
+                False,
+                reason,
+                session_key=session_key,
+                correlation_id=correlation_id,
+            )
+
         if not getattr(self, "_running", False) or getattr(self, "_draining", False):
-            return False
+            return _refused("gateway_draining")
 
         entry = await self.async_session_store.lookup_by_session_key(session_key)
         if entry is None or entry.origin is None:
-            return False
+            return _refused("unknown_session")
         if not getattr(self, "_running", False) or getattr(self, "_draining", False):
-            return False
+            return _refused("gateway_draining")
 
         source = dataclasses.replace(entry.origin)
         try:
@@ -19434,7 +19480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     plugin_id,
                     session_key,
                 )
-                return False
+                return _refused("unauthorized")
         except Exception:
             logger.warning(
                 "Plugin message injection authorization check failed: "
@@ -19443,11 +19489,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
                 exc_info=True,
             )
-            return False
+            return _refused("unauthorized")
 
         adapter = self._adapter_for_source(source)
         if adapter is None:
-            return False
+            return _refused("no_adapter")
+
+        metadata = {
+            "hermes_plugin_id": plugin_id,
+            "hermes_plugin_injection": True,
+            "gateway_session_key": session_key,
+            "gateway_session_id": entry.session_id,
+            "gateway_session_strict": True,
+        }
+        if correlation_id is not None:
+            metadata["hermes_plugin_injection_id"] = correlation_id
 
         event = MessageEvent(
             text=content,
@@ -19455,13 +19511,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source=source,
             internal=True,
             allow_gateway_control=False,
-            metadata={
-                "hermes_plugin_id": plugin_id,
-                "hermes_plugin_injection": True,
-                "gateway_session_key": session_key,
-                "gateway_session_id": entry.session_id,
-                "gateway_session_strict": True,
-            },
+            metadata=metadata,
         )
         await adapter.handle_message(event)
         logger.info(
@@ -19470,7 +19520,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key,
             entry.session_id,
         )
-        return True
+        return GatewayInjectionResult(
+            True,
+            "adopted",
+            session_id=entry.session_id,
+            session_key=session_key,
+            correlation_id=correlation_id,
+        )
 
     def _get_cached_session_source(self, session_key: str):
         if not session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19365,6 +19365,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         content: str,
         plugin_id: str,
         correlation_id: str | None = None,
+        delivery=None,
     ):
         """Delegate to :mod:`gateway.plugin_injection`."""
         from gateway.plugin_injection import dispatch_injection
@@ -19375,6 +19376,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             content=content,
             plugin_id=plugin_id,
             correlation_id=correlation_id,
+            delivery=delivery,
         )
 
     def _get_cached_session_source(self, session_key: str):

--- a/hermes_cli/plugin_injection.py
+++ b/hermes_cli/plugin_injection.py
@@ -10,11 +10,20 @@ authority subsystem.
 Settlement law
 --------------
 Every outcome here is either **settled** (a terminal fact: the event was adopted,
-or it was refused before reaching the session) or **indeterminate** (the dispatch
-is still in flight and may yet be adopted). An observation timeout is
-indeterminate, never a refusal: the caller stopped waiting, the host did not stop
-working. Collapsing that into ``accepted=False`` would let a webhook answer
-"failed" and retry a wake that is about to land, delivering it twice.
+or it was refused before reaching the session) or **indeterminate** (delivery is
+unknown and may yet be, or already have been, adopted). Refusal is the strong
+claim, and it is only made when the host can prove the event never crossed into
+``adapter.handle_message``:
+
+* an observation timeout is indeterminate -- the caller stopped waiting, the host
+  did not stop working;
+* cancellation or an adapter exception *after* that boundary is likewise
+  indeterminate, because the adapter may already have run its side effect;
+* cancellation that provably won the race against adapter entry stays a
+  terminal, retry-safe refusal.
+
+Collapsing any of these into a retry-safe ``accepted=False`` would let a webhook
+answer "failed" and re-send a wake that already landed, delivering it twice.
 
 ``correlation_id`` is a bounded opaque tag echoed into the dispatched event's
 metadata so a caller can *recognize* its event. It is deliberately **not** a
@@ -28,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -36,7 +46,9 @@ logger = logging.getLogger(__name__)
 # Reasons a gateway message injection can resolve to. ``adopted`` is the only
 # outcome that means the event reached the stored session. Everything else is a
 # refusal a caller can act on -- except ``timeout``, which is not an outcome at
-# all but the absence of one (see ``INDETERMINATE_REASONS``).
+# all but the absence of one, and ``cancelled``/``internal_error``, which are
+# refusals only while delivery is still disprovable (see ``INDETERMINATE_REASONS``
+# and ``DELIVERY_SENSITIVE_REASONS``).
 GATEWAY_INJECTION_REASONS = (
     "adopted",
     "unknown_session",
@@ -58,9 +70,57 @@ GATEWAY_INJECTION_REASONS = (
 # result carrying one of these is falsy but MUST NOT be read as a denial.
 INDETERMINATE_REASONS = frozenset({"timeout"})
 
+# Reasons whose settlement depends on how far dispatch got. Losing a dispatch to
+# cancellation or an exception is a proven refusal only while the event is still
+# on the host's side of ``adapter.handle_message``; past that boundary the
+# adapter may already have run its side effect, so the outcome is
+# delivery-unknown. See :class:`InjectionDelivery`.
+DELIVERY_SENSITIVE_REASONS = frozenset({"cancelled", "internal_error"})
+
 # Terminal refusals that still cannot be blindly retried, because the event may
 # already have reached the adapter before the failure surfaced.
 _UNSAFE_RETRY_REASONS = frozenset({"internal_error"})
+
+
+class InjectionDelivery:
+    """Tracks the one boundary that makes a refusal provable.
+
+    ``refused`` claims the event will never reach the session. That is only
+    true while dispatch has not entered ``adapter.handle_message``. Both sides
+    of the race arbitrate through this object: dispatch claims the boundary with
+    :meth:`enter_adapter`, a caller reserves cancellation with
+    :meth:`request_cancel`, and whoever gets there second is told it lost.
+    """
+
+    __slots__ = ("_lock", "_adapter_entered", "_cancel_requested")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._adapter_entered = False
+        self._cancel_requested = False
+
+    def enter_adapter(self) -> bool:
+        """Claim the adoption boundary; False when a cancel already won it."""
+        with self._lock:
+            if self._cancel_requested:
+                return False
+            self._adapter_entered = True
+            return True
+
+    def request_cancel(self) -> bool:
+        """Reserve cancellation; False when the adapter already has the event."""
+        with self._lock:
+            if self._adapter_entered:
+                return False
+            self._cancel_requested = True
+            return True
+
+    @property
+    def delivery_unknown(self) -> bool:
+        """Whether the host can no longer prove the event was not delivered."""
+        with self._lock:
+            return self._adapter_entered
+
 
 MAX_INJECTION_CORRELATION_ID = 128
 
@@ -95,7 +155,8 @@ class GatewayInjectionResult:
 
     @property
     def refused(self) -> bool:
-        """A terminal denial: the event will never reach the session."""
+        """A terminal denial: the host proved the event never crossed into the
+        adapter, so it will never reach the session."""
         return self.settled and not self.accepted
 
     @property
@@ -126,7 +187,7 @@ class GatewayInjectionHandle:
     would deliver the wake twice.
     """
 
-    __slots__ = ("_future", "_correlation_id", "_session_key")
+    __slots__ = ("_future", "_correlation_id", "_session_key", "_delivery")
 
     def __init__(
         self,
@@ -134,10 +195,12 @@ class GatewayInjectionHandle:
         *,
         correlation_id: Optional[str] = None,
         session_key: Optional[str] = None,
+        delivery: Optional[InjectionDelivery] = None,
     ) -> None:
         self._future = future
         self._correlation_id = correlation_id
         self._session_key = session_key
+        self._delivery = delivery
 
     @classmethod
     def resolved(cls, result: GatewayInjectionResult) -> "GatewayInjectionHandle":
@@ -160,16 +223,31 @@ class GatewayInjectionHandle:
         return bool(self._future.done())
 
     def cancel(self) -> bool:
-        """Cancel the pending dispatch; a later read reports ``cancelled``."""
+        """Cancel the pending dispatch; a later read reports ``cancelled``.
+
+        Cancelling once the adapter already holds the event does not undo the
+        wake, so the reported outcome becomes delivery-unknown rather than a
+        retry-safe refusal.
+        """
+        if self._delivery is not None:
+            self._delivery.request_cancel()
         return bool(self._future.cancel())
 
     def _failure(self, reason: str) -> GatewayInjectionResult:
+        settled = reason not in INDETERMINATE_REASONS
+        if (
+            settled
+            and reason in DELIVERY_SENSITIVE_REASONS
+            and self._delivery is not None
+            and self._delivery.delivery_unknown
+        ):
+            settled = False
         return GatewayInjectionResult(
             False,
             reason,
             session_key=self._session_key,
             correlation_id=self._correlation_id,
-            settled=reason not in INDETERMINATE_REASONS,
+            settled=settled,
         )
 
     def _coerce(self, value: Any) -> GatewayInjectionResult:

--- a/hermes_cli/plugin_injection.py
+++ b/hermes_cli/plugin_injection.py
@@ -1,0 +1,342 @@
+"""Typed outcomes for plugin-triggered gateway message injection.
+
+``PluginContext.inject_message()`` historically answered ``True`` as soon as a
+dispatch coroutine was *scheduled*, which is indistinguishable from an unknown
+session, a rotated session, revoked authorization, or a missing adapter. This
+module owns the typed contract that lets a caller tell adoption apart from a
+silent drop, so neither the plugin registry nor ``gateway/run.py`` grows another
+authority subsystem.
+
+Settlement law
+--------------
+Every outcome here is either **settled** (a terminal fact: the event was adopted,
+or it was refused before reaching the session) or **indeterminate** (the dispatch
+is still in flight and may yet be adopted). An observation timeout is
+indeterminate, never a refusal: the caller stopped waiting, the host did not stop
+working. Collapsing that into ``accepted=False`` would let a webhook answer
+"failed" and retry a wake that is about to land, delivering it twice.
+
+``correlation_id`` is a bounded opaque tag echoed into the dispatched event's
+metadata so a caller can *recognize* its event. It is deliberately **not** a
+durable idempotency key: nothing in this path deduplicates on it, and two
+injections carrying the same id both reach the session. Retry safety therefore
+comes from :attr:`GatewayInjectionResult.safe_to_retry`, not from the tag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Reasons a gateway message injection can resolve to. ``adopted`` is the only
+# outcome that means the event reached the stored session. Everything else is a
+# refusal a caller can act on -- except ``timeout``, which is not an outcome at
+# all but the absence of one (see ``INDETERMINATE_REASONS``).
+GATEWAY_INJECTION_REASONS = (
+    "adopted",
+    "unknown_session",
+    "unauthorized",
+    "no_adapter",
+    "gateway_draining",
+    "internal_error",
+    "not_scheduled",
+    "injection_denied",
+    "no_gateway",
+    "invalid_request",
+    "unsupported",
+    "cancelled",
+    "timeout",
+    "cli_queued",
+)
+
+# Reasons that describe an unfinished dispatch rather than a decided one. A
+# result carrying one of these is falsy but MUST NOT be read as a denial.
+INDETERMINATE_REASONS = frozenset({"timeout"})
+
+# Terminal refusals that still cannot be blindly retried, because the event may
+# already have reached the adapter before the failure surfaced.
+_UNSAFE_RETRY_REASONS = frozenset({"internal_error"})
+
+MAX_INJECTION_CORRELATION_ID = 128
+
+
+@dataclass(frozen=True)
+class GatewayInjectionResult:
+    """What gateway dispatch decided about one injected message.
+
+    ``accepted`` is truthy only for ``reason == "adopted"``, i.e. the event was
+    handed to the adapter that owns the stored session. ``session_id`` is the
+    host's identity for that session -- never anything the caller supplied.
+
+    ``settled`` distinguishes a decided outcome from an observation that ran out
+    of patience. Read :attr:`refused` before treating a falsy result as denial,
+    and :attr:`safe_to_retry` before re-issuing the injection.
+    """
+
+    accepted: bool
+    reason: str
+    session_id: Optional[str] = None
+    session_key: Optional[str] = None
+    correlation_id: Optional[str] = None
+    settled: bool = True
+
+    def __bool__(self) -> bool:
+        return self.accepted
+
+    @property
+    def indeterminate(self) -> bool:
+        """The dispatch has not resolved; it may still be adopted."""
+        return not self.settled
+
+    @property
+    def refused(self) -> bool:
+        """A terminal denial: the event will never reach the session."""
+        return self.settled and not self.accepted
+
+    @property
+    def safe_to_retry(self) -> bool:
+        """Whether re-issuing this injection cannot duplicate a delivered wake.
+
+        False for anything indeterminate. ``correlation_id`` does not make a
+        retry safe -- it is metadata, not durable idempotent admission -- so an
+        indeterminate result must be reconciled through the originating
+        :class:`GatewayInjectionHandle` instead of blindly re-sent.
+        """
+        return self.refused and self.reason not in _UNSAFE_RETRY_REASONS
+
+
+class GatewayInjectionHandle:
+    """Deferred :class:`GatewayInjectionResult` for an awaited injection.
+
+    Await it on the gateway loop; call :meth:`result` from another thread (the
+    shape a plugin's own HTTP listener needs when it must answer a request only
+    after dispatch resolved). Both paths return a result object rather than
+    raising, so a caller never has to guess whether a failure means "refused" or
+    "crashed".
+
+    The handle is also the **reconciliation path**. When :meth:`result` times
+    out it returns an indeterminate result and leaves the dispatch running; the
+    same handle can be polled with :meth:`settled` or read again with
+    :meth:`result` to learn the eventual outcome. Retrying the injection instead
+    would deliver the wake twice.
+    """
+
+    __slots__ = ("_future", "_correlation_id", "_session_key")
+
+    def __init__(
+        self,
+        future: Any,
+        *,
+        correlation_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> None:
+        self._future = future
+        self._correlation_id = correlation_id
+        self._session_key = session_key
+
+    @classmethod
+    def resolved(cls, result: GatewayInjectionResult) -> "GatewayInjectionHandle":
+        """Wrap an outcome that was decided before anything was scheduled."""
+        future: Any = concurrent.futures.Future()
+        future.set_result(result)
+        return cls(
+            future,
+            correlation_id=result.correlation_id,
+            session_key=result.session_key,
+        )
+
+    @property
+    def correlation_id(self) -> Optional[str]:
+        return self._correlation_id
+
+    @property
+    def settled(self) -> bool:
+        """Whether the eventual outcome is now readable without blocking."""
+        return bool(self._future.done())
+
+    def cancel(self) -> bool:
+        """Cancel the pending dispatch; a later read reports ``cancelled``."""
+        return bool(self._future.cancel())
+
+    def _failure(self, reason: str) -> GatewayInjectionResult:
+        return GatewayInjectionResult(
+            False,
+            reason,
+            session_key=self._session_key,
+            correlation_id=self._correlation_id,
+            settled=reason not in INDETERMINATE_REASONS,
+        )
+
+    def _coerce(self, value: Any) -> GatewayInjectionResult:
+        if isinstance(value, GatewayInjectionResult):
+            return value
+        return self._failure("internal_error")
+
+    async def _resolve(self) -> GatewayInjectionResult:
+        future = self._future
+        if isinstance(future, concurrent.futures.Future):
+            future = asyncio.wrap_future(future)
+        try:
+            return self._coerce(await future)
+        except asyncio.CancelledError:
+            # A cancelled *dispatch* is an outcome; a cancelled *caller* is not.
+            if self._future.cancelled():
+                return self._failure("cancelled")
+            raise
+        except Exception:
+            logger.warning("Gateway injection dispatch failed", exc_info=True)
+            return self._failure("internal_error")
+
+    def __await__(self):
+        return self._resolve().__await__()
+
+    def result(self, timeout: Optional[float] = None) -> GatewayInjectionResult:
+        """Block until dispatch resolves. Never call this on the gateway loop.
+
+        On timeout the dispatch is left running and an *indeterminate* result is
+        returned (``settled=False``, ``refused=False``). Read this handle again
+        to reconcile; do not re-inject.
+        """
+        future = self._future
+        if not isinstance(future, concurrent.futures.Future):
+            raise RuntimeError(
+                "GatewayInjectionHandle.result() would deadlock on the gateway "
+                "loop; await the handle instead"
+            )
+        try:
+            return self._coerce(future.result(timeout))
+        except concurrent.futures.TimeoutError:
+            # Not a refusal: we stopped watching, the dispatch did not stop.
+            return self._failure("timeout")
+        except concurrent.futures.CancelledError:
+            return self._failure("cancelled")
+        except Exception:
+            logger.warning("Gateway injection dispatch failed", exc_info=True)
+            return self._failure("internal_error")
+
+
+def validate_correlation_id(value: Any) -> bool:
+    """Correlation ids are opaque bounded tags, never routing information."""
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= MAX_INJECTION_CORRELATION_ID
+        and value.isprintable()
+    )
+
+
+def submit_to_gateway(
+    manager: Any,
+    *,
+    session_key: str,
+    content: str,
+    plugin_id: str,
+    await_dispatch: bool,
+    correlation_id: Optional[str],
+) -> Any:
+    """Hand an already-authorized injection to the live gateway injector.
+
+    The caller owns the config grant check; this owns only the mechanics of
+    talking to whatever injector the running host published.
+    """
+
+    def _refuse(reason: str) -> Any:
+        result = GatewayInjectionResult(
+            False, reason, session_key=session_key, correlation_id=correlation_id
+        )
+        return GatewayInjectionHandle.resolved(result) if await_dispatch else False
+
+    if not manager.has_gateway_message_injector:
+        logger.warning("inject_message: no live gateway is available")
+        return _refuse("no_gateway")
+
+    kwargs: Dict[str, Any] = {
+        "session_key": session_key,
+        "content": content,
+        "plugin_id": plugin_id,
+    }
+    # Only widen the injector call when the caller asked for the new behavior,
+    # so a host that published the original three-kwarg injector keeps working.
+    extra = [
+        name
+        for name, wanted in (
+            ("await_dispatch", await_dispatch),
+            ("correlation_id", correlation_id is not None),
+        )
+        if wanted
+    ]
+    if extra and not manager.gateway_injector_accepts(*extra):
+        logger.warning(
+            "inject_message: the live gateway injector does not support "
+            "dispatch-outcome reporting for plugin %s",
+            plugin_id,
+        )
+        return _refuse("unsupported")
+    if await_dispatch:
+        kwargs["await_dispatch"] = True
+    if correlation_id is not None:
+        kwargs["correlation_id"] = correlation_id
+
+    try:
+        outcome = manager.inject_gateway_message(**kwargs)
+    except Exception:
+        logger.warning(
+            "inject_message: gateway scheduling failed for plugin %s",
+            plugin_id,
+            exc_info=True,
+        )
+        return _refuse("internal_error")
+
+    if not await_dispatch:
+        return bool(outcome)
+    if isinstance(outcome, GatewayInjectionHandle):
+        return outcome
+    if isinstance(outcome, GatewayInjectionResult):
+        return GatewayInjectionHandle.resolved(outcome)
+    return _refuse("unsupported")
+
+
+# Host-authenticated identity fields, read task-locally so concurrent sessions
+# in one process never observe each other's coordinates.
+_CALL_CONTEXT_FIELDS = {
+    "session_key": "HERMES_SESSION_KEY",
+    "session_id": "HERMES_SESSION_ID",
+    "platform": "HERMES_SESSION_PLATFORM",
+    "source": "HERMES_SESSION_SOURCE",
+    "chat_id": "HERMES_SESSION_CHAT_ID",
+    "chat_type": "HERMES_SESSION_CHAT_TYPE",
+    "chat_name": "HERMES_SESSION_CHAT_NAME",
+    "thread_id": "HERMES_SESSION_THREAD_ID",
+    "user_id": "HERMES_SESSION_USER_ID",
+    "user_name": "HERMES_SESSION_USER_NAME",
+    "scope_id": "HERMES_SESSION_SCOPE_ID",
+    "message_id": "HERMES_SESSION_MESSAGE_ID",
+}
+
+
+def build_call_context(process_profile: str) -> Dict[str, str]:
+    """Identity of the turn that invoked a plugin, as the host knows it.
+
+    ``profile`` follows the same task-local rule as every other field: the
+    session's own ``HERMES_SESSION_PROFILE`` when a session is bound, falling
+    back to the process profile only when nothing is bound (plain CLI, cron,
+    tests). A multiplexed gateway serves several profiles from one process, so
+    reading the process profile while a session is bound would hand a plugin the
+    right chat and the wrong policy domain.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return {"profile": process_profile, **{k: "" for k in _CALL_CONTEXT_FIELDS}}
+
+    context = {
+        key: get_session_env(name, "") for key, name in _CALL_CONTEXT_FIELDS.items()
+    }
+    context["profile"] = (
+        get_session_env("HERMES_SESSION_PROFILE", "") or process_profile
+    )
+    return context

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1455,153 +1455,20 @@ class PluginState:
             atomic_json_write(self.path, data, mode=0o600)
 
 
-# Reasons a gateway message injection can resolve to. ``adopted`` is the only
-# outcome that means the event reached the stored session; every other value is
-# a refusal a caller can act on instead of a silent drop.
-GATEWAY_INJECTION_REASONS = (
-    "adopted",
-    "unknown_session",
-    "unauthorized",
-    "no_adapter",
-    "gateway_draining",
-    "internal_error",
-    "not_scheduled",
-    "injection_denied",
-    "no_gateway",
-    "invalid_request",
-    "unsupported",
-    "cancelled",
-    "timeout",
-    "cli_queued",
+# The typed injection contract lives in its own module so neither this registry
+# nor gateway/run.py grows another authority subsystem. Re-exported here because
+# plugins import it from the same place they import PluginContext.
+from hermes_cli.plugin_injection import (  # noqa: E402
+    GATEWAY_INJECTION_REASONS,
+    INDETERMINATE_REASONS,
+    MAX_INJECTION_CORRELATION_ID,
+    GatewayInjectionHandle,
+    GatewayInjectionResult,
+    build_call_context,
+    submit_to_gateway,
+    validate_correlation_id,
 )
 
-_MAX_INJECTION_CORRELATION_ID = 128
-
-
-@dataclass(frozen=True)
-class GatewayInjectionResult:
-    """What gateway dispatch decided about one injected message.
-
-    ``accepted`` is truthy only for ``reason == "adopted"``, i.e. the event was
-    handed to the adapter that owns the stored session. ``session_id`` is the
-    host's identity for that session -- never anything the caller supplied.
-    """
-
-    accepted: bool
-    reason: str
-    session_id: Optional[str] = None
-    session_key: Optional[str] = None
-    correlation_id: Optional[str] = None
-
-    def __bool__(self) -> bool:
-        return self.accepted
-
-
-class GatewayInjectionHandle:
-    """Deferred :class:`GatewayInjectionResult` for an awaited injection.
-
-    Await it on the gateway loop; call :meth:`result` from another thread (the
-    shape a plugin's own HTTP listener needs when it must answer a request only
-    after dispatch resolved). Both paths return a result object rather than
-    raising, so a caller never has to guess whether a failure means "refused"
-    or "crashed".
-    """
-
-    __slots__ = ("_future", "_correlation_id", "_session_key")
-
-    def __init__(
-        self,
-        future: Any,
-        *,
-        correlation_id: Optional[str] = None,
-        session_key: Optional[str] = None,
-    ) -> None:
-        self._future = future
-        self._correlation_id = correlation_id
-        self._session_key = session_key
-
-    @classmethod
-    def resolved(cls, result: GatewayInjectionResult) -> "GatewayInjectionHandle":
-        """Wrap an outcome that was decided before anything was scheduled."""
-        import concurrent.futures
-
-        future: Any = concurrent.futures.Future()
-        future.set_result(result)
-        return cls(
-            future,
-            correlation_id=result.correlation_id,
-            session_key=result.session_key,
-        )
-
-    @property
-    def correlation_id(self) -> Optional[str]:
-        return self._correlation_id
-
-    def cancel(self) -> bool:
-        """Cancel the pending dispatch; a later read reports ``cancelled``."""
-        return bool(self._future.cancel())
-
-    def _failure(self, reason: str) -> GatewayInjectionResult:
-        return GatewayInjectionResult(
-            False,
-            reason,
-            session_key=self._session_key,
-            correlation_id=self._correlation_id,
-        )
-
-    def _coerce(self, value: Any) -> GatewayInjectionResult:
-        if isinstance(value, GatewayInjectionResult):
-            return value
-        return self._failure("internal_error")
-
-    async def _resolve(self) -> GatewayInjectionResult:
-        import concurrent.futures
-
-        future = self._future
-        if isinstance(future, concurrent.futures.Future):
-            future = asyncio.wrap_future(future)
-        try:
-            return self._coerce(await future)
-        except asyncio.CancelledError:
-            # A cancelled *dispatch* is an outcome; a cancelled *caller* is not.
-            if self._future.cancelled():
-                return self._failure("cancelled")
-            raise
-        except Exception:
-            logger.warning("Gateway injection dispatch failed", exc_info=True)
-            return self._failure("internal_error")
-
-    def __await__(self):
-        return self._resolve().__await__()
-
-    def result(self, timeout: Optional[float] = None) -> GatewayInjectionResult:
-        """Block until dispatch resolves. Never call this on the gateway loop."""
-        import concurrent.futures
-
-        future = self._future
-        if not isinstance(future, concurrent.futures.Future):
-            raise RuntimeError(
-                "GatewayInjectionHandle.result() would deadlock on the gateway "
-                "loop; await the handle instead"
-            )
-        try:
-            return self._coerce(future.result(timeout))
-        except concurrent.futures.TimeoutError:
-            return self._failure("timeout")
-        except concurrent.futures.CancelledError:
-            return self._failure("cancelled")
-        except Exception:
-            logger.warning("Gateway injection dispatch failed", exc_info=True)
-            return self._failure("internal_error")
-
-
-def _validate_injection_correlation_id(value: Any) -> bool:
-    """Correlation ids are opaque bounded tags, never routing information."""
-    return (
-        isinstance(value, str)
-        and 0 < len(value) <= _MAX_INJECTION_CORRELATION_ID
-        and value.isprintable()
-    )
 
 
 class PluginContext:
@@ -2240,13 +2107,11 @@ class PluginContext:
             )
             return GatewayInjectionHandle.resolved(result) if await_dispatch else False
 
-        if correlation_id is not None and not _validate_injection_correlation_id(
-            correlation_id
-        ):
+        if correlation_id is not None and not validate_correlation_id(correlation_id):
             logger.warning(
                 "inject_message: correlation_id must be printable text of at "
                 "most %d characters",
-                _MAX_INJECTION_CORRELATION_ID,
+                MAX_INJECTION_CORRELATION_ID,
             )
             return _refuse("invalid_request")
 
@@ -2281,52 +2146,14 @@ class PluginContext:
             )
             return _refuse("injection_denied")
 
-        if not self._manager.has_gateway_message_injector:
-            logger.warning("inject_message: no live gateway is available")
-            return _refuse("no_gateway")
-
-        plugin_id = self.manifest.key or self.manifest.name
-        kwargs: Dict[str, Any] = {
-            "session_key": session_key,
-            "content": msg,
-            "plugin_id": plugin_id,
-        }
-        # Only widen the injector call when the caller asked for the new
-        # behavior, so a host that published the original three-kwarg injector
-        # keeps working unchanged.
-        extra = []
-        if await_dispatch:
-            extra.append("await_dispatch")
-        if correlation_id is not None:
-            extra.append("correlation_id")
-        if extra and not self._manager.gateway_injector_accepts(*extra):
-            logger.warning(
-                "inject_message: the live gateway injector does not support "
-                "dispatch-outcome reporting for plugin %s",
-                plugin_id,
-            )
-            return _refuse("unsupported")
-        if await_dispatch:
-            kwargs["await_dispatch"] = True
-        if correlation_id is not None:
-            kwargs["correlation_id"] = correlation_id
-        try:
-            outcome = self._manager.inject_gateway_message(**kwargs)
-        except Exception:
-            logger.warning(
-                "inject_message: gateway scheduling failed for plugin %s",
-                plugin_id,
-                exc_info=True,
-            )
-            return _refuse("internal_error")
-
-        if not await_dispatch:
-            return bool(outcome)
-        if isinstance(outcome, GatewayInjectionHandle):
-            return outcome
-        if isinstance(outcome, GatewayInjectionResult):
-            return GatewayInjectionHandle.resolved(outcome)
-        return _refuse("unsupported")
+        return submit_to_gateway(
+            self._manager,
+            session_key=session_key,
+            content=msg,
+            plugin_id=self.manifest.key or self.manifest.name,
+            await_dispatch=await_dispatch,
+            correlation_id=correlation_id,
+        )
 
     # -- host-authenticated call context -------------------------------------
 
@@ -2337,8 +2164,9 @@ class PluginContext:
         Tool handlers receive only what the model wrote into the arguments, so
         anything a plugin must *trust* has to come from here instead. Values
         are bound per asyncio task by the gateway, so concurrent sessions in
-        one process never read each other's identity. Every field is ``""``
-        when no session is bound (plain CLI, cron, tests).
+        one process never read each other's identity -- ``profile`` included.
+        Every field is ``""`` when no session is bound (plain CLI, cron,
+        tests), and ``profile`` then falls back to the process profile.
 
         The mapping is a fresh copy on each read; mutating it changes nothing.
 
@@ -2346,28 +2174,7 @@ class PluginContext:
         operator-approval receipt. An action that requires "a human approved
         this" cannot be authorized from this context and must fail closed.
         """
-        fields = {
-            "session_key": "HERMES_SESSION_KEY",
-            "session_id": "HERMES_SESSION_ID",
-            "platform": "HERMES_SESSION_PLATFORM",
-            "source": "HERMES_SESSION_SOURCE",
-            "chat_id": "HERMES_SESSION_CHAT_ID",
-            "chat_type": "HERMES_SESSION_CHAT_TYPE",
-            "chat_name": "HERMES_SESSION_CHAT_NAME",
-            "thread_id": "HERMES_SESSION_THREAD_ID",
-            "user_id": "HERMES_SESSION_USER_ID",
-            "user_name": "HERMES_SESSION_USER_NAME",
-            "scope_id": "HERMES_SESSION_SCOPE_ID",
-            "message_id": "HERMES_SESSION_MESSAGE_ID",
-        }
-        try:
-            from gateway.session_context import get_session_env
-        except Exception:
-            return {"profile": self.profile_name, **{k: "" for k in fields}}
-
-        context = {key: get_session_env(name, "") for key, name in fields.items()}
-        context["profile"] = self.profile_name
-        return context
+        return build_call_context(self.profile_name)
 
     def _gateway_injection_allowed(self) -> bool:
         """Return whether this plugin may trigger gateway session turns."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1459,16 +1459,17 @@ class PluginState:
 # nor gateway/run.py grows another authority subsystem. Re-exported here because
 # plugins import it from the same place they import PluginContext.
 from hermes_cli.plugin_injection import (  # noqa: E402
+    DELIVERY_SENSITIVE_REASONS,
     GATEWAY_INJECTION_REASONS,
     INDETERMINATE_REASONS,
     MAX_INJECTION_CORRELATION_ID,
     GatewayInjectionHandle,
     GatewayInjectionResult,
+    InjectionDelivery,
     build_call_context,
     submit_to_gateway,
     validate_correlation_id,
 )
-
 
 
 class PluginContext:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1455,6 +1455,155 @@ class PluginState:
             atomic_json_write(self.path, data, mode=0o600)
 
 
+# Reasons a gateway message injection can resolve to. ``adopted`` is the only
+# outcome that means the event reached the stored session; every other value is
+# a refusal a caller can act on instead of a silent drop.
+GATEWAY_INJECTION_REASONS = (
+    "adopted",
+    "unknown_session",
+    "unauthorized",
+    "no_adapter",
+    "gateway_draining",
+    "internal_error",
+    "not_scheduled",
+    "injection_denied",
+    "no_gateway",
+    "invalid_request",
+    "unsupported",
+    "cancelled",
+    "timeout",
+    "cli_queued",
+)
+
+_MAX_INJECTION_CORRELATION_ID = 128
+
+
+@dataclass(frozen=True)
+class GatewayInjectionResult:
+    """What gateway dispatch decided about one injected message.
+
+    ``accepted`` is truthy only for ``reason == "adopted"``, i.e. the event was
+    handed to the adapter that owns the stored session. ``session_id`` is the
+    host's identity for that session -- never anything the caller supplied.
+    """
+
+    accepted: bool
+    reason: str
+    session_id: Optional[str] = None
+    session_key: Optional[str] = None
+    correlation_id: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return self.accepted
+
+
+class GatewayInjectionHandle:
+    """Deferred :class:`GatewayInjectionResult` for an awaited injection.
+
+    Await it on the gateway loop; call :meth:`result` from another thread (the
+    shape a plugin's own HTTP listener needs when it must answer a request only
+    after dispatch resolved). Both paths return a result object rather than
+    raising, so a caller never has to guess whether a failure means "refused"
+    or "crashed".
+    """
+
+    __slots__ = ("_future", "_correlation_id", "_session_key")
+
+    def __init__(
+        self,
+        future: Any,
+        *,
+        correlation_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> None:
+        self._future = future
+        self._correlation_id = correlation_id
+        self._session_key = session_key
+
+    @classmethod
+    def resolved(cls, result: GatewayInjectionResult) -> "GatewayInjectionHandle":
+        """Wrap an outcome that was decided before anything was scheduled."""
+        import concurrent.futures
+
+        future: Any = concurrent.futures.Future()
+        future.set_result(result)
+        return cls(
+            future,
+            correlation_id=result.correlation_id,
+            session_key=result.session_key,
+        )
+
+    @property
+    def correlation_id(self) -> Optional[str]:
+        return self._correlation_id
+
+    def cancel(self) -> bool:
+        """Cancel the pending dispatch; a later read reports ``cancelled``."""
+        return bool(self._future.cancel())
+
+    def _failure(self, reason: str) -> GatewayInjectionResult:
+        return GatewayInjectionResult(
+            False,
+            reason,
+            session_key=self._session_key,
+            correlation_id=self._correlation_id,
+        )
+
+    def _coerce(self, value: Any) -> GatewayInjectionResult:
+        if isinstance(value, GatewayInjectionResult):
+            return value
+        return self._failure("internal_error")
+
+    async def _resolve(self) -> GatewayInjectionResult:
+        import concurrent.futures
+
+        future = self._future
+        if isinstance(future, concurrent.futures.Future):
+            future = asyncio.wrap_future(future)
+        try:
+            return self._coerce(await future)
+        except asyncio.CancelledError:
+            # A cancelled *dispatch* is an outcome; a cancelled *caller* is not.
+            if self._future.cancelled():
+                return self._failure("cancelled")
+            raise
+        except Exception:
+            logger.warning("Gateway injection dispatch failed", exc_info=True)
+            return self._failure("internal_error")
+
+    def __await__(self):
+        return self._resolve().__await__()
+
+    def result(self, timeout: Optional[float] = None) -> GatewayInjectionResult:
+        """Block until dispatch resolves. Never call this on the gateway loop."""
+        import concurrent.futures
+
+        future = self._future
+        if not isinstance(future, concurrent.futures.Future):
+            raise RuntimeError(
+                "GatewayInjectionHandle.result() would deadlock on the gateway "
+                "loop; await the handle instead"
+            )
+        try:
+            return self._coerce(future.result(timeout))
+        except concurrent.futures.TimeoutError:
+            return self._failure("timeout")
+        except concurrent.futures.CancelledError:
+            return self._failure("cancelled")
+        except Exception:
+            logger.warning("Gateway injection dispatch failed", exc_info=True)
+            return self._failure("internal_error")
+
+
+def _validate_injection_correlation_id(value: Any) -> bool:
+    """Correlation ids are opaque bounded tags, never routing information."""
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= _MAX_INJECTION_CORRELATION_ID
+        and value.isprintable()
+    )
+
+
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
 
@@ -2049,7 +2198,9 @@ class PluginContext:
         role: str = "user",
         *,
         session_key: str | None = None,
-    ) -> bool:
+        await_dispatch: bool = False,
+        correlation_id: str | None = None,
+    ) -> Any:
         """Inject a message into a CLI or gateway conversation.
 
         If the agent is idle (waiting for user input), this starts a new turn.
@@ -2060,13 +2211,44 @@ class PluginContext:
 
         Gateway injection requires an existing ``session_key`` and an explicit
         ``plugins.entries.<plugin_id>.allow_gateway_injection`` config grant.
-        A ``True`` return means the live gateway accepted the request for
-        asynchronous dispatch, not that platform delivery has completed.
 
-        Returns True if the message was queued successfully.
+        By default this returns ``True`` once the live gateway *accepted the
+        request for asynchronous dispatch* -- which cannot be distinguished
+        from an unknown session, a rotated session, revoked authorization, or a
+        missing adapter, all of which are only discovered later and logged.
+
+        Pass ``await_dispatch=True`` to get a :class:`GatewayInjectionHandle`
+        instead: await it (or call ``.result(timeout=...)`` off the gateway
+        loop) for a :class:`GatewayInjectionResult` naming what dispatch
+        actually decided, plus the host's ``session_id`` for the session that
+        received it. The default remains non-awaiting and unchanged.
+
+        ``correlation_id`` is an optional bounded opaque tag stamped onto the
+        dispatched event's metadata and echoed back in the result, so a caller
+        can prove *this* event reached *that* session. It is never routing
+        information: the route always comes from the stored session.
         """
         cli = self._manager._cli_ref
         msg = content if role == "user" else f"[{role}] {content}"
+
+        def _refuse(reason: str) -> Any:
+            result = GatewayInjectionResult(
+                False,
+                reason,
+                session_key=session_key,
+                correlation_id=correlation_id,
+            )
+            return GatewayInjectionHandle.resolved(result) if await_dispatch else False
+
+        if correlation_id is not None and not _validate_injection_correlation_id(
+            correlation_id
+        ):
+            logger.warning(
+                "inject_message: correlation_id must be printable text of at "
+                "most %d characters",
+                _MAX_INJECTION_CORRELATION_ID,
+            )
+            return _refuse("invalid_request")
 
         if cli is not None:
             if getattr(cli, "_agent_running", False):
@@ -2075,13 +2257,20 @@ class PluginContext:
             else:
                 # Agent is idle - queue as next input
                 cli._pending_input.put(msg)
+            if await_dispatch:
+                # CLI injection has no gateway dispatch stage to report on.
+                return GatewayInjectionHandle.resolved(
+                    GatewayInjectionResult(
+                        True, "cli_queued", correlation_id=correlation_id
+                    )
+                )
             return True
 
         if not session_key:
             logger.warning(
                 "inject_message: gateway mode requires an existing session_key"
             )
-            return False
+            return _refuse("invalid_request")
         if not self._gateway_injection_allowed():
             plugin_id = self.manifest.key or self.manifest.name
             logger.warning(
@@ -2090,28 +2279,95 @@ class PluginContext:
                 plugin_id,
                 plugin_id,
             )
-            return False
+            return _refuse("injection_denied")
 
         if not self._manager.has_gateway_message_injector:
             logger.warning("inject_message: no live gateway is available")
-            return False
+            return _refuse("no_gateway")
 
         plugin_id = self.manifest.key or self.manifest.name
-        try:
-            return bool(
-                self._manager.inject_gateway_message(
-                    session_key=session_key,
-                    content=msg,
-                    plugin_id=plugin_id,
-                )
+        kwargs: Dict[str, Any] = {
+            "session_key": session_key,
+            "content": msg,
+            "plugin_id": plugin_id,
+        }
+        # Only widen the injector call when the caller asked for the new
+        # behavior, so a host that published the original three-kwarg injector
+        # keeps working unchanged.
+        extra = []
+        if await_dispatch:
+            extra.append("await_dispatch")
+        if correlation_id is not None:
+            extra.append("correlation_id")
+        if extra and not self._manager.gateway_injector_accepts(*extra):
+            logger.warning(
+                "inject_message: the live gateway injector does not support "
+                "dispatch-outcome reporting for plugin %s",
+                plugin_id,
             )
+            return _refuse("unsupported")
+        if await_dispatch:
+            kwargs["await_dispatch"] = True
+        if correlation_id is not None:
+            kwargs["correlation_id"] = correlation_id
+        try:
+            outcome = self._manager.inject_gateway_message(**kwargs)
         except Exception:
             logger.warning(
                 "inject_message: gateway scheduling failed for plugin %s",
                 plugin_id,
                 exc_info=True,
             )
-            return False
+            return _refuse("internal_error")
+
+        if not await_dispatch:
+            return bool(outcome)
+        if isinstance(outcome, GatewayInjectionHandle):
+            return outcome
+        if isinstance(outcome, GatewayInjectionResult):
+            return GatewayInjectionHandle.resolved(outcome)
+        return _refuse("unsupported")
+
+    # -- host-authenticated call context -------------------------------------
+
+    @property
+    def call_context(self) -> Dict[str, str]:
+        """Identity of the turn that invoked this plugin, as the host knows it.
+
+        Tool handlers receive only what the model wrote into the arguments, so
+        anything a plugin must *trust* has to come from here instead. Values
+        are bound per asyncio task by the gateway, so concurrent sessions in
+        one process never read each other's identity. Every field is ``""``
+        when no session is bound (plain CLI, cron, tests).
+
+        The mapping is a fresh copy on each read; mutating it changes nothing.
+
+        Note what is deliberately absent: there is no host-authenticated
+        operator-approval receipt. An action that requires "a human approved
+        this" cannot be authorized from this context and must fail closed.
+        """
+        fields = {
+            "session_key": "HERMES_SESSION_KEY",
+            "session_id": "HERMES_SESSION_ID",
+            "platform": "HERMES_SESSION_PLATFORM",
+            "source": "HERMES_SESSION_SOURCE",
+            "chat_id": "HERMES_SESSION_CHAT_ID",
+            "chat_type": "HERMES_SESSION_CHAT_TYPE",
+            "chat_name": "HERMES_SESSION_CHAT_NAME",
+            "thread_id": "HERMES_SESSION_THREAD_ID",
+            "user_id": "HERMES_SESSION_USER_ID",
+            "user_name": "HERMES_SESSION_USER_NAME",
+            "scope_id": "HERMES_SESSION_SCOPE_ID",
+            "message_id": "HERMES_SESSION_MESSAGE_ID",
+        }
+        try:
+            from gateway.session_context import get_session_env
+        except Exception:
+            return {"profile": self.profile_name, **{k: "" for k in fields}}
+
+        context = {key: get_session_env(name, "") for key, name in fields.items()}
+        context["profile"] = self.profile_name
+        return context
 
     def _gateway_injection_allowed(self) -> bool:
         """Return whether this plugin may trigger gateway session turns."""
@@ -4206,12 +4462,38 @@ class PluginManager:
         if registered is not None and registered[0] is owner:
             self._gateway_message_injector = None
 
-    def inject_gateway_message(self, **kwargs: Any) -> bool:
-        """Submit a plugin-triggered turn to the live gateway."""
+    def gateway_injector_accepts(self, *names: str) -> bool:
+        """Whether the live injector accepts these keyword arguments.
+
+        Lets a caller fall back cleanly instead of relying on a ``TypeError``,
+        which would also swallow a genuine ``TypeError`` from inside a
+        correctly-shaped injector.
+        """
         registered = self._gateway_message_injector
         if registered is None:
             return False
-        return bool(registered[1](**kwargs))
+        try:
+            parameters = inspect.signature(registered[1]).parameters
+        except (TypeError, ValueError):
+            return False
+        if any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        ):
+            return True
+        return all(name in parameters for name in names)
+
+    def inject_gateway_message(self, **kwargs: Any) -> Any:
+        """Submit a plugin-triggered turn to the live gateway.
+
+        Returns whatever the registered injector returned: a bool for the
+        default fire-and-forget call, or a ``GatewayInjectionHandle`` when the
+        caller passed ``await_dispatch=True``.
+        """
+        registered = self._gateway_message_injector
+        if registered is None:
+            return False
+        return registered[1](**kwargs)
 
     def discover_and_load(self, force: bool = False) -> None:
         """Scan all plugin sources and load each plugin found.

--- a/tests/gateway/test_plugin_injection_dispatch_result.py
+++ b/tests/gateway/test_plugin_injection_dispatch_result.py
@@ -325,14 +325,23 @@ async def test_await_dispatch_reports_internal_dispatch_failure():
 
 
 @pytest.mark.asyncio
-async def test_await_dispatch_reports_a_cancelled_dispatch():
-    started = asyncio.Event()
+async def test_cancel_after_adapter_entry_cannot_claim_refusal_or_safe_retry():
+    """Once the adapter holds the event, non-delivery is no longer provable.
 
-    async def _slow(_event):
-        started.set()
-        await asyncio.sleep(30)
+    The adapter records its side effect before its next cancellation point, so a
+    cancel landing here may have interrupted a wake that already happened.
+    Reporting that as a retry-safe refusal is how the same wake gets delivered
+    twice.
+    """
+    delivered: list = []
+    entered = asyncio.Event()
 
-    adapter = SimpleNamespace(handle_message=_slow)
+    async def _blocking(event):
+        delivered.append(event)
+        entered.set()
+        await asyncio.Event().wait()
+
+    adapter = SimpleNamespace(handle_message=_blocking)
     loop = asyncio.get_running_loop()
     runner = _runner(_entry(), adapter, loop=loop)
 
@@ -342,12 +351,80 @@ async def test_await_dispatch_reports_a_cancelled_dispatch():
         plugin_id="wake-plugin",
         await_dispatch=True,
     )
-    await started.wait()
+    await entered.wait()
     handle.cancel()
     result = await handle
 
+    assert delivered, "the adapter side effect ran before cancellation"
     assert result.accepted is False
     assert result.reason == "cancelled"
+    assert result.settled is False
+    assert result.indeterminate is True
+    assert result.refused is False
+    assert result.safe_to_retry is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_adapter_entry_is_a_settled_retry_safe_refusal():
+    """Cancellation that provably wins the race is still a terminal refusal."""
+    looked_up = asyncio.Event()
+    hold = asyncio.Event()
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+
+    async def _blocked_lookup(_session_key):
+        looked_up.set()
+        await hold.wait()
+        return _entry()
+
+    runner._async_session_store.lookup_by_session_key = _blocked_lookup
+
+    handle = runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+    await looked_up.wait()
+    assert handle.cancel() is True
+    result = await handle
+
+    adapter.handle_message.assert_not_awaited()
+    assert result.accepted is False
+    assert result.reason == "cancelled"
+    assert result.settled is True
+    assert result.refused is True
+    assert result.safe_to_retry is True
+
+
+@pytest.mark.asyncio
+async def test_adapter_raising_after_a_side_effect_preserves_unknown_delivery():
+    """An adapter can deliver and then blow up; that is not a proven refusal."""
+    delivered: list = []
+
+    async def _explode(event):
+        delivered.append(event)
+        raise RuntimeError("adapter exploded after its side effect")
+
+    adapter = SimpleNamespace(handle_message=_explode)
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+
+    result = await runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+
+    assert delivered, "the adapter side effect ran before the exception"
+    assert result.accepted is False
+    assert result.reason == "internal_error"
+    assert result.settled is False
+    assert result.indeterminate is True
+    assert result.refused is False
+    assert result.safe_to_retry is False
 
 
 def test_await_dispatch_result_is_blocking_readable_from_another_thread():
@@ -697,13 +774,19 @@ async def test_correlation_id_is_metadata_not_idempotent_admission():
 def test_every_declared_reason_is_classified():
     """No reason may be silently unclassified as settled or indeterminate."""
     from hermes_cli.plugin_injection import (
+        DELIVERY_SENSITIVE_REASONS,
         GATEWAY_INJECTION_REASONS,
         INDETERMINATE_REASONS,
     )
 
     assert INDETERMINATE_REASONS <= set(GATEWAY_INJECTION_REASONS)
-    # Only an unfinished observation is indeterminate; everything else decided.
+    # Only an unfinished observation is unconditionally indeterminate.
     assert INDETERMINATE_REASONS == {"timeout"}
+    # These two settle only when the host can prove the adapter never got the
+    # event; after that boundary they become delivery-unknown.
+    assert DELIVERY_SENSITIVE_REASONS <= set(GATEWAY_INJECTION_REASONS)
+    assert DELIVERY_SENSITIVE_REASONS == {"cancelled", "internal_error"}
+    assert not (DELIVERY_SENSITIVE_REASONS & INDETERMINATE_REASONS)
     for reason in GATEWAY_INJECTION_REASONS:
         result = GatewayInjectionResult(
             reason in ("adopted", "cli_queued"),

--- a/tests/gateway/test_plugin_injection_dispatch_result.py
+++ b/tests/gateway/test_plugin_injection_dispatch_result.py
@@ -1,0 +1,577 @@
+"""Dispatch-outcome reporting for plugin-triggered gateway turns.
+
+``inject_message()`` returns ``True`` as soon as the dispatch coroutine is
+scheduled, which is indistinguishable from an unknown session, a rotated
+session, revoked authorization, or a missing adapter -- all of which answer
+``True`` and then silently drop the message. These tests pin the optional
+``await_dispatch`` path that reports what dispatch actually decided.
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+from hermes_cli.plugins import (
+    GatewayInjectionResult,
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
+
+SESSION_KEY = "agent:main:telegram:dm:42"
+
+
+def _entry(*, origin=True) -> SessionEntry:
+    source = None
+    if origin:
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+            user_id="42",
+            user_name="tester",
+        )
+    now = datetime.now()
+    return SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="session-42",
+        created_at=now,
+        updated_at=now,
+        origin=source,
+        platform=Platform.TELEGRAM,
+    )
+
+
+def _runner(entry, adapter=None, *, loop=None) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = SimpleNamespace()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        lookup_by_session_key=AsyncMock(return_value=entry),
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter} if adapter else {}
+    runner._profile_adapters = {}
+    runner._running = True
+    runner._draining = False
+    runner._background_tasks = set()
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._gateway_loop = loop
+    return runner
+
+
+def _context(manager: PluginManager) -> PluginContext:
+    return PluginContext(
+        PluginManifest(name="wake-plugin", key="wake-plugin", source="user"),
+        manager,
+    )
+
+
+def _grant_injection(tmp_path, monkeypatch) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"plugins": {"entries": {"wake-plugin": {"allow_gateway_injection": True}}}}
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level outcomes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_adopted_with_stored_session_identity():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    runner = _runner(entry, adapter)
+
+    result = await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="read the ledger",
+        plugin_id="wake-plugin",
+        correlation_id="evt-1",
+    )
+
+    assert isinstance(result, GatewayInjectionResult)
+    assert result.accepted is True
+    assert result.reason == "adopted"
+    assert result.session_id == entry.session_id
+    assert result.session_key == SESSION_KEY
+    assert result.correlation_id == "evt-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry", "with_adapter", "expected"),
+    [
+        (None, True, "unknown_session"),
+        (_entry(origin=False), True, "unknown_session"),
+        (_entry(), False, "no_adapter"),
+    ],
+)
+async def test_dispatch_names_each_unroutable_reason(entry, with_adapter, expected):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(entry, adapter if with_adapter else None)
+
+    result = await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    assert result.accepted is False
+    assert result.reason == expected
+    assert result.session_key == SESSION_KEY
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_names_unauthorized_separately_from_unknown_session():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+    runner._is_user_authorized = MagicMock(return_value=False)
+
+    result = await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    assert result.accepted is False
+    assert result.reason == "unauthorized"
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_names_unauthorized_when_the_check_itself_raises():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+    runner._is_user_authorized = MagicMock(side_effect=RuntimeError("allowlist down"))
+
+    result = await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    assert result.accepted is False
+    assert result.reason == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_names_gateway_draining():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+    runner._draining = True
+
+    result = await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    assert result.accepted is False
+    assert result.reason == "gateway_draining"
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_is_stamped_on_the_dispatched_event():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    runner = _runner(entry, adapter)
+
+    await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        correlation_id="evt-7",
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.metadata["hermes_plugin_injection_id"] == "evt-7"
+    assert event.metadata["gateway_session_id"] == entry.session_id
+    assert event.metadata["gateway_session_strict"] is True
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_absent_keeps_the_existing_metadata_shape():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    runner = _runner(entry, adapter)
+
+    await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.metadata == {
+        "hermes_plugin_id": "wake-plugin",
+        "hermes_plugin_injection": True,
+        "gateway_session_key": SESSION_KEY,
+        "gateway_session_id": entry.session_id,
+        "gateway_session_strict": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_never_becomes_a_route():
+    """A caller-supplied tag must not displace the host-resolved origin."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    runner = _runner(entry, adapter)
+
+    await runner._dispatch_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        correlation_id="telegram:dm:999",
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source == entry.origin
+    assert event.source is not entry.origin
+    assert event.source.chat_id == "42"
+
+
+# ---------------------------------------------------------------------------
+# Scheduling-level contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_scheduling_still_returns_a_plain_bool():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+
+    scheduled = runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+    )
+
+    assert scheduled is True
+    await asyncio.gather(*list(runner._background_tasks), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_await_dispatch_returns_an_awaitable_result_handle():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    loop = asyncio.get_running_loop()
+    runner = _runner(entry, adapter, loop=loop)
+
+    handle = runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+        correlation_id="evt-9",
+    )
+    result = await handle
+
+    assert result.accepted is True
+    assert result.reason == "adopted"
+    assert result.session_id == entry.session_id
+    assert result.correlation_id == "evt-9"
+
+
+@pytest.mark.asyncio
+async def test_await_dispatch_reports_a_dead_gateway_without_scheduling():
+    runner = _runner(_entry(), SimpleNamespace(handle_message=AsyncMock()), loop=None)
+
+    result = await runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "gateway_draining"
+
+
+@pytest.mark.asyncio
+async def test_await_dispatch_reports_internal_dispatch_failure():
+    adapter = SimpleNamespace(
+        handle_message=AsyncMock(side_effect=RuntimeError("adapter exploded"))
+    )
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+
+    result = await runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "internal_error"
+
+
+@pytest.mark.asyncio
+async def test_await_dispatch_reports_a_cancelled_dispatch():
+    started = asyncio.Event()
+
+    async def _slow(_event):
+        started.set()
+        await asyncio.sleep(30)
+
+    adapter = SimpleNamespace(handle_message=_slow)
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+
+    handle = runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+    await started.wait()
+    handle.cancel()
+    result = await handle
+
+    assert result.accepted is False
+    assert result.reason == "cancelled"
+
+
+def test_await_dispatch_result_is_blocking_readable_from_another_thread():
+    """The webhook edge answering an HTTP request runs off the gateway loop."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    ready = threading.Event()
+    holder: dict = {}
+
+    async def _serve():
+        loop = asyncio.get_running_loop()
+        runner = _runner(entry, adapter, loop=loop)
+        runner._install_plugin_message_injector = None  # unused here
+        holder["runner"] = runner
+        ready.set()
+        await asyncio.sleep(1.5)
+
+    thread = threading.Thread(
+        target=lambda: asyncio.run(_serve()),
+        daemon=True,
+    )
+    thread.start()
+    ready.wait(5)
+    runner = holder["runner"]
+
+    handle = runner._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+        correlation_id="evt-thread",
+    )
+    result = handle.result(timeout=5)
+    thread.join(timeout=5)
+
+    assert result.accepted is True
+    assert result.reason == "adopted"
+    assert result.correlation_id == "evt-thread"
+
+
+def test_blocking_result_reports_timeout_rather_than_raising():
+    entry = _entry()
+    ready = threading.Event()
+    holder: dict = {}
+
+    async def _slow(_event):
+        await asyncio.sleep(10)
+
+    async def _serve():
+        loop = asyncio.get_running_loop()
+        holder["runner"] = _runner(
+            entry, SimpleNamespace(handle_message=_slow), loop=loop
+        )
+        ready.set()
+        await asyncio.sleep(2)
+
+    thread = threading.Thread(target=lambda: asyncio.run(_serve()), daemon=True)
+    thread.start()
+    ready.wait(5)
+
+    handle = holder["runner"]._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+    )
+    result = handle.result(timeout=0.2)
+    thread.join(timeout=5)
+
+    assert result.accepted is False
+    assert result.reason == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# PluginContext surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_await_dispatch_surfaces_adoption(tmp_path, monkeypatch):
+    _grant_injection(tmp_path, monkeypatch)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    entry = _entry()
+    loop = asyncio.get_running_loop()
+    runner = _runner(entry, adapter, loop=loop)
+    manager = PluginManager()
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        runner._install_plugin_message_injector()
+        context = _context(manager)
+        result = await context.inject_message(
+            "read the ledger",
+            session_key=SESSION_KEY,
+            await_dispatch=True,
+            correlation_id="evt-ctx",
+        )
+
+    assert result.accepted is True
+    assert result.reason == "adopted"
+    assert result.session_id == entry.session_id
+    assert result.correlation_id == "evt-ctx"
+
+
+@pytest.mark.asyncio
+async def test_context_default_return_value_is_unchanged(tmp_path, monkeypatch):
+    _grant_injection(tmp_path, monkeypatch)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    loop = asyncio.get_running_loop()
+    runner = _runner(_entry(), adapter, loop=loop)
+    manager = PluginManager()
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        runner._install_plugin_message_injector()
+        scheduled = _context(manager).inject_message(
+            "read the ledger",
+            session_key=SESSION_KEY,
+        )
+
+    assert scheduled is True
+    await asyncio.gather(*list(runner._background_tasks), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_context_await_dispatch_fails_closed_without_the_config_grant(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(yaml.safe_dump({}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    manager = PluginManager()
+
+    result = await _context(manager).inject_message(
+        "read the ledger",
+        session_key=SESSION_KEY,
+        await_dispatch=True,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "injection_denied"
+
+
+@pytest.mark.asyncio
+async def test_context_await_dispatch_fails_closed_without_a_live_gateway(
+    tmp_path,
+    monkeypatch,
+):
+    _grant_injection(tmp_path, monkeypatch)
+    result = await _context(PluginManager()).inject_message(
+        "read the ledger",
+        session_key=SESSION_KEY,
+        await_dispatch=True,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "no_gateway"
+
+
+@pytest.mark.asyncio
+async def test_context_await_dispatch_requires_a_session_key(tmp_path, monkeypatch):
+    _grant_injection(tmp_path, monkeypatch)
+    result = await _context(PluginManager()).inject_message(
+        "read the ledger",
+        await_dispatch=True,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "invalid_request"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["", "x" * 129, "line\nbreak", "tab\tstop"])
+async def test_context_rejects_an_unbounded_correlation_id(
+    tmp_path, monkeypatch, bad
+):
+    _grant_injection(tmp_path, monkeypatch)
+    result = await _context(PluginManager()).inject_message(
+        "read the ledger",
+        session_key=SESSION_KEY,
+        await_dispatch=True,
+        correlation_id=bad,
+    )
+
+    assert result.accepted is False
+    assert result.reason == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_context_tolerates_an_injector_without_the_new_kwargs(
+    tmp_path,
+    monkeypatch,
+):
+    """A host that registered the pre-existing injector signature must not crash."""
+    _grant_injection(tmp_path, monkeypatch)
+    manager = PluginManager()
+
+    def _legacy_injector(*, session_key, content, plugin_id):
+        return True
+
+    manager.set_gateway_message_injector(object(), _legacy_injector)
+    context = _context(manager)
+
+    assert context.inject_message("hi", session_key=SESSION_KEY) is True
+
+    result = await context.inject_message(
+        "hi",
+        session_key=SESSION_KEY,
+        await_dispatch=True,
+    )
+    assert result.accepted is False
+    assert result.reason == "unsupported"
+
+
+def test_result_is_falsy_when_not_adopted():
+    assert not GatewayInjectionResult(False, "unknown_session")
+    assert GatewayInjectionResult(True, "adopted")
+
+
+def test_resolved_handle_is_readable_without_a_loop():
+    from hermes_cli.plugins import GatewayInjectionHandle
+
+    handle = GatewayInjectionHandle.resolved(
+        GatewayInjectionResult(False, "no_gateway", session_key=SESSION_KEY)
+    )
+    assert handle.result(timeout=0).reason == "no_gateway"
+    assert isinstance(handle._future, concurrent.futures.Future)

--- a/tests/gateway/test_plugin_injection_dispatch_result.py
+++ b/tests/gateway/test_plugin_injection_dispatch_result.py
@@ -79,9 +79,9 @@ def _grant_injection(tmp_path, monkeypatch) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(
-        yaml.safe_dump(
-            {"plugins": {"entries": {"wake-plugin": {"allow_gateway_injection": True}}}}
-        )
+        yaml.safe_dump({
+            "plugins": {"entries": {"wake-plugin": {"allow_gateway_injection": True}}}
+        })
     )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
@@ -521,9 +521,7 @@ async def test_context_await_dispatch_requires_a_session_key(tmp_path, monkeypat
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("bad", ["", "x" * 129, "line\nbreak", "tab\tstop"])
-async def test_context_rejects_an_unbounded_correlation_id(
-    tmp_path, monkeypatch, bad
-):
+async def test_context_rejects_an_unbounded_correlation_id(tmp_path, monkeypatch, bad):
     _grant_injection(tmp_path, monkeypatch)
     result = await _context(PluginManager()).inject_message(
         "read the ledger",
@@ -575,3 +573,141 @@ def test_resolved_handle_is_readable_without_a_loop():
     )
     assert handle.result(timeout=0).reason == "no_gateway"
     assert isinstance(handle._future, concurrent.futures.Future)
+
+
+# ---------------------------------------------------------------------------
+# Settlement: timeout is indeterminate, not a refusal
+# ---------------------------------------------------------------------------
+
+
+def test_blocking_result_timeout_is_indeterminate_and_reconciles_to_adoption():
+    """A read that gives up must not be readable as a denial.
+
+    The caller stops waiting; the host does not stop working. The same handle is
+    the reconciliation path to the eventual outcome -- re-injecting instead would
+    deliver the wake twice.
+    """
+    entry = _entry()
+    ready = threading.Event()
+    release = threading.Event()
+    reached_adapter = threading.Event()
+    holder: dict = {}
+
+    async def _blocked(_event):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, release.wait, 5)
+        reached_adapter.set()
+
+    async def _serve():
+        loop = asyncio.get_running_loop()
+        stop = asyncio.Event()
+        holder["runner"] = _runner(
+            entry, SimpleNamespace(handle_message=_blocked), loop=loop
+        )
+        holder["stop"] = lambda: loop.call_soon_threadsafe(stop.set)
+        ready.set()
+        await stop.wait()
+
+    thread = threading.Thread(target=lambda: asyncio.run(_serve()), daemon=True)
+    thread.start()
+    assert ready.wait(5)
+
+    handle = holder["runner"]._schedule_plugin_message_injection(
+        session_key=SESSION_KEY,
+        content="wake up",
+        plugin_id="wake-plugin",
+        await_dispatch=True,
+        correlation_id="evt-indeterminate",
+    )
+    try:
+        pending = handle.result(timeout=0.2)
+
+        # Falsy, but explicitly NOT a decided outcome.
+        assert bool(pending) is False
+        assert pending.reason == "timeout"
+        assert pending.settled is False
+        assert pending.indeterminate is True
+        assert pending.refused is False
+        # The whole point: a caller must not answer "failed, retry" here.
+        assert pending.safe_to_retry is False
+        assert handle.settled is False
+        assert not reached_adapter.is_set()
+
+        # The dispatch was never cancelled by the timeout; it still lands.
+        release.set()
+        final = handle.result(timeout=5)
+    finally:
+        release.set()
+        holder["stop"]()
+        thread.join(timeout=5)
+
+    assert reached_adapter.is_set()
+    assert final.accepted is True
+    assert final.reason == "adopted"
+    assert final.settled is True
+    assert final.correlation_id == "evt-indeterminate"
+
+
+def test_terminal_refusals_stay_terminal():
+    """Every non-timeout outcome remains a settled fact callers can act on."""
+    refusal = GatewayInjectionResult(False, "unknown_session")
+    assert refusal.settled is True
+    assert refusal.refused is True
+    assert refusal.indeterminate is False
+    assert refusal.safe_to_retry is True
+
+    adopted = GatewayInjectionResult(True, "adopted")
+    assert adopted.refused is False
+    assert adopted.safe_to_retry is False
+
+    # A dispatch that blew up may already have reached the adapter.
+    crashed = GatewayInjectionResult(False, "internal_error")
+    assert crashed.refused is True
+    assert crashed.safe_to_retry is False
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_is_metadata_not_idempotent_admission():
+    """The tag identifies an event; it never deduplicates one.
+
+    Nothing on this path stores correlation ids, so two injections carrying the
+    same id both reach the session. Retry safety comes from
+    ``GatewayInjectionResult.safe_to_retry``, not from the tag.
+    """
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(_entry(), adapter)
+
+    for _ in range(2):
+        result = await runner._dispatch_plugin_message_injection(
+            session_key=SESSION_KEY,
+            content="wake up",
+            plugin_id="wake-plugin",
+            correlation_id="evt-duplicate",
+        )
+        assert result.reason == "adopted"
+
+    assert adapter.handle_message.await_count == 2
+    ids = {
+        call.args[0].metadata["hermes_plugin_injection_id"]
+        for call in adapter.handle_message.await_args_list
+    }
+    assert ids == {"evt-duplicate"}
+
+
+def test_every_declared_reason_is_classified():
+    """No reason may be silently unclassified as settled or indeterminate."""
+    from hermes_cli.plugin_injection import (
+        GATEWAY_INJECTION_REASONS,
+        INDETERMINATE_REASONS,
+    )
+
+    assert INDETERMINATE_REASONS <= set(GATEWAY_INJECTION_REASONS)
+    # Only an unfinished observation is indeterminate; everything else decided.
+    assert INDETERMINATE_REASONS == {"timeout"}
+    for reason in GATEWAY_INJECTION_REASONS:
+        result = GatewayInjectionResult(
+            reason in ("adopted", "cli_queued"),
+            reason,
+            settled=reason not in INDETERMINATE_REASONS,
+        )
+        assert result.settled is not result.indeterminate

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -438,7 +438,7 @@ def test_scheduler_uses_threadsafe_bridge_outside_gateway_loop():
         future.set_result(True)
         return future
 
-    with patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit) as submit:
+    with patch("gateway.plugin_injection.safe_schedule_threadsafe", side_effect=_submit) as submit:
         assert (
             runner._schedule_plugin_message_injection(
                 session_key="key",
@@ -464,8 +464,8 @@ def test_scheduler_ignores_threadsafe_future_cancellation():
         return future
 
     with (
-        patch("gateway.run.safe_schedule_threadsafe", side_effect=_submit),
-        patch("gateway.run.logger.warning") as warning,
+        patch("gateway.plugin_injection.safe_schedule_threadsafe", side_effect=_submit),
+        patch("gateway.plugin_injection.logger.warning") as warning,
     ):
         assert (
             runner._schedule_plugin_message_injection(
@@ -530,7 +530,7 @@ def test_scheduler_rejects_submission_failure():
         coro.close()
         return None
 
-    with patch("gateway.run.safe_schedule_threadsafe", side_effect=_reject):
+    with patch("gateway.plugin_injection.safe_schedule_threadsafe", side_effect=_reject):
         assert (
             runner._schedule_plugin_message_injection(
                 session_key="key",

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -18,7 +18,12 @@ from gateway.platforms.base import (
 )
 from gateway.run import GatewayRunner
 from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
-from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from hermes_cli.plugins import (
+    InjectionDelivery,
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
 
 
 def _entry(*, origin=True) -> SessionEntry:
@@ -350,12 +355,14 @@ async def test_scheduler_submits_dispatch_on_live_gateway_loop():
     )
 
     await asyncio.sleep(0)
-    runner._dispatch_plugin_message_injection.assert_awaited_once_with(
-        session_key="agent:main:telegram:dm:42",
-        content="wake up",
-        plugin_id="notify-plugin",
-        correlation_id=None,
-    )
+    runner._dispatch_plugin_message_injection.assert_awaited_once()
+    kwargs = runner._dispatch_plugin_message_injection.await_args.kwargs
+    assert kwargs["session_key"] == "agent:main:telegram:dm:42"
+    assert kwargs["content"] == "wake up"
+    assert kwargs["plugin_id"] == "notify-plugin"
+    assert kwargs["correlation_id"] is None
+    # The delivery arbiter travels with every dispatch, awaited or not.
+    assert isinstance(kwargs["delivery"], InjectionDelivery)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_plugin_message_injection.py
+++ b/tests/gateway/test_plugin_message_injection.py
@@ -160,7 +160,8 @@ async def test_dispatch_uses_stored_origin_and_adapter_message_path():
         plugin_id="notify-plugin",
     )
 
-    assert accepted is True
+    assert accepted.accepted is True
+    assert accepted.reason == "adopted"
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "check the deployment"
@@ -201,7 +202,7 @@ async def test_dispatch_rejects_unroutable_session(entry, with_adapter):
         plugin_id="notify-plugin",
     )
 
-    assert accepted is False
+    assert accepted.accepted is False
     adapter.handle_message.assert_not_awaited()
 
 
@@ -221,7 +222,7 @@ async def test_dispatch_rechecks_current_authorization(raises):
         plugin_id="notify-plugin",
     )
 
-    assert accepted is False
+    assert accepted.accepted is False
     adapter.handle_message.assert_not_awaited()
 
 
@@ -259,7 +260,7 @@ async def test_dispatch_rejects_stored_role_only_authorization(monkeypatch):
         plugin_id="notify-plugin",
     )
 
-    assert accepted is False
+    assert accepted.accepted is False
     adapter.handle_message.assert_not_awaited()
 
 
@@ -288,7 +289,7 @@ async def test_dispatch_stops_when_gateway_drains_during_lookup():
     runner._draining = True
     release_lookup.set()
 
-    assert await dispatch is False
+    assert (await dispatch).accepted is False
     adapter.handle_message.assert_not_awaited()
 
 
@@ -353,6 +354,7 @@ async def test_scheduler_submits_dispatch_on_live_gateway_loop():
         session_key="agent:main:telegram:dm:42",
         content="wake up",
         plugin_id="notify-plugin",
+        correlation_id=None,
     )
 
 

--- a/tests/hermes_cli/test_plugin_call_context.py
+++ b/tests/hermes_cli/test_plugin_call_context.py
@@ -1,0 +1,129 @@
+"""Host-authenticated call context for plugin tool handlers.
+
+A plugin tool handler receives only what the model wrote into the tool
+arguments. Anything a plugin must *trust* -- which profile, which gateway
+session, which thread, which user -- has to come from the host instead, and
+has to stay correct when two gateway sessions run concurrently in one process.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _context() -> PluginContext:
+    return PluginContext(
+        PluginManifest(name="wake-plugin", key="wake-plugin", source="user"),
+        PluginManager(),
+    )
+
+
+@pytest.fixture
+def bound_session():
+    tokens = set_session_vars(
+        platform="telegram",
+        source="gateway",
+        chat_id="42",
+        chat_type="dm",
+        thread_id="7",
+        user_id="u-1",
+        user_name="tester",
+        scope_id="guild-9",
+        session_key="agent:main:telegram:dm:42",
+        session_id="session-42",
+        message_id="m-3",
+        profile="agent-management",
+    )
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_call_context_exposes_host_bound_session_identity(bound_session):
+    ctx = _context().call_context
+
+    assert ctx["session_key"] == "agent:main:telegram:dm:42"
+    assert ctx["session_id"] == "session-42"
+    assert ctx["platform"] == "telegram"
+    assert ctx["chat_id"] == "42"
+    assert ctx["chat_type"] == "dm"
+    assert ctx["thread_id"] == "7"
+    assert ctx["user_id"] == "u-1"
+    assert ctx["user_name"] == "tester"
+    assert ctx["scope_id"] == "guild-9"
+    assert ctx["message_id"] == "m-3"
+
+
+def test_call_context_reports_the_active_profile(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert _context().call_context["profile"] == _context().profile_name
+
+
+def test_call_context_is_empty_when_no_session_is_bound(monkeypatch):
+    for name in (
+        "HERMES_SESSION_KEY",
+        "HERMES_SESSION_ID",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_THREAD_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    ctx = _context().call_context
+    assert ctx["session_key"] == ""
+    assert ctx["session_id"] == ""
+
+
+def test_call_context_carries_no_operator_approval_receipt(bound_session):
+    """Documents the upstream gap: no host-authenticated approval identity.
+
+    Callers that need "a human approved this specific action" cannot get it
+    from the plugin call context, so any such action must fail closed rather
+    than trust a model-supplied assertion.
+    """
+    ctx = _context().call_context
+
+    assert "operator_approval" not in ctx
+    assert "approved_by" not in ctx
+    assert not any(key.startswith("approval") for key in ctx)
+
+
+def test_call_context_is_read_only(bound_session):
+    ctx = _context()
+    snapshot = ctx.call_context
+    snapshot["session_key"] = "agent:main:telegram:dm:999"
+
+    assert ctx.call_context["session_key"] == "agent:main:telegram:dm:42"
+
+
+@pytest.mark.asyncio
+async def test_call_context_is_task_local_across_concurrent_sessions():
+    """Two concurrent gateway turns must not read each other's identity."""
+    ctx = _context()
+    seen: dict[str, str] = {}
+    first_bound = asyncio.Event()
+
+    async def _turn(name: str, session_key: str, wait_for=None, release=None):
+        tokens = set_session_vars(session_key=session_key, session_id=name)
+        try:
+            if release is not None:
+                release.set()
+            if wait_for is not None:
+                await wait_for.wait()
+            await asyncio.sleep(0)
+            seen[name] = ctx.call_context["session_key"]
+        finally:
+            clear_session_vars(tokens)
+
+    await asyncio.gather(
+        _turn("a", "agent:main:telegram:dm:1", wait_for=first_bound),
+        _turn("b", "agent:main:telegram:dm:2", release=first_bound),
+    )
+
+    assert seen == {
+        "a": "agent:main:telegram:dm:1",
+        "b": "agent:main:telegram:dm:2",
+    }

--- a/tests/hermes_cli/test_plugin_call_context.py
+++ b/tests/hermes_cli/test_plugin_call_context.py
@@ -56,10 +56,31 @@ def test_call_context_exposes_host_bound_session_identity(bound_session):
     assert ctx["user_name"] == "tester"
     assert ctx["scope_id"] == "guild-9"
     assert ctx["message_id"] == "m-3"
+    # Profile is session identity, not process identity.
+    assert ctx["profile"] == "agent-management"
 
 
-def test_call_context_reports_the_active_profile(monkeypatch, tmp_path):
+def test_bound_profile_wins_over_the_process_profile(
+    monkeypatch, tmp_path, bound_session
+):
+    """A multiplexed gateway serves several profiles from one process.
+
+    Reading the process profile while a session is bound would hand a plugin the
+    right chat and the wrong policy domain.
+    """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ctx = _context()
+
+    assert ctx.call_context["profile"] == "agent-management"
+    assert ctx.call_context["profile"] != ctx.profile_name
+
+
+def test_call_context_falls_back_to_the_process_profile_when_unbound(
+    monkeypatch, tmp_path
+):
+    """Compatibility path: plain CLI, cron, and tests bind no session."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_SESSION_PROFILE", raising=False)
     assert _context().call_context["profile"] == _context().profile_name
 
 
@@ -126,4 +147,52 @@ async def test_call_context_is_task_local_across_concurrent_sessions():
     assert seen == {
         "a": "agent:main:telegram:dm:1",
         "b": "agent:main:telegram:dm:2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_context_profile_is_task_local_across_concurrent_sessions():
+    """Two profiles multiplexed in one process must not read each other's.
+
+    The failure this pins is a qualified-identity break at the policy boundary:
+    a plugin trusting ``call_context`` gets the right session key and the wrong
+    profile, so it authorizes against the wrong domain.
+    """
+    ctx = _context()
+    seen: dict[str, tuple[str, str]] = {}
+    first_bound = asyncio.Event()
+
+    async def _turn(name, *, profile, session_key, wait_for=None, release=None):
+        tokens = set_session_vars(
+            session_key=session_key, session_id=name, profile=profile
+        )
+        try:
+            if release is not None:
+                release.set()
+            if wait_for is not None:
+                await wait_for.wait()
+            await asyncio.sleep(0)
+            snapshot = ctx.call_context
+            seen[name] = (snapshot["profile"], snapshot["session_key"])
+        finally:
+            clear_session_vars(tokens)
+
+    await asyncio.gather(
+        _turn(
+            "a",
+            profile="agent-management",
+            session_key="agent:main:telegram:dm:1",
+            wait_for=first_bound,
+        ),
+        _turn(
+            "b",
+            profile="research",
+            session_key="agent:main:telegram:dm:2",
+            release=first_bound,
+        ),
+    )
+
+    assert seen == {
+        "a": ("agent-management", "agent:main:telegram:dm:1"),
+        "b": ("research", "agent:main:telegram:dm:2"),
     }

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -792,6 +792,10 @@ else:
 |-------|---------|
 | `accepted` | `True` only when the event reached the stored session's adapter. The result object is falsy otherwise. |
 | `reason` | `adopted`, `unknown_session`, `unauthorized`, `no_adapter`, `gateway_draining`, `internal_error`, `not_scheduled`, `injection_denied`, `no_gateway`, `invalid_request`, `unsupported`, `cancelled`, `timeout`, or `cli_queued`. |
+| `settled` | `False` only for `timeout` — the dispatch is still in flight and may yet be adopted. |
+| `indeterminate` | `not settled`. The outcome is unknown, not negative. |
+| `refused` | `True` for a *settled* denial: the event will never reach the session. |
+| `safe_to_retry` | `True` only when re-issuing the injection cannot duplicate a delivered wake. |
 | `session_id` | The host's id for the session that received the message. Set on `adopted`. |
 | `session_key` | The key that was resolved. |
 | `correlation_id` | Echo of the tag you supplied, if any. |
@@ -799,6 +803,23 @@ else:
 - `correlation_id` is an opaque bounded tag (printable, ≤128 characters). It is stamped onto the dispatched event's metadata as `hermes_plugin_injection_id` and echoed in the result so you can prove *this* event reached *that* session. It is never routing information — the platform, chat, thread, and user always come from the stored session.
 - `handle.result(...)` blocks and is only valid off the gateway loop; awaiting is the correct call on it. `handle.cancel()` cancels a pending dispatch, after which the result reads `cancelled`.
 - Both paths return a result object rather than raising, including on timeout and internal failure.
+
+:::danger A timeout is *unknown*, not *denied*
+`handle.result(timeout=...)` running out of patience does **not** cancel the dispatch. It returns `accepted=False, reason="timeout", settled=False` and the wake may still land a moment later.
+
+Check `refused` — not just falsiness — before reporting failure, and check `safe_to_retry` before re-sending. **`correlation_id` is metadata, not a durable idempotency key: nothing on this path deduplicates on it, so two injections carrying the same id both reach the session.** The reconciliation path is the *same handle*: poll `handle.settled` or call `handle.result(...)` again to learn the eventual outcome.
+
+```python
+result = handle.result(timeout=5)
+if result.accepted:
+    respond(200, {"status": "adopted", "session_id": result.session_id})
+elif result.refused:
+    respond(409, {"status": result.reason})
+else:
+    # Indeterminate. Do not re-inject; reconcile through this handle.
+    respond(202, {"status": "pending", "correlation_id": result.correlation_id})
+```
+:::
 - In CLI mode there is no gateway dispatch stage, so an awaited handle resolves immediately to `cli_queued`.
 - The default (`await_dispatch=False`) call is unchanged and still returns a plain `bool`.
 
@@ -814,8 +835,8 @@ if identity["session_key"] != expected_session_key:
 
 `ctx.call_context` returns a fresh `dict[str, str]` with `profile`, `session_key`, `session_id`, `platform`, `source`, `chat_id`, `chat_type`, `chat_name`, `thread_id`, `user_id`, `user_name`, `scope_id`, and `message_id`.
 
-- Values are bound per asyncio task by the gateway, so two concurrent sessions in one process never read each other's identity.
-- Every field is `""` when no session is bound — a plain CLI run, a cron job, or a test.
+- Values are bound per asyncio task by the gateway, so two concurrent sessions in one process never read each other's identity. This includes `profile`: a multiplexed gateway serves several profiles from one process, so `profile` is the *session's* profile, not the process's.
+- Every field is `""` when no session is bound — a plain CLI run, a cron job, or a test. `profile` then falls back to the active process profile.
 - The returned mapping is a copy; mutating it changes nothing.
 
 :::warning

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -104,6 +104,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
 | Inject messages | `ctx.inject_message(content, role="user", session_key=...)` - see [Injecting Messages](#injecting-messages) |
+| Read the host's identity for this turn | `ctx.call_context` — see [Trusted Call Context](#trusted-call-context) |
 | Ship data files | `Path(__file__).parent / "data" / "file.yaml"` |
 | Bundle skills | `ctx.register_skill(name, path)` — namespaced as `plugin:skill`, loaded via `skill_view("plugin:skill")` |
 | Gate on env vars | `requires_env: [API_KEY]` in plugin.yaml — prompted during `hermes plugins install` |
@@ -722,7 +723,7 @@ ctx.inject_message(
 )
 ```
 
-**Signature:** `ctx.inject_message(content: str, role: str = "user", *, session_key: str | None = None) -> bool`
+**Signature:** `ctx.inject_message(content: str, role: str = "user", *, session_key: str | None = None, await_dispatch: bool = False, correlation_id: str | None = None) -> bool | GatewayInjectionHandle`
 
 In CLI mode:
 
@@ -741,7 +742,7 @@ In gateway mode:
 - The route and conversation are pinned while dispatch is pending. Hermes drops the request if topic recovery changes the route or the session rotates before handling starts.
 - The request enters the platform adapter's normal message path. Active sessions use the existing busy-session queue rather than starting a competing turn.
 - Returns `True` when the live gateway accepts the request for asynchronous dispatch. This does not confirm that the agent turn or platform delivery has completed.
-- Returns `False` when `session_key` is omitted, the permission is not granted, or no live gateway can accept the request. Unknown or unroutable session keys discovered after asynchronous acceptance are written to the gateway log.
+- Returns `False` when `session_key` is omitted, the permission is not granted, or no live gateway can accept the request. Unknown or unroutable session keys discovered after asynchronous acceptance are written to the gateway log — use [`await_dispatch=True`](#confirming-dispatch-with-await_dispatch) to receive that outcome instead of only logging it.
 
 This enables plugins like remote control viewers, messaging bridges, or webhook receivers to feed messages into the conversation from external sources.
 
@@ -760,6 +761,65 @@ Only grant gateway injection to plugins you trust. Hermes checks this host API p
 
 :::note
 This plugin API does not expose a public HTTP endpoint or CLI command for external processes. The plugin must already know the target gateway `session_key`, for example from its own trusted configuration or previously retained session state.
+:::
+
+### Confirming dispatch with `await_dispatch`
+
+The default `True` return only means the gateway accepted the request for asynchronous dispatch. An unknown session key, a rotated session, revoked authorisation, and a missing adapter all return `True` too and are then dropped with a log line — so a caller that has to *report* whether the message landed (a webhook receiver answering an HTTP request, for example) cannot do it from the return value.
+
+Pass `await_dispatch=True` to get a `GatewayInjectionHandle` instead:
+
+```python
+handle = ctx.inject_message(
+    "New data arrived from the webhook",
+    session_key="agent:main:telegram:dm:123456789",
+    await_dispatch=True,
+    correlation_id=event_id,          # optional, bounded, opaque
+)
+
+result = await handle                 # on the gateway loop
+# result = handle.result(timeout=5)   # from another thread
+
+if result.accepted:
+    respond(200, {"status": "adopted", "session_id": result.session_id})
+else:
+    respond(409, {"status": result.reason})
+```
+
+`GatewayInjectionResult` fields:
+
+| Field | Meaning |
+|-------|---------|
+| `accepted` | `True` only when the event reached the stored session's adapter. The result object is falsy otherwise. |
+| `reason` | `adopted`, `unknown_session`, `unauthorized`, `no_adapter`, `gateway_draining`, `internal_error`, `not_scheduled`, `injection_denied`, `no_gateway`, `invalid_request`, `unsupported`, `cancelled`, `timeout`, or `cli_queued`. |
+| `session_id` | The host's id for the session that received the message. Set on `adopted`. |
+| `session_key` | The key that was resolved. |
+| `correlation_id` | Echo of the tag you supplied, if any. |
+
+- `correlation_id` is an opaque bounded tag (printable, ≤128 characters). It is stamped onto the dispatched event's metadata as `hermes_plugin_injection_id` and echoed in the result so you can prove *this* event reached *that* session. It is never routing information — the platform, chat, thread, and user always come from the stored session.
+- `handle.result(...)` blocks and is only valid off the gateway loop; awaiting is the correct call on it. `handle.cancel()` cancels a pending dispatch, after which the result reads `cancelled`.
+- Both paths return a result object rather than raising, including on timeout and internal failure.
+- In CLI mode there is no gateway dispatch stage, so an awaited handle resolves immediately to `cli_queued`.
+- The default (`await_dispatch=False`) call is unchanged and still returns a plain `bool`.
+
+## Trusted Call Context
+
+A tool handler receives only what the model wrote into the tool arguments. Anything the plugin has to *trust* — which profile, which gateway session, which thread, which user — must come from the host instead:
+
+```python
+identity = ctx.call_context
+if identity["session_key"] != expected_session_key:
+    return "refused: this action belongs to a different session"
+```
+
+`ctx.call_context` returns a fresh `dict[str, str]` with `profile`, `session_key`, `session_id`, `platform`, `source`, `chat_id`, `chat_type`, `chat_name`, `thread_id`, `user_id`, `user_name`, `scope_id`, and `message_id`.
+
+- Values are bound per asyncio task by the gateway, so two concurrent sessions in one process never read each other's identity.
+- Every field is `""` when no session is bound — a plain CLI run, a cron job, or a test.
+- The returned mapping is a copy; mutating it changes nothing.
+
+:::warning
+There is no host-authenticated *operator approval* field. `ctx.call_context` tells you which human session a turn came from, not that a human approved a specific action. A plugin action that requires explicit approval must fail closed rather than trust a model-supplied claim that approval was granted.
 :::
 
 ## Calling MCP servers from plugins

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -792,9 +792,9 @@ else:
 |-------|---------|
 | `accepted` | `True` only when the event reached the stored session's adapter. The result object is falsy otherwise. |
 | `reason` | `adopted`, `unknown_session`, `unauthorized`, `no_adapter`, `gateway_draining`, `internal_error`, `not_scheduled`, `injection_denied`, `no_gateway`, `invalid_request`, `unsupported`, `cancelled`, `timeout`, or `cli_queued`. |
-| `settled` | `False` only for `timeout` — the dispatch is still in flight and may yet be adopted. |
+| `settled` | `False` whenever delivery is unknown: always for `timeout`, and for `cancelled` / `internal_error` once dispatch already entered the adapter. |
 | `indeterminate` | `not settled`. The outcome is unknown, not negative. |
-| `refused` | `True` for a *settled* denial: the event will never reach the session. |
+| `refused` | `True` for a *settled* denial: the host proved the event never crossed into the adapter, so it will never reach the session. |
 | `safe_to_retry` | `True` only when re-issuing the injection cannot duplicate a delivered wake. |
 | `session_id` | The host's id for the session that received the message. Set on `adopted`. |
 | `session_key` | The key that was resolved. |
@@ -804,8 +804,10 @@ else:
 - `handle.result(...)` blocks and is only valid off the gateway loop; awaiting is the correct call on it. `handle.cancel()` cancels a pending dispatch, after which the result reads `cancelled`.
 - Both paths return a result object rather than raising, including on timeout and internal failure.
 
-:::danger A timeout is *unknown*, not *denied*
+:::danger A falsy result is not always a *denial*
 `handle.result(timeout=...)` running out of patience does **not** cancel the dispatch. It returns `accepted=False, reason="timeout", settled=False` and the wake may still land a moment later.
+
+The same holds once dispatch has entered the session's adapter: cancelling there, or an adapter that raises after doing its work, cannot prove the wake did not happen, so both report `settled=False, refused=False, safe_to_retry=False`. A cancel that provably wins the race *before* adapter entry stays a terminal, retry-safe refusal.
 
 Check `refused` — not just falsiness — before reporting failure, and check `safe_to_retry` before re-sending. **`correlation_id` is metadata, not a durable idempotency key: nothing on this path deduplicates on it, so two injections carrying the same id both reach the session.** The reconciliation path is the *same handle*: poll `handle.settled` or call `handle.result(...)` again to learn the eventual outcome.
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in dispatch receipt to the existing plugin message-injection API. Today `ctx.inject_message()` returns `True` when dispatch is scheduled, even if the target session is unknown, authorization was revoked, or no adapter exists. Plugins that must report whether a wake actually reached the stored gateway session cannot distinguish adoption from a later silent drop.

`await_dispatch=True` returns a bounded handle resolving to a structured result (`adopted`, `unknown_session`, `unauthorized`, `no_adapter`, `gateway_draining`, etc.) while preserving the existing boolean default. An optional opaque `correlation_id` links the request to the result without affecting routing.

The PR also exposes read-only, task-local `ctx.call_context` so plugin handlers can use host-bound profile/session/thread/user identity rather than model-supplied arguments. It deliberately does not claim operator approval.

## Related Issue

No existing issue found; this is a generic plugin API capability with a concrete webhook/session-wake consumer.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extend `PluginContext.inject_message()` with opt-in dispatch-result reporting.
- Add structured result/handle types and bounded correlation IDs.
- Return explicit refusal reasons from the gateway's existing dispatch seam.
- Add host-bound, task-local `PluginContext.call_context`.
- Preserve the existing non-awaiting boolean behavior by default.
- Document both APIs and their trust boundaries.
- Add focused gateway and plugin-context regression coverage.

## How to Test

1. `python -m pytest -q tests/gateway/test_plugin_injection_dispatch_result.py tests/gateway/test_plugin_message_injection.py tests/hermes_cli/test_plugin_call_context.py`
2. Confirm an existing session resolves to `adopted` with the host session ID.
3. Confirm unknown, unauthorized, unroutable, draining, cancelled, and timed-out cases resolve fail-closed with explicit reasons.

Current `main` result: **54 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused affected suites pass; leaving this unchecked rather than overstating a whole-repo run
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A; no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no contributor workflow change
- [x] I've considered cross-platform impact; implementation uses asyncio/concurrent futures and no platform-specific APIs
- [x] Tool descriptions/schemas — N/A; this extends the plugin host API, documented in the plugin guide

## Screenshots / Logs

```text
54 passed, 7 warnings in 8.75s
```
