### PR TITLE
fix(desktop): settings pages stuck on loading skeleton (off-screen window freeze + profile-switch re-seed)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -400,6 +400,7 @@ import {
   debounce,
   sanitizeWindowState,
   MIN_HEIGHT as WINDOW_MIN_HEIGHT,
+  MIN_VISIBLE,
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
 import { hiddenWindowsChildOptions } from './windows-child-options'
@@ -13919,6 +13920,43 @@ function closeQuickEntryWindow() {
   quickEntryWindow = null
 }
 
+// Keep the main window on a live display. A window restored to a display that
+// later goes away (e.g. a remote-desktop virtual display the user isn't
+// currently connected to) gets parked by Windows at (-32000,-32000) — with no
+// display event on some drivers — and Chromium treats the hidden page as
+// frozen, silently killing async work (queries, IPC replies, timers). Recover
+// to the primary work area.
+function keepMainWindowOnScreen(reason: string): void {
+  const win = mainWindow
+  if (!win || win.isDestroyed()) return
+
+  try {
+    const bounds = win.getBounds()
+    const displays = screen.getAllDisplays()
+    const onScreen = displays.some(({ workArea: a }) => {
+      if (!a) return false
+      const x = Math.min(bounds.x + bounds.width, a.x + a.width) - Math.max(bounds.x, a.x)
+      const y = Math.min(bounds.y + bounds.height, a.y + a.height) - Math.max(bounds.y, a.y)
+      return x >= MIN_VISIBLE && y >= MIN_VISIBLE
+    })
+
+    if (onScreen) return
+
+    const parked = bounds.x === -32000 && bounds.y === -32000
+    if (win.isMaximized()) win.unmaximize()
+    const primary = screen.getPrimaryDisplay().workArea
+    win.setBounds({
+      x: primary.x + 80,
+      y: primary.y + 80,
+      width: Math.min(bounds.width, primary.width - 160),
+      height: Math.min(bounds.height, primary.height - 160)
+    })
+    rememberLog(`[window-state] main window off-screen (${bounds.x},${bounds.y})${parked ? ' [parked]' : ''}; moved to primary display (${reason})`)
+  } catch (error) {
+    rememberLog(`[window-state] keepMainWindowOnScreen failed: ${error?.message || error}`)
+  }
+}
+
 function createWindow() {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
@@ -14011,6 +14049,12 @@ function createWindow() {
   if (process.env.TEST_WORKER_INDEX !== undefined) {
     revealController.reveal()
   }
+
+  // Displays can disappear after the window was restored onto them (e.g. a
+  // remote-desktop virtual display drops when the session ends), parking the
+  // window off-screen where Chromium freezes the page. See keepMainWindowOnScreen.
+  createdMainWindow.on('show', () => keepMainWindowOnScreen('show'))
+  setTimeout(() => keepMainWindowOnScreen('startup'), 1500)
 
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
@@ -17383,6 +17427,14 @@ app.whenReady().then(() => {
     screen.on('display-metrics-changed', reposition)
 
     screen.on('display-removed', reposition)
+  }
+
+  // Keep the main window on a live display (see keepMainWindowOnScreen): some
+  // virtual-display drivers vanish without a display event, so the event alone
+  // isn't enough — poll cheaply as a safety net on non-mac platforms.
+  screen.on('display-removed', () => keepMainWindowOnScreen('display-removed'))
+  if (!IS_MAC) {
+    setInterval(() => keepMainWindowOnScreen('interval'), 60_000)
   }
 
   // A hard crash can interrupt the in-memory restore loop after exact remote

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -220,6 +220,10 @@
       {
         "from": "assets/icon.ico",
         "to": "icon.ico"
+      },
+      {
+        "from": "node_modules/@nous-research/ui/dist/fonts",
+        "to": "node_modules/@nous-research/ui/dist/fonts"
       }
     ],
     "asar": true,

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -125,23 +125,38 @@ function ConfigSettingsInner({
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (loadedConfig && !configSeeded.current) {
+    // `config === null` re-seeds even when the record reference is unchanged:
+    // after a profile switch (or a frozen-page thaw) the draft is dropped, and
+    // React Query's structural sharing keeps the cached record reference stable,
+    // so this effect would otherwise never re-run on its own — the settings
+    // page would sit on its loading skeleton forever with healthy queries.
+    if (loadedConfig && (!configSeeded.current || config === null)) {
       configSeeded.current = true
       savedDiscoverySignatureRef.current = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(loadedConfig))
       setConfig(loadedConfig)
     }
-  }, [loadedConfig])
+  }, [loadedConfig, config])
 
   // A profile switch invalidates (but doesn't clear) the shared config query, so
   // the local draft would otherwise keep profile A's data and autosave it into
-  // B. Drop the seed + draft (re-seeds from B's refetch) and zero saveVersion so
-  // the pending debounced autosave is cancelled by its effect cleanup.
+  // B. Zero saveVersion so the pending debounced autosave is cancelled by its
+  // effect cleanup, then swap in the new profile's record as soon as it lands.
   useOnProfileSwitch(() => {
-    configSeeded.current = false
     savedDiscoverySignatureRef.current = undefined
-    setConfig(null)
     saveVersionRef.current = 0
     setSaveVersion(0)
+    configSeeded.current = false
+    // Seed from the refetch result directly instead of relying on the seed
+    // effect: the cached record reference can stay identical across a switch
+    // (React Query structural sharing), which would leave the effect above with
+    // nothing to observe — the page would keep profile A's data or, worse, sit
+    // on its loading skeleton forever.
+    void refetchConfig({ cancelRefetch: false }).then(result => {
+      if (result.data) {
+        configSeeded.current = true
+        setConfig(result.data)
+      }
+    })
   })
 
   useEffect(() => {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -14,7 +14,7 @@ import './store/translucency'
 import '@/debug/dev-only'
 
 import { QueryClientProvider } from '@tanstack/react-query'
-import { StrictMode } from 'react'
+import { StrictMode, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router'
 
@@ -44,6 +44,23 @@ if (import.meta.env.MODE !== 'production' || import.meta.env.VITE_PERF_PROBE ===
 }
 
 const winParam = new URLSearchParams(window.location.search).get('win')
+
+// When the main window comes back after being parked on a disconnected display
+// (see electron/main.ts keepMainWindowOnScreen), Chromium's page freeze can
+// leave settings queries in a stale state; refetch the settings data on
+// visibility recovery so a loading skeleton can't persist indefinitely.
+function RefetchOnVisible() {
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return
+      void queryClient.invalidateQueries({ queryKey: ['hermes-config-record'] })
+      void queryClient.invalidateQueries({ queryKey: ['hermes-config-schema'] })
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [])
+  return null
+}
 
 if (winParam === 'hud') {
   document.title = 'Hermes HUD'
@@ -85,6 +102,7 @@ if (winParam === 'overlay') {
                     Disabling transitions makes navigate() commit at default priority. */}
                   <HashRouter useTransitions={false}>
                     <App />
+                    <RefetchOnVisible />
                   </HashRouter>
                 </RootTooltipProvider>
               </HapticsProvider>


### PR DESCRIPTION
## Problem

The settings pages (model / browser / other config sections) hang on their loading skeleton indefinitely. The queries are healthy — `success` with full data in the React Query cache — yet the UI never leaves the `!config || !schema` gate. Two independent root causes stack on top of each other:

1. **Frozen page from an off-screen window.** The main window restores onto a display that later disappears (e.g. a remote-desktop virtual display the user isn't connected to). Windows parks such windows at `(-32000,-32000)` — with no display event on some drivers — and Chromium treats the hidden page as frozen: timers, IPC replies and query resolutions all stall. Every async surface dies silently.
2. **Profile-switch re-seed trap.** `useOnProfileSwitch` drops the local draft (`setConfig(null)`), but the seed effect only re-ran when the loaded record's *reference* changed. React Query structural sharing keeps that reference stable across identical refetches, so nothing re-seeded and the skeleton persisted even after the data was available.

Plus a packaging nit: `@nous-research/ui` fonts fail to load in the packaged app — `ERR_FILE_NOT_FOUND` for `resources/node_modules/@nous-research/ui/dist/fonts/*.woff2` (the ui package's `fonts.css` references `../fonts/` relative to the package, but `node_modules` is not packaged).

## Fixes (4 commits)

- **re-seed settings draft after profile switch** — seed whenever the draft is empty and data is available (`config === null` added to the effect condition + dep), and on profile switch seed directly from the refetch result instead of waiting for a reference change.
- **refetch settings queries when page thaws from freeze** — on `visibilitychange → visible`, invalidate the config record and schema queries so a thawed page refreshes instead of persisting a stale skeleton.
- **keep main window on a live display after monitor disconnect** — detect off-screen bounds (parked or no work-area overlap) and move the main window back to the primary display: on `show`, 1.5s after startup, on `display-removed` (previously macOS-only and wake-indicator-only), plus a 60s safety-net poll on non-mac platforms.
- **ship @nous-research/ui fonts in packaged app** — copy `node_modules/@nous-research/ui/dist/fonts` via `extraResources`.

## Verification

- Typecheck clean for touched files (`tsc -p .` and `tsc -p tsconfig.electron.json`: 0 errors in the touched files; only pre-existing workspace-level `vitest` module-resolution errors remain).
- Live CDP evidence from the broken instance: `visibilityState=hidden`, window rect `(-32000,-32000)`, config/schema queries `success` with data while the skeleton persisted. After moving the window to a live display and reloading, the same queries render instantly.
- Rebuilt the packaged app (`npm run pack`): model / browser / about settings tabs render fully (0 skeleton elements), font `ERR_FILE_NOT_FOUND` gone, window restores on the primary display.
