### PR TITLE
fix(serve): emit READY sentinel on real stdout after tui_gateway rebinds it

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19874,7 +19874,15 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # MUST go to the REAL stdout: importing tui_gateway.server (e.g. via
+            # install_exit_flush_signal_handlers below) rebinds sys.stdout to
+            # stderr at module level so stray print()s can't corrupt the
+            # gateway's JSON-RPC stdout. The Electron desktop waits for this
+            # sentinel on child.stdout only — if it lands on stderr the shell
+            # times out after 90s and the GUI never boots. sys.__stdout__ is the
+            # interpreter's original stdout and is unaffected by that rebind.
+            _sentinel_stream = getattr(sys, "__stdout__", None) or sys.stdout
+            print(f"{ready_token} port={actual_port}", file=_sentinel_stream, flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -91,7 +91,7 @@ def test_exit_code_is_distinct_tempfail():
 # ---------------------------------------------------------------------------
 
 
-def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
+def _spawn_serve(port: int, tmp_path: Path, separate_stderr: bool = False) -> subprocess.Popen:
     home = tmp_path / "hermes_home"
     home.mkdir(exist_ok=True)
     env = dict(os.environ)
@@ -114,7 +114,7 @@ def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
         cwd=str(REPO_ROOT),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE if separate_stderr else subprocess.STDOUT,
         text=True,
     )
 
@@ -195,6 +195,70 @@ def test_ephemeral_port_zero_unaffected(tmp_path):
         announced = int(ready_line.strip().rsplit("port=", 1)[1])
         assert announced > 0
         assert "BACKEND_PORT_IN_USE" not in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_ready_sentinel_lands_on_stdout_only(tmp_path):
+    """Regression for #96282: the desktop port waiter watches child.stdout ONLY.
+
+    Since 6d4e851d8 the serve startup path imports ``tui_gateway.server``
+    (``install_exit_flush_signal_handlers``), whose module-level
+    ``sys.stdout = sys.stderr`` rebind redirects a plain ``print()`` of the
+    READY sentinel to stderr. The Electron shell then times out after 90s even
+    though the backend is healthy. The sentinel must be written to the real
+    stdout (fd 1), which the rebind never touches.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    proc = _spawn_serve(port, tmp_path, separate_stderr=True)
+    out_lines: list[str] = []
+    err_lines: list[str] = []
+    ready = threading.Event()
+
+    def _pump_out():
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            out_lines.append(line)
+            if "HERMES_BACKEND_READY" in line:
+                ready.set()
+                return
+
+    def _pump_err():
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            err_lines.append(line)
+
+    t_out = threading.Thread(target=_pump_out, daemon=True)
+    t_err = threading.Thread(target=_pump_err, daemon=True)
+    t_out.start()
+    t_err.start()
+    ready.wait(120)
+    try:
+        out = "".join(out_lines)
+        err = "".join(err_lines)
+        assert ready.is_set(), (
+            f"no READY sentinel on stdout; stdout:\n{out}\nstderr:\n{err}"
+        )
+        assert f"HERMES_BACKEND_READY port={port}" in out
+        assert "BACKEND_PORT_IN_USE" not in out
+        # Give the stderr pump a moment to collect anything the bug would have
+        # written there (the sentinel and "listening" line land together right
+        # after the bind).
+        import time as _time
+
+        _time.sleep(0.5)
+        assert "HERMES_BACKEND_READY" not in err, (
+            "READY sentinel leaked onto stderr; the desktop waits on stdout "
+            f"only:\n{err}"
+        )
     finally:
         proc.terminate()
         try:


### PR DESCRIPTION
## Summary

The Electron desktop app fails to boot its local backend with `Timed out waiting for Hermes backend port announcement (90000ms)` even though the backend is healthy. Regression from #94724's `6d4e851d8` (fix(serve): bounded flush-on-SIGTERM + periodic incremental session flush).

**Root cause:** `6d4e851d8` added `from tui_gateway.server import install_exit_flush_signal_handlers` to the serve startup path (`hermes_cli/web_server.py`), and `tui_gateway/server.py` does this at module level:

```python
_real_stdout = sys.stdout
sys.stdout = sys.stderr   # keep stray prints off the JSON-RPC protocol stream
```

The import runs **before** the port-discovery sentinel is printed, so `print(f"{ready_token} port={actual_port}")` now lands on **stderr**. The desktop spawn (`apps/desktop/electron/backend-ready.ts` → `waitForDashboardPort`) watches **child.stdout only**, so it never sees the sentinel and times out after 90s, SIGTERMs the healthy backend, and the renderer loops `refreshProfiles failed after 3 attempt(s)`.

**Fix:** print the sentinel to the interpreter's original stdout (`sys.__stdout__`, fd 1), which the `sys.stdout = sys.stderr` rebind never touches. Minimal, server-side, and preserves the TUI gateway's JSON-RPC stdout purity.

**Regression test:** `test_ready_sentinel_lands_on_stdout_only` spawns serve with stdout/stderr captured **separately** and asserts the sentinel arrives on stdout only. The existing `_spawn_serve` helper combined both streams (`stderr=subprocess.STDOUT`), which is exactly why CI missed this. Verified: the new test FAILS on current main (sentinel stranded on stderr) and PASSES with this change; the full `test_serve_port_in_use.py` file passes 9/9.

## Test plan

- [x] `pytest tests/hermes_cli/test_serve_port_in_use.py` — 9 passed
- [x] New regression test fails without the fix, passes with it
- [x] Live verification: `hermes gui` desktop boot completes (`Hermes backend is ready. Finalizing desktop startup`) with zero timeouts/EPIPE errors

## Related issues

Fixes #96282 — Desktop boot times out: HERMES_BACKEND_READY sentinel printed to stderr after 6d4e851d8 (tui_gateway.server stdout redirect)
Also affects #96279, #96266, #96280 (and is consistent with #60323's macOS variant) — all manifest as the same 90s desktop boot timeout.
