### PR TITLE
fix(desktop): scope transcript render-budget clamp to hot-hidden panes

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -433,7 +433,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     setBudgetSessionKey(sessionKey)
     setHadGroups(hasGroups)
     setRenderBudget(FIRST_PAINT_BUDGET)
-  } else if (renderBudget > paneBudget) {
+  } else if (paneLifecycle === 'hot-hidden' && renderBudget > paneBudget) {
     // Apply the hidden budget during render so React never first commits the
     // stale full transcript after this pane moves to the background.
     setRenderBudget(paneBudget)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the desktop thread list where clicking "Show earlier messages" stops working after 2 or 3 clicks and refuses to load any further conversation history.

### Root Cause Details

1. In `ThreadMessageListInner` (`apps/desktop/src/components/assistant-ui/thread/list.tsx`), a render-phase check was added to throttle backgrounded/hidden tabs:
   ```tsx
   else if (renderBudget > paneBudget) {
     setRenderBudget(paneBudget)
   }
   ```
   The intended purpose (as noted in its comment) is to apply the hidden budget when a tab moves to the background (`paneLifecycle === 'hot-hidden'`). However, the check was written unconditionally without verifying `paneLifecycle === 'hot-hidden'`.

2. Why it worked for the first 2-3 clicks:
   - Initial hydration fetches up to 120 messages into memory (`LATEST_SESSION_MESSAGES_LIMIT = 120`).
   - The thread list initially renders with `renderBudget` set to `paneBudget` (600 units).
   - While the rendered groups fit within 600 units, `hiddenCount` is 0. Each click on "Show earlier messages" triggers `resolveShowEarlierAction`, which returns `'window'`, expanding `windowPages` across the in-memory messages.
   - Once the visible turns exceed 600 units, `hiddenCount` becomes greater than 0.
   - The next click switches `resolveShowEarlierAction` to `'dom'`, calling:
     ```tsx
     setRenderBudget(budget => budget + paneBudget)
     ```
   - React starts rendering with the higher budget (e.g. 1200), but immediately hits `renderBudget > paneBudget` in the component body. React calls `setRenderBudget(paneBudget)` during render, resetting the budget back to 600 before committing.
   - Because `renderBudget` is permanently clamped to 600, `hiddenCount` can never drop to 0. Every subsequent click evaluates to `'dom'`, gets clamped back down, and does nothing.

### Changes Made

In `apps/desktop/src/components/assistant-ui/thread/list.tsx`:
- Scoped the render-phase budget clamp to `paneLifecycle === 'hot-hidden' && renderBudget > paneBudget`.
- When a pane is in the foreground, `renderBudget` can now grow with each click as intended, paging back through the entire transcript. Background panes still drop their render budget to `paneBudget` (40 units) to conserve memory.

### Verification

- Tested locally on sessions with 150+ messages: clicking "Show earlier messages" now smoothly pages back through DOM history and triggers backend tail backfills when needed.
- All existing tests pass (`vitest run src/components/assistant-ui/thread/list.test.ts`).
