### PR TITLE
fix(auxiliary): stop named vision providers from rejecting explicit API keys

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6694,7 +6694,8 @@ def resolve_provider_client(
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
-            custom_key = (custom_entry.get("api_key") or "").strip()
+            explicit_custom_key = (explicit_api_key or "").strip()
+            custom_key = explicit_custom_key or (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)
@@ -6704,7 +6705,7 @@ def resolve_provider_client(
             # agent turn works while every auxiliary call (title generation,
             # compression, vision, embedding) 401s on the placeholder below.
             custom_key_cmd = str(custom_entry.get("key_cmd", "") or "").strip()
-            if custom_key_cmd:
+            if custom_key_cmd and not explicit_custom_key:
                 from agent.command_token_source import build_command_token_provider
                 custom_key = build_command_token_provider(
                     custom_key_cmd, custom_entry.get("name") or provider
@@ -7556,6 +7557,7 @@ def resolve_vision_provider_client(
                 return _finalize(requested, client, final_model)
         # Fallback: try without explicit base_url (old behavior)
         client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+                                                 api_key=resolved_api_key,
                                                  api_mode=resolved_api_mode,
                                                  main_runtime=runtime,
                                                  is_vision=True)
@@ -7564,6 +7566,7 @@ def resolve_vision_provider_client(
         return requested, client, final_model
 
     client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+                                             api_key=resolved_api_key,
                                              api_mode=resolved_api_mode,
                                              main_runtime=runtime,
                                              is_vision=True)

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -109,6 +109,28 @@ class TestResolveProviderClientNamedCustom:
         assert model == "my-model"
         assert "beans.local" in str(client.base_url)
 
+    def test_explicit_api_key_overrides_named_provider_credentials(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "beans",
+                    "base_url": "http://beans.local/v1",
+                    "api_key": "provider-key",
+                    "key_cmd": "printf command-key",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, _ = resolve_provider_client(
+            "beans",
+            "my-model",
+            explicit_api_key="task-key",
+        )
+
+        assert client.api_key == "task-key"
+
 
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {
@@ -203,6 +225,35 @@ class TestVisionPathApiMode:
         mock_gcc.assert_called_once()
         _, kwargs = mock_gcc.call_args
         assert kwargs.get("api_mode") == "chat_completions"
+
+    def test_named_provider_passes_task_api_key(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "auxiliary": {
+                "vision": {
+                    "provider": "beans",
+                    "model": "vision-model",
+                    "api_key": "task-key",
+                },
+            },
+            "custom_providers": [
+                {
+                    "name": "beans",
+                    "base_url": "http://beans.local/v1",
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client._get_cached_client") as mock_gcc:
+            mock_gcc.return_value = (MagicMock(), "vision-model")
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "beans"
+        assert client is not None
+        assert model == "vision-model"
+        _, kwargs = mock_gcc.call_args
+        assert kwargs.get("api_key") == "task-key"
 
 
 class TestProvidersDictApiModeAnthropicMessages:


### PR DESCRIPTION
## What does this PR do?

Auxiliary vision requests using a named custom provider can now use the explicit `auxiliary.vision.api_key` instead of silently sending the provider entry's empty or stale credential. Without this fix, an otherwise valid OpenAI-compatible vision request can fail with `401 Invalid token` even though the same endpoint, model, and token work outside the auxiliary path.

### Symptom

`vision_analyze` returns `401 Invalid token` when `auxiliary.vision` selects a named custom provider, supplies a valid per-task API key, and does not repeat that key in the provider entry.

### Impact

Users cannot run auxiliary vision through that named provider despite configuring a valid task-specific credential. The affected request may send the `no-key-required` placeholder instead.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:resolve_vision_provider_client` when a configured named provider has no explicit vision `base_url` but does have an explicit vision `api_key`.

**Causal chain:**
1. `_resolve_task_provider_model` resolves the task-specific API key.
2. The no-base-url vision branch calls `_get_cached_client` without that key, and the named-provider branch of `resolve_provider_client` ignores `explicit_api_key`.
3. The client falls back to provider-level credentials or `no-key-required`, so the authenticated endpoint rejects the request.

**Why it is wrong:** Explicit task configuration is documented as the highest-precedence auxiliary credential, but two resolver layers discard it.

**Working sibling / contrast:** Direct custom endpoints already pass `resolved_api_key` into `resolve_provider_client`, so the failure is specific to named providers on the no-explicit-base-url path.

**Ruled out:** The endpoint, model, image, and token are not invalid; the issue report confirms the equivalent direct `/chat/completions` request returns HTTP 200.

### Fix

Pass the resolved task API key through the cached vision client path, and make an explicit key override all named-provider credential sources, including `key_cmd`. Regression tests cover both resolver boundaries and explicit credential precedence.

## Related Issue

Fixes #96232

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - preserve the resolved vision API key and honor it in named custom provider resolution.
- `tests/agent/test_auxiliary_named_custom_providers.py` - cover vision key propagation and named-provider credential precedence.

## How to Test

1. Configure `auxiliary.vision.provider`, `model`, and `api_key` for a named custom provider without an inline provider key.
2. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py -k "explicit_api_key_overrides_named_provider_credentials or named_provider_passes_task_api_key" -q
```

3. Confirm both tests pass and the constructed client receives the task-specific key.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point for the focused regression tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; this restores documented credential precedence
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change is platform-independent resolver logic
- [x] Tool description/schema updates are N/A; no tool schema changed

## Screenshots / Logs

N/A; focused unit tests exercise both credential propagation boundaries.
