### PR TITLE
fix(kanban): prevent completion with live task process

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,61 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_refuses_active_dispatcher_process_until_it_exits(
+    monkeypatch, worker_env,
+):
+    """A live task-owned process must keep dispatcher completion from cleanup."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+    from tools.process_registry import ProcessSession, process_registry
+
+    tracked = ProcessSession(
+        id="proc_completion_guard",
+        command="scripts/gate-sperre nehmen",
+        task_id=worker_env,
+    )
+    monkeypatch.setitem(process_registry._running, tracked.id, tracked)
+
+    complete_calls = []
+    cleanup_calls = []
+    original_complete = kb.complete_task
+
+    def observed_complete(conn, task_id, **kwargs):
+        complete_calls.append(task_id)
+        return original_complete(conn, task_id, **kwargs)
+
+    def observed_cleanup(_conn, task_id):
+        cleanup_calls.append(task_id)
+
+    monkeypatch.setattr(kb, "complete_task", observed_complete)
+    monkeypatch.setattr(kb, "_cleanup_workspace", observed_cleanup)
+
+    rejected = json.loads(kt._handle_complete({"summary": "gate passed"}))
+    assert "error" in rejected
+    assert "process(action='wait')" in rejected["error"]
+    assert complete_calls == []
+    assert cleanup_calls == []
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+    # The same task can close only after its registered child has exited.
+    tracked.exited = True
+    completed = json.loads(kt._handle_complete({"summary": "gate passed"}))
+    assert completed["ok"] is True
+    assert complete_calls == [worker_env]
+    assert cleanup_calls == [worker_env]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "done"
+    finally:
+        conn.close()
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -746,6 +746,25 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            # A dispatcher-owned worker may have registered a bounded gate,
+            # build, or test run with terminal(background=True). Completing
+            # would immediately call kb._cleanup_workspace(), deleting the
+            # worktree before that child can finish its own cleanup/release
+            # path. Do not apply this lifecycle guard to in-process cron or
+            # delegated contexts: they do not own the dispatcher's task.
+            if _is_dispatcher_owned_worker():
+                from tools.process_registry import process_registry
+
+                if process_registry.has_active_processes(tid):
+                    return tool_error(
+                        f"kanban_complete refused: task {tid} still has a "
+                        "registered background process running. Your task is "
+                        "still in-flight and its workspace was not cleaned up. "
+                        "Call process(action='wait') or process(action='poll') "
+                        "until it exits, or deliberately stop only your own "
+                        "process before retrying kanban_complete."
+                    )
+
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
             # calling kanban_complete before acceptance criteria are met.


### PR DESCRIPTION
## Problem\nA dispatcher worker could mark its task done and trigger workspace cleanup while a task-owned background process was still alive. This could strand the gate lock.\n\n## Fix\nBefore dispatcher-owned `kanban_complete`, check the process registry. If the task still owns an active background process, completion fails closed; no process is killed and no workspace is cleaned.\n\n## Evidence\n- `scripts/run_tests.sh tests/tools/test_kanban_tools.py`: 33/33 passed\n- `ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py`: passed\n- `git diff --check`: passed\n\nScope: `tools/kanban_tools.py` and regression tests only.