### PR TITLE
fix(tui): log when the final session persist fails on finalize

### DIFF
--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -181,6 +181,47 @@ class TestFinalizeSessionPersistE2E:
         agent.commit_memory_session = lambda *a, **k: None
         return agent
 
+    def test_persist_failure_is_logged_not_swallowed(self, tmp_path, monkeypatch, caplog):
+        """A failed final persist must leave a diagnostic trace.
+
+        ``_finalize_session`` is the sole persist path after a WS
+        disconnect/restart, and ``AIAgent._persist_session`` contains no
+        exception handling of its own — a transient SQLite failure propagates
+        here. Swallowing it discards the unflushed turn with nothing in the log
+        to explain why the conversation vanished from state.db.
+        """
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from hermes_state import SessionDB
+        import tui_gateway.server as srv
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "sess-persist-fails"
+        db.create_session(session_id=session_id, source="tui")
+        monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+        turn = [
+            {"role": "user", "content": "important question"},
+            {"role": "assistant", "content": "important answer"},
+        ]
+        agent = self._real_agent(db, session_id, turn)
+
+        def boom(*a, **k):
+            raise RuntimeError("database is locked")
+
+        agent._persist_session = boom
+        session = _make_session(agent=agent, history=turn, session_key=session_id)
+
+        with caplog.at_level(logging.WARNING):
+            srv._finalize_session(session, end_reason="ws_disconnect")
+
+        assert any(
+            "persist" in r.message.lower() or "session" in r.message.lower()
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ), "a failed final persist must be logged, not swallowed"
+
     def test_unflushed_turn_survives_disconnect(self, tmp_path, monkeypatch):
         """A completed turn whose transcript flush did NOT durably persist
         (messages live only in agent._session_messages / session['history'],

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -216,8 +216,16 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     # ``conversation_history``: ``session["history"]`` and ``_session_messages`` alias the SAME list after a turn, so
     # the flush would treat every message as durable and skip it — data loss when finalize is the sole persist path.
     if hasattr(agent, "_persist_session") and (snapshot := getattr(agent, "_session_messages", None)):
-        with contextlib.suppress(Exception):
+        try:
             agent._persist_session(snapshot)
+        except Exception:
+            # This is the sole persist path after a WS disconnect/restart and
+            # _persist_session has no handling of its own, so a silent drop here
+            # loses the unflushed turn with no way to diagnose it. The sibling
+            # reaper path (session_reaper.py) already logs its failure.
+            logger.warning(
+                "Final session persist failed during finalize; unflushed turn may be lost",
+                exc_info=True)
     # interrupted=True so crash-recovery plugins can flush state (mirrors cli.py atexit).
     if agent is not None:
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Problem

`_finalize_session` (`tui_gateway/server.py`) makes a final attempt to persist the live transcript when a session tears down:

```python
if agent is not None and hasattr(agent, "_persist_session"):
    snapshot = getattr(agent, "_session_messages", None)
    if snapshot:
        try:
            agent._persist_session(snapshot)
        except Exception:
            pass
```

The comment directly above documents how load-bearing this call is — it exists because of *"a data-loss bug when finalize is the sole persist path after a WS disconnect/restart (e.g. the in-turn flush hit a transient SQLite failure)"*.

`AIAgent._persist_session` has **no exception handling of its own** (40 lines, zero `except`), so a transient failure propagates straight to this call site and was discarded.

I verified this by forcing the failure rather than assuming it:

```
_persist_session raises out to the caller : True
except clauses inside _persist_session    : 0
=> the except: pass at this call site swallows a real exception
```

## Why this one is worse than a normal silent handler

There is **no later retry**. The `/new` row-creation path recovers because `_flush_messages_to_session_db_unlocked` retries when `_session_db_created` is False. Nothing runs after finalize — it is the last thing that touches the session. So the unflushed turn is genuinely lost, and the log says nothing at all, which is exactly the *"conversation contains many events yet is absent from state.db across disconnect/restart"* symptom the E2E tests in this file were written to catch.

## Fix

Log a warning with `exc_info`. No control-flow change.

## Test

`test_persist_failure_is_logged_not_swallowed` drives a real `SessionDB` + real agent through `_finalize_session` with `_persist_session` raising, and asserts a warning is emitted. It sits alongside the existing `TestFinalizeSessionPersistE2E` cases.

- On `main`: **fails** — `AssertionError: a failed final persist must be logged, not swallowed`
- With this change: **passes**

```
tests/tui_gateway/test_finalize_session_persist.py ..........  10 passed
ruff check tui_gateway/server.py tests/...  All checks passed!
```

## Note on unrelated failures

A full `tests/tui_gateway/` run shows 5 failures. I checked each against a clean `origin/main` checkout on Windows:

- 4 are **pre-existing on main**: `test_bot_relay_methods.py::test_deliver_write_failure_still_removes_tempfile`, `test_compute_host.py::test_compute_host_line_json_seed_turn_interrupt`, `test_compute_host_phase1.py::test_append_log_record_single_write_lines`, `test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread`.
- 1 (`test_gui_surface_toolsets.py::test_holds_exactly_the_gui_affordances`) is **test-isolation pollution**, not a regression — it passes on its own (`10 passed`) both with and without this change.

## Context

This is the third silent-failure fix in this area (after #96194 and #96201). I scanned the rest of `tui_gateway/server.py` the same way — 89 broad `except: pass` handlers, cross-checked ast-grep against ripgrep (89 = 89) — and this is the only one where the callee both raises and has no recovery path. The others wrap callees that already log, or are cleanup/cosmetic paths where silence is correct.
