### PR TITLE
fix(guard): _cd_target raises PermissionError on non-traversable path

### DIFF
--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -325,7 +325,12 @@ def _cd_target(executable: str, args: list[str], cwd: Path) -> Path | None:
     if index >= len(args) or args[index] == "-":
         return None
     target = _resolve(args[index], cwd)
-    return target if target.is_dir() else None
+    # Use os.path.isdir (not Path.is_dir) — Path.is_dir() raises PermissionError
+    # when the path's parent directory is not traversable (e.g. a root-owned
+    # dir referenced mid-command: /root/...), which aborts the whole terminal
+    # command with a spurious error. os.path.isdir suppresses PermissionError
+    # and returns False, treating the target as "not a cd target".
+    return target if os.path.isdir(str(target)) else None
 
 
 def _shell_script_arg(args: list[str]) -> str | None:


### PR DESCRIPTION
## Problem
`tools/self_repo_guard.py`'s `_cd_target()` calls `Path.is_dir()` on a target parsed from an agent command. `Path.is_dir()` performs an unguarded `os.stat()` and raises `PermissionError` (not `FileNotFoundError`) when a path's *parent* directory is owned by another user and not traversable. Example: a monitoring command that references `/root/phalanx-digital-office` aborts the **entire terminal command** with a spurious `Failed to execute command: PermissionError: [Errno 13]`, even though the underlying shell command was harmless.

Logged symptom (repro):
```
terminal_tool exception ... PermissionError: [Errno 13] Permission denied: '/root/phalanx-digital-office'
```

## Root cause
`Path.is_dir()` is documented to swallow `FileNotFoundError`/OSError subclasses EXCEPT `PermissionError`, which it propagates. `os.path.isdir()` suppresses the entire `OSError` family and returns `False`.

## Fix
Switch to `os.path.isdir(str(target))` in `_cd_target`. An inaccessible path is treated as `not a cd target` (`None`), and the guard proceeds normally. This fixes the whole class: any non-traversable parent (.e.g `/root/...`, `/proc/` mounts) referenced in a `cd`/`pushd` argument.

## Verification
- Repro: `Path('/root/phalanx-digital-office').is_dir()` \u2192 `PermissionError`; after fix `\u2192 'no cd target' (None)`.
- All existing `test_self_repo_guard.py` + `test_terminal_self_repo_guard.py` tests pass (123 on upstream main).