### PR TITLE
fix(zai): GLM-5.3 on the China endpoint accepts low/high/max only

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -79,16 +79,24 @@ def _is_glm_5_3(model: str | None) -> bool:
 
 
 def _glm_5_2_reasoning_effort(
-    reasoning_config: dict | None, *, model: str | None = None
+    reasoning_config: dict | None,
+    *,
+    model: str | None = None,
+    base_url: str | None = None,
 ) -> str | None:
     """Map Hermes reasoning effort onto GLM's native vocabulary.
 
     GLM-5.2 supports two enabled effort levels (``high``/``max``);
-    GLM-5.3 supports the graded ``low``/``medium``/``high``/``max`` scale.
-    ``xhigh``/``max``/``ultra`` request the top tier; anything below the
-    model's floor clamps to that floor. When reasoning is explicitly
-    disabled, or no effort preference is supplied, the server default is
-    left untouched.
+    GLM-5.3 supports the graded ``low``/``medium``/``high``/``max`` scale on
+    the international endpoint (api.z.ai, issue #91789). The China endpoint
+    (open.bigmodel.cn) rejects ``medium`` for GLM-5.3 with the same
+    "always-thinking" 400 the OX Alpha models return there — its accepted
+    set is ``low``/``high``/``max`` (#96222). ``xhigh``/``max``/``ultra``
+    request the top tier; anything below the model's floor clamps to that
+    floor; on the China endpoint ``medium`` clamps to ``low``
+    (nearest-weaker, the clamp_effort default — no silent escalation).
+    When reasoning is explicitly disabled, or no effort preference is
+    supplied, the server default is left untouched.
     """
     if not isinstance(reasoning_config, dict):
         return None
@@ -110,8 +118,18 @@ def _glm_5_2_reasoning_effort(
         clamp_effort,
     )
 
+    # The China endpoint (open.bigmodel.cn) serves GLM-5.3 with the same
+    # always-thinking rule as the OX Alpha models there: medium is a 400,
+    # only low/high/max are accepted (#96222). An unknown/absent base_url
+    # keeps the internationally verified graded scale — fail-open to the
+    # documented vocabulary rather than second-guessing relays.
+    _china_endpoint = "open.bigmodel.cn" in (base_url or "")
+
     if _is_glm_5_3(model):
-        efforts, overrides, floor = GLM53_EFFORTS, GLM53_OVERRIDES, "low"
+        if _china_endpoint:
+            efforts, overrides, floor = ("low", "high", "max"), {"xhigh": "max"}, "low"
+        else:
+            efforts, overrides, floor = GLM53_EFFORTS, GLM53_OVERRIDES, "low"
     else:
         efforts, overrides, floor = GLM52_EFFORTS, GLM52_OVERRIDES, "high"
 
@@ -123,7 +141,12 @@ class ZaiProfile(ProviderProfile):
     """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
 
     def build_api_kwargs_extras(
-        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        **context,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
@@ -138,7 +161,9 @@ class ZaiProfile(ProviderProfile):
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
         if _is_glm_5_2(model):
-            effort = _glm_5_2_reasoning_effort(reasoning_config, model=model)
+            effort = _glm_5_2_reasoning_effort(
+                reasoning_config, model=model, base_url=base_url
+            )
             if effort is not None:
                 top_level["reasoning_effort"] = effort
 

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -173,6 +173,48 @@ class TestZaiGLM53ReasoningEffort:
         )
         assert top_level == {"reasoning_effort": "low"}
 
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", "low"),
+            # medium is a 400 on the China endpoint (same always-thinking
+            # rule as the OX Alpha models there) — nearest-weaker is low.
+            ("medium", "low"),
+            ("high", "high"),
+            ("max", "max"),
+            ("xhigh", "max"),
+        ],
+    )
+    def test_china_endpoint_glm53_drops_medium(
+        self, zai_profile, effort, expected
+    ):
+        """#96222: open.bigmodel.cn serves GLM-5.3 with low/high/max only."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+        )
+        assert top_level == {"reasoning_effort": expected}
+
+    def test_unknown_base_url_keeps_graded_scale(self, zai_profile):
+        """An absent/relay base_url stays on the internationally verified
+        vocabulary — fail-open rather than second-guessing relays."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="glm-5.3",
+            base_url=None,
+        )
+        assert top_level == {"reasoning_effort": "medium"}
+
+    def test_china_endpoint_glm52_unchanged(self, zai_profile):
+        """GLM-5.2's high/max vocabulary is endpoint-independent."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="glm-5.2",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+
     def test_glm_5_2_still_clamps_low_to_high(self, zai_profile):
         """The 5.3 widening must not leak into 5.2's two-level wire."""
         _, top_level = zai_profile.build_api_kwargs_extras(


### PR DESCRIPTION
## What does this PR do?

The GLM-5.3 graded effort vocabulary (`low`/`medium`/`high`/`max`) was verified live on the **international** endpoint `api.z.ai` (#91789), but the **China** endpoint `https://open.bigmodel.cn/api/paas/v4` rejects `medium` for GLM-5.3 with the same "always-thinking" 400 the OX Alpha models return there — its accepted set is `low`/`high`/`max` (#96222). A China user on the **global default** `reasoning_effort: medium` with provider `zai` therefore 400'd on every turn and Hermes silently fell back to the fallback provider (zero token usage on the primary).

The zai profile's effort resolver now takes the transport's `base_url` (already passed into `build_api_kwargs_extras`, previously unused):

- **GLM-5.3 + China endpoint** (`open.bigmodel.cn` in base_url): vocabulary drops to `low`/`high`/`max`; `medium` clamps to `low` (nearest-weaker — no silent escalation); `xhigh` still requests the top tier (`max`).
- **GLM-5.3 + unknown/absent base_url**: the internationally verified graded scale stays — fail-open to the documented vocabulary rather than second-guessing relays.
- **GLM-5.2**: untouched — its `high`/`max` wire is endpoint-independent.

## Related Issue

Fixes #96222

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `plugins/model-providers/zai/__init__.py`
  - `_glm_5_2_reasoning_effort` accepts `base_url`; when it points at the China endpoint and the model is GLM-5.3, the effort set is `("low", "high", "max")` with `{"xhigh": "max"}` and floor `low`; docstring documents the endpoint split and the OX-Alpha-same-gateway evidence.
  - `ZaiProfile.build_api_kwargs_extras` declares `base_url` explicitly and threads it to the resolver.
- `tests/plugins/model_providers/test_zai_profile.py` (+8): China-endpoint GLM-5.3 matrix (medium→low, xhigh→max, low/high/max pass); unknown/absent base_url keeps the graded scale (medium passes); China base_url leaves GLM-5.2's clamp to high unchanged.

## How to Test

1. `python -m pytest tests/plugins/model_providers/test_zai_profile.py -q` — should pass (47 passed).
2. Red/green: on unpatched `main`, `test_china_endpoint_glm53_drops_medium[medium-low]` fails (medium passes through to the wire); with this PR the full matrix passes.
3. Provider family unchanged: `python -m pytest tests/plugins/model_providers/ -q` — should pass (242 passed).
4. Manual (per the issue): provider `zai` with `base_url: https://open.bigmodel.cn/api/paas/v4`, model `glm-5.3`, `agent.reasoning_effort: medium` — requests now send `reasoning_effort: low` and the primary provider stays active instead of 400+silent-fallback.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the endpoint split rationale and the OX-Alpha same-gateway evidence documented at the vocabulary selection)
- [x] New and existing unit tests pass locally (8 new; 242 across the provider family)
- [x] Changes are backward compatible (international endpoint and relay traffic byte-identical; only the China endpoint's GLM-5.3 mapping changes)
