### PR TITLE
fix(cron): trust the gateway runtime lock for builtin-ticker liveness (salvage #95947)

### DIFF
--- a/contributors/emails/magnus.lundstedt@infidyne.com
+++ b/contributors/emails/magnus.lundstedt@infidyne.com
@@ -1,0 +1,1 @@
+magnuslundstedt

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -78,6 +78,15 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
+        # The gateway runtime lock is held for exactly the gateway's lifetime, so it
+        # is a more reliable "is the ticker's process alive" signal than PID scanning
+        # — and inside the gateway process it short-circuits to True, so the in-gateway
+        # cron tool never emits a false "gateway not running" (find_gateway_pids can
+        # transiently miss the gateway just after a restart).
+        from gateway.status import is_gateway_runtime_lock_active
+
+        if is_gateway_runtime_lock_active():
+            return True
         from hermes_cli.gateway import find_gateway_pids
 
         return bool(find_gateway_pids())

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -83,10 +83,16 @@ def _builtin_gateway_liveness() -> Optional[bool]:
         # — and inside the gateway process it short-circuits to True, so the in-gateway
         # cron tool never emits a false "gateway not running" (find_gateway_pids can
         # transiently miss the gateway just after a restart).
-        from gateway.status import is_gateway_runtime_lock_active
+        try:
+            from gateway.status import is_gateway_runtime_lock_active
 
-        if is_gateway_runtime_lock_active():
-            return True
+            if is_gateway_runtime_lock_active():
+                return True
+        except Exception:
+            # A crashing lock probe is "unknown", not "dead" — let the pid
+            # scan below still decide instead of collapsing the whole
+            # tri-state to None.
+            pass
         from hermes_cli.gateway import find_gateway_pids
 
         return bool(find_gateway_pids())

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -404,7 +404,24 @@ def cron_status():
         return
 
     pids = find_gateway_pids()
-    if pids:
+    gateway_alive_via_lock = False
+    if not pids:
+        # Same false-alarm class the cronjob tool fixed (#95947): the pid scan
+        # can transiently miss a live gateway (just after a restart) while the
+        # runtime lock — held for exactly the gateway's lifetime — proves the
+        # ticker's process is alive. Only declare "not running" when both the
+        # scan AND the lock say so.
+        try:
+            from gateway.status import get_running_pid, is_gateway_runtime_lock_active
+
+            if is_gateway_runtime_lock_active():
+                gateway_alive_via_lock = True
+                lock_pid = get_running_pid()
+                if lock_pid:
+                    pids = [lock_pid]
+        except Exception:
+            pass
+    if pids or gateway_alive_via_lock:
         # The gateway PROCESS is alive — but the cron ticker THREAD inside it
         # can die silently, or stay alive while every tick fails. Check both
         # the liveness heartbeat and the last-successful-tick marker so we
@@ -432,7 +449,8 @@ def cron_status():
                 f"no heartbeat for {int(hb_age)}s (expected every ~60s).",
                 Colors.YELLOW,
             ))
-            print(f"  PID: {', '.join(map(str, pids))}")
+            if pids:
+                print(f"  PID: {', '.join(map(str, pids))}")
             print("  Cron jobs may NOT be firing. Restart: hermes gateway restart")
         elif hb_age is not None and ok_age is not None and ok_age > STALE_AFTER:
             # Loop is alive (fresh heartbeat) but no tick has SUCCEEDED in a
@@ -442,7 +460,8 @@ def cron_status():
                 f"succeeded in {int(ok_age)}s — ticks may be failing.",
                 Colors.YELLOW,
             ))
-            print(f"  PID: {', '.join(map(str, pids))}")
+            if pids:
+                print(f"  PID: {', '.join(map(str, pids))}")
             last_error = get_ticker_last_error()
             if last_error:
                 # Show WHY ticks fail — e.g. a root-rewritten jobs.json
@@ -470,7 +489,8 @@ def cron_status():
             print("  Check the gateway log for 'Cron tick error'.")
         else:
             print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
-            print(f"  PID: {', '.join(map(str, pids))}")
+            if pids:
+                print(f"  PID: {', '.join(map(str, pids))}")
             if hb_age is not None:
                 print(f"  Ticker heartbeat: {int(hb_age)}s ago")
     else:

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -278,3 +278,43 @@ class TestRuntimeLockFirstLiveness:
             patch("hermes_cli.gateway.find_gateway_pids", return_value=[424242]),
         ):
             assert cron_cli._builtin_gateway_liveness() is True
+
+
+class TestCronStatusLockFirst:
+    """`hermes cron status` shares the lock-first false-alarm fix (#95947).
+
+    Sibling site of `_builtin_gateway_liveness`: it previously declared
+    "Gateway is not running — cron jobs will NOT fire" from a bare
+    `find_gateway_pids()` miss even while the runtime lock proved the
+    gateway (and its ticker) alive.
+    """
+
+    def _run_status(self, *, pids, lock_active, lock_pid=None):
+        from unittest.mock import patch
+        import io
+        from contextlib import redirect_stdout
+
+        import hermes_cli.cron as cron_cli
+
+        out = io.StringIO()
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=list(pids)),
+            patch(
+                "gateway.status.is_gateway_runtime_lock_active",
+                return_value=lock_active,
+            ),
+            patch("gateway.status.get_running_pid", return_value=lock_pid),
+            redirect_stdout(out),
+        ):
+            cron_cli.cron_status()
+        return out.getvalue()
+
+    def test_lock_active_suppresses_not_running_false_alarm(self, hermes_env):
+        text = self._run_status(pids=[], lock_active=True, lock_pid=4242)
+        assert "NOT fire" not in text
+        assert "Gateway is running" in text or "running" in text
+
+    def test_no_lock_no_pids_still_warns(self, hermes_env):
+        text = self._run_status(pids=[], lock_active=False)
+        assert "NOT fire" in text

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -162,11 +162,20 @@ from contextlib import ExitStack
 
 
 class _LivenessPatches:
-    """Context manager patching the provider/gateway-pid probes."""
+    """Context manager patching the provider/gateway-pid probes.
 
-    def __init__(self, *, provider, pids):
+    Also pins the gateway runtime lock probe to *inactive* by default so
+    these tests are deterministic even when a real gateway (holding the
+    real lock) runs on the developer's machine — the lock-first check in
+    ``_builtin_gateway_liveness`` would otherwise short-circuit to True
+    and mask the pid-scan behavior under test. Pass ``lock_active=True``
+    to exercise the lock-first path itself.
+    """
+
+    def __init__(self, *, provider, pids, lock_active=False):
         self._provider = provider
         self._pids = pids
+        self._lock_active = lock_active
 
     def __enter__(self):
         from unittest.mock import patch
@@ -190,11 +199,82 @@ class _LivenessPatches:
                 return_value=list(self._pids),
             )
         )
+        self._stack.enter_context(
+            patch(
+                "gateway.status.is_gateway_runtime_lock_active",
+                return_value=self._lock_active,
+            )
+        )
         return self
 
     def __exit__(self, *exc):
         return self._stack.__exit__(*exc)
 
 
-def patch_liveness(*, provider, pids):
-    return _LivenessPatches(provider=provider, pids=pids)
+def patch_liveness(*, provider, pids, lock_active=False):
+    return _LivenessPatches(provider=provider, pids=pids, lock_active=lock_active)
+
+
+class TestRuntimeLockFirstLiveness:
+    """The gateway runtime lock is the primary liveness signal (#95947).
+
+    ``find_gateway_pids`` can transiently return empty while the gateway is
+    up (right after a restart) and excludes the current PID by design
+    (#13242), so a single-process gateway probed as dead while its own
+    ticker was firing (#94143 class). The lock is held for exactly the
+    gateway's lifetime and short-circuits to True before the pid scan.
+    """
+
+    def test_lock_active_reports_alive_despite_empty_pid_scan(self, hermes_env):
+        """The reported false alarm: lock held, pid scan empty → alive."""
+        _create_job()
+        with patch_liveness(provider="builtin", pids=[], lock_active=True):
+            from tools.cronjob_tools import cronjob
+
+            result = json.loads(cronjob(action="list"))
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_lock_inactive_falls_back_to_pid_scan(self):
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("gateway.status.is_gateway_runtime_lock_active", return_value=False),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[424242]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is True
+
+    def test_no_lock_no_pids_is_false(self):
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("gateway.status.is_gateway_runtime_lock_active", return_value=False),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is False
+
+    def test_lock_probe_failure_still_falls_back(self):
+        """A crashing lock probe must not poison the tri-state helper —
+        the pid scan still decides (the outer except returns None only
+        when both probes fail)."""
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch(
+                "gateway.status.is_gateway_runtime_lock_active",
+                side_effect=OSError("lock probe failed"),
+            ),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[424242]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is True


### PR DESCRIPTION
## Summary

The `cronjob` tool / `hermes cron` no longer emit false "Gateway is not running — jobs won't fire" warnings while the builtin ticker is alive: `_builtin_gateway_liveness` now checks the gateway runtime lock first (held for exactly the gateway's lifetime) and only falls back to the PID scan when the lock reads inactive.

Salvage of the cron half of #95947 by @magnuslundstedt (cherry-picked, authorship preserved) + a follow-up commit with the regression tests and a probe-failure hardening.

## Why lock-first

`find_gateway_pids()` excludes the current PID by design (#13242) and can transiently return empty right after a restart — so the in-gateway cron tool probed its own live gateway as dead (#94143 class), and external CLI checks could false-alarm during restarts. The lock covers both: inside the gateway it short-circuits to True; outside, an active lock proves some gateway process is alive. Verified live: on a box where the pid scan is unreliable, `is_gateway_runtime_lock_active()` correctly reports the running gateway.

## Changes

**Commit 3 (review finding folded):** `hermes cron status` had the identical false alarm in the same file — a bare `find_gateway_pids()` miss printed "Gateway is not running — cron jobs will NOT fire" while the lock proved otherwise. The not-running verdict now requires scan AND lock to read dead (+2 regression tests).


- `hermes_cli/cron.py`: lock-first liveness (@magnuslundstedt) + our hardening — a crashing lock probe is "unknown", not "dead": the pid scan still decides instead of the tri-state collapsing to `None`
- `tests/cron/test_87033_cronjob_gateway_liveness.py`: 4 regression tests (lock-held + empty scan → alive; inactive-lock fallback both ways; crashing probe still falls back), test-shape adapted from #94155 by @liuhao1024; `patch_liveness` now pins the lock probe inactive by default so the pre-existing pid-scan tests stay deterministic on dev machines where a real gateway holds the real lock
- `contributors/emails/`: mapping for the contributor

## Validation

| | |
|---|---|
| tests/cron/test_87033_cronjob_gateway_liveness.py | 14 passed (8 existing + 6 new) |
| Full tests/cron/ vs origin/main baseline | 0 new failures (5 pre-existing test_monitor_kind env failures identical on main) |
| Mutation check (cron.py reverted to main, tests kept) | lock-first test fails → restored passes |
| ruff | clean |

## Credit

- Cron lock-first fix by @magnuslundstedt in #95947 (commit cherry-picked with authorship preserved). The MCP half of that PR was a duplicate of #94339, which merged separately.
- Test shape and the in-gateway-process diagnosis from @liuhao1024's #94155 (co-authored on the test commit) — that PR identified the self-excluded-PID case first; the lock mechanism here covers it plus the post-restart transient-scan-miss.

Closes #95947. Supersedes #94155.
