### PR TITLE
fix(mcp): stop leaking an unawaited watcher coroutine per stdio tool call (salvage #96044)

### DIFF
--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -92,3 +92,36 @@ def test_watcher_resolves_when_all_children_are_dead():
             )
 
     asyncio.run(_run())
+
+
+def test_watch_ok_probe_does_not_create_unawaited_coroutine():
+    """The fast-fail gate must inspect the watcher, not call it (#96044).
+
+    The old probe — inspect.isawaitable(_watch_children()) — created a
+    fresh coroutine per stdio tool call and never awaited it, emitting
+    'coroutine ... was never awaited' RuntimeWarnings under -W error and
+    churning the GC. Pin that the shipped source no longer calls the
+    watcher during the probe.
+    """
+    import inspect as _inspect
+
+    import tools.mcp_tool as mcp_mod
+
+    src = _inspect.getsource(mcp_mod)
+    assert "isawaitable(_watch_children())" not in src
+    assert "iscoroutinefunction(_watch_children)" in src
+
+
+def test_watch_ok_semantics_mock_vs_real():
+    """MagicMock watchers stay on the plain-await path; real async defs
+    (and AsyncMock) qualify for the fast-fail race — same split the old
+    isawaitable(call) probe produced, without the coroutine leak."""
+    import inspect as _inspect
+    from unittest.mock import AsyncMock, MagicMock
+
+    async def _real_watcher():  # what the real method looks like
+        pass
+
+    assert _inspect.iscoroutinefunction(_real_watcher) is True
+    assert _inspect.iscoroutinefunction(AsyncMock()) is True
+    assert _inspect.iscoroutinefunction(MagicMock()) is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6174,7 +6174,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and (inspect.iscoroutinefunction(_watch_children) or callable(_watch_children))
+                        and inspect.iscoroutinefunction(_watch_children)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6174,7 +6174,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        and (inspect.iscoroutinefunction(_watch_children) or callable(_watch_children))
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:


### PR DESCRIPTION
## Summary

The stdio fast-fail gate no longer leaks an unawaited coroutine on every MCP stdio tool call: the `_watch_ok` probe inspected awaitability by **calling** the child watcher (`inspect.isawaitable(_watch_children())`), creating a fresh never-awaited coroutine per call ("coroutine was never awaited" RuntimeWarning spam + GC churn). It now inspects the function without invoking it.

Salvage of the unique hunk from #96044 by @loulanyue (authorship preserved). The other half of that PR — the `_stdio_children_dead` polarity fix — was already on main via #94339.

## Changes

- `tools/mcp_tool.py` (@loulanyue): probe `_watch_children` without calling it. Our follow-up tightens the replacement to `inspect.iscoroutinefunction(_watch_children)` alone — the originally proposed `or callable(...)` arm would have flipped MagicMock-stubbed sessions into the fast-fail race (callable(MagicMock) is True), breaking the plain-await path the surrounding comment routes stubs to.
- 2 regression tests: source pin that the probe no longer calls the watcher (behavioral test infeasible — the leak only manifests as a GC-time RuntimeWarning), plus a semantic contract test (real async def / AsyncMock → race path, MagicMock → plain await).

## Validation

| | |
|---|---|
| tests/tools/test_mcp_stdio_children_dead.py + test_mcp_tool.py | 109 passed |
| Mutation check (mcp_tool.py reverted to main) | pin test fails → restored passes |
| Probe semantics (live) | iscoroutinefunction: real async def True, AsyncMock True, MagicMock False |
| Behavior-delta audit | only disagreement case (sync def returning awaitable) unreachable in-repo, degrades to plain await (safe) |
| Sibling sweep | 25 other isawaitable() sites all probe already-produced values — this was the only call-to-probe |
| ruff | clean |

## Credit

Coroutine-leak find and fix by @loulanyue in #96044. Closes #96044 (its polarity half was superseded by #94339).

First report of the leak: @glupta in #95938 (also reported independently by @ilgo in #96030). @liuhao1024 shipped an equivalent earlier fix in #95939 (create-once-and-reuse shape) — see that PR for the credit note on why this shape was preferred.

Closes #95938. Closes #96030. Refs #96016.

