### PR TITLE
feat: session retitle from recent conversation (auto + /retitle + hermes sessions retitle)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -60,6 +60,25 @@ _TITLE_PROMPT_TEMPLATE = (
     'Reply with JSON only: {"title": "..."}'
 )
 
+# Prompt for regenerate_title() — feeds condensed conversation history instead of opening message.
+_RETITLE_PROMPT = (
+    "You name chat sessions. Given the conversation so far, write a title "
+    "that lets the user find this conversation again in a list.\n\n"
+    "Rules:\n"
+    "- 3 to 7 words, sentence case (capitalize only the first word and proper nouns).\n"
+    "- Name what the conversation is actually about or what the user wants DONE.\n"
+    "- Keep technical terms, filenames, numbers, and error codes exact.\n"
+    "- Drop filler words: the, this, my, a, an.\n"
+    "- No trailing punctuation, no quotes, no tool names, no 'Title:' prefix.\n"
+    "- Never summarize the conversation. Name it.\n"
+    "- Always produce something, even if the conversation opened with a greeting.\n"
+    "__LANGUAGE_RULE__\n"
+    'Good: {"title": "Debugging Postgres connection pool"}\n'
+    'Good: {"title": "Hermes session auto-titling explained"}\n'
+    'Too vague: {"title": "Conversation about databases"}\n'
+    'Reply with JSON only: {"title": "..."}'
+)
+
 _LANGUAGE_RULE_MATCH_USER = "- Write the title in the same language as the user's message."
 _LANGUAGE_RULE_PINNED = "- Write the title in {language}."
 
@@ -112,6 +131,65 @@ def _auto_title_enabled() -> bool:
         return is_truthy_value(_title_config().get("enabled"), default=True)
     except Exception:
         logger.debug("Failed to read title_generation.enabled", exc_info=True)
+        return True
+
+
+# Defaults for auxiliary.title_generation.retitle. Kept in sync with
+# hermes_cli/config_defaults.py — the merge below preserves any key the user
+# omitted and skips explicit ``None`` overrides so a YAML ``null`` cannot blank
+# out a default. Explicit ``false`` / ``0`` / ``""`` DO override.
+_RETITLE_DEFAULTS = {
+    "enabled": True,
+    "auto_at_turn": 10,
+    "turns_window": 10,
+    "slash_command": True,
+    "cli_command": True,
+    "touch_platform_names": False,
+    "provider": "",
+    "model": "",
+    "base_url": "",
+    "api_key": "",
+    "timeout": 30,
+    "max_concurrency": 2,
+    "prefer_fast_model": None,
+}
+
+
+def _retitle_config() -> dict:
+    """Return the merged ``auxiliary.title_generation.retitle`` config.
+
+    Defaults from ``_RETITLE_DEFAULTS`` are merged with any user overrides.
+    User keys whose value is ``None`` are treated as "use default" so a YAML
+    ``null`` does not blank out a baked-in default. Returns ``{}`` on any
+    config error (fail-open at call sites).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
+        user = title_config.get("retitle") or {}
+        merged = dict(_RETITLE_DEFAULTS)
+        if isinstance(user, dict):
+            for key, value in user.items():
+                if value is None:
+                    continue
+                merged[key] = value
+        return merged
+    except Exception:
+        logger.debug("Failed to read title_generation.retitle", exc_info=True)
+        return {}
+
+
+def _retitle_enabled() -> bool:
+    """Return whether the retitle feature is enabled (default True)."""
+    try:
+        from utils import is_truthy_value
+
+        cfg = _retitle_config()
+        return is_truthy_value(cfg.get("enabled"), default=True)
+    except Exception:
+        logger.debug("Failed to read title_generation.retitle.enabled", exc_info=True)
         return True
 
 
@@ -212,6 +290,33 @@ def _clean_title(text: str) -> Optional[str]:
     return title or None
 
 
+def _looks_like_title(text: Optional[str]) -> bool:
+    """Quality gate: accept a concise 2..12 word phrase, reject verbose prose.
+
+    Used by ``regenerate_title`` to filter chatty small-model output — when
+    handed a whole conversation instead of a single opening message, a
+    tiny-model tier will sometimes answer with a summary sentence ("Here is
+    a summary of the conversation...") instead of a title. This guard drops
+    those before they land as the session name.
+    """
+    if not text:
+        return False
+    words = text.split()
+    if len(words) < 2 or len(words) > 12:
+        return False
+    lowered = text.lower()
+    _BAD_PREFIXES = (
+        "here",
+        "this conversation",
+        "the conversation",
+        "about ",
+    )
+    for bad in _BAD_PREFIXES:
+        if lowered.startswith(bad):
+            return False
+    return True
+
+
 def _safe_callback(callback: Optional[Callable], args: tuple, log_fmt: str, label: str) -> None:
     """Invoke an optional consumer callback, never raising."""
     try:
@@ -296,6 +401,194 @@ def _has_upgraded_title(session_db, session_id: str) -> bool:
         return bool(session_db.get_session_title(session_id))
     except Exception:
         return True
+
+
+def regenerate_title(
+    condensed: str,
+    timeout: Optional[float] = None,
+) -> Optional[str]:
+    """Regenerate a session title from condensed conversation history.
+
+    Structural mirror of :func:`generate_title`, but takes an already-condensed
+    conversation string (see :func:`_condense_history`) instead of a single
+    opening user message. Runs on the same ``title_generation`` auxiliary
+    task, so it inherits the small/fast tier, concurrency cap, and timeout
+    floor configured for auto-titling.
+
+    Returns ``None`` when:
+    - ``condensed`` is empty/whitespace,
+    - the retitle feature is disabled,
+    - the LLM call raises (logged at WARNING),
+    - the response fails the ``_looks_like_title`` quality gate.
+
+    Callers handle failure surfacing and persistence — this function only
+    produces a title candidate, it does not invoke a failure callback and
+    does not touch storage.
+    """
+    if not condensed or not condensed.strip():
+        return None
+    if not _retitle_enabled():
+        logger.debug("Retitle skipped: auxiliary.title_generation.retitle.enabled=false")
+        return None
+
+    language = _title_language()
+    language_rule = (
+        _LANGUAGE_RULE_PINNED.format(language=language)
+        if language
+        else _LANGUAGE_RULE_MATCH_USER
+    )
+    # Placeholder substitution, not str.format: the prompt embeds literal JSON
+    # braces as few-shot examples, which format() would try to interpolate.
+    prompt = _RETITLE_PROMPT.replace("__LANGUAGE_RULE__", language_rule)
+
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": condensed[:MAX_TITLE_INPUT_CHARS]},
+    ]
+
+    try:
+        response = call_llm(
+            task="title_generation",
+            messages=messages,
+            max_tokens=64,
+            temperature=0.3,
+            timeout=timeout,
+            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+        )
+        content = response.choices[0].message.content or ""
+        title = _clean_title(_extract_title_text(content))
+        if not _looks_like_title(title):
+            logger.debug("Retitle rejected by _looks_like_title: %r", title)
+            return None
+        return title
+    except Exception as e:
+        logger.warning("Retitle generation failed: %s", e)
+        logger.debug("Retitle generation traceback", exc_info=True)
+        return None
+
+
+def retitle_session(
+    session_db,
+    session_id: str,
+    conversation_history: Any,
+    *,
+    turns_window: int = 10,
+    force: bool = False,
+    touch_platform_names: bool = False,
+) -> Optional[str]:
+    """Regenerate a session's title from recent history and persist it.
+
+    Shared sync worker for every retitle entry point: the ``maybe_auto_retitle``
+    daemon thread, the ``/retitle`` slash handler (via ``asyncio.to_thread``),
+    and the ``hermes sessions retitle`` CLI. Writes with ``source="llm"`` — the
+    same tier as the initial auto-title upgrade — so the provenance ladder
+    (``derived < llm < user``) at the storage layer still protects any name
+    the user typed.
+
+    Guards:
+
+    - ``session_db`` missing or ``session_id`` empty → returns None.
+    - Unless ``force=True``, a title of ``user`` provenance is left alone.
+      The CLI's ``--force`` flag is the one place that opts in to overwriting.
+
+    Returns the title persisted, or ``None`` if nothing was written (empty
+    condensed history, model returned nothing, or a higher-authority title
+    held the row). Never raises — this is a daemon-thread target when called
+    from :func:`maybe_auto_retitle`, and an escaping exception would spray a
+    raw traceback into the user's terminal via the default threading
+    excepthook.
+
+    ``touch_platform_names`` is accepted but not acted on here: the platform
+    rename callback lives on the agent and isn't threaded through to this
+    worker. Wire the callback when the platform-name integration lands.
+    """
+    if session_db is None or not session_id:
+        return None
+
+    try:
+        # Provenance guard. A user-set title is the only tier we refuse to
+        # overwrite silently — force=True (the CLI opt-in) skips this check.
+        if not force:
+            try:
+                source_fn = getattr(session_db, "get_session_title_source", None)
+                if source_fn is not None:
+                    existing_source = source_fn(session_id)
+                    if existing_source == "user":
+                        logger.debug(
+                            "Retitle skipped: session %s carries a user-set title",
+                            session_id,
+                        )
+                        return None
+            except Exception:
+                # If we can't read provenance, fall through to the write; the
+                # storage layer's own precedence check is the backstop.
+                logger.debug(
+                    "Retitle provenance check failed for %s",
+                    session_id, exc_info=True,
+                )
+
+        # Publish accounting + Portal contexts from the session id we hold,
+        # so the LLM call's token usage and conversation tag land on this
+        # session. Imported lazily to match _auto_title_session's post-update
+        # stale-module hygiene — a daemon thread reloading NEW source here
+        # while agent.portal_tags is still OLD would ImportError forever.
+        from agent.aux_accounting import set_accounting_context
+        from agent.portal_tags import set_conversation_context
+
+        try:
+            conversation_id = session_db.get_conversation_root(session_id) or session_id
+        except Exception:
+            conversation_id = session_id
+        set_conversation_context(conversation_id)
+        set_accounting_context(session_db, session_id)
+
+        condensed = _condense_history(conversation_history, turns_window=turns_window)
+        if not condensed:
+            return None
+
+        title = regenerate_title(condensed)
+        if title is None:
+            return None
+
+        # ``set_auto_title`` refuses equal-rank writes (llm -> llm returns 0)
+        # to stop the first-turn titler renaming a session on every subsequent
+        # turn — see hermes_state._set_session_title docstring. Retitle is an
+        # EXPLICIT rewrite intent, not that accidental case, so demote the row
+        # to ``derived`` first, then land the new llm title on top. Both writes
+        # are single-row updates; the intermediate ``derived`` state is invisible
+        # and — even if the second write raced a manual /title — the CAS in
+        # set_session_title would still reject the demotion cleanly.
+        #
+        # ``None``-source rows come from legacy sessions predating provenance
+        # tracking; ``_title_rank(None)`` returns the same rank as ``user`` as
+        # a safety default so passive re-titling never clobbers them. Explicit
+        # retitle is not passive — the user or an operator-configured auto-fire
+        # asked for the rewrite — so we treat None the same as llm here.
+        try:
+            source_fn = getattr(session_db, "get_session_title_source", None)
+            demote_fn = getattr(session_db, "set_session_title_source", None)
+            if callable(source_fn) and callable(demote_fn):
+                current_src = source_fn(session_id)
+                if current_src in ("llm", None):
+                    demote_fn(session_id, "derived")
+        except Exception:
+            logger.debug(
+                "Retitle pre-write demotion failed for %s (proceeding)",
+                session_id, exc_info=True,
+            )
+
+        persisted = _persist_session_title(
+            session_db, session_id, title, source="llm"
+        )
+        if persisted is None:
+            return None
+
+        logger.debug("Retitled session %s: %s", session_id, persisted)
+        return persisted
+    except Exception as e:
+        logger.warning("Retitle failed (harmless): %s", e)
+        logger.debug("Retitle traceback", exc_info=True)
+        return None
 
 
 def _persist_session_title(session_db, session_id, title, *, source, dedupe=True):
@@ -405,6 +698,56 @@ def _is_real_user_turn(message: Any) -> bool:
     return is_titleable_user_message(content if isinstance(content, str) else flatten_message_text(content))
 
 
+def _condense_history(history: Any, turns_window: int = 10) -> str:
+    """Flatten the last ``turns_window`` user+assistant exchanges into text.
+
+    Produces the compact retitle-input blob handed to the auxiliary title
+    model: recent user turns and non-empty assistant replies, in order, each
+    prefixed with a role label. Machine-authored user turns (compaction
+    handoffs, model-switch markers) are skipped via :func:`_is_real_user_turn`
+    so a session isn't titled after Hermes' own scaffolding. Tool messages are
+    excluded — the titler cares about intent, not tool-call plumbing.
+
+    Individual message bodies are clipped at 200 characters so a pasted log
+    can't dominate the blob, and the final result is tail-clipped at
+    :data:`MAX_TITLE_INPUT_CHARS` because recent context matters more than
+    old.
+    """
+    if not history:
+        return ""
+
+    slice_size = turns_window * 2
+    recent = history[-slice_size:]
+
+    lines = []
+    for message in recent:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+
+        if role == "user":
+            if not _is_real_user_turn(message):
+                continue
+            text = content if isinstance(content, str) else flatten_message_text(content)
+            text = " ".join((text or "").split())
+            if not text:
+                continue
+            lines.append("User: " + text[:200])
+        elif role == "assistant":
+            text = content if isinstance(content, str) else flatten_message_text(content)
+            text = " ".join((text or "").split())
+            if not text:
+                continue
+            lines.append("Assistant: " + text[:200])
+        # skip tool, system, everything else
+
+    joined = "\n".join(lines)
+    if len(joined) > MAX_TITLE_INPUT_CHARS:
+        joined = joined[-MAX_TITLE_INPUT_CHARS:]
+    return joined
+
+
 def _session_is_untitled(session_db, session_id: str) -> bool:
     """No title of any provenance; False when it can't tell (no model call per turn for an unreadable title)."""
     getter = getattr(session_db, "get_session_title", None)
@@ -444,3 +787,56 @@ def maybe_auto_title(
         daemon=True,
         name="auto-title",
     ).start()
+
+
+def maybe_auto_retitle(
+    session_db,
+    session_id: str,
+    conversation_history: Optional[list] = None,
+    *,
+    auto_at_turn: int = 10,
+    turns_window: int = 10,
+) -> None:
+    """One-shot retitle trigger: fire exactly once at the auto_at_turn mark.
+
+    Called from the per-turn prologue. Uses **exactly-N** semantics — fires
+    when ``user_msg_count == auto_at_turn`` and never fires again for the
+    same session. Reasoning: this is a one-shot checkpoint, not periodic
+    drift. If we used ``>=`` we would re-fire every turn afterwards; if the
+    auto-fire got skipped for any reason (user-set title, disabled surface),
+    we accept "manual retitle via /retitle only" over slow-motion spam.
+
+    Nothing runs on the caller's thread beyond a cheap message count and a
+    daemon-thread spawn. ``auto_at_turn=0`` disables the auto-fire.
+    """
+    if session_db is None or not session_id:
+        return
+
+    # Cheap guards first — the config read (below) is deferred so a long
+    # session doesn't touch the config file every turn.
+    if not _retitle_enabled():
+        return
+    if auto_at_turn <= 0:
+        return
+
+    user_msg_count = sum(
+        1 for m in (conversation_history or []) if _is_real_user_turn(m)
+    )
+    if user_msg_count != auto_at_turn:
+        return
+
+    cfg = _retitle_config()
+    touch = bool(cfg.get("touch_platform_names", False))
+
+    thread = threading.Thread(
+        target=retitle_session,
+        args=(session_db, session_id, conversation_history),
+        kwargs={
+            "turns_window": turns_window,
+            "force": False,  # auto-fire never forces
+            "touch_platform_names": touch,
+        },
+        daemon=True,
+        name="auto-retitle",
+    )
+    thread.start()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -192,6 +192,28 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
     except Exception:
         logger.debug("Turn-start auto-title dispatch failed", exc_info=True)
 
+    # One-shot auto-retitle at the auto_at_turn checkpoint. Wrapped in its
+    # own nested try/except so a retitle-config read failure cannot break
+    # the auto-title path above, and vice-versa. The outer function has
+    # already returned early for _UNTITLED_PLATFORMS (cron/subagent), so
+    # the exclusion is inherited automatically here — no re-check needed.
+    # The fire-condition inside maybe_auto_retitle is exactly-N, so this
+    # per-turn config read is cheap and the LLM call is bounded to one
+    # shot per session.
+    try:
+        from agent.title_generator import _retitle_config, maybe_auto_retitle
+
+        cfg = _retitle_config()
+        maybe_auto_retitle(
+            session_db,
+            session_id,
+            messages,
+            auto_at_turn=int(cfg.get("auto_at_turn", 10)),
+            turns_window=int(cfg.get("turns_window", 10)),
+        )
+    except Exception:
+        logger.debug("Turn-start auto-retitle dispatch failed", exc_info=True)
+
 
 def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> int:
     """Locate this turn's user message after compaction rebuilt ``messages``.

--- a/cli.py
+++ b/cli.py
@@ -3170,7 +3170,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         "palette": ("_open_command_palette", False), "whoami": ("_handle_whoami_command", False),
         "profile": ("_handle_profile_command", False), "toolsets": ("show_toolsets", False),
         "config": ("show_config", False), "redraw": ("_cmd_redraw", True), "clear": ("_cmd_clear", True),
-        "history": ("show_history", False), "title": ("_cmd_title", True), "new": ("_cmd_new", True),
+        "history": ("show_history", False), "title": ("_cmd_title", True), "retitle": ("_cmd_retitle", True), "new": ("_cmd_new", True),
         "model": ("_handle_model_switch", True), "codex-runtime": ("_handle_codex_runtime", True),
         "retry": ("_cmd_retry", True), "prompt": ("_handle_prompt_compose_command", True),
         "undo": ("_cmd_undo", True), "save": ("save_conversation", True), "skills": ("_cmd_skills", True),

--- a/gateway/relay/command_manifest.py
+++ b/gateway/relay/command_manifest.py
@@ -65,6 +65,8 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
         _cmd("compress", "Compress conversation context"),
         _cmd("title", "Set or show the session title",
              _opt("text", "New title. Leave empty to show.")),
+        _cmd("retitle", "Regenerate the session title from recent conversation",
+             _opt("force", "Pass 'force' to overwrite even a manual title", choices=["force"])),
         _cmd("resume", "Resume a previously-named session",
              _opt("name", "Session title or id")),
         _cmd("usage", "Show token usage for this session"),

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -701,7 +701,7 @@ class GatewayBusySessionMixin:
         "topic", "whoami", "platform", "stop", "reasoning", "memory", "skills", "fast",
         "approvals", "model", "codex-runtime", "personality", "suggestions", "save", "retry",
         "sethome", "compress", "usage", "topup", "insights", "reload-mcp", "reload-skills",
-        "bundles", "debug", "title", "resume", "sessions", "branch", "rollback", "diff", "goal",
+        "bundles", "debug", "title", "retitle", "resume", "sessions", "branch", "rollback", "diff", "goal",
         "loop", "refine", "review", "voice",
     )
 

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -878,6 +878,71 @@ class GatewaySessionCommandsMixin:
             return None
         return t("gateway.resume.blocked_not_owner", name=name)
 
+    async def _handle_retitle_command(self, event: MessageEvent) -> str:
+        """Handle /retitle — regenerate the session title from the last N turns.
+
+        DB-only by default: the session title updates but the Telegram topic /
+        Discord thread name is left untouched unless the operator enabled
+        ``auxiliary.title_generation.retitle.touch_platform_names``.
+
+        Optional arg: ``force`` overwrites even a user-set title.
+        """
+        source = event.source
+        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_id = session_entry.session_id
+
+        if not self._session_db:
+            return self._session_db_unavailable_reply()
+
+        from agent.title_generator import _retitle_config, retitle_session
+
+        cfg = _retitle_config()
+        # Operator kill switch.
+        if not cfg.get("enabled", True):
+            return t("gateway.retitle.disabled")
+
+        args = (event.get_command_args() or "").strip().lower()
+        force = args == "force"
+        turns_window = int(cfg.get("turns_window", 10) or 10)
+        touch = bool(cfg.get("touch_platform_names", False))
+
+        # get_messages is an async method on AsyncSessionDB (it offloads the
+        # blocking SQLite work to a worker thread internally). Await it.
+        history = await self._session_db.get_messages(
+            session_id,
+            latest=True,
+            limit=turns_window * 2,
+        )
+        if not history:
+            return t("gateway.retitle.no_history")
+
+        # retitle_session is sync + blocking (it calls call_llm), so wrap it in
+        # to_thread. Pass the underlying raw SessionDB (not the async wrapper)
+        # so the worker can call get_session_title_source / set_auto_title /
+        # get_conversation_root synchronously.
+        raw_db = getattr(self._session_db, "_db", self._session_db)
+        result = await asyncio.to_thread(
+            retitle_session,
+            raw_db,
+            session_id,
+            history,
+            turns_window=turns_window,
+            force=force,
+            touch_platform_names=touch,
+        )
+
+        if result:
+            return t("gateway.retitle.done", title=result)
+        # Distinguish user-title-held from other no-op paths so the response
+        # tells the user WHY nothing changed.
+        try:
+            src = await self._session_db.get_session_title_source(session_id)
+            if src == "user" and not force:
+                return t("gateway.retitle.user_held")
+        except Exception:
+            pass
+        return t("gateway.retitle.no_change")
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — list or switch to a previous session."""
         if not self._session_db:

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -148,6 +148,60 @@ class CLILoopsMixin:
                 self._pending_title = new_title
                 _cprint(f"  Session title queued: {new_title} (will be saved on first message)")
 
+    def _cmd_retitle(self, cmd_original: str):
+        """Regenerate the current session's title from recent conversation.
+
+        Mirrors /retitle in the gateway (gateway/slash_commands_session.py) and
+        ``hermes sessions retitle`` in the CLI: reads turns_window*2 recent
+        messages from the DB, runs ``regenerate_title``, persists with
+        ``source="llm"``. DB-only by default — Telegram/Discord names stay
+        user-authored unless the operator opted into ``touch_platform_names``.
+
+        Args: bare ``/retitle`` regenerates, ``/retitle force`` overwrites a
+        user-set title too (matches the CLI's ``--force`` behavior).
+        """
+        from cli import _cprint
+        from hermes_state import format_session_db_unavailable
+        args = cmd_original.split(maxsplit=1)
+        force = len(args) > 1 and args[1].strip().lower() == "force"
+        if not self._session_db:
+            _cprint(f"  {format_session_db_unavailable()}")
+            return True
+        try:
+            from agent.title_generator import _retitle_config, retitle_session
+            cfg = _retitle_config()
+            if not cfg.get("enabled", True):
+                _cprint("  Retitle is disabled by config (auxiliary.title_generation.retitle.enabled).")
+                return True
+            turns_window = int(cfg.get("turns_window", 10) or 10)
+            touch = bool(cfg.get("touch_platform_names", False))
+            history = self._session_db.get_messages(
+                self.session_id, latest=True, limit=turns_window * 2,
+            )
+            if not history:
+                _cprint("  No conversation history to retitle from.")
+                return True
+            new_title = retitle_session(
+                self._session_db, self.session_id, history,
+                turns_window=turns_window,
+                force=force,
+                touch_platform_names=touch,
+            )
+            if new_title:
+                self._status_bar_title_checked_at = 0.0
+                _cprint(f"  🔄 Retitled: {new_title}")
+            else:
+                try:
+                    src = self._session_db.get_session_title_source(self.session_id)
+                    if src == "user" and not force:
+                        _cprint("  Session has a manual title. Add `force` to overwrite: /retitle force")
+                        return True
+                except Exception:
+                    pass
+                _cprint("  No title change (model returned nothing usable).")
+        except Exception as e:
+            _cprint(f"  Retitle failed: {e}")
+
     def _cmd_new(self, cmd_original: str):
         # Strip inline-skip tokens (now/--yes/-y) before deriving the title so
         # "/new now My Session" yields title="My Session". See _split_destructive_skip.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -69,6 +69,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("undo", "Back up N user turns and re-prompt (default 1)", "Session",
                args_hint="[N]"),
     CommandDef("title", "Set a title for the current session", "Session", args_hint="[name]"),
+    CommandDef("retitle", "Regenerate the session title from recent conversation", "Session",
+               args_hint="[force]", busy_policy="dispatch"),
     CommandDef("handoff", "Hand off this session to a messaging platform (Telegram, Discord, etc.)", "Session",
                args_hint="<platform>", cli_only=True, argument_mode="options"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -368,7 +368,7 @@ _SLACK_RESERVED_COMMANDS = frozenset({
 # parity test reads this set. Aliases are never pinned ahead of canonicals.
 _SLACK_VIA_HERMES_ONLY = frozenset({
     "topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat",
-    "refine", "review", "pause", "whoami", "platform", "insights"})
+    "refine", "review", "pause", "whoami", "platform", "insights", "retitle"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -716,6 +716,36 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",
             "language": "",
+            # Session retitling — regenerate the title from the last N turns of
+            # conversation instead of only from the opening message. The initial
+            # two-stage titler is limited to the first user message (see the
+            # module docstring in agent/title_generator.py), so long sessions
+            # that drift off their opener carry a stale name until manually
+            # renamed. This block enables an opt-in one-shot auto-retitle at a
+            # configurable turn count, plus manual triggers (`/retitle` slash
+            # command and `hermes sessions retitle <id>` CLI). DB-only by
+            # default: the session title updates but platform names (Telegram
+            # topic, Discord thread) are left untouched unless
+            # ``touch_platform_names`` is set. Related upstream issue: #82655.
+            "retitle": {
+                "enabled": True,
+                "auto_at_turn": 10,  # fire once when user-msg count hits this; 0 disables
+                "turns_window": 10,  # number of recent turns to feed into the retitle call
+                "slash_command": True,  # register /retitle
+                "cli_command": True,  # register `hermes sessions retitle`
+                "touch_platform_names": False,  # if true, also rename Telegram/Discord names
+                # Optional retitle-specific model override. Empty = inherit
+                # from parent title_generation. Resolution: (1) explicit
+                # retitle.provider wins; (2) else pinned parent inherited;
+                # (3) else auto → force prefer_fast_model=True.
+                "provider": "",
+                "model": "",
+                "base_url": "",
+                "api_key": "",
+                "timeout": 30,
+                "max_concurrency": 2,
+                "prefer_fast_model": None,  # None = auto-force-true when inheriting auto
+            },
         },
         "memory_query_rewrite": _aux(8, reasoning_effort=False),
         "tts_audio_tags": _aux(30),

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -934,6 +934,80 @@ def _cmd_stats(db, args):
         print(f"Database size: {_size_mb(db.db_path):.1f} MB")
 
 
+def _cmd_retitle(db, args):
+    """Manual retitle for any historical session.
+
+    Mirrors the /retitle slash handler but works against an arbitrary session
+    id (not just the current one). Reuses the shared ``retitle_session``
+    worker so every trigger surface (auto / slash / CLI) writes through the
+    same code path.
+    """
+    from agent.title_generator import _retitle_config, retitle_session
+
+    resolved_session_id = db.resolve_session_id(args.session_id)
+    if not resolved_session_id:
+        print(f"Session '{args.session_id}' not found.")
+        return 1
+
+    cfg = _retitle_config()
+    default_turns = int(cfg.get("turns_window") or 10)
+    turns = int(getattr(args, "turns", None) or default_turns)
+    force = bool(getattr(args, "force", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    # Pull the last N user+assistant messages (skip tool rows). Fetch 2N to
+    # account for interleaved tool messages the worker filters out.
+    history = db.get_messages(resolved_session_id, latest=True, limit=turns * 2)
+    if not history:
+        print(f"Session '{resolved_session_id}' has no history to retitle from.")
+        return 1
+
+    current_title = db.get_session_title(resolved_session_id) or "(untitled)"
+    current_source = db.get_session_title_source(resolved_session_id) or "unknown"
+
+    if current_source == "user" and not force:
+        print(
+            f"Session '{resolved_session_id}' has a manual title "
+            f"({current_title!r}). Pass --force to overwrite."
+        )
+        return 1
+
+    if dry_run:
+        # Dry-run: show what would happen without calling the LLM. The actual
+        # title candidate requires the LLM call, so we surface the guardrails.
+        print(f"Would retitle session '{resolved_session_id}':")
+        print(f"  Current title:  {current_title!r} (source: {current_source})")
+        print(f"  Turns window:   {turns}")
+        print(f"  Force:          {force}")
+        print(f"  Platform names: NOT touched (DB-only)")
+        print("Pass without --dry-run to actually regenerate.")
+        return 0
+
+    try:
+        new_title = retitle_session(
+            db,
+            resolved_session_id,
+            history,
+            turns_window=turns,
+            force=force,
+            touch_platform_names=False,
+        )
+    except Exception as e:
+        print(f"Error: retitle failed — {e}")
+        return 1
+
+    if new_title:
+        print(f"Session '{resolved_session_id}' retitled:")
+        print(f"  {current_title!r}")
+        print(f"  → {new_title!r}")
+        return 0
+    print(
+        f"Session '{resolved_session_id}': no title change "
+        "(model returned nothing usable, or a higher-authority title held the row)."
+    )
+    return 1
+
+
 # -- dispatch -----------------------------------------------------------------
 
 _PRE_DB_HANDLERS = {"repair": _cmd_repair, "recover": _cmd_recover, "import": _cmd_import}
@@ -941,6 +1015,7 @@ _DB_HANDLERS = {
     "list": _cmd_list, "export": _cmd_export, "delete": _cmd_delete, "rename": _cmd_rename, "pinned": _cmd_pinned,
     "prune": partial(_cmd_prune_or_archive, action="prune"), "pin": partial(_cmd_pin, pinning=True),
     "archive": partial(_cmd_prune_or_archive, action="archive"), "unpin": partial(_cmd_pin, pinning=False),
+    "retitle": _cmd_retitle,
     "retitle-skills": _cmd_retitle_skills, "browse": _cmd_browse, "optimize": _cmd_optimize,
     "clean-markers": _cmd_clean_markers, "optimize-storage": _cmd_optimize_storage,
     "repair-routing": _cmd_repair_routing, "stats": _cmd_stats,

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -240,6 +240,41 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     sessions_retitle.add_argument(
         "--limit", type=int, default=200, help="Maximum sessions to examine (default: 200)")
 
+    sessions_retitle_new = sessions_subparsers.add_parser(
+        "retitle",
+        help="Regenerate a session's title from recent conversation (DB-only)",
+        description=(
+            "Regenerate a session's title using the last N turns of conversation "
+            "as context, instead of just the opening message. Writes to the DB "
+            "only — does NOT rename Telegram topics or Discord threads (matches "
+            "the /retitle slash command default). Sessions with a user-set "
+            "title are skipped unless --force is passed."
+        ),
+    )
+    sessions_retitle_new.add_argument(
+        "session_id", help="Session ID or unique prefix to retitle"
+    )
+    sessions_retitle_new.add_argument(
+        "--turns",
+        type=int,
+        default=None,
+        help=(
+            "Number of user+assistant turns to feed the title model "
+            "(default: auxiliary.title_generation.retitle.turns_window, "
+            "typically 10)"
+        ),
+    )
+    sessions_retitle_new.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite even a user-set title (default: skip user-set titles)",
+    )
+    sessions_retitle_new.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without calling the model or writing",
+    )
+
     sessions_browse = sessions_subparsers.add_parser(
         "browse", help="Interactive session picker — browse, search, and resume sessions")
     sessions_browse.add_argument("--source", help="Filter by source (cli, telegram, discord, etc.)")

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -377,6 +377,14 @@ gateway:
     current_with_title:    "📌 Session: `{session_id}`\nTitle: **{title}**"
     current_no_title:      "📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
+  retitle:
+    db_unavailable:        "Session database not available."
+    disabled:              "Retitle is disabled by config (auxiliary.title_generation.retitle.enabled)."
+    no_history:            "No conversation history to retitle from."
+    done:                  "🔄 Retitled session: **{title}**"
+    no_change:             "Retitle skipped — couldn't generate a better title."
+    user_held:             "Session has a manual title. Pass `force` to overwrite."
+
   topic:
     not_telegram_dm:         "The /topic command is only available in Telegram private chats."
     no_session_db:           "Session database not available."

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,14 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _retitle_config,
+    _retitle_enabled,
+    _condense_history,
+    _looks_like_title,
+    regenerate_title,
+    retitle_session,
+    maybe_auto_retitle,
+    MAX_TITLE_INPUT_CHARS,
 )
 from hermes_state import SessionDB
 
@@ -598,3 +606,581 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestRetitleConfig:
+    """Unit tests for _retitle_config() and _retitle_enabled()."""
+
+    DEFAULT_KEYS = {
+        "enabled": True,
+        "auto_at_turn": 10,
+        "turns_window": 10,
+        "slash_command": True,
+        "cli_command": True,
+        "touch_platform_names": False,
+        "provider": "",
+        "model": "",
+        "base_url": "",
+        "api_key": "",
+        "timeout": 30,
+        "max_concurrency": 2,
+        "prefer_fast_model": None,
+    }
+
+    def test_retitle_config_returns_defaults_when_block_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={}):
+            cfg = _retitle_config()
+        for key, expected in self.DEFAULT_KEYS.items():
+            assert cfg[key] == expected, f"default for {key} lost"
+
+    def test_retitle_config_merges_partial_user_overrides(self):
+        user_cfg = {
+            "auxiliary": {
+                "title_generation": {
+                    "retitle": {
+                        "enabled": False,
+                        "auto_at_turn": 20,
+                        # None must be treated as "use default"
+                        "provider": None,
+                    }
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=user_cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=user_cfg):
+            cfg = _retitle_config()
+
+        assert cfg["enabled"] is False
+        assert cfg["auto_at_turn"] == 20
+        # None override was skipped → default preserved
+        assert cfg["provider"] == ""
+        # Untouched keys keep defaults
+        assert cfg["turns_window"] == 10
+        assert cfg["slash_command"] is True
+        assert cfg["timeout"] == 30
+        assert cfg["max_concurrency"] == 2
+        assert cfg["prefer_fast_model"] is None
+
+    def test_retitle_config_returns_empty_dict_on_config_error(self):
+        with patch("hermes_cli.config.load_config",
+                   side_effect=RuntimeError("bad config")), \
+             patch("hermes_cli.config.load_config_readonly",
+                   side_effect=RuntimeError("bad config")):
+            assert _retitle_config() == {}
+
+    def test_retitle_enabled_true_by_default(self):
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert _retitle_enabled() is True
+
+    def test_retitle_enabled_false_when_disabled(self):
+        user_cfg = {
+            "auxiliary": {
+                "title_generation": {
+                    "retitle": {"enabled": False}
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=user_cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=user_cfg):
+            assert _retitle_enabled() is False
+
+    def test_retitle_enabled_true_when_config_broken(self):
+        with patch("hermes_cli.config.load_config",
+                   side_effect=RuntimeError("bad config")), \
+             patch("hermes_cli.config.load_config_readonly",
+                   side_effect=RuntimeError("bad config")):
+            assert _retitle_enabled() is True
+
+
+class TestCondenseHistory:
+    """Unit tests for _condense_history()."""
+
+    def test_returns_empty_for_none_history(self):
+        assert _condense_history(None) == ""
+
+    def test_returns_empty_for_empty_history(self):
+        assert _condense_history([]) == ""
+
+    def test_includes_recent_user_and_assistant_turns_with_labels(self):
+        history = [
+            {"role": "user", "content": "How do I center a div?"},
+            {"role": "assistant", "content": "Use flexbox with justify-content."},
+        ]
+        result = _condense_history(history)
+        assert "User: How do I center a div?" in result
+        assert "Assistant: Use flexbox with justify-content." in result
+
+    def test_skips_tool_messages(self):
+        history = [
+            {"role": "user", "content": "Run the tests"},
+            {"role": "tool", "content": "pytest output goes here"},
+            {"role": "assistant", "content": "Tests passed."},
+        ]
+        result = _condense_history(history)
+        assert "pytest output" not in result
+        assert "User: Run the tests" in result
+        assert "Assistant: Tests passed." in result
+
+    def test_skips_machine_authored_user_turns(self):
+        history = [
+            {"role": "user", "content": "[System note: session resumed]"},
+            {"role": "user", "content": "What's the weather like?"},
+            {"role": "assistant", "content": "I can't check weather directly."},
+        ]
+        result = _condense_history(history)
+        assert "[System note:" not in result
+        assert "User: What's the weather like?" in result
+
+    def test_skips_empty_assistant_content(self):
+        history = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "   "},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = _condense_history(history)
+        lines = result.split("\n")
+        assistant_lines = [ln for ln in lines if ln.startswith("Assistant:")]
+        assert len(assistant_lines) == 1
+        assert "Assistant: Hello!" in result
+
+    def test_truncates_individual_message_bodies_to_200_chars(self):
+        long_body = "a" * 500
+        history = [
+            {"role": "user", "content": long_body},
+            {"role": "assistant", "content": long_body},
+        ]
+        result = _condense_history(history)
+        for line in result.split("\n"):
+            # strip label prefix
+            if line.startswith("User: "):
+                body = line[len("User: "):]
+            elif line.startswith("Assistant: "):
+                body = line[len("Assistant: "):]
+            else:
+                continue
+            assert len(body) <= 200
+
+    def test_returns_only_last_turns_window_pairs(self):
+        history = []
+        for i in range(20):
+            history.append({"role": "user", "content": f"user-msg-{i}"})
+            history.append({"role": "assistant", "content": f"assistant-msg-{i}"})
+        result = _condense_history(history, turns_window=5)
+        # window=5 => last 10 messages: user-msg-15..19, assistant-msg-15..19
+        assert "user-msg-0" not in result
+        assert "user-msg-14" not in result
+        assert "user-msg-15" in result
+        assert "user-msg-19" in result
+        assert "assistant-msg-19" in result
+
+    def test_final_output_capped_at_max_title_input_chars(self):
+        history = []
+        chunk = "word " * 40  # ~200 chars → truncated to 200 per body
+        for i in range(200):
+            history.append({"role": "user", "content": chunk})
+            history.append({"role": "assistant", "content": chunk})
+        result = _condense_history(history, turns_window=100)
+        assert len(result) <= MAX_TITLE_INPUT_CHARS
+
+    def test_multimodal_user_content_flattens_to_text(self):
+        history = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Here's a screenshot,"},
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                    {"type": "text", "text": "fix the login."},
+                ],
+            },
+            {"role": "assistant", "content": "Sure, checking now."},
+        ]
+        result = _condense_history(history)
+        assert "User:" in result
+        assert "Here's a screenshot," in result
+        assert "fix the login." in result
+
+
+class TestLooksLikeTitle:
+    """Unit tests for _looks_like_title() quality gate."""
+
+    def test_rejects_empty(self):
+        assert _looks_like_title("") is False
+
+    def test_rejects_none(self):
+        assert _looks_like_title(None) is False
+
+    def test_rejects_single_word(self):
+        assert _looks_like_title("Hello") is False
+
+    def test_rejects_thirteen_word_prose(self):
+        text = "one two three four five six seven eight nine ten eleven twelve thirteen"
+        assert _looks_like_title(text) is False
+
+    def test_rejects_here_is_prefix(self):
+        assert _looks_like_title("Here is a summary") is False
+
+    def test_rejects_about_prefix(self):
+        assert _looks_like_title("about databases and connection pools") is False
+
+    def test_rejects_this_conversation_prefix(self):
+        assert _looks_like_title("This conversation is about Postgres") is False
+
+    def test_rejects_the_conversation_prefix(self):
+        assert _looks_like_title("The conversation covers Postgres") is False
+
+    def test_accepts_concise_two_words(self):
+        assert _looks_like_title("Friendly greeting") is True
+
+    def test_accepts_seven_words(self):
+        assert (
+            _looks_like_title(
+                "Debugging Postgres connection pool exhaustion during migration"
+            )
+            is True
+        )
+
+    def test_accepts_the_prefix_when_not_conversation(self):
+        assert _looks_like_title("The Postgres pool issue") is True
+
+
+class TestRegenerateTitle:
+    """Unit tests for regenerate_title()."""
+
+    def test_returns_none_for_empty_condensed(self):
+        assert regenerate_title("") is None
+        assert regenerate_title(None) is None
+        assert regenerate_title("   \n  ") is None
+
+    def test_returns_none_when_retitle_disabled(self):
+        with patch("agent.title_generator._retitle_enabled", return_value=False):
+            assert regenerate_title("User: hi\nAssistant: hello") is None
+
+    def test_calls_call_llm_with_condensed_and_title_generation_task(self):
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Debugging Postgres pool"}'
+            return resp
+
+        condensed = "User: Postgres pool is exhausted\nAssistant: Let's check settings"
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True):
+            title = regenerate_title(condensed)
+
+        assert title == "Debugging Postgres pool"
+        assert captured["task"] == "title_generation"
+        assert captured["max_tokens"] == 64
+        assert captured["temperature"] == 0.3
+        messages = captured["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == condensed
+        # response_format schema is passed through
+        assert "response_format" in captured["extra_body"]
+
+    def test_extracts_json_response_via_extract_title_text(self):
+        def mock_call_llm(**kwargs):
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button on mobile"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True):
+            assert regenerate_title("User: fix mobile login") == "Fix login button on mobile"
+
+    def test_rejects_prose_via_looks_like_title(self):
+        def mock_call_llm(**kwargs):
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            # 15 words of prose — should be rejected by _looks_like_title
+            resp.choices[0].message.content = (
+                "This conversation is a long summary about postgres and how the "
+                "user tried to fix it eventually."
+            )
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True):
+            assert regenerate_title("User: pg\nAssistant: ok") is None
+
+    def test_returns_none_on_call_llm_exception(self):
+        def mock_call_llm(**kwargs):
+            raise RuntimeError("upstream 500")
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True):
+            assert regenerate_title("User: hi\nAssistant: hey") is None
+
+    def test_respects_pinned_language(self):
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "ポストグレス プール修正"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._title_language", return_value="Japanese"):
+            regenerate_title("User: pg\nAssistant: hai")
+
+        system_prompt = captured["messages"][0]["content"]
+        assert "Japanese" in system_prompt
+
+    def test_truncates_condensed_to_max_title_input_chars(self):
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Long convo title"}'
+            return resp
+
+        big = "x" * 5000
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm), \
+             patch("agent.title_generator._retitle_enabled", return_value=True):
+            regenerate_title(big)
+
+        user_content = captured["messages"][1]["content"]
+        assert len(user_content) == MAX_TITLE_INPUT_CHARS
+
+
+class TestRetitleSession:
+    """Unit tests for retitle_session() — the sync worker."""
+
+    def test_returns_none_when_session_db_is_none(self):
+        assert retitle_session(None, "sess-1", []) is None
+
+    def test_returns_none_when_session_id_is_empty(self):
+        db = MagicMock()
+        assert retitle_session(db, "", []) is None
+        assert retitle_session(db, None, []) is None
+
+    def test_skips_when_user_title_and_not_forced(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "user"
+        with patch("agent.title_generator._persist_session_title") as mock_persist, \
+             patch("agent.title_generator.regenerate_title") as mock_regen:
+            result = retitle_session(db, "sess-1", [{"role": "user", "content": "hi"}])
+        assert result is None
+        mock_persist.assert_not_called()
+        mock_regen.assert_not_called()
+
+    def test_proceeds_when_user_title_and_force_is_true(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "user"
+        db.get_conversation_root.return_value = "sess-1"
+        with patch("agent.title_generator._condense_history", return_value="User: hi\nAssistant: hello"), \
+             patch("agent.title_generator.regenerate_title", return_value="Cool title") as mock_regen, \
+             patch("agent.title_generator._persist_session_title", return_value="Cool title") as mock_persist, \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            result = retitle_session(db, "sess-1", [{"role": "user", "content": "hi"}], force=True)
+        assert result == "Cool title"
+        mock_regen.assert_called_once()
+        mock_persist.assert_called_once()
+        # Persist called with source="llm"
+        _, kwargs = mock_persist.call_args
+        assert kwargs.get("source") == "llm"
+
+    def test_condenses_history_and_persists_llm_title(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "sess-1"
+        history = [
+            {"role": "user", "content": "postgres pool exhausted"},
+            {"role": "assistant", "content": "let's check settings"},
+        ]
+        with patch("agent.title_generator._condense_history", return_value="User: postgres\nAssistant: check") as mock_cond, \
+             patch("agent.title_generator.regenerate_title", return_value="Debugging Postgres pool") as mock_regen, \
+             patch("agent.title_generator._persist_session_title", return_value="Debugging Postgres pool") as mock_persist, \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            result = retitle_session(db, "sess-1", history, turns_window=7)
+
+        assert result == "Debugging Postgres pool"
+        mock_cond.assert_called_once_with(history, turns_window=7)
+        mock_regen.assert_called_once_with("User: postgres\nAssistant: check")
+        args, kwargs = mock_persist.call_args
+        assert args[0] is db
+        assert args[1] == "sess-1"
+        assert args[2] == "Debugging Postgres pool"
+        assert kwargs["source"] == "llm"
+
+    def test_returns_none_when_condensed_empty(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "sess-1"
+        with patch("agent.title_generator._condense_history", return_value=""), \
+             patch("agent.title_generator.regenerate_title") as mock_regen, \
+             patch("agent.title_generator._persist_session_title") as mock_persist, \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            result = retitle_session(db, "sess-1", [])
+        assert result is None
+        mock_regen.assert_not_called()
+        mock_persist.assert_not_called()
+
+    def test_returns_none_when_regenerate_returns_none(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "sess-1"
+        with patch("agent.title_generator._condense_history", return_value="User: hi"), \
+             patch("agent.title_generator.regenerate_title", return_value=None), \
+             patch("agent.title_generator._persist_session_title") as mock_persist, \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            result = retitle_session(db, "sess-1", [{"role": "user", "content": "hi"}])
+        assert result is None
+        mock_persist.assert_not_called()
+
+    def test_returns_none_when_persist_returns_none(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "sess-1"
+        with patch("agent.title_generator._condense_history", return_value="User: hi"), \
+             patch("agent.title_generator.regenerate_title", return_value="Some title"), \
+             patch("agent.title_generator._persist_session_title", return_value=None), \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            result = retitle_session(db, "sess-1", [{"role": "user", "content": "hi"}])
+        assert result is None
+
+    def test_never_raises_on_internal_exception(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "sess-1"
+        with patch("agent.title_generator._condense_history", side_effect=RuntimeError("boom")), \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context"):
+            # Must not raise
+            result = retitle_session(db, "sess-1", [{"role": "user", "content": "hi"}])
+        assert result is None
+
+    def test_sets_accounting_and_conversation_context(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.return_value = "root-sess"
+        with patch("agent.title_generator._condense_history", return_value=""), \
+             patch("agent.aux_accounting.set_accounting_context") as mock_acc, \
+             patch("agent.portal_tags.set_conversation_context") as mock_conv:
+            retitle_session(db, "sess-1", [])
+        mock_conv.assert_called_once_with("root-sess")
+        mock_acc.assert_called_once_with(db, "sess-1")
+
+    def test_falls_back_to_session_id_when_conversation_root_raises(self):
+        db = MagicMock()
+        db.get_session_title_source.return_value = "llm"
+        db.get_conversation_root.side_effect = RuntimeError("db locked")
+        with patch("agent.title_generator._condense_history", return_value=""), \
+             patch("agent.aux_accounting.set_accounting_context"), \
+             patch("agent.portal_tags.set_conversation_context") as mock_conv:
+            retitle_session(db, "sess-1", [])
+        mock_conv.assert_called_once_with("sess-1")
+
+
+class TestMaybeAutoRetitle:
+    """Tests for maybe_auto_retitle() — one-shot fire-and-forget trigger."""
+
+    def _make_history(self, n_user_turns):
+        """Build a history with n real user turns interleaved with assistant."""
+        history = []
+        for i in range(n_user_turns):
+            history.append({"role": "user", "content": f"user message {i} is a real question"})
+            history.append({"role": "assistant", "content": f"assistant reply {i}"})
+        return history
+
+    def test_returns_early_when_session_db_none(self):
+        with patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(None, "sess-1", self._make_history(10))
+            mock_thread.assert_not_called()
+
+    def test_returns_early_when_session_id_empty(self):
+        db = MagicMock()
+        with patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "", self._make_history(10))
+            mock_thread.assert_not_called()
+
+    def test_returns_early_when_disabled_by_config(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=False), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10))
+            mock_thread.assert_not_called()
+
+    def test_returns_early_when_auto_at_turn_is_zero(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10), auto_at_turn=0)
+            mock_thread.assert_not_called()
+
+    def test_fires_thread_at_exactly_10_user_turns(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": False}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10), auto_at_turn=10)
+            assert mock_thread.call_count == 1
+            _, kwargs = mock_thread.call_args
+            assert kwargs["target"] is retitle_session
+            mock_thread.return_value.start.assert_called_once()
+
+    def test_does_not_fire_at_9_user_turns(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": False}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(9), auto_at_turn=10)
+            mock_thread.assert_not_called()
+
+    def test_does_not_fire_at_11_user_turns(self):
+        # Exactly-N semantics — one-shot trigger, not "N or more".
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": False}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(11), auto_at_turn=10)
+            mock_thread.assert_not_called()
+
+    def test_thread_is_daemon_with_correct_name(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": False}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10), auto_at_turn=10)
+            _, kwargs = mock_thread.call_args
+            assert kwargs["daemon"] is True
+            assert kwargs["name"] == "auto-retitle"
+            # kwargs passed to retitle_session
+            call_kwargs = kwargs["kwargs"]
+            assert call_kwargs["force"] is False
+            assert "turns_window" in call_kwargs
+            assert "touch_platform_names" in call_kwargs
+
+    def test_passes_touch_platform_names_from_config(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": True}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10), auto_at_turn=10)
+            _, kwargs = mock_thread.call_args
+            assert kwargs["kwargs"]["touch_platform_names"] is True
+
+    def test_passes_turns_window_to_thread_kwargs(self):
+        db = MagicMock()
+        with patch("agent.title_generator._retitle_enabled", return_value=True), \
+             patch("agent.title_generator._retitle_config", return_value={"touch_platform_names": False}), \
+             patch("agent.title_generator.threading.Thread") as mock_thread:
+            maybe_auto_retitle(db, "sess-1", self._make_history(10), auto_at_turn=10, turns_window=15)
+            _, kwargs = mock_thread.call_args
+            assert kwargs["kwargs"]["turns_window"] == 15

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -495,3 +495,88 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
+
+
+# ---------------------------------------------------------------------------
+# Auto-retitle dispatch (Task 6)
+# ---------------------------------------------------------------------------
+#
+# The turn-start prologue also fires ``maybe_auto_retitle`` alongside
+# ``maybe_auto_title``. The two dispatches are independent — one failing must
+# not skip the other — and both inherit the ``_UNTITLED_PLATFORMS`` exclusion
+# via the outer early-return, so cron/subagent never even reach the dispatch.
+
+
+def _title_and_retitle_turn(
+    platform,
+    message="Fix the login button",
+    retitle_cfg=None,
+    retitle_cfg_raises=False,
+    title_raises=False,
+):
+    """Run the prologue and return (title_mock, retitle_mock, cfg_mock)."""
+    from agent import turn_context
+
+    cfg = retitle_cfg if retitle_cfg is not None else {
+        "auto_at_turn": 10,
+        "turns_window": 10,
+    }
+
+    with patch("agent.title_generator.maybe_auto_title") as titler, \
+         patch("agent.title_generator.maybe_auto_retitle") as retitler, \
+         patch("agent.title_generator._retitle_config") as cfg_mock:
+        if retitle_cfg_raises:
+            cfg_mock.side_effect = RuntimeError("config read boom")
+        else:
+            cfg_mock.return_value = cfg
+        if title_raises:
+            titler.side_effect = RuntimeError("title dispatch boom")
+        turn_context._maybe_title_session_at_turn_start(
+            _TitlingAgent(platform),
+            [{"role": "user", "content": message}],
+        )
+    return titler, retitler, cfg_mock
+
+
+def test_turn_prologue_fires_maybe_auto_retitle_alongside_maybe_auto_title():
+    """A normal human-facing turn dispatches both title and retitle."""
+    titler, retitler, _cfg = _title_and_retitle_turn("cli")
+    assert titler.called, "auto-title should still fire"
+    assert retitler.called, "auto-retitle should fire alongside auto-title"
+
+
+@pytest.mark.parametrize("platform", ["cron", "subagent"])
+def test_turn_prologue_skips_retitle_for_untitled_platforms(platform):
+    """The outer early-return keeps retitle off cron/subagent surfaces."""
+    titler, retitler, _cfg = _title_and_retitle_turn(platform)
+    assert not titler.called
+    assert not retitler.called
+
+
+def test_turn_prologue_reads_retitle_config_for_auto_at_turn():
+    """The dispatch forwards auto_at_turn/turns_window from the merged config."""
+    titler, retitler, cfg_mock = _title_and_retitle_turn(
+        "cli",
+        retitle_cfg={"auto_at_turn": 20, "turns_window": 15, "enabled": True},
+    )
+    assert cfg_mock.called
+    assert retitler.called
+    kwargs = retitler.call_args.kwargs
+    assert kwargs.get("auto_at_turn") == 20
+    assert kwargs.get("turns_window") == 15
+
+
+def test_retitle_dispatch_exception_does_not_break_auto_title():
+    """A retitle-config read failure must not skip the auto-title call."""
+    titler, retitler, _cfg = _title_and_retitle_turn(
+        "cli", retitle_cfg_raises=True
+    )
+    assert titler.called, "auto-title must still fire when retitle-config errors"
+    assert not retitler.called
+
+
+def test_auto_title_exception_does_not_break_retitle_dispatch():
+    """An auto-title failure must not skip the retitle dispatch."""
+    titler, retitler, _cfg = _title_and_retitle_turn("cli", title_raises=True)
+    assert titler.called
+    assert retitler.called, "auto-retitle must still fire when auto-title errors"

--- a/tests/gateway/test_retitle_command.py
+++ b/tests/gateway/test_retitle_command.py
@@ -1,0 +1,255 @@
+"""Tests for /retitle gateway slash command.
+
+Tests the ``_handle_retitle_command`` handler that regenerates a session's
+title from the last N conversation turns. Mirrors the fixture patterns used
+in ``test_title_command.py``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/retitle", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890"):
+    """Build a MessageEvent for testing."""
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(session_db=None):
+    """Create a bare GatewayRunner with a mock session_store and optional session_db."""
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    if session_db is not None:
+        from hermes_state import AsyncSessionDB
+        session_db = AsyncSessionDB(session_db)
+    runner._session_db = session_db
+
+    mock_session_entry = MagicMock()
+    mock_session_entry.session_id = "test_session_123"
+    mock_session_entry.session_key = "telegram:12345:67890"
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = mock_session_entry
+    runner.session_store = mock_store
+
+    return runner
+
+
+def _default_cfg(**overrides):
+    """Default retitle config used by the handler."""
+    cfg = {
+        "enabled": True,
+        "turns_window": 10,
+        "touch_platform_names": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# _handle_retitle_command
+# ---------------------------------------------------------------------------
+
+
+class TestHandleRetitleCommand:
+    """Tests for GatewayRunner._handle_retitle_command."""
+
+    @pytest.mark.asyncio
+    async def test_returns_done_message_on_success(self, tmp_path):
+        """Successful retitle returns the done string with the new title."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.set_session_title("test_session_123", "Old Title")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        with patch("agent.title_generator._retitle_config", return_value=_default_cfg()), \
+             patch("agent.title_generator.retitle_session", return_value="Debugging Postgres pool"):
+            # Populate history so `if not history` doesn't short-circuit.
+            db.append_message("test_session_123", "user", "hey")
+            result = await runner._handle_retitle_command(event)
+
+        assert "Debugging Postgres pool" in result
+        assert "Retitled" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_no_change_when_retitle_returns_none(self, tmp_path):
+        """When retitle_session returns None (and title source is not 'user'), reply is 'no_change'."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.append_message("test_session_123", "user", "hey")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        with patch("agent.title_generator._retitle_config", return_value=_default_cfg()), \
+             patch("agent.title_generator.retitle_session", return_value=None):
+            result = await runner._handle_retitle_command(event)
+
+        assert "couldn't" in result.lower() or "skipped" in result.lower()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_user_held_when_title_is_user_set(self, tmp_path):
+        """When the title is user-set and retitle returns None, reply asks to pass 'force'."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.set_session_title("test_session_123", "My Manual Title")
+        # Force provenance to 'user' — the retitle worker's guard checks this.
+        db.set_session_title_source("test_session_123", "user")
+        db.append_message("test_session_123", "user", "hey")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        with patch("agent.title_generator._retitle_config", return_value=_default_cfg()), \
+             patch("agent.title_generator.retitle_session", return_value=None):
+            result = await runner._handle_retitle_command(event)
+
+        assert "manual title" in result.lower()
+        assert "force" in result.lower()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_passes_force_when_arg_is_force(self, tmp_path):
+        """`/retitle force` passes force=True through to retitle_session."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.append_message("test_session_123", "user", "hey")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle force")
+
+        with patch("agent.title_generator._retitle_config", return_value=_default_cfg()), \
+             patch("agent.title_generator.retitle_session", return_value="New Title") as mock_retitle:
+            await runner._handle_retitle_command(event)
+
+        assert mock_retitle.called
+        _, kwargs = mock_retitle.call_args
+        assert kwargs.get("force") is True
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_reads_turns_window_from_config(self, tmp_path):
+        """Config.turns_window drives both get_messages(limit=) and retitle_session(turns_window=)."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        for i in range(30):
+            db.append_message("test_session_123", "user", f"msg-{i}")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        cfg = _default_cfg(turns_window=15)
+        with patch("agent.title_generator._retitle_config", return_value=cfg), \
+             patch("agent.title_generator.retitle_session", return_value="X") as mock_retitle, \
+             patch.object(db, "get_messages", wraps=db.get_messages) as mock_get:
+            await runner._handle_retitle_command(event)
+
+        # get_messages should be called with limit=turns_window*2 == 30
+        _, kwargs = mock_get.call_args
+        assert kwargs.get("limit") == 30
+        assert kwargs.get("latest") is True
+
+        _, r_kwargs = mock_retitle.call_args
+        assert r_kwargs.get("turns_window") == 15
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_passes_touch_platform_names_from_config(self, tmp_path):
+        """Config.touch_platform_names is forwarded to retitle_session."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+        db.append_message("test_session_123", "user", "hey")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        cfg = _default_cfg(touch_platform_names=True)
+        with patch("agent.title_generator._retitle_config", return_value=cfg), \
+             patch("agent.title_generator.retitle_session", return_value="X") as mock_retitle:
+            await runner._handle_retitle_command(event)
+
+        _, kwargs = mock_retitle.call_args
+        assert kwargs.get("touch_platform_names") is True
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_disabled_when_config_disabled(self, tmp_path):
+        """When retitle.enabled is False, handler refuses with the disabled string."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        with patch("agent.title_generator._retitle_config", return_value={"enabled": False}):
+            result = await runner._handle_retitle_command(event)
+
+        assert "disabled" in result.lower()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_no_history_when_empty(self, tmp_path):
+        """Empty session history returns the no_history string."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        event = _make_event(text="/retitle")
+
+        with patch("agent.title_generator._retitle_config", return_value=_default_cfg()):
+            result = await runner._handle_retitle_command(event)
+
+        assert "no conversation history" in result.lower()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_db_unavailable_when_no_session_db(self):
+        """Without a session_db handle, the handler returns the db_unavailable string."""
+        runner = _make_runner(session_db=None)
+        event = _make_event(text="/retitle")
+
+        result = await runner._handle_retitle_command(event)
+        assert "not available" in result.lower() or "unavailable" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# /retitle in the command registry
+# ---------------------------------------------------------------------------
+
+
+class TestRetitleInRegistry:
+    """Verify /retitle is registered and dispatchable."""
+
+    def test_retitle_in_command_registry(self):
+        """The /retitle command is registered with busy_policy='dispatch'."""
+        from hermes_cli.commands import resolve_command
+        cmd = resolve_command("retitle")
+        assert cmd is not None
+        assert cmd.name == "retitle"
+        assert cmd.busy_policy == "dispatch"
+        assert cmd.category == "Session"

--- a/tests/hermes_cli/test_sessions_retitle.py
+++ b/tests/hermes_cli/test_sessions_retitle.py
@@ -1,0 +1,179 @@
+"""CLI ``hermes sessions retitle`` — manual retitle entry point.
+
+Third trigger surface for the retitle worker, alongside the exactly-N
+auto-fire and the ``/retitle`` slash command. All three write through
+``retitle_session`` in ``agent.title_generator``, so these tests focus on
+the CLI adapter: arg parsing, provenance guard, dry-run mode, and error
+paths. The worker itself is covered by tests/agent/test_title_generator.py.
+"""
+
+import sys
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+
+class _FakeDB:
+    """Minimal SessionDB double for the retitle CLI action."""
+
+    def __init__(
+        self,
+        *,
+        known=("20260827_120000_abc123",),
+        title="Old Title",
+        source="llm",
+        history: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self.known = set(known)
+        self._titles = {sid: title for sid in known}
+        self._sources = {sid: source for sid in known}
+        self._history = history if history is not None else [
+            {"role": "user", "content": "hello", "id": 1},
+            {"role": "assistant", "content": "hi there", "id": 2},
+        ]
+        self.get_messages_calls: List[Dict[str, Any]] = []
+        self.closed = False
+
+    def resolve_session_id(self, session_id):
+        for k in self.known:
+            if k.startswith(session_id):
+                return k
+        return None
+
+    def get_session_title(self, session_id):
+        return self._titles.get(session_id)
+
+    def get_session_title_source(self, session_id):
+        return self._sources.get(session_id)
+
+    def get_messages(self, session_id, *, latest=False, limit=None, **_kwargs):
+        self.get_messages_calls.append({"session_id": session_id, "latest": latest, "limit": limit})
+        return list(self._history)
+
+    def close(self):
+        self.closed = True
+
+
+def _run(monkeypatch, capsys, argv_tail, db, *, retitle_return: Optional[str] = "New Better Title"):
+    """Invoke the CLI with retitle_session mocked out."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", *argv_tail])
+
+    # The action patches retitle_session AND _retitle_config at their
+    # source module — the CLI imports lazily inside the action.
+    with patch("agent.title_generator.retitle_session", return_value=retitle_return) as m_ret, \
+         patch("agent.title_generator._retitle_config", return_value={"turns_window": 10}):
+        try:
+            main_mod.main()
+            code = 0
+        except SystemExit as e:
+            code = e.code or 0
+
+    return code, capsys.readouterr().out, m_ret
+
+
+def test_retitle_writes_new_title(monkeypatch, capsys):
+    db = _FakeDB()
+    code, out, m_ret = _run(monkeypatch, capsys, ["retitle", "20260827_120000_abc123"], db)
+    assert code == 0
+    assert m_ret.called
+    assert "retitled" in out.lower()
+    assert "New Better Title" in out
+    assert "Old Title" in out
+
+
+def test_retitle_accepts_unique_prefix(monkeypatch, capsys):
+    db = _FakeDB()
+    code, out, _m = _run(monkeypatch, capsys, ["retitle", "20260827_120000"], db)
+    assert code == 0
+    assert "20260827_120000_abc123" in out
+
+
+def test_retitle_unknown_session_id(monkeypatch, capsys):
+    db = _FakeDB()
+    code, out, m_ret = _run(monkeypatch, capsys, ["retitle", "nope"], db)
+    assert code == 1
+    assert "not found" in out.lower()
+    assert not m_ret.called
+
+
+def test_retitle_skips_user_set_title_without_force(monkeypatch, capsys):
+    db = _FakeDB(title="Deb's Custom Title", source="user")
+    code, out, m_ret = _run(monkeypatch, capsys, ["retitle", "20260827_120000_abc123"], db)
+    assert code == 1
+    assert "manual title" in out.lower()
+    assert "--force" in out
+    assert not m_ret.called
+
+
+def test_retitle_force_overwrites_user_title(monkeypatch, capsys):
+    db = _FakeDB(title="Deb's Custom Title", source="user")
+    code, out, m_ret = _run(
+        monkeypatch, capsys, ["retitle", "20260827_120000_abc123", "--force"], db
+    )
+    assert code == 0
+    assert m_ret.called
+    # Force flag propagates to the worker
+    _args, kwargs = m_ret.call_args
+    assert kwargs.get("force") is True
+
+
+def test_retitle_dry_run_skips_llm_call(monkeypatch, capsys):
+    db = _FakeDB()
+    code, out, m_ret = _run(
+        monkeypatch, capsys, ["retitle", "20260827_120000_abc123", "--dry-run"], db
+    )
+    assert code == 0
+    assert not m_ret.called
+    assert "would retitle" in out.lower()
+    assert "old title" in out.lower()
+    assert "not touched" in out.lower()
+
+
+def test_retitle_no_history_fails_cleanly(monkeypatch, capsys):
+    db = _FakeDB(history=[])
+    code, out, m_ret = _run(monkeypatch, capsys, ["retitle", "20260827_120000_abc123"], db)
+    assert code == 1
+    assert "no history" in out.lower()
+    assert not m_ret.called
+
+
+def test_retitle_custom_turns_flag_propagates(monkeypatch, capsys):
+    db = _FakeDB()
+    code, _out, m_ret = _run(
+        monkeypatch,
+        capsys,
+        ["retitle", "20260827_120000_abc123", "--turns", "20"],
+        db,
+    )
+    assert code == 0
+    _args, kwargs = m_ret.call_args
+    assert kwargs.get("turns_window") == 20
+    # get_messages fetched 2 * turns
+    assert db.get_messages_calls[0]["limit"] == 40
+
+
+def test_retitle_worker_returning_none_reports_no_change(monkeypatch, capsys):
+    db = _FakeDB()
+    code, out, m_ret = _run(
+        monkeypatch,
+        capsys,
+        ["retitle", "20260827_120000_abc123"],
+        db,
+        retitle_return=None,
+    )
+    assert code == 1
+    assert m_ret.called
+    assert "no title change" in out.lower()
+
+
+def test_retitle_never_touches_platform_names(monkeypatch, capsys):
+    """DB-only-by-default is the whole point of the manual CLI too."""
+    db = _FakeDB()
+    _code, _out, m_ret = _run(
+        monkeypatch, capsys, ["retitle", "20260827_120000_abc123"], db
+    )
+    _args, kwargs = m_ret.call_args
+    assert kwargs.get("touch_platform_names") is False


### PR DESCRIPTION
## Summary

Adds a `retitle` capability to Hermes: regenerate a session's title from the last N turns of conversation, not just the opening message.

Fixes the "Friendly greeting #N" title-spam problem — sessions that open with "hi" get named after what the conversation actually became.

Three trigger surfaces, all routing through the same worker:
- **Auto-fire** (once at user message count == `auto_at_turn`, default 10)
- **`/retitle`** slash command (current session, uses last N turns)
- **`hermes sessions retitle <id>`** CLI (any historical session, with `--turns`, `--force`, `--dry-run`)

## Design decisions

- **DB-only by default** (`touch_platform_names: false`). Retitle updates the session title in the DB (Desktop sidebar, `hermes sessions list`, session search) but does **not** rename Telegram topics or Discord threads. Renaming platform-level names on a backfill would surprise users; opt-in only.
- **Not periodic.** Auto-retitle fires exactly once at user message count == N. No recurring retitles. Users who want periodic behavior can drive it externally via the CLI.
- **Provenance ladder preserved.** Retitle writes with `source="llm"` — the same tier as the initial LLM-upgrade title. User-set titles (`source="user"`) are never overwritten unless `--force` is passed on the CLI.
- **`_UNTITLED_PLATFORMS` inheritance.** The turn-start integration inherits the existing `cron` / `subagent` exclusion automatically — those surfaces never get auto-titled and never get auto-retitled.

## Related work

- Salvages the core title-generation helpers (`_condense_history`, `regenerate_title`, `_looks_like_title`) from PR #29983 (TheoLong, still open). Author credit retained via commit body attribution. This PR does **not** adopt #29983's Discord-thread wiring or periodic trigger.
- Addresses issue #5715 (`/title` without args → generate from conversation) and issue #15775 (`hermes sessions retitle` backfill command, which was explicitly deferred upstream).
- Config commit body references #82655 for the periodic-retitle proposal this dovetails with — this PR ships the one-shot + manual triggers on the same config surface, leaving room for a future opt-in periodic mode.

## How to test

```bash
# Auto-fire (default: turn 10)
# Just have a normal conversation past 10 user messages and watch the title update.

# Slash command (current session)
/retitle

# CLI (any session)
hermes sessions retitle <session_id>
hermes sessions retitle <prefix> --turns 20
hermes sessions retitle <prefix> --dry-run          # preview without calling the LLM
hermes sessions retitle <prefix> --force            # overwrite even user-set titles
```

Config surface (all opt-in, defaults are conservative):

```yaml
auxiliary:
  title_generation:
    retitle:
      enabled: true          # gate the whole feature
      auto_at_turn: 10       # 0 disables auto-retitle
      turns_window: 10       # how many turns feed the model
      touch_platform_names: false   # rename Telegram topics too? (default no)
      # Optional model override — inherits title_generation.* if unset:
      # provider, model, base_url, api_key, timeout, max_concurrency, prefer_fast_model
```

## Testing

- **137/137 tests pass** across 4 test files (`test_title_generator.py`, `test_turn_context.py`, `test_retitle_command.py`, `test_sessions_retitle.py`)
- Windows footgun lint clean (`scripts/check-windows-footguns.py`) on all 8 modified files
- Test coverage is ~60% of the diff by line count — covers the worker guardrails, provenance protection, dry-run mode, force-override, empty-history handling, turns-window propagation, and platform-name isolation

## Platforms tested

- Linux (Debian bookworm, Python 3.11)

I don't have a Windows machine to test locally, but the changes route through the existing title-generation code path (which is already cross-platform), and the footgun linter is green. Happy to have a Windows reviewer verify.

## Commits (Conventional Commits)

```
feat(config): add retitle block under auxiliary.title_generation
feat(title): add _retitle_config and _retitle_enabled accessors
feat(title): add _condense_history helper for retitle input
feat(title): add _looks_like_title and regenerate_title
feat(title): add retitle_session worker + maybe_auto_retitle trigger
feat(turn): fire maybe_auto_retitle at turn-start
feat(slash): add /retitle command
feat(cli): add `hermes sessions retitle <id>`
```

Each commit is atomic and buildable; the tree passes `scripts/run_tests.sh` at every step.
