### PR TITLE
fix(gateway): stop hung sessions from auto-resuming on every restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11579,6 +11579,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         await asyncio.to_thread(self._clear_restart_failure_count_sync, session_key)
 
+    async def _clear_completed_resume_state(self, session_key: str) -> None:
+        """Clear a completed recovery marker before consuming retry evidence."""
+        try:
+            await self.async_session_store.clear_resume_pending(session_key)
+        except Exception as exc:
+            logger.warning(
+                "Preserving restart failure count for %s because the completed "
+                "resume marker could not be persisted: %s",
+                session_key,
+                exc,
+            )
+            return
+        await self._clear_restart_failure_count(session_key)
+
     async def _launch_detached_restart_command(self) -> None:
         import shutil
         import subprocess
@@ -20956,14 +20970,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # succeeded and subsequent messages should no longer receive
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
-                await self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
+                await self._clear_completed_resume_state(session_key)
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7033,6 +7033,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # with the synthetic resume turns for the same session.  The queued
         # events drain only after all startup resume tasks have finished.
         self._startup_restore_in_progress = False
+        # Startup-resume attempts are counted before dispatch so SIGKILL cannot
+        # bypass the durable retry bound. Keep successfully persisted attempts
+        # process-local too, so graceful shutdown cannot count one twice.
+        self._startup_resume_attempt_keys: set[str] = set()
         # Set by start_gateway() only for an explicit ``--replace`` launch.
         # _connect_initial_adapter_with_timeout scopes it to each adapter's
         # cold-start connect and removes it before any reconnect can run.
@@ -11397,8 +11401,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and not entry.suspended
             )
         }
+        startup_attempt_keys = self.__dict__.get("_startup_resume_attempt_keys", set())
         for key in active_session_keys:
-            new_counts[key] = counts.get(key, 0) + 1
+            if key in startup_attempt_keys:
+                new_counts[key] = counts.get(key, 0)
+            else:
+                new_counts[key] = counts.get(key, 0) + 1
 
         try:
             atomic_json_write(path, new_counts, indent=None)
@@ -11427,6 +11435,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         counts[session_key] = previous + 1
         try:
             atomic_json_write(path, counts, indent=None)
+            self.__dict__.setdefault("_startup_resume_attempt_keys", set()).add(
+                session_key
+            )
         except Exception:
             logger.debug(
                 "Failed to persist startup auto-resume attempt for %s",
@@ -11497,6 +11508,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         import json
 
+        self.__dict__.setdefault("_startup_resume_attempt_keys", set()).discard(
+            session_key
+        )
         path = _hermes_home / self._STUCK_LOOP_FILE
         if not path.exists():
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11413,7 +11413,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-    def _record_startup_resume_attempt(self, session_key: str) -> None:
+    def _record_startup_resume_attempt(self, session_key: str) -> bool:
         """Persist one synthetic startup-resume attempt for ``session_key``.
 
         Unlike the shutdown counter, this runs before dispatch and therefore
@@ -11426,24 +11426,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         path = _hermes_home / self._STUCK_LOOP_FILE
         try:
             counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+            if not isinstance(counts, dict):
+                raise ValueError("restart failure ledger must be a JSON object")
         except Exception:
-            counts = {}
+            logger.warning(
+                "Refusing startup auto-resume for %s: restart failure ledger "
+                "could not be read",
+                session_key,
+                exc_info=True,
+            )
+            return False
 
         previous = counts.get(session_key, 0)
         if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
-            previous = 0
+            logger.warning(
+                "Refusing startup auto-resume for %s: restart failure count "
+                "is invalid",
+                session_key,
+            )
+            return False
         counts[session_key] = previous + 1
         try:
             atomic_json_write(path, counts, indent=None)
             self.__dict__.setdefault("_startup_resume_attempt_keys", set()).add(
                 session_key
             )
+            return True
         except Exception:
-            logger.debug(
-                "Failed to persist startup auto-resume attempt for %s",
+            logger.warning(
+                "Refusing startup auto-resume for %s: attempt could not be persisted",
                 session_key,
                 exc_info=True,
             )
+            return False
 
     def _suspend_stuck_loop_sessions(self) -> int:
         """Suspend sessions that have been active across too many restarts.
@@ -12504,7 +12519,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # every shutdown/finally path from running, so shutdown-only
             # accounting cannot bound this retry class. Successful completion
             # clears this same counter in _handle_message_with_agent.
-            self._record_startup_resume_attempt(entry.session_key)
+            if not self._record_startup_resume_attempt(entry.session_key):
+                continue
 
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11369,6 +11369,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
+    _STUCK_LOOP_LOCK = threading.Lock()
 
     @staticmethod
     def _validate_restart_failure_counts(counts) -> None:
@@ -11398,34 +11399,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import json
 
         path = _hermes_home / self._STUCK_LOOP_FILE
-        try:
-            counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-        except Exception:
-            counts = {}
+        with self._STUCK_LOOP_LOCK:
+            try:
+                counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+                self._validate_restart_failure_counts(counts)
+            except Exception:
+                logger.warning(
+                    "Could not update restart failure ledger; preserving it unchanged",
+                    exc_info=True,
+                )
+                return
 
-        # Retain unresolved startup-resume attempts. Successful turns already
-        # remove their count explicitly, so absence from this shutdown's
-        # active snapshot is not proof that a pending recovery succeeded.
-        new_counts = {
-            key: value
-            for key, value in counts.items()
-            if (
-                (entry := self.session_store._entries.get(key)) is not None
-                and entry.resume_pending
-                and not entry.suspended
-            )
-        }
-        startup_attempt_keys = self.__dict__.get("_startup_resume_attempt_keys", set())
-        for key in active_session_keys:
-            if key in startup_attempt_keys:
-                new_counts[key] = counts.get(key, 0)
-            else:
-                new_counts[key] = counts.get(key, 0) + 1
+            # Retain unresolved startup-resume attempts. Successful turns already
+            # remove their count explicitly, so absence from this shutdown's
+            # active snapshot is not proof that a pending recovery succeeded.
+            new_counts = {
+                key: value
+                for key, value in counts.items()
+                if (
+                    (entry := self.session_store._entries.get(key)) is not None
+                    and entry.resume_pending
+                    and not entry.suspended
+                )
+            }
+            startup_attempt_keys = self.__dict__.get("_startup_resume_attempt_keys", set())
+            for key in active_session_keys:
+                if key in startup_attempt_keys:
+                    new_counts[key] = counts.get(key, 0)
+                else:
+                    new_counts[key] = counts.get(key, 0) + 1
 
-        try:
-            atomic_json_write(path, new_counts, indent=None)
-        except Exception:
-            pass
+            try:
+                atomic_json_write(path, new_counts, indent=None)
+            except Exception:
+                logger.warning("Failed to update restart failure ledger", exc_info=True)
 
     def _record_startup_resume_attempt(self, session_key: str) -> bool:
         """Persist one synthetic startup-resume attempt for ``session_key``.
@@ -11438,32 +11445,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import json
 
         path = _hermes_home / self._STUCK_LOOP_FILE
-        try:
-            counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-            self._validate_restart_failure_counts(counts)
-        except Exception:
-            logger.warning(
-                "Refusing startup auto-resume for %s: restart failure ledger "
-                "could not be read",
-                session_key,
-                exc_info=True,
-            )
-            return False
+        with self._STUCK_LOOP_LOCK:
+            try:
+                counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+                self._validate_restart_failure_counts(counts)
+            except Exception:
+                logger.warning(
+                    "Refusing startup auto-resume for %s: restart failure ledger "
+                    "could not be read",
+                    session_key,
+                    exc_info=True,
+                )
+                return False
 
-        counts[session_key] = counts.get(session_key, 0) + 1
-        try:
-            atomic_json_write(path, counts, indent=None)
-            self.__dict__.setdefault("_startup_resume_attempt_keys", set()).add(
-                session_key
-            )
-            return True
-        except Exception:
-            logger.warning(
-                "Refusing startup auto-resume for %s: attempt could not be persisted",
-                session_key,
-                exc_info=True,
-            )
-            return False
+            counts[session_key] = counts.get(session_key, 0) + 1
+            try:
+                atomic_json_write(path, counts, indent=None)
+                self.__dict__.setdefault("_startup_resume_attempt_keys", set()).add(
+                    session_key
+                )
+                return True
+            except Exception:
+                logger.warning(
+                    "Refusing startup auto-resume for %s: attempt could not be persisted",
+                    session_key,
+                    exc_info=True,
+                )
+                return False
 
     def _suspend_stuck_loop_sessions(self) -> int:
         """Suspend sessions that have been active across too many restarts.
@@ -11475,54 +11483,92 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import json
 
         path = _hermes_home / self._STUCK_LOOP_FILE
-        if not path.exists():
-            return 0
+        with self._STUCK_LOOP_LOCK:
+            if not path.exists():
+                return 0
 
-        try:
-            counts = json.loads(path.read_text(encoding="utf-8"))
-            self._validate_restart_failure_counts(counts)
-        except Exception:
-            logger.warning(
-                "Could not evaluate restart failure ledger; preserving it unchanged",
-                exc_info=True,
-            )
-            return 0
-
-        suspended = 0
-        stuck_keys = [k for k, v in counts.items() if v >= self._STUCK_LOOP_THRESHOLD]
-
-        for session_key in stuck_keys:
             try:
+                counts = json.loads(path.read_text(encoding="utf-8"))
+                self._validate_restart_failure_counts(counts)
+            except Exception:
+                logger.warning(
+                    "Could not evaluate restart failure ledger; preserving it unchanged",
+                    exc_info=True,
+                )
+                return 0
+
+            changed_entries = []
+            stuck_keys = [k for k, v in counts.items() if v >= self._STUCK_LOOP_THRESHOLD]
+            for session_key in stuck_keys:
                 entry = self.session_store._entries.get(session_key)
                 if entry and not entry.suspended:
                     entry.suspended = True
-                    suspended += 1
+                    changed_entries.append(entry)
+
+            if changed_entries:
+                try:
+                    self.session_store._save()
+                except Exception:
+                    for entry in changed_entries:
+                        entry.suspended = False
+                    logger.warning(
+                        "Failed to persist stuck-session suspension; preserving retry ledger",
+                        exc_info=True,
+                    )
+                    return 0
+
+                for entry in changed_entries:
                     logger.warning(
                         "Auto-suspended stuck session %s (active across %d "
                         "consecutive restarts — likely a stuck loop)",
-                        session_key, counts[session_key],
+                        entry.session_key,
+                        counts[entry.session_key],
                     )
-            except Exception:
-                pass
 
-        if suspended:
+            # Remove only durably suspended rows. Other sessions may still be
+            # accumulating independent startup-resume failures.
+            removable = {
+                key
+                for key in stuck_keys
+                if (entry := self.session_store._entries.get(key)) is not None
+                and entry.suspended
+            }
             try:
-                self.session_store._save()
+                remaining = {k: v for k, v in counts.items() if k not in removable}
+                if remaining:
+                    atomic_json_write(path, remaining, indent=None)
+                else:
+                    path.unlink(missing_ok=True)
             except Exception:
-                pass
+                logger.warning("Failed to prune restart failure ledger", exc_info=True)
 
-        # Remove only suspended rows. Other sessions may still be accumulating
-        # independent startup-resume failures and must keep their progress.
-        try:
-            remaining = {k: v for k, v in counts.items() if k not in stuck_keys}
-            if remaining:
-                atomic_json_write(path, remaining, indent=None)
-            else:
-                path.unlink(missing_ok=True)
-        except Exception:
-            pass
+            return len(changed_entries)
 
-        return suspended
+    def _clear_restart_failure_count_sync(self, session_key: str) -> None:
+        """Clear one retry count while serializing the ledger transaction."""
+        import json
+
+        path = _hermes_home / self._STUCK_LOOP_FILE
+        with self._STUCK_LOOP_LOCK:
+            if not path.exists():
+                self.__dict__.setdefault("_startup_resume_attempt_keys", set()).discard(
+                    session_key
+                )
+                return
+            try:
+                counts = json.loads(path.read_text(encoding="utf-8"))
+                self._validate_restart_failure_counts(counts)
+                if session_key in counts:
+                    del counts[session_key]
+                    if counts:
+                        atomic_json_write(path, counts, indent=None)
+                    else:
+                        path.unlink(missing_ok=True)
+                self.__dict__.setdefault("_startup_resume_attempt_keys", set()).discard(
+                    session_key
+                )
+            except Exception:
+                logger.warning("Failed to clear restart failure count", exc_info=True)
 
     async def _clear_restart_failure_count(self, session_key: str) -> None:
         """Clear the restart-failure counter for a session that completed OK.
@@ -11531,24 +11577,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Offloaded to a thread because the caller (_handle_message_with_agent)
         runs on the event loop and atomic_json_write calls os.fsync.
         """
-        import json
-
-        self.__dict__.setdefault("_startup_resume_attempt_keys", set()).discard(
-            session_key
-        )
-        path = _hermes_home / self._STUCK_LOOP_FILE
-        if not path.exists():
-            return
-        try:
-            counts = json.loads(path.read_text(encoding="utf-8"))
-            if session_key in counts:
-                del counts[session_key]
-                if counts:
-                    await asyncio.to_thread(atomic_json_write, path, counts, indent=None)
-                else:
-                    path.unlink(missing_ok=True)
-        except Exception:
-            pass
+        await asyncio.to_thread(self._clear_restart_failure_count_sync, session_key)
 
     async def _launch_detached_restart_command(self) -> None:
         import shutil

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11370,8 +11370,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Increment restart-failure counters for sessions active at shutdown.
 
         Persists to a JSON file so counters survive across restarts.
-        Sessions NOT in active_session_keys are removed (they completed
-        successfully, so the loop is broken).
+        Existing counts survive while their session is still resume-pending;
+        successful turns clear their own count in
+        ``_clear_restart_failure_count``.  This matters when an unrelated
+        active session triggers a graceful shutdown while a prior startup
+        resume attempt is pending: rewriting only ``active_session_keys``
+        would otherwise erase that prior failure.
         """
         import json
 
@@ -11381,17 +11385,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             counts = {}
 
-        # Increment active sessions, remove inactive ones (loop broken)
-        new_counts = {}
+        # Retain unresolved startup-resume attempts. Successful turns already
+        # remove their count explicitly, so absence from this shutdown's
+        # active snapshot is not proof that a pending recovery succeeded.
+        new_counts = {
+            key: value
+            for key, value in counts.items()
+            if (
+                (entry := self.session_store._entries.get(key)) is not None
+                and entry.resume_pending
+                and not entry.suspended
+            )
+        }
         for key in active_session_keys:
             new_counts[key] = counts.get(key, 0) + 1
-        # Keep any entries that are still above 0 even if not active now
-        # (they might become active again next restart)
 
         try:
             atomic_json_write(path, new_counts, indent=None)
         except Exception:
             pass
+
+    def _record_startup_resume_attempt(self, session_key: str) -> None:
+        """Persist one synthetic startup-resume attempt for ``session_key``.
+
+        Unlike the shutdown counter, this runs before dispatch and therefore
+        survives SIGKILL.  A successful turn uses the existing clear path;
+        repeated crash-left attempts reach ``_STUCK_LOOP_THRESHOLD`` and are
+        suspended by ``_suspend_stuck_loop_sessions`` on the next boot.
+        """
+        import json
+
+        path = _hermes_home / self._STUCK_LOOP_FILE
+        try:
+            counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+        except Exception:
+            counts = {}
+
+        previous = counts.get(session_key, 0)
+        if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
+            previous = 0
+        counts[session_key] = previous + 1
+        try:
+            atomic_json_write(path, counts, indent=None)
+        except Exception:
+            logger.debug(
+                "Failed to persist startup auto-resume attempt for %s",
+                session_key,
+                exc_info=True,
+            )
 
     def _suspend_stuck_loop_sessions(self) -> int:
         """Suspend sessions that have been active across too many restarts.
@@ -11434,9 +11475,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        # Clear the file — counters start fresh after suspension
+        # Remove only suspended rows. Other sessions may still be accumulating
+        # independent startup-resume failures and must keep their progress.
         try:
-            path.unlink(missing_ok=True)
+            remaining = {k: v for k, v in counts.items() if k not in stuck_keys}
+            if remaining:
+                atomic_json_write(path, remaining, indent=None)
+            else:
+                path.unlink(missing_ok=True)
         except Exception:
             pass
 
@@ -12439,6 +12485,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     entry.session_key, exc,
                 )
                 continue
+
+            # Count the attempt before task creation. A hard kill can prevent
+            # every shutdown/finally path from running, so shutdown-only
+            # accounting cannot bound this retry class. Successful completion
+            # clears this same counter in _handle_message_with_agent.
+            self._record_startup_resume_attempt(entry.session_key)
 
             # Claim the session slot *before* spawning the task so that an
             # inbound message arriving between task creation and the task's

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11370,6 +11370,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
 
+    @staticmethod
+    def _validate_restart_failure_counts(counts) -> None:
+        """Reject ledgers whose retry evidence cannot be interpreted safely."""
+        if not isinstance(counts, dict):
+            raise ValueError("restart failure ledger must be a JSON object")
+        if any(
+            not isinstance(key, str)
+            or not isinstance(value, int)
+            or isinstance(value, bool)
+            or value < 0
+            for key, value in counts.items()
+        ):
+            raise ValueError("restart failure ledger contains an invalid count")
+
     def _increment_restart_failure_counts(self, active_session_keys: set) -> None:
         """Increment restart-failure counters for sessions active at shutdown.
 
@@ -11426,8 +11440,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         path = _hermes_home / self._STUCK_LOOP_FILE
         try:
             counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-            if not isinstance(counts, dict):
-                raise ValueError("restart failure ledger must be a JSON object")
+            self._validate_restart_failure_counts(counts)
         except Exception:
             logger.warning(
                 "Refusing startup auto-resume for %s: restart failure ledger "
@@ -11437,15 +11450,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return False
 
-        previous = counts.get(session_key, 0)
-        if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
-            logger.warning(
-                "Refusing startup auto-resume for %s: restart failure count "
-                "is invalid",
-                session_key,
-            )
-            return False
-        counts[session_key] = previous + 1
+        counts[session_key] = counts.get(session_key, 0) + 1
         try:
             atomic_json_write(path, counts, indent=None)
             self.__dict__.setdefault("_startup_resume_attempt_keys", set()).add(
@@ -11475,7 +11480,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         try:
             counts = json.loads(path.read_text(encoding="utf-8"))
+            self._validate_restart_failure_counts(counts)
         except Exception:
+            logger.warning(
+                "Could not evaluate restart failure ledger; preserving it unchanged",
+                exc_info=True,
+            )
             return 0
 
         suspended = 0

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3306,10 +3306,18 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or not entry.resume_pending:
                 return False
+            previous_reason = entry.resume_reason
+            previous_marked_at = entry.last_resume_marked_at
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
-            self._save()
+            try:
+                self._save()
+            except Exception:
+                entry.resume_pending = True
+                entry.resume_reason = previous_reason
+                entry.last_resume_marked_at = previous_marked_at
+                raise
             return True
 
     def prune_old_entries(self, max_age_days: int) -> int:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -233,6 +233,21 @@ class TestClearResumePending:
         # Not marked
         assert store.clear_resume_pending(entry.session_key) is False
 
+    def test_save_failure_restores_pending_marker(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, reason="shutdown_timeout")
+        marked_at = entry.last_resume_marked_at
+        store._save = MagicMock(side_effect=OSError("disk full"))
+
+        with pytest.raises(OSError, match="disk full"):
+            store.clear_resume_pending(entry.session_key)
+
+        assert entry.resume_pending is True
+        assert entry.resume_reason == "shutdown_timeout"
+        assert entry.last_resume_marked_at == marked_at
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
@@ -1198,6 +1213,32 @@ class TestStuckLoopEscalation:
             retained_key: 1,
             admitted_key: 1,
         }
+
+    @pytest.mark.asyncio
+    async def test_failed_resume_marker_clear_preserves_retry_count(
+        self, tmp_path, monkeypatch
+    ):
+        """Retry evidence survives until resume_pending is durably cleared."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, _adapter = make_restart_runner()
+        session_key = "agent:main:telegram:dm:marker-save-failure"
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        counts_file.write_text(json.dumps({session_key: 2}), encoding="utf-8")
+        runner._startup_resume_attempt_keys = {session_key}
+        runner._async_session_store = MagicMock()
+        runner._async_session_store._store = runner.session_store
+        runner._async_session_store.clear_resume_pending = AsyncMock(
+            side_effect=OSError("disk full")
+        )
+
+        await runner._clear_completed_resume_state(session_key)
+
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == {session_key: 2}
+        assert runner._startup_resume_attempt_keys == {session_key}
 
     @pytest.mark.asyncio
     async def test_startup_resume_dispatches_after_persisted_attempt(

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -913,6 +913,95 @@ class TestStuckLoopEscalation:
         assert final_runner._schedule_resume_pending_sessions() == 0
         final_adapter.handle_message.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_graceful_shutdown_does_not_double_count_startup_resume(
+        self, tmp_path, monkeypatch
+    ):
+        """One startup recovery counts once even when its process drains."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setattr(
+            "gateway.restart_loop_guard.check_and_record", lambda *_a, **_k: False
+        )
+        source = make_restart_source(chat_id="graceful-loop")
+        pending_entry = SessionEntry(
+            session_key="agent:main:telegram:dm:graceful-loop",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+
+        for attempt in range(1, GatewayRunner._STUCK_LOOP_THRESHOLD + 1):
+            runner, adapter = make_restart_runner()
+            runner.session_store._entries = {pending_entry.session_key: pending_entry}
+            gate = asyncio.Event()
+
+            async def hold_resume(_event):
+                await gate.wait()
+
+            adapter.handle_message = AsyncMock(side_effect=hold_resume)
+
+            assert runner._suspend_stuck_loop_sessions() == 0
+            assert runner._schedule_resume_pending_sessions() == 1
+            runner._increment_restart_failure_counts({pending_entry.session_key})
+
+            counts = json.loads(counts_file.read_text(encoding="utf-8"))
+            assert counts[pending_entry.session_key] == attempt
+            gate.set()
+            await asyncio.sleep(0)
+
+        final_runner, final_adapter = make_restart_runner()
+        final_runner.session_store._entries = {
+            pending_entry.session_key: pending_entry
+        }
+        final_adapter.handle_message = AsyncMock()
+
+        assert final_runner._suspend_stuck_loop_sessions() == 1
+        assert final_runner._schedule_resume_pending_sessions() == 0
+
+    @pytest.mark.asyncio
+    async def test_successful_startup_resume_restores_shutdown_accounting(
+        self, tmp_path, monkeypatch
+    ):
+        """A later ordinary active turn is counted after recovery succeeds."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, _adapter = make_restart_runner()
+        source = make_restart_source(chat_id="recovered")
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:recovered",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+
+        runner._record_startup_resume_attempt(entry.session_key)
+        await runner._clear_restart_failure_count(entry.session_key)
+        entry.resume_pending = False
+        runner._increment_restart_failure_counts({entry.session_key})
+
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        counts = json.loads(counts_file.read_text(encoding="utf-8"))
+        assert counts == {entry.session_key: 1}
+
 
 @pytest.mark.asyncio
 async def test_auto_resume_sets_sentinel_before_task_execution():

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1075,6 +1075,41 @@ class TestStuckLoopEscalation:
         assert counts_file.read_text(encoding="utf-8") == malformed
 
     @pytest.mark.asyncio
+    async def test_startup_resume_rejects_malformed_sibling_count(
+        self, tmp_path, monkeypatch
+    ):
+        """One poisoned row must not disable another session's retry bound."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, adapter = make_restart_runner()
+        source = make_restart_source(chat_id="malformed-sibling")
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:malformed-sibling",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+        adapter.handle_message = AsyncMock()
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        malformed_counts = {"poisoned-session": "invalid", entry.session_key: 2}
+        counts_file.write_text(json.dumps(malformed_counts), encoding="utf-8")
+
+        assert runner._suspend_stuck_loop_sessions() == 0
+        assert runner._schedule_resume_pending_sessions() == 0
+        adapter.handle_message.assert_not_awaited()
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == malformed_counts
+
+    @pytest.mark.asyncio
     async def test_startup_resume_dispatches_after_persisted_attempt(
         self, tmp_path, monkeypatch
     ):

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -860,6 +860,59 @@ class TestStuckLoopEscalation:
         assert second.session_id != entry.session_id
         assert second.auto_reset_reason == "suspended"
 
+    @pytest.mark.asyncio
+    async def test_startup_auto_resume_attempts_eventually_suspend_after_sigkill(
+        self, tmp_path, monkeypatch
+    ):
+        """Crash-left resumes must be bounded even without graceful shutdown.
+
+        A SIGKILL never reaches ``stop()`` and therefore cannot increment the
+        shutdown-time restart counter.  Each actual startup auto-resume attempt
+        must persist an attempt itself so a long-running hang (whose restart
+        interval exceeds the global loop guard window) is eventually retired.
+        """
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        # Model the reported >1h hang: every inter-boot gap exceeds the global
+        # guard's 300s chain window, so that process-wide breaker never trips.
+        monkeypatch.setattr(
+            "gateway.restart_loop_guard.check_and_record", lambda *_a, **_k: False
+        )
+        source = make_restart_source(chat_id="sigkill-loop")
+        pending_entry = SessionEntry(
+            session_key="agent:main:telegram:dm:sigkill-loop",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+
+        for _attempt in range(GatewayRunner._STUCK_LOOP_THRESHOLD):
+            runner, adapter = make_restart_runner()
+            runner.session_store._entries = {pending_entry.session_key: pending_entry}
+            adapter.handle_message = AsyncMock()
+
+            assert runner._suspend_stuck_loop_sessions() == 0
+            assert runner._schedule_resume_pending_sessions() == 1
+            await asyncio.sleep(0)
+
+        final_runner, final_adapter = make_restart_runner()
+        final_runner.session_store._entries = {
+            pending_entry.session_key: pending_entry
+        }
+        final_adapter.handle_message = AsyncMock()
+
+        assert final_runner._suspend_stuck_loop_sessions() == 1
+        assert pending_entry.suspended is True
+        assert final_runner._schedule_resume_pending_sessions() == 0
+        final_adapter.handle_message.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_auto_resume_sets_sentinel_before_task_execution():

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1002,6 +1002,113 @@ class TestStuckLoopEscalation:
         counts = json.loads(counts_file.read_text(encoding="utf-8"))
         assert counts == {entry.session_key: 1}
 
+    @pytest.mark.asyncio
+    async def test_startup_resume_requires_persisted_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed attempt publication must prevent synthetic dispatch."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, adapter = make_restart_runner()
+        source = make_restart_source(chat_id="write-failure")
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:write-failure",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+        adapter.handle_message = AsyncMock()
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        counts_file.write_text(json.dumps({entry.session_key: 2}), encoding="utf-8")
+
+        def fail_write(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", fail_write)
+
+        assert runner._schedule_resume_pending_sessions() == 0
+        adapter.handle_message.assert_not_awaited()
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == {
+            entry.session_key: 2
+        }
+
+    @pytest.mark.asyncio
+    async def test_startup_resume_preserves_malformed_attempt_ledger(
+        self, tmp_path, monkeypatch
+    ):
+        """Unknown persisted attempts must not be reset before dispatch."""
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, adapter = make_restart_runner()
+        source = make_restart_source(chat_id="malformed-ledger")
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:malformed-ledger",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+        adapter.handle_message = AsyncMock()
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        malformed = "{not-json"
+        counts_file.write_text(malformed, encoding="utf-8")
+
+        assert runner._schedule_resume_pending_sessions() == 0
+        adapter.handle_message.assert_not_awaited()
+        assert counts_file.read_text(encoding="utf-8") == malformed
+
+    @pytest.mark.asyncio
+    async def test_startup_resume_dispatches_after_persisted_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        """Successful durable admission still schedules the recovery turn."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, adapter = make_restart_runner()
+        source = make_restart_source(chat_id="persisted-attempt")
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:persisted-attempt",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_interrupted",
+            last_resume_marked_at=datetime.now(),
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+        adapter.handle_message = AsyncMock()
+
+        assert runner._schedule_resume_pending_sessions() == 1
+        await asyncio.sleep(0)
+        adapter.handle_message.assert_awaited_once()
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == {
+            entry.session_key: 1
+        }
+
 
 @pytest.mark.asyncio
 async def test_auto_resume_sets_sentinel_before_task_execution():

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1109,6 +1109,96 @@ class TestStuckLoopEscalation:
         adapter.handle_message.assert_not_awaited()
         assert json.loads(counts_file.read_text(encoding="utf-8")) == malformed_counts
 
+    def test_shutdown_preserves_malformed_attempt_ledger(self, tmp_path, monkeypatch):
+        """Graceful shutdown must not replace unknown retry evidence."""
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, _adapter = make_restart_runner()
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        malformed = "{not-json"
+        counts_file.write_text(malformed, encoding="utf-8")
+
+        runner._increment_restart_failure_counts({"agent:main:telegram:dm:active"})
+
+        assert counts_file.read_text(encoding="utf-8") == malformed
+
+    def test_failed_suspension_save_preserves_retry_evidence(
+        self, tmp_path, monkeypatch
+    ):
+        """An in-memory suspension cannot consume its durable retry count."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, _adapter = make_restart_runner()
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:save-failure",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            resume_pending=True,
+        )
+        runner.session_store._entries = {entry.session_key: entry}
+        runner.session_store._save = MagicMock(side_effect=OSError("disk full"))
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        counts = {entry.session_key: GatewayRunner._STUCK_LOOP_THRESHOLD}
+        counts_file.write_text(json.dumps(counts), encoding="utf-8")
+
+        assert runner._suspend_stuck_loop_sessions() == 0
+        assert entry.suspended is False
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == counts
+
+    @pytest.mark.asyncio
+    async def test_retry_ledger_transactions_do_not_lose_concurrent_admission(
+        self, tmp_path, monkeypatch
+    ):
+        """A stale successful-turn clear cannot erase a newer admission."""
+        import json
+        import threading
+
+        from gateway.run import GatewayRunner, atomic_json_write as real_atomic_write
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner, _adapter = make_restart_runner()
+        clearing_key = "agent:main:telegram:dm:clearing"
+        retained_key = "agent:main:telegram:dm:retained"
+        admitted_key = "agent:main:telegram:dm:admitted"
+        counts_file = tmp_path / GatewayRunner._STUCK_LOOP_FILE
+        counts_file.write_text(
+            json.dumps({clearing_key: 1, retained_key: 1}), encoding="utf-8"
+        )
+        clear_write_started = threading.Event()
+        release_clear_write = threading.Event()
+
+        def controlled_write(path, payload, **kwargs):
+            if clearing_key not in payload and admitted_key not in payload:
+                clear_write_started.set()
+                assert release_clear_write.wait(timeout=5)
+            real_atomic_write(path, payload, **kwargs)
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", controlled_write)
+        clear_task = asyncio.create_task(
+            runner._clear_restart_failure_count(clearing_key)
+        )
+        assert await asyncio.to_thread(clear_write_started.wait, 5)
+        admission_task = asyncio.create_task(
+            asyncio.to_thread(runner._record_startup_resume_attempt, admitted_key)
+        )
+        await asyncio.sleep(0)
+        assert not admission_task.done()
+
+        release_clear_write.set()
+        await clear_task
+        assert await admission_task is True
+        assert json.loads(counts_file.read_text(encoding="utf-8")) == {
+            retained_key: 1,
+            admitted_key: 1,
+        }
+
     @pytest.mark.asyncio
     async def test_startup_resume_dispatches_after_persisted_attempt(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## What does this PR do?

Prevents a restart-interrupted gateway session from being auto-resumed forever after repeated hard kills. The gateway now counts each synthetic startup resume before dispatch, so attempts survive SIGKILL and the existing stuck-session suspension threshold can retire a repeatedly hung session while the gateway continues serving new inbound messages.

### Symptom

A `resume_pending=restart_interrupted` session can consume one CPU thread until the agent idle watchdog fires, then be replayed again on every later gateway restart.

### Impact

The affected session repeatedly consumes CPU for up to the watchdog duration and cannot recover without manual session-state surgery. The startup restore gate is already bounded for other channels, but it does not prevent the same bad session from being replayed on the next boot.

### Bug Cause

**Trigger:** `gateway/run.py` / `GatewayRunner._schedule_resume_pending_sessions()` schedules a fresh synthetic turn for every eligible restart-interrupted session.

**Causal chain:**
1. An unclean systemd stop leaves a durable `resume_pending` session.
2. Startup dispatches the synthetic resume, but a SIGKILL during the hung turn bypasses the shutdown-only `.restart_failure_counts` update.
3. A later boot sees no per-session failure count and dispatches the same turn again.

**Why it is wrong:** the global restart-loop guard only chains boots whose gaps stay within its configured maximum. A resume that hangs for about an hour exceeds the default 300-second gap, so each boot begins a new global chain while the per-session shutdown counter remains unchanged.

**Working sibling / contrast:** fast crash loops are stopped by the global restart-loop guard, and graceful shutdowns update the existing per-session counter. The missing case is a long startup resume terminated by SIGKILL.

**Ruled out:** the startup restore drain bound is not the missing guard. It releases queued inbound messages after its timeout, but intentionally leaves the slow resume turn running and does not persist a failed attempt for the next boot.

### Fix

- Persist each authorized, adapter-ready startup resume attempt before creating its task, and refuse dispatch unless the increment is durably published.
- Preserve malformed or unreadable retry evidence instead of resetting it, and serialize ledger transactions so concurrent completion cannot erase a newer admission.
- Reuse the existing `.restart_failure_counts` file and successful-turn clear path rather than adding a second session counter.
- Preserve unresolved per-session counts when unrelated sessions shut down or another stuck session is suspended.
- Keep retry evidence until both stuck-session suspension and successful recovery state are durably persisted.
- Add regressions for SIGKILL-left attempts, publication failures, malformed ledgers, concurrent updates, suspension-save failures, and recovery-marker save failures.

## Related Issue

Partially fixes #96181. This PR owns the cross-boot retry-budget durability half. The remaining in-boot no-progress timeout is tracked by #95548 and its complementary implementation in #95663.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - make durable retry publication an admission condition and serialize retry-ledger state transitions.
- `gateway/session.py` - restore the in-memory resume marker when durable clearing fails.
- `tests/gateway/test_restart_resume_pending.py` - cover retry bounds and fail-closed persistence/error/concurrency paths.

## How to Test

Run the restart-resume gateway regression suite:

```bash
scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py -q
```

The focused suite passes 48 tests on this branch.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant gateway suite and all 48 focused tests pass
- [x] I've added tests for my changes
- [x] I've tested the deterministic regression on Windows 11; Linux/systemd integration verification is pending review

### Documentation & Housekeeping

- [x] Relevant code documentation and docstrings are updated
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; the state logic uses existing profile-scoped JSON persistence
- [x] Tool descriptions and schemas are N/A because no tool behavior changed

## Screenshots / Logs

N/A - this is gateway session-state behavior covered by the focused regression suite.
