### PR TITLE
fix(update): keep messaging extras after runtime repair

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7854,7 +7854,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             runtime_repairs = []
             update_managed_uv(repair_observer=runtime_repairs.append)
-            ensure_uv(repair_observer=runtime_repairs.append)
+            repair_uv = ensure_uv(repair_observer=runtime_repairs.append)
             runtime_repaired = next(
                 (result for result in runtime_repairs if result.repaired),
                 None,
@@ -7875,20 +7875,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # "Already up to date!" and exits without doing the one job it
             # was spawned for.
             handed_off_sync = os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1"
+            needs_core_dependency_repair = handed_off_sync or not healthy
             if handed_off_sync:
                 print("→ Finishing the dependency install handed off by hermes.exe...")
             elif not healthy:
                 print("⚠ Checkout is current, but the venv is unhealthy:")
                 print(f"  {detail}")
                 print("→ Repairing Python dependencies...")
-            if handed_off_sync or not healthy:
+            if needs_core_dependency_repair or runtime_repaired is not None:
                 # Self-lock deferral (#86735): the repair rewrites the venv
                 # too — same mapped-extension hazard as the update sync.
                 _m()._abort_dependency_sync_if_self_locked(_windows_gateway_resume)
                 _write_update_incomplete_marker()
-                from hermes_cli.managed_uv import ensure_uv
-
-                repair_uv = ensure_uv()
                 # A managed install whose venv is gone entirely (interrupted
                 # repair after the old venv was moved aside) needs the venv
                 # recreated before dependencies can be installed into it.
@@ -7911,9 +7909,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                     repair_env = managed_python_env()
                     repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
-                    _m()._install_python_dependencies_with_optional_fallback(
-                        [repair_uv, "pip"], env=repair_env, group="all"
-                    )
+                    if needs_core_dependency_repair:
+                        _m()._install_python_dependencies_with_optional_fallback(
+                            [repair_uv, "pip"], env=repair_env, group="all"
+                        )
                     _m()._refresh_active_lazy_features(
                         [repair_uv, "pip"],
                         env=repair_env,
@@ -7925,9 +7924,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         env=repair_env,
                     )
                 else:
-                    _m()._install_python_dependencies_with_optional_fallback(
-                        [sys.executable, "-m", "pip"], group="all"
-                    )
+                    if needs_core_dependency_repair:
+                        _m()._install_python_dependencies_with_optional_fallback(
+                            [sys.executable, "-m", "pip"], group="all"
+                        )
                     _m()._refresh_active_lazy_features(
                         [sys.executable, "-m", "pip"],
                         features=active_lazy_features,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7883,9 +7883,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print(f"  {detail}")
                 print("→ Repairing Python dependencies...")
             if needs_core_dependency_repair or runtime_repaired is not None:
-                # Self-lock deferral (#86735): the repair rewrites the venv
-                # too — same mapped-extension hazard as the update sync.
-                _m()._abort_dependency_sync_if_self_locked(_windows_gateway_resume)
+                if needs_core_dependency_repair:
+                    # Self-lock deferral (#86735): the core sync rewrites the
+                    # venv and has the same mapped-extension hazard as an
+                    # update sync. Runtime repair has already completed here;
+                    # handing off now would discard the pre-repair snapshots.
+                    _m()._abort_dependency_sync_if_self_locked(
+                        _windows_gateway_resume
+                    )
                 _write_update_incomplete_marker()
                 # A managed install whose venv is gone entirely (interrupted
                 # repair after the old venv was moved aside) needs the venv

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -255,6 +255,97 @@ def test_cmd_update_captures_and_propagates_pre_rebuild_snapshot(
     ]
 
 
+def test_cmd_update_restores_snapshots_after_healthy_runtime_repair(
+    tmp_path, monkeypatch
+):
+    """A healthy replacement venv still needs its optional deps restored."""
+    from hermes_cli import managed_uv, update_cmd
+
+    (tmp_path / ".git").mkdir()
+    snapshot = ["platform.telegram"]
+    tool_snapshot = ["langfuse"]
+    refresh_calls = []
+    restore_calls = []
+
+    class RestoreReached(Exception):
+        pass
+
+    def fake_run(cmd, **kwargs):
+        if "rev-parse" in cmd:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list" in cmd:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_refresh(prefix, *, env=None, features=None):
+        refresh_calls.append((prefix, env, features))
+        return True
+
+    def fake_restore(dependencies, prefix, *, env=None):
+        restore_calls.append((dependencies, prefix, env))
+        raise RestoreReached
+
+    def fake_update_managed_uv(*, repair_observer=None, **kwargs):
+        if repair_observer is not None:
+            repair_observer(managed_uv.RuntimeRepairResult("repaired"))
+        return "uv"
+
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(m, "_capture_active_lazy_features", lambda: snapshot.copy())
+    monkeypatch.setattr(
+        m, "_capture_active_tool_dependencies", lambda: tool_snapshot.copy()
+    )
+    monkeypatch.setattr(m, "_is_windows", lambda: False)
+    monkeypatch.setattr(m, "_run_pre_update_backup", lambda args: None)
+    monkeypatch.setattr(m, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(m, "_resume_windows_gateways_after_update", lambda state: None)
+    monkeypatch.setattr(update_cmd, "_discard_lockfile_churn", lambda *args: None)
+    monkeypatch.setattr(
+        m,
+        "_get_origin_url",
+        lambda *args: "https://github.com/NousResearch/hermes-agent.git",
+    )
+    monkeypatch.setattr(m, "_resolve_update_branch", lambda args: "main")
+    monkeypatch.setattr(m, "_stash_local_changes_if_needed", lambda *args: None)
+    monkeypatch.setattr(update_cmd, "_invalidate_update_cache", lambda: None)
+    monkeypatch.setattr(
+        update_cmd, "_venv_core_imports_healthy", lambda: (True, "")
+    )
+    monkeypatch.setattr(update_cmd, "_write_update_incomplete_marker", lambda: None)
+    monkeypatch.setattr(
+        m,
+        "_install_python_dependencies_with_optional_fallback",
+        lambda *args, **kwargs: pytest.fail(
+            "a healthy replacement must not reinstall core dependencies"
+        ),
+    )
+    monkeypatch.setattr(m, "_refresh_active_lazy_features", fake_refresh)
+    monkeypatch.setattr(m, "_restore_active_tool_dependencies", fake_restore)
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+    monkeypatch.setattr(managed_uv, "update_managed_uv", fake_update_managed_uv)
+    monkeypatch.setattr(managed_uv, "ensure_uv", lambda **kwargs: "uv")
+
+    args = SimpleNamespace(
+        yes=True,
+        force=False,
+        force_venv=False,
+        no_backup=True,
+        backup=False,
+        branch=None,
+    )
+    with pytest.raises(RestoreReached):
+        m._cmd_update_impl(args, gateway_mode=False)
+
+    from hermes_cli.managed_uv import managed_python_env
+
+    expected_env = managed_python_env()
+    expected_env["VIRTUAL_ENV"] = str(tmp_path / "venv")
+    assert refresh_calls == [(["uv", "pip"], expected_env, snapshot)]
+    assert restore_calls == [
+        (tool_snapshot, ["uv", "pip"], expected_env)
+    ]
+
+
 
 
 

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -314,6 +314,13 @@ def test_cmd_update_restores_snapshots_after_healthy_runtime_repair(
     monkeypatch.setattr(update_cmd, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(
         m,
+        "_abort_dependency_sync_if_self_locked",
+        lambda *args, **kwargs: pytest.fail(
+            "runtime-only restoration must not hand off after venv cutover"
+        ),
+    )
+    monkeypatch.setattr(
+        m,
         "_install_python_dependencies_with_optional_fallback",
         lambda *args, **kwargs: pytest.fail(
             "a healthy replacement must not reinstall core dependencies"

--- a/tests/tools/test_send_message_tool_missing_dependency.py
+++ b/tests/tools/test_send_message_tool_missing_dependency.py
@@ -1,5 +1,9 @@
 import asyncio
 import builtins
+import os
+import shlex
+import subprocess
+import sys
 
 from tools.send_message_tool import _send_telegram
 
@@ -16,9 +20,22 @@ def test_telegram_missing_dependency_recommends_uv(monkeypatch):
 
     result = asyncio.run(_send_telegram("token", "123", "hello"))
 
+    install_argv = [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        sys.executable,
+        "python-telegram-bot",
+    ]
+    install_command = (
+        subprocess.list2cmdline(install_argv)
+        if os.name == "nt"
+        else shlex.join(install_argv)
+    )
     assert result == {
         "error": (
             "python-telegram-bot not installed. "
-            "Run: uv pip install python-telegram-bot"
+            f"Run: {install_command}"
         )
     }

--- a/tests/tools/test_send_message_tool_missing_dependency.py
+++ b/tests/tools/test_send_message_tool_missing_dependency.py
@@ -1,0 +1,24 @@
+import asyncio
+import builtins
+
+from tools.send_message_tool import _send_telegram
+
+
+def test_telegram_missing_dependency_recommends_uv(monkeypatch):
+    real_import = builtins.__import__
+
+    def without_telegram(name, *args, **kwargs):
+        if name == "telegram" or name.startswith("telegram."):
+            raise ImportError("telegram unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_telegram)
+
+    result = asyncio.run(_send_telegram("token", "123", "hello"))
+
+    assert result == {
+        "error": (
+            "python-telegram-bot not installed. "
+            "Run: uv pip install python-telegram-bot"
+        )
+    }

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1658,7 +1658,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             result["warnings"] = warnings
         return result
     except ImportError:
-        return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
+        return {
+            "error": (
+                "python-telegram-bot not installed. "
+                "Run: uv pip install python-telegram-bot"
+            )
+        }
     except Exception as e:
         return _error(f"Telegram send failed: {e}")
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,6 +10,9 @@ import json
 import logging
 import os
 import re
+import shlex
+import subprocess
+import sys
 import time
 
 
@@ -1658,10 +1661,23 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             result["warnings"] = warnings
         return result
     except ImportError:
+        install_argv = [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "python-telegram-bot",
+        ]
+        install_command = (
+            subprocess.list2cmdline(install_argv)
+            if os.name == "nt"
+            else shlex.join(install_argv)
+        )
         return {
             "error": (
                 "python-telegram-bot not installed. "
-                "Run: uv pip install python-telegram-bot"
+                f"Run: {install_command}"
             )
         }
     except Exception as e:


### PR DESCRIPTION
## What does this PR do?

A successful managed Python runtime repair could remove previously installed messaging extras while still reporting the update as complete. This change restores the pre-repair lazy and Hermes Tools dependency snapshots on the no-new-commits path, even when the replacement venv passes its core import smoke test, and gives standalone Telegram delivery an actionable uv install command.

### Symptom

After `hermes update` repairs a SQLite-vulnerable managed runtime, a later standalone Telegram cron delivery can fail with `python-telegram-bot not installed` even though the update reported success.

### Impact

Optional messaging and tool capabilities that were installed before the rebuild can disappear from the replacement venv. Live gateway delivery may mask the loss until a standalone delivery path starts in the repaired environment.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py:7877` / the no-new-commits branch after `repair_vulnerable_runtime` returns `repaired`.

**Causal chain:**
1. Runtime repair replaces the live venv with a candidate built from the curated `all` dependency group.
2. The candidate passes the core import probe, so the updater skips the dependency recovery block.
3. The pre-repair lazy and Hermes Tools snapshots are never restored, leaving optional platform packages absent while the update reports success.

**Why it is wrong:** Core import health proves only that the replacement runtime can start Hermes. It does not prove that optional dependencies present before the destructive rebuild survived.

**Working sibling / contrast:** The normal post-pull path always calls `_refresh_active_lazy_features(..., features=active_lazy_features)` and restores active tool dependencies after dependency synchronization.

**Ruled out:** Lazy feature discovery correctly detects installed Telegram, Discord, and Slack anchors before repair. The loss occurs because the healthy no-update branch never consumes that snapshot.

### Fix

Treat a successful runtime replacement as a reason to enter dependency restoration even when core imports are healthy. Reuse the already resolved managed uv path, restore only optional snapshots in that case, and avoid a redundant core dependency reinstall. The standalone Telegram error now recommends `uv pip install python-telegram-bot`, which works with Hermes' uv-managed environments.

## Related Issue

Fixes #96180

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - restore captured lazy and tool dependencies after a healthy no-update runtime repair without reinstalling core dependencies.
- `tools/send_message_tool.py` - replace the unusable bare pip guidance with the uv command.
- `tests/hermes_cli/test_lazy_refresh_venv_repair.py` - cover the repaired-runtime plus healthy-core branch and both dependency snapshots.
- `tests/tools/test_send_message_tool_missing_dependency.py` - verify the standalone Telegram missing-dependency guidance.

## How to Test

1. Run the update regression test that simulates a successful runtime replacement and a healthy core venv.
2. Run the standalone Telegram missing-dependency test with the Telegram import blocked.
3. Verify both focused test files pass through the repository test wrapper:

```bash
scripts/run_tests.sh tests/hermes_cli/test_lazy_refresh_venv_repair.py tests/tools/test_send_message_tool_missing_dependency.py -q
```

Result: 9 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the focused regression path on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact: the production branch is platform-neutral and Phase B will verify the Linux managed-runtime path
- [x] Tool description and schema updates are N/A
