### PR TITLE
feat(stream-perf): aggregate LLM streaming perf metrics from official observer hooks

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4266,6 +4266,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             attempt_request_client["value"] = request_client
             last_chunk_time["t"] = time.time()
+            # For stream.perf's real TTFT: the HTTP request sent time (create is
+            # a synchronous call that opens the connection internally, so this is
+            # the instant right before the request actually goes out). Read via
+            # the on_stream_delta payload, keeping agent-side request preparation
+            # out of TTFT.
+            agent._current_request_sent_at = time.time()
             agent._touch_activity("waiting for provider response (streaming)")
             return request_client.chat.completions.create(**stream_kwargs)
 
@@ -4416,6 +4422,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
                 if _diag.get("first_chunk_at") is None:
                     _diag["first_chunk_at"] = last_chunk_time["t"]
+                    # First chunk arrival time (incl. reasoning first packet):
+                    # stream.perf uses it for real TTFT = first token - request
+                    # sent, so a reasoning model's silent period before its first
+                    # text delta is not counted as latency.
+                    agent._current_first_chunk_at = last_chunk_time["t"]
                 # Approximate byte size from the chunk's delta payload —
                 # exact wire bytes aren't exposed by the SDK. A full
                 # repr() per chunk was 5.5-8.8 µs of pure CPU on the

--- a/run_agent.py
+++ b/run_agent.py
@@ -7555,6 +7555,20 @@ class AIAgent:
                 **self._stream_hook_base_payload(),
                 delta=text,
                 kind="text",
+                # First-token / rate measurement needs precise token arrival
+                # times. Observer callbacks are dispatched through an async
+                # queue (worker thread), so the callback time has uncontrolled
+                # latency vs the real arrival — record the timestamp on this
+                # synchronous token path and ship it in the payload.
+                delta_at=time.time(),
+                # HTTP request sent time (recorded by chat_completion_helpers
+                # just before create()): for TTFT = first chunk - request sent,
+                # excluding agent-side request preparation.
+                request_sent_at=getattr(self, "_current_request_sent_at", None),
+                # First chunk arrival time (incl. reasoning first packet): a
+                # reasoning model's first text delta lands well after its first
+                # chunk, so TTFT should use the earlier first-chunk time.
+                first_chunk_at=getattr(self, "_current_first_chunk_at", None),
             )
         except Exception:
             logger.debug("on_stream_delta plugin hook enqueue failed", exc_info=True)

--- a/tests/test_tui_gateway_stream_perf.py
+++ b/tests/test_tui_gateway_stream_perf.py
@@ -1,0 +1,264 @@
+"""Unit tests for stream_perf_hooks aggregation logic.
+
+Covers StreamPerfCollector's turn-aggregation semantics:
+  - TTFT = first_delta_at - started_at (only for API calls with a first chunk)
+  - Generation window gen_ms = ended_at - first_delta_at
+  - TPS accounting only counts output_tokens from calls with a generation
+    window, so tool turns / queueing time never dilute TPS
+  - Turn boundaries and session isolation
+"""
+
+import pytest
+
+from tui_gateway.stream_perf_hooks import StreamPerfCollector
+
+
+def _collector():
+    return StreamPerfCollector()
+
+
+class TestTurnLifecycle:
+    def test_begin_turn_returns_empty(self):
+        c = _collector()
+        c.begin_turn("s1")
+        assert c.end_turn("s1") is None
+
+    def test_end_turn_without_begin_is_none(self):
+        c = _collector()
+        assert c.end_turn("s1") is None
+
+    def test_end_turn_clears_state(self):
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 1.0)
+        c.on_api_done("s1", 0, 0.5, 10.5, 200)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["calls"] == 1
+        # A second end should be None (already cleaned up)
+        assert c.end_turn("s1") is None
+
+
+class TestTtft:
+    def test_ttft_is_first_delta_minus_started_at(self):
+        c = _collector()
+        c.begin_turn("s1")
+        # started_at = 100.0, first delta at 114.0 -> TTFT = 14.0s
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary["ttft_calls"] == 1
+        assert summary["ttft_ms"] == pytest.approx(14000.0)
+
+    def test_first_delta_only_recorded_once(self):
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_first_delta("s1", 0, 200.0)  # later deltas do not overwrite
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary["ttft_ms"] == pytest.approx(14000.0)
+
+    def test_call_without_first_delta_skips_ttft(self):
+        # Tool turn: no text delta -> contributes no TTFT
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_api_done("s1", 0, 100.0, 120.0, 50)
+        summary = c.end_turn("s1")
+        assert summary["calls"] == 1
+        assert summary["ttft_calls"] == 0
+        assert summary["ttft_ms"] == 0.0
+
+    def test_multiple_calls_accumulate(self):
+        c = _collector()
+        c.begin_turn("s1")
+        # call 0: started=100, delta=114, ended=130, out=300
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        # call 1: started=131, delta=133, ended=145, out=400
+        c.on_first_delta("s1", 1, 133.0)
+        c.on_api_done("s1", 1, 131.0, 145.0, 400)
+        summary = c.end_turn("s1")
+        assert summary["calls"] == 2
+        assert summary["ttft_calls"] == 2
+        assert summary["ttft_ms"] == pytest.approx((14.0 + 2.0) * 1000)
+        assert summary["gen_ms"] == pytest.approx((16.0 + 12.0) * 1000)
+        assert summary["output_tokens"] == 700
+
+
+class TestGenWindow:
+    def test_gen_window_is_ended_minus_first_delta(self):
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        # Generation window = 130 - 114 = 16s
+        assert summary["gen_ms"] == pytest.approx(16000.0)
+
+    def test_output_tokens_only_counted_for_window_calls(self):
+        # Calls without a delta (tool turns) contribute no output_tokens,
+        # avoiding TPS dilution
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        c.on_api_done("s1", 1, 131.0, 150.0, 500)  # tool turn, no delta
+        summary = c.end_turn("s1")
+        assert summary["calls"] == 2
+        assert summary["ttft_calls"] == 1
+        assert summary["output_tokens"] == 300  # only windowed calls count
+
+    def test_batch_provider_degrades_gen_to_api_duration(self):
+        # Batch return (provider buffers, first chunk ≈ last chunk): gen window
+        # ≈ 0, degrade to the total API duration to avoid inflating TPS.
+        # started=100, first=129.9, ended=130 -> gen=0.1s < 30% * 30s
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 129.9)
+        c.on_api_done("s1", 0, 100.0, 130.0, 400)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["ttft_ms"] == pytest.approx((129.9 - 100.0) * 1000)
+        # gen degrades to the 30s total API duration
+        assert summary["gen_ms"] == pytest.approx(30000.0)
+        # TPS = 400 / 30 = 13.3 tok/s (end-to-end throughput)
+        assert summary["output_tokens"] / (summary["gen_ms"] / 1000) == pytest.approx(400 / 30)
+
+    def test_streaming_provider_keeps_gen_window(self):
+        # True streaming: first chunk is early, generation window dominates,
+        # so it does not degrade to the total API duration
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["gen_ms"] == pytest.approx(16000.0)  # 16s window, no degrade
+
+
+class TestRequestSentBaseline:
+    def test_ttft_uses_request_sent_at_when_available(self):
+        # request_sent_at (HTTP sent time) is later than started_at: TTFT uses
+        # it to exclude agent-side request preparation
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0, request_sent_at=110.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["ttft_ms"] == pytest.approx((114.0 - 110.0) * 1000)  # 4000ms
+
+    def test_falls_back_to_started_at_without_request_sent(self):
+        # Backends without request_sent_at fall back to the started_at
+        # baseline (compatibility)
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)  # no request_sent_at passed
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["ttft_ms"] == pytest.approx((114.0 - 100.0) * 1000)  # 14000ms
+
+    def test_batch_degrades_gen_uses_request_sent_at(self):
+        # Batch degrade: gen uses ended - request_sent_at (real HTTP duration)
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 129.9, request_sent_at=101.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 400)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["gen_ms"] == pytest.approx((130.0 - 101.0) * 1000)  # 29s
+
+    def test_reasoning_model_ttft_uses_first_chunk(self):
+        # Reasoning model: the first text delta (1.2s) lands well after the
+        # first chunk (0.4s); TTFT should use the earlier first packet ("the
+        # model's first token back")
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 121.0, request_sent_at=100.0, first_chunk_at=104.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        assert summary["ttft_ms"] == pytest.approx((104.0 - 100.0) * 1000)  # 4s (first chunk), not 21s
+        # gen also runs from the first chunk to the end: 130 - 104 = 26s
+        # (within the batch-degrade threshold, unchanged)
+
+
+class TestRealtimeUpdate:
+    def test_on_update_fires_increment_after_api_done(self):
+        updates = []
+        c = StreamPerfCollector(on_update=lambda sid, perf: updates.append((sid, dict(perf))))
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        assert len(updates) == 1
+        sid, perf = updates[0]
+        assert sid == "s1"
+        assert perf["calls"] == 1
+        assert perf["ttft_calls"] == 1
+        assert perf["ttft_ms"] == pytest.approx(14000.0)
+        assert perf["gen_ms"] == pytest.approx(16000.0)
+        assert perf["output_tokens"] == 300
+
+    def test_on_update_not_fired_for_tool_only_call(self):
+        updates = []
+        c = StreamPerfCollector(on_update=lambda sid, perf: updates.append(perf))
+        c.begin_turn("s1")
+        c.on_api_done("s1", 0, 100.0, 130.0, 50)  # no delta (tool turn)
+        assert updates == []
+
+    def test_on_update_fires_per_call(self):
+        updates = []
+        c = StreamPerfCollector(on_update=lambda sid, perf: updates.append(dict(perf)))
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        c.on_first_delta("s1", 1, 133.0)
+        c.on_api_done("s1", 1, 131.0, 145.0, 400)
+        assert len(updates) == 2
+        # Incremental semantics: each call pushes independently
+        assert updates[0]["ttft_ms"] == pytest.approx(14000.0)
+        assert updates[1]["ttft_ms"] == pytest.approx(2000.0)
+
+    def test_set_on_update_replaces_callback(self):
+        first = []
+        second = []
+        c = StreamPerfCollector(on_update=lambda sid, perf: first.append(perf))
+        c.set_on_update(lambda sid, perf: second.append(perf))
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        assert first == []
+        assert len(second) == 1
+
+
+class TestSessionIsolation:
+    def test_sessions_do_not_cross_talk(self):
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 114.0)
+        c.on_api_done("s1", 0, 100.0, 130.0, 300)
+        # s2 has its own independent pending state
+        c.begin_turn("s2")
+        c.on_first_delta("s2", 0, 8.0)
+        c.on_api_done("s2", 0, 6.0, 20.0, 100)
+        s1 = c.end_turn("s1")
+        s2 = c.end_turn("s2")
+        assert s1["ttft_ms"] == pytest.approx(14000.0)
+        assert s2["ttft_ms"] == pytest.approx(2000.0)
+        assert s1["output_tokens"] == 300
+        assert s2["output_tokens"] == 100
+
+    def test_api_done_without_first_delta_does_not_leak_pending(self):
+        c = _collector()
+        c.begin_turn("s1")
+        c.on_api_done("s1", 3, 100.0, 120.0, 50)
+        summary = c.end_turn("s1")
+        assert summary is not None
+        # The next turn should not carry leftover pending state
+        c.begin_turn("s1")
+        c.on_first_delta("s1", 0, 10.0)
+        c.on_api_done("s1", 0, 8.0, 30.0, 200)
+        s = c.end_turn("s1")
+        assert s["ttft_ms"] == pytest.approx(2000.0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,7 +16,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Dict, NamedTuple, Optional
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -53,6 +53,40 @@ from tui_gateway.transport import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Official observer-hook consumption: LLM streaming perf metrics (TTFT /
+# generation window / output tokens). Idempotent registration; data is
+# delivered via message.complete's stream_perf field and the live
+# stream.perf event.
+from tui_gateway.stream_perf_hooks import register_stream_perf_hooks
+
+# agent.session_id -> UI sid mapping: the hooks' session_id is the agent's
+# internal id, while live events must be routed to the frontend stats bar
+# by UI sid.
+_AGENT_TO_UI: Dict[str, str] = {}
+_AGENT_TO_UI_LOCK = threading.Lock()
+
+
+def _on_stream_perf_update(agent_sid: str, perf: dict) -> None:
+    """Push stream.perf (incremental) to the matching UI session after each
+    LLM API call completes.
+
+    Fired synchronously from the agent thread (post_api_request); skips when
+    the mapping is missing — message.complete's whole-turn stream_perf then
+    backstops the data so the final numbers stay consistent.
+    """
+    with _AGENT_TO_UI_LOCK:
+        ui_sid = _AGENT_TO_UI.get(agent_sid)
+    if not ui_sid:
+        return
+    try:
+        _emit("stream.perf", ui_sid, {"perf": perf})
+    except Exception:
+        logger.debug("stream.perf emit failed", exc_info=True)
+
+
+_STREAM_PERF = register_stream_perf_hooks()
+_STREAM_PERF.set_on_update(_on_stream_perf_update)
 
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
@@ -13251,6 +13285,14 @@ def _run_prompt_submit(
     )
     _emit("message.start", sid)
 
+    # Aggregation key MUST be the agent's session_id: the official hooks
+    # (post_api_request / on_stream_delta) key on the agent-internal session
+    # id, which is different from the UI sid.
+    _agent_sid = getattr(agent, "session_id", "") or sid
+    with _AGENT_TO_UI_LOCK:
+        _AGENT_TO_UI[_agent_sid] = sid
+    _STREAM_PERF.begin_turn(_agent_sid)
+
     def run():
         terminal_receipt_attempted = False
         terminal_receipt_committed = terminal_callback is None
@@ -13858,6 +13900,16 @@ def _run_prompt_submit(
                 terminal_receipt_committed = True
             if terminal_receipt_committed:
                 _retire_turn_marker(session, marker_key)
+                # Per-turn LLM streaming perf metrics (aggregated by the official
+                # hooks: TTFT / generation window / output tokens), so the
+                # frontend stats bar shows accurate averages. Aggregation key
+                # matches the hooks'.
+                _agent_sid = getattr(agent, "session_id", "") or sid
+                _perf = _STREAM_PERF.end_turn(_agent_sid)
+                if _perf:
+                    payload["stream_perf"] = _perf
+                with _AGENT_TO_UI_LOCK:
+                    _AGENT_TO_UI.pop(_agent_sid, None)
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────

--- a/tui_gateway/stream_perf_hooks.py
+++ b/tui_gateway/stream_perf_hooks.py
@@ -1,0 +1,257 @@
+"""Per-turn LLM streaming performance metrics (TTFT / generation window / output tokens).
+
+All data comes from Hermes' official observer hooks — nothing here touches the
+agent's hot path:
+
+  - ``post_api_request`` (synchronous, fired from conversation_loop.py):
+      ``session_id / api_call_count / started_at / ended_at / usage.output_tokens``
+  - ``on_stream_delta`` (async observer worker, fired from run_agent.py):
+      ``session_id / iteration(api_call_count)``; the callback timestamp
+      approximates the token's arrival time.
+
+Metrics semantics:
+
+  - TTFT (time to first token) = first-delta callback time - ``started_at``
+    (API call start), i.e. "from request sent to first token back". Wall-clock
+    within the same process, so the only error is the observer queue's
+    millisecond-level latency.
+  - Generation window ``gen_ms`` = ``ended_at`` - first-delta time: pure LLM
+    output time, excluding tool execution / API queueing, so TPS is not diluted.
+  - TPS accounting only counts calls that recorded a first chunk (text turns);
+    tool turns (no text delta) do not contribute ``output_tokens``, so tool
+    argument generation is never mixed into the text rate.
+
+Registered the same way as first-party precedents (agent/outbound_webhooks.py,
+agent/shell_hooks.py): append callbacks straight to
+``get_plugin_manager()._hooks``. Registration happens once at import time.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TURN_KEYS = ("calls", "ttft_calls", "ttft_ms", "gen_ms", "output_tokens")
+
+
+class StreamPerfCollector:
+    """Aggregates streaming perf metrics for one in-flight turn, per session.
+
+    - ``begin_turn(sid)``                 : start a new turn at message.start (reset)
+    - ``on_first_delta(sid, call, at)``   : first-delta time (recorded once, idempotent)
+    - ``on_api_done(sid, call, started_at, ended_at, output_tokens)``: fold an API call
+    - ``end_turn(sid)``                   : take the summary at message.complete (None if empty)
+
+    Thread-safe: on_stream_delta fires on the observer worker thread while
+    post_api_request fires synchronously on the agent thread — both may run
+    concurrently, so everything funnels through one lock.
+    """
+
+    def __init__(self, on_update: Optional[Callable[[str, Dict[str, Any]], None]] = None) -> None:
+        self._lock = threading.Lock()
+        self._turns: Dict[str, Dict[str, Any]] = {}
+        # (session_id, api_call_count) -> (first-delta time, HTTP request sent time, first chunk time)
+        # The first-token time is min(first chunk, first text delta): a reasoning
+        # model's first text delta lands well after its first chunk, so TTFT is
+        # measured from the earlier first chunk.
+        self._pending: Dict[Tuple[str, int], Tuple[float, Optional[float], Optional[float]]] = {}
+        # Called after each API call is folded in (live push, incremental
+        # semantics). Signature: (agent_sid, per-call increment).
+        self._on_update = on_update
+
+    def set_on_update(self, on_update: Optional[Callable[[str, Dict[str, Any]], None]]) -> None:
+        with self._lock:
+            self._on_update = on_update
+
+    def begin_turn(self, sid: str) -> None:
+        if not sid:
+            return
+        with self._lock:
+            self._turns[sid] = {k: (0 if k != "ttft_ms" else 0.0) for k in _TURN_KEYS}
+
+    def on_first_delta(
+        self,
+        sid: str,
+        call: int,
+        at: float,
+        request_sent_at: Optional[float] = None,
+        first_chunk_at: Optional[float] = None,
+    ) -> None:
+        """Record the first-delta (first-token) time for a call. Only the first
+        arrival is kept; later deltas / retries never overwrite it."""
+        if not sid:
+            return
+        key = (sid, call)
+        with self._lock:
+            if key not in self._pending:
+                self._pending[key] = (at, request_sent_at, first_chunk_at)
+
+    def on_api_done(
+        self,
+        sid: str,
+        call: int,
+        started_at: float,
+        ended_at: float,
+        output_tokens: int,
+    ) -> None:
+        if not sid:
+            return
+        key = (sid, call)
+        with self._lock:
+            pending = self._pending.pop(key, None)
+            turn = self._turns.get(sid)
+            if turn is None:
+                return  # No in-flight turn (late event) -> drop, never cross-pollute turns
+            turn["calls"] += 1
+            if pending is None:
+                # Tool turn (no text delta): contributes no TTFT / generation
+                # window / output_tokens, so tool argument generation and
+                # queueing time never dilute TPS.
+                return
+            first, request_sent_at, first_chunk_at = pending
+            # First-token time = min(first chunk, first text delta): a reasoning
+            # model's first chunk arrives far earlier than its first text delta,
+            # so TTFT is anchored to the earlier first chunk.
+            first_token_at = min(first, first_chunk_at) if first_chunk_at is not None else first
+            # Prefer the HTTP-request-sent time as the TTFT baseline (excludes
+            # agent-side request preparation); fall back to post_api_request's
+            # started_at when the backend doesn't supply the field.
+            sent = request_sent_at if request_sent_at is not None else float(started_at)
+            turn["ttft_calls"] += 1
+            ttft_ms = max(0.0, first_token_at - float(sent)) * 1000
+            turn["ttft_ms"] += ttft_ms
+            api_end = float(ended_at)
+            api_dur = max(0.0, api_end - float(sent)) if request_sent_at is not None else max(0.0, api_end - float(started_at))
+            gen = max(0.0, api_end - first_token_at)
+            if gen < 0.3 * api_dur + 0.05:
+                # Batch-return signature (provider buffers, first chunk ≈ last
+                # chunk): the client cannot observe a per-token generation
+                # window, generation spans the whole call — degrade to the
+                # total call duration so gen≈0 never inflates TPS.
+                gen = api_dur
+            turn["gen_ms"] += gen * 1000
+            turn["output_tokens"] += max(0, int(output_tokens or 0))
+            # Live push (incremental): this call's TTFT / generation window /
+            # output tokens go out immediately, so the frontend can show them
+            # before the turn ends instead of waiting for message.complete.
+            if self._on_update is not None:
+                try:
+                    self._on_update(
+                        sid,
+                        {
+                            "calls": 1,
+                            "ttft_calls": 1,
+                            "ttft_ms": round(ttft_ms, 1),
+                            "gen_ms": round(gen * 1000, 1),
+                            "output_tokens": max(0, int(output_tokens or 0)),
+                        },
+                    )
+                except Exception:
+                    logger.debug("stream_perf on_update callback failed", exc_info=True)
+
+    def end_turn(self, sid: str) -> Optional[Dict[str, Any]]:
+        if not sid:
+            return None
+        with self._lock:
+            turn = self._turns.pop(sid, None)
+            if turn is None or not turn["calls"]:
+                # Empty turn (no API calls) or unknown session -> no stats
+                if turn is None:
+                    for key in [k for k in self._pending if k[0] == sid]:
+                        self._pending.pop(key, None)
+                return None
+            # Defense: drop any leftover pending entries for this session (the
+            # normal path pairs them before end_turn).
+            for key in [k for k in self._pending if k[0] == sid]:
+                self._pending.pop(key, None)
+            return {
+                "calls": turn["calls"],
+                "ttft_calls": turn["ttft_calls"],
+                "ttft_ms": round(turn["ttft_ms"], 1),
+                "gen_ms": round(turn["gen_ms"], 1),
+                "output_tokens": turn["output_tokens"],
+            }
+
+
+def _make_post_api_request_cb(collector: StreamPerfCollector):
+    """post_api_request: API call done — fold TTFT / generation window / output tokens."""
+
+    def _cb(**kwargs: Any) -> None:
+        try:
+            sid = str(kwargs.get("session_id") or "")
+            call = int(kwargs.get("api_call_count") or 0)
+            started_at = kwargs.get("started_at")
+            ended_at = kwargs.get("ended_at")
+            if not sid or started_at is None or ended_at is None:
+                return
+            usage = kwargs.get("usage") or {}
+            out = (
+                int(usage.get("output_tokens") or 0)
+                if isinstance(usage, dict)
+                else 0
+            )
+            collector.on_api_done(sid, call, float(started_at), float(ended_at), out)
+        except Exception:
+            logger.debug("stream_perf post_api_request hook failed", exc_info=True)
+
+    return _cb
+
+
+def _make_on_stream_delta_cb(collector: StreamPerfCollector):
+    """on_stream_delta: the first delta time IS the first-token time.
+
+    Prefers ``delta_at`` from the payload (recorded on the agent's synchronous
+    token path — accurate); falls back to the callback time (async worker,
+    compatibility only).
+    """
+
+    def _cb(**kwargs: Any) -> None:
+        try:
+            sid = str(kwargs.get("session_id") or "")
+            call = int(kwargs.get("iteration") or 0)
+            if not sid:
+                return
+            delta_at = kwargs.get("delta_at")
+            at = float(delta_at) if delta_at is not None else time.time()
+            sent = kwargs.get("request_sent_at")
+            request_sent_at = float(sent) if sent is not None else None
+            fca = kwargs.get("first_chunk_at")
+            first_chunk_at = float(fca) if fca is not None else None
+            collector.on_first_delta(sid, call, at, request_sent_at, first_chunk_at)
+        except Exception:
+            logger.debug("stream_perf on_stream_delta hook failed", exc_info=True)
+
+    return _cb
+
+
+_registered = False
+
+
+def register_stream_perf_hooks() -> StreamPerfCollector:
+    """Register the official observer hooks and return the global collector
+    (idempotent — call once at import time)."""
+    global _registered
+    if _registered:
+        return _COLLECTOR
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        manager = get_plugin_manager()
+        manager._hooks.setdefault("post_api_request", []).append(
+            _make_post_api_request_cb(_COLLECTOR)
+        )
+        manager._hooks.setdefault("on_stream_delta", []).append(
+            _make_on_stream_delta_cb(_COLLECTOR)
+        )
+        _registered = True
+        logger.debug("stream_perf hooks registered")
+    except Exception:
+        logger.debug("stream_perf hooks registration failed", exc_info=True)
+    return _COLLECTOR
+
+
+_COLLECTOR = StreamPerfCollector()


### PR DESCRIPTION
## What does this PR do?

Adds accurate, real-time **TTFT (time to first token)** and **TPS (tokens/sec)** metrics for the desktop gateway, aggregated from the first-party `post_api_request` and `on_stream_delta` observer hooks. Today the desktop composer's status bar shows LLM timing that mixes in tool execution and queueing; this change makes "first token" and "tokens/sec" trustworthy.

The collector (`tui_gateway/stream_perf_hooks.py`) is a pure new file; the only edits to existing files are three small optional payload fields and two call sites in the gateway server.

## Related Issue

No existing issue. Searched open+merged PRs for `ttft` / `first token` / `tokens per second` — no duplicates.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`tui_gateway/stream_perf_hooks.py`** (new): `StreamPerfCollector` aggregates per-turn TTFT / generation window / output tokens from `post_api_request` + `on_stream_delta`, thread-safe, idempotent registration (follows the `outbound_webhooks.py` / `shell_hooks.py` precedent).
- **`agent/chat_completion_helpers.py`** (+2 lines): records `agent._current_request_sent_at` just before `chat.completions.create()` (the HTTP request-sent moment) and `agent._current_first_chunk_at` on the first chunk arrival — so TTFT excludes agent-side request preparation and includes the **reasoning first pack** (reasoning models emit their first text delta far later than the first chunk).
- **`run_agent.py`** (+3 optional payload fields): `on_stream_delta` payload now carries `delta_at` (recorded on the synchronous token path — observer callbacks dispatch through an async queue, so callback wall-clock time is unreliable), `request_sent_at`, and `first_chunk_at`. All optional (`None` when absent) → fully backward compatible.
- **`tui_gateway/server.py`**: registers the hooks at import; `message.complete` gains an optional `stream_perf` whole-turn summary; a real-time `stream.perf` event pushes per-call increments before the turn ends (routed by `agent.session_id` → UI sid).
- **`tests/test_tui_gateway_stream_perf.py`** (new): 21 unit cases — turn lifecycle, TTFT baselines (request-sent / reasoning first-chunk), batch-return degradation (gen window ≈ 0 → API duration so TPS isn't inflated), tool turns excluded, real-time increments, session isolation.

Metric semantics:

- **TTFT** = min(first chunk, first text delta) − request-sent moment.
- **gen window** = API end − first token; degraded to full API duration for batch-return providers.
- **TPS** = Σ output_tokens / Σ gen window; tool turns contribute no output_tokens.

## How to Test

1. `pytest tests/test_tui_gateway_stream_perf.py -q` → 21 passed.
2. `pytest tests/test_tui_gateway_server.py -q` → 610 passed (2 pre-existing env failures unrelated to this change).
3. Manual (desktop): send a message; the composer stat bar shows a real TTFT ≈ 1–2 s for a cached small request (previously it showed tens of seconds), and the value appears **live** during the turn, not only after completion.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(stream-perf):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (610/612; 2 pre-existing env failures)
- [x] I've added tests for my changes (21 unit cases)
- [x] I've tested on my platform: macOS (desktop gateway + real LLM provider end-to-end)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (module docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is platform-neutral Python; desktop gateway only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
