### PR TITLE
fix(cli): stop injecting clarify.timeout into config defaults

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -516,9 +516,6 @@ def load_cli_config() -> Dict[str, Any]:
 
             "skin": "default",
         },
-        "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
-        },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution


### PR DESCRIPTION
`load_cli_config()` hardcoded `clarify.timeout = 120` into its defaults dict, which was then deep-merged into the user config. `resolve_clarify_timeout()` checks the legacy `clarify.timeout` before `agent.clarify_timeout`, so the hardcoded default always won — even when the user explicitly set `agent.clarify_timeout` in config.yaml.

Fix by removing the `clarify` section from `load_cli_config()` defaults. When `clarify.timeout` is absent from the merged config, the resolver falls through to `agent.clarify_timeout` (or the 3600s fallback), matching the behavior that already works in the gateway/backend path.

Closes #96208.