### PR TITLE
fix(cli): log when the pre-exit memory flush fails to drain

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -756,8 +756,16 @@ def _shutdown_agent_memory_provider(agent) -> None:
     # ~5s drain would cancel it, so give it a bounded head start (watchdog is the backstop).
     _mm = getattr(agent, '_memory_manager', None)
     if _mm is not None and hasattr(_mm, 'flush_pending'):
-        with suppress(Exception):
-            _mm.flush_pending(timeout=10)
+        try:
+            # flush_pending() catches its own exceptions and reports failure via a
+            # False return, so `suppress`/`except` alone never fires here. Check the
+            # result or the dropped extraction stays silent.
+            if not _mm.flush_pending(timeout=10):
+                logger.warning(
+                    "Memory flush did not drain before exit; pending extraction may be lost"
+                )
+        except Exception:
+            logger.warning("Memory flush failed before exit", exc_info=True)
     # Forward the agent's transcript so on_session_end hooks see the real conversation;
     # no-arg fallback for stubs / partially-initialised agents.
     _session_msgs = getattr(agent, '_session_messages', None)

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -223,6 +223,42 @@ def test_run_cleanup_flushes_pending_memory_manager_work(tmp_path):
     mm.flush_pending.assert_called_once_with(timeout=10)
 
 
+def test_run_cleanup_warns_when_flush_pending_reports_failure(caplog):
+    """A failed/timed-out drain must not exit silently.
+
+    ``MemoryManager.flush_pending`` swallows its own exceptions and reports
+    failure through a ``False`` return, so the caller's ``except`` clause never
+    fires. Ignoring the return value drops the old session's extraction with no
+    trace — the exact loss the surrounding bounded-drain logic exists to stop.
+    """
+    import logging
+
+    import cli as _cli_mod
+
+    agent = MagicMock()
+    mm = MagicMock()
+    mm.flush_pending.return_value = False  # drain timed out or failed
+    agent._memory_manager = mm
+    agent._session_messages = []
+
+    old_ref = _cli_mod._active_agent_ref
+    _cli_mod._active_agent_ref = agent
+    _cli_mod._cleanup_done = False
+    try:
+        with caplog.at_level(logging.WARNING):
+            _cli_mod._run_cleanup(notify_session_finalize=False)
+    finally:
+        _cli_mod._cleanup_done = True
+        _cli_mod._active_agent_ref = old_ref
+
+    mm.flush_pending.assert_called_once_with(timeout=10)
+    assert any(
+        "memory" in r.message.lower() and "flush" in r.message.lower()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    ), "a failed memory flush must be logged, not swallowed"
+
+
 
 
 


### PR DESCRIPTION
## Problem

`_run_cleanup` gives the memory manager's serialized worker a bounded drain via `flush_pending(timeout=10)` before `shutdown_all()`'s short-fuse drain runs. The surrounding comment states the intent: a `/new` shortly before exit leaves an LLM-bound extraction task queued, and without this barrier *"a `/new` then quit silently drops the old session's extraction."*

The call was written as:

```python
try:
    _mm.flush_pending(timeout=10)
except Exception:
    pass
```

`MemoryManager.flush_pending` (`agent/memory_manager.py`) catches its own exceptions and signals failure through a **`False` return**:

```python
except Exception:
    return False
```

So the `except Exception: pass` here can never fire, and the discarded return value is the only failure signal there is. On a timeout or a failed drain the queued extraction is dropped with **no log line, no warning, nothing** — precisely the silent loss this code block exists to prevent.

I confirmed the behaviour rather than inferring it:

```
flush_pending returns False on executor error   : True
flush_pending returns False on timeout          : True
caller receives an exception                    : False
```

## Fix

Check the return value, and keep the `except` as a backstop that logs instead of swallowing.

## Consistency with existing code

`run_agent.py:_ensure_db_session` already handles the same class of failure this way:

```python
except Exception as e:
    # Transient failure (e.g. SQLite lock). Keep _session_db alive —
    # _session_db_created stays False so next run_conversation() retries.
    logger.warning("Session DB creation failed (will retry next turn): %s", e)
```

This change brings the memory-flush path in line with that precedent.

## Test

`test_run_cleanup_warns_when_flush_pending_reports_failure` drives `flush_pending` to return `False` and asserts a warning is emitted.

- On `main`: **fails** — `AssertionError: a failed memory flush must be logged, not swallowed`
- With this change: **passes**

```
tests/cli/test_cli_new_session.py .......  7 passed
ruff check cli.py tests/cli/test_cli_new_session.py  All checks passed!
```

## Note on unrelated failures

A wider run of `tests/cli/` shows 4 failures in `test_cli_light_mode.py` (`TestOsc11DrainGuard`) and `test_worktree.py` (`TestPrMergedEscapeHatch`). I verified these are **pre-existing on a clean `origin/main` checkout on Windows** and are unrelated to this change.

## Scope

One behavioural change, no control-flow change on the success path. This does not touch the other `except: pass` handlers in the same function — several of them wrap callees that already log internally (`finalize_session` logs `logger.warning(..., exc_info=True)` on every branch), so adding logging there would be noise.
