### PR TITLE
fix(desktop): recover legacy macOS TCC venvs before Python boot

### DIFF
--- a/apps/desktop/electron/macos-tcc-anchor-recovery.test.ts
+++ b/apps/desktop/electron/macos-tcc-anchor-recovery.test.ts
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, test } from 'vitest'
+
+import { recoverLegacyMacosTccAnchor } from './macos-tcc-anchor-recovery'
+
+const temporaryRoots: string[] = []
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function makeAnchoredVenv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-tcc-recovery-'))
+  temporaryRoots.push(root)
+
+  const venvRoot = path.join(root, 'venv')
+  const bin = path.join(venvRoot, 'bin')
+  const source = path.join(root, 'uv', 'bin', 'python3.11')
+  const python = path.join(bin, 'python')
+  const marker = path.join(bin, '.tcc-anchor-source')
+
+  fs.mkdirSync(path.dirname(source), { recursive: true })
+  fs.mkdirSync(bin, { recursive: true })
+  fs.writeFileSync(source, Buffer.from('cffaedfe00000000', 'hex'), { mode: 0o755 })
+  fs.writeFileSync(python, 'broken anchored interpreter', { mode: 0o755 })
+  fs.writeFileSync(marker, source)
+  fs.symlinkSync('python', path.join(bin, 'python3'))
+  fs.writeFileSync(path.join(bin, 'python3.11'), 'another anchored copy', { mode: 0o755 })
+
+  return { root, venvRoot, bin, source, python, marker }
+}
+
+test('is a no-op outside macOS', () => {
+  const fixture = makeAnchoredVenv()
+  let probes = 0
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'linux',
+    venvRoot: fixture.venvRoot,
+    probePython: () => {
+      probes += 1
+
+      return true
+    }
+  })
+
+  assert.deepEqual(result, { status: 'not-applicable', reason: 'platform' })
+  assert.equal(probes, 0)
+  assert.equal(fs.lstatSync(fixture.python).isSymbolicLink(), false)
+  assert.equal(fs.existsSync(fixture.marker), true)
+})
+
+test('is a no-op when the legacy marker is absent', () => {
+  const fixture = makeAnchoredVenv()
+  fs.unlinkSync(fixture.marker)
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: () => true
+  })
+
+  assert.deepEqual(result, { status: 'not-applicable', reason: 'marker-absent' })
+  assert.equal(fs.lstatSync(fixture.python).isSymbolicLink(), false)
+})
+
+test('does not trust a relative, multiline, or in-venv source path', () => {
+  for (const markerValue of ['../python', '/safe/python\n/other/python', 'relative\0python']) {
+    const fixture = makeAnchoredVenv()
+    fs.writeFileSync(fixture.marker, markerValue)
+
+    const result = recoverLegacyMacosTccAnchor({
+      platform: 'darwin',
+      venvRoot: fixture.venvRoot,
+      probePython: () => true
+    })
+
+    assert.deepEqual(result, { status: 'failed', reason: 'invalid-marker' })
+    assert.equal(fs.lstatSync(fixture.python).isSymbolicLink(), false)
+    assert.equal(fs.existsSync(fixture.marker), true)
+  }
+
+  const fixture = makeAnchoredVenv()
+  const inVenvSource = path.join(fixture.bin, 'recorded-python')
+  fs.writeFileSync(inVenvSource, Buffer.from('cffaedfe00000000', 'hex'), { mode: 0o755 })
+  fs.writeFileSync(fixture.marker, inVenvSource)
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: () => true
+  })
+
+  assert.deepEqual(result, { status: 'failed', reason: 'unsafe-source' })
+  assert.equal(fs.lstatSync(fixture.python).isSymbolicLink(), false)
+  assert.equal(fs.existsSync(fixture.marker), true)
+})
+
+test('leaves the venv untouched when the recorded interpreter fails its import probe', () => {
+  const fixture = makeAnchoredVenv()
+  const canonicalSource = fs.realpathSync(fixture.source)
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: candidate => candidate !== canonicalSource
+  })
+
+  assert.deepEqual(result, { status: 'failed', reason: 'source-probe-failed' })
+  assert.equal(fs.readFileSync(fixture.python, 'utf8'), 'broken anchored interpreter')
+  assert.equal(fs.existsSync(fixture.marker), true)
+})
+
+test('does not execute an executable marker target that is not a Mach-O binary', () => {
+  const fixture = makeAnchoredVenv()
+  fs.writeFileSync(fixture.source, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+  let probes = 0
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: () => {
+      probes += 1
+
+      return true
+    }
+  })
+
+  assert.deepEqual(result, { status: 'failed', reason: 'unsafe-source' })
+  assert.equal(probes, 0)
+  assert.equal(fs.lstatSync(fixture.python).isSymbolicLink(), false)
+  assert.equal(fs.existsSync(fixture.marker), true)
+})
+
+test('atomically restores python and its aliases after both probes pass', () => {
+  const fixture = makeAnchoredVenv()
+  const canonicalSource = fs.realpathSync(fixture.source)
+  const probed: string[] = []
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: candidate => {
+      probed.push(candidate)
+
+      return true
+    }
+  })
+
+  assert.deepEqual(result, { status: 'recovered' })
+  assert.deepEqual(probed, [canonicalSource, fixture.python])
+  assert.equal(fs.readlinkSync(fixture.python), canonicalSource)
+  assert.equal(fs.readlinkSync(path.join(fixture.bin, 'python3')), 'python')
+  assert.equal(fs.readlinkSync(path.join(fixture.bin, 'python3.11')), 'python')
+  assert.equal(fs.existsSync(fixture.marker), false)
+  assert.deepEqual(
+    fs.readdirSync(fixture.bin).filter(name => name.includes('tcc-recovery')),
+    []
+  )
+})
+
+test('rolls back every interpreter and keeps the marker when the repaired venv fails its probe', () => {
+  const fixture = makeAnchoredVenv()
+  const canonicalSource = fs.realpathSync(fixture.source)
+  const originalPython3Target = fs.readlinkSync(path.join(fixture.bin, 'python3'))
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: candidate => candidate === canonicalSource
+  })
+
+  assert.deepEqual(result, { status: 'failed', reason: 'venv-probe-failed' })
+  assert.equal(fs.readFileSync(fixture.python, 'utf8'), 'broken anchored interpreter')
+  assert.equal(fs.readlinkSync(path.join(fixture.bin, 'python3')), originalPython3Target)
+  assert.equal(fs.readFileSync(path.join(fixture.bin, 'python3.11'), 'utf8'), 'another anchored copy')
+  assert.equal(fs.existsSync(fixture.marker), true)
+  assert.deepEqual(
+    fs.readdirSync(fixture.bin).filter(name => name.includes('tcc-recovery')),
+    []
+  )
+})
+
+test('finishes alias cleanup when python was already restored before a prior attempt stopped', () => {
+  const fixture = makeAnchoredVenv()
+  fs.unlinkSync(fixture.python)
+  fs.symlinkSync(fixture.source, fixture.python)
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: () => true
+  })
+
+  assert.deepEqual(result, { status: 'recovered' })
+  assert.equal(fs.readlinkSync(fixture.python), fixture.source)
+  assert.equal(fs.readlinkSync(path.join(fixture.bin, 'python3')), 'python')
+  assert.equal(fs.readlinkSync(path.join(fixture.bin, 'python3.11')), 'python')
+  assert.equal(fs.existsSync(fixture.marker), false)
+})
+
+test('does not replace a symlinked python that points somewhere other than the recorded source', () => {
+  const fixture = makeAnchoredVenv()
+  const otherPython = path.join(fixture.root, 'other-python')
+  fs.writeFileSync(otherPython, Buffer.from('cffaedfe00000000', 'hex'), { mode: 0o755 })
+  fs.unlinkSync(fixture.python)
+  fs.symlinkSync(otherPython, fixture.python)
+
+  const result = recoverLegacyMacosTccAnchor({
+    platform: 'darwin',
+    venvRoot: fixture.venvRoot,
+    probePython: () => true
+  })
+
+  assert.deepEqual(result, { status: 'not-applicable', reason: 'python-not-anchored' })
+  assert.equal(fs.readlinkSync(fixture.python), otherPython)
+  assert.equal(fs.existsSync(fixture.marker), true)
+})

--- a/apps/desktop/electron/macos-tcc-anchor-recovery.ts
+++ b/apps/desktop/electron/macos-tcc-anchor-recovery.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+type RecoveryResult =
+  | { status: 'not-applicable'; reason: 'platform' | 'marker-absent' | 'python-not-anchored' }
+  | {
+      status: 'failed'
+      reason:
+        | 'invalid-marker'
+        | 'unsafe-source'
+        | 'source-probe-failed'
+        | 'venv-probe-failed'
+        | 'filesystem-error'
+    }
+  | { status: 'recovered' }
+
+interface RecoveryOptions {
+  platform?: NodeJS.Platform | string
+  venvRoot: string
+  probePython: (pythonPath: string) => boolean
+}
+
+interface Replacement {
+  destination: string
+  target: string
+  staged: string
+  backup: string
+  backupCreated: boolean
+}
+
+const MARKER_NAME = '.tcc-anchor-source'
+const MAX_MARKER_BYTES = 4096
+const PYTHON_ALIAS = /^python3(?:\.\d+)?$/
+const MACH_O_MAGICS = new Set(['feedface', 'feedfacf', 'cefaedfe', 'cffaedfe', 'cafebabe', 'bebafeca', 'cafebabf', 'bfbafeca'])
+
+function isInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate)
+
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+}
+
+function probeSafely(probePython: (pythonPath: string) => boolean, pythonPath: string): boolean {
+  try {
+    return probePython(pythonPath) === true
+  } catch {
+    return false
+  }
+}
+
+function hasMachOHeader(filePath: string): boolean {
+  const file = fs.openSync(filePath, 'r')
+
+  try {
+    const header = Buffer.alloc(4)
+
+    return fs.readSync(file, header, 0, header.length, 0) === header.length && MACH_O_MAGICS.has(header.toString('hex'))
+  } finally {
+    fs.closeSync(file)
+  }
+}
+
+function cleanupReplacementFiles(replacements: Replacement[], removeBackups = false): void {
+  for (const replacement of replacements) {
+    const candidates = [replacement.staged]
+
+    if (removeBackups || !replacement.backupCreated) {
+      candidates.push(replacement.backup)
+    }
+
+    for (const candidate of candidates) {
+      try {
+        fs.unlinkSync(candidate)
+      } catch {
+        // These names are unique to this recovery attempt. Leaving one
+        // behind is safer than disturbing a working interpreter.
+      }
+    }
+  }
+}
+
+function rollback(replacements: Replacement[]): void {
+  for (const replacement of [...replacements].reverse()) {
+    try {
+      if (replacement.backupCreated) {
+        fs.renameSync(replacement.backup, replacement.destination)
+        replacement.backupCreated = false
+      }
+    } catch {
+      // Keep an unrestored backup in place for manual recovery. Never throw
+      // from the early boot path or delete the only remaining original.
+    }
+  }
+
+  cleanupReplacementFiles(replacements)
+}
+
+/**
+ * Repair venvs damaged by the reverted macOS TCC interpreter anchor before
+ * Desktop asks Python to import anything. The marker and real-file interpreter
+ * are both legacy artifacts from #95131/#95478; ordinary venvs are untouched.
+ *
+ * Every replacement is staged in venv/bin and can be rolled back until the
+ * restored interpreter passes the caller's real Hermes import probe. The
+ * marker is removed only after that verification succeeds.
+ */
+function recoverLegacyMacosTccAnchor(options: RecoveryOptions): RecoveryResult {
+  const platform = options.platform ?? process.platform
+
+  if (platform !== 'darwin') {
+    return { status: 'not-applicable', reason: 'platform' }
+  }
+
+  const venvRoot = options.venvRoot
+  const bin = path.join(venvRoot, 'bin')
+  const marker = path.join(bin, MARKER_NAME)
+  const python = path.join(bin, 'python')
+
+  let markerStat: fs.Stats
+
+  try {
+    markerStat = fs.lstatSync(marker)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'not-applicable', reason: 'marker-absent' }
+    }
+
+    return { status: 'failed', reason: 'filesystem-error' }
+  }
+
+  if (!path.isAbsolute(venvRoot) || !markerStat.isFile() || markerStat.size <= 0 || markerStat.size > MAX_MARKER_BYTES) {
+    return { status: 'failed', reason: 'invalid-marker' }
+  }
+
+  let pythonStat: fs.Stats
+
+  try {
+    pythonStat = fs.lstatSync(python)
+  } catch {
+    return { status: 'failed', reason: 'filesystem-error' }
+  }
+
+  if (!pythonStat.isSymbolicLink() && !pythonStat.isFile()) {
+    return { status: 'not-applicable', reason: 'python-not-anchored' }
+  }
+
+  let source: string
+
+  try {
+    source = fs.readFileSync(marker, 'utf8')
+  } catch {
+    return { status: 'failed', reason: 'filesystem-error' }
+  }
+
+  if (source !== source.trim() || source.includes('\0') || source.includes('\n') || source.includes('\r') || !path.isAbsolute(source)) {
+    return { status: 'failed', reason: 'invalid-marker' }
+  }
+
+  try {
+    const sourceStat = fs.statSync(source)
+    const realVenv = fs.realpathSync(venvRoot)
+    const realSource = fs.realpathSync(source)
+
+    if (!sourceStat.isFile() || isInside(realVenv, realSource) || !hasMachOHeader(source)) {
+      return { status: 'failed', reason: 'unsafe-source' }
+    }
+
+    fs.accessSync(source, fs.constants.X_OK)
+    source = realSource
+  } catch {
+    return { status: 'failed', reason: 'unsafe-source' }
+  }
+
+  if (!probeSafely(options.probePython, source)) {
+    return { status: 'failed', reason: 'source-probe-failed' }
+  }
+
+  let pythonAlreadyRestored = false
+
+  if (pythonStat.isSymbolicLink()) {
+    try {
+      pythonAlreadyRestored = fs.realpathSync(python) === source
+    } catch {
+      return { status: 'not-applicable', reason: 'python-not-anchored' }
+    }
+
+    if (!pythonAlreadyRestored) {
+      return { status: 'not-applicable', reason: 'python-not-anchored' }
+    }
+  }
+
+  const attempt = `${process.pid}-${randomUUID()}`
+  let aliases: string[]
+
+  try {
+    aliases = fs
+      .readdirSync(bin)
+      .filter(name => PYTHON_ALIAS.test(name))
+      .map(name => path.join(bin, name))
+      .filter(alias => {
+        const stat = fs.lstatSync(alias)
+
+        return stat.isFile() || stat.isSymbolicLink()
+      })
+  } catch {
+    return { status: 'failed', reason: 'filesystem-error' }
+  }
+
+  const replacements: Replacement[] = [
+    ...(pythonAlreadyRestored
+      ? []
+      : [{ destination: python, target: source, staged: '', backup: '', backupCreated: false }]),
+    ...aliases.map(alias => ({
+      destination: alias,
+      target: 'python',
+      staged: '',
+      backup: '',
+      backupCreated: false
+    }))
+  ]
+
+  for (const replacement of replacements) {
+    const name = path.basename(replacement.destination)
+    replacement.staged = path.join(bin, `.${name}.tcc-recovery-${attempt}.new`)
+    replacement.backup = path.join(bin, `.${name}.tcc-recovery-${attempt}.old`)
+  }
+
+  try {
+    for (const replacement of replacements) {
+      fs.symlinkSync(replacement.target, replacement.staged)
+    }
+
+    for (const replacement of replacements) {
+      const destinationStat = fs.lstatSync(replacement.destination)
+
+      if (destinationStat.isSymbolicLink()) {
+        fs.symlinkSync(fs.readlinkSync(replacement.destination), replacement.backup)
+      } else {
+        fs.linkSync(replacement.destination, replacement.backup)
+      }
+
+      replacement.backupCreated = true
+      fs.renameSync(replacement.staged, replacement.destination)
+    }
+
+    if (!probeSafely(options.probePython, python)) {
+      rollback(replacements)
+
+      return { status: 'failed', reason: 'venv-probe-failed' }
+    }
+
+    fs.unlinkSync(marker)
+  } catch {
+    rollback(replacements)
+
+    return { status: 'failed', reason: 'filesystem-error' }
+  }
+
+  cleanupReplacementFiles(replacements, true)
+
+  return { status: 'recovered' }
+}
+
+export { recoverLegacyMacosTccAnchor, type RecoveryOptions, type RecoveryResult }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -226,6 +226,7 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import { recoverLegacyMacosTccAnchor } from './macos-tcc-anchor-recovery'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
   assertManagedUpdatePreflightClear,
@@ -4329,11 +4330,49 @@ function readBootstrapMarker() {
 // or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
 // ever having written the bootstrap marker -- so we must be able to recognise
 // "already installed" off the filesystem alone, not just the marker.
+let legacyMacosTccRecoveryAttempted = false
+
+function recoverLegacyMacosRuntimeBeforeProbe() {
+  if (!IS_MAC || legacyMacosTccRecoveryAttempted) {
+    return
+  }
+
+  legacyMacosTccRecoveryAttempted = true
+
+  const pythonPathEntries = [ACTIVE_HERMES_ROOT, ...getVenvSitePackagesEntries(VENV_ROOT)]
+
+  // Do not let shell-level Python overrides make a broken recorded source
+  // appear healthy. The only extra import paths needed here are the managed
+  // checkout and its own venv dependencies.
+  const probeEnv = {
+    PYTHONHOME: '',
+    PYTHONPATH: pythonPathEntries.join(path.delimiter),
+    PYTHONSTARTUP: '',
+    __PYVENV_LAUNCHER__: ''
+  }
+
+  const result = recoverLegacyMacosTccAnchor({
+    venvRoot: VENV_ROOT,
+    probePython: pythonPath => canImportHermesCli(pythonPath, { env: probeEnv })
+  })
+
+  if (result.status === 'recovered') {
+    rememberLog('[runtime] restored the Python symlink from the reverted macOS TCC anchor')
+  } else if (result.status === 'failed') {
+    rememberLog(`[runtime] legacy macOS TCC anchor recovery skipped safely (${result.reason})`)
+  }
+}
+
 function isActiveRuntimeUsable() {
   const venvPython = getVenvPython(VENV_ROOT)
+  const sourceRootUsable = isHermesSourceRoot(ACTIVE_HERMES_ROOT)
+
+  if (sourceRootUsable) {
+    recoverLegacyMacosRuntimeBeforeProbe()
+  }
 
   return (
-    isHermesSourceRoot(ACTIVE_HERMES_ROOT) &&
+    sourceRootUsable &&
     fileExists(venvPython) &&
     canImportHermesCli(venvPython, {
       env: {


### PR DESCRIPTION
## What does this PR do?

Repairs a macOS venv damaged by the reverted TCC interpreter anchor before Desktop asks that venv to run Python.

The revert in #95563 added `check_macos_tcc_anchor_removed()` to `hermes doctor`, but the affected interpreter can fail before any Python code starts (#95425 / #95541). This leaves Desktop unable to classify the active runtime or reach the Python-based repair. #95775 adds an update-command pre-heal, but that is complementary: a dynamically linked anchored `venv/bin/python` cannot enter the update command either.

Desktop now performs one narrowly gated Node/Electron recovery before its normal Hermes import probe:

- macOS only, and only under Desktop's canonical managed venv
- requires the exact legacy `.tcc-anchor-source` marker and a real-file `venv/bin/python`
- rejects malformed, relative, in-venv, non-executable, and non-Mach-O marker targets before executing anything
- canonicalizes the recorded target and probes it with the real Hermes dependency imports, using only the managed checkout and venv site-packages
- stages symlinks in `venv/bin`, preserves each original with a same-directory hard link/symlink backup, and atomically renames replacements into place
- probes the repaired `venv/bin/python`; any failure atomically rolls originals back and preserves the marker
- removes the marker and private backups only after the repaired runtime passes
- can finish alias cleanup after an interrupted attempt already restored `bin/python`

Ordinary installs have no legacy marker and take a cheap no-op path. No network, authentication, Tailscale, SSH, or update-policy behavior changes.

## Related issues and PRs

- Refs #95425
- Refs #95541
- Refs #95563
- Complements #95759 / #95775 by healing before Python boot rather than from inside the update command
- Compatible with the proposed forward TCC design in #95605; this path only handles the reverted anchor's legacy marker

## Validation

- TDD red/green: the new suite first failed because the recovery module did not exist, then passed after implementation.
- `vitest run --project electron electron/macos-tcc-anchor-recovery.test.ts electron/backend-probes.test.ts` — 21 passed.
- `tsc -p tsconfig.electron.json --noEmit` — passed.
- ESLint on the two new files and `electron/main.ts` — passed.
- `npm run build` — production renderer and Electron main bundle passed; the recovery code is present in `dist/electron-main.mjs`.
- Real macOS reproduction using a temporary copy of an affected venv from #95425/#95541:
  - before recovery: Hermes dependency import failed
  - recovery result: `recovered`
  - after recovery: Hermes dependency import passed
  - marker removed; no transaction leftovers
- Full Electron suite: 1,938 passed, 6 skipped, with one unrelated existing environment-dependent failure in `managed-ssh-update.test.ts`. The same targeted failure reproduces unchanged on the unmodified local branch (`status 127` instead of `0`).

## Security and failure behavior

The marker is treated as untrusted input. The recovery will not execute its target until structural, location, executable-bit, and Mach-O checks pass. Python environment overrides are neutralized for the probe so they cannot make a bad interpreter appear healthy. All errors fail closed into the existing bootstrap path, and logs contain only a reason code, never the marker target.
