### PR TITLE
fix(serve): announce READY sentinel on fd 1, not the redirected sys.stdout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19874,7 +19874,18 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # tui_gateway.server (imported above for the flush-on-SIGTERM
+            # handlers, #94724) redirects sys.stdout→sys.stderr at import time
+            # to keep stray prints off the JSON-RPC protocol stream. fd 1 is
+            # still the real stdout — and the Desktop spawn watches
+            # child.stdout for this sentinel — so write to the fd, not to the
+            # (redirected) sys.stdout, or the desktop times out after 90s
+            # against a perfectly healthy backend.
+            _ready_line = f"{ready_token} port={actual_port}\n"
+            try:
+                os.write(1, _ready_line.encode())
+            except OSError:
+                print(_ready_line, end="", flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -91,7 +91,7 @@ def test_exit_code_is_distinct_tempfail():
 # ---------------------------------------------------------------------------
 
 
-def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
+def _spawn_serve(port: int, tmp_path: Path, merge_stderr: bool = True) -> subprocess.Popen:
     home = tmp_path / "hermes_home"
     home.mkdir(exist_ok=True)
     env = dict(os.environ)
@@ -114,7 +114,7 @@ def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
         cwd=str(REPO_ROOT),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
         text=True,
     )
 
@@ -201,3 +201,46 @@ def test_ephemeral_port_zero_unaffected(tmp_path):
             proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+def test_ready_sentinel_arrives_on_stdout_not_stderr(tmp_path):
+    """#96282 — the Desktop spawn watches child.stdout for the READY sentinel.
+
+    ``tui_gateway.server`` (imported on the serve startup path since 6d4e851d8
+    for the flush-on-SIGTERM handlers) redirects ``sys.stdout`` to
+    ``sys.stderr`` at import time. If the sentinel is printed through the
+    redirected ``sys.stdout``, it lands on stderr and the desktop times out
+    after 90s against a perfectly healthy backend. The sentinel must reach
+    the real stdout (fd 1).
+
+    The other E2E tests here merge stderr into stdout, which is exactly how
+    the regression slipped past CI — this test keeps the streams separate.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    proc = _spawn_serve(port, tmp_path, merge_stderr=False)
+    try:
+        # stdout only: the sentinel MUST arrive here (desktop watches this pipe)
+        ready, lines = _read_until(proc, "HERMES_BACKEND_READY")
+        out = "".join(lines)
+        assert ready, (
+            f"READY sentinel not on stdout (desktop boot would time out); "
+            f"stdout:\n{out}"
+        )
+        assert f"HERMES_BACKEND_READY port={port}" in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        # Drain stderr after exit so the pipe doesn't fill and block the child
+        # on platforms with small pipe buffers.
+        if proc.stderr is not None:
+            try:
+                proc.stderr.read()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

Fixes #96282.

Since 6d4e851d8 (#94724 item 2) the serve startup path imports
`tui_gateway.server` (for the flush-on-SIGTERM handlers) **before** printing
the `HERMES_(BACKEND|DASHBOARD)_READY port=<n>` sentinel. That module
redirects `sys.stdout` to `sys.stderr` at import time (to keep stray prints
off the JSON-RPC protocol stream), so the sentinel now lands on **stderr** —
while the Electron desktop spawn (`apps/desktop/electron/backend-ready.ts`,
`waitForDashboardPort`) watches **child.stdout** only.

Result: the backend is healthy and announces its port in ~2s, but the desktop
times out after 90s ("Timed out waiting for Hermes backend port announcement"),
SIGTERMs a perfectly good backend, and the renderer loops
`refreshProfiles failed after 3 attempt(s)`.

Repro on current main:

```
$ python -m hermes_cli.main --profile default serve --host 127.0.0.1 --port 0 > out.log 2> err.log
$ cat out.log   # empty
$ cat err.log
HERMES_BACKEND_READY port=62788
  Hermes backend listening on 127.0.0.1:62788
```

## Fix

Write the sentinel to the real stdout file descriptor — fd 1 is the pipe the
desktop reads and is untouched by the Python-level `sys.stdout` redirect —
with a `print()` fallback for exotic environments where fd 1 isn't writable
(e.g. closed):

```python
os.write(1, f"{ready_token} port={actual_port}\n".encode())
```

## Test plan

- [x] New regression test `test_ready_sentinel_arrives_on_stdout_not_stderr`
      in `tests/hermes_cli/test_serve_port_in_use.py` — spawns a real serve
      with stdout/stderr captured **separately** and asserts the sentinel
      arrives on stdout. The existing E2E tests merge stderr into stdout,
      which is exactly how the regression slipped past CI.
- [x] Verified the new test **fails** on unfixed main (reproduces the
      desktop's 90s-timeout failure mode) and **passes** with this patch.
- [x] Full `tests/hermes_cli/test_serve_port_in_use.py` suite passes with the
      patch (existing conflict/ephemeral-port contracts untouched).
- [x] End-to-end on macOS: desktop-spawned backend now announces on stdout
      and the desktop connects (reporter-verified).
