### PR TITLE
test(conformance): publish Phase 3a deadline cells

### DIFF
--- a/tests/conformance/deadline/README.md
+++ b/tests/conformance/deadline/README.md
@@ -1,0 +1,20 @@
+# Deadline-layer conformance cells — Phase 3: poisoned-state contract
+
+Machine-checked acceptance cells for Phase 3a of #85125. The cells became
+hard-green after the Phase 3a protocol salvage (#93796) and conformance harness
+salvage (#93794) merged.
+
+## Contract under test
+
+- `run_bounded_async` and `run_bounded_sync` accept an optional `backend=`.
+  When a bounded call times out, the layer calls
+  `backend.mark_suspect(reason)` exactly once. A call that completes on time
+  never marks its backend.
+- Backends without `mark_suspect` are tolerated. Incremental Phase 3b adoption
+  must never weaken the deadline bound.
+- Reuse recycling through `ensure_healthy()` remains consumer-scoped. The
+  shared layer only publishes the suspect mark.
+
+The cells are deterministic and LLM-free. They exercise the real
+`agent.deadline` machinery without mocking the layer under test. A failure is
+a contract regression and must not be converted back to `xfail`.

--- a/tests/conformance/deadline/__init__.py
+++ b/tests/conformance/deadline/__init__.py
@@ -1,0 +1,1 @@
+"""Conformance cells for the unified deadline layer (#85125)."""

--- a/tests/conformance/deadline/test_phase3_poisoned_state.py
+++ b/tests/conformance/deadline/test_phase3_poisoned_state.py
@@ -1,0 +1,100 @@
+"""Hard-green Phase 3 acceptance cells for the poisoned-state contract.
+
+These cells assert that ``run_bounded_*`` marks a timed-out backend suspect
+exactly once, never marks on completion, and tolerates backends that have not
+adopted the protocol. They exercise the real deadline machinery without
+mocking the layer under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from agent.deadline import run_bounded_async, run_bounded_sync
+
+TIMEOUT_S = 0.05
+
+
+class RecordingBackend:
+    """Minimal structural adopter that records suspect reasons."""
+
+    def __init__(self) -> None:
+        self.suspect_reasons: list[str] = []
+
+    def mark_suspect(self, reason: str) -> None:
+        self.suspect_reasons.append(reason)
+
+    def ensure_healthy(self) -> bool:
+        return not self.suspect_reasons
+
+
+def test_timeout_marks_backend_suspect_once() -> None:
+    """An async timeout marks its backend once with the operation label."""
+
+    async def never() -> Any:
+        await asyncio.Event().wait()
+
+    async def run() -> RecordingBackend:
+        backend = RecordingBackend()
+        result = await run_bounded_async(
+            never(), TIMEOUT_S, label="cell3a-async", backend=backend
+        )
+        assert result.timed_out, "a never-completing awaitable must time out"
+        return backend
+
+    backend = asyncio.run(run())
+    assert len(backend.suspect_reasons) == 1
+    assert "cell3a-async" in backend.suspect_reasons[0]
+
+
+def test_completion_never_marks_backend() -> None:
+    """A call that completes on time leaves its backend unmarked."""
+
+    async def immediate() -> str:
+        return "done"
+
+    async def run() -> RecordingBackend:
+        backend = RecordingBackend()
+        result = await run_bounded_async(
+            immediate(), TIMEOUT_S, label="cell3a-complete", backend=backend
+        )
+        assert not result.timed_out and result.value == "done"
+        return backend
+
+    backend = asyncio.run(run())
+    assert backend.suspect_reasons == []
+
+
+def test_sync_flavor_marks_on_timeout() -> None:
+    """The synchronous flavor enforces the same suspect-mark contract."""
+
+    def block() -> None:
+        time.sleep(10)
+
+    backend = RecordingBackend()
+    result = run_bounded_sync(block, TIMEOUT_S, label="cell3a-sync", backend=backend)
+    assert result.timed_out
+    assert len(backend.suspect_reasons) == 1
+    assert "cell3a-sync" in backend.suspect_reasons[0]
+
+
+def test_non_adopting_backend_is_tolerated() -> None:
+    """Missing mark_suspect cannot weaken the deadline bound."""
+
+    class PlainBackend:
+        pass
+
+    async def never() -> Any:
+        await asyncio.Event().wait()
+
+    async def run() -> Any:
+        result = await run_bounded_async(
+            never(), TIMEOUT_S, label="cell3a-plain", backend=PlainBackend()
+        )
+        assert result.timed_out
+        return result
+
+    result = asyncio.run(run())
+    assert result.label == "cell3a-plain"


### PR DESCRIPTION
## Summary

- Publish the Phase 3a deadline acceptance cells promised by #93796 now that the conformance harness from #93794 is on `main`.
- Cover both async and sync timeout paths: an adopting backend is marked suspect exactly once and the reason includes the operation label.
- Pin the two fail-open boundaries: a completed operation is never marked, and a backend that has not adopted `mark_suspect` continues to work normally.
- Keep these cells hard-green. A regression fails the suite instead of being hidden behind `xfail`.

## Scope

This PR only adds the pending Phase 3a conformance cells. #95599 already owns the separate fix for the duplicate `SuspectableBackend` definition, so there is no overlapping production-code change here.

## Test plan

- `pytest -q tests/conformance tests/agent/test_deadline.py` — 68 passed, 2 planned skips
- `ruff check tests/conformance/deadline` — passed
- `ruff format --check tests/conformance/deadline` — passed
- `git diff --check` — passed

Refs #85125, #93794, #93796
Related: #95599
