### PR TITLE
fix(gateway): make macOS supervision diagnostics portable

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -204,7 +204,7 @@ def spawn_async_diagnostic(
 
     Runs as a detached subprocess so it can't block the asyncio event loop
     or compete with platform teardown.  The subprocess uses its own
-    ``timeout`` so a wedged ``ps`` still self-cleans within
+    Python timeout supervisor so a wedged ``ps`` still self-cleans within
     ``timeout_seconds``.
 
     Returns the subprocess PID on success, ``None`` on failure.  Never
@@ -226,19 +226,36 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
-    script = (
+    common_script = (
         f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
     )
+    if sys.platform == "darwin":
+        platform_script = (
+            "echo '--- process snapshot (top 60 by cpu) ---'; "
+            "ps -axo pid,ppid,%cpu,%mem,state,etime,command -r 2>/dev/null | head -60; "
+            "echo '--- gateway and parent ---'; "
+            f"ps -p {os.getpid()} -o pid,ppid,%cpu,%mem,state,etime,command 2>/dev/null || true; "
+            f"parent_pid=$(ps -p {os.getpid()} -o ppid= 2>/dev/null | tr -d ' '); "
+            "if [ -n \"$parent_pid\" ]; then "
+            "ps -p \"$parent_pid\" -o pid,ppid,%cpu,%mem,state,etime,command 2>/dev/null || true; "
+            "fi; "
+            "echo '--- load ---'; uptime 2>/dev/null || true; "
+            "sysctl -n vm.loadavg 2>/dev/null || true; "
+            "echo '--- virtual memory ---'; vm_stat 2>/dev/null | head -20 || true; "
+        )
+    else:
+        platform_script = (
+            "echo '--- process snapshot (top 60 by cpu) ---'; "
+            "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+            "echo '--- pstree of self ---'; "
+            f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+            "echo '--- load ---'; cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || "
+            "journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+        )
+    script = common_script + platform_script + "echo '=== end ==='"
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -248,6 +265,27 @@ def spawn_async_diagnostic(
     except OSError:
         return None
 
+    # Use the running Python interpreter as the timeout supervisor.  GNU
+    # ``timeout`` is not part of macOS, even though macOS is a supported POSIX
+    # target.  The wrapper gives the diagnostic shell its own process group so
+    # a deadline can terminate the whole snapshot rather than only ``bash``.
+    timeout_wrapper = """
+import os
+import signal
+import subprocess
+import sys
+
+child = subprocess.Popen(["bash", "-c", sys.argv[1]], start_new_session=True)
+try:
+    child.wait(timeout=float(sys.argv[2]))
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(child.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    child.wait()
+"""
+
     try:
         # Detach from our process group so the subprocess survives even
         # if systemd kills our cgroup with KillMode=control-group (which
@@ -255,7 +293,7 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            [sys.executable, "-c", timeout_wrapper, script, str(timeout_seconds)],
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5041,6 +5041,15 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <!-- macOS 26 (Darwin 25.x) hands launchd-spawned jobs
+             XPC_SERVICE_NAME=0 — the same sentinel an interactive shell
+             inherits — so is_gateway_supervisor_process() cannot tell the
+             service's own startup from a stray shell launch, and
+             _guard_supervised_gateway_conflict() exits 1 in a respawn/refuse
+             loop. Declare the documented external-supervisor opt-in so the
+             guard stands down for the job launchd itself started. -->
+        <key>HERMES_GATEWAY_EXTERNAL_SUPERVISOR</key>
+        <string>1</string>
     </dict>
 
     <key>LimitLoadToSessionType</key>

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -114,6 +114,10 @@ class TestSpawnAsyncDiagnostic:
         contents = log_path.read_text(encoding="utf-8", errors="replace")
         assert "shutdown diagnostic" in contents
         assert "SIGTERM" in contents
+        assert "--- process snapshot (top 60 by cpu) ---" in contents
+        assert "PID" in contents
+        assert "--- load ---" in contents
+        assert "=== end ===" in contents
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fix two macOS gateway supervision/diagnostic issues:

- declare `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1` in generated launchd plists so the launchd-owned gateway does not enter a respawn/refuse loop when Darwin exposes the non-distinguishing `XPC_SERVICE_NAME=0` sentinel;
- replace the GNU-only `timeout` executable in shutdown diagnostics with a small wrapper driven by the running Python interpreter, including process-group termination on deadline.

## Why

macOS is a supported POSIX target but does not ship GNU `timeout`. As a result, shutdown diagnostics silently failed to spawn. On macOS 26, the launchd environment can also make the service process look like an unsupervised shell launch unless the existing explicit external-supervisor opt-in is present in the generated plist.

## How to test

```bash
python -m pytest \
  tests/gateway/test_shutdown_forensics.py \
  tests/gateway/test_status.py \
  tests/hermes_cli/test_gateway_external_supervisor.py \
  tests/hermes_cli/test_gateway.py \
  tests/hermes_cli/test_gateway_service.py \
  -o 'addopts=' -q
```

Result: `211 passed, 6 skipped`.

Manual verification on macOS:

- regenerated launchd plist contains the external-supervisor opt-in;
- gateway remains supervised by launchd;
- shutdown diagnostic subprocess is created without a system `timeout` binary.

## Platforms tested

- macOS 26.3.1, Python 3.11

Windows keeps the existing early return. Linux continues to run the same Bash diagnostic under the portable Python deadline wrapper.
