### PR TITLE
fix(desktop): guard project mutations in all-profiles view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -1,10 +1,15 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { $showAllProfiles } from '@/store/profile'
+
 import { ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  $showAllProfiles.set(false)
+})
 
 // jsdom doesn't implement ResizeObserver; Radix's PopoverContent/Arrow use it
 // (via @radix-ui/react-use-size) to measure the arrow once the popover is
@@ -25,6 +30,7 @@ vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
       common: { cancel: 'Cancel', confirm: 'Confirm', done: 'Done', loading: 'Loading…' },
+      profiles: { selectPrompt: 'Select a profile to manage projects.' },
       sidebar: {
         projects: {
           copyPath: 'Copy path',
@@ -115,4 +121,20 @@ describe('ProjectMenu', () => {
     // chain rather than getting silently dropped on an intermediate wrapper.
     expect(await screen.findByRole('button', { name: 'No color' })).toBeTruthy()
   }, 15000)
+
+  it('does not offer profile-owned mutations in the all-profiles view', async () => {
+    $showAllProfiles.set(true)
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(
+      (await screen.findByRole('menuitem', { name: 'Select a profile to manage projects.' })).getAttribute(
+        'aria-disabled'
+      )
+    ).toBe('true')
+    expect(screen.queryByRole('menuitem', { name: 'Delete…' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Rename' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Appearance' })).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -22,6 +22,7 @@ import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { $panesFlipped, dismissAutoProject } from '@/store/layout'
+import { $profileScope, ALL_PROFILES } from '@/store/profile'
 import {
   copyPath,
   deleteProject,
@@ -54,6 +55,8 @@ function useProjectActions({
 }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
+  const profileScope = useStore($profileScope)
+  const canManage = profileScope !== ALL_PROFILES
   const target = { id: project.id, name: project.label }
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
@@ -76,7 +79,7 @@ function useProjectActions({
   // Rename / add folder / set active — explicit projects only (auto ones lack a
   // materialized record). Appearance is handled per-surface (popover vs submenu)
   // by the caller since its picker chrome differs.
-  const identityItems: ActionItemSpec[] = project.isAuto
+  const identityItems: ActionItemSpec[] = project.isAuto || !canManage
     ? []
     : [
         { icon: 'edit', key: 'rename', label: p.menuRename, onSelect: () => openProjectRename(target) },
@@ -114,13 +117,15 @@ function useProjectActions({
 
   const dangerItem: ActionItemSpec = project.isAuto
     ? { icon: 'trash', key: 'remove', label: p.removeFromSidebar, onSelect: removeAuto, variant: 'destructive' }
-    : {
-        icon: 'trash',
-        key: 'delete',
-        label: `${p.menuDelete}…`,
-        onSelect: () => setConfirmDeleteOpen(true),
-        variant: 'destructive'
-      }
+    : !canManage
+      ? { disabled: true, icon: 'account', key: 'select-profile', label: t.profiles.selectPrompt, onSelect: () => {} }
+      : {
+          icon: 'trash',
+          key: 'delete',
+          label: `${p.menuDelete}…`,
+          onSelect: () => setConfirmDeleteOpen(true),
+          variant: 'destructive'
+        }
 
   const confirmDialog = (
     <ConfirmDialog
@@ -134,7 +139,7 @@ function useProjectActions({
     />
   )
 
-  return { confirmDialog, dangerItem, identityItems, pathItems }
+  return { canManage, confirmDialog, dangerItem, identityItems, pathItems }
 }
 
 // Per-project actions. The kebab keeps its row-anchored Appearance popover; the
@@ -166,7 +171,7 @@ export function ProjectMenu({
   // when the panes are flipped (sidebar on the right).
   const panesFlipped = useStore($panesFlipped)
 
-  const { confirmDialog, dangerItem, identityItems, pathItems } = useProjectActions({
+  const { canManage, confirmDialog, dangerItem, identityItems, pathItems } = useProjectActions({
     isActive,
     onExitScope,
     project,
@@ -234,20 +239,21 @@ export function ProjectMenu({
             // Inherited (auto) repos can still be themed — the change adopts the
             // repo as a real project. Rename / add-folder / set-active stay out
             // until then (they need the materialized record).
+            canManage &&
             project.path && (
               <>
                 {appearanceItem}
                 <DropdownMenuSeparator />
               </>
             )
-          ) : (
+          ) : canManage ? (
             <>
               {identityItems.slice(0, 1).map(item => renderActionItem(DROPDOWN_KIT, item))}
               {appearanceItem}
               {identityItems.slice(1).map(item => renderActionItem(DROPDOWN_KIT, item))}
               <DropdownMenuSeparator />
             </>
-          )}
+          ) : null}
           {pathItems.map(item => renderActionItem(DROPDOWN_KIT, item))}
           <DropdownMenuSeparator />
           {renderActionItem(DROPDOWN_KIT, dangerItem)}
@@ -294,14 +300,14 @@ export function ProjectContextMenu({
   const { t } = useI18n()
   const p = t.sidebar.projects
 
-  const { confirmDialog, dangerItem, identityItems, pathItems } = useProjectActions({
+  const { canManage, confirmDialog, dangerItem, identityItems, pathItems } = useProjectActions({
     isActive,
     onExitScope,
     project,
     scoped
   })
 
-  const canTheme = !project.isAuto || Boolean(project.path)
+  const canTheme = canManage && (!project.isAuto || Boolean(project.path))
 
   const applyAppearance = (patch: { color?: null | string; icon?: null | string }) => {
     void setProjectAppearance(project, patch)


### PR DESCRIPTION
## Problem

The aggregated **All profiles** project tree exposes project actions whose RPCs require a specific profile. `projectParams()` rejects those writes before they reach the gateway, so Delete appears to do nothing after the optimistic rollback; Rename, Appearance, Add folder, and Set active have the same ownership problem.

## Fix

- derive a shared `canManage` guard from `$profileScope !== ALL_PROFILES`
- hide profile-owned identity and Appearance actions in the aggregated view
- replace Delete with a disabled prompt to select a profile
- preserve read-only path actions and local auto-project dismissal
- apply the guard consistently to both the kebab menu and context menu

## Testing

- `npx vitest run --project ui src/app/chat/sidebar/projects` → 5 files, 82 tests passed
- `npx eslint src/app/chat/sidebar/projects/project-menu.tsx src/app/chat/sidebar/projects/project-menu.test.tsx` → clean
- `npx tsc -p . --noEmit` → clean
- `git diff --check origin/main...HEAD` → clean

## Scope

This is the class-level project-action guard related to #94738. PR #94739 covers the Delete symptom and also adds a separate project-creation affordance; this PR deliberately keeps creation UX out and guards every profile-owned mutation exposed by both project menus.

## AI assistance disclosure

Root-cause analysis, implementation, and verification were performed with Hermes Agent. All reported commands were run against this branch.