### PR TITLE
fix(desktop): pass owning profile in body for session archive/pin/unread

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -10,7 +10,12 @@ vi.mock('./client', () => ({
 }))
 
 const client = await import('./client')
-const { listSidebarSessions } = await import('./sessions')
+const {
+  listSidebarSessions,
+  setSessionArchived,
+  setSessionPinnedRemote,
+  setSessionUnreadRemote
+} = await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
@@ -39,5 +44,47 @@ describe('listSidebarSessions remote ownership', () => {
     })
 
     expect(result.recents.sessions[0]).toMatchObject({ connection_id: 'prometheus', id: 'remote-session' })
+  })
+})
+
+describe('session mutation profile propagation', () => {
+  it('setSessionArchived passes the owning profile in the body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-1', true, 'worker-beta')
+
+    expect(hermesApi).toHaveBeenCalledWith(expect.objectContaining({
+      body: { archived: true, profile: 'worker-beta' }
+    }))
+  })
+
+  it('setSessionPinnedRemote passes the owning profile in the body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionPinnedRemote('sess-1', true, 'worker-beta')
+
+    expect(hermesApi).toHaveBeenCalledWith(expect.objectContaining({
+      body: { pinned: true, profile: 'worker-beta' }
+    }))
+  })
+
+  it('setSessionUnreadRemote passes the owning profile in the body', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionUnreadRemote('sess-1', true, 'worker-beta')
+
+    expect(hermesApi).toHaveBeenCalledWith(expect.objectContaining({
+      body: { unread: true, profile: 'worker-beta' }
+    }))
+  })
+
+  it('omits the body profile when no owning profile is given', async () => {
+    hermesApi.mockResolvedValue({ ok: true } as never)
+
+    await setSessionArchived('sess-1', true)
+
+    expect(hermesApi).toHaveBeenCalledWith(expect.objectContaining({
+      body: { archived: true }
+    }))
   })
 })

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -295,7 +295,7 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived }
+    body: { archived, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -308,7 +308,7 @@ export function setSessionPinnedRemote(id: string, pinned: boolean, profile?: st
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { pinned }
+    body: { pinned, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -321,7 +321,7 @@ export function setSessionUnreadRemote(id: string, unread: boolean, profile?: st
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { unread }
+    body: { unread, ...(profile ? { profile } : {}) }
   })
 }
 


### PR DESCRIPTION
## What

Archiving, pinning, or toggling unread on a session owned by a **non-default profile** fails with 404 (or mutates the wrong profile), because the owning profile never reaches the server's state.db resolver.

## Root Cause

`PATCH /api/sessions/{id}` (`rename_session_endpoint` in `hermes_cli/web_routers/sessions.py`) resolves the target profile from the request **body**:

```py
db = _open_session_db_for_profile(body.profile, read_only=False)
```

Three Desktop mutation functions in `apps/desktop/src/api/sessions.ts` spread `profile` only at the **top level** (which Electron uses to route the request to the correct backend), and omit it from the **body**:

| Function | Before |
|---|---|
| `setSessionArchived` | `body: { archived }` |
| `setSessionPinnedRemote` | `body: { pinned }` |
| `setSessionUnreadRemote` | `body: { unread }` |

`renameSession` — which hits the *same* endpoint — already passes both copies (`body: { title, ...(profile ? { profile } : {}) }`), so this is a long-standing inconsistency. The `body: { archived }` line dates back to the function's original introduction (2026-06-01) and has never carried the body copy.

When the body `profile` is missing, the backend opens the **default** profile's `state.db`. A session owned by another profile isn't there → 404 "Session not found".

## Fix

Add the owning profile to the body of all three mutations, mirroring `renameSession`:

```ts
body: { archived, ...(profile ? { profile } : {}) }
body: { pinned,   ...(profile ? { profile } : {}) }
body: { unread,   ...(profile ? { profile } : {}) }
```

## Type of Change

- [x] Bug fix (non-breaking)

## How to Test

```
cd apps/desktop
npx vitest run src/api/sessions.test.ts   # 5 passed (1 existing + 4 new)
npx tsc -p . --noEmit                     # clean
```

New tests assert that each of the three mutations puts the owning profile in the body, and that the body profile is omitted when no owning profile is given.

## Related

Related to #44138 (`fix(desktop): pass owning profile to server on session delete/archive`). That PR covers `delete` + `archive` but (a) is based on the pre-split `hermes.ts` (the file has since been refactored into `src/api/sessions.ts`), (b) omits `pinned`/`unread`, and (c) has been open since 2026-06-11. This PR covers all three mutations against the current code, with no unrelated files.

## Checklist

- [x] Tests added / updated
- [x] `tsc` typecheck passes
- [x] No unrelated files included
