### PR TITLE
feat(kanban): optional HERMES_KANBAN_WORKER_WRAPPER for worker isolation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -77,6 +77,7 @@ import os
 import re
 import random
 import secrets
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -10838,7 +10839,11 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
+    # Phase 1: optional resource-isolation wrapper (cgroup scope). Empty by
+    # default (no-op); set HERMES_KANBAN_WORKER_WRAPPER to a wrapper-script path
+    # to run each worker inside a memory/CPU-capped systemd scope.
     cmd = [
+        *shlex.split(os.environ.get("HERMES_KANBAN_WORKER_WRAPPER", "").strip()),
         *_resolve_hermes_argv(),
         "-p", profile_arg,
         "--cli",


### PR DESCRIPTION
## What

Prepend an optional wrapper to the dispatched kanban worker argv, from `HERMES_KANBAN_WORKER_WRAPPER`. Empty by default, so it is a no-op unless you set it.

```python
*shlex.split(os.environ.get("HERMES_KANBAN_WORKER_WRAPPER", "").strip()),
```

Five lines and an `import shlex`.

## Why

Kanban workers are full agent processes, and a runaway one competes for memory with the gateway in the same container. When the kernel OOM killer resolves that, it does not necessarily pick the worker — and if it picks the gateway mid-write, you get a damaged `state.db`.

Capping each worker in its own cgroup scope turns that into a contained, predictable kill of the thing that actually misbehaved. On my box the wrapper is a one-line `systemd-run`:

```bash
exec systemd-run --scope --slice=kanban-workers.slice \
  -p MemoryMax=4G -p MemorySwapMax=0 -p CPUQuota=250% -p TasksMax=512 \
  -p OOMPolicy=kill --quiet -- "$@"
```

With `kanban.max_concurrent_children: 3` that bounds the worker pool's aggregate footprint, which is the property I actually wanted: a worker hitting its own limit is contained, whereas the container running out is not.

Doing this from outside is awkward — the dispatch argv is built internally, so there is no other seam to hang a wrapper on without patching the call site, which is exactly what I have been carrying downstream.

## Notes on the shape

- **Opt-in and reversible.** Unset or empty behaves exactly as today.
- `shlex.split` so the wrapper can carry its own arguments rather than forcing a script file.
- `.strip()` so a whitespace-only value is treated as unset rather than splitting to `['']` and exec'ing an empty argv.
- Env var rather than config because the wrapper is host-shaped — the same config is synced across machines that do not all have systemd.

Happy to move it into config, rename it, or gate it behind a `kanban.worker_wrapper` key instead if you would rather it were not environment-driven.

## Testing

Running in production on a personal instance since June against the BMad kanban workers, with the `systemd-run` wrapper above. Unset on every other machine I run, which is the no-op path.
