### PR TITLE
test(hermes_cli): make test_default_path pass on native Windows (salvage #96003)

### DIFF
--- a/contributors/emails/paulapsp157@gmail.com
+++ b/contributors/emails/paulapsp157@gmail.com
@@ -1,0 +1,1 @@
+Aoshi-Dev

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -37,7 +38,18 @@ class TestGetHermesHome:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_HOME", None)
             home = get_hermes_home()
-            assert home == Path.home() / ".hermes"
+            if sys.platform == "win32":
+                # Windows default is %LOCALAPPDATA%\hermes — see
+                # hermes_constants._get_platform_default_hermes_home.
+                local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+                base = (
+                    Path(local_appdata)
+                    if local_appdata
+                    else Path.home() / "AppData" / "Local"
+                )
+                assert home == base / "hermes"
+            else:
+                assert home == Path.home() / ".hermes"
 
 
 class TestEnsureHermesHome:


### PR DESCRIPTION
## Summary
`TestGetHermesHome.test_default_path` asserted `~/.hermes` unconditionally; the native Windows default is `%LOCALAPPDATA%\hermes`, so the test failed on Windows independent of anything else.

Salvaged from #96003 by @Aoshi-Dev with authorship preserved — the parse-guard half of that PR was superseded by #96169 (merged), and this test fix was its independent residual value.

## Changes
- `tests/hermes_cli/test_config.py`: branch the assertion by platform (mirrors `hermes_constants._get_platform_default_hermes_home`, including the LOCALAPPDATA-unset fallback)
- `contributors/emails/`: attribution mapping for the contributor

## Validation
| | |
|---|---|
| tests/hermes_cli/test_config.py | 110 passed |
| POSIX branch | unchanged behavior |

## Credit
Original fix by @Aoshi-Dev in #96003.