### PR TITLE
feat(models): add minimax/minimax-m3:free to OpenRouter picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -115,6 +115,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
+    ("minimax/minimax-m3:free",                "free"),
     # Z-AI
     ("z-ai/glm-5.3",                           ""),
     ("z-ai/glm-5.3-flash",                     ""),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -117,6 +117,10 @@
           "description": ""
         },
         {
+          "id": "minimax/minimax-m3:free",
+          "description": "free"
+        },
+        {
           "id": "z-ai/glm-5.3",
           "description": ""
         },


### PR DESCRIPTION
# Add minimax/minimax-m3:free to OpenRouter model picker

## Summary

The OpenRouter picker (`fetch_openrouter_models` in `hermes_cli/models.py`)
builds its list from a **curated** set of model IDs, then filters that set
against OpenRouter's live `/v1/models` catalog (checking tool support and
free-tier pricing). It does not dynamically discover all `:free` variants —
only models explicitly listed in the curated set appear in the picker.

`minimax/minimax-m3:free` exists on OpenRouter (free tier via GMICloud, 1M
context, supports tool calling) but was missing from both the in-repo
fallback list (`OPENROUTER_MODELS`) and the remote catalog manifest
(`website/static/api/model-catalog.json`).

This PR adds `minimax/minimax-m3:free` to both curated sources so it shows
up in the picker alongside the paid variant. The picker's existing
`_openrouter_model_supports_tools` and `_openrouter_model_is_free` checks
will validate it against the live catalog before surfacing it.

## Changes

- `hermes_cli/models.py`: add `("minimax/minimax-m3:free", "free")` to the
  `OPENROUTER_MODELS` curated list
- `website/static/api/model-catalog.json`: add the `minimax/minimax-m3:free`
  entry with `"description": "free"`

## Test plan

- [ ] `hermes model` picker shows `minimax/minimax-m3:free` with the "free" badge
- [ ] Selecting it routes correctly via OpenRouter
