### PR TITLE
fix(auxiliary): thread the explicit vision api_key to named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7556,6 +7556,7 @@ def resolve_vision_provider_client(
                 return _finalize(requested, client, final_model)
         # Fallback: try without explicit base_url (old behavior)
         client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+                                                 api_key=resolved_api_key or None,
                                                  api_mode=resolved_api_mode,
                                                  main_runtime=runtime,
                                                  is_vision=True)
@@ -7563,7 +7564,16 @@ def resolve_vision_provider_client(
             return requested, None, None
         return requested, client, final_model
 
+    # Explicit provider selection (including named custom providers, e.g.
+    # auxiliary.vision.provider: my-vision-provider). The resolved per-task
+    # api_key must reach the client builder — dropping it here sent the
+    # credential-pool / auth.json key for the provider instead of the
+    # explicitly configured auxiliary.vision.api_key, 401-ing on named
+    # custom providers whose pool credential differs or is absent (#96232).
+    # ``or None`` keeps the pool/env resolution path byte-identical when no
+    # explicit key was configured.
     client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+                                             api_key=resolved_api_key or None,
                                              api_mode=resolved_api_mode,
                                              main_runtime=runtime,
                                              is_vision=True)

--- a/tests/agent/test_vision_explicit_named_provider_key.py
+++ b/tests/agent/test_vision_explicit_named_provider_key.py
@@ -1,0 +1,79 @@
+"""Regression test: explicit auxiliary.vision.api_key must reach the client (#96232).
+
+`resolve_vision_provider_client` with an explicitly configured named provider
+(e.g. ``auxiliary.vision.provider: my-vision-provider``) dropped the resolved
+per-task ``api_key`` on its final ``_get_cached_client`` call, so the
+credential-pool / auth.json key for the provider was sent instead — a 401 on
+named custom providers whose pool credential differs from the explicit
+``auxiliary.vision.api_key``. The zai branch above already threaded the key;
+the generic named-provider path now does too.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  default: test-model\n"
+        "custom_providers:\n"
+        "  - name: my-vision-provider\n"
+        "    base_url: https://example.invalid/v1\n"
+        "    api_mode: chat_completions\n"
+        "    model: my-vision-model\n"
+    )
+
+
+def _capture_client(captured):
+    def _fake_cached_client(provider, model=None, async_mode=False,
+                            base_url=None, api_key=None, api_mode=None,
+                            main_runtime=None, is_vision=False, task=None):
+        captured["provider"] = provider
+        captured["api_key"] = api_key
+        return MagicMock(), model
+
+    return _fake_cached_client
+
+
+class TestVisionExplicitNamedProviderKey:
+    def test_explicit_api_key_reaches_the_client_builder(self, monkeypatch):
+        """The explicitly configured per-task key must be what the client is
+        built with — not the pool/auth.json credential."""
+        from agent import auxiliary_client as ac
+
+        # Non-secret test fixture value via env (never a usable credential).
+        monkeypatch.setenv("HERMES_TEST_VISION_KEY", "test-key-not-a-credential")
+        explicit_key = os.environ["HERMES_TEST_VISION_KEY"]
+
+        captured = {}
+        with patch.object(ac, "_get_cached_client", _capture_client(captured)):
+            provider, client, final_model = ac.resolve_vision_provider_client(
+                provider="my-vision-provider",
+                model="my-vision-model",
+                api_key=explicit_key,
+            )
+
+        assert provider == "my-vision-provider"
+        assert client is not None
+        assert captured["api_key"] == explicit_key
+        assert captured["provider"] == "my-vision-provider"
+
+    def test_absent_api_key_stays_none(self):
+        """No explicit key → None passes through so the pool/env resolution
+        path inside the builder is unchanged."""
+        from agent import auxiliary_client as ac
+
+        captured = {}
+        with patch.object(ac, "_get_cached_client", _capture_client(captured)):
+            ac.resolve_vision_provider_client(
+                provider="my-vision-provider",
+                model="my-vision-model",
+            )
+
+        assert captured["api_key"] is None


### PR DESCRIPTION
## What does this PR do?

`resolve_vision_provider_client`'s final generic branch — explicit provider selection, which is how **named custom providers** (`auxiliary.vision.provider: my-vision-provider`) are routed — dropped the resolved per-task `api_key` on its `_get_cached_client` call. The zai branch ten lines above already threads it; the generic path didn't. The client builder therefore fell back to the provider's credential-pool / `auth.json` key, so a valid, explicitly configured `auxiliary.vision.api_key` on a named custom provider whose pool credential differs (or is absent) produced `401 Invalid token` on every `vision_analyze` call — while the same provider, token, model, and image worked fine through direct OpenAI-compatible calls and through normal chat (#96232).

The resolved key is now passed through (`or None`, so the pool/env resolution path is byte-identical when no explicit key was configured); the zai no-base-url fallback branch gets the same threading.

## Related Issue

Fixes #96232

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/auxiliary_client.py` — the final generic branch and the zai fallback branch of `resolve_vision_provider_client` pass `api_key=resolved_api_key or None` to `_get_cached_client`, mirroring the zai explicit-URL branch; rationale documented at the site.
- `tests/agent/test_vision_explicit_named_provider_key.py` (new, 2 tests): the explicitly configured per-task key reaches the client builder for a named custom provider (captured at the `_get_cached_client` seam); an absent key passes `None` so the pool path is unchanged.

## How to Test

1. `python -m pytest tests/agent/test_vision_explicit_named_provider_key.py -q` — should pass (2 passed).
2. Red/green: on unpatched `main`, the first test fails (the captured `api_key` is `None` — the explicit key was dropped); with this PR both pass.
3. Adjacent suites: `python -m pytest tests/agent/test_vision_resolved_args.py -q` — should pass. Observed pre-existing failure on this machine (verified identical on unpatched `main`, unrelated to this diff): `test_auxiliary_named_custom_providers.py::TestProvidersDictApiModeAnthropicMessages::test_resolve_provider_client_returns_anthropic_client` (expects `AnthropicAuxiliaryClient`, gets `OpenAI`) — a `resolve_provider_client` anthropic-wire selection issue, not the vision resolver this PR touches.
4. Manual (per the issue): named custom provider + `auxiliary.vision.api_key` — `vision_analyze` now authenticates with the explicit key instead of 401-ing.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the dropped-key mechanism and the `or None` no-key contract documented at the call site)
- [x] New and existing unit tests pass locally (2 new; adjacent vision suites green)
- [x] Changes are backward compatible (`api_key or None` keeps the no-explicit-key path identical)
