### PR TITLE
fix: honor api_key_env alias in providers dict resolver

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -750,8 +750,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # they're not configured.
             if not is_provider_enabled(entry):
                 continue
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # Resolve the API key from the env var name stored in key_env.
+            # api_key_env is the documented snake_case alias for key_env (see
+            # _normalize_custom_provider_entry in hermes_cli/config.py); honor
+            # it here so providers: entries written with only api_key_env
+            # resolve their key instead of 401ing with no-key-required.
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -785,6 +785,48 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
 
 
 
+def test_named_custom_provider_providers_dict_honors_api_key_env(monkeypatch):
+    """The ``providers:`` dict resolver must honor ``api_key_env`` — the
+    documented snake_case alias for ``key_env`` (see
+    ``_normalize_custom_provider_entry`` in ``hermes_cli/config.py``).
+
+    Regression: ``_get_named_custom_provider`` read only ``key_env`` for
+    ``providers:`` entries, so a provider written with just ``api_key_env``
+    resolved to an empty key and every auxiliary/delegation/fallback call
+    401'd with ``no-key-required``.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("VENDOR_KEY", "vendor-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "vendor": {
+                    "base_url": "https://vendor.example.com/v1",
+                    "api_key_env": "VENDOR_KEY",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    entry = rp._get_named_custom_provider("vendor")
+
+    assert entry is not None
+    assert entry["base_url"] == "https://vendor.example.com/v1"
+    assert entry["api_key"] == "vendor-secret"
+
+
 def test_named_custom_provider_wins_over_builtin_alias(monkeypatch):
     """A custom_providers entry named after a built-in *alias* (not a canonical
     provider name) must win over the built-in.  Regression guard for #15743:


### PR DESCRIPTION
## Summary
Fixes #44666.

`_get_named_custom_provider()` reads only `key_env` for `providers:` dict entries, so a provider written with the documented `api_key_env` alias (snake_case, see `_normalize_custom_provider_entry` in `hermes_cli/config.py`) resolves to an empty key and every auxiliary/delegation/fallback call 401s with `no-key-required`.

## Fix
Read `key_env` OR `api_key_env`, matching `hermes_cli/fallback_config.py` and `agent/auxiliary_client.py`.

## Test
Added `test_named_custom_provider_providers_dict_honors_api_key_env` (fails before, passes after). Full resolution test file: 60/60 pass.
