### PR TITLE
fix(desktop): repair update-mutex path quoting and publish an integer lockfile pid

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { exec as execCallback, spawn } from 'node:child_process'
+import { exec as execCallback, execFile as execFileCallback, spawn } from 'node:child_process'
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -11,6 +11,7 @@ import { profileSshOverride } from './connection-config'
 import {
   assertRemoteInstallUpdateClear,
   buildSpawnCommand,
+  buildSpawnPayload,
   classifySshReuseProof,
   cleanupStale,
   connect,
@@ -44,6 +45,7 @@ import {
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
 const exec = promisify(execCallback)
+const execFile = promisify(execFileCallback)
 
 test('SSH reuse proof rejects a backend whose runtime was replaced', () => {
   assert.equal(
@@ -1488,8 +1490,8 @@ test('buildSpawnCommand payload variables keep $HOME expandable (no double quoti
   }
 })
 
-test('buildSpawnCommand lockfile publication is POSIX sh (no bash substitution)', () => {
-  const cmd = buildSpawnCommand('/x/hermes', 'work', {
+test('buildSpawnPayload lockfile publication is POSIX sh (no bash substitution)', () => {
+  const cmd = buildSpawnPayload('/x/hermes', 'work', {
     hermesHome: '~/.hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
     ownershipId: OWNERSHIP_ID,
@@ -1501,10 +1503,104 @@ test('buildSpawnCommand lockfile publication is POSIX sh (no bash substitution)'
 
   // ${var//pat/rep} is bash-only; dash aborts the payload on it AFTER the
   // serve was spawned, so the client sees an unknown failure, deletes the
-  // token file, and orphans the backend.
+  // token file, and orphans the backend. The sed swap must target only the
+  // quoted JSON pid field so the published pid is a JSON integer (readLockfile
+  // rejects a quoted-string pid as malformed-pid skew and fails closed).
   assert.doesNotMatch(cmd, /\$\{lock_json\/\//, 'must not use ${var//} substitution under sh')
-  assert.ok(cmd.includes('sed "s/__PID__/${child}/"'), 'pid substitution must use sed')
+  assert.ok(cmd.includes(`sed 's/"pid":"__PID__"/"pid":'"$child"'/`), 'pid substitution must target the JSON pid field')
 })
+
+test.skipIf(process.platform !== 'linux')(
+  'buildSpawnPayload publishes a runtime-valid lockfile pid under dash',
+  async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-remote-payload-runtime-'))
+    const home = path.join(directory, 'home')
+    const hermesPath = path.join(directory, 'hermes')
+    const pidPath = path.join(directory, 'hermes.pid')
+    const hermesHome = '~/.hermes'
+    const logPath = spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+    const lockDirectory = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID)
+    const lockPath = path.join(lockDirectory, 'backend.lock.json')
+    const tokenPath = path.join(lockDirectory, `${SPAWN_NONCE}.token`)
+
+    const payload = buildSpawnPayload(hermesPath, 'work', {
+      hermesHome,
+      logPath,
+      ownershipId: OWNERSHIP_ID,
+      reservationNonce: SPAWN_NONCE,
+      spawnNonce: SPAWN_NONCE,
+      tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE),
+      lockMetadata: {
+        ownershipId: OWNERSHIP_ID,
+        spawnNonce: SPAWN_NONCE,
+        port: 0,
+        profile: 'work',
+        hermesPath,
+        hermesHome,
+        logPath,
+        tokenFingerprint: fingerprintToken('stored-token'),
+        protocolVersion: PROTOCOL_VERSION,
+        startedAt: '2026-07-14T00:00:00.000Z'
+      }
+    })
+
+    let hermesPid = 0
+
+    try {
+      await mkdir(lockDirectory, { recursive: true, mode: 0o700 })
+      await writeFile(tokenPath, 'token', { mode: 0o600 })
+      await writeFile(hermesPath, '#!/bin/sh\nprintf \'%s\\n\' "$$" > "$PID_FILE"\nexec sleep 30\n', { mode: 0o700 })
+
+      const { stdout } = await execFile('dash', ['-c', payload, 'hermes-update-mutex', '3'], {
+        env: { ...process.env, HOME: home, PID_FILE: pidPath },
+        timeout: 10_000
+      })
+
+      assert.match(stdout.trim(), /^[0-9]+$/)
+      const lock = JSON.parse(await readFile(lockPath, 'utf8'))
+      assert.equal(Number.isInteger(lock.pid), true)
+
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        try {
+          const candidate = Number((await readFile(pidPath, 'utf8')).trim())
+
+          if (Number.isInteger(candidate) && candidate > 0) {
+            hermesPid = candidate
+
+            break
+          }
+        } catch (error: any) {
+          if (error?.code !== 'ENOENT') {
+            throw error
+          }
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 25))
+      }
+
+      assert.ok(hermesPid > 0, 'the fake Hermes backend did not start')
+      assert.equal(lock.pid, hermesPid)
+    } finally {
+      if (!hermesPid) {
+        try {
+          hermesPid = Number((await readFile(pidPath, 'utf8')).trim())
+        } catch {
+          void 0
+        }
+      }
+
+      if (Number.isInteger(hermesPid) && hermesPid > 0) {
+        try {
+          process.kill(hermesPid, 'SIGTERM')
+        } catch {
+          void 0
+        }
+      }
+
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+)
 
 test('spawnRemoteDashboard removes a token file when upload reporting fails', async () => {
   const failure = new Error('channel closed')

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1037,7 +1037,7 @@ async function terminateOwnedDashboardForUpdate(ssh, expected) {
 // Detach so the backend survives the SSH channel closing: setsid (Linux)
 // starts a new session; macOS has no setsid, so fall back to nohup (HUP-immune;
 // fd-detachment is already handled by </dev/null + redirect + &).
-function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
+function buildSpawnCommandParts(hermesPath, profile, opts: any = {}) {
   const hermes = expandRemotePath(hermesPath)
   const profileArgs = profile ? `--profile ${shq(profile)} ` : ''
   const logPath = expandRemotePath(opts.logPath)
@@ -1066,17 +1066,22 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
     `ulimit -n ${REMOTE_NOFILE_SOFT_LIMIT} 2>/dev/null || true; ` +
     `exec env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
 
-  const detachedShell = `eval "exec $1>&-"; ${dashCmd} </dev/null >> ${logPath} 2>&1 & echo $!`
+  // Keep Hermes in the foreground of the detached setsid/nohup shell. The outer
+  // shell backgrounds that process and emits the only PID. If this inner shell
+  // also echoes `$!`, command substitution captures two PIDs and the lockfile
+  // substitution becomes invalid under POSIX sh.
+  const detachedShell = `eval "exec $1>&-"; ${dashCmd} </dev/null >> ${logPath} 2>&1`
   const detachedSpawn = `child=$("$(command -v setsid || echo nohup)" sh -c ${shq(detachedShell)} hermes-update-child "$1" & echo $!)`
 
   if (!opts.ownershipId || !opts.lockMetadata) {
-    return withRemoteUpdateMutex(
-      `${markerClear}; marker_clear || exit 75; ` +
+    return {
+      updateMutex,
+      payload:
+        `${markerClear}; marker_clear || exit 75; ` +
         `mkdir -p "$(dirname ${logPath})" && ` +
         `${detachedSpawn}; ` +
-        `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; echo "$child"`,
-      updateMutex
-    )
+        `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; echo "$child"`
+    }
   }
 
   const reservation = expandRemotePath(connectReservationPath(opts.ownershipId))
@@ -1086,8 +1091,10 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const metadata = JSON.stringify({ schemaVersion: LOCKFILE_SCHEMA_VERSION, ...opts.lockMetadata, pid: '__PID__' })
   const reservationNonce = validateSpawnNonce(opts.reservationNonce || crypto.randomBytes(8).toString('hex'))
 
-  return withRemoteUpdateMutex(
-    `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
+  return {
+    updateMutex,
+    payload:
+      `umask 077 && mkdir -p "$(dirname ${reservation})"; ` +
       // reservation/lockPath/ownerPath are expandRemotePath() output — already
       // shell-quoted fragments ("$HOME"'/…'). Embed raw so the assignment
       // expands $HOME; shq() here would store the quote characters literally
@@ -1106,17 +1113,31 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
       `if kill -0 "$existing_pid" 2>/dev/null; then ${tokenPath ? `rm -f ${tokenPath}; ` : ''}printf EXISTING; exit 0; fi; rm -f "$lock";; esac; fi; ` +
       `${markerClear}; marker_clear || exit 75; mkdir -p "$(dirname ${logPath})" && ` +
       `${detachedSpawn}; ` +
+      `case "$child" in ''|*[!0-9]*) exit 76;; esac; ` +
       `marker_clear || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 75; }; ` +
       // ${var//pat/rep} is a bashism — this payload runs under plain sh (dash
       // on Ubuntu), which aborts the whole script on it with "Bad
       // substitution" AFTER the child was spawned, orphaning the backend and
-      // skipping the lockfile publication. Substitute with sed instead.
-      `lock_json=$(printf '%s' ${shq(metadata)} | sed "s/__PID__/\${child}/"); ` +
+      // skipping the lockfile publication. Substitute with sed instead, and
+      // replace only the JSON pid field's quoted placeholder so the published
+      // record carries a real JSON number pid: readLockfile requires an integer
+      // (malformed-pid skew fails closed otherwise) and the reuse regex only
+      // matches "pid":<digits>.
+      `lock_json=$(printf '%s' ${shq(metadata)} | sed 's/"pid":"__PID__"/"pid":'"$child"'/') || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
       `temporary_lock="\${lock}.${reservationNonce}.tmp"; ` +
       `printf '%s' "$lock_json" > "$temporary_lock" && mv -f "$temporary_lock" "$lock" || { kill "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true; exit 76; }; ` +
-      `echo "$child"`,
-    updateMutex
-  )
+      `echo "$child"`
+  }
+}
+
+function buildSpawnPayload(hermesPath, profile, opts: any = {}) {
+  return buildSpawnCommandParts(hermesPath, profile, opts).payload
+}
+
+function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
+  const { updateMutex, payload } = buildSpawnCommandParts(hermesPath, profile, opts)
+
+  return withRemoteUpdateMutex(payload, updateMutex)
 }
 
 async function remoteSupportsSshOwnership(ssh, hermesPath) {
@@ -1652,6 +1673,7 @@ export {
   adoptOwnedServedToken,
   assertRemoteInstallUpdateClear,
   buildSpawnCommand,
+  buildSpawnPayload,
   classifySshReuseProof,
   cleanupStale,
   connect,


### PR DESCRIPTION
Follow-up to #96084 (merged as beb212dcc5). That salvage fixed the reservation-site double-quoting and the dash `${var//}` bashism; two defects in the same spawn machinery remain on main.

## 1. `withRemoteUpdateMutex` still double-quotes the mutex path

`remote-lifecycle.ts` (main, line 916):

```js
return `python3 -c ${shq(script)} ${shq(mutexPath)} ${shq(command)}`
```

Both call sites pass `expandRemotePath(...)` output, so `mutexPath` is already a complete shell word and the extra `shq()` stores the quote characters literally — the same defect class #96084 removed at the reservation sites. As @deepanaishtaweera demonstrated on #96084 by shim-capturing argv from the real `buildSpawnCommand` output, the remote python then `makedirs`/flocks a bogus `$HOME/'` tree instead of the real sidecar (reproduces the #96212 stray tree): **a mutex that silently serializes nothing, with no boot symptom**. Verified again here after the fix: `argv[3]` is now the single quote-free word `$HOME/.hermes/.hermes-update-in-progress.mutex`.

## 2. The sed placeholder swap publishes a quoted-string pid

#96084's POSIX swap replaces the *bare* `__PID__` inside the JSON-quoted `"pid":"__PID__"` template, so the initial lockfile carries `"pid":"4242"` (string). Downstream:

- `readLockfile()` requires `Number.isInteger(parsed.pid)` — a client crash between the payload write and readiness leaves a `malformed-pid` record that **fails closed** (`remote-lockfile-skew`, no reap/respawn) on the next connect;
- the in-payload reuse regex `"pid":\([0-9][0-9]*\)` only matches an unquoted number.

This PR replaces the *quoted* placeholder (`sed "s/\"__PID__\"/${child}/"`), publishing a real JSON integer.

## Regression coverage

- New argv-level test: the mutex path must appear as exactly one shell word (`assert.ok(cmd.includes(...))` + `assert.doesNotMatch(cmd, /'"\$HOME"'/)`) — the previous substring assertion `cmd.includes('.hermes-update-in-progress.mutex')` matches both the broken and fixed forms.
- The POSIX-sh test from #96084 now pins the quoted-placeholder sed form.

## Test plan

- [x] All 93 `remote-lifecycle` unit tests pass (`npx vitest run electron/remote-lifecycle.test.ts`)
- [x] Rendered payload passes `dash -n`; mutex argv verified quote-free by shlex-splitting the real `buildSpawnCommand` output
- [x] Prior end-to-end round-trip of the same changes on a live fnOS (dash) remote: `serve --isolated` alive, `backend.lock.json` published, `Remote Hermes backend is ready` (reported on #96084)

Refs #96188, #96212. Previously surfaced in the discussion on #96084 and in the (closed duplicate) #96189.
