### PR TITLE
fix(desktop): repair the SSH remote spawn payload (double-quoted paths + dash bashism)

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1084,6 +1084,18 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const tokenPath = tokenFilePath ? expandRemotePath(tokenFilePath) : ''
   const ownerPath = `${reservation}/owner`
   const metadata = JSON.stringify({ schemaVersion: LOCKFILE_SCHEMA_VERSION, ...opts.lockMetadata, pid: '__PID__' })
+
+  // The payload runs under `sh` — dash on Debian/Ubuntu — so the PID is spliced
+  // in by concatenation. `${var//pat/repl}` is a bashism; dash aborts the whole
+  // spawn with "Bad substitution". Splitting on the QUOTED placeholder also
+  // keeps `pid` a JSON number: readLockfile() rejects a string pid as
+  // malformed-pid skew.
+  const metadataParts = metadata.split('"__PID__"')
+
+  if (metadataParts.length !== 2) {
+    throw new Error('Lock metadata must contain exactly one PID placeholder.')
+  }
+
   const reservationNonce = validateSpawnNonce(opts.reservationNonce || crypto.randomBytes(8).toString('hex'))
 
   return withRemoteUpdateMutex(
@@ -1103,7 +1115,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       `${markerClear}; marker_clear || exit 75; mkdir -p "$(dirname ${logPath})" && ` +
       `${detachedSpawn}; ` +
       `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; ` +
-      `lock_json=${shq(metadata)}; lock_json=\${lock_json//__PID__/$child}; ` +
+      `lock_json=${shq(metadataParts[0])}"$child"${shq(metadataParts[1])}; ` +
       `temporary_lock="\${lock}.${reservationNonce}.tmp"; ` +
       `printf '%s' "$lock_json" > "$temporary_lock" && mv -f "$temporary_lock" "$lock" || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
       `echo "$child"`,

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -735,9 +735,12 @@ async function disconnect(ssh, ownershipId) {
 
 function buildOwnedStaleTerminationCommand(lock, ownershipId) {
   const pid = Number(lock.pid)
-  const expectedPath = shq(expandRemotePath(lock.hermesPath))
-  const expectedHome = lock.hermesHome ? shq(expandRemotePath(lock.hermesHome)) : "''"
-  const expectedToken = shq(expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce)))
+  // expandRemotePath() already returns a shell-ready fragment ("$HOME"'/…');
+  // wrapping it in shq() again would assign the literal text `"$HOME"…` and no
+  // argv comparison below could ever match.
+  const expectedPath = expandRemotePath(lock.hermesPath)
+  const expectedHome = lock.hermesHome ? expandRemotePath(lock.hermesHome) : "''"
+  const expectedToken = expandRemotePath(spawnTokenPath(ownershipId, lock.spawnNonce))
   const nonce = shq(lock.spawnNonce)
   const profile = shq(lock.profile || '')
   const command = `$(ps -ww -o command= -p ${pid} 2>/dev/null || true)`
@@ -910,7 +913,9 @@ finally:
 sys.exit(result.returncode if result is not None else 1)
 `.trim()
 
-  return `python3 -c ${shq(script)} ${shq(mutexPath)} ${shq(command)}`
+  // mutexPath is already an expandRemotePath() fragment ("$HOME"'/…'), i.e.
+  // shell-ready. Re-quoting it turns `"$HOME"` into literal text.
+  return `python3 -c ${shq(script)} ${mutexPath} ${shq(command)}`
 }
 
 /**
@@ -1083,7 +1088,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   return withRemoteUpdateMutex(
     `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
-      `reservation=${shq(reservation)}; lock=${shq(lockPath)}; owner_file=${shq(ownerPath)}; ` +
+      `reservation=${reservation}; lock=${lockPath}; owner_file=${ownerPath}; ` +
       `reservation_nonce=${shq(reservationNonce)}; ` +
       `i=0; while ! mkdir "$reservation" 2>/dev/null; do ` +
       `owner_data=$(cat "$owner_file" 2>/dev/null || true); owner_pid=${'${owner_data%%:*}'}; ` +


### PR DESCRIPTION
Fixes #96212.

`expandRemotePath()` returns a **shell-ready fragment** — `"$HOME"'/…'` for a `~/` path, `'/…'` for an absolute one. Three call sites in `remote-lifecycle.ts` pass that result through `shq()` a second time, so the remote shell receives the literal characters `"$HOME"'/…'` rather than an expandable word.

### What breaks

1. **Boot livelock.** `mkdir "$reservation"` returns `ENOENT` on every iteration, so the connect reservation is never acquired; the loop spins its full 600 iterations (~30 s) and exits 75 *while holding the global update flock*. Desktop's exec timeout is 20 s, so the client aborts first and leaves an orphaned `python3` flock holder on the remote. Every retry appends another waiter — I measured 186 queued and a host-wide 257 forks/sec — so the queue grows faster than it drains and the user sees `SSH operation to <host> timed out` forever.

2. **Update mutex in the wrong place.** It is created under a directory literally named `'` (`$HOME/'/home/<user>/.hermes/.hermes-update-in-progress.mutex'`), so it does not serialize against the real updater. Reproduces in CI too: `apps/desktop`'s vitest run leaves an `apps/desktop/'/` directory behind.

3. **Owned-stale reaper always REFUSED.** `buildOwnedStaleTerminationCommand` assigns `path`/`home`/`token` the literal `"$HOME"…` text and then matches `case "$cmd" in *"$path"*)` against real argv — never a match, so Desktop can never reclaim its own orphaned backend.

### The change

Interpolate the fragments directly, matching how `marker`, `logPath` and `hermes` are already used in the very same builders.

```diff
-      `reservation=${shq(reservation)}; lock=${shq(lockPath)}; owner_file=${shq(ownerPath)}; ` +
+      `reservation=${reservation}; lock=${lockPath}; owner_file=${ownerPath}; ` +
```

### Verification

- `npx vitest run --project electron electron/remote-lifecycle.test.ts` → 89/89 pass.
- Confirmed against the live failure with `strace` on the remote before and after; the `mkdir` that returned `ENOENT` now succeeds and the reservation is taken immediately.

Worth considering separately: the retry loop's `kill -0 … || { rm -rf "$reservation"; continue; }` branch skips the `i` increment, so a persistently-contended reservation can spin unbounded; and the 20 s client exec timeout being shorter than the loop's own 30 s budget is what converts a clean `exit 75` into an accumulating queue of orphaned flock holders.
