### PR TITLE
feat(models): Inkling + MiniMax M3 free SKUs land in the OpenRouter picker (salvage #93250, #96234)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -493,6 +493,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek": 128000,
     # Meta
     "llama": 131072,
+    # Thinking Machines — Inkling family ships with a 1M context window
+    # (max output 256K).  Verified against OpenRouter live metadata
+    # (context_length 1,048,576 for inkling, inkling-small, and the
+    # :free SKUs, 2026-08-27).  Substring matching means "inkling"
+    # covers inkling-small and every :free/:batch variant; the :batch
+    # SKU's smaller live window (524,288) is served by the provider's
+    # live metadata when available.
+    "inkling": 1_048_576,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
     "qwen3.8-max": 1_000_000,     # 1M context (OpenRouter & Nous portal, verified 2026-08-03)

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -131,6 +131,13 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # reasoning variants.
     ("ox-alpha", 300),
     ("x-preview-f-free", 300),
+    # Thinking Machines Inkling (thinkingmachines/inkling[-small][:free]
+    # on OpenRouter).  Reasoning model (OpenRouter supported_parameters
+    # includes "reasoning"); 1M context — same tier as the Grok
+    # reasoning variants and Ox Alpha.  "inkling" left-anchors on the
+    # slug after the aggregator prefix and the right anchor accepts the
+    # "-" separator, so inkling-small and the :free SKUs all match.
+    ("inkling", 300),
 )
 
 
@@ -161,7 +168,12 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
 # in each entry for debuggability (log/inspection), even though _match_any
 # only consumes floor + pattern.
 _SORTED_REASONING_FLOORS: list[tuple[str, float, re.Pattern[str]]] = [
-    (slug, floor, re.compile(r"^" + re.escape(slug) + r"(?:$|[\-._])"))
+    # Right anchor: end-of-string or a slug separator.  ``:`` is in the
+    # separator class because OpenRouter SKU/routing suffixes
+    # (``:free``, ``:batch``, ``:nitro``, ``:floor``) attach directly to
+    # the slug — ``thinkingmachines/inkling:free`` must match the
+    # ``inkling`` entry the same way ``inkling-small`` does.
+    (slug, floor, re.compile(r"^" + re.escape(slug) + r"(?:$|[\-._:])"))
     for slug, floor in sorted(
         _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
     )

--- a/contributors/emails/ekzhang1@gmail.com
+++ b/contributors/emails/ekzhang1@gmail.com
@@ -1,0 +1,1 @@
+ekzhang

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -135,6 +135,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
+    ("thinkingmachines/inkling:free",          "free"),
+    ("thinkingmachines/inkling-small:free",    "free"),
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -115,7 +115,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
-    ("minimax/minimax-m3:free",                "free"),
     # Z-AI
     ("z-ai/glm-5.3",                           ""),
     ("z-ai/glm-5.3-flash",                     ""),
@@ -137,6 +136,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Free tier
     ("thinkingmachines/inkling:free",          "free"),
     ("thinkingmachines/inkling-small:free",    "free"),
+    ("minimax/minimax-m3:free",                "free"),
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -85,6 +85,12 @@ import pytest
     ("x-ai/grok-4.5", 300.0),
     ("x-ai/grok-4.6", 300.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
+    # Thinking Machines Inkling — family entry covers -small and the
+    # OpenRouter :free / :batch SKU suffixes (":" is a slug separator
+    # in the right anchor, same as "-").
+    ("thinkingmachines/inkling", 300.0),
+    ("thinkingmachines/inkling:free", 300.0),
+    ("thinkingmachines/inkling-small:free", 300.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-26T14:32:05Z",
+  "updated_at": "2026-08-27T09:32:16Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -160,6 +160,14 @@
         {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
+        },
+        {
+          "id": "thinkingmachines/inkling:free",
+          "description": "free"
+        },
+        {
+          "id": "thinkingmachines/inkling-small:free",
+          "description": "free"
         },
         {
           "id": "openrouter/elephant-alpha",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-27T09:32:16Z",
+  "updated_at": "2026-08-27T09:39:24Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -117,10 +117,6 @@
           "description": ""
         },
         {
-          "id": "minimax/minimax-m3:free",
-          "description": "free"
-        },
-        {
           "id": "z-ai/glm-5.3",
           "description": ""
         },
@@ -167,6 +163,10 @@
         },
         {
           "id": "thinkingmachines/inkling-small:free",
+          "description": "free"
+        },
+        {
+          "id": "minimax/minimax-m3:free",
           "description": "free"
         },
         {


### PR DESCRIPTION
## Summary
`thinkingmachines/inkling:free` and `thinkingmachines/inkling-small:free` are now in the curated OpenRouter picker — salvages PR #93250 (@ekzhang) onto current main with authorship preserved. `minimax/minimax-m3:free` landed on main via #96234 (@kshitijk4poor) mid-flight; this PR relocates that entry into the Free tier section per house convention. Supersedes #96245 (auto-closed by a branch rebuild during the Aug 27 zero-job CI dispatch window; GitHub refuses reopen after a closed-state force-push).

## Changes
- `hermes_cli/models.py`: three `:free` entries added to `OPENROUTER_MODELS` (grouped in the Free tier section per house convention); manifest regenerated via `scripts/build_model_catalog.py`
- `agent/model_metadata.py`: `inkling` family context entry (1,048,576 — OpenRouter live metadata, 2026-08-27); new family slug previously had no entry
- `agent/reasoning_timeouts.py`: Inkling added to the reasoning stale-timeout floor table (300s tier — OpenRouter marks the family reasoning-capable); right-anchor separator class widened to include `:` so SKU suffixes (`:free`/`:batch`/`:nitro`) inherit their family floor — `inkling:free` previously fell through
- `tests/agent/test_reasoning_stale_timeout_floor.py`: regression cases for the family entry + `:` separator
- `contributors/emails/`: mapping for ekzhang

Deliberate scope notes: pricing snapshot untouched (OpenRouter bills via live `official_models_api`; `:free` SKUs are $0 by construction and `is_free_tier_model` already recognizes the `:free` suffix). `minimax-m3:free` needed no metadata work — existing `minimax-m3` substring entry (1M ctx) covers it, verified.

## Validation
| Check | Result |
|---|---|
| `OPENROUTER_MODELS` contains all 3, no dupes, isolated HERMES_HOME E2E | pass |
| Live OpenRouter `/v1/models` carries all 3 ids (ctx 1,048,576) | pass |
| `get_reasoning_stale_timeout_floor("thinkingmachines/inkling:free")` | 300.0 (was None) |
| `DEFAULT_CONTEXT_LENGTHS` resolution for both families | 1,048,576 / 1,000,000 |
| Targeted suites (models, catalog, gmi, pricing, minimax, validation, floors) | 270/270 pass |
| ruff on touched files | clean |

## Infographic

![Free models join the catalog](https://v3b.fal.media/files/b/0aa800a6/gGDzl_ax-XgtxAJHT_BR0_ej9WU3AB.png)
