### PR TITLE
fix(desktop): stop double-quoting remote paths in SSH spawn command

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1107,7 +1107,12 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       `${markerClear}; marker_clear || exit 75; mkdir -p "$(dirname ${logPath})" && ` +
       `${detachedSpawn}; ` +
       `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; ` +
-      `lock_json=${shq(metadata)}; lock_json=\${lock_json//__PID__/$child}; ` +
+      // POSIX sh (dash on fnOS/Debian remotes) has no ${var//pat/repl} — that
+      // bashism dies with "Bad substitution" before the backend starts. Use
+      // sed for the placeholder swap instead, replacing the QUOTED placeholder
+      // so the published record carries a real JSON number pid (readLockfile
+      // requires an integer, and the reuse regex matches "pid":<digits>).
+      `lock_json=${shq(metadata)}; lock_json=$(printf '%s' "$lock_json" | sed "s/\\"__PID__\\"/$child/"); ` +
       `temporary_lock="\${lock}.${reservationNonce}.tmp"; ` +
       `printf '%s' "$lock_json" > "$temporary_lock" && mv -f "$temporary_lock" "$lock" || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
       `echo "$child"`,

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -735,9 +735,11 @@ async function disconnect(ssh, ownershipId) {
 
 function buildOwnedStaleTerminationCommand(lock, ownershipId) {
   const pid = Number(lock.pid)
-  const expectedPath = shq(expandRemotePath(lock.hermesPath))
-  const expectedHome = lock.hermesHome ? shq(expandRemotePath(lock.hermesHome)) : "''"
-  const expectedToken = shq(expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce)))
+  // expandRemotePath already returns a fully shell-quoted word; do not shq()
+  // it a second time or the literal quotes never match the live argv below.
+  const expectedPath = expandRemotePath(lock.hermesPath)
+  const expectedHome = lock.hermesHome ? expandRemotePath(lock.hermesHome) : "''"
+  const expectedToken = expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce))
   const nonce = shq(lock.spawnNonce)
   const profile = shq(lock.profile || '')
   const command = `$(ps -ww -o command= -p ${pid} 2>/dev/null || true)`
@@ -910,7 +912,10 @@ finally:
 sys.exit(result.returncode if result is not None else 1)
 `.trim()
 
-  return `python3 -c ${shq(script)} ${shq(mutexPath)} ${shq(command)}`
+  // mutexPath arrives already shell-quoted via expandRemotePath at the call
+  // site; wrapping it in shq() again would double-escape the path (the
+  // "reservation='\"$HOME\"'..." boot failure).
+  return `python3 -c ${shq(script)} ${mutexPath} ${shq(command)}`
 }
 
 /**
@@ -1083,7 +1088,11 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   return withRemoteUpdateMutex(
     `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
-      `reservation=${shq(reservation)}; lock=${shq(lockPath)}; owner_file=${shq(ownerPath)}; ` +
+      // reservation/lockPath/ownerPath are already fully shell-quoted words
+      // from expandRemotePath (or a quoted word + literal suffix). Do NOT shq()
+      // them again — that bakes literal quotes into the path, so the remote
+      // mkdir creates `"$HOME"'/...' ` instead of the real directory.
+      `reservation=${reservation}; lock=${lockPath}; owner_file=${ownerPath}; ` +
       `reservation_nonce=${shq(reservationNonce)}; ` +
       `i=0; while ! mkdir "$reservation" 2>/dev/null; do ` +
       `owner_data=$(cat "$owner_file" 2>/dev/null || true); owner_pid=${'${owner_data%%:*}'}; ` +


### PR DESCRIPTION
Fixes #96188

## Summary

`expandRemotePath()` already returns a fully shell-quoted word, but three call sites wrapped its result in `shq()` again. The double-escaping bakes literal quote characters into remote paths, so:

- the ownership-reservation `mkdir` targets a garbage path (`reservation='"$HOME"'...` in remote logs),
- the `serve --isolated` backend never starts, no `backend.lock.json` is written,
- Desktop reports `Desktop boot failed` / SSH timeout even though the transport is healthy.

## Changes (apps/desktop/electron/remote-lifecycle.ts)

- `buildSpawnCommand`: drop outer `shq()` on `reservation` / `lockPath` / `ownerPath` (boot-blocker)
- `withRemoteUpdateMutex`: drop outer `shq()` on `mutexPath` (caused a process stuck flock-ing a wrong path, with retries queuing behind it)
- `buildOwnedStaleTerminationCommand`: drop outer `shq()` on `expectedPath` / `expectedHome` / `expectedToken` (latent — the argv identity match would always REFUSE)

## Test plan

- [x] All 89 existing `remote-lifecycle` unit tests pass (`npx vitest run electron/remote-lifecycle.test.ts`)
- [x] Rendered spawn command inspected: `reservation="$HOME"'/.hermes/...'` expands correctly; no literal quotes remain in the path
- [ ] End-to-end: reconnect a macOS Desktop client to a Linux remote and confirm the backend spawns and `backend.lock.json` is published
