### PR TITLE
fix(desktop): a cross-profile project filter no longer empties the sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -146,8 +146,8 @@ import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
-import { resolveLiveProjectFilter } from './project-filter'
 import { SidebarLoadMoreRow } from './load-more-row'
+import { resolveLiveProjectFilter } from './project-filter'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
@@ -429,6 +429,7 @@ export function ChatSidebar({
     () => resolveLiveProjectFilter(persistedProjectFilter, projectTree),
     [persistedProjectFilter, projectTree]
   )
+
   const projectTreeLoading = useStore($projectTreeLoading)
   const removedSessionIds = useStore($removedSessionIds)
   const reposScanning = useStore($reposScanning)

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -146,6 +146,7 @@ import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
+import { resolveLiveProjectFilter } from './project-filter'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { filterSessionsByProfileScope } from './profile-scope'
@@ -355,7 +356,7 @@ export function ChatSidebar({
   const grouping = useStore($sidebarGrouping)
   const ordering = useStore($sidebarOrdering)
   const statusFilter = useStore($sidebarStatusFilter)
-  const projectFilter = useStore($sidebarProjectFilter)
+  const persistedProjectFilter = useStore($sidebarProjectFilter)
   const profileFilter = useStore($sidebarProfileFilter)
   const prFilter = useStore($sidebarPrFilter)
   const prDataWanted = useStore($sidebarPrDataWanted)
@@ -420,6 +421,14 @@ export function ChatSidebar({
   const projectOrderIds = useStore($sidebarProjectOrderIds)
   const projects = useStore($projects)
   const projectTree = useStore($projectTree)
+  // The persisted project filter's storage is shared across profiles, so ids
+  // picked in another profile don't resolve in the active one and the raw
+  // membership whitelist empties every tier of the sidebar (#96246). Narrow
+  // to ids the ACTIVE tree resolves; dead ids are inert, not fatal.
+  const projectFilter = useMemo(
+    () => resolveLiveProjectFilter(persistedProjectFilter, projectTree),
+    [persistedProjectFilter, projectTree]
+  )
   const projectTreeLoading = useStore($projectTreeLoading)
   const removedSessionIds = useStore($removedSessionIds)
   const reposScanning = useStore($reposScanning)

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -147,11 +147,11 @@ import type { SidebarNavItem } from '../../types'
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
-import { resolveLiveProjectFilter } from './project-filter'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
+import { resolveLiveProjectFilter } from './project-filter'
 import {
   excludeProjectSessions,
   liveSessionProjectId,
@@ -421,6 +421,7 @@ export function ChatSidebar({
   const projectOrderIds = useStore($sidebarProjectOrderIds)
   const projects = useStore($projects)
   const projectTree = useStore($projectTree)
+
   // The persisted project filter's storage is shared across profiles, so ids
   // picked in another profile don't resolve in the active one and the raw
   // membership whitelist empties every tier of the sidebar (#96246). Narrow

--- a/apps/desktop/src/app/chat/sidebar/project-filter.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-filter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveLiveProjectFilter } from './project-filter'
+
+describe('resolveLiveProjectFilter', () => {
+  const treeA = [{ id: 'p_aaa' }, { id: '/Users/me/repos/alpha' }] as const
+  const treeB = [{ id: 'p_bbb' }, { id: '/Users/me/repos/beta' }] as const
+
+  it('returns the filter unchanged when it is empty', () => {
+    expect(resolveLiveProjectFilter([], treeA)).toEqual([])
+  })
+
+  it('keeps ids the active tree resolves', () => {
+    expect(resolveLiveProjectFilter(['p_aaa', '/Users/me/repos/alpha'], treeA)).toEqual([
+      'p_aaa',
+      '/Users/me/repos/alpha'
+    ])
+  })
+
+  it('drops ids that only resolve in another profile (#96246)', () => {
+    // Persisted in profile B, active profile is A: nothing resolves, the
+    // filter must become inert instead of filtering everything out.
+    expect(resolveLiveProjectFilter(['p_bbb', '/Users/me/repos/beta'], treeA)).toEqual([])
+  })
+
+  it('keeps the live half of a mixed filter', () => {
+    expect(resolveLiveProjectFilter(['p_bbb', 'p_aaa'], treeA)).toEqual(['p_aaa'])
+  })
+
+  it('fails open while the tree is loading', () => {
+    // Empty/pending tree → no narrowing yet; re-hydrates when the tree lands.
+    expect(resolveLiveProjectFilter(['p_aaa'], [])).toEqual([])
+    expect(resolveLiveProjectFilter(['p_aaa'], null)).toEqual([])
+    expect(resolveLiveProjectFilter(['p_aaa'], undefined)).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/project-filter.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-filter.ts
@@ -19,8 +19,14 @@ export function resolveLiveProjectFilter(
   projectFilter: readonly string[],
   tree: readonly { id: string }[] | null | undefined
 ): readonly string[] {
-  if (!projectFilter.length) return projectFilter
-  if (!tree || !tree.length) return []
+  if (!projectFilter.length) {
+    return projectFilter
+  }
+
+  if (!tree || !tree.length) {
+    return []
+  }
+
   const liveIds = new Set(tree.map(project => project.id))
   return projectFilter.filter(id => liveIds.has(id))
 }

--- a/apps/desktop/src/app/chat/sidebar/project-filter.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-filter.ts
@@ -1,0 +1,26 @@
+/**
+ * Project-filter resolution against the ACTIVE profile's project tree.
+ *
+ * The sidebar's project filter is a `persistentAtom` whose storage key is
+ * shared across profiles. Ids picked in profile B (explicit `p_<hex>` ids or
+ * repo-root paths) do not resolve against profile A's per-profile
+ * `projects.db`, and both application sites treat the raw filter as a
+ * membership whitelist — so one cross-profile switch empties every tier of
+ * the sidebar, reading as data loss until the filter is manually cleared
+ * (#96246).
+ *
+ * `resolveLiveProjectFilter` narrows the persisted filter to ids the given
+ * tree actually resolves. Ids that resolve nowhere become inert (the filter
+ * stops narrowing) instead of fatal (everything filters out). While the tree
+ * is still loading (empty), an explicit non-empty filter resolves to an
+ * empty live set — fail-open, matching the tree-refresh re-hydration timing.
+ */
+export function resolveLiveProjectFilter(
+  projectFilter: readonly string[],
+  tree: readonly { id: string }[] | null | undefined
+): readonly string[] {
+  if (!projectFilter.length) return projectFilter
+  if (!tree || !tree.length) return []
+  const liveIds = new Set(tree.map(project => project.id))
+  return projectFilter.filter(id => liveIds.has(id))
+}

--- a/apps/desktop/src/app/chat/sidebar/project-filter.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-filter.ts
@@ -28,5 +28,6 @@ export function resolveLiveProjectFilter(
   }
 
   const liveIds = new Set(tree.map(project => project.id))
+
   return projectFilter.filter(id => liveIds.has(id))
 }


### PR DESCRIPTION
## What does this PR do?

In a multi-profile desktop setup, the sidebar's project filter is a `persistentAtom` backed by `window.localStorage` under a key **shared across profiles** (`hermes.desktop.sidebarProjectFilter`). Project ids picked in profile B (explicit `p_<hex>` ids or repo-root paths) do not resolve against profile A's per-profile `projects.db`, and both filter application sites treat the raw list as a membership whitelist — so after one profile switch every tier of the sidebar empties (sessions, explicit projects, even Home), reading as data loss ("my history disappeared") until the user manually clears the filter. The reporter verified this on a live install by extracting the leveldb bytes: the stored array held six ids, **all** belonging to other profiles (#96246).

The fix implements the reporter's option (b) — dead ids become inert instead of fatal. The sidebar derives its working filter through a new pure `resolveLiveProjectFilter(filter, tree)`: persisted ids are narrowed to the ids the **active** profile's tree actually resolves. A filter whose ids resolve nowhere stops narrowing (the sidebar shows everything), and while the tree is still loading an explicit filter resolves empty — fail-open, re-hydrating when the tree lands. The persisted atom itself is untouched, so unchecking in the filter menu still clears the stored ids and single-profile behavior is byte-identical.

## Related Issue

Fixes #96246

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `apps/desktop/src/app/chat/sidebar/project-filter.ts` (new): `resolveLiveProjectFilter` pure helper with the mechanism documented.
- `apps/desktop/src/app/chat/sidebar/index.tsx`: the component reads the persisted atom as `persistedProjectFilter` and derives `projectFilter` via the helper against the live `$projectTree` — both downstream application sites (the session predicate and the project-tree lane filter) and `filtersNarrow` automatically use the resolved filter.
- `apps/desktop/src/app/chat/sidebar/project-filter.test.ts` (new, 5 tests): empty filter unchanged; live ids kept; cross-profile ids all dead → inert empty; mixed filter keeps the live half; fail-open on a loading/absent tree.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/sidebar/project-filter.test.ts` — should pass (5 passed).
2. Full sidebar suite: `npx vitest run src/app/chat/sidebar/` — should pass (25 files / 225 tests).
3. `npx tsc --noEmit` — clean.
4. Manual (per the issue): ≥2 profiles, set a Project filter in profile B, switch to profile A — the sidebar now shows A's full tree instead of the empty "no sessions match these filters" state; switching back and forth and restarting keeps working (dead ids stay inert until unchecked in the menu).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the shared-storage-key mechanism and the fail-open loading contract documented on the helper and at the derivation site)
- [x] New and existing unit tests pass locally (5 new; 225 sidebar tests; tsc clean)
- [x] Changes are backward compatible (persisted storage untouched; single-profile and same-profile filtering byte-identical — the derived filter equals the persisted one whenever the tree resolves its ids)
