### PR TITLE
fix(cli): log when the /new session-row creation fails

### DIFF
--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -498,7 +498,7 @@ class CLISessionMixin:
         """Start a fresh session with a new session ID and cleared agent state."""
         from cli import (
             CLI_CONFIG, _parse_reasoning_config, _parse_service_tier_config,
-            _sync_process_session_id, datetime)
+            _sync_process_session_id, datetime, logger)
         old_session_id = self.session_id
         _boundary_snapshot = None
         if self.agent:
@@ -560,7 +560,7 @@ class CLISessionMixin:
                 self.agent._invalidate_system_prompt()
 
             if self._session_db:
-                with contextlib.suppress(Exception):
+                try:
                     self.agent._session_db_created = False
                     self._session_db.create_session(
                         session_id=self.session_id,
@@ -570,6 +570,13 @@ class CLISessionMixin:
                             "max_iterations": self.max_turns, "reasoning_config": self.reasoning_config,
                         })
                     self.agent._session_db_created = True
+                except Exception as e:
+                    # Transient failure (e.g. SQLite lock). _session_db_created stays
+                    # False so the next flush retries via _ensure_db_session(); log so a
+                    # persistently missing row is diagnosable instead of silent.
+                    logger.warning(
+                        "Session DB row creation failed on /new (will retry next turn): %s", e
+                    )
                 if title:
                     title = _apply_new_session_title(self, title)
             # Tell memory providers the session_id rotated (reset=True flushes per-session

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -179,6 +179,41 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
 
 
 
+def test_new_session_logs_when_session_row_creation_fails(tmp_path, caplog):
+    """A failed session-row INSERT on /new must leave a diagnostic trace.
+
+    ``SessionDB.create_session`` does not catch its own exceptions, so a
+    transient failure (SQLite lock, disk full) propagates here. Swallowing it
+    silently leaves ``_session_db_created`` False with nothing in the log to
+    explain why the row is missing for the rest of the turn.
+    """
+    import logging
+
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    real_create = cli._session_db.create_session
+    calls = {"n": 0}
+
+    def boom(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("database is locked")
+        return real_create(*args, **kwargs)
+
+    cli._session_db.create_session = boom
+
+    with caplog.at_level(logging.WARNING):
+        cli.process_command("/new")
+
+    assert calls["n"] >= 1, "create_session should have been attempted"
+    assert cli.agent._session_db_created is False
+    assert any(
+        "session" in r.message.lower()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    ), "a failed session-row creation must be logged, not swallowed"
+
+
 def test_new_session_delivers_context_engine_boundary_synchronously(tmp_path):
     """The context-engine on_session_end must fire during /new itself.
 


### PR DESCRIPTION
## Problem

`HermesCLI.new_session` recreates the session DB row for the fresh session id:

```python
try:
    self.agent._session_db_created = False
    self._session_db.create_session(...)
    self.agent._session_db_created = True
except Exception:
    pass
```

`SessionDB.create_session` (`hermes_state.py`) does **not** catch its own exceptions — it delegates straight to `_insert_session_row` and returns the id:

```python
def create_session(self, session_id: str, source: str, **kwargs) -> str:
    """Create a new session record. Returns the session_id."""
    self._insert_session_row(session_id, source, **kwargs)
    return session_id
```

I verified this by forcing the failure rather than assuming it:

```
create_session raises out to the caller : True
=> the except: pass at this call site swallows a real exception
```

So a transient failure (SQLite lock, disk full) is discarded with no log line.

## Scope — deliberately understated

This is **not** permanent data loss, and I want to be precise about that. `_session_db_created` stays `False`, and `_flush_messages_to_session_db_unlocked` retries on the next flush:

```python
# Retry row creation if the earlier attempt failed transiently.
if not self._session_db_created:
    self._ensure_db_session()
```

What is actually lost is the **diagnostic signal**: a persistently failing INSERT (bad permissions, full disk, corrupt DB) produces no output at all, so a missing session row is undebuggable. The row is genuinely lost only if the process exits before the next flush.

I checked the retry path specifically because it weakens the case for this change; reporting it seemed more useful than overselling the bug.

## Fix

Log a warning and keep the retry semantics unchanged.

## Consistency

`run_agent.py:_ensure_db_session` already handles this identical failure this way:

```python
except Exception as e:
    # Transient failure (e.g. SQLite lock). Keep _session_db alive —
    # _session_db_created stays False so next run_conversation() retries.
    logger.warning("Session DB creation failed (will retry next turn): %s", e)
```

Two call sites, same operation, two different behaviours — this aligns the CLI one with the existing precedent.

## Test

`test_new_session_logs_when_session_row_creation_fails` makes the first `create_session` raise and asserts a warning is emitted.

- On `main`: **fails** — `AssertionError: a failed session-row creation must be logged, not swallowed`
- With this change: **passes**

```
tests/cli/test_cli_new_session.py .......  7 passed
ruff check cli.py tests/cli/test_cli_new_session.py  All checks passed!
```

## Note on unrelated failures

A wider `tests/cli/` run shows pre-existing failures in `test_cli_light_mode.py` (`TestOsc11DrainGuard`) and `test_worktree.py` (`TestPrMergedEscapeHatch`). I confirmed these fail on a clean `origin/main` checkout on Windows and are unrelated to this change.
