### PR TITLE
feat(desktop): configure group member inference

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4702,16 +4702,37 @@ function groupLastActivity(room) {
   return log.length ? log[log.length - 1].at || 0 : 0
 }
 
-/** Seat a group's member roster: local bots whose meta names the group, plus
- *  the room record's stored descriptors (remote members can't ride bot-meta).
- *  Prefers the LIVE roster row for a stored descriptor when present. */
+/** Seat a group's member roster. Modern roomId-backed rooms persist every
+ *  source-qualified member, so their non-empty stored roster is authoritative;
+ *  otherwise stale local profile metadata could re-seat a bot removed in Settings.
+ *  Legacy rooms still combine local profile membership with stored remote
+ *  descriptors. Prefers the LIVE roster row when present. */
 function groupChatMemberBots(group, roster, metaByName) {
+  const room = $groupChats.get()[group] || {}
+  const stored = room.members || []
+
+  if (stored.length && room.roomId) {
+    const seated = new Set()
+    const members = []
+
+    for (const descriptor of stored) {
+      const key = botRosterKey(descriptor)
+
+      if (seated.has(key)) {
+        continue
+      }
+
+      seated.add(key)
+      members.push((roster || []).find(bot => botRosterKey(bot) === key) || descriptor)
+    }
+
+    return members
+  }
+
   const local = (roster || []).filter(
     bot => !bot.remoteSource && botGroups(botRosterMeta(bot, metaByName)).includes(group)
   )
-  const stored = ($groupChats.get()[group] || {}).members || []
   const seated = new Set(local.map(botRosterKey))
-  const remote = []
 
   for (const descriptor of stored) {
     const key = botRosterKey(descriptor)
@@ -4721,10 +4742,10 @@ function groupChatMemberBots(group, roster, metaByName) {
     }
 
     seated.add(key)
-    remote.push((roster || []).find(bot => botRosterKey(bot) === key) || descriptor)
+    local.push((roster || []).find(bot => botRosterKey(bot) === key) || descriptor)
   }
 
-  return [...local, ...remote]
+  return local
 }
 
 /** Persist source-qualified identities for every selected member. The active
@@ -4749,6 +4770,52 @@ function durableGroupChatMembers(bots) {
       sourceScoped: true
     }
   })
+}
+
+/** Replace an existing room's complete member set. The durable room roster is
+ *  authoritative; local profile metadata is updated as a compatibility and
+ *  discovery projection, including removal from profiles no longer seated. */
+async function replaceGroupChatMembers(group, bots) {
+  const unique = []
+  const seen = new Set()
+
+  for (const bot of bots || []) {
+    const key = botRosterKey(bot)
+
+    if (!key || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    unique.push(bot)
+  }
+
+  if (unique.length < 2 || unique.length > GROUP_CHAT_MAX_MEMBERS) {
+    throw new Error(`Group chats require 2–${GROUP_CHAT_MAX_MEMBERS} bots`)
+  }
+
+  const metaByName = $botMeta.get()
+  const nextLocal = new Set(unique.filter(bot => !bot.remoteSource).map(bot => bot.name))
+  const affectedLocal = new Set(nextLocal)
+
+  for (const [name, meta] of Object.entries(metaByName || {})) {
+    if (botGroups(meta).includes(group)) {
+      affectedLocal.add(name)
+    }
+  }
+
+  await Promise.all(
+    [...affectedLocal].map(name =>
+      saveBotMeta(name, groupMembershipPatch($botMeta.get()[name], group, nextLocal.has(name)))
+    )
+  )
+
+  updateGroupChat(group, room => {
+    room.members = durableGroupChatMembers(unique)
+    return room
+  })
+
+  return unique
 }
 
 /** Existing group names, alphabetical — feeds the Manage-groups dialog. */
@@ -9292,14 +9359,31 @@ function GroupDialog({ bot, onClose }) {
   const current = botGroups(meta[bot?.name])
   const groups = knownGroups(meta)
 
-  const setMembership = (group, enabled) => {
-    saveBotMeta(bot.name, groupMembershipPatch(meta[bot.name], group, enabled))
-    host.notify({
-      kind: 'info',
-      message: enabled
-        ? `${displayName(bot, meta[bot.name])} added to “${group}”`
-        : `${displayName(bot, meta[bot.name])} removed from “${group}”`
-    })
+  const setMembership = async (group, enabled) => {
+    try {
+      const room = $groupChats.get()[group]
+
+      if (Array.isArray(room?.members) && room.members.length) {
+        const currentMembers = groupChatMemberBots(group, $lastRoster.get(), $botMeta.get())
+        const botKey = botRosterKey(bot)
+        const nextMembers = enabled
+          ? [...currentMembers.filter(member => botRosterKey(member) !== botKey), bot]
+          : currentMembers.filter(member => botRosterKey(member) !== botKey)
+
+        await replaceGroupChatMembers(group, nextMembers)
+      } else {
+        await saveBotMeta(bot.name, groupMembershipPatch($botMeta.get()[bot.name], group, enabled))
+      }
+
+      host.notify({
+        kind: 'info',
+        message: enabled
+          ? `${displayName(bot, $botMeta.get()[bot.name])} added to “${group}”`
+          : `${displayName(bot, $botMeta.get()[bot.name])} removed from “${group}”`
+      })
+    } catch (error) {
+      host.notifyError(error, `Could not update “${group}” members`)
+    }
   }
 
   return jsx(Dialog, {
@@ -9334,7 +9418,7 @@ function GroupDialog({ bot, onClose }) {
                     children: [
                       jsx(Checkbox, {
                         checked: enabled,
-                        onCheckedChange: checked => setMembership(group, checked === true)
+                        onCheckedChange: checked => void setMembership(group, checked === true)
                       }),
                       jsx('span', { children: group })
                     ]
@@ -9351,7 +9435,7 @@ function GroupDialog({ bot, onClose }) {
             const trimmed = name.trim()
 
             if (trimmed) {
-              setMembership(trimmed, true)
+              void setMembership(trimmed, true)
               setName('')
             }
           },
@@ -9464,21 +9548,45 @@ function GroupImageControls({ image, onImage, seedName, seedMembers }) {
 /** Edit an existing group chat's name and picture. Renames re-key the room
  *  and every local member's membership (renameGroupChat); the picture rides
  *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
-function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
+function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRenamed }) {
   const rooms = useValue($groupChats)
+  const allMeta = useValue($botMeta)
   const current = (rooms[group] || {}).image || null
   const [name, setName] = useState(group)
   const [image, setImage] = useState(current)
+  const [checked, setChecked] = useState({})
+
+  const candidatesByKey = new Map()
+
+  for (const bot of members || []) {
+    candidatesByKey.set(botRosterKey(bot), bot)
+  }
+
+  // Prefer a live roster row over its persisted descriptor while retaining
+  // offline members that exist only in the room record.
+  for (const bot of roster || []) {
+    candidatesByKey.set(botRosterKey(bot), bot)
+  }
+
+  const candidates = [...candidatesByKey.values()]
+  const selected = candidates.filter(bot => checked[botRosterKey(bot)])
+  const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
 
   useEffect(() => {
     if (open) {
       setName(group)
       setImage(current)
+      setChecked(Object.fromEntries((members || []).map(bot => [botRosterKey(bot), true])))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group])
 
   const save = async () => {
+    if (selected.length < 2 || selected.length > GROUP_CHAT_MAX_MEMBERS) {
+      host.notifyError(new Error(`Group chats require 2–${GROUP_CHAT_MAX_MEMBERS} bots`), 'Could not save group')
+      return
+    }
+
     const finalName = await renameGroupChat(group, name, members)
 
     if (finalName === null) {
@@ -9487,6 +9595,13 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
 
     if (image !== current) {
       setGroupChatImage(finalName, image)
+    }
+
+    try {
+      await replaceGroupChatMembers(finalName, selected)
+    } catch (error) {
+      host.notifyError(error, 'Could not save group members')
+      return
     }
 
     onClose()
@@ -9510,7 +9625,7 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
           children: [
             jsx(DialogTitle, { children: 'Group settings' }),
             jsx(DialogDescription, {
-              children: 'Rename the group or set a room picture. Members and history are kept.'
+              children: `Rename the group, set a room picture, or choose 2–${GROUP_CHAT_MAX_MEMBERS} members.`
             })
           ]
         }),
@@ -9533,10 +9648,57 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
             onChange: event => setName(event.target.value)
           })
         }),
+        jsxs('div', {
+          className: 'grid gap-1.5',
+          children: [
+            jsx('div', {
+              className: 'text-xs font-medium text-(--ui-text-secondary)',
+              children: `Members (${selected.length}/${GROUP_CHAT_MAX_MEMBERS})`
+            }),
+            jsx(ScrollArea, {
+              className: 'max-h-52 min-h-0 rounded-md border border-(--ui-border-subtle)',
+              children: jsx('div', {
+                'aria-label': 'Group members',
+                className: 'grid gap-0.5 p-1.5',
+                children: candidates.map(bot => {
+                  const key = botRosterKey(bot)
+                  const isChecked = Boolean(checked[key])
+                  const disabled = !isChecked && atCap
+                  const meta = botRosterMeta(bot, allMeta)
+
+                  return jsxs('label', {
+                    className: cn(
+                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-(--chrome-action-hover)',
+                      disabled && 'cursor-not-allowed opacity-50'
+                    ),
+                    children: [
+                      jsx(Checkbox, {
+                        checked: isChecked,
+                        disabled,
+                        onCheckedChange: value => setChecked(prev => ({ ...prev, [key]: Boolean(value) }))
+                      }),
+                      jsx('span', { className: 'min-w-0 flex-1 truncate', children: displayName(bot, meta) }),
+                      bot.remoteSource && bot.connectionLabel
+                        ? jsx('span', {
+                            className: 'truncate text-[0.625rem] text-(--ui-text-quaternary)',
+                            children: bot.connectionLabel
+                          })
+                        : null
+                    ]
+                  }, key)
+                })
+              })
+            })
+          ]
+        }),
         jsxs(DialogFooter, {
           children: [
             jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
-            jsx(Button, { disabled: !name.trim(), onClick: () => void save(), children: 'Save' })
+            jsx(Button, {
+              disabled: !name.trim() || selected.length < 2,
+              onClick: () => void save(),
+              children: `Save (${selected.length})`
+            })
           ]
         })
       ]
@@ -10160,6 +10322,7 @@ function GroupClarifyCard({ entry, members }) {
 function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
+  const roster = useValue($lastRoster)
   const room = rooms[group] || { log: [], running: false }
   const [draft, setDraft] = useState('')
   const [confirmDisband, setConfirmDisband] = useState(false)
@@ -10869,6 +11032,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       jsx(GroupChatSettingsDialog, {
         group,
         members,
+        roster,
         open: settingsOpen,
         onClose: () => setSettingsOpen(false)
       }),

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4174,7 +4174,13 @@ async function deliverRemoteRosterMentions(bots, userText, sender) {
  *  duplicate keys make React reconciliation repeat whole blocks of the list
  *  on every poll repaint (the Aug 2026 dupe-bots smear). */
 function botRosterKey(bot) {
-  return `${bot?.connectionId || 'legacy'}::${bot?.name || 'default'}`
+  const name = bot?.name
+
+  if (!name) {
+    return null
+  }
+
+  return `${bot?.connectionId || 'legacy'}::${name}`
 }
 
 // ── cross-connection routing ─────────────────────────────────────────────────
@@ -4718,7 +4724,7 @@ function groupChatMemberBots(group, roster, metaByName) {
     for (const descriptor of stored) {
       const key = botRosterKey(descriptor)
 
-      if (seated.has(key)) {
+      if (!key || seated.has(key)) {
         continue
       }
 
@@ -4737,7 +4743,7 @@ function groupChatMemberBots(group, roster, metaByName) {
   for (const descriptor of stored) {
     const key = botRosterKey(descriptor)
 
-    if (seated.has(key)) {
+    if (!key || seated.has(key)) {
       continue
     }
 
@@ -4752,7 +4758,7 @@ function groupChatMemberBots(group, roster, metaByName) {
  *  source's row may become remote after a connection switch, so retaining it
  *  here is what keeps the same room intact across machines. */
 function durableGroupChatMembers(bots) {
-  return (bots || []).map(bot => {
+  return (bots || []).filter(bot => botRosterKey(bot)).map(bot => {
     // Keep the friendly identity on the stored descriptor: after a
     // connection switch the live roster row may be gone, and renamed-tag
     // mentions must still resolve against the persisted member.
@@ -4790,8 +4796,8 @@ async function replaceGroupChatMembers(group, bots) {
     unique.push(bot)
   }
 
-  if (unique.length < 2 || unique.length > GROUP_CHAT_MAX_MEMBERS) {
-    throw new Error(`Group chats require 2–${GROUP_CHAT_MAX_MEMBERS} bots`)
+  if (!unique.length || unique.length > GROUP_CHAT_MAX_MEMBERS) {
+    throw new Error(`Group chats require 1–${GROUP_CHAT_MAX_MEMBERS} bots`)
   }
 
   const metaByName = $botMeta.get()
@@ -4804,11 +4810,72 @@ async function replaceGroupChatMembers(group, bots) {
     }
   }
 
-  await Promise.all(
-    [...affectedLocal].map(name =>
-      saveBotMeta(name, groupMembershipPatch($botMeta.get()[name], group, nextLocal.has(name)))
-    )
+  const names = [...affectedLocal]
+  const writes = await Promise.allSettled(
+    names.map(name => saveBotMeta(name, groupMembershipPatch(metaByName[name], group, nextLocal.has(name))))
   )
+  const failed = writes
+    .map((result, index) => ({ result, name: names[index] }))
+    .filter(({ result }) => result.status === 'rejected' || result.value?.serverOutcome === 'failed')
+
+  if (failed.length) {
+    // Only profiles whose new metadata was confirmed remotely need a remote
+    // rollback. A profile that explicitly rejected the write is already at the
+    // old remote value; trying to "restore" it would make a failed rollback
+    // look like a remote inconsistency that this operation did not create.
+    const persistedNames = new Set(
+      writes
+        .map((result, index) => ({ result, name: names[index] }))
+        .filter(({ result }) => result.status === 'fulfilled' && result.value?.serverOutcome === 'persisted')
+        .map(({ name }) => name)
+    )
+    const rollbackNames = names.filter(name => persistedNames.has(name))
+    const rollbackResults = await Promise.allSettled(
+      rollbackNames.map(name => {
+        const prior = metaByName[name] || {}
+        return saveBotMeta(name, {
+          groups: Array.isArray(prior.groups) ? prior.groups : [],
+          group: prior.group || null
+        })
+      })
+    )
+    const rollbackFailures = rollbackResults
+      .map((result, index) => ({ result, name: rollbackNames[index] }))
+      .filter(({ result }) => result.status === 'rejected' || result.value?.serverOutcome !== 'persisted')
+
+    // saveBotMeta is a merge API for normal edits. Restore the exact snapshot
+    // locally as the final reconciliation step so profiles that had no
+    // explicit group fields are not left with synthetic empty projections.
+    $botMeta.set(metaByName)
+    try {
+      Promise.resolve(pluginCtx?.storage?.set?.('bot-meta', metaByName)).catch(() => undefined)
+    } catch {
+      /* local atom is still reconciled for this window */
+    }
+
+    const details = failed.map(({ name, result }) => {
+      if (result.status === 'rejected') {
+        return `${name}: ${result.reason?.message || 'write failed'}`
+      }
+
+      return `${name}: server rejected the write`
+    })
+
+    if (rollbackFailures.length) {
+      const rollbackDetails = rollbackFailures.map(({ name, result }) => {
+        if (result.status === 'rejected') {
+          return `${name}: ${result.reason?.message || 'rollback failed'}`
+        }
+
+        return `${name}: rollback was not confirmed by the server`
+      })
+      throw new Error(
+        `Could not save group members (${details.join(', ')}); rollback could not be confirmed (${rollbackDetails.join(', ')}), remote metadata may be inconsistent`
+      )
+    }
+
+    throw new Error(`Could not save group members (${details.join(', ')}); changes were rolled back`)
+  }
 
   updateGroupChat(group, room => {
     room.members = durableGroupChatMembers(unique)
@@ -5799,14 +5866,36 @@ async function harvestStrandedGroupReply(group, member) {
 async function runGroupChatRounds(group, members, thread) {
   const startEpoch = ($groupChats.get()[group] || {}).epoch || 0
   const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === startEpoch
+  const activeMembers = () => {
+    const room = $groupChats.get()[group] || {}
+
+    // Modern rooms persist the complete source-qualified roster. Re-read it
+    // at every round and member boundary so removing a bot during an active
+    // turn cannot schedule that bot again later in the same drive.
+    if (Array.isArray(room.members)) {
+      const activeKeys = new Set(room.members.map(botRosterKey).filter(Boolean))
+      return members.filter(member => {
+        const key = botRosterKey(member)
+        return key && activeKeys.has(key)
+      })
+    }
+
+    return members
+  }
   let posted = 0
 
   try {
     for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
+      const roundMembers = activeMembers()
+
+      if (!roundMembers.length) {
+        return
+      }
+
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
       // late, never lost.
-      for (const member of members) {
+      for (const member of roundMembers) {
         if (!isCurrent()) {
           recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
           return
@@ -5829,12 +5918,12 @@ async function runGroupChatRounds(group, members, thread) {
       // value shape, since markers are a bare number pre-thread or
       // {before, thread} post-thread.
       const strandedNow = ($groupChats.get()[group] || {}).stranded || {}
-      const responders = rotateGroupSpeakers(resolveGroupResponders(roomLog, members), round)
+      const responders = rotateGroupSpeakers(resolveGroupResponders(roomLog, roundMembers), round)
         .filter(member => !Object.prototype.hasOwnProperty.call(strandedNow, groupMemberKey(member)))
       let spokeThisRound = 0
 
       for (const member of responders) {
-        if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
+        if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES || !activeMembers().some(active => botRosterKey(active) === botRosterKey(member))) {
           if (!isCurrent()) {
             recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
           }
@@ -9555,42 +9644,61 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
   const [name, setName] = useState(group)
   const [image, setImage] = useState(current)
   const [checked, setChecked] = useState({})
+  const [query, setQuery] = useState('')
+  const [workingGroup, setWorkingGroup] = useState(group)
 
   const candidatesByKey = new Map()
 
   for (const bot of members || []) {
-    candidatesByKey.set(botRosterKey(bot), bot)
+    const key = botRosterKey(bot)
+
+    if (key) {
+      candidatesByKey.set(key, bot)
+    }
   }
 
   // Prefer a live roster row over its persisted descriptor while retaining
   // offline members that exist only in the room record.
   for (const bot of roster || []) {
-    candidatesByKey.set(botRosterKey(bot), bot)
+    const key = botRosterKey(bot)
+
+    if (key) {
+      candidatesByKey.set(key, bot)
+    }
   }
 
   const candidates = [...candidatesByKey.values()]
   const selected = candidates.filter(bot => checked[botRosterKey(bot)])
+  const visible = filterBots(candidates, allMeta, query)
   const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
 
   useEffect(() => {
     if (open) {
       setName(group)
       setImage(current)
-      setChecked(Object.fromEntries((members || []).map(bot => [botRosterKey(bot), true])))
+      setChecked(Object.fromEntries((members || []).filter(bot => botRosterKey(bot)).map(bot => [botRosterKey(bot), true])))
+      setQuery('')
+      setWorkingGroup(group)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group])
 
   const save = async () => {
-    if (selected.length < 2 || selected.length > GROUP_CHAT_MAX_MEMBERS) {
-      host.notifyError(new Error(`Group chats require 2–${GROUP_CHAT_MAX_MEMBERS} bots`), 'Could not save group')
+    if (!selected.length || selected.length > GROUP_CHAT_MAX_MEMBERS) {
+      host.notifyError(new Error(`Group chats require 1–${GROUP_CHAT_MAX_MEMBERS} bots`), 'Could not save group')
       return
     }
 
-    const finalName = await renameGroupChat(group, name, members)
+    let finalName = workingGroup
 
-    if (finalName === null) {
-      return // collision — dialog stays open for a different name
+    if (workingGroup === group) {
+      finalName = await renameGroupChat(group, name, members)
+
+      if (finalName === null) {
+        return // collision — dialog stays open for a different name
+      }
+
+      setWorkingGroup(finalName)
     }
 
     if (image !== current) {
@@ -9611,6 +9719,11 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
     }
   }
 
+  const disband = async () => {
+    await disbandGroupChat(workingGroup, members)
+    onClose()
+  }
+
   return jsx(Dialog, {
     open,
     onOpenChange: value => {
@@ -9625,7 +9738,7 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
           children: [
             jsx(DialogTitle, { children: 'Group settings' }),
             jsx(DialogDescription, {
-              children: `Rename the group, set a room picture, or choose 2–${GROUP_CHAT_MAX_MEMBERS} members.`
+              children: `Rename the group, set a room picture, or choose 1–${GROUP_CHAT_MAX_MEMBERS} members.`
             })
           ]
         }),
@@ -9648,8 +9761,15 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
             onChange: event => setName(event.target.value)
           })
         }),
+        jsx(SearchField, {
+          'aria-label': 'Search group members',
+          containerClassName: 'w-full',
+          inputClassName: 'w-full',
+          placeholder: 'Search members…',
+          value: query,
+          onChange: setQuery
+        }),
         jsxs('div', {
-          className: 'grid gap-1.5',
           children: [
             jsx('div', {
               className: 'text-xs font-medium text-(--ui-text-secondary)',
@@ -9660,7 +9780,7 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
               children: jsx('div', {
                 'aria-label': 'Group members',
                 className: 'grid gap-0.5 p-1.5',
-                children: candidates.map(bot => {
+                children: visible.map(bot => {
                   const key = botRosterKey(bot)
                   const isChecked = Boolean(checked[key])
                   const disabled = !isChecked && atCap
@@ -9694,8 +9814,11 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
         jsxs(DialogFooter, {
           children: [
             jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
+            selected.length === 0
+              ? jsx(Button, { variant: 'destructive', onClick: () => void disband(), children: 'Disband' })
+              : null,
             jsx(Button, {
-              disabled: !name.trim() || selected.length < 2,
+              disabled: !name.trim() || !selected.length,
               onClick: () => void save(),
               children: `Save (${selected.length})`
             })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -806,6 +806,7 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       sessions: room.sessions || {},
       stranded: room.stranded || {},
       members: Array.isArray(room.members) ? room.members : [],
+      roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -807,6 +807,7 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       stranded: room.stranded || {},
       members: Array.isArray(room.members) ? room.members : [],
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+      pendingMemberConfigs: room.pendingMemberConfigs || {},
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
@@ -4216,6 +4217,272 @@ async function requestForBot(bot, method, params = {}) {
   return host.request(method, params)
 }
 
+const GROUP_REASONING_INHERIT = '__inherit__'
+const GROUP_REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+
+function normalizeGroupMemberRuntimeConfig(description, options = []) {
+  const model = description?.model || {}
+
+  return {
+    provider: String(model.provider || '').trim(),
+    model: String(model.default || '').trim(),
+    reasoning: String(description?.reasoning_effort || '').trim().toLowerCase() || GROUP_REASONING_INHERIT,
+    options: (options || []).filter(provider => provider?.slug).map(provider => ({
+      slug: provider.slug,
+      name: provider.name || provider.slug,
+      models: (provider.models || [])
+        .map(candidate => (typeof candidate === 'string' ? candidate : candidate?.id || candidate?.name || ''))
+        .filter(Boolean)
+    }))
+  }
+}
+
+function groupMemberRuntimeCapability(bot, live = true) {
+  if (bot?.remoteSource && !live) {
+    return {
+      editable: false,
+      reason: 'This member is offline. Reconnect its source to update durable settings.'
+    }
+  }
+
+  if (bot?.remoteSource && typeof host.requestProfile !== 'function') {
+    return {
+      editable: false,
+      reason: 'Update Hermes Desktop to edit settings on another connection.'
+    }
+  }
+
+  return { editable: true, reason: '' }
+}
+
+function validateGroupMemberRuntimeConfig(config) {
+  const provider = String(config?.provider || '').trim()
+  const model = String(config?.model || '').trim()
+  const reasoning = String(config?.reasoning || '').trim().toLowerCase()
+  const options = Array.isArray(config?.options) ? config.options : []
+
+  if (!provider || !model) {
+    return 'Choose both a provider and model.'
+  }
+
+  const providerOption = options.find(option => option?.slug === provider)
+
+  if (!providerOption) {
+    return `Provider “${provider}” is unavailable on this member’s connection. Choose an available provider.`
+  }
+
+  if (!(providerOption.models || []).includes(model)) {
+    return `Model “${model}” is unavailable from ${provider}. Choose an available model.`
+  }
+
+  if (reasoning !== GROUP_REASONING_INHERIT && !GROUP_REASONING_EFFORTS.includes(reasoning)) {
+    return `Choose a supported reasoning effort (${GROUP_REASONING_EFFORTS.join(', ')}).`
+  }
+
+  return null
+}
+
+function sameGroupMemberRuntimeConfig(left, right) {
+  return (
+    String(left?.provider || '').trim() === String(right?.provider || '').trim() &&
+    String(left?.model || '').trim() === String(right?.model || '').trim() &&
+    String(left?.reasoning || '').trim().toLowerCase() === String(right?.reasoning || '').trim().toLowerCase()
+  )
+}
+
+async function loadGroupMemberRuntimeConfig(bot, live) {
+  const capability = groupMemberRuntimeCapability(bot, live)
+
+  if (!capability.editable) {
+    return { status: 'unsupported', reason: capability.reason, bot }
+  }
+
+  try {
+    const [description, inventory] = await Promise.all([
+      requestForBot(bot, 'profiles.describe', { name: bot.name }),
+      requestForBot(bot, 'model.options', {
+        profile: bot.name,
+        include_unconfigured: false,
+        explicit_only: false,
+        refresh: true
+      })
+    ])
+
+    if (!description || !Object.prototype.hasOwnProperty.call(description, 'reasoning_effort')) {
+      return {
+        status: 'unsupported',
+        reason: 'Update this member’s Hermes gateway to edit model and reasoning settings safely.',
+        bot
+      }
+    }
+
+    const normalized = normalizeGroupMemberRuntimeConfig(description, inventory?.providers)
+    const validation = validateGroupMemberRuntimeConfig(normalized)
+
+    return {
+      status: 'ready',
+      bot,
+      baseline: normalized,
+      draft: { provider: normalized.provider, model: normalized.model, reasoning: normalized.reasoning },
+      options: normalized.options,
+      error: validation
+    }
+  } catch (error) {
+    return {
+      status: 'error',
+      reason: `Could not load durable settings: ${error?.message || 'connection failed'}`,
+      bot
+    }
+  }
+}
+
+function groupMemberRuntimePayload(bot, config) {
+  const reasoning = String(config.reasoning || '').trim().toLowerCase()
+  return {
+    name: bot.name,
+    provider: String(config.provider || '').trim(),
+    model: String(config.model || '').trim(),
+    reasoning_effort: reasoning === GROUP_REASONING_INHERIT ? '' : reasoning
+  }
+}
+
+function cloneGroupMemberRuntimePending(pending) {
+  if (!pending || typeof pending !== 'object') {
+    return {}
+  }
+  return Object.fromEntries(
+    Object.entries(pending).map(([key, config]) => [key, { ...config }])
+  )
+}
+
+function snapshotGroupMemberRuntimePending(group) {
+  return cloneGroupMemberRuntimePending($groupChats.get()[group]?.pendingMemberConfigs)
+}
+
+function restoreGroupMemberRuntimePending(group, pending) {
+  updateGroupChat(group, room => {
+    room.pendingMemberConfigs = cloneGroupMemberRuntimePending(pending)
+    return room
+  })
+}
+
+async function rollbackGroupSettingsRename(finalName, originalName, members) {
+  const restoredName = await renameGroupChat(finalName, originalName, members)
+  if (restoredName !== originalName) {
+    throw new Error(`Could not restore original room name ${originalName}`)
+  }
+  return restoredName
+}
+
+async function saveGroupMemberRuntimeConfigs(group, configs) {
+  const changed = (configs || []).filter(entry =>
+    entry?.bot && entry?.baseline && entry?.draft && !sameGroupMemberRuntimeConfig(entry.baseline, entry.draft)
+  )
+
+  for (const entry of changed) {
+    const error = validateGroupMemberRuntimeConfig({ ...entry.draft, options: entry.options })
+
+    if (error) {
+      throw new Error(`${displayName(entry.bot, botRosterMeta(entry.bot, $botMeta.get()))}: ${error}`)
+    }
+  }
+
+  const committed = []
+
+  try {
+    for (const entry of changed) {
+      const result = await requestForBot(entry.bot, 'profiles.configure', groupMemberRuntimePayload(entry.bot, entry.draft))
+      const applied = result?.applied || {}
+
+      if (result?.ok === false || applied.model !== true || applied.reasoning_effort !== true) {
+        throw new Error(`${entry.bot.name} rejected the provider/model/reasoning update`)
+      }
+
+      committed.push(entry)
+    }
+  } catch (error) {
+    const rollback = await Promise.allSettled(
+      committed.reverse().map(entry =>
+        requestForBot(entry.bot, 'profiles.configure', groupMemberRuntimePayload(entry.bot, entry.baseline))
+      )
+    )
+    const uncertain = rollback.some(result =>
+      result.status === 'rejected' ||
+      result.value?.ok === false ||
+      result.value?.applied?.model !== true ||
+      result.value?.applied?.reasoning_effort !== true
+    )
+
+    throw new Error(
+      `${error?.message || 'Member settings save failed'}; ${
+        uncertain ? 'rollback could not be confirmed, profile settings may be inconsistent' : 'changes were rolled back'
+      }`
+    )
+  }
+
+  if (changed.length) {
+    updateGroupChat(group, room => {
+      const pending = { ...(room.pendingMemberConfigs || {}) }
+
+      for (const entry of changed) {
+        pending[groupMemberKey(entry.bot)] = {
+          provider: String(entry.draft.provider || '').trim(),
+          model: String(entry.draft.model || '').trim(),
+          reasoning: String(entry.draft.reasoning || '').trim().toLowerCase() === GROUP_REASONING_INHERIT
+            ? 'inherit'
+            : String(entry.draft.reasoning || '').trim().toLowerCase()
+        }
+      }
+
+      room.pendingMemberConfigs = pending
+      return room
+    })
+  }
+
+  return { changed: changed.length }
+}
+
+async function applyPendingGroupMemberRuntime(group, member, sessionId) {
+  const memberKey = groupMemberKey(member)
+  const pending = $groupChats.get()[group]?.pendingMemberConfigs?.[memberKey]
+
+  if (!pending) {
+    return false
+  }
+
+  try {
+    const modelResult = await requestForBot(member, 'config.set', {
+      session_id: sessionId,
+      profile: member.name,
+      key: 'model',
+      value: `${pending.model} --provider ${pending.provider} --session`
+    })
+    if (modelResult?.confirm_required) {
+      throw new Error(modelResult.confirm_message || `Model switch for ${member.name} requires confirmation`)
+    }
+    if (modelResult?.deferred) {
+      throw new Error(`Member session is still busy; saved settings for ${member.name} remain pending`)
+    }
+    await requestForBot(member, 'config.set', {
+      session_id: sessionId,
+      profile: member.name,
+      key: 'reasoning',
+      value: pending.reasoning
+    })
+  } catch (error) {
+    throw new Error(`Could not apply saved settings for ${member.name}: ${error?.message || 'runtime update failed'}`)
+  }
+
+  updateGroupChat(group, room => {
+    const next = { ...(room.pendingMemberConfigs || {}) }
+    delete next[memberKey]
+    room.pendingMemberConfigs = next
+    return room
+  })
+
+  return true
+}
+
 /** Stable per-member identity inside a group room. Local members keep their
  *  bare name (compat with rooms persisted before cross-connection groups);
  *  remote members get the source-qualified key so `dixie` on the Mini and a
@@ -4880,6 +5147,10 @@ async function replaceGroupChatMembers(group, bots) {
 
   updateGroupChat(group, room => {
     room.members = durableGroupChatMembers(unique)
+    const seated = new Set(unique.map(groupMemberKey))
+    room.pendingMemberConfigs = Object.fromEntries(
+      Object.entries(room.pendingMemberConfigs || {}).filter(([key]) => seated.has(key))
+    )
     return room
   })
 
@@ -5149,6 +5420,8 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],
+        // Per-member inference changes wait here until that member's next turn.
+        pendingMemberConfigs: room.pendingMemberConfigs || {},
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).
@@ -5637,6 +5910,12 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
   if (!runtime) {
     return null
   }
+
+  // Profile settings are committed by Group Settings, but an existing hidden
+  // member session already owns a live agent. Switch that session only at this
+  // boundary — after the prior turn finished and before the next prompt — so an
+  // in-flight response can never observe a half-swapped provider/model.
+  await applyPendingGroupMemberRuntime(group, member, runtime)
 
   recordGroupActivity(group, { kind: 'working', member: member.name, thread })
 
@@ -9635,6 +9914,140 @@ function GroupImageControls({ image, onImage, seedName, seedMembers }) {
   })
 }
 
+function GroupMemberRuntimeEditor({ bot, live, entry, onEntry }) {
+  const key = botRosterKey(bot)
+
+  useEffect(() => {
+    if (!key) {
+      return
+    }
+
+    onEntry({ status: 'loading', bot })
+    let cancelled = false
+    void loadGroupMemberRuntimeConfig(bot, live).then(result => {
+      if (!cancelled) {
+        onEntry(result)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+    // The member key and reachability define this load's lifecycle. Including
+    // the parent-owned entry or inline onEntry callback would cancel the
+    // request as soon as the initial "loading" update re-renders the row.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, live])
+
+  if (!entry || entry.status === 'loading') {
+    return jsxs('div', {
+      className: 'flex items-center gap-2 py-1 text-[0.6875rem] text-(--ui-text-tertiary)',
+      children: [
+        jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-quaternary)' }),
+        'Loading effective provider, model, and reasoning…'
+      ]
+    })
+  }
+
+  if (entry.status !== 'ready') {
+    return jsxs('div', {
+      className: 'rounded-md border border-(--ui-stroke-secondary) bg-(--chrome-action-hover) px-2 py-1.5 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)',
+      children: [jsx(Codicon, { name: 'warning', className: 'mr-1' }), entry.reason]
+    })
+  }
+
+  const draft = entry.draft
+  const provider = entry.options.find(option => option.slug === draft.provider)
+  const models = provider?.models || []
+  const error = validateGroupMemberRuntimeConfig({ ...draft, options: entry.options })
+  const staged = !sameGroupMemberRuntimeConfig(entry.baseline, draft)
+  const reasoningLabel = draft.reasoning === GROUP_REASONING_INHERIT ? 'inherited/default' : draft.reasoning
+  const patchDraft = patch => onEntry({
+    ...entry,
+    draft: { ...draft, ...patch },
+    error: validateGroupMemberRuntimeConfig({ ...draft, ...patch, options: entry.options })
+  })
+
+  return jsxs('div', {
+    className: 'grid gap-1.5 pt-1.5',
+    children: [
+      jsxs('div', {
+        className: 'grid grid-cols-3 gap-1.5',
+        children: [
+          jsxs(Select, {
+            value: draft.provider,
+            onValueChange: value => {
+              const next = entry.options.find(option => option.slug === value)
+              patchDraft({ provider: value, model: next?.models?.[0] || '' })
+            },
+            children: [
+              jsx(SelectTrigger, {
+                className: 'h-7 min-w-0 rounded-md text-[0.6875rem]',
+                'aria-label': `Provider for ${bot.name}`,
+                children: jsx(SelectValue, {})
+              }),
+              jsx(SelectContent, {
+                children: entry.options.map(option =>
+                  jsx(SelectItem, { value: option.slug, children: option.name || option.slug }, option.slug)
+                )
+              })
+            ]
+          }),
+          jsxs(Select, {
+            value: draft.model,
+            onValueChange: model => patchDraft({ model }),
+            children: [
+              jsx(SelectTrigger, {
+                className: 'h-7 min-w-0 rounded-md text-[0.6875rem]',
+                'aria-label': `Model for ${bot.name}`,
+                children: jsx(SelectValue, {})
+              }),
+              jsx(SelectContent, {
+                children: models.map(model => jsx(SelectItem, { value: model, children: model }, model))
+              })
+            ]
+          }),
+          jsxs(Select, {
+            value: draft.reasoning,
+            onValueChange: reasoning => patchDraft({ reasoning }),
+            children: [
+              jsx(SelectTrigger, {
+                className: 'h-7 min-w-0 rounded-md text-[0.6875rem]',
+                'aria-label': `Reasoning effort for ${bot.name}`,
+                children: jsx(SelectValue, {})
+              }),
+              jsx(SelectContent, {
+                children: [
+                  jsx(SelectItem, { value: GROUP_REASONING_INHERIT, children: 'inherited/default' }, GROUP_REASONING_INHERIT),
+                  ...GROUP_REASONING_EFFORTS.map(reasoning =>
+                    jsx(SelectItem, { value: reasoning, children: reasoning }, reasoning)
+                  )
+                ]
+              })
+            ]
+          })
+        ]
+      }),
+      error
+        ? jsx('div', { className: 'text-[0.65rem] leading-4 text-(--ui-accent)', children: error })
+        : staged
+          ? jsx('div', {
+              className: 'text-[0.65rem] font-medium text-(--ui-text-secondary)',
+              children: 'Staged — applies before this member’s next group turn.'
+            })
+          : jsx('div', {
+              className: 'text-[0.65rem] text-(--ui-text-quaternary)',
+              children: `Current effective: ${draft.provider} · ${draft.model} · ${reasoningLabel}`
+            })
+    ]
+  })
+}
+
+/** Close the settings dialog without persisting its React-local draft. */
+function cancelGroupSettingsDraft(onClose) {
+  onClose()
+}
+
 /** Edit an existing group chat's name and picture. Renames re-key the room
  *  and every local member's membership (renameGroupChat); the picture rides
  *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
@@ -9647,6 +10060,8 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
   const [checked, setChecked] = useState({})
   const [query, setQuery] = useState('')
   const [workingGroup, setWorkingGroup] = useState(group)
+  const [memberConfigs, setMemberConfigs] = useState({})
+  const [saving, setSaving] = useState(false)
 
   const candidatesByKey = new Map()
 
@@ -9672,6 +10087,17 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
   const selected = candidates.filter(bot => checked[botRosterKey(bot)])
   const visible = filterBots(candidates, allMeta, query)
   const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
+  const liveRosterKeys = new Set((roster || []).map(botRosterKey).filter(Boolean))
+  const selectedConfigEntries = selected
+    .map(bot => memberConfigs[botRosterKey(bot)])
+    .filter(entry => entry?.status === 'ready')
+  const configsLoading = selected.some(bot => {
+    const entry = memberConfigs[botRosterKey(bot)]
+    return !entry || entry.status === 'loading'
+  })
+  const configError = selectedConfigEntries.find(entry =>
+    validateGroupMemberRuntimeConfig({ ...entry.draft, options: entry.options })
+  )
 
   useEffect(() => {
     if (open) {
@@ -9680,39 +10106,87 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
       setChecked(Object.fromEntries((members || []).filter(bot => botRosterKey(bot)).map(bot => [botRosterKey(bot), true])))
       setQuery('')
       setWorkingGroup(group)
+      setMemberConfigs({})
+      setSaving(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group])
 
   const save = async () => {
+    if (saving) {
+      return
+    }
+
     if (!selected.length || selected.length > GROUP_CHAT_MAX_MEMBERS) {
       host.notifyError(new Error(`Group chats require 1–${GROUP_CHAT_MAX_MEMBERS} bots`), 'Could not save group')
       return
     }
 
-    let finalName = workingGroup
-
-    if (workingGroup === group) {
-      finalName = await renameGroupChat(group, name, members)
-
-      if (finalName === null) {
-        return // collision — dialog stays open for a different name
-      }
-
-      setWorkingGroup(finalName)
-    }
-
-    if (image !== current) {
-      setGroupChatImage(finalName, image)
-    }
-
-    try {
-      await replaceGroupChatMembers(finalName, selected)
-    } catch (error) {
-      host.notifyError(error, 'Could not save group members')
+    if (configsLoading) {
+      host.notifyError(new Error('Wait for member settings to finish loading.'), 'Could not save group')
       return
     }
 
+    if (configError) {
+      const message = validateGroupMemberRuntimeConfig({ ...configError.draft, options: configError.options })
+      host.notifyError(new Error(`${configError.bot.name}: ${message}`), 'Could not save group')
+      return
+    }
+
+    setSaving(true)
+
+    let finalName = workingGroup
+    let renamed = false
+    const pendingBefore = snapshotGroupMemberRuntimePending(workingGroup)
+
+    try {
+      if (workingGroup === group) {
+        finalName = await renameGroupChat(group, name, members)
+
+        if (finalName === null) {
+          setSaving(false)
+          return // collision — dialog stays open for a different name
+        }
+
+        renamed = finalName !== group
+        setWorkingGroup(finalName)
+      }
+
+      if (image !== current) {
+        setGroupChatImage(finalName, image)
+      }
+
+      await replaceGroupChatMembers(finalName, selected)
+      await saveGroupMemberRuntimeConfigs(finalName, selectedConfigEntries)
+    } catch (error) {
+      let rollbackError = null
+      try {
+        await replaceGroupChatMembers(finalName, members)
+        setGroupChatImage(finalName, current)
+        if (renamed) {
+          await rollbackGroupSettingsRename(finalName, group, members)
+          setWorkingGroup(group)
+        }
+      } catch (rollbackFailure) {
+        rollbackError = rollbackFailure
+      }
+
+      const rollbackTarget = renamed && !rollbackError ? group : finalName
+      restoreGroupMemberRuntimePending(rollbackTarget, pendingBefore)
+
+      host.notifyError(
+        new Error(
+          rollbackError
+            ? `${error?.message || 'save failed'}; room rollback could not be confirmed: ${rollbackError?.message || 'unknown error'}`
+            : `${error?.message || 'save failed'}; room changes were rolled back`
+        ),
+        'Could not save group settings'
+      )
+      setSaving(false)
+      return
+    }
+
+    setSaving(false)
     onClose()
 
     if (finalName !== group) {
@@ -9728,18 +10202,18 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
   return jsx(Dialog, {
     open,
     onOpenChange: value => {
-      if (!value) {
+      if (!value && !saving) {
         onClose()
       }
     },
     children: jsxs(DialogContent, {
-      className: 'max-w-sm',
+      className: 'max-h-[90vh] max-w-2xl overflow-y-auto',
       children: [
         jsxs(DialogHeader, {
           children: [
             jsx(DialogTitle, { children: 'Group settings' }),
             jsx(DialogDescription, {
-              children: `Rename the group, set a room picture, or choose 1–${GROUP_CHAT_MAX_MEMBERS} members.`
+              children: `Choose 1–${GROUP_CHAT_MAX_MEMBERS} members and stage each member’s provider, model, and reasoning. Save applies them to subsequent turns only.`
             })
           ]
         }),
@@ -9777,7 +10251,7 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
               children: `Members (${selected.length}/${GROUP_CHAT_MAX_MEMBERS})`
             }),
             jsx(ScrollArea, {
-              className: 'max-h-52 min-h-0 rounded-md border border-(--ui-border-subtle)',
+              className: 'max-h-[28rem] min-h-0 rounded-md border border-(--ui-border-subtle)',
               children: jsx('div', {
                 'aria-label': 'Group members',
                 className: 'grid gap-0.5 p-1.5',
@@ -9787,22 +10261,38 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
                   const disabled = !isChecked && atCap
                   const meta = botRosterMeta(bot, allMeta)
 
-                  return jsxs('label', {
+                  return jsxs('div', {
                     className: cn(
-                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-(--chrome-action-hover)',
+                      'grid rounded-md border border-transparent px-1.5 py-1 text-xs hover:bg-(--chrome-action-hover)',
+                      isChecked && 'border-(--ui-border-subtle) bg-(--chrome-action-hover)',
                       disabled && 'cursor-not-allowed opacity-50'
                     ),
                     children: [
-                      jsx(Checkbox, {
-                        checked: isChecked,
-                        disabled,
-                        onCheckedChange: value => setChecked(prev => ({ ...prev, [key]: Boolean(value) }))
-                      }),
-                      jsx('span', { className: 'min-w-0 flex-1 truncate', children: displayName(bot, meta) }),
-                      bot.remoteSource && bot.connectionLabel
-                        ? jsx('span', {
+                      jsxs('label', {
+                        className: cn('flex cursor-pointer items-center gap-2', disabled && 'cursor-not-allowed'),
+                        children: [
+                          jsx(Checkbox, {
+                            checked: isChecked,
+                            disabled,
+                            onCheckedChange: value => setChecked(prev => ({ ...prev, [key]: Boolean(value) }))
+                          }),
+                          jsx('span', { className: 'min-w-0 flex-1 truncate', children: displayName(bot, meta) }),
+                          jsx('span', {
                             className: 'truncate text-[0.625rem] text-(--ui-text-quaternary)',
-                            children: bot.connectionLabel
+                            children: bot.remoteSource
+                              ? liveRosterKeys.has(key)
+                                ? bot.connectionLabel || 'remote'
+                                : `${bot.connectionLabel || 'remote'} · offline`
+                              : 'local'
+                          })
+                        ]
+                      }),
+                      isChecked
+                        ? jsx(GroupMemberRuntimeEditor, {
+                            bot,
+                            live: liveRosterKeys.has(key),
+                            entry: memberConfigs[key],
+                            onEntry: entry => setMemberConfigs(prev => ({ ...prev, [key]: entry }))
                           })
                         : null
                     ]
@@ -9814,14 +10304,19 @@ function GroupChatSettingsDialog({ group, members, roster, open, onClose, onRena
         }),
         jsxs(DialogFooter, {
           children: [
-            jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
+            jsx(Button, {
+              variant: 'secondary',
+              disabled: saving,
+              onClick: () => cancelGroupSettingsDraft(onClose),
+              children: 'Cancel'
+            }),
             selected.length === 0
-              ? jsx(Button, { variant: 'destructive', onClick: () => void disband(), children: 'Disband' })
+              ? jsx(Button, { variant: 'destructive', disabled: saving, onClick: () => void disband(), children: 'Disband' })
               : null,
             jsx(Button, {
-              disabled: !name.trim() || !selected.length,
+              disabled: saving || configsLoading || Boolean(configError) || !name.trim() || !selected.length,
               onClick: () => void save(),
-              children: `Save (${selected.length})`
+              children: saving ? 'Saving…' : `Save (${selected.length})`
             })
           ]
         })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1158,6 +1158,50 @@ test('source contract: group roster rows expose a confirmed Delete Group action'
   assert.match(pluginSource, /children: 'Delete Group'/)
   assert.match(pluginSource, /title: 'Delete group chat\?'/)
   assert.match(pluginSource, /await disbandGroupChat\(deletingGroup\.name, deletingGroup\.members\)/)
+})
+
+test('existing group members can be replaced without stale profile metadata reseating removed bots', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [
+    { name: 'research', title: '' },
+    { name: 'builder', title: '' },
+    { name: 'ops', title: '' }
+  ]
+
+  gc.$botMeta.set({
+    research: { groups: ['Core'], group: 'Core' },
+    builder: { groups: ['Core'], group: 'Core' },
+    ops: { groups: [], group: null }
+  })
+  gc.updateGroupChat('Core', room => {
+    room.members = [roster[0], roster[1]]
+    room.roomId = 'room-core'
+    return room
+  }, { sync: false })
+
+  await gc.replaceGroupChatMembers('Core', [roster[1], roster[2]])
+
+  assert.equal(JSON.stringify(gc.$groupChats.get().Core.members.map(member => member.name)), JSON.stringify(['builder', 'ops']))
+  assert.equal(gc.$botMeta.get().research.groups.includes('Core'), false)
+  assert.equal(gc.$botMeta.get().builder.groups.includes('Core'), true)
+  assert.equal(gc.$botMeta.get().ops.groups.includes('Core'), true)
+  assert.equal(
+    JSON.stringify(gc.groupChatMemberBots('Core', roster, gc.$botMeta.get()).map(member => member.name)),
+    JSON.stringify(['builder', 'ops'])
+  )
+})
+
+test('existing groups enforce the same member-count bounds as creation', async () => {
+  const gc = load(() => '(pass)')
+
+  await assert.rejects(() => gc.replaceGroupChatMembers('Core', [{ name: 'solo' }]), /require 2/)
+})
+
+test('source contract: Group settings exposes persistent member checkboxes after creation', () => {
+  assert.match(pluginSource, /function GroupChatSettingsDialog\(\{ group, members, roster, open, onClose, onRenamed \}\)/)
+  assert.match(pluginSource, /'aria-label': 'Group members'/)
+  assert.match(pluginSource, /await replaceGroupChatMembers\(finalName, selected\)/)
+  assert.match(pluginSource, /disabled: !name\.trim\(\) \|\| selected\.length < 2/)
 })
 
 test('disband: removes only this membership, room log, workspace, and needs-you state', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, failedMetaNames = [], failedMetaCalls = {} } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -29,6 +29,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   const titleToStored = new Map()
   const sharedUiMeta = {}
   const uiMetaRevisions = {}
+  const metaCallCounts = new Map()
   let sessionSequence = 0
   // busyUntilResumeCall[profile] = N: this profile's session.resume reports
   // inflight/running for its first N calls, then flips to done — simulating
@@ -71,6 +72,11 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
           }
         }
         if (method === 'profiles.configure') {
+          const metaCall = (metaCallCounts.get(params.name) || 0) + 1
+          metaCallCounts.set(params.name, metaCall)
+          if (failedMetaNames.includes(params.name) || failedMetaCalls[params.name]?.includes(metaCall)) {
+            return { applied: { ui_meta: false, ui_meta_conflicts: { simulated: true } } }
+          }
           if (conflictOnce && !injectedConflict) {
             injectedConflict = true
             sharedUiMeta['hermes-bots-groups'] = {
@@ -196,7 +202,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, durableGroupChatMembers, filterBots, botRosterKey, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1170,12 +1176,16 @@ test('existing group members can be replaced without stale profile metadata rese
 
   gc.$botMeta.set({
     research: { groups: ['Core'], group: 'Core' },
-    builder: { groups: ['Core'], group: 'Core' },
+    builder: { groups: ['Core'], group: 'Core', title: 'Keep this title', hidden: true, model: 'keep-model' },
     ops: { groups: [], group: null }
   })
   gc.updateGroupChat('Core', room => {
     room.members = [roster[0], roster[1]]
     room.roomId = 'room-core'
+    room.log = [{ id: 'entry-1', text: 'keep transcript', at: 1 }]
+    room.watermarks = { 'legacy::builder': 1 }
+    room.sessions = { 'legacy::builder': 'sid-builder' }
+    room.image = 'data:image/png;base64,room'
     return room
   }, { sync: false })
 
@@ -1184,24 +1194,164 @@ test('existing group members can be replaced without stale profile metadata rese
   assert.equal(JSON.stringify(gc.$groupChats.get().Core.members.map(member => member.name)), JSON.stringify(['builder', 'ops']))
   assert.equal(gc.$botMeta.get().research.groups.includes('Core'), false)
   assert.equal(gc.$botMeta.get().builder.groups.includes('Core'), true)
+  assert.equal(gc.$botMeta.get().builder.title, 'Keep this title')
+  assert.equal(gc.$botMeta.get().builder.hidden, true)
+  assert.equal(gc.$botMeta.get().builder.model, 'keep-model')
   assert.equal(gc.$botMeta.get().ops.groups.includes('Core'), true)
+  assert.equal(gc.$groupChats.get().Core.roomId, 'room-core')
+  assert.equal(gc.$groupChats.get().Core.log[0].text, 'keep transcript')
+  assert.equal(gc.$groupChats.get().Core.watermarks['legacy::builder'], 1)
+  assert.equal(gc.$groupChats.get().Core.sessions['legacy::builder'], 'sid-builder')
+  assert.equal(gc.$groupChats.get().Core.image, 'data:image/png;base64,room')
   assert.equal(
     JSON.stringify(gc.groupChatMemberBots('Core', roster, gc.$botMeta.get()).map(member => member.name)),
     JSON.stringify(['builder', 'ops'])
   )
 })
 
-test('existing groups enforce the same member-count bounds as creation', async () => {
+test('existing groups allow one member but reject zero and more than the cap', async () => {
   const gc = load(() => '(pass)')
 
-  await assert.rejects(() => gc.replaceGroupChatMembers('Core', [{ name: 'solo' }]), /require 2/)
+  await gc.replaceGroupChatMembers('Core', [{ name: 'solo' }])
+  const requestsBeforeInvalidSelections = gc.requests.length
+  const durableBeforeInvalidSelections = JSON.stringify(gc.storageWrites.get('group-chats'))
+  await assert.rejects(() => gc.replaceGroupChatMembers('Core', []), /require 1/)
+  await assert.rejects(
+    () => gc.replaceGroupChatMembers('Core', Array.from({ length: 7 }, (_, index) => ({ name: `bot-${index}` }))),
+    /require 1/
+  )
+  assert.equal(gc.requests.length, requestsBeforeInvalidSelections)
+  assert.equal(JSON.stringify(gc.storageWrites.get('group-chats')), durableBeforeInvalidSelections)
+})
+
+test('group roster identity ignores falsy keys and keeps mixed local, remote, and offline members', () => {
+  const gc = load(() => '(pass)')
+  const local = { name: 'builder' }
+  const remote = { name: 'builder', remoteSource: true, connectionId: 'mini', connectionLabel: 'Mini' }
+  const offline = { name: 'ops', remoteSource: true, connectionId: 'nas', sourceScoped: true }
+
+  assert.equal(gc.botRosterKey({}), null)
+  assert.equal(gc.botRosterKey({ name: '' }), null)
+  assert.equal(gc.botRosterKey(local), 'legacy::builder')
+  assert.equal(gc.botRosterKey(remote), 'mini::builder')
+  assert.equal(
+    JSON.stringify(gc.durableGroupChatMembers([{}, local, remote, offline]).map(member => member.name)),
+    JSON.stringify(['builder', 'builder', 'ops'])
+  )
+
+  gc.$groupChats.set({ Core: { roomId: 'room-core', members: [{}, local, remote, offline] } })
+  assert.equal(
+    JSON.stringify(gc.groupChatMemberBots('Core', [local, remote], {}).map(member => [member.name, member.connectionId || 'local'])),
+    JSON.stringify([['builder', 'local'], ['builder', 'mini'], ['ops', 'nas']])
+  )
+})
+
+test('member search matches title, handle, and source without changing roster order', () => {
+  const gc = load(() => '(pass)')
+  const roster = [
+    { name: 'alpha', handle: 'first-bot' },
+    { name: 'beta', handle: 'second-bot', connectionLabel: 'Homelab' },
+    { name: 'gamma', handle: 'third-bot' }
+  ]
+  const meta = { alpha: { title: 'Planner' } }
+
+  assert.equal(JSON.stringify(gc.filterBots(roster, meta, 'plan').map(bot => bot.name)), JSON.stringify(['alpha']))
+  assert.equal(JSON.stringify(gc.filterBots(roster, meta, '@second').map(bot => bot.name)), JSON.stringify(['beta']))
+  assert.equal(JSON.stringify(gc.filterBots(roster, meta, 'home').map(bot => bot.name)), JSON.stringify(['beta']))
 })
 
 test('source contract: Group settings exposes persistent member checkboxes after creation', () => {
   assert.match(pluginSource, /function GroupChatSettingsDialog\(\{ group, members, roster, open, onClose, onRenamed \}\)/)
   assert.match(pluginSource, /'aria-label': 'Group members'/)
   assert.match(pluginSource, /await replaceGroupChatMembers\(finalName, selected\)/)
-  assert.match(pluginSource, /disabled: !name\.trim\(\) \|\| selected\.length < 2/)
+  assert.match(pluginSource, /disabled: !name\.trim\(\) \|\| !selected\.length/)
+  assert.match(pluginSource, /'aria-label': 'Search group members'/)
+  assert.match(pluginSource, /children: 'Disband'/)
+})
+
+test('failed metadata writes roll back local projections and leave the room roster unchanged', async () => {
+  const gc = load(() => '(pass)', { failedMetaNames: ['ops'] })
+  const roster = [{ name: 'builder' }, { name: 'ops' }]
+
+  gc.$botMeta.set({ builder: { groups: ['Core'], group: 'Core' }, ops: { groups: [], group: null } })
+  gc.updateGroupChat('Core', room => {
+    room.members = [{ name: 'builder', remoteSource: true, sourceScoped: true }]
+    return room
+  }, { sync: false })
+
+  const priorDurable = JSON.stringify(gc.storageWrites.get('group-chats'))
+  await assert.rejects(() => gc.replaceGroupChatMembers('Core', roster), /rolled back/)
+  assert.deepEqual(gc.$botMeta.get().builder.groups, ['Core'])
+  assert.deepEqual(gc.$botMeta.get().ops.groups, [])
+  assert.deepEqual(gc.$groupChats.get().Core.members.map(member => member.name), ['builder'])
+  assert.equal(JSON.stringify(gc.storageWrites.get('group-chats')), priorDurable, 'failed save does not write a new room roster')
+})
+
+test('a failed metadata rollback reports uncertain remote consistency instead of claiming success', async () => {
+  const gc = load(() => '(pass)', { failedMetaCalls: { ops: [1], builder: [2] } })
+  const roster = [{ name: 'builder' }, { name: 'ops' }]
+
+  gc.$botMeta.set({ builder: { groups: ['Core'], group: 'Core' }, ops: { groups: ['Core'], group: 'Core' } })
+  gc.updateGroupChat('Core', room => {
+    room.members = [{ name: 'builder' }]
+    return room
+  }, { sync: false })
+
+  await assert.rejects(
+    () => gc.replaceGroupChatMembers('Core', roster),
+    /remote metadata may be inconsistent/
+  )
+  assert.deepEqual(gc.$groupChats.get().Core.members.map(member => member.name), ['builder'])
+})
+
+test('member-save failure after rename leaves the renamed room as the retry target', async () => {
+  const gc = load(() => '(pass)', { failedMetaCalls: { ops: [2] } })
+  const members = [{ name: 'builder' }, { name: 'ops' }]
+
+  gc.$botMeta.set({ builder: { groups: ['Core'], group: 'Core' }, ops: { groups: ['Core'], group: 'Core' } })
+  gc.updateGroupChat('Core', room => {
+    room.roomId = 'room-1'
+    room.image = 'data:image/png;base64,room'
+    room.log = [{ id: 'entry-1', from: { kind: 'user' }, text: 'keep me', at: 1 }]
+    room.watermarks = { 'legacy::builder': 1 }
+    room.sessions = { 'legacy::builder': 'sid-builder' }
+    room.members = members
+    return room
+  }, { sync: false })
+
+  assert.equal(await gc.renameGroupChat('Core', 'Renamed', members), 'Renamed')
+  assert.equal(gc.$groupChats.get().Renamed.roomId, 'room-1')
+  assert.equal(gc.$groupChats.get().Renamed.image, 'data:image/png;base64,room')
+  assert.equal(gc.$groupChats.get().Renamed.log[0].id, 'entry-1')
+  assert.equal(gc.$groupChats.get().Renamed.watermarks['legacy::builder'], 1)
+  assert.equal(gc.$groupChats.get().Renamed.sessions['legacy::builder'], 'sid-builder')
+  await assert.rejects(() => gc.replaceGroupChatMembers('Renamed', members), /rolled back/)
+  assert.equal(gc.$groupChats.get().Core, undefined)
+  assert.ok(gc.$groupChats.get().Renamed)
+
+  await gc.replaceGroupChatMembers('Renamed', members)
+  assert.equal(JSON.stringify(gc.$groupChats.get().Renamed.members.map(member => member.name)), JSON.stringify(['builder', 'ops']))
+})
+
+test('a removed member is not scheduled again after an active turn changes the roster', async () => {
+  let gc
+  gc = load((profile) => {
+    if (profile === 'research') {
+      gc.$groupChats.set({
+        ...gc.$groupChats.get(),
+        Core: { ...gc.$groupChats.get().Core, members: [{ name: 'research' }] }
+      })
+      return 'research result'
+    }
+    return 'should not run'
+  })
+
+  gc.sendToGroupChat('Core', [{ name: 'research' }, { name: 'builder' }], 'start')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Core || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.deepEqual(gc.calls.map(call => call.profile), ['research'])
 })
 
 test('disband: removes only this membership, room log, workspace, and needs-you state', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, failedMetaNames = [], failedMetaCalls = {}, storageState } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, failedMetaNames = [], failedMetaCalls = {}, storageState, profileDescriptions = {}, modelOptionsByProfile = {}, failedRuntimeProfiles = [], confirmRuntimeProfiles = [], deferredRuntimeProfiles = [], useEffectImpl } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -46,6 +46,10 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   }
   const context = {
     atom,
+    useEffect: useEffectImpl || (() => undefined),
+    jsx: (type, props) => ({ type, props }),
+    jsxs: (type, props) => ({ type, props }),
+    GlyphSpinner: () => null,
     setTimeout: fn => {
       if (deferredTimers) {
         setImmediate(fn)
@@ -61,6 +65,41 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     host: {
       request: async (method, params) => {
         requests.push({ method, params })
+        if (method === 'profiles.describe') {
+          return profileDescriptions[params.name] || {
+            model: { provider: 'anthropic', default: 'claude-default' },
+            reasoning_effort: 'medium'
+          }
+        }
+        if (method === 'model.options') {
+          return modelOptionsByProfile[params?.profile || 'default'] || {
+            providers: [
+              { slug: 'anthropic', models: ['claude-default', 'claude-deep'] },
+              { slug: 'openai-codex', models: ['gpt-5.6'] }
+            ]
+          }
+        }
+        if (method === 'config.set') {
+          if (failedRuntimeProfiles.includes(params.profile)) {
+            throw new Error(`runtime update rejected for ${params.profile}`)
+          }
+          if (params.key === 'model' && confirmRuntimeProfiles.includes(params.profile)) {
+            return {
+              key: params.key,
+              value: params.value,
+              confirm_required: true,
+              confirm_message: `confirm runtime model for ${params.profile}`
+            }
+          }
+          if (params.key === 'model' && deferredRuntimeProfiles.includes(params.profile)) {
+            return {
+              key: params.key,
+              value: params.value,
+              deferred: true
+            }
+          }
+          return { key: params.key, value: params.value }
+        }
         if (method === 'profiles.list') {
           return {
             profiles: [
@@ -73,6 +112,24 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
           }
         }
         if (method === 'profiles.configure') {
+          if ('model' in params || 'provider' in params || 'reasoning_effort' in params) {
+            if (failedRuntimeProfiles.includes(params.name)) {
+              return {
+                ok: false,
+                applied: {
+                  ...('model' in params || 'provider' in params ? { model: false } : {}),
+                  ...('reasoning_effort' in params ? { reasoning_effort: false } : {})
+                }
+              }
+            }
+            return {
+              ok: true,
+              applied: {
+                ...('model' in params || 'provider' in params ? { model: true } : {}),
+                ...('reasoning_effort' in params ? { reasoning_effort: true } : {})
+              }
+            }
+          }
           const metaCall = (metaCallCounts.get(params.name) || 0) + 1
           metaCallCounts.set(params.name, metaCall)
           if (failedMetaNames.includes(params.name) || failedMetaCalls[params.name]?.includes(metaCall)) {
@@ -203,7 +260,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, durableGroupChatMembers, filterBots, botRosterKey, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, durableGroupChatMembers, filterBots, botRosterKey, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, normalizeGroupMemberRuntimeConfig: typeof normalizeGroupMemberRuntimeConfig === "function" ? normalizeGroupMemberRuntimeConfig : undefined, validateGroupMemberRuntimeConfig: typeof validateGroupMemberRuntimeConfig === "function" ? validateGroupMemberRuntimeConfig : undefined, saveGroupMemberRuntimeConfigs: typeof saveGroupMemberRuntimeConfigs === "function" ? saveGroupMemberRuntimeConfigs : undefined, applyPendingGroupMemberRuntime: typeof applyPendingGroupMemberRuntime === "function" ? applyPendingGroupMemberRuntime : undefined, snapshotGroupMemberRuntimePending: typeof snapshotGroupMemberRuntimePending === "function" ? snapshotGroupMemberRuntimePending : undefined, restoreGroupMemberRuntimePending: typeof restoreGroupMemberRuntimePending === "function" ? restoreGroupMemberRuntimePending : undefined, rollbackGroupSettingsRename: typeof rollbackGroupSettingsRename === "function" ? rollbackGroupSettingsRename : undefined, groupMemberRuntimeCapability: typeof groupMemberRuntimeCapability === "function" ? groupMemberRuntimeCapability : undefined, GroupMemberRuntimeEditor: typeof GroupMemberRuntimeEditor === "function" ? GroupMemberRuntimeEditor : undefined, cancelGroupSettingsDraft: typeof cancelGroupSettingsDraft === "function" ? cancelGroupSettingsDraft : undefined, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   context.plugin.register({
@@ -1264,9 +1321,384 @@ test('source contract: Group settings exposes persistent member checkboxes after
   assert.match(pluginSource, /function GroupChatSettingsDialog\(\{ group, members, roster, open, onClose, onRenamed \}\)/)
   assert.match(pluginSource, /'aria-label': 'Group members'/)
   assert.match(pluginSource, /await replaceGroupChatMembers\(finalName, selected\)/)
-  assert.match(pluginSource, /disabled: !name\.trim\(\) \|\| !selected\.length/)
   assert.match(pluginSource, /'aria-label': 'Search group members'/)
   assert.match(pluginSource, /children: 'Disband'/)
+})
+
+test('member runtime config validates provider/model pairs and disables unsupported offline edits', () => {
+  const gc = load(() => '(pass)')
+  assert.equal(typeof gc.validateGroupMemberRuntimeConfig, 'function')
+  assert.equal(typeof gc.groupMemberRuntimeCapability, 'function')
+
+  const options = [{ slug: 'anthropic', models: ['claude-default', 'claude-deep'] }]
+  assert.equal(
+    gc.validateGroupMemberRuntimeConfig({ provider: 'anthropic', model: 'claude-deep', reasoning: 'high', options }),
+    null
+  )
+  assert.match(
+    gc.validateGroupMemberRuntimeConfig({ provider: 'missing', model: 'ghost', reasoning: 'high', options }),
+    /Provider “missing” is unavailable/
+  )
+  assert.match(
+    gc.validateGroupMemberRuntimeConfig({ provider: 'anthropic', model: 'ghost', reasoning: 'high', options }),
+    /Model “ghost” is unavailable/
+  )
+  assert.match(
+    gc.validateGroupMemberRuntimeConfig({ provider: 'anthropic', model: 'claude-deep', reasoning: 'impossible', options }),
+    /reasoning effort/i
+  )
+
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(gc.groupMemberRuntimeCapability({ name: 'ops', remoteSource: true, connectionId: 'nas' }, false))),
+    { editable: false, reason: 'This member is offline. Reconnect its source to update durable settings.' }
+  )
+})
+
+test('inherited reasoning remains editable and clears the profile and next-turn session override', async () => {
+  const gc = load(() => '(pass)', {
+    profileDescriptions: {
+      builder: {
+        model: { provider: 'anthropic', default: 'claude-default' },
+        reasoning_effort: ''
+      }
+    }
+  })
+  const normalized = gc.normalizeGroupMemberRuntimeConfig(
+    {
+      model: { provider: 'anthropic', default: 'claude-default' },
+      reasoning_effort: ''
+    },
+    [{ slug: 'anthropic', models: ['claude-default'] }]
+  )
+  assert.equal(normalized.reasoning, '__inherit__')
+  assert.equal(gc.validateGroupMemberRuntimeConfig(normalized), null)
+
+  const builder = { name: 'builder' }
+  await gc.saveGroupMemberRuntimeConfigs('Core', [
+    {
+      bot: builder,
+      baseline: { provider: 'anthropic', model: 'claude-default', reasoning: 'high' },
+      draft: { provider: 'anthropic', model: 'claude-default', reasoning: '__inherit__' },
+      options: normalized.options
+    }
+  ])
+
+  const profileWrite = gc.requests.find(request => request.method === 'profiles.configure')
+  assert.equal(profileWrite.params.reasoning_effort, '')
+  assert.equal(gc.$groupChats.get().Core.pendingMemberConfigs.builder.reasoning, 'inherit')
+
+  await gc.applyPendingGroupMemberRuntime('Core', builder, 'rt-builder')
+  const reasoningWrite = gc.requests.find(request =>
+    request.method === 'config.set' && request.params.key === 'reasoning'
+  )
+  assert.equal(reasoningWrite.params.value, 'inherit')
+})
+
+test('member runtime editor keeps its in-flight load across the parent loading-state rerender', async () => {
+  let cleanup
+  let previousDeps
+  const useEffectImpl = (effect, deps) => {
+    const changed = !previousDeps || deps.some((value, index) => value !== previousDeps[index])
+    if (!changed) {
+      return
+    }
+    cleanup?.()
+    previousDeps = [...deps]
+    cleanup = effect()
+  }
+  const gc = load(() => '(pass)', { useEffectImpl })
+  const bot = { name: 'builder' }
+  let entry
+
+  gc.GroupMemberRuntimeEditor({ bot, live: true, entry, onEntry: value => { entry = value } })
+  assert.equal(entry.status, 'loading')
+
+  gc.GroupMemberRuntimeEditor({ bot, live: true, entry, onEntry: value => { entry = value } })
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(entry.status, 'ready')
+  assert.equal(entry.draft.model, 'claude-default')
+})
+
+test('member runtime Save commits only changed final-roster profiles and stages the next turn without touching room identity/history', async () => {
+  const gc = load(() => '(pass)')
+  const builder = { name: 'builder' }
+  const research = { name: 'research' }
+  gc.updateGroupChat('Core', room => {
+    room.roomId = 'room-core'
+    room.log = [{ id: 'entry-1', text: 'keep transcript', at: 1 }]
+    room.sessions = { builder: 'sid-builder' }
+    room.members = [builder, research]
+    return room
+  }, { sync: false })
+
+  const configs = [
+    {
+      bot: builder,
+      baseline: { provider: 'anthropic', model: 'claude-default', reasoning: 'medium' },
+      draft: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' },
+      options: [{ slug: 'anthropic', models: ['claude-default', 'claude-deep'] }]
+    },
+    {
+      bot: research,
+      baseline: { provider: 'anthropic', model: 'claude-default', reasoning: 'medium' },
+      draft: { provider: 'anthropic', model: 'claude-default', reasoning: 'medium' },
+      options: [{ slug: 'anthropic', models: ['claude-default', 'claude-deep'] }]
+    }
+  ]
+
+  const result = await gc.saveGroupMemberRuntimeConfigs('Core', configs)
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), { changed: 1 })
+  const writes = gc.requests.filter(request => request.method === 'profiles.configure')
+  assert.deepEqual(JSON.parse(JSON.stringify(writes)), [
+    {
+      method: 'profiles.configure',
+      params: {
+        name: 'builder',
+        provider: 'anthropic',
+        model: 'claude-deep',
+        reasoning_effort: 'high'
+      }
+    }
+  ])
+
+  const room = gc.$groupChats.get().Core
+  assert.equal(room.roomId, 'room-core')
+  assert.equal(room.log[0].text, 'keep transcript')
+  assert.equal(room.sessions.builder, 'sid-builder')
+  assert.deepEqual(JSON.parse(JSON.stringify(room.pendingMemberConfigs.builder)), {
+    provider: 'anthropic', model: 'claude-deep', reasoning: 'high'
+  })
+})
+
+test('member runtime Save rolls back earlier profile writes when a later member fails', async () => {
+  const gc = load(() => '(pass)', { failedRuntimeProfiles: ['research'] })
+  const options = [{ slug: 'anthropic', models: ['claude-default', 'claude-deep'] }]
+  const configs = [
+    {
+      bot: { name: 'builder' },
+      baseline: { provider: 'anthropic', model: 'claude-default', reasoning: 'medium' },
+      draft: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' },
+      options
+    },
+    {
+      bot: { name: 'research' },
+      baseline: { provider: 'anthropic', model: 'claude-default', reasoning: 'medium' },
+      draft: { provider: 'anthropic', model: 'claude-deep', reasoning: 'low' },
+      options
+    }
+  ]
+
+  await assert.rejects(() => gc.saveGroupMemberRuntimeConfigs('Core', configs), /research.*rejected.*rolled back/i)
+  const writes = gc.requests.filter(request => request.method === 'profiles.configure')
+  assert.equal(writes.length, 3)
+  assert.equal(writes[0].params.name, 'builder')
+  assert.equal(writes[1].params.name, 'research')
+  assert.deepEqual(JSON.parse(JSON.stringify(writes[2].params)), {
+    name: 'builder',
+    provider: 'anthropic',
+    model: 'claude-default',
+    reasoning_effort: 'medium'
+  })
+  assert.equal(gc.$groupChats.get().Core?.pendingMemberConfigs, undefined)
+})
+
+test('pending member runtime changes apply immediately before the next prompt and then clear', async () => {
+  const gc = load(() => 'done')
+  const member = { name: 'builder' }
+  gc.updateGroupChat('Core', room => {
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' }
+    }
+    return room
+  }, { sync: false })
+
+  await gc.applyPendingGroupMemberRuntime('Core', member, 'rt-builder')
+
+  const relevant = gc.requests.filter(request => ['config.set', 'prompt.submit'].includes(request.method))
+  assert.deepEqual(JSON.parse(JSON.stringify(relevant)), [
+    {
+      method: 'config.set',
+      params: {
+        session_id: 'rt-builder',
+        profile: 'builder',
+        key: 'model',
+        value: 'claude-deep --provider anthropic --session'
+      }
+    },
+    {
+      method: 'config.set',
+      params: { session_id: 'rt-builder', profile: 'builder', key: 'reasoning', value: 'high' }
+    }
+  ])
+  assert.equal(gc.$groupChats.get().Core.pendingMemberConfigs.builder, undefined)
+})
+
+test('group turn integration applies pending settings before submitting that member prompt', async () => {
+  const gc = load(() => 'done')
+  const member = { name: 'builder' }
+  gc.updateGroupChat('Core', room => {
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' }
+    }
+    return room
+  }, { sync: false })
+
+  gc.sendToGroupChat('Core', [member], 'use the new settings')
+  for (let i = 0; i < 200 && gc.$groupChats.get().Core?.running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const methods = gc.requests
+    .filter(request => ['config.set', 'prompt.submit'].includes(request.method))
+    .map(request => request.method)
+  assert.deepEqual(methods, ['config.set', 'config.set', 'prompt.submit'])
+  assert.equal(gc.calls[0].profile, 'builder')
+  assert.equal(gc.$groupChats.get().Core.pendingMemberConfigs.builder, undefined)
+})
+
+test('member selector removal prunes pending settings only for members outside the final roster', async () => {
+  const gc = load(() => '(pass)')
+  const builder = { name: 'builder' }
+  const ops = { name: 'ops' }
+  gc.updateGroupChat('Core', room => {
+    room.members = [builder, ops]
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' },
+      ops: { provider: 'anthropic', model: 'claude-default', reasoning: 'low' }
+    }
+    return room
+  }, { sync: false })
+
+  await gc.replaceGroupChatMembers('Core', [builder])
+
+  assert.equal(JSON.stringify(Object.keys(gc.$groupChats.get().Core.pendingMemberConfigs)), JSON.stringify(['builder']))
+  assert.equal(JSON.stringify(gc.$groupChats.get().Core.members.map(member => member.name)), JSON.stringify(['builder']))
+})
+
+test('failed staged Save can restore pending settings pruned by the roster write', async () => {
+  const gc = load(() => '(pass)')
+  const builder = { name: 'builder' }
+  const ops = { name: 'ops' }
+  gc.updateGroupChat('Core', room => {
+    room.members = [builder, ops]
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' },
+      ops: { provider: 'anthropic', model: 'claude-default', reasoning: 'low' }
+    }
+    return room
+  }, { sync: false })
+
+  const pendingBefore = gc.snapshotGroupMemberRuntimePending('Core')
+  await gc.replaceGroupChatMembers('Core', [builder])
+  assert.equal(gc.$groupChats.get().Core.pendingMemberConfigs.ops, undefined)
+
+  gc.restoreGroupMemberRuntimePending('Core', pendingBefore)
+  const expected = {
+    builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' },
+    ops: { provider: 'anthropic', model: 'claude-default', reasoning: 'low' }
+  }
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(gc.$groupChats.get().Core.pendingMemberConfigs)),
+    expected
+  )
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(gc.storageWrites.get('group-chats').Core.pendingMemberConfigs)),
+    expected,
+    'rollback persistence keeps the same pending settings as the live room'
+  )
+})
+
+test('rename rollback reports an old-name collision instead of claiming success', async () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'builder' }]
+  gc.$groupChats.set({
+    Core: { log: [], watermarks: {}, members, epoch: 0, running: false },
+    Renamed: { log: [], watermarks: {}, members, epoch: 0, running: false }
+  })
+
+  await assert.rejects(
+    () => gc.rollbackGroupSettingsRename('Renamed', 'Core', members),
+    /could not restore original room name/i
+  )
+  assert.ok(gc.$groupChats.get().Renamed)
+  assert.ok(gc.$groupChats.get().Core)
+})
+
+test('failed next-turn runtime application stays pending and never reports false success', async () => {
+  const gc = load(() => 'should not run', { failedRuntimeProfiles: ['builder'] })
+  const member = { name: 'builder' }
+  gc.updateGroupChat('Core', room => {
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' }
+    }
+    return room
+  }, { sync: false })
+
+  await assert.rejects(
+    () => gc.applyPendingGroupMemberRuntime('Core', member, 'rt-builder'),
+    /Could not apply saved settings for builder.*runtime update rejected/i
+  )
+  assert.deepEqual(JSON.parse(JSON.stringify(gc.$groupChats.get().Core.pendingMemberConfigs.builder)), {
+    provider: 'anthropic', model: 'claude-deep', reasoning: 'high'
+  })
+  assert.equal(gc.requests.some(request => request.method === 'prompt.submit'), false)
+})
+
+test('next-turn runtime application rejects a model switch that still requires confirmation', async () => {
+  const gc = load(() => 'should not run', { confirmRuntimeProfiles: ['builder'] })
+  const member = { name: 'builder' }
+  gc.updateGroupChat('Core', room => {
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' }
+    }
+    return room
+  }, { sync: false })
+
+  await assert.rejects(
+    () => gc.applyPendingGroupMemberRuntime('Core', member, 'rt-builder'),
+    /confirm runtime model for builder/i
+  )
+  assert.deepEqual(JSON.parse(JSON.stringify(gc.$groupChats.get().Core.pendingMemberConfigs.builder)), {
+    provider: 'anthropic', model: 'claude-deep', reasoning: 'high'
+  })
+  assert.equal(gc.requests.some(request => request.method === 'prompt.submit'), false)
+})
+
+test('next-turn runtime application stays pending when the member session is still busy', async () => {
+  const gc = load(() => 'should not run', { deferredRuntimeProfiles: ['builder'] })
+  const member = { name: 'builder' }
+  gc.updateGroupChat('Core', room => {
+    room.pendingMemberConfigs = {
+      builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' }
+    }
+    return room
+  }, { sync: false })
+
+  await assert.rejects(
+    () => gc.applyPendingGroupMemberRuntime('Core', member, 'rt-builder'),
+    /session is still busy/i
+  )
+  assert.deepEqual(JSON.parse(JSON.stringify(gc.$groupChats.get().Core.pendingMemberConfigs.builder)), {
+    provider: 'anthropic', model: 'claude-deep', reasoning: 'high'
+  })
+  assert.equal(gc.requests.some(request => request.method === 'prompt.submit'), false)
+})
+
+test('Cancel discards the staged member draft without profile or room writes', () => {
+  const gc = load(() => '(pass)')
+  const staged = { builder: { provider: 'anthropic', model: 'claude-deep', reasoning: 'high' } }
+  const before = JSON.stringify(staged)
+  let closed = 0
+
+  gc.cancelGroupSettingsDraft(() => {
+    closed += 1
+  })
+
+  assert.equal(closed, 1)
+  assert.equal(JSON.stringify(staged), before)
+  assert.equal(gc.requests.some(request => request.method === 'profiles.configure'), false)
+  assert.equal(gc.storageWrites.has('group-chats'), false)
 })
 
 test('failed metadata writes roll back local projections and leave the room roster unchanged', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, failedMetaNames = [], failedMetaCalls = {} } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, failedMetaNames = [], failedMetaCalls = {}, storageState } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -30,6 +30,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   const sharedUiMeta = {}
   const uiMetaRevisions = {}
   const metaCallCounts = new Map()
+  const storageWrites = storageState || new Map()
   let sessionSequence = 0
   // busyUntilResumeCall[profile] = N: this profile's session.resume reports
   // inflight/running for its first N calls, then flips to done — simulating
@@ -205,9 +206,8 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
       '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, replaceGroupChatMembers, groupChatMemberBots, durableGroupChatMembers, filterBots, botRosterKey, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
-  const storageWrites = new Map()
   context.plugin.register({
-    storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
+    storage: { get: key => storageWrites.get(key) ?? null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
   return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
@@ -1352,6 +1352,44 @@ test('a removed member is not scheduled again after an active turn changes the r
   }
 
   assert.deepEqual(gc.calls.map(call => call.profile), ['research'])
+})
+
+test('saved roster removal survives sync persistence and excludes the member from the next reloaded turn', async () => {
+  const storageState = new Map()
+  const first = load(() => '(pass)', { storageState })
+  const research = { name: 'research' }
+  const builder = { name: 'builder' }
+
+  first.$botMeta.set({
+    research: { groups: ['Core'], group: 'Core' },
+    builder: { groups: ['Core'], group: 'Core' }
+  })
+  first.updateGroupChat('Core', room => {
+    room.roomId = 'room-core'
+    room.members = first.durableGroupChatMembers([research, builder])
+    room.log = [{ id: 'seed', from: { kind: 'user', name: 'You' }, text: 'history', at: 1, thread: 'seed' }]
+    return room
+  }, { sync: false })
+
+  await first.replaceGroupChatMembers('Core', [research])
+  for (let i = 0; i < 20 && (first.uiMetaRevisions['hermes-bots-groups'] || 0) < 1; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const reloaded = load(() => '(pass)', { storageState })
+  await new Promise(resolve => setImmediate(resolve))
+  reloaded.$botMeta.set({
+    research: { groups: ['Core'], group: 'Core' },
+    builder: { groups: ['Core'], group: 'Core' }
+  })
+  const nextMembers = reloaded.groupChatMemberBots('Core', [research, builder], reloaded.$botMeta.get())
+
+  reloaded.sendToGroupChat('Core', nextMembers, 'next turn')
+  for (let i = 0; i < 200 && (reloaded.$groupChats.get().Core || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.deepEqual(reloaded.calls.map(call => call.profile), ['research'])
 })
 
 test('disband: removes only this membership, room log, workspace, and needs-you state', async () => {

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -80,6 +80,8 @@ _profile_to_dict = late("_profile_to_dict")
 _resolve_profile_dir = late("_resolve_profile_dir")
 _spawn_hermes_action = late("_spawn_hermes_action")
 _strip_session_list_rows = late("_strip_session_list_rows")
+_apply_main_model_assignment = late("_apply_main_model_assignment")
+_normalize_main_model_assignment = late("_normalize_main_model_assignment")
 _write_profile_mcp_servers = late("_write_profile_mcp_servers")
 _write_profile_model = late("_write_profile_model")
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8125,6 +8125,39 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     assert cfg_clamp["display"]["sections"]["thinking"] == "collapsed"
 
 
+def test_config_set_reasoning_inherit_clears_live_session_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n",
+        encoding="utf-8",
+    )
+    agent = types.SimpleNamespace(
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+    server._sessions["sid"] = _session(agent=agent)
+    server._sessions["sid"]["create_reasoning_override"] = {
+        "enabled": True,
+        "effort": "high",
+    }
+
+    response = server.handle_request(
+        {
+            "id": "inherit-reasoning",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "reasoning",
+                "value": "inherit",
+            },
+        }
+    )
+
+    assert response["result"]["value"] == "inherit"
+    assert agent.reasoning_config is None
+    assert "create_reasoning_override" not in server._sessions["sid"]
+    assert server._load_cfg()["agent"]["reasoning_effort"] == "medium"
+
+
 def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")

--- a/tests/tui_gateway/test_profiles_inference_config.py
+++ b/tests/tui_gateway/test_profiles_inference_config.py
@@ -1,0 +1,231 @@
+"""Profile inference settings exposed to Bot Mode group member editors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import tui_gateway.server as srv
+
+
+def _write_config(home, payload):
+    (home / "config.yaml").write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _read_config(home):
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+
+
+def test_profiles_describe_and_configure_round_trip_inference_settings(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(
+        home,
+        {
+            "model": {"provider": "anthropic", "default": "claude-old"},
+            "agent": {"reasoning_effort": "low", "max_iterations": 77},
+            "display": {"theme": "dark"},
+        },
+    )
+
+    before = srv._methods["profiles.describe"]("describe-before", {"name": "default"})["result"]
+    assert before["model"] == {"provider": "anthropic", "default": "claude-old"}
+    assert before["reasoning_effort"] == "low"
+
+    configured = srv._methods["profiles.configure"](
+        "configure",
+        {
+            "name": "default",
+            "provider": "openai-codex",
+            "model": "gpt-5.6",
+            "reasoning_effort": "high",
+        },
+    )["result"]
+
+    assert configured["ok"] is True
+    assert configured["applied"] == {"model": True, "reasoning_effort": True}
+    saved = _read_config(home)
+    assert saved["model"] == {"provider": "openai-codex", "default": "gpt-5.6"}
+    assert saved["agent"] == {"reasoning_effort": "high", "max_iterations": 77}
+    assert saved["display"] == {"theme": "dark"}
+
+    after = srv._methods["profiles.describe"]("describe-after", {"name": "default"})["result"]
+    assert after["model"] == {"provider": "openai-codex", "default": "gpt-5.6"}
+    assert after["reasoning_effort"] == "high"
+
+
+def test_profiles_configure_reconciles_stale_model_endpoint_fields(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(
+        home,
+        {
+            "model": {
+                "provider": "anthropic",
+                "default": "claude-old",
+                "base_url": "https://old-provider.example/v1",
+                "context_length": 1234,
+            },
+            "agent": {"reasoning_effort": "medium"},
+        },
+    )
+
+    configured = srv._methods["profiles.configure"](
+        "configure-provider-switch",
+        {
+            "name": "default",
+            "provider": "openai-codex",
+            "model": "gpt-5.6",
+            "reasoning_effort": "high",
+        },
+    )["result"]
+
+    assert configured["ok"] is True
+    saved_model = _read_config(home)["model"]
+    assert saved_model["provider"] == "openai-codex"
+    assert saved_model["default"] == "gpt-5.6"
+    assert saved_model["base_url"] == ""
+    assert "context_length" not in saved_model
+
+
+def test_profiles_configure_rejects_invalid_reasoning_without_partial_model_write(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    original = {
+        "model": {"provider": "anthropic", "default": "claude-old"},
+        "agent": {"reasoning_effort": "medium"},
+        "custom": {"keep": True},
+    }
+    _write_config(home, original)
+
+    configured = srv._methods["profiles.configure"](
+        "configure-invalid",
+        {
+            "name": "default",
+            "provider": "openai-codex",
+            "model": "gpt-5.6",
+            "reasoning_effort": "impossible",
+        },
+    )["result"]
+
+    assert configured["ok"] is False
+    assert configured["applied"] == {"model": False, "reasoning_effort": False}
+    assert configured["errors"]["reasoning_effort"].startswith("Unsupported reasoning effort")
+    assert _read_config(home) == original
+
+
+def test_profiles_configure_reports_incomplete_model_pair_as_model_error(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    original = {
+        "model": {"provider": "anthropic", "default": "claude-old"},
+        "agent": {"reasoning_effort": "medium"},
+    }
+    _write_config(home, original)
+
+    configured = srv._methods["profiles.configure"](
+        "configure-incomplete-model",
+        {
+            "name": "default",
+            "provider": "openai-codex",
+            "reasoning_effort": "high",
+        },
+    )["result"]
+
+    assert configured["ok"] is False
+    assert configured["applied"] == {"model": False, "reasoning_effort": False}
+    assert configured["errors"] == {"model": "Model and provider are required together"}
+    assert _read_config(home) == original
+
+
+def test_profiles_configure_keys_transaction_failure_to_requested_inference_fields(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    original = {
+        "model": {"provider": "anthropic", "default": "claude-old"},
+        "agent": {"reasoning_effort": "medium"},
+    }
+    _write_config(home, original)
+
+    def fail_save(_cfg):
+        raise OSError("disk full")
+
+    import hermes_cli.config as config_module
+
+    monkeypatch.setattr(config_module, "save_config", fail_save)
+    configured = srv._methods["profiles.configure"](
+        "configure-transaction-failure",
+        {
+            "name": "default",
+            "provider": "openai-codex",
+            "model": "gpt-5.6",
+            "reasoning_effort": "high",
+        },
+    )["result"]
+
+    assert configured["ok"] is False
+    assert configured["applied"] == {"model": False, "reasoning_effort": False}
+    assert configured["errors"] == {
+        "model": "disk full",
+        "reasoning_effort": "disk full",
+    }
+    assert _read_config(home) == original
+
+
+def test_profiles_configure_clears_reasoning_override(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_config(
+        home,
+        {
+            "model": {"provider": "anthropic", "default": "claude-old"},
+            "agent": {"reasoning_effort": "high", "max_iterations": 77},
+        },
+    )
+
+    configured = srv._methods["profiles.configure"](
+        "configure-clear-reasoning",
+        {"name": "default", "reasoning_effort": ""},
+    )["result"]
+
+    assert configured["ok"] is True
+    assert configured["applied"] == {"reasoning_effort": True}
+    saved = _read_config(home)
+    assert "reasoning_effort" not in saved["agent"]
+    assert saved["agent"]["max_iterations"] == 77
+
+
+def test_model_options_scopes_inventory_to_requested_profile(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "builder"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_cli.inventory as inventory
+    from hermes_constants import get_hermes_home
+
+    monkeypatch.setattr(
+        inventory,
+        "build_model_options_payload",
+        lambda *_args, **_kwargs: {
+            "home": str(get_hermes_home()),
+            "providers": [],
+        },
+    )
+
+    result = srv._methods["model.options"](
+        "model-options-builder",
+        {"profile": "builder", "include_unconfigured": False},
+    )["result"]
+
+    assert result["home"] == str(profile)

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -467,6 +467,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("model.options")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.inventory import build_model_options_payload

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -528,7 +528,8 @@ def _(rid, params: dict) -> dict:
     """Full configuration snapshot of one profile, for an editor UI.
 
     Params: ``name`` (required). Result:
-    ``{name, description, soul, model: {provider, default}, skills:
+    ``{name, description, soul, model: {provider, default}, reasoning_effort,
+    skills:
     [{name, enabled}], toolsets: [{name, description, tool_count, enabled}]}``
 
     Skill enablement mirrors the disabled-list model (installed = enabled
@@ -663,6 +664,13 @@ def _(rid, params: dict) -> dict:
                 pass
 
             model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+            agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+            raw_reasoning_effort = agent_cfg.get("reasoning_effort", "")
+            reasoning_effort = (
+                "none"
+                if raw_reasoning_effort is False
+                else str(raw_reasoning_effort or "").strip().lower()
+            )
 
             description = ""
             try:
@@ -682,6 +690,7 @@ def _(rid, params: dict) -> dict:
                         "provider": str(model_cfg.get("provider") or ""),
                         "default": str(model_cfg.get("default") or ""),
                     },
+                    "reasoning_effort": reasoning_effort,
                     "skills": installed,
                     "toolsets": toolsets_out,
                     "toolsets_pinned": pinned_set is not None,
@@ -701,6 +710,7 @@ def _(rid, params: dict) -> dict:
     Params: ``name`` (required) plus any of:
     ``description`` (str), ``soul`` (str, full SOUL.md replacement),
     ``model`` + ``provider`` (both required together),
+    ``reasoning_effort`` (canonical reasoning level; empty clears the override),
     ``disabled_skills`` (list[str], replace semantics),
     ``enabled_toolsets`` (list[str], replace semantics; empty list clears
     the pin so every toolset is enabled again), and
@@ -830,16 +840,87 @@ def _(rid, params: dict) -> dict:
             except Exception:
                 applied["description"] = False
 
-        model = str(params.get("model") or "").strip()
-        provider = str(params.get("provider") or "").strip()
-        if model and provider:
-            try:
-                from hermes_cli.web_routers.profiles import _write_profile_model
+        inference_keys = {"model", "provider", "reasoning_effort"}
+        inference_requested = any(key in params for key in inference_keys)
+        if inference_requested:
+            model_requested = "model" in params or "provider" in params
+            reasoning_requested = "reasoning_effort" in params
+            model = str(params.get("model") or "").strip()
+            provider = str(params.get("provider") or "").strip()
+            reasoning_effort = str(params.get("reasoning_effort") or "").strip().lower()
+            inference_errors = {}
 
-                _write_profile_model(profile_dir, provider, model)
-                applied["model"] = True
-            except Exception:
-                applied["model"] = False
+            if model_requested and not (model and provider):
+                inference_errors["model"] = "Model and provider are required together"
+
+            if reasoning_requested:
+                try:
+                    from hermes_constants import parse_reasoning_effort
+
+                    if reasoning_effort and parse_reasoning_effort(reasoning_effort) is None:
+                        inference_errors["reasoning_effort"] = (
+                            "Unsupported reasoning effort; choose none, minimal, low, "
+                            "medium, high, xhigh, max, or ultra"
+                        )
+                except Exception:
+                    inference_errors["reasoning_effort"] = (
+                        "Unsupported reasoning effort; choose none, minimal, low, "
+                        "medium, high, xhigh, max, or ultra"
+                    )
+
+            if inference_errors:
+                if model_requested:
+                    applied["model"] = False
+                if reasoning_requested:
+                    applied["reasoning_effort"] = False
+                return _ok(
+                    rid,
+                    {"ok": False, "applied": applied, "errors": inference_errors},
+                )
+
+            token = set_hermes_home_override(str(profile_dir))
+            try:
+                from hermes_cli.config import load_config, save_config
+                from hermes_cli.web_routers.profiles import (
+                    _apply_main_model_assignment,
+                    _normalize_main_model_assignment,
+                )
+
+                loaded_cfg = load_config()
+                cfg = loaded_cfg if isinstance(loaded_cfg, dict) else {}
+                if model_requested:
+                    provider, model = _normalize_main_model_assignment(provider, model)
+                    cfg["model"] = _apply_main_model_assignment(
+                        cfg.get("model", {}), provider, model
+                    )
+                if reasoning_requested:
+                    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+                    if reasoning_effort:
+                        agent_cfg["reasoning_effort"] = reasoning_effort
+                    else:
+                        agent_cfg.pop("reasoning_effort", None)
+                    if agent_cfg:
+                        cfg["agent"] = agent_cfg
+                    else:
+                        cfg.pop("agent", None)
+                save_config(cfg)
+                if model_requested:
+                    applied["model"] = True
+                if reasoning_requested:
+                    applied["reasoning_effort"] = True
+            except Exception as exc:
+                if model_requested:
+                    applied["model"] = False
+                if reasoning_requested:
+                    applied["reasoning_effort"] = False
+                errors = {}
+                if model_requested:
+                    errors["model"] = str(exc)
+                if reasoning_requested:
+                    errors["reasoning_effort"] = str(exc)
+                return _ok(rid, {"ok": False, "applied": applied, "errors": errors})
+            finally:
+                reset_hermes_home_override(token)
 
         needs_cfg = (
             isinstance(params.get("disabled_skills"), list)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12391,6 +12391,31 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 return _ok(rid, {"key": key, "value": "clamp"})
 
+            if arg in {"inherit", "inherited", "default"}:
+                if global_scope or session is None:
+                    loaded_cfg = _load_cfg_raw()
+                    cfg = loaded_cfg if isinstance(loaded_cfg, dict) else {}
+                    agent_cfg = (
+                        cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+                    )
+                    agent_cfg.pop("reasoning_effort", None)
+                    if agent_cfg:
+                        cfg["agent"] = agent_cfg
+                    else:
+                        cfg.pop("agent", None)
+                    _save_cfg(cfg)
+                if session is not None:
+                    session.pop("create_reasoning_override", None)
+                    if session.get("agent") is not None:
+                        session["agent"].reasoning_config = None
+                        _persist_live_session_runtime(session)
+                        _emit(
+                            "session.info",
+                            params.get("session_id", ""),
+                            _session_info(session["agent"], session),
+                        )
+                return _ok(rid, {"key": key, "value": "inherit"})
+
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")


### PR DESCRIPTION
## Summary

- Adds staged per-member provider, model, and reasoning controls to Bot Mode Group Settings.
- Save persists profile-scoped inference settings; Cancel remains draft-only.
- Applied configuration takes effect on the member's next group turn; failures retain pending state and never falsely report success.

## Dependency

This branch is intentionally stacked on the unresolved roster-management work in #91389 and also contains its next-turn roster persistence repair. It is therefore a **draft** and must not merge until that upstream dependency is resolved/rebased.

## Verification

- Hermes Bots plugin tests: 91 passed, 0 failed
- Profile/gateway Python tests: 609 passed, 0 failed
- Desktop typecheck, lint, build: passed
- `git diff --check`: passed
- Independent read-only review: passed

Closes #96136.