### PR TITLE
fix(models): order pickers by primary and fallbacks

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -148,6 +148,57 @@ describe('the catalog owns model curation', () => {
     expect(indexOf(/Deepseek V4 Flash/i)).toBeLessThan(indexOf(/Deepseek V4 Pro/i))
   })
 
+  it('uses the canonical xai-oauth identity emitted for the grok-oauth config alias', async () => {
+    setVisibleModels(
+      new Set([modelVisibilityKey('xai-oauth', 'grok-4.6'), modelVisibilityKey('anthropic', 'claude-opus-5')])
+    )
+    getGlobalModelOptions.mockResolvedValue({
+      preferred_models: [
+        { provider: 'xai-oauth', model: 'grok-4.6' },
+        { provider: 'anthropic', model: 'claude-opus-5' }
+      ],
+      providers: [
+        { models: ['claude-opus-5'], name: 'Anthropic', slug: 'anthropic' },
+        { models: ['grok-4.6'], name: 'xAI', slug: 'xai-oauth' }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Grok 4\.6/i)
+
+    const labels = screen.getAllByRole('menuitem').map(row => row.textContent ?? '')
+    const indexOf = (needle: RegExp) => labels.findIndex(label => needle.test(label))
+
+    expect(indexOf(/Grok 4\.6/i)).toBeLessThan(indexOf(/Opus 5/i))
+  })
+
+  it('ranks a collapsed family by its preferred fast-model member', async () => {
+    setVisibleModels(
+      new Set([modelVisibilityKey('alibaba', 'qwen3.8-max'), modelVisibilityKey('alibaba', 'deepseek-v4-pro')])
+    )
+    getGlobalModelOptions.mockResolvedValue({
+      preferred_models: [
+        { provider: 'alibaba', model: 'qwen3.8-max-fast' },
+        { provider: 'alibaba', model: 'deepseek-v4-pro' }
+      ],
+      providers: [
+        {
+          models: ['qwen3.8-max-fast', 'deepseek-v4-pro', 'qwen3.8-max'],
+          name: 'Alibaba',
+          slug: 'alibaba'
+        }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Qwen3\.8 Max/i)
+
+    const labels = screen.getAllByRole('menuitem').map(row => row.textContent ?? '')
+    const indexOf = (needle: RegExp) => labels.findIndex(label => needle.test(label))
+
+    expect(indexOf(/Qwen3\.8 Max/i)).toBeLessThan(indexOf(/Deepseek V4 Pro/i))
+  })
+
   it('offers Edit Models without the host wiring it up', async () => {
     renderMenu()
     await screen.findByText(/Gemini 3\.1 Pro/i)

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -112,6 +112,42 @@ describe('the catalog owns model curation', () => {
     })
   })
 
+  it('renders the configured primary then fallbacks instead of alphabetical providers', async () => {
+    setVisibleModels(
+      new Set([
+        modelVisibilityKey('openai-codex', 'gpt-5.6-sol'),
+        modelVisibilityKey('anthropic', 'claude-opus-5'),
+        modelVisibilityKey('alibaba', 'qwen3.8-max'),
+        modelVisibilityKey('alibaba', 'deepseek-v4-flash-0731'),
+        modelVisibilityKey('alibaba', 'deepseek-v4-pro')
+      ])
+    )
+    getGlobalModelOptions.mockResolvedValue({
+      preferred_models: [
+        { provider: 'openai-codex', model: 'gpt-5.6-sol' },
+        { provider: 'anthropic', model: 'claude-opus-5' },
+        { provider: 'alibaba', model: 'qwen3.8-max' },
+        { provider: 'alibaba', model: 'deepseek-v4-flash-0731' },
+        { provider: 'alibaba', model: 'deepseek-v4-pro' }
+      ],
+      providers: [
+        { models: ['deepseek-v4-pro', 'qwen3.8-max', 'deepseek-v4-flash-0731'], name: 'Alibaba', slug: 'alibaba' },
+        { models: ['claude-opus-5'], name: 'Anthropic', slug: 'anthropic' },
+        { models: ['gpt-5.6-sol'], name: 'ChatGPT', slug: 'openai-codex' }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/GPT-5\.6-sol/i)
+
+    const labels = screen.getAllByRole('menuitem').map(row => row.textContent ?? '')
+    const indexOf = (needle: RegExp) => labels.findIndex(label => needle.test(label))
+
+    expect(indexOf(/GPT-5\.6-sol/i)).toBeLessThan(indexOf(/Opus 5/i))
+    expect(indexOf(/Qwen3\.8 Max/i)).toBeLessThan(indexOf(/Deepseek V4 Flash/i))
+    expect(indexOf(/Deepseek V4 Flash/i)).toBeLessThan(indexOf(/Deepseek V4 Pro/i))
+  })
+
   it('offers Edit Models without the host wiring it up', async () => {
     renderMenu()
     await screen.findByText(/Gemini 3\.1 Pro/i)

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -239,6 +239,11 @@ export function ModelCatalogMenu({
 
   const providers = modelOptions.data?.providers
 
+  const preferredModels = useMemo(
+    () => modelOptions.data?.preferred_models ?? [],
+    [modelOptions.data?.preferred_models]
+  )
+
   // The catalog carries MoA presets as a virtual `moa` provider row. Keep it
   // out of the main groups so presets never show up twice.
   const moaPresets = useMemo(
@@ -277,8 +282,15 @@ export function ModelCatalogMenu({
   )
 
   const groups = useMemo(
-    () => groupModels(pickerProviders, search, { model: current.model, provider: current.provider }, shownKeys),
-    [pickerProviders, search, current.model, current.provider, shownKeys]
+    () =>
+      groupModels(
+        pickerProviders,
+        search,
+        { model: current.model, provider: current.provider },
+        shownKeys,
+        preferredModels
+      ),
+    [pickerProviders, search, current.model, current.provider, shownKeys, preferredModels]
   )
 
   // Presets are searchable rows like everything else — an unfiltered preset
@@ -715,10 +727,28 @@ function groupModels(
   providers: ModelOptionProvider[],
   search: string,
   current: { model: string; provider: string },
-  visible: Set<string> | null
+  visible: Set<string> | null,
+  preferredModels: NonNullable<ModelOptionsResponse['preferred_models']> = []
 ): ProviderGroup[] {
   const q = normalize(search)
   const groups: ProviderGroup[] = []
+
+  const preferredRanks = new Map(
+    preferredModels.map((entry, index) => [
+      modelVisibilityKey(normalize(entry.provider), normalize(entry.model)),
+      index
+    ])
+  )
+
+  const providerRanks = new Map<string, number>()
+
+  preferredModels.forEach((entry, index) => {
+    const provider = normalize(entry.provider)
+
+    if (!providerRanks.has(provider)) {
+      providerRanks.set(provider, index)
+    }
+  })
 
   for (const provider of providers) {
     const allFamilies = collapseModelFamilies(provider.models ?? [])
@@ -756,14 +786,50 @@ function groupModels(
 
     const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
 
+    families.sort((a, b) => {
+      const aRank = preferredRanks.get(modelVisibilityKey(normalize(provider.slug), normalize(a.id)))
+      const bRank = preferredRanks.get(modelVisibilityKey(normalize(provider.slug), normalize(b.id)))
+
+      if (aRank === undefined && bRank === undefined) {
+        return 0
+      }
+
+      if (aRank === undefined) {
+        return 1
+      }
+
+      if (bRank === undefined) {
+        return -1
+      }
+
+      return aRank - bRank
+    })
+
     if (families.length > 0) {
       groups.push({ families, provider })
     }
   }
 
-  // Stable, logical group order: alphabetical by provider name. (The backend
-  // floats the current provider first, which would reshuffle on every switch.)
-  groups.sort((a, b) => a.provider.name.localeCompare(b.provider.name))
+  // Configured primary/fallback order is stable across session switches. Older
+  // backends omit it, so keep the historical alphabetical order as fallback.
+  groups.sort((a, b) => {
+    const aRank = providerRanks.get(normalize(a.provider.slug))
+    const bRank = providerRanks.get(normalize(b.provider.slug))
+
+    if (aRank === undefined && bRank === undefined) {
+      return a.provider.name.localeCompare(b.provider.name)
+    }
+
+    if (aRank === undefined) {
+      return 1
+    }
+
+    if (bRank === undefined) {
+      return -1
+    }
+
+    return aRank - bRank
+  })
 
   return groups
 }

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -514,10 +514,12 @@ export function ModelCatalogMenu({
                     const isCurrent = activeId !== null
                     const name = modelDisplayParts(family.id).name
                     const caps = group.provider.capabilities?.[family.id]
+
                     // Managed local model loading into memory right now:
                     // real load percent, keyed by exact model id (remote
                     // providers never collide with GGUF stems).
-                    const loadProgress = loadingModels[family.id] ?? (family.fastId ? loadingModels[family.fastId] : undefined)
+                    const loadProgress =
+                      loadingModels[family.id] ?? (family.fastId ? loadingModels[family.fastId] : undefined)
 
                     // Effective settings for this row: the live choice when it's
                     // the active model, otherwise its remembered preset. Row
@@ -614,7 +616,9 @@ export function ModelCatalogMenu({
                   })}
                 {!collapsed &&
                   slug === LOCAL_PROVIDER_SLUG &&
-                  shownDownloads.map(job => <DownloadingModelRow jobId={job.jobId} key={job.jobId} target={job.target} />)}
+                  shownDownloads.map(job => (
+                    <DownloadingModelRow jobId={job.jobId} key={job.jobId} target={job.target} />
+                  ))}
               </DropdownMenuGroup>
             )
           })}
@@ -692,10 +696,7 @@ function DownloadingModelRow({ jobId, target }: { jobId: string; target: string 
   const { t } = useI18n()
   const copy = t.modelPicker
 
-  const percent = useStoreSelector(
-    $localRuntimeJobs,
-    jobs => jobs.find(job => job.job_id === jobId)?.percent ?? null
-  )
+  const percent = useStoreSelector($localRuntimeJobs, jobs => jobs.find(job => job.job_id === jobId)?.percent ?? null)
 
   return (
     <DropdownMenuItem
@@ -718,6 +719,30 @@ function DownloadingModelRow({ jobId, target }: { jobId: string; target: string 
       </span>
     </DropdownMenuItem>
   )
+}
+
+function preferredFamilyRank(
+  preferredRanks: ReadonlyMap<string, number>,
+  provider: string,
+  family: ModelFamily
+): number | undefined {
+  let rank: number | undefined
+
+  // A rendered row represents both the base model and its optional -fast
+  // sibling. Rank the row by whichever configured member appears first.
+  for (const model of [family.id, family.fastId]) {
+    if (!model) {
+      continue
+    }
+
+    const candidate = preferredRanks.get(modelVisibilityKey(provider, normalize(model)))
+
+    if (candidate !== undefined && (rank === undefined || candidate < rank)) {
+      rank = candidate
+    }
+  }
+
+  return rank
 }
 
 // Collapsed we show the user's chosen models (or the curated default); typing
@@ -785,10 +810,11 @@ function groupModels(
         : undefined
 
     const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
+    const providerId = normalize(provider.slug)
 
     families.sort((a, b) => {
-      const aRank = preferredRanks.get(modelVisibilityKey(normalize(provider.slug), normalize(a.id)))
-      const bRank = preferredRanks.get(modelVisibilityKey(normalize(provider.slug), normalize(b.id)))
+      const aRank = preferredFamilyRank(preferredRanks, providerId, a)
+      const bRank = preferredFamilyRank(preferredRanks, providerId, b)
 
       if (aRank === undefined && bRank === undefined) {
         return 0

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -437,6 +437,7 @@ export interface ModelCapabilities {
 
 export interface ModelOptionsResponse {
   model?: string
+  preferred_models?: Array<{ model: string; provider: string }>
   provider?: string
   providers?: ModelOptionProvider[]
 }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7833,6 +7833,21 @@ def _prompt_model_selection(
             return None
         return mid
 
+    # Reorder the catalog from the configured primary/fallback chain first.
+    # The current-model pin below remains the final interaction affordance.
+    if confirm_provider:
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.inventory import configured_model_order, order_models_for_provider
+
+            model_ids = order_models_for_provider(
+                list(model_ids),
+                confirm_provider,
+                configured_model_order(load_config()),
+            )
+        except Exception:
+            pass
+
     # Reorder: current model first, then the rest (deduplicated)
     ordered = []
     if current_model and current_model in model_ids:

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -40,6 +40,131 @@ from typing import Any, Optional
 # ─── Public types ───────────────────────────────────────────────────────
 
 
+def configured_model_order(config: dict | None) -> tuple[tuple[str, str], ...]:
+    """Return the configured primary model followed by fallbacks, deduplicated."""
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    cfg = config if isinstance(config, dict) else {}
+    entries: list[tuple[str, str]] = []
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        entries.append(
+            (
+                str(model_cfg.get("provider") or "").strip(),
+                str(
+                    model_cfg.get("default")
+                    or model_cfg.get("model")
+                    or model_cfg.get("name")
+                    or ""
+                ).strip(),
+            )
+        )
+
+    entries.extend(
+        (
+            str(entry.get("provider") or "").strip(),
+            str(entry.get("model") or "").strip(),
+        )
+        for entry in get_fallback_chain(cfg)
+    )
+
+    ordered: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for provider, model in entries:
+        provider = _provider_order_identity(provider)
+        if not provider or not model:
+            continue
+        identity = (provider, model.lower())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        ordered.append((provider, model))
+    return tuple(ordered)
+
+
+def _provider_order_identity(provider: str) -> str:
+    raw = str(provider or "").strip().lower()
+    if not raw:
+        return ""
+    try:
+        from hermes_cli.models import normalize_provider
+
+        return normalize_provider(raw) or raw
+    except Exception:
+        return raw
+
+
+def order_provider_slugs(
+    slugs: list[str],
+    preferred_models: tuple[tuple[str, str], ...],
+) -> list[str]:
+    """Move configured providers first while preserving every other order."""
+    ranks: dict[str, int] = {}
+    for index, (provider, _model) in enumerate(preferred_models):
+        ranks.setdefault(_provider_order_identity(provider), index)
+    return [
+        slug
+        for _index, slug in sorted(
+            enumerate(slugs),
+            key=lambda item: (
+                ranks.get(_provider_order_identity(item[1]), len(preferred_models) + item[0]),
+                item[0],
+            ),
+        )
+    ]
+
+
+def order_models_for_provider(
+    models: list[str],
+    provider: str,
+    preferred_models: tuple[tuple[str, str], ...],
+) -> list[str]:
+    """Move configured models for one provider first, preserving the rest."""
+    provider_id = _provider_order_identity(provider)
+    ranks = {
+        model.lower(): index
+        for index, (candidate_provider, model) in enumerate(preferred_models)
+        if _provider_order_identity(candidate_provider) == provider_id
+    }
+    return [
+        model
+        for _index, model in sorted(
+            enumerate(models),
+            key=lambda item: (ranks.get(item[1].lower(), len(preferred_models) + item[0]), item[0]),
+        )
+    ]
+
+
+def _apply_configured_model_order(
+    rows: list[dict],
+    preferred_models: tuple[tuple[str, str], ...],
+) -> list[dict]:
+    if not preferred_models:
+        return rows
+
+    slugs = [str(row.get("slug") or "") for row in rows]
+    ordered_slugs = order_provider_slugs(slugs, preferred_models)
+    slug_ranks = {slug: index for index, slug in enumerate(ordered_slugs)}
+    ordered_rows = [
+        row
+        for original_index, row in sorted(
+            enumerate(rows),
+            key=lambda item: (
+                slug_ranks.get(str(item[1].get("slug") or ""), len(rows) + item[0]),
+                item[0],
+            ),
+        )
+    ]
+    for row in ordered_rows:
+        models = list(row.get("models") or [])
+        row["models"] = order_models_for_provider(
+            models,
+            str(row.get("slug") or ""),
+            preferred_models,
+        )
+    return ordered_rows
+
+
 @dataclass(frozen=True)
 class ConfigContext:
     """Snapshot of the model + provider config every inventory caller
@@ -53,6 +178,7 @@ class ConfigContext:
     user_providers: dict
     custom_providers: list
     excluded_providers: list = None
+    preferred_models: tuple[tuple[str, str], ...] = ()
 
     def with_overrides(
         self,
@@ -111,6 +237,7 @@ def load_picker_context() -> ConfigContext:
         user_providers=stringify_provider_map(cfg.get("providers")),
         custom_providers=get_compatible_custom_providers(cfg),
         excluded_providers=excluded if isinstance(excluded, list) else [],
+        preferred_models=configured_model_order(cfg),
     )
 
 
@@ -303,6 +430,7 @@ def build_models_payload(
         _apply_picker_hints(rows)
     if canonical_order:
         rows = _reorder_canonical(rows)
+    rows = _apply_configured_model_order(rows, ctx.preferred_models)
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
@@ -315,6 +443,10 @@ def build_models_payload(
         "providers": rows,
         "model": ctx.current_model,
         "provider": ctx.current_provider,
+        "preferred_models": [
+            {"provider": provider, "model": model}
+            for provider, model in ctx.preferred_models
+        ],
     }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4118,6 +4118,12 @@ def select_provider_and_model(args=None):
         ]
     else:
         _visible_slugs = [p.slug for p in CANONICAL_PROVIDERS]
+    from hermes_cli.inventory import configured_model_order, order_provider_slugs
+
+    _visible_slugs = order_provider_slugs(
+        _visible_slugs,
+        configured_model_order(config),
+    )
     grouped_rows = group_providers(_visible_slugs)
 
     # The group/slug that should be pre-selected: the active provider's group

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -387,6 +387,41 @@ class TestCustomProviderModelSwitch:
         assert "Local Ollama" in active_label
         assert "currently active" in active_label
 
+    def test_picker_orders_primary_provider_before_fallback_providers(
+        self, config_home
+    ):
+        from hermes_cli.main import select_provider_and_model
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5.6-sol\n"
+            "fallback_providers:\n"
+            "- provider: anthropic\n"
+            "  model: claude-opus-5\n"
+            "- provider: alibaba\n"
+            "  model: qwen3.8-max\n"
+            "custom_providers: []\n",
+            encoding="utf-8",
+        )
+        captured = {}
+
+        def _capture_and_cancel(labels, default=0):
+            captured["labels"] = labels
+            return len(labels) - 1
+
+        with patch(
+            "hermes_cli.main._prompt_provider_choice",
+            side_effect=_capture_and_cancel,
+        ), patch("builtins.print"):
+            select_provider_and_model()
+
+        labels = captured["labels"]
+        openai_index = next(i for i, label in enumerate(labels) if label.startswith("OpenAI ▸"))
+        anthropic_index = next(i for i, label in enumerate(labels) if label.startswith("Anthropic"))
+        assert openai_index < anthropic_index
+
     def test_key_env_providers_dict_preserves_existing_api_key(
         self, config_home, monkeypatch
     ):

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 from hermes_cli.inventory import (
     ConfigContext,
     build_models_payload,
+    configured_model_order,
     load_picker_context,
 )
 
@@ -38,6 +39,38 @@ def _cfg(model=None, providers=None, custom_providers=None) -> dict:
         "providers": providers if providers is not None else {},
         "custom_providers": custom_providers if custom_providers is not None else [],
     }
+
+
+def test_load_picker_context_records_primary_then_fallback_model_order():
+    config = _cfg(
+        model={"provider": "openai-codex", "default": "gpt-5.6-sol"},
+    )
+    config["fallback_providers"] = [
+        {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+        {"provider": "anthropic", "model": "claude-opus-5"},
+        {"provider": "grok-oauth", "model": "grok-4.6"},
+        {"provider": "kimi-coding", "model": "k3-256k"},
+        {"provider": "", "model": "must-be-ignored"},
+        {"provider": "alibaba", "model": "qwen3.8-max"},
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("hermes_cli.config.get_compatible_custom_providers", return_value=[]),
+    ):
+        ctx = load_picker_context()
+
+    assert ctx.preferred_models == (
+        ("openai-codex", "gpt-5.6-sol"),
+        ("anthropic", "claude-opus-5"),
+        ("xai-oauth", "grok-4.6"),
+        ("kimi-coding", "k3-256k"),
+        ("alibaba", "qwen3.8-max"),
+    )
+
+
+def test_configured_model_order_does_not_infer_a_missing_primary_provider():
+    assert configured_model_order({"model": {"default": "providerless-model"}}) == ()
 
 
 def test_load_picker_context_coerces_numeric_yaml_provider():
@@ -110,6 +143,73 @@ def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     }
 
 
+def test_models_payload_prioritizes_primary_then_fallback_models():
+    rows = [
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "models": ["claude-opus-5"],
+            "total_models": 1,
+        },
+        {
+            "slug": "alibaba",
+            "name": "Alibaba",
+            "models": ["deepseek-v4-pro", "qwen3.8-max", "deepseek-v4-flash-0731"],
+            "total_models": 3,
+        },
+        {
+            "slug": "openai-codex",
+            "name": "OpenAI Codex",
+            "models": ["gpt-5.6-sol"],
+            "total_models": 1,
+        },
+        {
+            "slug": "gemini",
+            "name": "Gemini",
+            "models": ["gemini-3.7-flash"],
+            "total_models": 1,
+        },
+    ]
+    ctx = ConfigContext(
+        current_provider="openai-codex",
+        current_model="gpt-5.6-sol",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        preferred_models=(
+            ("openai-codex", "gpt-5.6-sol"),
+            ("anthropic", "claude-opus-5"),
+            ("alibaba", "qwen3.8-max"),
+            ("alibaba", "deepseek-v4-flash-0731"),
+            ("alibaba", "deepseek-v4-pro"),
+        ),
+    )
+
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx, canonical_order=True)
+
+    configured_slugs = [
+        row["slug"] for row in payload["providers"] if row["slug"] != "moa"
+    ]
+    assert configured_slugs == [
+        "openai-codex",
+        "anthropic",
+        "alibaba",
+        "gemini",
+    ]
+    alibaba = next(row for row in payload["providers"] if row["slug"] == "alibaba")
+    assert alibaba["models"] == [
+        "qwen3.8-max",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-pro",
+    ]
+    assert payload["preferred_models"] == [
+        {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+        {"provider": "anthropic", "model": "claude-opus-5"},
+        {"provider": "alibaba", "model": "qwen3.8-max"},
+        {"provider": "alibaba", "model": "deepseek-v4-flash-0731"},
+        {"provider": "alibaba", "model": "deepseek-v4-pro"},
+    ]
 
 
 def test_cli_model_picker_forwards_force_refresh_to_probe_flags():

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -112,6 +112,52 @@ def test_prompt_model_selection_fallback_uses_line_editor_for_custom_model(
     assert _prompt_model_selection(["vendor/default-model"]) == "vendor/edited-model"
 
 
+def test_prompt_model_selection_orders_models_from_primary_fallback_chain(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli.auth import _prompt_model_selection
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openai-codex\n"
+        "  default: gpt-5.6-sol\n"
+        "fallback_providers:\n"
+        "- provider: alibaba\n"
+        "  model: qwen3.8-max\n"
+        "- provider: alibaba\n"
+        "  model: deepseek-v4-flash-0731\n"
+        "- provider: alibaba\n"
+        "  model: deepseek-v4-pro\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    captured = {}
+
+    def _capture_and_skip(_title, choices, **_kwargs):
+        captured["choices"] = choices
+        return len(choices) - 1
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _capture_and_skip)
+
+    _prompt_model_selection(
+        ["deepseek-v4-pro", "qwen3.8-max", "deepseek-v4-flash-0731"],
+        confirm_provider="alibaba",
+    )
+
+    labels = [
+        "".join(text for text, _style in choice)
+        for choice in captured["choices"][:3]
+    ]
+    assert labels == [
+        "qwen3.8-max",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-pro",
+    ]
+
+
 def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _remove_custom_provider
 


### PR DESCRIPTION
## Summary

- derive a stable ordered model preference from the configured primary model followed by `fallback_providers`
- apply that order to provider and model rows in the shared model inventory and the classic `hermes model` CLI picker
- expose the optional order in `model.options` so Hermes Desktop can render the same shortlist order
- keep the historical alphabetical Desktop order when connected to an older backend that does not advertise `preferred_models`

## Problem

Hermes already treats `fallback_providers` as an ordered chain, but the model pickers discarded that user intent:

- Desktop regrouped providers alphabetically, so Anthropic appeared before a configured OpenAI/Codex primary
- the classic CLI used canonical provider/model catalog order
- several configured models under the same provider could appear in a different order from the fallback chain

This made the fallback configuration and the visible shortlist disagree.

## Behavior

The effective picker order is now:

1. configured primary provider/model
2. configured fallbacks in declared order
3. every remaining catalog entry in its previous stable order

Duplicate primary/fallback pairs are removed, picker provider aliases are canonicalized, and malformed providerless primary entries do not invent a preference. The current-model cursor behavior is preserved inside the CLI model menu.

## Verification

- Python inventory and CLI behavior tests
- Desktop model catalog, model menu, edit submenu, visibility, and model-options tests
- Desktop TypeScript typecheck
- Ruff, ESLint, Prettier, and `git diff --check`
- production Desktop build with the exact commit stamp
