### PR TITLE
fix(desktop): allow profiles to opt out of cron scheduler

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -102,7 +102,7 @@ from gateway.status import (
     read_runtime_status,
     resolve_gateway_liveness,
 )
-from utils import env_var_enabled
+from utils import env_var_enabled, is_truthy_value
 
 try:
     from fastapi import (
@@ -262,6 +262,25 @@ def _parent_start_markers_match(actual: str, expected: str) -> bool:
 # asyncio.Lock() binds to whatever loop was active at import time, which breaks
 # when the same module is used across TestClient instances or uvicorn reloads.
 # ---------------------------------------------------------------------------
+
+def _desktop_cron_ticker_enabled() -> bool:
+    """Return whether this Desktop backend should own the cron scheduler.
+
+    Desktop owns cron by default.  A profile hosted beside dedicated gateway
+    processes can opt out so the process-global MCP registry in the pooled
+    Desktop backend cannot execute another profile's scheduled work.
+    """
+    try:
+        config = load_config() or {}
+    except Exception:
+        _log.exception("Desktop cron: config load failed; keeping scheduler enabled")
+        return True
+
+    cron_config = config.get("cron") if isinstance(config, dict) else None
+    if not isinstance(cron_config, dict):
+        return True
+    return is_truthy_value(cron_config.get("desktop_scheduler"), default=True)
+
 
 def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
     """Tick the cron scheduler from inside the desktop dashboard backend.
@@ -446,14 +465,17 @@ async def _lifespan(app: "FastAPI"):
         except Exception:
             _log.exception("Desktop startup: orphan gateway reap failed")
 
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+        if _desktop_cron_ticker_enabled():
+            cron_stop = threading.Event()
+            cron_thread = threading.Thread(
+                target=_start_desktop_cron_ticker,
+                args=(cron_stop,),
+                daemon=True,
+                name="desktop-cron-ticker",
+            )
+            cron_thread.start()
+        else:
+            _log.info("Desktop cron scheduler disabled by cron.desktop_scheduler")
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4805,6 +4805,25 @@ class TestDesktopCronTicker:
         with self._client():
             assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
 
+    def test_ticker_does_not_run_when_disabled_in_config(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+        import hermes_cli.web_server as ws
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setattr(
+            ws,
+            "load_config",
+            lambda: {"cron": {"desktop_scheduler": False}},
+        )
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+        with self._client():
+            assert not called.wait(0.25), "desktop cron ticker ignored its config opt-out"
+
 
 class TestServeIndexMissingIndex:
     """_serve_index must not raise per-request when index.html vanishes


### PR DESCRIPTION
## Summary

Desktop-hosted profiles can now opt out of the process-wide cron scheduler with `cron.desktop_scheduler: false`. This prevents a pooled Desktop backend from claiming scheduled work that belongs to a profile with its own gateway, while preserving the existing default behavior for ordinary Desktop installations.

## Validation

- Added a regression test that fails on the prior behavior and passes with the profile opt-out.
- Verified the existing Desktop ticker and multi-profile scheduler-provider tests: 36 passed.

