### PR TITLE
fix(status): plugin platforms report configured via the credential chain

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -540,13 +540,31 @@ def show_status(args):
 
     # Plugin-registered platforms
     try:
+        from gateway.config import PlatformConfig
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             # Per-entry guard: one raising probe must not abort the listing
             # of every remaining plugin platform (matches the other three
             # check_fn call sites).
             try:
-                configured = bool(entry.check_fn())
+                # "configured" must follow the same semantic chain the
+                # gateway uses for "is this platform usable" (is_connected ->
+                # validate_config), NOT check_fn: for several plugins
+                # (teams, photon, a2a) check_fn is the PASSIVE dependency
+                # probe (SDK importability / stdlib-only), so reporting it as
+                # "configured" showed platforms with only commented-out .env
+                # template lines as configured the moment the optional SDKs
+                # were installed (#96190). Every current plugin registers
+                # validate_config/is_connected; an entry with neither is
+                # reported not configured rather than trusting a probe whose
+                # credential semantics are unknowable at this call site.
+                probe_cfg = PlatformConfig()
+                if entry.is_connected is not None:
+                    configured = bool(entry.is_connected(probe_cfg))
+                elif entry.validate_config is not None:
+                    configured = bool(entry.validate_config(probe_cfg))
+                else:
+                    configured = False
             except Exception:
                 configured = False
             status_str = "configured" if configured else "not configured"

--- a/tests/hermes_cli/test_status_plugin_platforms.py
+++ b/tests/hermes_cli/test_status_plugin_platforms.py
@@ -1,0 +1,110 @@
+"""Regression tests for the plugin-platform list in ``hermes status`` (#96190).
+
+``check_fn`` is the registry's PASSIVE dependency probe; for several plugins
+(teams, photon, a2a) it answers "are the SDKs importable right now?", not "are
+credentials configured". Reporting it as "configured" showed platforms with
+only commented-out .env template lines as configured the moment the optional
+SDKs landed in the venv. The status listing now follows the same semantic
+chain the gateway uses for platform usability — ``is_connected`` ->
+``validate_config`` — falling back to ``check_fn`` only for plugins that
+register neither (buzz/ntfy style probes that already gate on credentials).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import hermes_cli.status as status_mod
+
+
+class _FakeRegistry:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def plugin_entries(self):
+        return self._entries
+
+
+def _entry(label, *, is_connected=None, validate_config=None, check_fn=lambda: True):
+    return SimpleNamespace(
+        label=label,
+        is_connected=is_connected,
+        validate_config=validate_config,
+        check_fn=check_fn,
+    )
+
+
+def _run_status(capsys, entries, monkeypatch):
+    monkeypatch.setattr(
+        "gateway.platform_registry.platform_registry", _FakeRegistry(entries)
+    )
+    # The import inside the plugin loop resolves through sys.modules; patch
+    # the registry symbol on the real module too.
+    import gateway.platform_registry as real_registry
+
+    monkeypatch.setattr(real_registry, "platform_registry", _FakeRegistry(entries))
+
+    status_mod.show_status(SimpleNamespace(deep=False))
+    return capsys.readouterr().out
+
+
+class TestPluginPlatformStatus:
+    def test_dependency_probe_alone_never_means_configured(self, capsys, monkeypatch):
+        """check_fn=True (SDK importable) with no credential slots must
+        report NOT configured (#96190)."""
+        out = _run_status(
+            capsys,
+            [_entry("Teams", check_fn=lambda: True)],
+            monkeypatch,
+        )
+        line = next(l for l in out.splitlines() if "Teams" in l)
+        assert "not configured" in line
+
+    def test_validate_config_drives_configured(self, capsys, monkeypatch):
+        """With validate_config registered, its verdict is the answer."""
+        entries = [
+            _entry("ProbeFalse", validate_config=lambda cfg: False, check_fn=lambda: True),
+            _entry("ProbeTrue", validate_config=lambda cfg: True, check_fn=lambda: True),
+        ]
+        out = _run_status(capsys, entries, monkeypatch)
+        line_f = next(l for l in out.splitlines() if "ProbeFalse" in l)
+        line_t = next(l for l in out.splitlines() if "ProbeTrue" in l)
+        assert "not configured" in line_f
+        assert "configured" in line_t
+        assert "not configured" not in line_t
+
+    def test_is_connected_takes_priority_over_validate(self, capsys, monkeypatch):
+        entries = [
+            _entry(
+                "ConnOK",
+                is_connected=lambda cfg: True,
+                validate_config=lambda cfg: False,
+                check_fn=lambda: False,
+            )
+        ]
+        out = _run_status(capsys, entries, monkeypatch)
+        line = next(l for l in out.splitlines() if "ConnOK" in l)
+        assert "configured" in line
+        assert "not configured" not in line
+
+    def test_no_semantic_slots_fails_to_not_configured(self, capsys, monkeypatch):
+        """An entry registering neither is_connected nor validate_config is
+        reported not configured — check_fn's credential semantics are
+        unknowable at this call site, and every current plugin registers
+        both slots."""
+        entries = [
+            _entry("Bare", check_fn=lambda: False),
+        ]
+        out = _run_status(capsys, entries, monkeypatch)
+        line = next(l for l in out.splitlines() if "Bare" in l)
+        assert "not configured" in line
+
+    def test_raising_probe_fails_closed_per_entry(self, capsys, monkeypatch):
+        entries = [
+            _entry("Bad", validate_config=lambda cfg: (_ for _ in ()).throw(ValueError("boom"))),
+            _entry("Good", validate_config=lambda cfg: True),
+        ]
+        out = _run_status(capsys, entries, monkeypatch)
+        bad = next(l for l in out.splitlines() if "Bad" in l)
+        good = next(l for l in out.splitlines() if "Good" in l)
+        assert "not configured" in bad
+        assert "configured" in good


### PR DESCRIPTION
## What does this PR do?

The plugin-platform list in `hermes status` reported `check_fn()` as "configured". For several plugins (teams, photon, a2a) `check_fn` is the registry's **PASSIVE dependency probe** — SDK importability / stdlib-only availability — so the moment an update installed the optional platform SDKs into the venv, every platform with only commented-out `.env` template lines flipped to "✓ configured (plugin)", while the legacy list in the same command's output correctly said "✗ not configured" for the exact same platforms (#96190: Discord, WhatsApp, Slack, Teams, WeCom, WeCom Callback, Mattermost, Home Assistant, Photon, A2A — zero active credentials among them).

The listing now follows the same semantic chain the gateway itself uses for platform usability (`gateway/config.py`'s `is_connected -> validate_config`): each plugin entry is probed with an empty `PlatformConfig` via `is_connected` when registered, else `validate_config`, and an entry registering **neither** slot is reported "not configured" — `check_fn`'s credential semantics are unknowable at this call site, and every current plugin (teams, photon, buzz, ntfy, a2a, …) registers both slots, so the guard changes nothing for well-formed entries.

## Related Issue

Fixes #96190

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/status.py` — the plugin-platform loop probes `is_connected` -> `validate_config` over an empty `PlatformConfig` instead of `check_fn`; per-entry fail-closed guard kept; rationale documented at the site.
- `tests/hermes_cli/test_status_plugin_platforms.py` (new, 5 tests): a check_fn-only entry never reads as configured; `validate_config` drives the verdict; `is_connected` takes priority over `validate_config`; an entry with neither semantic slot fails to "not configured"; one raising probe fails closed per entry without aborting the listing.

## How to Test

1. `python -m pytest tests/hermes_cli/test_status_plugin_platforms.py -q` — should pass (5 passed).
2. Red/green: on unpatched `main`, four of the five tests fail (the check_fn-only entry reads "configured", the chain priority and per-entry fail-closed are absent); with this PR all five pass.
3. Manual (per the issue): with only commented-out `SLACK_BOT_TOKEN`/`TEAMS_CLIENT_ID` etc. template lines in `.env` and the optional SDKs installed, `hermes status` now shows those platforms as "✗ not configured (plugin)", agreeing with the legacy list.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the passive-probe vs credential-chain distinction and the no-slot guard documented at the call site)
- [x] New and existing unit tests pass locally (5 new)
- [x] Changes are backward compatible (plugins registering both slots — all current ones — keep their validate/is_connected verdicts; only the mislabeled dependency probe path changes)
