### PR TITLE
fix(copilot): unblock GitHub Enterprise Cloud authentication

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -52,7 +52,7 @@ from hermes_cli.config import cfg_get
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import base_url_host_matches, is_copilot_api_base_url, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -1331,7 +1331,7 @@ def init_agent(
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)
             elif base_url_host_matches(effective_base, "api.routermint.com"):
                 client_kwargs["default_headers"] = _ra()._routermint_headers()
-            elif base_url_host_matches(effective_base, "githubcopilot.com"):
+            elif is_copilot_api_base_url(effective_base):
                 from hermes_cli.models import copilot_default_headers
 
                 client_kwargs["default_headers"] = copilot_default_headers()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -49,7 +49,13 @@ from agent.credential_pool import (
 )
 from agent.error_classifier import FailoverReason
 from agent.turn_context import drop_stale_api_content
-from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
+from utils import (
+    atomic_json_write,
+    base_url_host_matches,
+    base_url_hostname,
+    env_var_enabled,
+    is_copilot_api_base_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2679,7 +2685,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # missing Copilot headers here closes the whole class. We only ADD missing
     # keys — never override headers a caller deliberately set.
     try:
-        if base_url_host_matches(str(client_kwargs.get("base_url", "")), "githubcopilot.com"):
+        if is_copilot_api_base_url(str(client_kwargs.get("base_url", ""))):
             from hermes_cli.models import copilot_default_headers
             existing = dict(client_kwargs.get("default_headers") or {})
             existing_lower = {k.lower() for k in existing}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -168,7 +168,15 @@ from agent.model_metadata import (
 )
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    is_copilot_api_base_url,
+    is_truthy_value,
+    model_forces_max_completion_tokens,
+    normalize_proxy_env_vars,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1566,7 +1574,7 @@ class _CodexCompletionsAdapter:
         # through this adapter instead of agent/transports/codex.py's
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
-        _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        _is_github_for_input = is_copilot_api_base_url(_host_for_input)
         # Auxiliary calls never send ``context_management`` (native
         # compaction is a main-turn feature), so they must never replay a
         # compaction checkpoint from the replayed history nor let one
@@ -1699,7 +1707,7 @@ class _CodexCompletionsAdapter:
             _host_src = str(getattr(self._client, "base_url", "") or "")
             _is_xai = base_url_host_matches(_host_src, "x.ai") or base_url_host_matches(_host_src, "api.x.ai")
             _is_github = (
-                base_url_host_matches(_host_src, "githubcopilot.com")
+                is_copilot_api_base_url(_host_src)
                 or base_url_host_matches(_host_src, "models.github.ai")
             )
             if not _is_xai and not _is_github and "prompt_cache_key" not in resp_kwargs:
@@ -2816,7 +2824,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-            elif base_url_host_matches(base_url, "githubcopilot.com"):
+            elif is_copilot_api_base_url(base_url):
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
@@ -2856,7 +2864,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-        elif base_url_host_matches(base_url, "githubcopilot.com"):
+        elif is_copilot_api_base_url(base_url):
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
@@ -4733,7 +4741,7 @@ def _recoverable_pool_provider(
         return "nous"
     if base_url_host_matches(base, "api.anthropic.com"):
         return "anthropic"
-    if base_url_host_matches(base, "githubcopilot.com"):
+    if is_copilot_api_base_url(base):
         return "copilot"
     if base_url_host_matches(base, "api.kimi.com"):
         return "kimi-coding"
@@ -5062,7 +5070,7 @@ def _auth_refresh_provider_for_route(
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized and normalized != "auto":
         return normalized
-    if base_url_host_matches(client_base_url, "api.githubcopilot.com"):
+    if is_copilot_api_base_url(client_base_url):
         return "copilot"
     if base_url_host_matches(client_base_url, "chatgpt.com"):
         return "openai-codex"
@@ -6227,7 +6235,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()
-    elif base_url_host_matches(sync_base_url, "githubcopilot.com"):
+    elif is_copilot_api_base_url(sync_base_url):
         from hermes_cli.copilot_auth import copilot_request_headers
 
         async_kwargs["default_headers"] = copilot_request_headers(
@@ -6634,7 +6642,7 @@ def resolve_provider_client(
                 extra["default_query"] = _dq
             if base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-            elif base_url_host_matches(custom_base, "githubcopilot.com"):
+            elif is_copilot_api_base_url(custom_base):
                 from hermes_cli.copilot_auth import copilot_request_headers
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
@@ -6929,7 +6937,7 @@ def resolve_provider_client(
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
-        elif base_url_host_matches(base_url, "githubcopilot.com"):
+        elif is_copilot_api_base_url(base_url):
             from hermes_cli.copilot_auth import copilot_request_headers
 
             headers.update(copilot_request_headers(
@@ -7600,8 +7608,7 @@ def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> di
             and _read_nous_auth() is None
             and (
                 _custom_host == "api.openai.com"
-                or _custom_host == "api.githubcopilot.com"
-                or _custom_host.endswith(".githubcopilot.com")
+                or is_copilot_api_base_url(custom_base)
             )):
         return {"max_completion_tokens": value}
     # ...and for any caller serving a newer OpenAI-family model by name.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -46,7 +46,13 @@ from agent.message_sanitization import (
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
-from utils import base_url_host_matches, base_url_hostname, env_float, env_int
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    env_int,
+    is_copilot_api_base_url,
+)
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
@@ -1880,7 +1886,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         _ct = agent._get_transport()
         is_github_responses = (
             base_url_host_matches(agent.base_url, "models.github.ai")
-            or base_url_host_matches(agent.base_url, "githubcopilot.com")
+            or is_copilot_api_base_url(agent.base_url)
         )
         is_codex_backend = (
             agent.provider == "openai-codex"
@@ -1965,7 +1971,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     _is_or = agent._is_openrouter_url()
     _is_gh = (
         base_url_host_matches(agent._base_url_lower, "models.github.ai")
-        or base_url_host_matches(agent._base_url_lower, "githubcopilot.com")
+        or is_copilot_api_base_url(agent._base_url_lower)
     )
     _is_nous = base_url_host_matches(agent._base_url_lower, "nousresearch.com")
     _is_nvidia = base_url_host_matches(agent._base_url_lower, "integrate.api.nvidia.com")

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -21,7 +21,13 @@ import yaml
 if TYPE_CHECKING:  # pragma: no cover — runtime import is lazy (see below)
     import requests
 
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, base_url_hostname
+from utils import (
+    atomic_json_write,
+    atomic_yaml_write,
+    base_url_host_matches,
+    base_url_hostname,
+    is_copilot_api_base_url,
+)
 
 from hermes_constants import OPENROUTER_MODELS_URL
 from agent.message_metadata import PERSISTENCE_ONLY_MESSAGE_FIELDS
@@ -776,6 +782,8 @@ def _infer_provider_from_url(base_url: str) -> Optional[str]:
     normalized = _normalize_base_url(base_url)
     if not normalized:
         return None
+    if is_copilot_api_base_url(normalized):
+        return "copilot"
     parsed = urlparse(normalized if "://" in normalized else f"https://{normalized}")
     host = parsed.netloc.lower() or parsed.path.lower()
     for url_part, provider in _URL_TO_PROVIDER.items():

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -388,10 +388,31 @@ _EXCHANGE_FAILURE_TTL_PERMANENT_SECONDS = 1800.0   # 401/403/404: won't heal
 _EXCHANGE_PERMANENT_HTTP_STATUSES = frozenset({401, 403, 404})
 
 
+def _token_exchange_urls() -> tuple[str, ...]:
+    """Return token-exchange endpoints for the configured GitHub host."""
+    from utils import base_url_hostname
+
+    host = base_url_hostname(os.getenv("COPILOT_GH_HOST", "").strip())
+    if not host or host == "github.com":
+        return (_TOKEN_EXCHANGE_URL,)
+    return (
+        f"https://api.{host}/copilot_internal/v2/token",
+        f"https://{host}/api/v3/copilot_internal/v2/token",
+    )
+
+
 def _token_fingerprint(raw_token: str) -> str:
     """Short fingerprint of a raw token for cache keying (avoids storing full token)."""
     import hashlib
     return hashlib.sha256(raw_token.encode()).hexdigest()[:16]
+
+
+def _exchange_cache_fingerprint(raw_token: str) -> str:
+    """Scope exchanged-token caches to the GitHub host that minted them."""
+    exchange_urls = _token_exchange_urls()
+    if exchange_urls == (_TOKEN_EXCHANGE_URL,):
+        return _token_fingerprint(raw_token)
+    return _token_fingerprint(f"{raw_token}\0{exchange_urls[0]}")
 
 
 def _read_jwt_store(path: Path) -> Optional[dict]:
@@ -427,7 +448,7 @@ def evict_cached_exchanged_token(raw_token: str) -> None:
     """
     if not raw_token:
         return
-    fp = _token_fingerprint(raw_token)
+    fp = _exchange_cache_fingerprint(raw_token)
     _jwt_cache.pop(fp, None)
     # Also clear any negative-cache entry: eviction is an explicit "force a
     # fresh exchange" signal from the stale-credential recovery path, so the
@@ -523,8 +544,9 @@ def _save_jwt_to_disk(
 def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[str, float, Optional[str]]:
     """Exchange a raw GitHub token for a short-lived Copilot API token.
 
-    Calls ``GET https://api.github.com/copilot_internal/v2/token`` with
-    the raw GitHub token and returns ``(api_token, expires_at, base_url)``.
+    Calls the public GitHub exchange endpoint, or the enterprise endpoints
+    derived from ``COPILOT_GH_HOST``, and returns
+    ``(api_token, expires_at, base_url)``.
 
     The returned token is a semicolon-separated string (not a standard JWT)
     used as ``Authorization: Bearer <token>`` for Copilot API requests.
@@ -538,7 +560,7 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     """
     import urllib.request
 
-    fp = _token_fingerprint(raw_token)
+    fp = _exchange_cache_fingerprint(raw_token)
 
     # Check in-process cache first
     cached = _jwt_cache.get(fp)
@@ -570,49 +592,52 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
             f"for another {int(_fail_until - time.time())}s"
         )
 
-    req = urllib.request.Request(
-        _TOKEN_EXCHANGE_URL,
-        method="GET",
-        headers={
-            "Authorization": f"token {raw_token}",
-            "User-Agent": _EXCHANGE_USER_AGENT,
-            "Accept": "application/json",
-            "Editor-Version": _EDITOR_VERSION,
-        },
-    )
 
     # Retry with backoff. Startup network races (launchd relaunch, VPN/DHCP
     # settling) make the first attempt flaky; without this the sole failure
     # silently degrades to the raw token for the whole process lifetime.
     # Permanent HTTP rejections (401/403/404 — token not Copilot-entitled,
-    # revoked, or org-blocked) skip the retry loop entirely: backoff exists
-    # for transient network races, and sleeping on an auth rejection just
-    # blocks the caller for ~4.5s with an identical outcome.
+    # revoked, or org-blocked) skip retries for that endpoint. Enterprise
+    # configurations may then try their alternate API-v3 endpoint.
     data = None
     last_exc: Optional[Exception] = None
     permanent_failure = False
-    for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
-            break
-        except Exception as exc:  # noqa: BLE001 — retry all, re-raise below
-            last_exc = exc
-            status = getattr(exc, "code", None) or getattr(exc, "status", None)
-            if status in _EXCHANGE_PERMANENT_HTTP_STATUSES:
-                permanent_failure = True
-                logger.debug(
-                    "Copilot token exchange rejected (HTTP %s); not retrying",
-                    status,
-                )
+    for exchange_url in _token_exchange_urls():
+        req = urllib.request.Request(
+            exchange_url,
+            method="GET",
+            headers={
+                "Authorization": f"token {raw_token}",
+                "User-Agent": _EXCHANGE_USER_AGENT,
+                "Accept": "application/json",
+                "Editor-Version": _EDITOR_VERSION,
+            },
+        )
+        for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    data = json.loads(resp.read().decode())
                 break
-            if attempt < _EXCHANGE_MAX_ATTEMPTS - 1:
-                sleep_s = _EXCHANGE_BACKOFF_BASE_SECONDS * (attempt + 1)
-                logger.debug(
-                    "Copilot token exchange attempt %d/%d failed (%s); retrying in %.1fs",
-                    attempt + 1, _EXCHANGE_MAX_ATTEMPTS, exc, sleep_s,
-                )
-                time.sleep(sleep_s)
+            except Exception as exc:  # noqa: BLE001 — retry all, re-raise below
+                last_exc = exc
+                status = getattr(exc, "code", None) or getattr(exc, "status", None)
+                permanent_failure = status in _EXCHANGE_PERMANENT_HTTP_STATUSES
+                if status in _EXCHANGE_PERMANENT_HTTP_STATUSES:
+                    logger.debug(
+                        "Copilot token exchange rejected at %s (HTTP %s); trying next endpoint",
+                        exchange_url,
+                        status,
+                    )
+                    break
+                if attempt < _EXCHANGE_MAX_ATTEMPTS - 1:
+                    sleep_s = _EXCHANGE_BACKOFF_BASE_SECONDS * (attempt + 1)
+                    logger.debug(
+                        "Copilot token exchange attempt %d/%d failed (%s); retrying in %.1fs",
+                        attempt + 1, _EXCHANGE_MAX_ATTEMPTS, exc, sleep_s,
+                    )
+                    time.sleep(sleep_s)
+        if data is not None:
+            break
     if data is None:
         ttl = (
             _EXCHANGE_FAILURE_TTL_PERMANENT_SECONDS
@@ -620,9 +645,7 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
             else _EXCHANGE_FAILURE_TTL_TRANSIENT_SECONDS
         )
         _exchange_failure_cache[fp] = time.time() + ttl
-        raise ValueError(
-            f"Copilot token exchange failed after {_EXCHANGE_MAX_ATTEMPTS} attempts: {last_exc}"
-        ) from last_exc
+        raise ValueError(f"Copilot token exchange failed: {last_exc}") from last_exc
     _exchange_failure_cache.pop(fp, None)
 
     api_token = data.get("token", "")

--- a/run_agent.py
+++ b/run_agent.py
@@ -220,7 +220,15 @@ from agent.tool_dispatch_helpers import (
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
+from utils import (
+    atomic_json_write,
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    is_copilot_api_base_url,
+    is_truthy_value,
+    model_forces_max_completion_tokens,
+)
 
 
 # Internal flags that mark a message as ephemeral empty-response/prefill
@@ -1413,15 +1421,8 @@ class AIAgent:
 
     def _is_github_copilot_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""
-        if base_url is not None:
-            hostname = base_url_hostname(base_url)
-        else:
-            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
-                getattr(self, "_base_url_lower", "")
-            )
-        if not hostname:
-            return False
-        return hostname == "api.githubcopilot.com" or hostname.endswith(".githubcopilot.com")
+        url = base_url if base_url is not None else getattr(self, "_base_url_lower", "")
+        return is_copilot_api_base_url(url)
 
     def _resolved_api_call_timeout(self) -> float:
         """Resolve the effective per-call request timeout in seconds.
@@ -1594,7 +1595,7 @@ class AIAgent:
     def _is_copilot_url(self) -> bool:
         """Return True when the base URL targets GitHub Copilot or GitHub Models."""
         return (
-            base_url_host_matches(self._base_url_lower, "api.githubcopilot.com")
+            is_copilot_api_base_url(self._base_url_lower)
             or base_url_host_matches(self._base_url_lower, "models.github.ai")
         )
 
@@ -5409,7 +5410,7 @@ class AIAgent:
         # unaffected (they don't go through here).
         request_kwargs["max_retries"] = 0
         if (
-            base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
+            is_copilot_api_base_url(str(request_kwargs.get("base_url", "")))
             and self._api_kwargs_have_image_parts(api_kwargs or {})
         ):
             request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
@@ -6344,7 +6345,7 @@ class AIAgent:
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):
             self._client_kwargs["default_headers"] = _routermint_headers()
-        elif base_url_host_matches(base_url, "githubcopilot.com"):
+        elif is_copilot_api_base_url(base_url):
             from hermes_cli.models import copilot_default_headers
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
@@ -7639,7 +7640,7 @@ class AIAgent:
             return True
         if (
             base_url_host_matches(self._base_url_lower, "models.github.ai")
-            or base_url_host_matches(self._base_url_lower, "githubcopilot.com")
+            or is_copilot_api_base_url(self._base_url_lower)
         ):
             try:
                 from hermes_cli.models import github_model_reasoning_efforts

--- a/tests/hermes_cli/test_base_url_host_identity.py
+++ b/tests/hermes_cli/test_base_url_host_identity.py
@@ -123,10 +123,21 @@ def test_run_agent_copilot_url_predicate():
     assert probe._is_copilot_url() is True
     probe._base_url_lower = "https://proxy.test/api.githubcopilot.com/v1"
     assert probe._is_copilot_url() is False
+    probe._base_url_lower = "https://copilot-api.acme.ghe.com"
+    assert probe._is_copilot_url() is True
     probe._base_url_lower = "https://models.github.ai/inference"
     assert probe._is_copilot_url() is True
     probe._base_url_lower = "https://models.github.ai.evil.com/v1"
     assert probe._is_copilot_url() is False
+
+
+def test_ghec_copilot_url_infers_provider():
+    from agent.model_metadata import _infer_provider_from_url
+
+    assert (
+        _infer_provider_from_url("https://copilot-api.acme.ghe.com")
+        == "copilot"
+    )
 
 
 def test_dotted_model_name_provider_allowlist_host_anchored():

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -50,6 +51,59 @@ class TestExchangeCopilotToken:
         req = call_args[0][0]
         assert req.get_header("Authorization") == "token gho_test123"
         assert "GitHubCopilotChat" in req.get_header("User-agent")
+
+    @patch("urllib.request.urlopen")
+    def test_ghec_exchange_uses_enterprise_api_host(self, mock_urlopen, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        monkeypatch.setenv("COPILOT_GH_HOST", "acme.ghe.com")
+        mock_urlopen.return_value = self._mock_urlopen(token="tid=enterprise")
+
+        exchange_copilot_token("ghu_enterprise")
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == (
+            "https://api.acme.ghe.com/copilot_internal/v2/token"
+        )
+
+    @patch("urllib.request.urlopen")
+    def test_ghec_exchange_falls_back_to_api_v3(self, mock_urlopen, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        monkeypatch.setenv("COPILOT_GH_HOST", "acme.ghe.com")
+        rejected = urllib.error.HTTPError(
+            url="https://api.acme.ghe.com/copilot_internal/v2/token",
+            code=404,
+            msg="not found",
+            hdrs=None,
+            fp=None,
+        )
+        mock_urlopen.side_effect = [
+            rejected,
+            self._mock_urlopen(token="tid=enterprise"),
+        ]
+
+        exchange_copilot_token("ghu_enterprise")
+
+        assert [call.args[0].full_url for call in mock_urlopen.call_args_list] == [
+            "https://api.acme.ghe.com/copilot_internal/v2/token",
+            "https://acme.ghe.com/api/v3/copilot_internal/v2/token",
+        ]
+
+    @patch("urllib.request.urlopen")
+    def test_exchange_cache_is_scoped_to_github_host(self, mock_urlopen, monkeypatch):
+        from hermes_cli.copilot_auth import exchange_copilot_token
+
+        mock_urlopen.side_effect = [
+            self._mock_urlopen(token="tid=public"),
+            self._mock_urlopen(token="tid=enterprise"),
+        ]
+        public_token, _, _ = exchange_copilot_token("ghu_shared")
+        monkeypatch.setenv("COPILOT_GH_HOST", "acme.ghe.com")
+        enterprise_token, _, _ = exchange_copilot_token("ghu_shared")
+
+        assert public_token == "tid=public"
+        assert enterprise_token == "tid=enterprise"
 
 
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -281,3 +281,25 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
     assert "X-OpenRouter-Cache-TTL" not in headers
 
 
+@patch("run_agent.OpenAI")
+def test_ghec_copilot_base_url_applies_copilot_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://copilot-api.acme.ghe.com",
+        model="gpt-5.4",
+        provider="copilot",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url(
+        "https://copilot-api.acme.ghe.com"
+    )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["Editor-Version"].startswith("vscode/")
+    assert headers["Copilot-Integration-Id"] == "vscode-chat"
+
+

--- a/tests/test_base_url_hostname.py
+++ b/tests/test_base_url_hostname.py
@@ -8,7 +8,7 @@ tests/agent/test_direct_provider_url_detection.py.
 
 from __future__ import annotations
 
-from utils import base_url_hostname, base_url_host_matches
+from utils import base_url_hostname, base_url_host_matches, is_copilot_api_base_url
 
 
 # ─── base_url_hostname ────────────────────────────────────────────────────
@@ -86,6 +86,20 @@ class TestBaseUrlHostMatchesEdgeCases:
         assert base_url_host_matches("", "openrouter.ai") is False
         assert base_url_host_matches(None, "openrouter.ai") is False  # type: ignore[arg-type]
 
+
+class TestCopilotApiBaseUrl:
+    def test_recognizes_ghec_copilot_api_host(self):
+        assert is_copilot_api_base_url(
+            "https://copilot-api.acme.ghe.com/v1"
+        ) is True
+
+    def test_rejects_ghec_lookalikes(self):
+        assert is_copilot_api_base_url(
+            "https://copilot-api.acme.ghe.com.evil.test/v1"
+        ) is False
+        assert is_copilot_api_base_url(
+            "https://evil.test/copilot-api.acme.ghe.com/v1"
+        ) is False
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -922,3 +922,15 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+def is_copilot_api_base_url(base_url: str) -> bool:
+    """Return whether *base_url* targets a Copilot inference API host."""
+    hostname = base_url_hostname(base_url)
+    if not hostname:
+        return False
+    if hostname == "githubcopilot.com" or hostname.endswith(".githubcopilot.com"):
+        return True
+    if hostname.startswith("copilot-api.") and hostname.endswith(".ghe.com"):
+        return True
+    return False


### PR DESCRIPTION
## What does this PR do?

GitHub Enterprise Cloud Copilot users can now exchange enterprise GitHub tokens against their tenant endpoints and send inference requests to `copilot-api.<tenant>.ghe.com` with the required Copilot headers. Without this change, token exchange targets public GitHub and fails with HTTP 401, or inference reaches the enterprise API without `Editor-Version` and fails with HTTP 400.

### Symptom

With `COPILOT_GH_HOST=<tenant>.ghe.com` and `COPILOT_API_BASE_URL=https://copilot-api.<tenant>.ghe.com`, token exchange still calls `api.github.com`. If exchange is bypassed or locally corrected, inference paths classify only `*.githubcopilot.com` as Copilot and omit required headers on the GHEC host.

### Impact

GHEC Copilot authentication and inference are unusable for the reported configuration. Public GitHub Copilot behavior is unaffected.

### Bug Cause

**Trigger:** `hermes_cli/copilot_auth.py:exchange_copilot_token` and Copilot URL checks across the agent client builders.

**Causal chain:**
1. An enterprise user configures a GHEC GitHub host and tenant Copilot API base URL.
2. Token exchange uses a hardcoded public URL, while later client paths recognize only the `githubcopilot.com` suffix.
3. The enterprise token is rejected by public GitHub, or GHEC inference rejects requests missing Copilot IDE headers.

**Why it is wrong:** Both authentication endpoint selection and inference behavior depend on the configured enterprise route, but the implementation encoded public-host assumptions in separate layers.

**Working sibling / contrast:** Public GitHub Copilot already exchanges through `api.github.com` and receives Copilot headers because `api.githubcopilot.com` matches the existing suffix checks.

**Ruled out:** `COPILOT_API_BASE_URL` resolution is not the source of the inference URL mismatch; the configured URL reaches the GHEC endpoint. The failure occurs because host classification does not apply the Copilot request contract there.

### Fix

- Derive enterprise exchange candidates from `COPILOT_GH_HOST`, trying both `api.<host>/copilot_internal/v2/token` and `<host>/api/v3/copilot_internal/v2/token`.
- Scope exchanged-token caches to the GitHub host that minted each token.
- Centralize Copilot API host recognition for public, legacy enterprise, and `copilot-api.*.ghe.com` hosts, then use it across main and auxiliary client routing, header injection, replay handling, provider inference, and token parameter selection.

## Related Issue

Closes #96164

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/copilot_auth.py` - derive GHEC exchange endpoints, add fallback, and isolate token caches by host.
- `utils.py` - add host-anchored Copilot API recognition including GHEC.
- `agent/` and `run_agent.py` - apply the shared classifier to every Copilot-specific request path.
- `tests/` - cover exchange routing, fallback, cache isolation, GHEC host safety, provider inference, and required headers.

## How to Test

1. Configure a GHEC Copilot tenant and run a Copilot request; token exchange should target the tenant and inference should include `Editor-Version` and `Copilot-Integration-Id`.
2. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_copilot*.py tests/hermes_cli/test_base_url_host_identity.py tests/test_base_url_hostname.py tests/test_copilot_initiator.py tests/run_agent/test_copilot*.py tests/run_agent/test_provider_attribution_headers.py tests/agent/test_auxiliary_client.py -q
```

Result: 298 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test entry on the relevant tests and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested the implementation on Windows 11 with mocked enterprise HTTP boundaries.

### Documentation & Housekeeping

- [x] Documentation update is not required; existing configuration keys are unchanged.
- [x] `cli-config.yaml.example` update is not required; no config keys were added or changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not required; no workflow changed.
- [x] Cross-platform impact was considered; URL selection and matching use platform-independent standard-library behavior.
- [x] Tool descriptions and schemas are not affected.
