### PR TITLE
fix(desktop): refetch Bot Chat on roster reopen instead of idle snapshot

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -191,6 +191,41 @@ describe('useSessionTileDelegate resumeTile', () => {
 
     expect(runtimeId).toBe('runtime-a')
     expect(requestGateway).not.toHaveBeenCalled()
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+  })
+
+  it('merges persisted messages into a warm tile on explicit reopen (#96183)', async () => {
+    const stateA = {
+      busy: false,
+      messages: [{ id: 'm1', parts: [{ type: 'text', text: 'old' }], role: 'user' }],
+      storedSessionId: 'stored-a'
+    }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-a', 'runtime-a']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-a', stateA]]) }
+    const updateSessionState = vi.fn((_id, updater) => updater(stateA))
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({
+      messages: [
+        { id: 'm1', content: 'old', role: 'user' },
+        { id: 'm2', content: 'cron delivery', role: 'user' }
+      ],
+      session_id: 'stored-a'
+    } as never)
+
+    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState })
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-a', { refreshTranscript: true })
+
+    expect(runtimeId).toBe('runtime-a')
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(getLatestSessionMessages).toHaveBeenCalled()
+    expect(updateSessionState).toHaveBeenCalled()
+
+    const updater = updateSessionState.mock.calls[0][1] as (state: typeof stateA) => { messages: Array<{ parts?: Array<{ text?: string }> }> }
+    const next = updater(stateA)
+    const texts = next.messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+
+    expect(texts.some(text => text.includes('cron delivery'))).toBe(true)
   })
 
   it('falls through to a real resume when the warm binding has no transcript (post-wake empty tile)', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
 
+import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
-import { toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
 import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
@@ -10,11 +11,30 @@ import type { SessionResumeResponse } from '@/types/hermes'
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
 import { singleFlightSessionResume } from '../../session/hooks/use-prompt-actions/single-flight-resume'
 import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
-import { resolveSessionOwner } from '../../session/hooks/use-session-actions/utils'
+import {
+  chatMessageArraysEquivalent,
+  reconcileResumeMessages,
+  resolveSessionOwner
+} from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
 import type { GatewayRequester } from '../types'
 
 type SessionStateCache = ReturnType<typeof useSessionStateCache>
+
+function mergeTileTranscript(
+  previous: ChatMessage[],
+  prefetchMessages: SessionResumeResponse['messages'] | undefined
+): ChatMessage[] {
+  const prefetched = toChatMessages(prefetchMessages ?? [])
+
+  if (!prefetched.length) {
+    return previous
+  }
+
+  const persisted = graftRefreshedTailOntoBackfill(prefetched, previous)
+
+  return reconcileResumeMessages(persisted, previous)
+}
 
 interface SessionTileDelegateParams {
   archiveSession: (storedSessionId: string) => Promise<unknown>
@@ -165,9 +185,10 @@ export function useSessionTileDelegate({
           }
         )
       },
-      resumeTile: async storedSessionId => {
+      resumeTile: async (storedSessionId, options) => {
         const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
+        const refreshTranscript = options?.refreshTranscript === true
 
         // Warm path: reuse a live binding — but only when it still carries a
         // transcript (or is mid-turn, where messages legitimately stream in).
@@ -175,7 +196,17 @@ export function useSessionTileDelegate({
         // transcript or a stale pre-reconnect survivor; reusing it painted the
         // post-sleep/wake tile permanently empty. Fall through to a real
         // resume instead — it's idempotent for a genuinely live session.
-        if (existing && cached?.storedSessionId === storedSessionId && (cached.busy || cached.messages.length > 0)) {
+        //
+        // Explicit reopen (`refreshTranscript`) must still REST-merge: the
+        // warm snapshot is whatever the tile last painted, and cron bot-chat
+        // deliveries that landed while the panel's WS was down never arrive
+        // as realtime events (#96183).
+        if (
+          existing &&
+          cached?.storedSessionId === storedSessionId &&
+          (cached.busy || cached.messages.length > 0) &&
+          !refreshTranscript
+        ) {
           publishSessionState(existing, cached)
 
           return existing
@@ -193,8 +224,23 @@ export function useSessionTileDelegate({
             ? { connectionId: owner.connectionId, profile: owner.targetProfile || owner.profile }
             : owner
 
+        const prefetchPromise = getLatestSessionMessages(storedSessionId, restScope).catch(() => null)
+
+        if (existing && cached?.storedSessionId === storedSessionId && (cached.busy || cached.messages.length > 0)) {
+          const prefetch = await prefetchPromise
+          const merged = mergeTileTranscript(cached.messages, prefetch?.messages)
+
+          if (!chatMessageArraysEquivalent(cached.messages, merged)) {
+            updateSessionState(existing, state => ({ ...state, messages: merged }), storedSessionId)
+          } else {
+            publishSessionState(existing, cached)
+          }
+
+          return existing
+        }
+
         const [prefetch, resumed] = await Promise.all([
-          getLatestSessionMessages(storedSessionId, restScope).catch(() => null),
+          prefetchPromise,
           singleFlightSessionResume(storedSessionId, () =>
             requestForSessionProfile<SessionResumeResponse>(owner, requestGateway, 'session.resume', {
               session_id: storedSessionId,
@@ -224,8 +270,7 @@ export function useSessionTileDelegate({
             ...(typeof info?.provider === 'string' ? { provider: info.provider } : {}),
             ...(typeof info?.reasoning_effort === 'string' ? { reasoningEffort: info.reasoning_effort } : {}),
             ...(typeof info?.fast === 'boolean' ? { fast: info.fast } : {}),
-            messages:
-              state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
+            messages: mergeTileTranscript(state.messages, prefetch?.messages ?? resumed?.messages)
           }),
           storedSessionId
         )

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -90,7 +90,8 @@ import {
   $focusedSessionState,
   $focusedStoredSessionId,
   $sessionStates,
-  $sessionTiles
+  $sessionTiles,
+  sessionTileDelegate
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
@@ -977,8 +978,25 @@ export const host = {
           // session-states cache kept across a bot switch (#93604). Callers
           // that represent an explicit user navigation pass forceResume to
           // skip the heuristic entirely; the resume is idempotent either way.
+          //
+          // Bot Chat opens as a tab/tile. requestSessionResume is consumed
+          // only when the MAIN route is that session, so a roster reopen of
+          // an already-mounted tile would paint the idle snapshot and never
+          // pull messages that arrived while the panel WS was down (#96183).
+          // Refresh the tile transcript in place instead.
           if (options.awaitHydration && (options.forceResume || !surfaceHealthy)) {
-            requestSessionResume(storedSessionId, ownerRoute || undefined)
+            const existingTile = $sessionTiles.get().some(tile => tile.storedSessionId === storedSessionId)
+            const tileDelegate = existingTile ? sessionTileDelegate() : null
+
+            if (tileDelegate) {
+              try {
+                await tileDelegate.resumeTile(storedSessionId, { refreshTranscript: true })
+              } catch {
+                requestSessionResume(storedSessionId, ownerRoute || undefined)
+              }
+            } else {
+              requestSessionResume(storedSessionId, ownerRoute || undefined)
+            }
           }
 
           if (options.awaitHydration) {

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -44,7 +44,8 @@ vi.mock('@/store/session-states', async () => {
     $focusedSessionState: atom(null),
     $focusedStoredSessionId: atom(null),
     $sessionTiles: atom([]),
-    $sessionStates: atom({})
+    $sessionStates: atom({}),
+    sessionTileDelegate: vi.fn(() => null)
   }
 })
 vi.mock('@/store/profile', async () => {
@@ -128,8 +129,14 @@ const {
   setShowAllProfiles
 } = await import('@/store/profile')
 
-const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId, $sessionStates, $sessionTiles } =
-  await import('@/store/session-states')
+const {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  $sessionStates,
+  $sessionTiles,
+  sessionTileDelegate
+} = await import('@/store/session-states')
 
 const { setWorkspaceScope } = await import('@/components/pane-shell/workspace-scope')
 
@@ -156,6 +163,7 @@ const profile = (name: string): ProfileInfo => ({
 
 afterEach(() => {
   vi.clearAllMocks()
+  vi.mocked(sessionTileDelegate).mockReturnValue(null)
   vi.mocked(activeGatewayConnectionId).mockReturnValue('local')
   $activeGatewayProfile.set('remote-worker')
   $gatewaySwapTarget.set(null)
@@ -716,6 +724,32 @@ describe('profile-aware plugin session opens', () => {
 
     await opening
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('refreshes an already-open Bot Chat tile instead of trusting the idle snapshot (#96183)', async () => {
+    const resumeTile = vi.fn(async () => 'runtime-bot-chat')
+
+    vi.mocked(sessionTileDelegate).mockReturnValue({ resumeTile } as never)
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($sessionTiles, [{ storedSessionId: 'bot-chat' }] as never)
+    setMockAtom($focusedStoredSessionId, 'bot-chat')
+    setMockAtom($focusedRuntimeId, 'runtime-bot-chat')
+    setMockAtom($focusedSessionState, { messages: [{ id: 'stale-history', parts: [], role: 'assistant' }] } as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000,
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'hyoseob'
+    })
+
+    await opening
+
+    expect(resumeTile).toHaveBeenCalledWith('bot-chat', { refreshTranscript: true })
+    expect(requestSessionResume).not.toHaveBeenCalled()
   })
 
   it('forces a resume on an explicit bot switch even when a cached transcript looks healthy (#93604)', async () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1215,8 +1215,11 @@ export interface SessionTileDelegate {
    *  right pane" bug). Bindings re-record from live post-reconnect events. */
   invalidateRuntimeBindings?(preserveStoredSessionIds?: ReadonlySet<string>): void
   /** Bind a live runtime id for a stored session (resume without touching
-   *  the main view). Returns the runtime id, or throws. */
-  resumeTile(storedSessionId: string): Promise<string>
+   *  the main view). Returns the runtime id, or throws.
+   *  `refreshTranscript` forces a REST merge even when a warm cached
+   *  transcript already exists — reopen-after-idle must not paint the
+   *  snapshot that was current when the panel last had a socket. */
+  resumeTile(storedSessionId: string, options?: { refreshTranscript?: boolean }): Promise<string>
   /** Retire one runtime's busy/awaiting claim through the wiring cache
    *  (updateSessionState), so cache, focused view, busyRef, and tile mirrors
    *  settle together. Returns false when the cache holds no busy state for


### PR DESCRIPTION
## What does this PR do?

Reopening a Bot Chat panel after idle still painted the cached transcript. Cron `deliver='bot-chat:<profile>'` writes to the canonical session while the panel WS is down; first-open hydrates from REST, but reopen focused an already-mounted tile.

`forceResume` already requested `session.resume` on the main route. Bot Chat opens as a tab, so that request is ignored when the hash is not the tile's session, and `resumeTile`'s warm path returned the cached runtime without fetching. Explicit reopen now calls `resumeTile({ refreshTranscript: true })`, which REST-merges the persisted tail into the tile cache. Ordinary tile remounts keep the warm path.

## Related Issue

Fixes #96183

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/sdk/index.ts` — `forceResume` on an existing tile refreshes that tile instead of posting a main-route resume
- `apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts` — `resumeTile(..., { refreshTranscript: true })` merges `getLatestSessionMessages` into the warm cache
- Tests for the SDK tile path and the warm-cache merge

## How to Test

```text
cd apps/desktop
npx vitest run --project ui src/sdk/profile-routing.test.ts src/app/contrib/hooks/use-session-tile-delegate.test.ts
# 59 passed
```

Not re-tested on the reporter's multi-bot macOS setup (no Bot Mode cron harness here). `@8934173` offered to re-test once this lands.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (desktop vitest ui)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (tile transcript merge)
