### PR TITLE
fix(web): advance keyless failover ring on Tavily daily_cap_reached

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -54,6 +54,7 @@ _RATE_LIMIT_MARKERS = (
     "429",
     "quota exceeded",
     "slow down",
+    "daily_cap_reached",
 )
 
 


### PR DESCRIPTION
## Summary

When the keyless Tavily endpoint returns `daily_cap_reached`, the keyless search failover ring stops instead of advancing to the next free provider (firecrawl, keenable, exa, parallel). This leaves subagents with no web search capability even though alternative free backends are available.

## Root Cause

`plugins/web/keyless_mcp.py::_is_rate_limitish()` classifies error messages to decide whether to advance the failover ring. Its `_RATE_LIMIT_MARKERS` tuple recognizes rate-limit/quota phrases like `"429"`, `"quota exceeded"`, `"too many requests"` — but **not** Tavily's `"daily_cap_reached"` error code, which arrives in the response body rather than as an HTTP status. The loop returns at the first Tavily failure and never tries the remaining keyless vendors.

## Fix

Add `"daily_cap_reached"` to `_RATE_LIMIT_MARKERS`. The keyring ring now treats Tavily's daily cap as a provider-local availability failure (same class as rate limits) and advances to the next free provider.

This is a one-line addition to an existing tuple — no new logic, no new control flow.

## Related

- Closes #96185
- Related to #91609 (HTTP 401/403 stopping the ring) and PR #91619 (keyless auth rejection failover) — same root cause class (provider-local availability failure stopping the ring), different error shape.