### PR TITLE
feat(desktop): safely decode gzip JSON responses

### DIFF
--- a/apps/desktop/electron/api-transport.test.ts
+++ b/apps/desktop/electron/api-transport.test.ts
@@ -13,18 +13,80 @@
  */
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { gzipSync } from 'node:zlib'
 
 import { afterAll, describe, expect, it } from 'vitest'
 
 import {
+  decodeJsonResponseBody,
   destroyKeepaliveAgents,
   downloadAgentFor,
   isIdempotentMethod,
   isTransientTransportError,
+  JSON_ACCEPT_ENCODING,
   jsonAgentFor,
   shouldRetryRequest,
   withRetry
 } from './api-transport'
+
+async function* bodyChunks(...chunks: Buffer[]) {
+  yield* chunks
+}
+
+describe('bounded JSON response decoding', () => {
+  it('advertises only the supported gzip encoding', () => {
+    expect(JSON_ACCEPT_ENCODING).toBe('gzip')
+  })
+
+  it('reads identity responses without changing their bytes', async () => {
+    const result = await decodeJsonResponseBody(bodyChunks(Buffer.from('{"ok":'), Buffer.from('true}')), undefined)
+
+    expect(result.toString('utf8')).toBe('{"ok":true}')
+  })
+
+  it('decodes a gzip response', async () => {
+    const compressed = gzipSync(Buffer.from('{"sessions":[1,2,3]}'))
+    const result = await decodeJsonResponseBody(bodyChunks(compressed), 'GZip')
+
+    expect(result.toString('utf8')).toBe('{"sessions":[1,2,3]}')
+  })
+
+  it('rejects unsupported response encodings instead of parsing compressed bytes', async () => {
+    await expect(decodeJsonResponseBody(bodyChunks(Buffer.from('data')), 'br')).rejects.toThrow(
+      'Unsupported JSON response content-encoding: br'
+    )
+  })
+
+  it('rejects malformed gzip data', async () => {
+    await expect(decodeJsonResponseBody(bodyChunks(Buffer.from('not gzip')), 'gzip')).rejects.toThrow()
+  })
+
+  it('bounds compressed bytes before buffering the full response', async () => {
+    await expect(
+      decodeJsonResponseBody(bodyChunks(Buffer.alloc(5), Buffer.alloc(5)), 'identity', {
+        maxWireBytes: 8,
+        maxDecodedBytes: 64
+      })
+    ).rejects.toThrow('JSON response exceeds the 8-byte wire limit')
+  })
+
+  it('bounds decompressed output to resist gzip bombs', async () => {
+    const compressed = gzipSync(Buffer.alloc(1024, 65))
+
+    await expect(
+      decodeJsonResponseBody(bodyChunks(compressed), 'gzip', {
+        maxWireBytes: 1024,
+        maxDecodedBytes: 128
+      })
+    ).rejects.toThrow()
+  })
+
+  it('rejects trailing garbage after a valid gzip member', async () => {
+    const compressed = Buffer.concat([gzipSync(Buffer.from('{"ok":true}')), Buffer.from('garbage')])
+
+    await expect(decodeJsonResponseBody(bodyChunks(compressed), 'gzip')).rejects.toThrow()
+  })
+})
 
 function errWithCode(code: string, message = code): NodeJS.ErrnoException {
   const e: NodeJS.ErrnoException = new Error(message)
@@ -257,6 +319,42 @@ function listen(server: http.Server): Promise<string> {
     })
   })
 }
+
+describe('live: gzip JSON negotiation', () => {
+  it('requests gzip and decodes the compressed response', async () => {
+    const server = http.createServer((req, res) => {
+      expect(req.headers['accept-encoding']).toBe(JSON_ACCEPT_ENCODING)
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-encoding', 'gzip')
+      res.end(gzipSync(Buffer.from('{"sessions":[{"id":"one"}]}')))
+    })
+    const base = await listen(server)
+
+    try {
+      const result = await new Promise<any>((resolve, reject) => {
+        const req = http.request(
+          new URL(`${base}/api/sessions`),
+          {
+            agent: jsonAgentFor('http:'),
+            headers: { 'accept-encoding': JSON_ACCEPT_ENCODING }
+          },
+          res => {
+            void decodeJsonResponseBody(res, res.headers['content-encoding'])
+              .then(body => resolve(JSON.parse(body.toString('utf8'))))
+              .catch(reject)
+          }
+        )
+
+        req.on('error', reject)
+        req.end()
+      })
+
+      expect(result).toEqual({ sessions: [{ id: 'one' }] })
+    } finally {
+      server.close()
+    }
+  })
+})
 
 describe('live: GET burst against a server that resets keep-alive sockets', () => {
   it('bare attempts fail with ECONNRESET/hang-up; retried GETs all succeed', async () => {

--- a/apps/desktop/electron/api-transport.ts
+++ b/apps/desktop/electron/api-transport.ts
@@ -35,6 +35,71 @@
 
 import http from 'node:http'
 import https from 'node:https'
+import { gunzip } from 'node:zlib'
+
+const JSON_ACCEPT_ENCODING = 'gzip'
+const JSON_RESPONSE_MAX_WIRE_BYTES = 16 * 1024 * 1024
+const JSON_RESPONSE_MAX_DECODED_BYTES = 64 * 1024 * 1024
+
+type JsonResponseDecodeOptions = {
+  maxWireBytes?: number
+  maxDecodedBytes?: number
+}
+
+function gunzipBounded(input: Buffer, maxOutputLength: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    gunzip(input, { maxOutputLength }, (error, output) => {
+      if (error) {
+        reject(error)
+
+        return
+      }
+
+      resolve(output)
+    })
+  })
+}
+
+async function decodeJsonResponseBody(
+  body: AsyncIterable<Uint8Array>,
+  contentEncoding: string | string[] | undefined,
+  options: JsonResponseDecodeOptions = {}
+): Promise<Buffer> {
+  const maxWireBytes = options.maxWireBytes ?? JSON_RESPONSE_MAX_WIRE_BYTES
+  const maxDecodedBytes = options.maxDecodedBytes ?? JSON_RESPONSE_MAX_DECODED_BYTES
+  const chunks: Buffer[] = []
+  let wireBytes = 0
+
+  for await (const chunk of body) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    wireBytes += buffer.length
+
+    if (wireBytes > maxWireBytes) {
+      throw new Error(`JSON response exceeds the ${maxWireBytes}-byte wire limit`)
+    }
+
+    chunks.push(buffer)
+  }
+
+  const encoded = Buffer.concat(chunks, wireBytes)
+  const encoding = String(Array.isArray(contentEncoding) ? contentEncoding.join(',') : contentEncoding || 'identity')
+    .trim()
+    .toLowerCase()
+
+  if (encoding === 'identity') {
+    if (encoded.length > maxDecodedBytes) {
+      throw new Error(`JSON response exceeds the ${maxDecodedBytes}-byte decoded limit`)
+    }
+
+    return encoded
+  }
+
+  if (encoding !== JSON_ACCEPT_ENCODING) {
+    throw new Error(`Unsupported JSON response content-encoding: ${encoding}`)
+  }
+
+  return gunzipBounded(encoded, maxDecodedBytes)
+}
 
 // JSON pool: many small concurrent calls (session lists, config, prompts).
 const HTTP_JSON_AGENT = new http.Agent({ keepAlive: true, maxSockets: 50 })
@@ -168,10 +233,12 @@ async function withRetry(makeAttempt, options: any = {}) {
 }
 
 export {
+  decodeJsonResponseBody,
   destroyKeepaliveAgents,
   downloadAgentFor,
   isIdempotentMethod,
   isTransientTransportError,
+  JSON_ACCEPT_ENCODING,
   jsonAgentFor,
   shouldRetryRequest,
   withRetry

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,14 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
+import {
+  decodeJsonResponseBody,
+  destroyKeepaliveAgents,
+  downloadAgentFor,
+  JSON_ACCEPT_ENCODING,
+  jsonAgentFor,
+  withRetry
+} from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
@@ -5031,6 +5038,7 @@ function fetchJson(url, token, options: any = {}) {
               ...headersForRemoteRequest(url),
               ...(options.headers || {}),
               'Content-Type': contentType,
+              'Accept-Encoding': JSON_ACCEPT_ENCODING,
               'X-Hermes-Session-Token': token,
               // RFC 8252 native flow authenticates the gated gateway with a bearer
               // token instead of the loopback session-token header. When
@@ -5042,48 +5050,47 @@ function fetchJson(url, token, options: any = {}) {
             }
           },
           res => {
-            const chunks = []
-            res.on('error', reject)
-            res.on('data', chunk => chunks.push(chunk))
-            res.on('end', () => {
-              const text = Buffer.concat(chunks).toString('utf8')
+            void decodeJsonResponseBody(res, res.headers['content-encoding'])
+              .then(responseBody => {
+                const text = responseBody.toString('utf8')
 
-              if ((res.statusCode || 500) >= 400) {
-                reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+                if ((res.statusCode || 500) >= 400) {
+                  reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
 
-                return
-              }
+                  return
+                }
 
-              if (!text) {
-                resolve(null)
+                if (!text) {
+                  resolve(null)
 
-                return
-              }
+                  return
+                }
 
-              // A 2xx response whose body is HTML means the request fell through
-              // to the SPA index.html (e.g. an unregistered /api path). JSON.parse
-              // would throw an opaque `Unexpected token '<'` here, so surface a
-              // clear diagnostic with the offending URL instead.
-              const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
-              const contentType = String(res.headers['content-type'] || '')
+                // A 2xx response whose body is HTML means the request fell through
+                // to the SPA index.html (e.g. an unregistered /api path). JSON.parse
+                // would throw an opaque `Unexpected token '<'` here, so surface a
+                // clear diagnostic with the offending URL instead.
+                const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
+                const contentType = String(res.headers['content-type'] || '')
 
-              if (looksHtml || contentType.includes('text/html')) {
-                reject(
-                  new Error(
-                    `Expected JSON from ${url} but got HTML (status ${res.statusCode}). ` +
-                      'The endpoint is likely missing on the Hermes backend.'
+                if (looksHtml || contentType.includes('text/html')) {
+                  reject(
+                    new Error(
+                      `Expected JSON from ${url} but got HTML (status ${res.statusCode}). ` +
+                        'The endpoint is likely missing on the Hermes backend.'
+                    )
                   )
-                )
 
-                return
-              }
+                  return
+                }
 
-              try {
-                resolve(JSON.parse(text))
-              } catch {
-                reject(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
-              }
-            })
+                try {
+                  resolve(JSON.parse(text))
+                } catch {
+                  reject(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
+                }
+              })
+              .catch(reject)
           }
         )
 


### PR DESCRIPTION
## Summary

- advertise `Accept-Encoding: gzip` for the Electron main process token/bearer JSON transport
- decode gzip responses before existing JSON/error handling
- cap buffered wire data at 16 MiB and decompressed output at 64 MiB
- fail closed on malformed or unsupported encodings

## Why

The OAuth/session path uses Electron Chromium networking, which already handles response content codings. The token/bearer REST helper uses Node `http.request`, so it neither advertises compression nor decompresses a gzip response. Large session-list responses are highly compressible, making this a material reduction for remote Desktop connections.

The change is intentionally scoped to the low-level JSON helper. It does not alter Dashboard fetches, downloads, WebSocket/permessage-deflate behavior, auth headers, routing, or retry semantics.

## Security

- only `gzip` and `identity` are accepted
- compressed input is bounded before full buffering
- `zlib.gunzip` uses `maxOutputLength` to resist decompression bombs
- malformed gzip and trailing invalid data fail instead of reaching JSON parsing
- no response content or credentials are logged

## Validation

- `npm --prefix apps/desktop test -- --project electron electron/api-transport.test.ts` (36 passed)
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint -- --quiet`
- `npm --prefix apps/desktop run build`
- full Electron run: 1940 passed, 6 skipped; one unrelated existing `managed-ssh-update` fixture failed because its generated updater exited 127

Coverage reporting was not run because this checkout does not include the optional `@vitest/coverage-v8` package.