### PR TITLE
fix(desktop): stop hiding direct bot-to-bot DM replies behind a collapse

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -160,12 +160,20 @@ const InterAgentCollapsedNotice: FC<{ sender: string }> = ({ sender }) => (
  * vary: settling is now a prop change React applies in place.
  */
 const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }> = ({ sender, ...props }) => {
+  // The collapse (Grok-bots parity: "Replied to X", expandable) is ONLY for
+  // replies that land inside a SHARED GROUP room, where the exchange is one
+  // event among many and the sender-side notice already narrates it. A DIRECT
+  // bot-to-bot DM has no other place to surface the answer — collapsing it
+  // hides the response entirely (the bug report). The thread opting a message
+  // into the collapse sets `data-inter-agent-collapse`; absent that, the reply
+  // renders expanded (visible) like any other assistant turn.
+  const collapse = useAuiState(s => s.message.metadata?.custom?.interAgentCollapse === true)
   const isRunning = useAuiState(s => s.message.status?.type === 'running')
 
   return (
     <AssistantMessageBody
       {...props}
-      collapsedNotice={isRunning ? null : <InterAgentCollapsedNotice sender={sender} />}
+      collapsedNotice={collapse && !isRunning ? <InterAgentCollapsedNotice sender={sender} /> : null}
     />
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
@@ -83,11 +83,14 @@ function Harness({ messages }: { messages: ThreadMessage[] }) {
 const DELIVERY = 'Message from 🤖 Hermes (@hermes): please check the build'
 
 describe('inter-agent collapse gate', () => {
-  it('collapses a settled reply to an inter-agent delivery', async () => {
+  it('shows a settled reply to an inter-agent delivery inline (not collapsed)', async () => {
     render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'build is green', false)]} />)
 
-    expect(await screen.findByText(/Replied to/)).toBeTruthy()
-    expect(screen.getByText('show reply')).toBeTruthy()
+    // The response is visible without expanding anything — a direct DM has no
+    // other place to surface it (regression: collapsing hid the reply).
+    expect(await screen.findByText('build is green')).toBeTruthy()
+    expect(screen.queryByText(/Replied to/)).toBeNull()
+    expect(screen.queryByText('show reply')).toBeNull()
   })
 
   it('does NOT collapse while that reply is still streaming', async () => {
@@ -104,6 +107,22 @@ describe('inter-agent collapse gate', () => {
 
     await screen.findByText('ordinary answer')
     expect(screen.queryByText(/Replied to/)).toBeNull()
+  })
+
+  // Regression: a DIRECT bot-to-bot DM (the sender is a bot, not the human,
+  // and the two are NOT in a shared group) must show the responding bot's
+  // reply inline — collapsing it behind a closed "show reply" <details>
+  // hides the answer entirely, which is the bug report. Only in-group or
+  // human-visible conversation collapses for Grok-bots parity.
+  it('shows a direct bot-to-bot reply inline (not collapsed/hidden)', async () => {
+    render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'the build is green', false)]} />)
+
+    // The reply text itself must be visible without expanding anything.
+    const reply = await screen.findByText('the build is green')
+    expect(reply).toBeTruthy()
+    // No collapse affordance => the response is not hidden behind a toggle.
+    expect(screen.queryByText(/Replied to/)).toBeNull()
+    expect(screen.queryByText('show reply')).toBeNull()
   })
 
   it('clears the streaming marker once the turn settles', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
@@ -142,10 +142,10 @@ describe('streaming-status invalidation scope', () => {
   })
 
   it('keeps the same root DOM node across the settle transition', async () => {
-    // The inter-agent reply collapses once it settles. Rendering that as a
-    // competing root swapped the element type at this position, so React
-    // unmounted the row and mounted a fresh one — discarding the DOM the
-    // scroll anchor was holding.
+    // A direct bot-to-bot reply now renders EXPANDED (visible) on settle, not
+    // collapsed behind a "Replied to" toggle — collapsing hid the response in
+    // a DM (regression fix). The root still updates in place (no remount that
+    // would discard the scroll anchor), and the reply text stays shown.
     const delivery = 'Message from 🤖 Hermes (@hermes): please check the build'
     const messages = [user('u1', delivery), assistant('a1', 'working on it', true)]
     const { container, findByText, rerender } = render(<Harness messages={messages} />)
@@ -156,8 +156,14 @@ describe('streaming-status invalidation scope', () => {
     expect(before).toBeTruthy()
 
     rerender(<Harness messages={[messages[0], assistant('a1', 'working on it', false)]} />)
-    await findByText(/Replied to/)
+    await findByText('working on it')
 
+    // Reply visible, not collapsed behind a "Replied to" toggle. The inbound
+    // "Message from X" notice (aui_agent-message-note) is the incoming row and
+    // is expected; only the REPLY must not collapse.
+    expect(container.querySelector('[data-slot="aui_agent-reply-notice"]')).toBeNull()
+    expect(container.textContent).not.toMatch(/Replied to/)
+    expect(container.textContent).not.toMatch(/show reply/)
     const after = container.querySelector('[data-slot="aui_assistant-message-root"]')
 
     // Same element, updated in place — not a remount.


### PR DESCRIPTION
## Summary

A reply to an inter-agent delivery (a `Message from X` row) was **unconditionally collapsed** into a closed `Replied to X` / `show reply` `<details>` in the receiving bot's Bot Chat. For a **direct bot-to-bot DM** (the two bots are *not* in a shared group) that reply is the only place the response appears, so collapsing it hid the answer entirely — the responding bot's message never showed. Group chats render through a separate room view and never hit this path, which is why groups looked fine while direct DMs did not.

## Fix

`apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx` — gate the collapse on an opt-in flag (`message.metadata.custom.interAgentCollapse === true`). Direct DMs now render the reply expanded and visible, like any other assistant turn. The collapse remains available for surfaces that explicitly opt in (e.g. shared group rooms for Grok-bots parity).

## Verification

- Added a regression test (direct DM reply must be visible inline, not collapsed) — failed before the fix, passes after.
- Updated two existing tests that had encoded the buggy collapse behavior.
- **Desktop thread vitest suite: 28 files / 170 tests pass.**
- TypeScript clean (`tsc --noEmit`).

## ⚠️ Provisional — needs further certification

This is **provisionally-tested code**. It has **not** been certified against:
- a full Electron release build / bundle smoke test (only the vitest UI project was run against source),
- the cross-connection relay e2e path (bot-to-bot across two gateways),
- manual verification in a running desktop app.

Please treat the collapse opt-in flag as the integration point to validate: a group room that wants the old "Replied to" collapse must set `interAgentCollapse` on its inter-agent replies, which this PR does **not** wire up (group rooms use a different render path and were never collapsing). Recommend review + a release-build smoke test before merge.

🤖 Generated with Hermes Agent (Nous Research)