### PR TITLE
fix(desktop): give Windows cold-start a 30s WS probe and i18n retry

### DIFF
--- a/apps/desktop/electron/gateway-ws-probe.test.ts
+++ b/apps/desktop/electron/gateway-ws-probe.test.ts
@@ -13,7 +13,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { probeGatewayWebSocket } from './gateway-ws-probe'
+import { DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READY_GRACE_MS, probeGatewayWebSocket } from './gateway-ws-probe'
 
 // Minimal WebSocket double: records listeners synchronously (the probe attaches
 // them in its executor) and exposes emit() so the test can replay events.
@@ -47,6 +47,13 @@ function makeFakeWs(): { FakeWs: new (url: string) => any; instances: any[] } {
 }
 
 const FAST = { connectTimeoutMs: 1_000, readyGraceMs: 10 }
+
+test('production defaults outlast Windows cold-start GIL import stalls (#96177)', () => {
+  // Observed backend import stalls are 12–28s. The previous 10s/750ms pair
+  // failed the first probe on virtually every cold launch.
+  assert.equal(DEFAULT_CONNECT_TIMEOUT_MS, 30_000)
+  assert.equal(DEFAULT_READY_GRACE_MS, 3_000)
+})
 
 test('probe resolves ok when the socket opens and stays open', async () => {
   const { FakeWs, instances } = makeFakeWs()

--- a/apps/desktop/electron/gateway-ws-probe.ts
+++ b/apps/desktop/electron/gateway-ws-probe.ts
@@ -25,12 +25,20 @@
  * caller passes the Node/Electron global ``WebSocket``.
  */
 
-const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
+// Windows cold-start: the Python backend can hold the GIL for 12–28s while
+// importing gateway platform modules (feishu/lark, weixin, telegram) before
+// the WebSocket listener is actually ready. A 10s connect budget then
+// declares the backend dead, spawns a second one, and the UI never
+// recovers (#96177). 30s covers that stall with headroom; tests inject
+// FAST timeouts so they are not coupled to this production budget.
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
 // After the upgrade is accepted, a gateway that rejects the credential
 // post-handshake closes the socket almost immediately. Wait a short grace
 // window: a frame (gateway.ready) or a still-open socket means success; an
 // early close means the upgrade was accepted but the session was refused.
-const DEFAULT_READY_GRACE_MS = 750
+// The same GIL stall can delay the first ready frame past 750ms, so the
+// production grace matches the longer connect budget.
+const DEFAULT_READY_GRACE_MS = 3_000
 
 /**
  * Attempt a live WebSocket connection and classify the outcome.

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -97,23 +97,25 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
-    // Four attempts: immediate + 1s + 2s + 4s backoff. Stay on the initial
+    // Four attempts: immediate + 1s + 2s + 4s backoff. Flush the rejected
+    // promise, then the scheduled retry, at each step. Stay on the initial
     // locale while retries are in flight so a slow backend does not flash
     // English before the real display.language arrives.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(
-        CONFIG_LOAD_BASE_DELAY_MS + CONFIG_LOAD_BASE_DELAY_MS * 2 + CONFIG_LOAD_BASE_DELAY_MS * 4
-      )
-    })
+    for (const delay of [0, CONFIG_LOAD_BASE_DELAY_MS, CONFIG_LOAD_BASE_DELAY_MS * 2, CONFIG_LOAD_BASE_DELAY_MS * 4]) {
+      await act(async () => {
+        if (delay > 0) {
+          await vi.advanceTimersByTimeAsync(delay)
+        }
 
-    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+        await Promise.resolve()
+      })
+    }
 
     expect(configClient.getConfig).toHaveBeenCalledTimes(CONFIG_LOAD_MAX_ATTEMPTS)
+    expect(screen.getByTestId('loading').textContent).toBe('false')
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
     expect(configClient.saveConfig).not.toHaveBeenCalled()
-
-    vi.useRealTimers()
   })
 
   it('retries a cold-start config miss and applies display.language once the gateway answers', async () => {
@@ -137,21 +139,27 @@ describe('I18nProvider', () => {
     expect(screen.getByTestId('locale').textContent).toBe('en')
 
     await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+    expect(screen.getByTestId('loading').textContent).toBe('true')
+
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(CONFIG_LOAD_BASE_DELAY_MS)
+      await Promise.resolve()
     })
     expect(screen.getByTestId('locale').textContent).toBe('en')
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(CONFIG_LOAD_BASE_DELAY_MS * 2)
+      await Promise.resolve()
     })
 
-    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'))
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
     expect(screen.getByTestId('label').textContent).toBe('语言')
     expect(screen.getByTestId('loading').textContent).toBe('false')
     expect(configClient.getConfig).toHaveBeenCalledTimes(3)
     expect(configClient.saveConfig).not.toHaveBeenCalled()
-
-    vi.useRealTimers()
   })
 
   it('does not schedule another config retry after unmount', async () => {

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -1,9 +1,15 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConfigRecord } from '@/hermes'
 
-import { type I18nConfigClient, I18nProvider, useI18n } from './context'
+import {
+  CONFIG_LOAD_BASE_DELAY_MS,
+  CONFIG_LOAD_MAX_ATTEMPTS,
+  type I18nConfigClient,
+  I18nProvider,
+  useI18n
+} from './context'
 import type { Locale } from './types'
 
 function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
@@ -27,6 +33,7 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
 describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -77,6 +84,8 @@ describe('I18nProvider', () => {
   })
 
   it('keeps English usable when config loading fails', async () => {
+    vi.useFakeTimers()
+
     const configClient: I18nConfigClient = {
       getConfig: vi.fn().mockRejectedValue(new Error('config unavailable')),
       saveConfig: vi.fn()
@@ -88,11 +97,91 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
+    // Four attempts: immediate + 1s + 2s + 4s backoff. Stay on the initial
+    // locale while retries are in flight so a slow backend does not flash
+    // English before the real display.language arrives.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        CONFIG_LOAD_BASE_DELAY_MS + CONFIG_LOAD_BASE_DELAY_MS * 2 + CONFIG_LOAD_BASE_DELAY_MS * 4
+      )
+    })
+
     await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
 
+    expect(configClient.getConfig).toHaveBeenCalledTimes(CONFIG_LOAD_MAX_ATTEMPTS)
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
     expect(configClient.saveConfig).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('retries a cold-start config miss and applies display.language once the gateway answers', async () => {
+    vi.useFakeTimers()
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('gateway warming'))
+        .mockRejectedValueOnce(new Error('gateway warming'))
+        .mockResolvedValue({ display: { language: 'zh-Hans' } }),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient} initialLocale="en">
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONFIG_LOAD_BASE_DELAY_MS)
+    })
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONFIG_LOAD_BASE_DELAY_MS * 2)
+    })
+
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'))
+    expect(screen.getByTestId('label').textContent).toBe('语言')
+    expect(screen.getByTestId('loading').textContent).toBe('false')
+    expect(configClient.getConfig).toHaveBeenCalledTimes(3)
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('does not schedule another config retry after unmount', async () => {
+    vi.useFakeTimers()
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockRejectedValue(new Error('gateway warming')),
+      saveConfig: vi.fn()
+    }
+
+    const view = render(
+      <I18nProvider configClient={configClient} initialLocale="zh">
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(configClient.getConfig).toHaveBeenCalledTimes(1)
+    view.unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONFIG_LOAD_BASE_DELAY_MS * 8)
+    })
+
+    expect(configClient.getConfig).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
   })
 
   it('loads zh-hant from display.language config', async () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -92,6 +92,16 @@ export interface I18nProviderProps {
   initialLocale?: unknown
 }
 
+/** One-shot `/api/config` can miss a Windows cold-start GIL stall. Four
+ *  attempts with exponential backoff (1s, 2s, 4s) cover the 12–28s import
+ *  window without locking English for the rest of the session (#96177). */
+export const CONFIG_LOAD_MAX_ATTEMPTS = 4
+export const CONFIG_LOAD_BASE_DELAY_MS = 1_000
+
+function configLoadRetryDelayMs(attempt: number): number {
+  return CONFIG_LOAD_BASE_DELAY_MS * 2 ** attempt
+}
+
 export function I18nProvider({ children, configClient = defaultConfigClient, initialLocale }: I18nProviderProps) {
   const [locale, setLocaleState] = useState<Locale>(() => normalizeLocale(initialLocale))
   const [isLoadingConfig, setIsLoadingConfig] = useState(false)
@@ -113,31 +123,69 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     }
 
     let cancelled = false
+    let retryTimeoutId: ReturnType<typeof setTimeout> | undefined
+
+    const finishFailure = (error: unknown) => {
+      setConfigLoadError(toError(error))
+      setLocaleState(DEFAULT_LOCALE)
+      setIsLoadingConfig(false)
+    }
+
+    const fetchConfig = (attempt: number) => {
+      if (cancelled) {
+        return
+      }
+
+      configClient
+        .getConfig()
+        .then(config => {
+          if (cancelled) {
+            return
+          }
+
+          const language = getConfigDisplayLanguage(config)
+
+          if (language) {
+            setLocaleState(normalizeLocale(language))
+            setConfigLoadError(null)
+            setIsLoadingConfig(false)
+            return
+          }
+
+          // Gateway answered but display.language is not in the payload yet
+          // (still warming). Retry rather than snapping to English.
+          if (attempt + 1 < CONFIG_LOAD_MAX_ATTEMPTS) {
+            retryTimeoutId = setTimeout(() => fetchConfig(attempt + 1), configLoadRetryDelayMs(attempt))
+            return
+          }
+
+          setLocaleState(normalizeLocale(language))
+          setIsLoadingConfig(false)
+        })
+        .catch(error => {
+          if (cancelled) {
+            return
+          }
+
+          if (attempt + 1 < CONFIG_LOAD_MAX_ATTEMPTS) {
+            retryTimeoutId = setTimeout(() => fetchConfig(attempt + 1), configLoadRetryDelayMs(attempt))
+            return
+          }
+
+          finishFailure(error)
+        })
+    }
 
     setIsLoadingConfig(true)
     setConfigLoadError(null)
-
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
-        }
-      })
-      .catch(error => {
-        if (!cancelled) {
-          setConfigLoadError(toError(error))
-          setLocaleState(DEFAULT_LOCALE)
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingConfig(false)
-        }
-      })
+    fetchConfig(0)
 
     return () => {
       cancelled = true
+
+      if (retryTimeoutId !== undefined) {
+        clearTimeout(retryTimeoutId)
+      }
     }
   }, [configClient, initialLocale])
 


### PR DESCRIPTION
## What does this PR do?

On Windows cold start the Python backend can hold the GIL for 12–28s while importing gateway platform modules, so the desktop WS probe (10s connect / 750ms ready grace) declares the backend dead and spawns a second one. Independently, `I18nProvider` fetches `/api/config` once: if that misses the same window, the UI locks English for the rest of the session.

This raises the production probe budget to 30s / 3s (tests still inject FAST timeouts) and retries the locale fetch four times with exponential backoff (1s, 2s, 4s), clearing the timer on unmount. English is only applied after the last miss.

## Related Issue

Fixes #96177

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/gateway-ws-probe.ts` — `DEFAULT_CONNECT_TIMEOUT_MS = 30_000`, `DEFAULT_READY_GRACE_MS = 3_000`
- `apps/desktop/src/i18n/context.tsx` — retry `/api/config` instead of snapping to `DEFAULT_LOCALE` on the first failure
- Tests for the new defaults, retry-then-apply, exhaustion fallback, and unmount cancellation

## How to Test

```text
cd apps/desktop
npx vitest run --project ui src/i18n/context.test.tsx
# 13 passed
npx vitest run --project electron electron/gateway-ws-probe.test.ts
# 10 passed
```

Not runtime-tested on a Windows OptiPlex cold boot (no Windows box here). Probe tests inject FAST timeouts so they are not coupled to the production budget.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (desktop vitest ui + electron projects)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (timeouts + retry loop; no visual change when config loads on the first try)
