### PR TITLE
fix(doctor): respect enabled session auto-pruning

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -414,7 +414,11 @@ STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 
-def _render_state_db_stats(stats: dict, holders=None) -> list:
+def _render_state_db_stats(
+    stats: dict,
+    holders=None,
+    auto_prune_enabled: bool | None = None,
+) -> list:
     """Turn a collect_state_db_stats() dict into doctor output lines.
 
     Returns a list of ``(kind, text, detail)`` tuples where kind is one of
@@ -478,22 +482,26 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
     # trigram layout (fts_storage_version marker absent) — the offline
     # optimize-storage pass that migrates/compacts the FTS indexes.
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
-        detail = (
-            "consider enabling sessions.auto_prune in config.yaml "
-            "to bound growth"
-        )
+        details = []
+        if auto_prune_enabled is not True:
+            details.append(
+                "consider enabling sessions.auto_prune in config.yaml "
+                "to bound growth"
+            )
         legacy_trigram = (
             fts is not None
             and fts.get("messages_fts_trigram")
             and stats.get("fts_storage_version") is None
         )
         if stats.get("fts_rebuild_pending") or legacy_trigram:
-            detail += (
-                "; run 'hermes sessions optimize-storage' offline "
+            details.append(
+                "run 'hermes sessions optimize-storage' offline "
                 "(with the gateway stopped) to compact FTS storage"
             )
+        kind = "warn" if details else "info"
+        detail = "; ".join(details) if details else "sessions.auto_prune is enabled"
         lines.append((
-            "warn",
+            kind,
             f"state.db is large ({_human_bytes(logical)})",
             f"({detail})",
         ))
@@ -2169,12 +2177,22 @@ def run_doctor(args):
 
             _db_stats = collect_state_db_stats(state_db_path)
             _db_holders = count_db_holders(state_db_path)
+            try:
+                from hermes_cli.config import load_config
+
+                _sessions_cfg = (load_config() or {}).get("sessions") or {}
+                _auto_prune_enabled = bool(_sessions_cfg.get("auto_prune", False))
+            except Exception:
+                _auto_prune_enabled = None
+
             for _kind, _text, _detail in _render_state_db_stats(
-                _db_stats, holders=_db_holders
+                _db_stats,
+                holders=_db_holders,
+                auto_prune_enabled=_auto_prune_enabled,
             ):
                 if _kind == "warn":
                     check_warn(_text, _detail)
-                    if "auto_prune" in _detail:
+                    if "consider enabling sessions.auto_prune" in _detail:
                         issues.append(
                             "state.db is large — enable sessions.auto_prune "
                             "in config.yaml"

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -224,6 +224,39 @@ def test_render_large_db_with_pending_rebuild_suggests_optimize():
     assert "optimize-storage" in blob
 
 
+def test_render_large_db_with_auto_prune_enabled_is_informational():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big),
+        holders=None,
+        auto_prune_enabled=True,
+    )
+
+    matching = [line for line in lines if "state.db is large" in line[1]]
+    assert len(matching) == 1
+    assert matching[0][0] == "info"
+    assert matching[0][2] == "(sessions.auto_prune is enabled)"
+
+
+def test_render_large_db_pending_rebuild_with_auto_prune_only_suggests_optimize():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, fts_rebuild_pending=True),
+        holders=None,
+        auto_prune_enabled=True,
+    )
+
+    matching = [line for line in lines if "state.db is large" in line[1]]
+    assert len(matching) == 1
+    assert matching[0][0] == "warn"
+    assert "optimize-storage" in matching[0][2]
+    assert "consider enabling" not in matching[0][2]
+
+
 def test_render_large_db_legacy_trigram_suggests_optimize():
     from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
 


### PR DESCRIPTION
## What

Make the `state.db` size diagnostic aware of `sessions.auto_prune`:

- keep the large-database size visible;
- stop recommending that users enable auto-pruning when it is already enabled;
- keep `optimize-storage` as a warning when an FTS rebuild or legacy trigram layout still requires it;
- add focused rendering regression tests.

## Why

On long-running installations, `hermes doctor` currently reports a large `state.db` and recommends enabling `sessions.auto_prune` even when the setting is already enabled. This creates a false remediation item and prevents a clean, actionable doctor result.

## How to test

```bash
python -m pytest tests/test_state_db_stats.py tests/test_session_vacuum_config.py -o 'addopts=' -q
```

Result: `17 passed`.

## Platforms tested

- macOS 26.3.1, Python 3.11

The rendering helper is platform-independent; config loading uses the existing Hermes config path.
