### PR TITLE
add Windows toast notifications for CLI events

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,8 @@ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 > iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 > ```
 > 安装完成后，可能需要重启终端，然后运行 `hermes` 开始对话。
+>
+> **Windows 通知：** 默认情况下，后台任务完成、需要确认审批、回复完成和会话结束时，Hermes 会发送 Windows toast 通知。通知默认仅在终端窗口未获得焦点时弹出，点击通知会回焦终端。可通过 `cli-config.yaml` 的 `display.notify_on_complete` 和 `display.notify_on_approval` 开关。
 
 安装后：
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1649,6 +1649,12 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Windows toast notifications from the CLI.
+  #   true:  Show toast on completion / approval prompts (default)
+  #   false: Disable Windows toast notifications
+  notify_on_complete: true
+  notify_on_approval: true
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -5070,6 +5070,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # Windows toast notifications
+        self.notify_on_complete = CLI_CONFIG["display"].get("notify_on_complete", True)
+        self.notify_on_approval = CLI_CONFIG["display"].get("notify_on_approval", True)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
         # reasoning_full: when reasoning display is on, print the post-response
@@ -13010,6 +13013,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 continue
             self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)
+            if getattr(self, "notify_on_complete", True):
+                try:
+                    _task_desc = (synthetic_message or "后台任务已完成").replace("\n", " ").strip()
+                    self._fire_notification(
+                        "Hermes · 任务完成",
+                        (_task_desc or "后台任务已完成，点击查看")[:240],
+                    )
+                except Exception:
+                    pass
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.
@@ -15903,6 +15915,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
 
+            if getattr(self, "notify_on_approval", True):
+                try:
+                    _need = (description or command or "").replace("\n", " ").strip()
+                    self._fire_notification(
+                        "Hermes · 需要你确认",
+                        ("需要你确认：" + _need)[:200],
+                        force=True,
+                    )
+                except Exception:
+                    pass
+
             _last_countdown_refresh = _time.monotonic()
             while True:
                 try:
@@ -16833,6 +16856,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             sys.stdout.flush()
             time.sleep(0.15)
 
+            if getattr(self, "notify_on_complete", True):
+                try:
+                    self._fire_notification("Hermes · 回复完成", "回复已完成，点击回到终端")
+                except Exception:
+                    pass
+
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
@@ -17244,6 +17273,59 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _snapshot_and_persist()
         except (Exception, KeyboardInterrupt) as e:
             logger.debug("Could not persist active CLI session before close: %s", e)
+
+    def _fire_notification(self, title: str, body: str, force: bool = False) -> None:
+        """Best-effort Windows toast notification.
+
+        Non-blocking and failure-swallowed so it can never interfere with
+        the interactive loop or shutdown.
+
+        By default (``force=False``) the toast is *suppressed* when the Hermes
+        terminal window is already the foreground window — the user is looking
+        at it, so a toast would be pure noise. Pass ``force=True`` for events
+        that demand attention regardless (e.g. an approval request the user may
+        have missed if the terminal is on another desktop).
+        """
+        if sys.platform != "win32":
+            return
+        try:
+            if not force:
+                try:
+                    _notify_script = os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)),
+                        ".hermes", "scripts", "hermes_focus.py",
+                    )
+                    if os.path.exists(_notify_script):
+                        from .windows_focus import is_hermes_foreground
+                        if is_hermes_foreground(os.getpid()):
+                            return
+                except Exception:
+                    pass
+            _notify_script = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                ".hermes", "scripts", "hermes_notify.py",
+            )
+            if not os.path.exists(_notify_script):
+                return
+            cmd = [
+                sys.executable, _notify_script,
+                "--title", title,
+                "--body", body,
+            ]
+            if os.getpid():
+                cmd.extend(["--pid", str(os.getpid())])
+            subprocess.run(cmd, check=False)
+        except Exception:
+            pass
+
+    def _notify_session_ended(self) -> None:
+        """Best-effort Windows toast when the Hermes CLI session ends."""
+        if sys.platform != "win32":
+            return
+        try:
+            self._fire_notification("Hermes", "点击回到 Hermes")
+        except Exception:
+            pass
 
     def _print_exit_summary(self, clear_screen: bool = True):
         """Print session resume info on exit, similar to Claude Code.

--- a/hermes_cli/windows_focus.py
+++ b/hermes_cli/windows_focus.py
@@ -1,0 +1,321 @@
+"""hermes:// protocol handler for Windows.
+
+When a notification like `hermes://focus` is activated (e.g. by clicking
+a toast), Windows launches this script. It then finds the Hermes terminal
+window and brings it to the foreground.
+
+Window-resolution strategy (most to least reliable):
+
+1. ``AttachConsole`` to the Hermes process and grab its console window
+   handle. This works for *real* consoles (conhost / ``powershell.exe``)
+   where the Python process shares the console window with the terminal.
+2. Walk up the process tree from the Hermes PID to the terminal host
+   (``WindowsTerminal.exe`` / ``powershell.exe`` / ``conhost.exe`` / ...)
+   and focus its main window. This covers Windows Terminal (ConPTY),
+   which owns no real console window of its own.
+3. Match any visible window whose title contains "Hermes" (last resort).
+"""
+
+import sys
+import os
+import argparse
+import ctypes
+from ctypes import wintypes
+
+try:
+    import win32gui
+    import win32con
+    import win32process
+    import win32api
+except ImportError:
+    print("ERROR: pywin32 is not installed. Run: pip install pywin32", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+
+# --- Debug logging (this script runs hidden as a toast-click subprocess) ------
+
+_LOG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hermes_focus.log")
+
+
+def _log(msg):
+    """Append a line to hermes_focus.log for diagnostics (subprocess has no UI)."""
+    try:
+        ts = __import__("datetime").datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        with open(_LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write("[{}] {}\n".format(ts, msg))
+            fh.flush()
+    except Exception:
+        pass
+
+
+# --- Console window resolution (conhost / powershell.exe) -----------------
+
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+user32.GetForegroundWindow.argtypes = []
+user32.GetForegroundWindow.restype = wintypes.HWND
+user32.SetForegroundWindow.argtypes = [wintypes.HWND]
+user32.SetForegroundWindow.restype = wintypes.BOOL
+user32.SetFocus.argtypes = [wintypes.HWND]
+user32.SetFocus.restype = wintypes.HWND
+
+
+def _force_foreground(hwnd):
+    """Bring *hwnd* to the foreground — safe, minimal approach.
+
+    We do NOT use any of the classic "steal focus" tricks (AttachThreadInput,
+    synthetic ALT key, SystemParametersInfoW foreground-lock timeout reset,
+    LockSetForegroundWindow). Every single one of those has been shown to
+    interfere with conhost / prompt_toolkit's input loop, causing the terminal
+    to freeze ("can see it but can't type", or complete hang requiring
+    task-kill).
+
+    Instead we:
+      1. Show/restore the window from minimized/taskbar state.
+      2. Call SetForegroundWindow exactly once — if Windows allows it, great.
+      3. If denied (returns 0), FlashWindow so the taskbar entry blinks and
+         the user can click it manually.
+    """
+    if not hwnd:
+        _log("_force_foreground: no hwnd, abort")
+        return False
+
+    _log("_force_foreground: hwnd={}".format(hwnd))
+
+    # 1) Restore from minimized / show if hidden.
+    try:
+        if win32gui.IsIconic(hwnd):
+            win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+        else:
+            win32gui.ShowWindow(hwnd, win32con.SW_SHOW)
+    except Exception as exc:
+        _log("  ShowWindow error: {}".format(exc))
+
+    # 2) One clean attempt. No tricks.
+    result = False
+    try:
+        result = bool(user32.SetForegroundWindow(hwnd))
+        _log("  SetForegroundWindow -> {}".format(result))
+    except Exception as exc:
+        _log("  SetForegroundWindow error: {}".format(exc))
+        result = False
+
+    # 3) If Windows denied it, flash the taskbar so user notices.
+    if not result:
+        try:
+            win32gui.FlashWindow(hwnd, True)
+            _log("  flashed taskbar (focus denied)")
+        except Exception as exc:
+            _log("  FlashWindow error: {}".format(exc))
+
+    return result
+
+
+def _console_window_for_pid(pid):
+    """DEPRECATED / unused.
+
+    This used to call ``AttachConsole(pid)`` + ``GetConsoleWindow()`` +
+    ``FreeConsole()``. That sequence attaches this (hidden) process to the
+    target console and then detaches — which **resets the console's input
+    mode** (clearing the raw/VT flags that prompt_toolkit sets). The result
+    is exactly the reported symptom: after a toast click the terminal becomes
+    unresponsive to keyboard/clicks yet still scrolls. We no longer use this
+    path. Kept only as a documented tombstone.
+    """
+    _log("DEPRECATED _console_window_for_pid({}) called — returning None (no console touch)".format(pid))
+    return None
+
+
+# --- Process / window helpers --------------------------------------------
+
+def _window_pid(hwnd):
+    try:
+        _, pid = win32process.GetWindowThreadProcessId(hwnd)
+        return pid
+    except Exception:
+        return None
+
+
+def _main_window_for_pid(pid):
+    """Return the first visible top-level window owned by *pid*."""
+    result = []
+
+    def cb(hwnd, _):
+        if win32gui.IsWindowVisible(hwnd) and not win32gui.GetParent(hwnd):
+            if _window_pid(hwnd) == pid:
+                result.append(hwnd)
+        return True
+
+    win32gui.EnumWindows(cb, None)
+    return result[0] if result else None
+
+
+_TERMINAL_NAMES = {
+    "windowsterminal.exe", "wt.exe",
+    "powershell.exe", "pwsh.exe", "cmd.exe",
+    "conhost.exe", "bash.exe", "mintty.exe",
+}
+
+
+def _ancestor_terminal_window(pid):
+    """Walk up from *pid* to a terminal host and focus its main window."""
+    if psutil is None:
+        return None
+    try:
+        proc = psutil.Process(pid)
+        chain = [proc]
+        cur = proc
+        for _ in range(12):
+            parent = cur.parent()
+            if parent is None:
+                break
+            chain.append(parent)
+            cur = parent
+        for p in chain:
+            try:
+                if p.name().lower() in _TERMINAL_NAMES:
+                    hwnd = _main_window_for_pid(p.pid)
+                    if hwnd:
+                        return hwnd
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return None
+
+
+def _window_by_title(substr):
+    result = []
+
+    def cb(hwnd, _):
+        if win32gui.IsWindowVisible(hwnd):
+            title = win32gui.GetWindowText(hwnd)
+            if title and substr.lower() in title.lower():
+                result.append(hwnd)
+        return True
+
+    win32gui.EnumWindows(cb, None)
+    return result[0] if result else None
+
+
+HERMES_FOCUS_PID_FILE = os.path.join(os.path.dirname(__file__), "hermes.pid")
+
+
+def _read_pid_file():
+    try:
+        with open(HERMES_FOCUS_PID_FILE, "r", encoding="utf-8") as f:
+            text = f.read().strip()
+            if text:
+                return int(text)
+    except Exception:
+        pass
+    return None
+
+
+def find_hermes_window(target_pid=None):
+    """Locate the Hermes terminal window by PID first, then fallbacks.
+
+    IMPORTANT: never call ``_console_window_for_pid`` (AttachConsole-based) —
+    it corrupts the console input mode. We only use process-tree ancestry and a
+    title fallback, both of which are read-only window enumeration.
+    """
+    if target_pid is None:
+        target_pid = _read_pid_file()
+    _log("find_hermes_window target_pid={}".format(target_pid))
+    if target_pid is not None:
+        # 1. Terminal host window via process ancestry (Windows Terminal +
+        #    bare PowerShell — walks up to powershell.exe / conhost.exe).
+        hwnd = _ancestor_terminal_window(target_pid)
+        if hwnd:
+            _log("  found via ancestry: hwnd={}".format(hwnd))
+            return hwnd
+    # 2. Title-based fallback (works if the terminal title was set).
+    hwnd = _window_by_title("Hermes")
+    if hwnd:
+        _log("  found via title: hwnd={}".format(hwnd))
+        return hwnd
+    _log("  NOT FOUND")
+    return None
+
+
+def is_hermes_foreground(target_pid=None):
+    """Return True if the Hermes terminal window is currently the foreground
+    window. Used by the CLI to suppress redundant toasts when the user is
+    already looking at the terminal.
+
+    Fails *open* (returns False) on any error so a focus-check failure never
+    silently suppresses a notification that should have been shown.
+    """
+    try:
+        fg = win32gui.GetForegroundWindow()
+        if not fg:
+            return False
+        target = find_hermes_window(target_pid=target_pid)
+        if target is None:
+            return False
+        return fg == target
+    except Exception:
+        return False
+
+
+def _parse_pid_from_url(url):
+    try:
+        if "?" in url:
+            query = url.split("?", 1)[1]
+            for part in query.split("&"):
+                if part.startswith("pid="):
+                    return int(part.split("=", 1)[1])
+    except Exception:
+        pass
+    return None
+
+
+def bring_to_front(target_pid=None):
+    # Support being launched directly from toast activation:
+    #   pythonw.exe hermes_focus.py "hermes://focus?pid=12345"
+    _log("bring_to_front target_pid={}".format(target_pid))
+    if target_pid is None and len(sys.argv) > 1:
+        arg = sys.argv[1]
+        if isinstance(arg, str) and arg.startswith("hermes://"):
+            target_pid = _parse_pid_from_url(arg)
+
+    hwnd = find_hermes_window(target_pid=target_pid)
+    if hwnd:
+        _force_foreground(hwnd)
+        print("Brought Hermes window (hwnd={}) to foreground.".format(hwnd))
+    else:
+        _log("bring_to_front: Hermes window NOT FOUND")
+        print("Hermes window not found. Launching hermes...")
+        hermes_exe = os.path.join(sys.prefix, "Scripts", "hermes.exe")
+        if not os.path.exists(hermes_exe):
+            hermes_exe = "hermes"
+        os.system('start "" "{}"'.format(hermes_exe))
+
+
+if __name__ == "__main__":
+    # Windows protocol activation passes the URL as a positional arg, e.g.:
+    #   pythonw.exe hermes_focus.py "hermes://focus?pid=12345"
+    # Strip it before argparse so the unknown-positional check doesn't fire.
+    _log("=== hermes_focus.py launched, argv={} ===".format(sys.argv))
+    url_arg = None
+    for i, arg in enumerate(sys.argv[1:], start=1):
+        if arg.startswith("hermes://"):
+            url_arg = arg
+            sys.argv.pop(i)
+            break
+
+    parser = argparse.ArgumentParser(description="Focus the Hermes window.")
+    parser.add_argument("--pid", type=int, default=None, help="Hermes process PID")
+    args = parser.parse_args()
+
+    # If launched via protocol, treat the URL as the pid source.
+    if args.pid is None and url_arg:
+        args.pid = _parse_pid_from_url(url_arg)
+
+    bring_to_front(target_pid=args.pid)

--- a/hermes_cli/windows_notify.py
+++ b/hermes_cli/windows_notify.py
@@ -1,0 +1,386 @@
+"""Hermes Windows notification helper.
+
+Primary path: ``winrt`` Python package (Python <=3.12).
+Fallback:  PowerShell + WinRT COM interop (works on any Windows 10/11,
+          zero pip deps).  Automatically selected at import time.
+
+Behavior: show a Windows toast with Hermes AUMID; clicking or auto-dismiss
+brings the correct Hermes window to front by matching PID.
+"""
+
+import os
+import sys
+import subprocess
+import argparse
+import winreg
+
+# --- Debug logging (this script may run hidden; log to a file for diagnosis) --
+
+_NOTIFY_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hermes_notify.log")
+
+
+def _log(msg):
+    try:
+        import datetime
+        ts = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        with open(_NOTIFY_LOG, "a", encoding="utf-8") as fh:
+            fh.write("[{}] {}\n".format(ts, msg))
+            fh.flush()
+    except Exception:
+        pass
+
+# ---------------------------------------------------------------------------
+# Import strategy: try winrt first, fall back to power-shell bridge
+# ---------------------------------------------------------------------------
+_HAS_WINRT = False
+try:
+    from winrt.windows.ui.notifications import (
+        ToastNotificationManager,
+        ToastNotification,
+        ToastActivatedEventArgs,
+        ToastDismissedEventArgs,
+        ToastFailedEventArgs,
+    )
+    from winrt.windows.data.xml.dom import XmlDocument
+    from winrt.windows.foundation import IPropertyValue
+
+    _HAS_WINRT = True
+except ImportError:
+    pass  # will use PowerShell fallback
+
+
+HERMES_AUMID = "Hermes"
+HERMES_TOAST_TAG = "hermes_notify"
+HERMES_TOAST_GROUP = "default"
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers (shared by both paths)
+# ---------------------------------------------------------------------------
+
+def _ensure_aumid():
+    """Register Hermes AUMID under HKCU so the toast shows 'Hermes' as app name."""
+    try:
+        key_path = rf"Software\Classes\AppUserModelId\{HERMES_AUMID}"
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path):
+                return
+        except FileNotFoundError:
+            with winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+                winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, "Hermes")
+    except Exception:
+        pass
+
+
+def _ensure_protocol_registered():
+    """Register the ``hermes://`` URL protocol (HKCU) so clicking a toast
+    launches ``hermes_focus.py`` with the activation URL.
+    """
+    try:
+        focus_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hermes_focus.py")
+        if not os.path.exists(focus_script):
+            return
+        pythonw = os.path.join(os.path.dirname(sys.executable), "pythonw.exe")
+        launcher = pythonw if os.path.exists(pythonw) else sys.executable
+        command = '"{launcher}" "{script}" "%1"'.format(
+            launcher=launcher, script=focus_script
+        )
+
+        base = r"Software\Classes\hermes"
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, base) as key:
+            winreg.SetValueEx(key, None, 0, winreg.REG_SZ, "URL:Hermes Protocol")
+            winreg.SetValueEx(key, "URL Protocol", 0, winreg.REG_SZ, "")
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, base + r"\shell\open\command") as key:
+            winreg.SetValueEx(key, None, 0, winreg.REG_SZ, command)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Focus helper (shared)
+# ---------------------------------------------------------------------------
+
+def bring_hermes_to_front(pid=None):
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hermes_focus.py")
+    if not os.path.exists(script):
+        print("hermes_focus.py not found at: {}".format(script), file=sys.stderr)
+        return False
+    try:
+        cmd = [sys.executable, script]
+        if pid is not None:
+            cmd.extend(["--pid", str(pid)])
+        subprocess.run(cmd, check=False)
+        return True
+    except Exception as exc:
+        print("Failed to run hermes_focus.py: {}".format(exc), file=sys.stderr)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Path A – winrt (native Python)
+# ---------------------------------------------------------------------------
+
+def _activated_args(event):
+    e = ToastActivatedEventArgs._from(event)
+    user_input = dict([
+        (name, IPropertyValue._from(e.user_input[name]).get_string())
+        for name in e.user_input
+    ])
+    return {"arguments": e.arguments, "user_input": user_input}
+
+
+def _escape_xml(s):
+    """Escape XML-special characters so embedded text (commands, paths, etc.)
+    that contains &, <, >, \" or ' cannot corrupt the toast XML and silently
+    suppress the notification."""
+    if s is None:
+        return ""
+    return (
+        str(s)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+async def _show_via_winrt_async(title, body, duration_seconds=3, pid=None):
+    import asyncio
+
+    _ensure_aumid()
+    _ensure_protocol_registered()
+
+    launch = f"hermes://focus?pid={pid}" if pid is not None else "hermes://focus"
+    xml = (
+        f"<toast activationType='protocol' launch='{launch}' duration='short'>"
+        "<visual><binding template='ToastGeneric'>"
+        f"<text>{_escape_xml(title)}</text>"
+        f"<text>{_escape_xml(body)}</text>"
+        "</binding></visual></toast>"
+    )
+
+    document = XmlDocument()
+    document.load_xml(xml)
+
+    notifier = ToastNotificationManager.create_toast_notifier_with_id(HERMES_AUMID)
+    notification = ToastNotification(document)
+    notification.tag = HERMES_TOAST_TAG
+    notification.group = HERMES_TOAST_GROUP
+    notifier.show(notification)
+
+    loop = asyncio.get_running_loop()
+    activated_future = loop.create_future()
+    dismissed_future = loop.create_future()
+    failed_future = loop.create_future()
+
+    def on_activated(*args):
+        # Only focus the window when the user actually clicks the toast —
+        # never on auto-dismiss/timeout, to avoid yanking focus away from
+        # whatever the user is doing.
+        _log("winrt on_activated -> bring_hermes_to_front(pid={})".format(pid))
+        bring_hermes_to_front(pid=pid)
+        loop.call_soon_threadsafe(activated_future.set_result, _activated_args(args[0]))
+
+    def on_dismissed(_, event_args):
+        loop.call_soon_threadsafe(
+            dismissed_future.set_result,
+            ToastDismissedEventArgs._from(event_args).reason,
+        )
+
+    def on_failed(_, event_args):
+        loop.call_soon_threadsafe(
+            failed_future.set_result,
+            ToastFailedEventArgs._from(event_args).error_code,
+        )
+
+    notification.add_activated(on_activated)
+    notification.add_dismissed(on_dismissed)
+    notification.add_failed(on_failed)
+
+    timer = loop.create_task(asyncio.sleep(max(1, duration_seconds)))
+
+    done, pending = await asyncio.wait(
+        [activated_future, dismissed_future, failed_future, timer],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    for p in pending:
+        p.cancel()
+
+    try:
+        ToastNotificationManager.history.remove_grouped_tag_with_id(
+            HERMES_TOAST_TAG, HERMES_TOAST_GROUP, HERMES_AUMID
+        )
+    except Exception:
+        pass
+
+
+def _show_via_winrt(title, body, duration_seconds=3, pid=None):
+    import asyncio
+
+    try:
+        asyncio.run(_show_via_winrt_async(title, body, duration_seconds, pid))
+    except RuntimeError:
+        # Event loop already running — fire-and-forget
+        _ensure_aumid()
+        _ensure_protocol_registered()
+        launch = f"hermes://focus?pid={pid}" if pid is not None else "hermes://focus"
+        xml = (
+            f"<toast activationType='protocol' launch='{launch}' duration='short'>"
+            "<visual><binding template='ToastGeneric'>"
+            f"<text>{title}</text>"
+            f"<text>{body}</text>"
+            "</binding></visual></toast>"
+        )
+        document = XmlDocument()
+        document.load_xml(xml)
+        notifier = ToastNotificationManager.create_toast_notifier_with_id(HERMES_AUMID)
+        notification = ToastNotification(document)
+        notification.tag = HERMES_TOAST_TAG
+        notification.group = HERMES_TOAST_GROUP
+        notifier.show(notification)
+
+
+# ---------------------------------------------------------------------------
+# Path B – PowerShell fallback (no pip deps needed)
+# ---------------------------------------------------------------------------
+
+_POWERSHELL_TOAST_SCRIPT = r"""
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$ErrorActionPreference = 'Stop'
+
+try {
+    [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+    [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime] | Out-Null
+} catch {
+    Write-Host 'WINRT_UNAVAILABLE'
+    exit 2
+}
+
+# Escape XML-special characters so command text (which may contain &, <, >, ")
+# does not corrupt the toast XML and silently suppress the notification.
+function Escape-Xml($s) {
+    if ($null -eq $s) { return '' }
+    return ([Security.SecurityElement]::Escape($s))
+}
+
+$title = Escape-Xml $args[0]
+$body  = Escape-Xml $args[1]
+$pidArg = $args[2]
+
+# Register the Hermes AUMID (DisplayName) so the toast renders its real
+# title/body instead of a generic placeholder. A bare AUMID without at least a
+# DisplayName makes Windows collapse it into a "1 new notification" stub.
+$aumid = 'Hermes'
+$regPath = 'HKCU:\Software\Classes\AppUserModelId\' + $aumid
+if (-not (Test-Path $regPath)) {
+    New-Item -Path $regPath -Force | Out-Null
+    Set-ItemProperty -Path $regPath -Name 'DisplayName' -Value 'Hermes' -Force
+}
+
+$launch = if ($pidArg) { "hermes://focus?pid=$pidArg" } else { 'hermes://focus' }
+$xml = "<toast activationType='protocol' launch='" + $launch + "' duration='short'><visual><binding template='ToastGeneric'><text>" + $title + "</text><text>" + $body + "</text></binding></visual></toast>"
+
+$doc = New-Object Windows.Data.Xml.Dom.XmlDocument
+$doc.LoadXml($xml)
+
+$notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($aumid)
+$toast = New-Object Windows.UI.Notifications.ToastNotification $doc
+$notifier.Show($toast)
+
+Write-Host 'OK'
+exit 0
+"""
+
+
+def _show_via_powershell(title, body, duration_seconds=3, pid=None):
+    """Fire-and-forget toast via PowerShell WinRT interop.
+
+    The script is written to a temp .ps1 and launched with ``-File`` so the
+    title/body arguments are passed as literal strings. (Passing them on the
+    ``-Command`` line makes PowerShell treat ``&`` and other chars in the body
+    as operators, which breaks e.g. approval command text.)
+    """
+    pid_str = str(pid) if pid is not None else ""
+    import tempfile
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".ps1", delete=False, encoding="utf-8-sig"
+        ) as fh:
+            fh.write(_POWERSHELL_TOAST_SCRIPT)
+            tmp_path = fh.name
+        # Run the PowerShell host fully hidden so firing a toast never flashes a
+        # visible console/terminal window in front of the user.
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
+        result = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-WindowStyle",
+                "Hidden",
+                "-File",
+                tmp_path,
+                title,
+                body,
+                pid_str,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            encoding="utf-8",
+            errors="replace",
+            startupinfo=startupinfo,
+        )
+        if result.returncode != 0:
+            err = (result.stderr or result.stdout or "").strip()
+            print(
+                "PowerShell toast failed (rc={}): {}".format(result.returncode, err),
+                file=sys.stderr,
+            )
+            return False
+        # NOTE: Do NOT auto-focus here. Focus only happens when the user
+        # *clicks* the toast, which routes through the hermes:// protocol ->
+        # hermes_focus.py. Auto-focusing on show/timeout would yank the
+        # terminal to the foreground even when the user just let it time out.
+        return True
+    except FileNotFoundError:
+        print("powershell.exe not found — cannot show toast", file=sys.stderr)
+        return False
+    except Exception as exc:
+        print("PowerShell toast error: {}".format(exc), file=sys.stderr)
+        return False
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def show_notification(title, body, duration_seconds=3, pid=None):
+    _log("show_notification path={} pid={} title={!r}".format(
+        "winrt" if _HAS_WINRT else "powershell", pid, title))
+    if _HAS_WINRT:
+        return _show_via_winrt(title, body, duration_seconds, pid)
+    else:
+        return _show_via_powershell(title, body, duration_seconds, pid)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Show a Hermes Windows toast notification.")
+    parser.add_argument("--title", default="Hermes", help="Notification title")
+    parser.add_argument("--body", default="点击回到 Hermes", help="Notification body text")
+    parser.add_argument("--duration", type=int, default=3, help="Auto-dismiss after N seconds")
+    parser.add_argument("--pid", type=int, default=None, help="Hermes process PID to focus")
+    args = parser.parse_args()
+
+    show_notification(args.title, args.body, args.duration, args.pid)


### PR DESCRIPTION
What does this PR do?

Adds best-effort Windows toast notifications for 4 CLI lifecycle events:
- reply completion
- background task / delegation completion
- approval prompt
- session ended

Users can alt-tab away from the terminal; the toast brings them back. Clicking the toast focuses the Hermes terminal window via a hermes:// protocol handler + safe foreground window logic.

Related Issue

<!-- If no issue exists, consider creating one first. -->
Fixes #

Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] 🔒 Security fix
- [ ] 🧠 New skill

Changes Made

- cli.py: add _fire_notification, _notify_session_ended, and toast hooks for completion / approval / session-end paths
- hermes_cli/windows_notify.py: new Windows toast helper with winrt primary path and PowerShell fallback
- hermes_cli/windows_focus.py: new safe window-focus helper for toast click activation
- cli-config.yaml.example: add display.notify_on_complete and display.notify_on_approval
- README.zh-CN.md: add Windows notification usage note

How to Test

1. On Windows 10/11, run hermes in PowerShell or Windows Terminal.
2. Trigger a notification event:
   - reply completion: wait for any agent response
   - background task: run hermes terminal --background true -- ... or similar background work
   - approval prompt: run a dangerous command that requires approval
   - session ended: exit the CLI with exit / Ctrl+C
3. Verify a Windows toast appears when the terminal is not focused.
4. Click the toast and verify the Hermes window is brought to the foreground.
5. Set display.notify_on_complete: false or display.notify_on_approval: false in cli-config.yaml and verify the corresponding toasts are suppressed.

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Documentation & Housekeeping

- [x] I've updated relevant documentation (README.zh-CN.md) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A