### PR TITLE
fix(desktop): relaunch across overlapping bundle updates

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -325,6 +325,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { guardRendererBootAcrossUpdate, shouldQuiesceForExternalUpdate } from './renderer-update-overlap'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -2125,6 +2126,7 @@ function directoryExists(filePath) {
 // marker's own age ceiling; covers a stuck-but-alive updater).
 const UPDATE_WAIT_TIMEOUT_MS = 20 * 60 * 1000
 const UPDATE_WAIT_POLL_MS = 1000
+const EXTERNAL_UPDATE_RENDERER_POLL_MS = 500
 // How long the desktop lingers on the "updating, don't reopen" overlay after
 // spawning the detached updater, before it quits to release the venv shim. The
 // old 600ms was long enough to register the child process but far too short for
@@ -2146,6 +2148,167 @@ function updateGateDeps() {
     hasLiveMarker: () => Boolean(readLiveUpdateMarker(HERMES_HOME)),
     isUpdateInFlight: () => updateInFlight
   }
+}
+
+let rendererBootHeldForUpdate = false
+let externalUpdateRendererMonitor: NodeJS.Timeout | null = null
+let externalUpdateRendererQuiescing = false
+
+function surfaceDetachedUpdateResult() {
+  try {
+    const result = readAndConsumeHandoffResult(HERMES_HOME)
+
+    if (result && result.ok && result.manual) {
+      rememberLog(`[updates] detached update finished with manual action (branch ${result.branch}): ${result.message}`)
+      dialog.showMessageBox({
+        type: 'warning',
+        title: 'Hermes update',
+        message: 'The update finished, but needs one more step',
+        detail: result.message
+      })
+    } else if (result && result.ok) {
+      rememberLog(`[updates] detached update finished OK (branch ${result.branch})`)
+    } else if (result) {
+      rememberLog(`[updates] detached update FAILED (exit ${result.exitCode}): ${result.message}`)
+      dialog.showErrorBox(
+        'Hermes update did not finish',
+        `${result.message}\n\nDetails: ${path.join(HERMES_HOME, 'logs', 'desktop-update-handoff.log')}`
+      )
+    }
+  } catch (err) {
+    rememberLog(`[updates] could not read hand-off result: ${err.message}`)
+  }
+}
+
+async function guardRendererBootForUpdateOverlap() {
+  if (DEV_SERVER) {
+    surfaceDetachedUpdateResult()
+
+    return false
+  }
+
+  rendererBootHeldForUpdate = true
+  let announced = false
+
+  const action = await guardRendererBootAcrossUpdate(updateGateDeps(), {
+    onWaitTick: reason => {
+      if (!announced) {
+        announced = true
+        rememberLog(`[updates] renderer boot parked behind active update (${reason})`)
+      }
+    },
+    pollMs: UPDATE_WAIT_POLL_MS,
+    timeoutMs: UPDATE_WAIT_TIMEOUT_MS
+  })
+
+  if (action === 'continue') {
+    rendererBootHeldForUpdate = false
+    surfaceDetachedUpdateResult()
+
+    return false
+  }
+
+  if (action === 'abort') {
+    rememberLog('[updates] renderer boot aborted: update marker remained live through the wait timeout')
+    dialog.showErrorBox(
+      'Hermes update is still running',
+      'Hermes did not load the Desktop interface because its application files are still being updated. ' +
+        'Wait for the update to finish, then reopen Hermes.'
+    )
+    flushDesktopLogBufferSync()
+    app.exit(1)
+
+    return true
+  }
+
+  rememberLog('[updates] overlapping update finished; relaunching before loading the renderer')
+
+  try {
+    app.relaunch()
+  } catch (error) {
+    rememberLog(`[updates] post-update renderer relaunch failed: ${error?.message || error}`)
+    dialog.showErrorBox(
+      'Hermes could not relaunch after updating',
+      'The update finished, but Hermes could not safely reload its Desktop files. Quit Hermes completely and reopen it.'
+    )
+    flushDesktopLogBufferSync()
+    app.exit(1)
+
+    return true
+  }
+
+  flushDesktopLogBufferSync()
+  app.exit(0)
+
+  return true
+}
+
+function stopExternalUpdateRendererMonitor() {
+  if (externalUpdateRendererMonitor) {
+    clearInterval(externalUpdateRendererMonitor)
+    externalUpdateRendererMonitor = null
+  }
+}
+
+async function quiesceRendererForBundleUpdate({ relaunch }: { relaunch: boolean }) {
+  externalUpdateRendererQuiescing = true
+  rendererBootHeldForUpdate = true
+  stopExternalUpdateRendererMonitor()
+
+  let relaunchScheduled = !relaunch
+
+  if (relaunch) {
+    try {
+      app.relaunch()
+      relaunchScheduled = true
+    } catch (error) {
+      rememberLog(`[updates] renderer relaunch scheduling failed: ${error?.message || error}`)
+    }
+  }
+
+  // Destroy Chromium before waiting on backend shutdown. The updater owns the
+  // packaged files now, so even a visually idle renderer must not issue another
+  // lazy-chunk request against the bundle generation being replaced.
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.destroy()
+    }
+  }
+
+  if (relaunch && !relaunchScheduled) {
+    dialog.showErrorBox(
+      'Hermes paused for an update',
+      'Hermes closed its Desktop interface before the application files changed, but could not schedule a relaunch. ' +
+        'Wait for the update to finish, then reopen Hermes.'
+    )
+  }
+
+  flushDesktopLogBufferSync()
+  await exitAfterBackendShutdown(relaunchScheduled ? 0 : 1)
+}
+
+function startExternalUpdateRendererMonitor() {
+  if (!IS_MAC || DEV_SERVER || externalUpdateRendererMonitor) {
+    return
+  }
+
+  externalUpdateRendererMonitor = setInterval(() => {
+    const markerLive = Boolean(readLiveUpdateMarker(HERMES_HOME))
+
+    if (
+      !shouldQuiesceForExternalUpdate({
+        alreadyQuiescing: externalUpdateRendererQuiescing,
+        isQuittingForHandoff,
+        markerLive,
+        updateInFlight
+      })
+    ) {
+      return
+    }
+
+    rememberLog('[updates] external update detected; quiescing the live renderer before its bundle changes')
+    void quiesceRendererForBundleUpdate({ relaunch: true })
+  }, EXTERNAL_UPDATE_RENDERER_POLL_MS)
 }
 
 // Block until no live update is in progress (or we hit the wait timeout).
@@ -2177,41 +2340,27 @@ async function waitForUpdateToFinish() {
   // update gate — success gets a log line, failure gets a real dialog
   // (previously a failed detached update was indistinguishable from
   // "nothing happened").
-  try {
-    const result = readAndConsumeHandoffResult(HERMES_HOME)
-
-    if (result && result.ok && result.manual) {
-      // Update landed but the user must act (reopen/reinstall/sandbox). On
-      // machines with no shim browser and no notifier this dialog is the
-      // FIRST time the message is visible — it must not be a log line.
-      rememberLog(`[updates] detached update finished with manual action (branch ${result.branch}): ${result.message}`)
-      dialog.showMessageBox({
-        type: 'warning',
-        title: 'Hermes update',
-        message: 'The update finished, but needs one more step',
-        detail: result.message
-      })
-    } else if (result && result.ok) {
-      rememberLog(`[updates] detached update finished OK (branch ${result.branch})`)
-    } else if (result) {
-      rememberLog(`[updates] detached update FAILED (exit ${result.exitCode}): ${result.message}`)
-      dialog.showErrorBox(
-        'Hermes update did not finish',
-        `${result.message}\n\nDetails: ${path.join(HERMES_HOME, 'logs', 'desktop-update-handoff.log')}`
-      )
-    }
-  } catch (err) {
-    rememberLog(`[updates] could not read hand-off result: ${err.message}`)
-  }
+  surfaceDetachedUpdateResult()
 
   if (outcome === 'clear') {
     return false
   }
 
   if (outcome === 'timeout') {
-    rememberLog('[updates] update still in progress after wait timeout; starting backend anyway')
-  } else {
-    rememberLog('[updates] update finished; proceeding with backend start')
+    rememberLog('[updates] update remained live through the backend wait timeout; refusing to resume the renderer')
+    dialog.showErrorBox(
+      'Hermes update is still running',
+      'Hermes closed its Desktop interface because its application files are still being updated. ' +
+        'Wait for the update to finish, then reopen Hermes.'
+    )
+    await quiesceRendererForBundleUpdate({ relaunch: false })
+
+    return true
+  }
+
+  if (outcome === 'finished') {
+    rememberLog('[updates] update finished after renderer startup; relaunching with one consistent bundle generation')
+    await quiesceRendererForBundleUpdate({ relaunch: true })
   }
 
   return true
@@ -17298,6 +17447,12 @@ if (!isPrimaryInstance) {
       handleDeepLink(url)
     }
 
+    if (rendererBootHeldForUpdate) {
+      rememberLog('[updates] suppressing second-instance window while renderer boot is parked behind an update')
+
+      return
+    }
+
     ensureMainWindow(mainWindow, {
       isReady: app.isReady(),
       createWindow,
@@ -17315,10 +17470,14 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()
+
+  if (await guardRendererBootForUpdateOverlap()) {
+    return
+  }
 
   const systemCa = installWindowsSystemCaTrust(tls)
 
@@ -17391,6 +17550,7 @@ app.whenReady().then(() => {
   // captured by the original transaction before removing the journal entry.
   void resumeManagedSshRecoveries()
   createWindow()
+  startExternalUpdateRendererMonitor()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)
@@ -17400,6 +17560,12 @@ app.whenReady().then(() => {
   }
 
   app.on('activate', () => {
+    if (rendererBootHeldForUpdate) {
+      rememberLog('[updates] suppressing Dock activation while renderer boot is parked behind an update')
+
+      return
+    }
+
     // Recreate the primary window if it's gone. Guard on mainWindow directly
     // (not just total window count) so a dock click still restores the main
     // window when only secondary session windows remain open.
@@ -17485,6 +17651,8 @@ app.on('before-quit', event => {
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  stopExternalUpdateRendererMonitor()
 
   // A detached remote updater can outlive this Electron process. Do not tear
   // down its SSH observer/restore transaction at the generic SSH shutdown

--- a/apps/desktop/electron/renderer-update-overlap.test.ts
+++ b/apps/desktop/electron/renderer-update-overlap.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  guardRendererBootAcrossUpdate,
+  shouldQuiesceForExternalUpdate
+} from './renderer-update-overlap'
+import { markerPath, readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
+
+test('renderer boot continues immediately when no update owns the install', async () => {
+  let ticks = 0
+
+  const action = await guardRendererBootAcrossUpdate(
+    { hasLiveMarker: () => false, isUpdateInFlight: () => false },
+    {
+      onWaitTick: () => {
+        ticks += 1
+      },
+      pollMs: 1,
+      sleep: async () => {},
+      timeoutMs: 100
+    }
+  )
+
+  assert.equal(action, 'continue')
+  assert.equal(ticks, 0)
+})
+
+test('renderer boot relaunches after an overlapping marker clears', async () => {
+  let marker = true
+  let ticks = 0
+
+  const action = await guardRendererBootAcrossUpdate(
+    { hasLiveMarker: () => marker, isUpdateInFlight: () => false },
+    {
+      onWaitTick: reason => {
+        ticks += 1
+        assert.equal(reason, 'marker')
+
+        if (ticks === 2) {
+          marker = false
+        }
+      },
+      pollMs: 1,
+      sleep: async () => {},
+      timeoutMs: 100
+    }
+  )
+
+  assert.equal(action, 'relaunch')
+  assert.equal(ticks, 2)
+})
+
+test('renderer boot also relaunches after an in-process update clears', async () => {
+  let inFlight = true
+
+  const action = await guardRendererBootAcrossUpdate(
+    { hasLiveMarker: () => false, isUpdateInFlight: () => inFlight },
+    {
+      onWaitTick: () => {
+        inFlight = false
+      },
+      pollMs: 1,
+      sleep: async () => {},
+      timeoutMs: 100
+    }
+  )
+
+  assert.equal(action, 'relaunch')
+})
+
+test('renderer boot aborts instead of loading files while a live update times out', async () => {
+  let clock = 0
+
+  const action = await guardRendererBootAcrossUpdate(
+    { hasLiveMarker: () => true, isUpdateInFlight: () => false },
+    {
+      now: () => clock,
+      pollMs: 10,
+      sleep: async ms => {
+        clock += ms
+      },
+      timeoutMs: 30
+    }
+  )
+
+  assert.equal(action, 'abort')
+})
+
+test('real update marker integration parks, observes clearance, and requires relaunch', async () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-renderer-update-overlap-'))
+
+  try {
+    writeUpdateMarker(hermesHome, process.pid)
+    assert.ok(readLiveUpdateMarker(hermesHome))
+
+    let ticks = 0
+
+    const action = await guardRendererBootAcrossUpdate(
+      {
+        hasLiveMarker: () => Boolean(readLiveUpdateMarker(hermesHome)),
+        isUpdateInFlight: () => false
+      },
+      {
+        onWaitTick: () => {
+          ticks += 1
+
+          if (ticks === 2) {
+            fs.unlinkSync(markerPath(hermesHome))
+          }
+        },
+        pollMs: 1,
+        sleep: async () => {},
+        timeoutMs: 100
+      }
+    )
+
+    assert.equal(action, 'relaunch')
+    assert.equal(ticks, 2)
+  } finally {
+    fs.rmSync(hermesHome, { recursive: true, force: true })
+  }
+})
+
+test('live external markers quiesce a renderer exactly once', () => {
+  assert.equal(
+    shouldQuiesceForExternalUpdate({
+      alreadyQuiescing: false,
+      isQuittingForHandoff: false,
+      markerLive: true,
+      updateInFlight: false
+    }),
+    true
+  )
+
+  for (const state of [
+    { alreadyQuiescing: true, isQuittingForHandoff: false, markerLive: true, updateInFlight: false },
+    { alreadyQuiescing: false, isQuittingForHandoff: true, markerLive: true, updateInFlight: false },
+    { alreadyQuiescing: false, isQuittingForHandoff: false, markerLive: true, updateInFlight: true },
+    { alreadyQuiescing: false, isQuittingForHandoff: false, markerLive: false, updateInFlight: false }
+  ]) {
+    assert.equal(shouldQuiesceForExternalUpdate(state), false)
+  }
+})
+
+test('main waits before creating a renderer and suppresses second-instance windows while parked', () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+  const readyStart = mainSource.indexOf('app.whenReady().then(')
+  const createWindow = mainSource.indexOf('\n  createWindow()', readyStart)
+  const guard = mainSource.indexOf('await guardRendererBootForUpdateOverlap()', readyStart)
+  const suppressSecondInstance = mainSource.indexOf('if (rendererBootHeldForUpdate)', mainSource.indexOf("app.on('second-instance'"))
+  const suppressDockActivation = mainSource.indexOf('if (rendererBootHeldForUpdate)', mainSource.indexOf("app.on('activate'"))
+
+  assert.ok(readyStart >= 0, 'whenReady boot block must exist')
+  assert.ok(guard > readyStart, 'update-overlap guard must run during ready boot')
+  assert.ok(createWindow > guard, 'normal renderer creation must happen only after the update-overlap guard')
+  assert.ok(suppressSecondInstance >= 0, 'second-instance launches must not bypass the renderer boot hold')
+  assert.ok(suppressDockActivation >= 0, 'Dock activation must not recreate a renderer during the boot hold')
+})
+
+test('main monitors for external CLI updates after the renderer starts', () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+  const createWindow = mainSource.indexOf('\n  createWindow()', mainSource.indexOf('app.whenReady().then('))
+  const monitor = mainSource.indexOf('startExternalUpdateRendererMonitor()', createWindow)
+  const quiesceFunction = mainSource.indexOf('async function quiesceRendererForBundleUpdate(')
+  const quiesceEnd = mainSource.indexOf('function startExternalUpdateRendererMonitor()', quiesceFunction)
+  const quiesceSource = mainSource.slice(quiesceFunction, quiesceEnd)
+
+  assert.ok(createWindow >= 0)
+  assert.ok(monitor > createWindow, 'external update monitor must be installed after normal renderer startup')
+  assert.ok(quiesceFunction >= 0, 'live renderers need one orderly update-quiesce path')
+  assert.match(quiesceSource, /app\.relaunch\(\)[\s\S]*?BrowserWindow\.getAllWindows\(\)[\s\S]*?win\.destroy\(\)/)
+})
+
+test('a backend wait that observes an overlapping update cannot resume the old renderer generation', () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+  const waitStart = mainSource.indexOf('async function waitForUpdateToFinish()')
+  const waitEnd = mainSource.indexOf('\nfunction unpackedPathFor(', waitStart)
+  const waitSource = mainSource.slice(waitStart, waitEnd)
+
+  assert.ok(waitStart >= 0)
+  assert.match(waitSource, /outcome === 'timeout'[\s\S]*?await quiesceRendererForBundleUpdate\(\{ relaunch: false \}\)/)
+  assert.match(waitSource, /outcome === 'finished'[\s\S]*?await quiesceRendererForBundleUpdate\(\{ relaunch: true \}\)/)
+  assert.doesNotMatch(waitSource, /starting backend anyway|proceeding with backend start/)
+})

--- a/apps/desktop/electron/renderer-update-overlap.ts
+++ b/apps/desktop/electron/renderer-update-overlap.ts
@@ -1,0 +1,54 @@
+import {
+  type UpdateGateDeps,
+  waitForUpdateClearance,
+  type WaitForUpdateClearanceOptions
+} from './update-gate'
+
+type RendererBootAction = 'continue' | 'relaunch' | 'abort'
+
+interface ExternalUpdateRendererState {
+  alreadyQuiescing: boolean
+  isQuittingForHandoff: boolean
+  markerLive: boolean
+  updateInFlight: boolean
+}
+
+/**
+ * A renderer may load packaged files only from one stable bundle generation.
+ * If this process had to wait for an updater, relaunch it after clearance so
+ * Chromium cannot retain the old module graph / ASAR view. A live marker that
+ * outlasts the bounded wait fails closed instead of loading mutable files.
+ */
+async function guardRendererBootAcrossUpdate(
+  deps: UpdateGateDeps,
+  options: WaitForUpdateClearanceOptions
+): Promise<RendererBootAction> {
+  const outcome = await waitForUpdateClearance(deps, options)
+
+  if (outcome === 'clear') {
+    return 'continue'
+  }
+
+  if (outcome === 'finished') {
+    return 'relaunch'
+  }
+
+  return 'abort'
+}
+
+/**
+ * An update started outside this Desktop process (for example `hermes update`
+ * in Terminal) must quiesce its already-live renderer before the bundle swap.
+ * The in-app handoff owns its own orderly quit/relaunch and must not race this
+ * monitor.
+ */
+function shouldQuiesceForExternalUpdate(state: ExternalUpdateRendererState): boolean {
+  return state.markerLive && !state.updateInFlight && !state.isQuittingForHandoff && !state.alreadyQuiescing
+}
+
+export {
+  type ExternalUpdateRendererState,
+  guardRendererBootAcrossUpdate,
+  type RendererBootAction,
+  shouldQuiesceForExternalUpdate
+}


### PR DESCRIPTION
Fixes #85868.

## Problem

A live macOS renderer can outlive a `hermes update` rebuild of the packaged Desktop bundle. Its old Vite module graph then requests hashed lazy chunks from the new on-disk generation, producing blank/error-boundary views and misleading session hydration failures. #85887 protects against a torn on-disk copy, but it does not stop an already-running renderer from spanning two complete bundle generations.

## Change

- Gate renderer creation on the existing update marker, before any BrowserWindow is created.
- Relaunch after a startup overlap clears so Chromium loads exactly one bundle generation.
- Monitor live macOS renderers for external CLI update markers; schedule relaunch, destroy renderer windows, and shut down the Desktop backend before the bundle changes.
- Suppress second-instance and Dock window creation while the renderer is parked.
- Fail closed on a live-marker timeout instead of starting a backend or renderer against mutable application files.
- Keep the existing in-app updater handoff authoritative so the monitor cannot race it.

No authentication, transport, routing, remote protocol, or compression behavior changes.

## Validation

- Targeted update-marker/gate/overlap tests: 34 passed.
- Electron TypeScript typecheck: passed.
- ESLint: passed.
- Production Desktop build and macOS pack: passed.
- Isolated packaged-app E2E:
  - startup with live marker created no renderer;
  - marker clearance caused a clean relaunch and renderer creation;
  - marker appearing under an already-live renderer destroyed it and relaunched into the startup gate;
  - final clearance caused a second clean relaunch on a stable bundle.
- Full Desktop suite: 8018 passed, 6 skipped, 1 unrelated pre-existing failure in `managed-ssh-update.test.ts` (`127` vs `0`).