### PR TITLE
feat(memory): extract durable facts from Russian prompts

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -369,6 +369,10 @@ class HolographicMemoryProvider(MemoryProvider):
     # -- Auto-extraction (on_session_end) ------------------------------------
 
     def _auto_extract_facts(self, messages: list) -> None:
+        store = self._store
+        if store is None:
+            return
+
         # Local import (pattern used in initialize()): the compressor module is
         # heavier than this plugin and is only needed when auto_extract is on.
         from agent.context_compressor import (
@@ -402,11 +406,20 @@ class HolographicMemoryProvider(MemoryProvider):
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
             re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bя\s+(?:предпочитаю|люблю|использую|хочу|не\s+люблю)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bмне\s+(?:нравится|удобнее|важно)\s+(.+)', re.IGNORECASE),
         ]
         _DECISION_PATTERNS = [
             re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
             re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bмы\s+(?:решили|договорились|выбрали)\s+(.+)', re.IGNORECASE),
+            re.compile(r'\bпроект\s+(?:использует|требует)\s+(.+)', re.IGNORECASE),
         ]
+        _EXPLICIT_MEMORY_PATTERN = re.compile(
+            r'^\s*(?:запомни|помни|сохрани\s+в\s+память)'
+            r'(?:\s*[:,-]\s*|\s+)(.+)',
+            re.IGNORECASE | re.DOTALL,
+        )
 
         extracted = 0
         for msg in messages:
@@ -429,10 +442,21 @@ class HolographicMemoryProvider(MemoryProvider):
             if not isinstance(content, str) or len(content) < 10:
                 continue
 
+            explicit = _EXPLICIT_MEMORY_PATTERN.match(content)
+            if explicit:
+                fact_content = explicit.group(1).strip()
+                if fact_content:
+                    try:
+                        store.add_fact(fact_content[:400], category="general")
+                        extracted += 1
+                    except Exception:
+                        pass
+                continue
+
             for pattern in _PREF_PATTERNS:
                 if pattern.search(content):
                     try:
-                        self._store.add_fact(content[:400], category="user_pref")
+                        store.add_fact(content[:400], category="user_pref")
                         extracted += 1
                     except Exception:
                         pass
@@ -441,7 +465,7 @@ class HolographicMemoryProvider(MemoryProvider):
             for pattern in _DECISION_PATTERNS:
                 if pattern.search(content):
                     try:
-                        self._store.add_fact(content[:400], category="project")
+                        store.add_fact(content[:400], category="project")
                         extracted += 1
                     except Exception:
                         pass

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -122,6 +122,40 @@ def test_real_user_messages_still_extracted_alongside_summary(tmp_path):
     provider.shutdown()
 
 
+@pytest.mark.parametrize(
+    ("message", "expected", "category"),
+    [
+        ("Я предпочитаю краткие ответы по-русски", "краткие ответы", "user_pref"),
+        ("Мы решили использовать PostgreSQL для хранения", "PostgreSQL", "project"),
+        ("Запомни: рабочая папка проекта — ~/src/app", "рабочая папка", "general"),
+    ],
+)
+def test_russian_durable_facts_are_extracted(tmp_path, message, expected, category):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+
+    assert provider._store is not None
+    facts = provider._store.list_facts(limit=100)
+    assert len(facts) == 1
+    assert expected in facts[0]["content"]
+    assert facts[0]["category"] == category
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Помнишь, как мы познакомились?",
+        "Запомнилась поездка в Казань прошлым летом",
+    ],
+)
+def test_russian_words_starting_with_memory_verbs_are_not_extracted(tmp_path, message):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
 # ---------------------------------------------------------------------------
 # is_compaction_summary_message — public helper contract
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extend Holographic Memory auto-extraction with Russian-language durable-fact patterns:

- user preferences such as `Я предпочитаю ...` and `Мне нравится ...`;
- project decisions such as `Мы решили ...` and `Проект использует ...`;
- explicit memory requests such as `Запомни: ...`, storing the payload without the command prefix;
- regression coverage for category and content.

## Why

The current auto-extractor only recognizes English patterns, so otherwise equivalent Russian user preferences and project decisions are silently omitted from Holographic Memory.

The existing compaction-summary guard remains unchanged, and explicit-memory matches stop further pattern processing to avoid duplicate facts from one message.

## How to test

```bash
python -m pytest tests/plugins/memory -o 'addopts=' -q
```

Result: `368 passed`.

## Platforms tested

- macOS 26.3.1, Python 3.11

The change uses Python Unicode-aware regular expressions and is platform-independent.
