### PR TITLE
fix(serve): write READY sentinel to real fd 1 so desktop handshake survives stdout redirect

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19889,6 +19889,15 @@ def start_server(
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
             print(f"{ready_token} port={actual_port}", flush=True)
+            # Desktop spawn listens on stdout for this sentinel; a serve-path
+            # stdout redirect can push it to stderr, so also write it to the
+            # real fd 1 (sys.__stdout__) to guarantee the Electron handshake.
+            try:
+                import sys as _sys
+                _sys.__stdout__.write(f"{ready_token} port={actual_port}\n")
+                _sys.__stdout__.flush()
+            except Exception:
+                pass
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -119,6 +119,41 @@ def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
     )
 
 
+def _spawn_serve_separate_streams(port: int, tmp_path: Path) -> subprocess.Popen:
+    """Like ``_spawn_serve`` but keeps stdout and stderr separate.
+
+    The desktop spawn's ``waitForDashboardPort`` reads *only* child stdout
+    for the ``HERMES_BACKEND_READY``/``HERMES_DASHBOARD_READY`` sentinel.
+    Merging the streams (as ``_spawn_serve`` does with
+    ``stderr=subprocess.STDOUT``) hides regressions where the sentinel is
+    printed to stderr instead — exactly what #96282's stdout redirect caused.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir(exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        HERMES_HOME=str(home),
+        HERMES_SERVE_HEADLESS="1",
+        PYTHONUNBUFFERED="1",
+    )
+    for k in ("HERMES_DESKTOP", "HERMES_PARENT_PID", "HERMES_PARENT_START_MARKER",
+              "HERMES_PARENT_NONCE"):
+        env.pop(k, None)
+    code = (
+        "from hermes_cli.web_server import start_server\n"
+        f"start_server(host='127.0.0.1', port={port}, open_browser=False, "
+        "headless=True)\n"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
 def _read_until(proc: subprocess.Popen, token: str, timeout: float = 120.0):
     """Collect stdout lines until ``token`` appears, process exits, or timeout."""
     lines: list[str] = []
@@ -195,6 +230,35 @@ def test_ephemeral_port_zero_unaffected(tmp_path):
         announced = int(ready_line.strip().rsplit("port=", 1)[1])
         assert announced > 0
         assert "BACKEND_PORT_IN_USE" not in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_ready_sentinel_on_stdout_for_desktop(tmp_path):
+    """#96282 regression: READY sentinel must land on *stdout*.
+
+    The Electron desktop spawn watches only child stdout for the port
+    announcement. A serve-path stdout redirect (``tui_gateway.server``
+    mutating ``sys.stdout`` at import time) pushed the sentinel to stderr,
+    so a healthy backend was SIGTERMed after the 90s desktop timeout. With
+    streams kept separate, this test fails if the sentinel ever stops
+    appearing on stdout again.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    proc = _spawn_serve_separate_streams(port, tmp_path)
+    try:
+        ready, out_lines = _read_until(proc, "HERMES_BACKEND_READY")
+        stdout_text = "".join(out_lines)
+        assert ready, f"no READY sentinel on stdout; stdout:\n{stdout_text}"
+        assert f"HERMES_BACKEND_READY port={port}" in stdout_text
     finally:
         proc.terminate()
         try:


### PR DESCRIPTION
## Bug Description

Fixes #96282

Since upgrading to the build containing `6d4e851d8` (fix(serve): bounded flush-on-SIGTERM + periodic incremental session flush, #94724 item 2), Hermes Desktop fails to boot its local backend with:

```
[boot] Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

even though the backend is fully healthy — `HERMES_BACKEND_READY port=XXXXX` is present in `desktop.log` but arrives on the wrong stream.

## Root Cause

`tui_gateway/server.py:401` redirects stdout at import time:

```python
_real_stdout = sys.stdout
sys.stdout = sys.stderr   # keep stray prints off the JSON-RPC protocol stream
```

`6d4e851d8` added this import to the serve startup path (`hermes_cli/web_server.py`):

```python
from tui_gateway.server import install_exit_flush_signal_handlers
install_exit_flush_signal_handlers()
```

which runs **before** the port sentinel is printed:

```python
ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
print(f"{ready_token} port={actual_port}", flush=True)
```

so the sentinel now lands on **stderr**, while the desktop spawn (`apps/desktop/electron/backend-ready.ts`, `waitForDashboardPort`) watches **child.stdout only**. Result: healthy backend announces in ~2s, desktop times out at 90s, SIGTERMs the backend, and the renderer loops `refreshProfiles failed after 3 attempt(s)`.

## Fix

After the sentinel `print`, also write it to the real fd 1 (`sys.__stdout__`) so the Electron handshake succeeds regardless of any serve-path stdout redirect:

```python
ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
print(f"{ready_token} port={actual_port}", flush=True)
# Desktop spawn listens on stdout for this sentinel; a serve-path
# stdout redirect can push it to stderr, so also write it to the
# real fd 1 (sys.__stdout__) to guarantee the Electron handshake.
try:
    import sys as _sys
    _sys.__stdout__.write(f"{ready_token} port={actual_port}\n")
    _sys.__stdout__.flush()
except Exception:
    pass
```

This is minimal and robust to either future fix (not mutating `sys.stdout` globally at import, or restoring it before the sentinel).

## Regression Test

`tests/hermes_cli/test_serve_port_in_use.py`:

- Add `_spawn_serve_separate_streams` — the existing `_spawn_serve` merges stderr into stdout (`stderr=subprocess.STDOUT`), which is exactly why CI missed this bug.
- Add `test_ready_sentinel_on_stdout_for_desktop` — asserts the sentinel appears on **stdout** specifically (the stream Electron reads).

## How to Verify

1. `python -m pytest tests/hermes_cli/test_serve_port_in_use.py -v` → 9/9 pass
2. Without the fix, `test_ready_sentinel_on_stdout_for_desktop` fails with `no READY sentinel on stdout` (verified locally, 120s timeout)
3. Launch Hermes Desktop → boot completes in ~1s, `desktop.log` shows `Hermes backend is ready. Finalizing desktop startup` (verified locally on macOS arm64)

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass (full file 9/9 green)
- [x] Manual verification of the fix (Desktop boots, sentinel appears twice — once via stdout)

## Risk Assessment

Low — the added write is wrapped in try/except, only runs on the successful-bind path, and writes a line identical to what `print` already emits. The only behavioral change is that the sentinel line also appears on the real fd 1, which is what Electron already expects.
