### PR TITLE
fix(hindsight): set User-Agent on version probe

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -247,7 +247,10 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     if not api_url:
         return None
     url = api_url.rstrip("/") + "/version"
-    req = urllib.request.Request(url)
+    # Some WAF/CDN frontends reject urllib's default ``Python-urllib`` UA.
+    # A rejected probe silently looks like a legacy Hindsight API and disables
+    # session-scoped append/deduplication, so send the project's explicit UA.
+    req = urllib.request.Request(url, headers={"User-Agent": "HermesAgent/1.0"})
     if api_key:
         req.add_header("Authorization", f"Bearer {api_key}")
     try:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -28,6 +28,7 @@ from plugins.memory.hindsight import (
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
+    _fetch_hindsight_api_version,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -1235,6 +1236,38 @@ class TestUpdateModeAppendCapability:
         from plugins.memory.hindsight import _append_capability_cache, _append_capability_lock
         with _append_capability_lock:
             _append_capability_cache.clear()
+
+    def test_version_probe_sends_explicit_user_agent(self, monkeypatch):
+        """WAF-fronted APIs must not see urllib's commonly blocked default UA."""
+        captured = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"api_version":"0.9.2"}'
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        version = _fetch_hindsight_api_version(
+            "https://memory.example.com/", api_key="test-key", timeout=3.0
+        )
+
+        request = captured["request"]
+        assert version == "0.9.2"
+        assert request.full_url == "https://memory.example.com/version"
+        assert request.get_header("User-agent") == "HermesAgent/1.0"
+        assert request.get_header("Authorization") == "Bearer test-key"
+        assert captured["timeout"] == 3.0
 
     def test_legacy_api_falls_back_to_per_process_doc_id(self, provider, monkeypatch):
         """API returns no /version (or pre-0.5.0) — sync_turn must use the


### PR DESCRIPTION
## Summary

- send the existing `HermesAgent/1.0` User-Agent on the Hindsight `/version` probe
- add a behavioral regression test covering URL normalization, auth, timeout, response parsing, and the explicit header

## Problem

`_fetch_hindsight_api_version` uses `urllib` without an explicit User-Agent. Some WAF/CDN frontends reject the default `Python-urllib/x.y` User-Agent. The probe then returns `None`, which is indistinguishable from a legacy Hindsight API.

That false legacy result is cached and disables `update_mode="append"`: retains fall back to per-process document IDs, fragmenting a session across documents and disabling append/deduplication even when the server supports it.

Reproduced against a Cloudflare-fronted self-hosted Hindsight deployment on current Hermes and Hindsight 0.9.2:

- default `Python-urllib/3.11` User-Agent: HTTP 403
- explicit Hermes User-Agent: HTTP 200 with `api_version=0.9.2`

## Why this fix

`HermesAgent/1.0` is already used by other Hermes `urllib` requests that must work through WAF frontends. The change preserves the existing authorization header, timeout, parsing, caching, and safe legacy fallback.

## Verification

- `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q` — 85 passed
- `uv run --no-sync ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- `git diff --check` — passed
