### PR TITLE
fix(models): openrouter/elephant-alpha no longer offered (delisted from live catalog)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -137,7 +137,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("thinkingmachines/inkling:free",          "free"),
     ("thinkingmachines/inkling-small:free",    "free"),
     ("minimax/minimax-m3:free",                "free"),
-    ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),
     ("poolside/laguna-xs-2.1:free",            "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-27T09:39:24Z",
+  "updated_at": "2026-08-27T11:03:10Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -167,10 +167,6 @@
         },
         {
           "id": "minimax/minimax-m3:free",
-          "description": "free"
-        },
-        {
-          "id": "openrouter/elephant-alpha",
           "description": "free"
         },
         {


### PR DESCRIPTION
## Summary
`openrouter/elephant-alpha` no longer appears in the curated OpenRouter picker — the model is gone from OpenRouter's live catalog (probed 2026-08-27), so the entry was a dead pick.

Delist credit: @orouge97 flagged the removal in PR #80036 (closed with the free-model picker cluster; this adopts that piece).

## Changes
- `hermes_cli/models.py`: entry removed from `OPENROUTER_MODELS`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`

Deliberately kept: the generic `"elephant"` context entry in `agent/model_metadata.py` (bare-slug metadata survives delists so manually-typed ids still behave) and the self-consistent mock fixtures in `tests/hermes_cli/test_model_catalog.py`.

## Validation
| Check | Result |
|---|---|
| Live `/api/v1/models` probe: id absent | confirmed |
| Slug absent from curated list + regenerated manifest | confirmed |
| Targeted suites (models, catalog) | 98/98 pass |

## Infographic

![elephant-alpha delisted](https://v3b.fal.media/files/b/0aa802a1/ggyiBlnj4czgTHPxpGZZA_4rATo7BC.png)
