### PR TITLE
fix(desktop): group chats stop leaking (empty) sentinels and stop swallowing real answers behind (pass) (#94308, #94376)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7256,12 +7256,24 @@ function groupChatEntryId() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
+/** The agent loop's "(empty)" terminal sentinel (empty_response_exhausted) is
+ *  a FAILURE marker, never bot text. Mirror gateway/run.py's user-friendly
+ *  substitution so the room log never shows the raw sentinel. */
+const GROUP_EMPTY_SENTINEL = '(empty)'
+const GROUP_EMPTY_FRIENDLY =
+  '⚠️ The model returned no response after processing tool results. ' +
+  'This can happen with some models — try again or rephrase your question.'
+function normalizeGroupChatText(text) {
+  const trimmed = String(text || '').trim()
+  return trimmed === GROUP_EMPTY_SENTINEL ? GROUP_EMPTY_FRIENDLY : trimmed
+}
+
 function appendGroupChatEntry(group, from, text, thread, images) {
   const entry = {
     id: groupChatEntryId(),
     at: Date.now(),
     from,
-    text: String(text).trim(),
+    text: normalizeGroupChatText(text),
     thread: thread || 'legacy'
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6723,7 +6723,9 @@ function isGroupPassText(text) {
  *  substantive (non-pass) assistant answer over a trailing pass — a Codex
  *  intent-ack continuation nudge can land a complete answer and then get a
  *  synthetic "(pass)" to the nudge itself, which must not hide the answer.
- *  Returns null only when no assistant message appears in that range. */
+ *  When only pass text exists in range, returns the newest (last
+ *  chronological) one rather than the oldest. Returns null only when no
+ *  assistant message appears in that range. */
 function pickGroupTurnReply(messages, before) {
   let passText = null
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6718,6 +6718,42 @@ function isGroupPassText(text) {
   return /^\(?\s*pass\s*\)?\.?$/i.test(trimmed)
 }
 
+/** #94376: pick the reply a finished turn should surface among the messages
+ *  appended since `before`. Scans newest-first and prefers the last
+ *  substantive (non-pass) assistant answer over a trailing pass — a Codex
+ *  intent-ack continuation nudge can land a complete answer and then get a
+ *  synthetic "(pass)" to the nudge itself, which must not hide the answer.
+ *  Returns null only when no assistant message appears in that range. */
+function pickGroupTurnReply(messages, before) {
+  let passText = null
+
+  for (let i = messages.length - 1; i >= before; i--) {
+    const msg = messages[i]
+
+    if (msg?.role !== 'assistant') {
+      continue
+    }
+
+    const text = typeof msg.content === 'string'
+      ? msg.content
+      : Array.isArray(msg.content)
+        ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
+        : msg?.text || ''
+    const replyText = String(text).trim()
+
+    if (isGroupPassText(replyText)) {
+      if (passText === null) {
+        passText = replyText
+      }
+      continue
+    }
+
+    return replyText
+  }
+
+  return passText
+}
+
 /** Deterministic @mention parse. Handles @name, @"two words" via display
  *  titles, and @everyone/@all. Names match case-insensitively against member
  *  profile names, display titles, and collapsed no-space forms. */
@@ -7723,25 +7759,16 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
     const done = !busy && !awaitingUser
 
     if (messages.length > before && done) {
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const msg = messages[i]
+      const replyText = pickGroupTurnReply(messages, before)
 
-        if (msg?.role === 'assistant') {
-          const text = typeof msg.content === 'string'
-            ? msg.content
-            : Array.isArray(msg.content)
-              ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
-              : msg?.text || ''
-          const replyText = String(text).trim()
+      if (replyText !== null) {
+        recordGroupActivity(group, {
+          kind: isGroupPassText(replyText) ? 'passed' : 'replied',
+          member: member.name,
+          thread
+        })
 
-          recordGroupActivity(group, {
-            kind: isGroupPassText(replyText) ? 'passed' : 'replied',
-            member: member.name,
-            thread
-          })
-
-          return replyText
-        }
+        return replyText
       }
 
       recordGroupActivity(group, { kind: 'passed', member: member.name, thread })
@@ -7822,33 +7849,20 @@ async function harvestStrandedGroupReply(group, member) {
     return
   }
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
+  const reply = pickGroupTurnReply(messages, strandedBefore)
 
-    if (msg?.role === 'assistant') {
-      const text = typeof msg.content === 'string'
-        ? msg.content
-        : Array.isArray(msg.content)
-          ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
-          : msg?.text || ''
-      const reply = String(text).trim()
-
-      if (reply && !isGroupPassText(reply)) {
-        recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
-        appendGroupChatEntry(
-          group,
-          { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
-          reply,
-          strandedThread
-        )
-        updateGroupChat(group, r => {
-          r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
-          return r
-        })
-      }
-
-      return
-    }
+  if (reply && !isGroupPassText(reply)) {
+    recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
+    appendGroupChatEntry(
+      group,
+      { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+      reply,
+      strandedThread
+    )
+    updateGroupChat(group, r => {
+      r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
+      return r
+    })
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-empty-sentinel.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-empty-sentinel.test.mjs
@@ -213,7 +213,7 @@ async function drain(gc, group) {
 }
 
 test('(empty) sentinel: a "(empty)" member reply is converted like the gateway, never appended raw', async () => {
-  const gc = load((profile, prompt) => {
+  const gc = load(profile => {
     if (profile === 'research') return '(empty)'
     return '(pass)'
   })
@@ -228,7 +228,7 @@ test('(empty) sentinel: a "(empty)" member reply is converted like the gateway, 
 })
 
 test('(empty) sentinel: normal replies are untouched', async () => {
-  const gc = load((profile, prompt) => {
+  const gc = load(profile => {
     if (profile === 'research') return 'I am not empty.'
     return '(pass)'
   })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-empty-sentinel.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-empty-sentinel.test.mjs
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Load the plugin in a vm with a scripted cli.exec so member turns are
+ *  deterministic. `turnScript(profile, prompt)` returns the member's reply
+ *  text (or throws to simulate a failed turn). */
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => {
+      if (process.env.TRACE_ATOM && value && typeof value === 'object' && value.Grind) {
+        console.error('ATOM SET Grind stranded=', JSON.stringify(value.Grind.stranded), new Error().stack.split('\n').slice(2,5).join(' | '))
+      }
+      values.set(slot, value)
+    } }
+    values.set(slot, initial)
+    return slot
+  }
+  const calls = []
+  const clarifyResponds = []
+  const approvalResponds = []
+  const requests = []
+  const sessions = new Map()
+  const runtimeToStored = new Map()
+  const titleToStored = new Map()
+  const sharedUiMeta = {}
+  const uiMetaRevisions = {}
+  let sessionSequence = 0
+  const resumeCallCounts = new Map()
+  let injectedConflict = false
+
+  const resolveSession = (profile, target) => {
+    const stored = runtimeToStored.get(target) || (sessions.has(target) ? target : titleToStored.get(`${profile}::${target}`))
+    return stored ? sessions.get(stored) : null
+  }
+  const context = {
+    atom,
+    setTimeout: fn => {
+      if (deferredTimers) {
+        setImmediate(fn)
+        return 1
+      }
+      fn()
+      return 0
+    },
+    clearTimeout: () => undefined,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async (method, params) => {
+        requests.push({ method, params })
+        if (method === 'profiles.list') {
+          return {
+            profiles: [
+              {
+                name: 'default',
+                ui_meta: { ...sharedUiMeta },
+                ui_meta_revisions: { ...uiMetaRevisions }
+              }
+            ]
+          }
+        }
+        if (method === 'profiles.configure') {
+          if (conflictOnce && !injectedConflict) {
+            injectedConflict = true
+            sharedUiMeta['hermes-bots-groups'] = {
+              version: 2,
+              rooms: {
+                Shared: {
+                  revision: 1,
+                  log: [{ id: 'writer-a:1', from: { kind: 'user', name: 'You' }, text: 'alpha', at: 1 }],
+                  members: [{ name: 'alpha' }]
+                }
+              }
+            }
+            uiMetaRevisions['hermes-bots-groups'] = 1
+            return {
+              applied: {
+                ui_meta: false,
+                ui_meta_conflicts: { 'hermes-bots-groups': { expected: 0, actual: 1 } },
+                ui_meta_revisions: { 'hermes-bots-groups': 1 }
+              }
+            }
+          }
+          const expected = params.ui_meta_expected_revisions || null
+          if (expected) {
+            for (const key of Object.keys(params.ui_meta || {})) {
+              if ((uiMetaRevisions[key] || 0) !== expected[key]) {
+                return {
+                  applied: {
+                    ui_meta: false,
+                    ui_meta_conflicts: {
+                      [key]: { expected: expected[key], actual: uiMetaRevisions[key] || 0 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          for (const [key, value] of Object.entries(params.ui_meta || {})) {
+            if (value === null) {
+              delete sharedUiMeta[key]
+            } else {
+              sharedUiMeta[key] = value
+            }
+            uiMetaRevisions[key] = (uiMetaRevisions[key] || 0) + 1
+          }
+          return { applied: { ui_meta: true, ui_meta_revisions: { ...uiMetaRevisions } } }
+        }
+        if (method === 'session.create') {
+          sessionSequence += 1
+          const stored = `sid-${params.profile}-${sessionSequence}`
+          const runtime = `rt-${params.profile}-${sessionSequence}`
+          const session = { stored, runtime, profile: params.profile, title: params.title, messages: [] }
+          sessions.set(stored, session)
+          runtimeToStored.set(runtime, stored)
+          titleToStored.set(`${params.profile}::${params.title}`, stored)
+          return { session_id: runtime, stored_session_id: stored, message_count: 0, messages: [] }
+        }
+        if (method === 'session.resume') {
+          const session = resolveSession(params.profile, params.session_id)
+          if (!session) {
+            const err = new Error(`session not found: ${params.session_id}`)
+            err.code = 4007
+            throw err
+          }
+          const profile = params.profile
+          const seen = (resumeCallCounts.get(profile) || 0) + 1
+          resumeCallCounts.set(profile, seen)
+          const limit = busyUntilResumeCall && busyUntilResumeCall[profile]
+          const busy = Boolean(limit && seen <= limit)
+          const clarify = clarifyUntilResumeCall && clarifyUntilResumeCall[profile]
+          const pendingClarify = clarify && seen <= clarify.until ? clarify.payload : null
+          const approval = approvalUntilResumeCall && approvalUntilResumeCall[profile]
+          const pendingApproval = approval && seen <= approval.until ? approval.payload : null
+          return {
+            session_id: session.runtime,
+            session_key: session.stored,
+            message_count: session.messages.length,
+            messages: [...session.messages],
+            inflight: busy,
+            running: busy,
+            ...(pendingClarify ? { pending_clarify: pendingClarify } : {}),
+            ...(pendingApproval ? { pending_approval: pendingApproval } : {})
+          }
+        }
+        if (method === 'prompt.submit') {
+          const session = resolveSession(null, params.session_id)
+          if (!session) {
+            throw new Error(`runtime session not found: ${params.session_id}`)
+          }
+          session.messages.push({ role: 'user', content: params.text })
+          calls.push({
+            profile: session.profile,
+            prompt: params.text,
+            runtime: session.runtime,
+            stored: session.stored,
+            title: session.title
+          })
+          const reply = turnScript(session.profile, params.text, calls.length, session)
+          session.messages.push({ role: 'assistant', content: reply })
+          return {}
+        }
+        if (method === 'clarify.respond') {
+          clarifyResponds.push({ ...params })
+          return { ok: true }
+        }
+        if (method === 'approval.respond') {
+          approvalResponds.push({ ...params })
+          return { resolved: true }
+        }
+        return {}
+      },
+      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } },
+      notify: () => undefined,
+      notifyError: () => undefined
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+    )
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  const storageWrites = new Map()
+  context.plugin.register({
+    storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
+    register: () => undefined
+  })
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
+}
+
+function roomLog(gc, group) {
+  return (gc.$groupChats.get()[group] || { log: [] }).log
+}
+
+const FRIENDLY = '⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your question.'
+
+async function drain(gc, group) {
+  for (let i = 0; i < 200 && (gc.$groupChats.get()[group] || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+}
+
+test('(empty) sentinel: a "(empty)" member reply is converted like the gateway, never appended raw', async () => {
+  const gc = load((profile, prompt) => {
+    if (profile === 'research') return '(empty)'
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Sentinel', [{ name: 'research', title: '' }], '@research thoughts?')
+  await drain(gc, 'Sentinel')
+
+  const memberEntries = roomLog(gc, 'Sentinel').filter(e => e.from.kind === 'member')
+  assert.ok(memberEntries.length === 1, `expected exactly 1 member entry, got ${memberEntries.length}`)
+  assert.equal(memberEntries[0].text, FRIENDLY)
+  assert.equal(memberEntries[0].text.includes('(empty)'), false)
+})
+
+test('(empty) sentinel: normal replies are untouched', async () => {
+  const gc = load((profile, prompt) => {
+    if (profile === 'research') return 'I am not empty.'
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Sentinel2', [{ name: 'research', title: '' }], '@research hi')
+  await drain(gc, 'Sentinel2')
+
+  const memberEntries = roomLog(gc, 'Sentinel2').filter(e => e.from.kind === 'member')
+  assert.equal(memberEntries.length, 1)
+  assert.equal(memberEntries[0].text, 'I am not empty.')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1527,6 +1527,40 @@ test('stranded harvest: a timed-out turn whose reply landed late posts into the 
   assert.equal(gc.$groupChats.get().Late.stranded.research, undefined, 'marker consumed')
 })
 
+test('stranded harvest: a rescued reply prefers the substantive answer over a trailing synthetic (pass)', async () => {
+  const gc = load(() => '(pass)')
+
+  // #94376 class bug at the second call site: the late-landing turn ends
+  // with a Codex intent-ack continuation nudge that gets a synthetic
+  // "(pass)" — the harvest must still surface the substantive answer that
+  // preceded it, not the trailing pass.
+  gc.updateGroupChat('Rescue', r => {
+    r.stranded = { research: 0 }
+    r.sessions = { research: 'sid-research' }
+    return r
+  })
+  gc.sessions.set('sid-research', {
+    stored: 'sid-research',
+    runtime: 'rt-research',
+    profile: 'research',
+    title: 'Group: Rescue',
+    messages: [
+      { role: 'user', content: 'the turn prompt' },
+      { role: 'assistant', content: 'Here is the full research result, delivered late.' },
+      { role: 'user', content: '[System: Continue now. Execute the required tool calls and only send your final answer after completing the task.]' },
+      { role: 'assistant', content: '(pass)' }
+    ]
+  })
+
+  await gc.harvestStrandedGroupReply('Rescue', { name: 'research', title: '' })
+
+  const log = roomLog(gc, 'Rescue')
+  assert.equal(log.length, 1)
+  assert.equal(log[0].from.name, 'research')
+  assert.match(log[0].text, /delivered late/)
+  assert.equal(gc.$groupChats.get().Rescue.stranded.research, undefined, 'marker consumed')
+})
+
 test('stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running', async () => {
   // research is confirmed busy on exactly its first two session.resume
   // calls — the number of harvest-only touches the FIXED code makes across

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs
@@ -18,7 +18,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Harness mirroring group-chat-attachments.test.mjs, extended with a
  *  refcounted host.requestProfile/host.retainProfile pair so socket lease
  *  lifetimes are assertable. */
-function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 'hello from turn' } = {}) {
+function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 'hello from turn', replyMessages = null } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -114,7 +114,13 @@ function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 
         throw err
       }
       session.messages.push({ role: 'user', content: params.text })
-      session.messages.push({ role: 'assistant', content: reply })
+      if (replyMessages) {
+        for (const msg of replyMessages) {
+          session.messages.push(msg)
+        }
+      } else {
+        session.messages.push({ role: 'assistant', content: reply })
+      }
       return {}
     }
     return {}
@@ -269,4 +275,29 @@ test('hosts without retainProfile still run the turn (feature detection)', async
   const reply = await gc.runGroupChatMemberTurn('Room', ROUTED_MEMBER, 'hi', 't1', [])
 
   assert.equal(reply, 'legacy ok')
+})
+
+// #94376: a Codex intent-ack continuation nudge can land a substantive
+// answer, then get a synthetic "(pass)" reply to the nudge itself. The
+// substantive answer must still surface, not the trailing pass.
+test('a substantive answer followed by a synthetic continuation (pass) still surfaces the answer', async () => {
+  const gc = load({
+    replyMessages: [
+      { role: 'assistant', content: "Yes. I welcomed them, and I'll review their first assignments with them." },
+      { role: 'user', content: '[System: Continue now. Execute the required tool calls and only send your final answer after completing the task.]' },
+      { role: 'assistant', content: '(pass)' }
+    ]
+  })
+
+  const reply = await gc.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'Did you welcome the new teammate?', 't1', [])
+
+  assert.equal(reply, "Yes. I welcomed them, and I'll review their first assignments with them.")
+})
+
+test('a genuine pass-only turn (no prior substantive answer) still reads as silent', async () => {
+  const gc = load({ reply: '(pass)' })
+
+  const reply = await gc.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'anything new?', 't1', [])
+
+  assert.equal(reply, '(pass)')
 })

--- a/contributors/emails/aydinhrrs@gmail.com
+++ b/contributors/emails/aydinhrrs@gmail.com
@@ -1,0 +1,1 @@
+RibatTRW


### PR DESCRIPTION
## Summary
Group-chat turns stop leaking protocol sentinels and stop swallowing real answers (#94308, #94376). Consolidates the two halves of the sentinel-protocol seam, both filed Aug 25:

- **Selection half — #94386 (@chelsealong):** the turn's reply extraction backward-scanned to the LAST assistant message, so when Codex intent-ack scaffolding appended a trailing `(pass)`, it shadowed the member's real answer and the whole turn was suppressed as silent (#94376's real shape: over-suppression, not a leak). Now the scan keeps the last SUBSTANTIVE non-pass message; the stranded-harvest path is pinned by test.
- **Normalization half — #94310 (@RibatTRW, earliest submitter 00:08 vs 02:38):** the agent core's `(empty)` failure sentinel isn't in the pass vocabulary and rendered as a literal `(empty)` bubble (#94308). `appendGroupChatEntry` now rewrites the exact sentinel to the gateway's friendly notice; anything else passes through untouched.

## Validation
| | Result |
|---|---|
| vm suite | 604 (main) → 607 → **609/609** after both halves |
| sabotage | one test per half fails with its hunk reverted |
| eslint | clean (2 no-unused-vars in the raw test file fixed in follow-up) |

**Live A/B (real Electron + backends, room "大司命, Testbot"):** on main, an `(empty)` reply renders as a literal `(empty)` bubble; on this branch the same flow renders "⚠️ The model returned no response…" instead.

| Main | Fix |
|---|---|
| ![raw sentinel](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/S5_EMPTY_MAIN.png) | ![friendly notice](https://gist.githubusercontent.com/teknium1/642f893fc010d690c3d9e7c03136213a/raw/S5_EMPTY_FIX.png) |

Fixes #94308, #94376. Source PRs #94310 + #94386 to be closed with credit after merge.

## Infographic

![Sentinel protocol](https://v3b.fal.media/files/b/0aa80019/RpB0T0tPdcPb1Zppdb-np_5aduJKNL.png)
