### PR TITLE
fix(kanban): reap workers after terminal transitions

### DIFF
--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -84,6 +84,7 @@ __all__ = [
     "run_bounded_async",
     "run_bounded_sync",
     "kill_process_tree",
+    "terminate_process_tree",
 ]
 
 # Upper bound for any timeout handed to platform wait primitives.
@@ -648,6 +649,219 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
         except Exception:
             continue
     return signalled
+
+
+def terminate_process_tree(
+    pid: int,
+    *,
+    expected_start_time: Optional[int] = None,
+    grace_seconds: float = 5.0,
+    include_parent: bool = True,
+) -> dict[str, Any]:
+    """Terminate one identity-bound process tree with bounded escalation.
+
+    This is the lifecycle counterpart to :func:`kill_process_tree`: callers
+    that own a durable PID record pass the process start-time fingerprint
+    captured at spawn.  A recycled PID is treated as the original process
+    already being gone and is never signalled.  The root and descendants are
+    bound to identity-aware ``psutil.Process`` handles before the final
+    fingerprint check. POSIX sends SIGTERM, waits ``grace_seconds``, then
+    SIGKILLs every survivor. Windows hard-kills the same bound handles rather
+    than routing through PID-only ``taskkill``, which could target a recycled
+    PID after verification.
+
+    ``include_parent=False`` is for a process performing its own final cleanup:
+    descendants are drained but the caller stays alive long enough to flush
+    durable state before it exits itself.
+    """
+    result: dict[str, Any] = {
+        "identity_verified": False,
+        "identity_mismatch": False,
+        "identity_unavailable": False,
+        "termination_attempted": False,
+        "terminated": False,
+        "still_alive": False,
+        "sigkill": False,
+        "reaped": False,
+        "target_count": 0,
+    }
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return result
+    if pid <= 0:
+        return result
+
+    try:
+        import psutil
+
+        parent = psutil.Process(pid)
+        # Force psutil to cache the root's creation time now. Its signal,
+        # liveness, and wait methods can then reject a later PID incarnation.
+        parent.create_time()
+    except Exception:
+        try:
+            from gateway.status import _pid_exists
+
+            pid_exists = bool(_pid_exists(pid))
+        except Exception:
+            pid_exists = expected_start_time is not None
+        if pid_exists and expected_start_time is not None:
+            result.update(identity_unavailable=True, still_alive=True)
+        else:
+            result.update(terminated=True, still_alive=False, reaped=True)
+        return result
+
+    if expected_start_time is not None:
+        try:
+            from gateway.status import get_process_identity
+
+            live_start = get_process_identity(pid, process=parent)
+        except Exception:
+            live_start = None
+        if live_start is None:
+            try:
+                alive = bool(parent.is_running())
+            except Exception:
+                alive = False
+            if alive:
+                result.update(identity_unavailable=True, still_alive=True)
+            else:
+                result.update(terminated=True, reaped=True)
+            return result
+        if live_start != int(expected_start_time):
+            result.update(
+                identity_mismatch=True,
+                terminated=True,
+                still_alive=False,
+                reaped=True,
+            )
+            return result
+        result["identity_verified"] = True
+
+    def _alive(proc) -> bool:
+        try:
+            return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
+        except Exception:
+            return False
+
+    try:
+        targets = parent.children(recursive=True)
+    except Exception:
+        targets = []
+    if include_parent:
+        targets.append(parent)
+    # Dedupe while preserving psutil's children-before-parent order.
+    unique = []
+    seen: set[tuple[int, float]] = set()
+    for proc in targets:
+        try:
+            key = (int(proc.pid), float(proc.create_time()))
+        except Exception:
+            continue
+        if key not in seen:
+            seen.add(key)
+            unique.append(proc)
+    targets = unique
+    result["target_count"] = len(targets)
+    if not targets:
+        result.update(terminated=True, still_alive=False, reaped=True)
+        return result
+
+    result["termination_attempted"] = True
+    signal_targets = targets
+    if include_parent:
+        # Stop the writer first so it cannot react to a child shutdown by
+        # launching another helper outside the original descendant snapshot.
+        signal_targets = [parent] + [proc for proc in targets if proc != parent]
+    if sys.platform == "win32":
+        # Windows has no graceful tree signal. Kill each identity-bound handle;
+        # never fall back to taskkill /PID after the final identity check.
+        result["sigkill"] = True
+        for proc in signal_targets:
+            try:
+                if _alive(proc):
+                    proc.kill()
+            except Exception:
+                continue
+        deadline = time.monotonic() + max(float(grace_seconds), 0.0)
+        while time.monotonic() < deadline:
+            if not any(_alive(proc) for proc in targets):
+                break
+            time.sleep(0.05)
+        survivors = [proc for proc in targets if _alive(proc)]
+        for proc in targets:
+            if _alive(proc):
+                continue
+            try:
+                proc.wait(timeout=0)
+            except Exception:
+                pass
+        result.update(
+            terminated=not survivors,
+            still_alive=bool(survivors),
+            reaped=not survivors,
+            survivor_pids=[int(proc.pid) for proc in survivors],
+        )
+        return result
+
+    for proc in signal_targets:
+        try:
+            if _alive(proc):
+                proc.terminate()
+        except Exception:
+            continue
+
+    deadline = time.monotonic() + max(float(grace_seconds), 0.0)
+    while time.monotonic() < deadline:
+        if not any(_alive(proc) for proc in targets):
+            break
+        time.sleep(0.05)
+
+    # A still-live root may have forked between the first snapshot and TERM.
+    # Fold any such descendants into the escalation set before SIGKILL.
+    if include_parent and _alive(parent):
+        try:
+            for proc in parent.children(recursive=True):
+                key = (int(proc.pid), float(proc.create_time()))
+                if key not in seen:
+                    seen.add(key)
+                    targets.append(proc)
+        except Exception:
+            pass
+    result["target_count"] = len(targets)
+    survivors = [proc for proc in targets if _alive(proc)]
+    if survivors:
+        result["sigkill"] = True
+        for proc in survivors:
+            try:
+                proc.kill()
+            except Exception:
+                continue
+        kill_deadline = time.monotonic() + 1.0
+        while time.monotonic() < kill_deadline:
+            if not any(_alive(proc) for proc in survivors):
+                break
+            time.sleep(0.02)
+
+    survivors = [proc for proc in targets if _alive(proc)]
+    # Reap direct children when this process is their parent.  Process.wait()
+    # is identity-aware and returns immediately for zombies/already-gone rows;
+    # failures simply mean init/the real parent owns the reap.
+    for proc in targets:
+        if _alive(proc):
+            continue
+        try:
+            proc.wait(timeout=0)
+        except Exception:
+            pass
+    result.update(
+        terminated=not survivors,
+        still_alive=bool(survivors),
+        reaped=not survivors,
+        survivor_pids=[int(proc.pid) for proc in survivors],
+    )
+    return result
 
 
 class SuspectableBackend:

--- a/cli.py
+++ b/cli.py
@@ -1456,31 +1456,107 @@ def _wait_for_oneshot_background_completions(cli) -> None:
         )
 
 
+def _kanban_worker_run_is_terminal() -> bool:
+    """Return whether this dispatcher-owned process's exact run has ended."""
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if not task_id or not raw_run_id:
+        return False
+    try:
+        run_id = int(raw_run_id)
+    except (TypeError, ValueError):
+        return False
+    try:
+        from hermes_cli import kanban_db as _kb
+
+        with _kb.connect_closing() as conn:
+            row = conn.execute(
+                "SELECT ended_at FROM task_runs WHERE id = ? AND task_id = ?",
+                (run_id, task_id),
+            ).fetchone()
+        return bool(row and row["ended_at"] is not None)
+    except Exception:
+        logger.debug("kanban terminal-run probe failed", exc_info=True)
+        return False
+
+
+def _shutdown_terminal_kanban_worker() -> None:
+    """Drain descendants, flush diagnostics, then hard-exit a terminal worker."""
+    try:
+        from tools.process_registry import process_registry
+
+        process_registry.kill_all(
+            source="kanban_terminal_handoff",
+            consume_output=True,
+        )
+    except Exception:
+        logger.debug("kanban tracked-process shutdown failed", exc_info=True)
+    try:
+        from agent.deadline import terminate_process_tree
+
+        terminate_process_tree(
+            os.getpid(),
+            grace_seconds=1.5,
+            include_parent=False,
+        )
+    except Exception:
+        logger.debug("kanban descendant shutdown failed", exc_info=True)
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        logging.shutdown()
+    finally:
+        # Python waits for non-daemon threads during normal shutdown. A durable
+        # Kanban handoff must not linger for those threads after its descendants
+        # were explicitly drained.
+        os._exit(0)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
+    terminal_kanban_handoff = _kanban_worker_run_is_terminal()
     try:
-        # Linger (bounded) for background processes the turn spawned with
-        # notify_on_complete=true BEFORE any teardown. The one-shot parent
-        # owns those children's stdout pipes; exiting now kills the delivery
-        # a few seconds later. Bot Mode handoff replies dispatched from a
-        # short-lived `hermes -p <bot> chat -Q` recipient (message_agent /
-        # bot_relay spawns) are exactly this shape and were silently
-        # destroyed on parent exit (#90879).
         try:
-            _wait_for_oneshot_background_completions(cli)
-        except Exception:
-            logger.debug("one-shot background completion wait failed", exc_info=True)
-        # Durable flush FIRST: memory-provider shutdown inside _run_cleanup
-        # can issue aux-LLM calls, and nothing after it may fail in a way
-        # that loses the turn (#88583).
-        try:
-            _flush_one_shot_session_store(cli)
-        except Exception:
-            logger.debug("one-shot session store flush failed", exc_info=True)
-        _notify_single_query_session_finalize(cli)
-        _run_cleanup(notify_session_finalize=False)
+            # Normal one-shot queries linger for notify_on_complete background work.
+            # A terminal Kanban run has already committed its durable handoff and
+            # must instead stop its processes immediately; the default linger is
+            # 600 seconds and was the direct source of orphan-looking workers.
+            if terminal_kanban_handoff:
+                try:
+                    from tools.process_registry import process_registry
+
+                    process_registry.kill_all(
+                        source="kanban_terminal_handoff",
+                        consume_output=True,
+                    )
+                except Exception:
+                    logger.debug(
+                        "kanban tracked-process shutdown failed", exc_info=True
+                    )
+            else:
+                try:
+                    _wait_for_oneshot_background_completions(cli)
+                except Exception:
+                    logger.debug(
+                        "one-shot background completion wait failed", exc_info=True
+                    )
+            # Durable flush FIRST: memory-provider shutdown inside _run_cleanup
+            # can issue aux-LLM calls, and nothing after it may fail in a way
+            # that loses the turn (#88583).
+            try:
+                _flush_one_shot_session_store(cli)
+            except Exception:
+                logger.debug("one-shot session store flush failed", exc_info=True)
+            _notify_single_query_session_finalize(cli)
+            _run_cleanup(notify_session_finalize=False)
+        finally:
+            cli._release_active_session()
     finally:
-        cli._release_active_session()
+        # A terminal run has already committed its durable handoff. Even if a
+        # notifier, cleanup hook, or lease release raises, do not fall back to
+        # Python's unbounded non-daemon-thread shutdown path.
+        if terminal_kanban_handoff:
+            _shutdown_terminal_kanban_worker()
 
 
 def _reset_terminal_input_modes_on_exit() -> None:

--- a/contributors/emails/20184606+alessio84@users.noreply.github.com
+++ b/contributors/emails/20184606+alessio84@users.noreply.github.com
@@ -1,0 +1,2 @@
+alessio84
+# Kanban terminal-worker cleanup

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -19,6 +19,7 @@ import os
 import re
 import shlex
 import signal
+import struct
 import subprocess
 import sys
 import threading
@@ -343,6 +344,22 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _parse_linux_proc_start_time(raw_stat: str) -> Optional[int]:
+    """Parse field 22 from ``/proc/<pid>/stat`` without splitting ``comm``.
+
+    Field 2 is parenthesized and may itself contain spaces or ``)``. The last
+    closing parenthesis terminates it; the remaining tokens begin at field 3.
+    """
+    comm_end = raw_stat.rfind(")")
+    if comm_end < 0:
+        return None
+    trailing_fields = raw_stat[comm_end + 1 :].split()
+    try:
+        return int(trailing_fields[19])  # field 22 relative to field 3
+    except (IndexError, ValueError):
+        return None
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return a stable per-process start-time fingerprint, or None.
 
@@ -364,8 +381,12 @@ def _get_process_start_time(pid: int) -> Optional[int]:
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text(encoding="utf-8").split()[21])
-    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        parsed = _parse_linux_proc_start_time(
+            stat_path.read_text(encoding="utf-8")
+        )
+        if parsed is not None:
+            return parsed
+    except (FileNotFoundError, PermissionError, OSError):
         pass
 
     # No /proc (macOS / Windows): psutil is a hard dependency and exposes a
@@ -381,6 +402,49 @@ def _get_process_start_time(pid: int) -> Optional[int]:
 def get_process_start_time(pid: int) -> Optional[int]:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
+
+
+def _process_create_time_token(create_time: float) -> int:
+    """Encode a psutil creation timestamp without lossy decimal rounding.
+
+    ``psutil.Process.create_time()`` is a float on macOS and Windows.  The
+    historical status helper rounds it to centiseconds for compatibility with
+    existing PID files, but that is too coarse for durable worker identities:
+    two process incarnations can otherwise compare equal during rapid PID
+    reuse.  The IEEE-754 bit pattern is stable across repeated reads and fits
+    in SQLite's signed INTEGER range for positive epoch timestamps.
+    """
+    return int.from_bytes(struct.pack("!d", float(create_time)), "big")
+
+
+def get_process_identity(pid: int, *, process=None) -> Optional[int]:
+    """Return a non-lossy process-birth token for durable ownership records.
+
+    Linux keeps the kernel ``/proc`` start ticks used by
+    :func:`get_process_start_time`; callers pair those boot-relative ticks with
+    a boot/incarnation token.  On macOS and Windows, preserve psutil's complete
+    creation-time value rather than quantizing it to centiseconds.  Supplying
+    an already-open ``process`` lets a caller bind a psutil process handle
+    before the final identity comparison and retain that identity through
+    signaling.
+    """
+    stat_path = Path(f"/proc/{pid}/stat")
+    try:
+        parsed = _parse_linux_proc_start_time(
+            stat_path.read_text(encoding="utf-8")
+        )
+        if parsed is not None:
+            return parsed
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+
+    try:
+        import psutil  # type: ignore
+
+        proc = process if process is not None else psutil.Process(pid)
+        return _process_create_time_token(proc.create_time())
+    except Exception:
+        return None
 
 
 def _read_process_cmdline(pid: int) -> Optional[str]:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1739,6 +1739,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
                     "error": r.error,
                     "metadata": r.metadata,
                     "worker_pid": r.worker_pid,
+                    "worker_start_time": r.worker_start_time,
                     "started_at": r.started_at,
                     "ended_at": r.ended_at,
                 }
@@ -2671,6 +2672,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps({
             "reclaimed": res.reclaimed,
+            "cleaned_terminal": res.cleaned_terminal,
             "crashed": res.crashed,
             "timed_out": res.timed_out,
             "stale": res.stale,
@@ -2690,6 +2692,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
+    print(f"Cleaned terminal workers: {len(res.cleaned_terminal)}")
+    if res.cleaned_terminal:
+        print(f"  {', '.join(res.cleaned_terminal)}")
     print(f"Crashed:      {len(res.crashed)}")
     if res.crashed:
         print(f"  {', '.join(res.crashed)}")
@@ -3023,7 +3028,9 @@ def _cmd_runs(args: argparse.Namespace) -> int:
                 "outcome": r.outcome, "started_at": r.started_at,
                 "ended_at": r.ended_at, "summary": r.summary,
                 "error": r.error, "metadata": r.metadata,
-                "worker_pid": r.worker_pid, "step_key": r.step_key,
+                "worker_pid": r.worker_pid,
+                "worker_start_time": r.worker_start_time,
+                "step_key": r.step_key,
             } for r in runs
         ], indent=2, ensure_ascii=False))
         return 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -334,6 +334,7 @@ def _fire_dispatch_tick_hook(
             result.reclaimed,
             result.promoted,
             result.reconciled_orphans,
+            result.cleaned_terminal,
             result.crashed,
             result.stale,
             result.timed_out,
@@ -1141,6 +1142,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Kernel process start-time fingerprint captured with worker_pid.  Keep
+    # this additive field last so legacy positional Task(...) callers retain
+    # their original argument binding.
+    worker_start_time: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1183,6 +1188,9 @@ class Task:
                 else (row["spawn_failures"] if "spawn_failures" in keys else 0)
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
+            worker_start_time=(
+                row["worker_start_time"] if "worker_start_time" in keys else None
+            ),
             last_failure_error=(
                 row["last_failure_error"] if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
@@ -1265,6 +1273,9 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    # Additive durable process identity.  Appended with a default to preserve
+    # the public legacy positional Run(...) constructor.
+    worker_start_time: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1281,6 +1292,11 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            worker_start_time=(
+                row["worker_start_time"]
+                if "worker_start_time" in set(row.keys())
+                else None
+            ),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1359,6 +1375,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- exceeds DEFAULT_FAILURE_LIMIT consecutive non-successes.
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     worker_pid           INTEGER,
+    -- Kernel start-time fingerprint paired with worker_pid. Prevents a stale
+    -- run from signalling an unrelated process after PID reuse.
+    worker_start_time    INTEGER,
     -- Short excerpt of the most recent failure's error text.
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
@@ -1465,6 +1484,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    worker_start_time   INTEGER,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -2582,6 +2602,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
     if "worker_pid" not in cols:
         _add_column_if_missing(conn, "tasks", "worker_pid", "worker_pid INTEGER")
+    if "worker_start_time" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "worker_start_time", "worker_start_time INTEGER"
+        )
     if "last_failure_error" not in cols:
         added = _add_column_if_missing(
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
@@ -2775,9 +2799,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "worker_start_time" not in run_cols:
+            _add_column_if_missing(
+                conn,
+                "task_runs",
+                "worker_start_time",
+                "worker_start_time INTEGER",
+            )
         with write_txn(conn):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+                "       worker_start_time, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
                 "FROM tasks "
                 "WHERE status = 'running' AND current_run_id IS NULL"
@@ -2788,14 +2823,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     """
                     INSERT INTO task_runs (
                         task_id, profile, status,
-                        claim_lock, claim_expires, worker_pid,
+                        claim_lock, claim_expires, worker_pid, worker_start_time,
                         max_runtime_seconds, last_heartbeat_at,
                         started_at
-                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row["id"], row["assignee"], row["claim_lock"],
                         row["claim_expires"], row["worker_pid"],
+                        row["worker_start_time"],
                         row["max_runtime_seconds"], row["last_heartbeat_at"],
                         started,
                     ),
@@ -2873,7 +2909,8 @@ _REBUILD_SPECS = {
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " task_id TEXT NOT NULL, profile TEXT, step_key TEXT,"
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
-        " worker_pid INTEGER, max_runtime_seconds INTEGER,"
+        " worker_pid INTEGER, worker_start_time INTEGER,"
+        " max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
         " error TEXT)",
@@ -3132,13 +3169,50 @@ def _new_task_id() -> str:
     return "t_" + secrets.token_hex(4)
 
 
+def _worker_boot_id() -> Optional[str]:
+    """Return a host-incarnation fingerprint that changes across reboots.
+
+    ``worker_start_time`` alone is only ticks since boot on Linux and can recur
+    after a reboot. Embedding this value in the persisted claim identity keeps
+    durable Kanban rows from ever signalling a same-hostname process belonging
+    to a later OS incarnation.
+    """
+    try:
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+            encoding="utf-8"
+        ).strip()
+        if boot_id:
+            return f"linux-{boot_id}"
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+    try:
+        import psutil  # type: ignore
+
+        return f"boot-time-{int(round(psutil.boot_time() * 100))}"
+    except Exception:
+        return None
+
+
+def _claim_boot_id(claim_lock: Optional[str]) -> Optional[str]:
+    """Extract the optional boot fingerprint from a modern claim identity."""
+    if not claim_lock:
+        return None
+    for component in claim_lock.split(":")[1:]:
+        if component.startswith("boot="):
+            return component.removeprefix("boot=") or None
+    return None
+
+
 def _claimer_id() -> str:
-    """Return a ``host:pid`` string that identifies this claimer."""
+    """Return a persisted ``host[:boot=<id>]:pid`` claimer identity."""
     import socket
     try:
         host = socket.gethostname() or "unknown"
     except Exception:
         host = "unknown"
+    boot_id = _worker_boot_id()
+    if boot_id:
+        return f"{host}:boot={boot_id}:{os.getpid()}"
     return f"{host}:{os.getpid()}"
 
 
@@ -4321,6 +4395,18 @@ def _append_event(
     )
 
 
+_WORKER_HANDOFF_OUTCOMES = frozenset(
+    {
+        "completed",
+        "blocked",
+        "dependency_wait",
+        "review_requested",
+        "changes_requested",
+        "scheduled",
+    }
+)
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4330,15 +4416,17 @@ def _end_run(
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
     status: Optional[str] = None,
+    retain_worker: bool = False,
 ) -> Optional[int]:
-    """Close the currently-active run for ``task_id`` and clear the pointer.
+    """Close the active run while retaining a still-owned worker identity.
 
-    ``outcome`` is the semantic result (completed / blocked / crashed /
-    timed_out / spawn_failed / gave_up / reclaimed). ``status`` is the
-    run-row status (usually just ``outcome``, but callers can pass it
-    explicitly). Returns the closed run_id or ``None`` if no active run
-    existed (e.g. a CLI user calling ``hermes kanban complete`` on a
-    task that was never claimed).
+    Worker-initiated handoffs can make the task/run terminal before the
+    one-shot Python process has actually exited. For those outcomes, the
+    ended run and task retain ``claim_lock`` + ``(worker_pid,
+    worker_start_time)`` until :func:`cleanup_terminal_workers` proves the
+    exact process tree is gone and reaped. Dispatcher-side failures already
+    terminate the worker before ending the run and therefore clear process
+    state immediately.
     """
     now = int(time.time())
     row = conn.execute(
@@ -4347,6 +4435,18 @@ def _end_run(
     if not row or not row["current_run_id"]:
         return None
     run_id = int(row["current_run_id"])
+    process_row = conn.execute(
+        "SELECT claim_lock, claim_expires, worker_pid, worker_start_time "
+        "FROM task_runs WHERE id = ? AND ended_at IS NULL",
+        (run_id,),
+    ).fetchone()
+    retain_process_claim = bool(
+        (retain_worker or outcome in _WORKER_HANDOFF_OUTCOMES)
+        and process_row
+        and process_row["claim_lock"]
+        and process_row["worker_pid"]
+    )
+    retain = 1 if retain_process_claim else 0
     conn.execute(
         """
         UPDATE task_runs
@@ -4356,9 +4456,10 @@ def _end_run(
                error         = ?,
                metadata      = ?,
                ended_at      = ?,
-               claim_lock    = NULL,
-               claim_expires = NULL,
-               worker_pid    = NULL
+               claim_lock    = CASE WHEN ? THEN claim_lock ELSE NULL END,
+               claim_expires = CASE WHEN ? THEN ? ELSE NULL END,
+               worker_pid    = CASE WHEN ? THEN worker_pid ELSE NULL END,
+               worker_start_time = CASE WHEN ? THEN worker_start_time ELSE NULL END
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -4369,12 +4470,34 @@ def _end_run(
             error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now,
+            retain,
+            retain,
+            now,
+            retain,
+            retain,
             run_id,
         ),
     )
-    conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
-    )
+    if retain_process_claim:
+        conn.execute(
+            "UPDATE tasks SET current_run_id = NULL, claim_lock = ?, "
+            "claim_expires = ?, worker_pid = ?, worker_start_time = ? "
+            "WHERE id = ? AND current_run_id = ?",
+            (
+                process_row["claim_lock"],
+                now,
+                process_row["worker_pid"],
+                process_row["worker_start_time"],
+                task_id,
+                run_id,
+            ),
+        )
+    else:
+        conn.execute(
+            "UPDATE tasks SET current_run_id = NULL, worker_start_time = NULL "
+            "WHERE id = ?",
+            (task_id,),
+        )
     return run_id
 
 
@@ -4670,7 +4793,8 @@ def claim_task(
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on re-claim'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_start_time = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -4978,7 +5102,7 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at, "
+        "SELECT id, claim_lock, worker_pid, worker_start_time, claim_expires, last_heartbeat_at, "
         "       assignee "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
@@ -5000,7 +5124,11 @@ def release_stale_claims(
         if (
             host_local
             and row["worker_pid"]
-            and _pid_alive(row["worker_pid"])
+            and _worker_identity_alive(
+                row["worker_pid"],
+                row["worker_start_time"],
+                row["claim_lock"],
+            )
             and not heartbeat_stale
         ):
             new_expires = now + _resolve_claim_ttl_seconds()
@@ -5040,7 +5168,8 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"], row["claim_lock"],
+            worker_start_time=row["worker_start_time"], signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -5054,7 +5183,7 @@ def release_stale_claims(
             retry_status = _retry_status_for_run(conn, row["id"])
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_start_time = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
                 (retry_status, row["id"], row["claim_lock"], now),
@@ -5130,7 +5259,8 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, claim_lock, worker_pid, worker_start_time "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -5140,13 +5270,25 @@ def reclaim_task(
         return False
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
-        row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        row["worker_pid"], prev_lock,
+        worker_start_time=row["worker_start_time"], signal_fn=signal_fn,
     )
+    if _worker_survived_termination(termination):
+        if row["status"] == "running":
+            _defer_reclaim_for_live_worker(
+                conn,
+                task_id,
+                prev_lock,
+                int(time.time()),
+                termination,
+                reason="manual_reclaim_worker_alive",
+            )
+        return False
     with write_txn(conn):
         retry_status = _retry_status_for_run(conn, task_id)
         cur = conn.execute(
             "UPDATE tasks SET status = ?, claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
+            "claim_expires = NULL, worker_pid = NULL, worker_start_time = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
             (retry_status, task_id, prev_lock),
@@ -5449,6 +5591,7 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       worker_start_time = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -5466,6 +5609,7 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       worker_start_time = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -5577,8 +5721,12 @@ def complete_task(
     _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
-    # Clean up the scratch workspace and any stale tmux session for the worker.
-    _cleanup_workspace(conn, task_id)
+    # A worker can call complete before its process has exited. Defer workspace
+    # removal until the dispatcher has terminated/reaped that exact worker so
+    # its cwd and final artifacts remain valid during shutdown.
+    completed_task = get_task(conn, task_id)
+    if completed_task is None or completed_task.worker_pid is None:
+        _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
     if fire_lifecycle_hook:
         _fire_kanban_lifecycle_hook(
@@ -6315,6 +6463,7 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       worker_start_time = NULL,
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -6372,6 +6521,7 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       worker_start_time = NULL,
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
@@ -6411,6 +6561,7 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           worker_start_time = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6426,6 +6577,7 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           worker_start_time = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6604,7 +6756,8 @@ def request_review(
                SET status        = 'review',
                    claim_lock    = NULL,
                    claim_expires = NULL,
-                   worker_pid    = NULL
+                   worker_pid    = NULL,
+                   worker_start_time = NULL
             """ + assignee_sql + """
              WHERE id = ?
                AND status IN ('running', 'ready')
@@ -6739,7 +6892,8 @@ def request_changes(
                    assignee = COALESCE(?, assignee),
                    claim_lock = NULL,
                    claim_expires = NULL,
-                   worker_pid = NULL
+                   worker_pid = NULL,
+                   worker_start_time = NULL
              WHERE id = ? AND status = 'running' AND current_run_id = ?
             """,
             (new_status, implementer, task_id, int(current_run_id)),
@@ -6859,7 +7013,8 @@ def _reclaim_dangling_run(
                SET status = 'reclaimed', outcome = 'reclaimed',
                    summary = COALESCE(summary, ?),
                    ended_at = ?,
-                   claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                   claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_start_time = NULL
              WHERE id = ? AND ended_at IS NULL
             """,
             (note, now, int(stale["current_run_id"])),
@@ -6994,8 +7149,15 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
-            # consecutive_failures deliberately PRESERVED: review reopen is
+            "claim_lock = CASE WHEN worker_pid IS NOT NULL THEN claim_lock ELSE NULL END, "
+            "claim_expires = CASE WHEN worker_pid IS NOT NULL THEN claim_expires ELSE NULL END, "
+            "worker_start_time = CASE WHEN worker_pid IS NOT NULL "
+            "THEN worker_start_time ELSE NULL END "
+            # A review handoff with a recorded PID may still own a just-ended
+            # worker, so preserve that exact identity until terminal cleanup.
+            # A claim with no PID is safe to clear; a genuinely late Popen
+            # registration reattaches through _set_worker_pid's run CAS.
+            # consecutive_failures is deliberately preserved: review reopen is
             # not a success signal; only complete_task resets the breaker
             # counter (mirrors unblock_task, #35072).
             + assignee_sql
@@ -7054,14 +7216,14 @@ def invalidate_descendants_for_parent_reopen(
 
     Live ``running`` descendants keep the termination behavior (a running
     child building on a retracted premise is wasted spend): their run is
-    closed ``reclaimed`` and their worker is killed via
-    :func:`_terminate_reclaimed_worker` — the same helper the reclaim paths
-    use. Events/comments are written inside the transaction and the kill
+    closed ``reclaimed`` and their worker is drained through
+    :func:`cleanup_terminal_workers` — the same run-scoped CAS the dispatcher
+    uses. Events/comments are written inside the transaction and cleanup
     happens strictly post-commit, so the audit trail exists BEFORE the
     worker dies. When this function opened its own transaction it performs
-    the terminations itself after commit; when composing under a caller's
-    transaction the caller MUST drain the returned ``terminations`` list
-    with ``_terminate_reclaimed_worker`` after its own commit.
+    cleanup itself after commit; when composing under a caller's transaction
+    the caller MUST invoke :func:`cleanup_terminal_workers` after its own
+    commit. The returned termination tuples remain for API compatibility.
 
     ``consecutive_failures`` is reset to 0 on every invalidated descendant:
     ancestor reopen is a deliberate operator action, so demoted work gets a
@@ -7075,12 +7237,16 @@ def invalidate_descendants_for_parent_reopen(
 
     Returns ``{"invalidated": [...], "terminations": [...]}`` where each
     invalidated entry is ``{id, prior_status, new_status, resume_status}``
-    and each termination is a ``(worker_pid, claim_lock)`` tuple.
+    and each public termination remains the historical
+    ``(worker_pid, claim_lock)`` tuple. ``termination_identities`` carries the
+    internal three-tuple including ``worker_start_time`` for safe signalling.
     """
     caller_owns_txn = bool(getattr(conn, "in_transaction", False))
     now = int(time.time())
     invalidated: list[dict[str, Any]] = []
-    terminations: list[tuple[Optional[int], Optional[str]]] = []
+    terminations: list[
+        tuple[Optional[int], Optional[str], Optional[int]]
+    ] = []
     with write_txn(conn, allow_nested=True):
         rows = conn.execute(
             """
@@ -7091,7 +7257,8 @@ def invalidate_descendants_for_parent_reopen(
                 FROM task_links l
                 JOIN descendants d ON d.id = l.parent_id
             )
-            SELECT t.id, t.status, t.current_run_id, t.worker_pid, t.claim_lock
+            SELECT t.id, t.status, t.current_run_id, t.worker_pid,
+                   t.worker_start_time, t.claim_lock
             FROM descendants d
             JOIN tasks t ON t.id = d.id
             ORDER BY t.id
@@ -7110,22 +7277,40 @@ def invalidate_descendants_for_parent_reopen(
                 resume_status = _retry_status_for_run(
                     conn, row["id"], row["current_run_id"]
                 )
-                terminations.append((row["worker_pid"], row["claim_lock"]))
+                terminations.append(
+                    (
+                        row["worker_pid"],
+                        row["claim_lock"],
+                        row["worker_start_time"],
+                    )
+                )
                 run_id = _end_run(
                     conn,
                     row["id"],
                     outcome="reclaimed",
                     status="todo",
                     summary=f"ancestor {task_id} reopened",
+                    retain_worker=True,
                 )
             # consecutive_failures = 0: deliberate operator reset — see
             # docstring for why this diverges from reopen_review_task.
-            conn.execute(
-                "UPDATE tasks SET status = 'todo', completed_at = NULL, "
-                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
-                "current_run_id = NULL, consecutive_failures = 0 WHERE id = ?",
-                (row["id"],),
-            )
+            if previous_status == "running" and row["worker_pid"] is not None:
+                # _end_run retained the exact process identity. Keep it on the
+                # now-todo task until post-commit cleanup proves that worker is
+                # gone; claim_task() therefore cannot spawn a duplicate writer.
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo', completed_at = NULL, "
+                    "current_run_id = NULL, consecutive_failures = 0 WHERE id = ?",
+                    (row["id"],),
+                )
+            else:
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo', completed_at = NULL, "
+                    "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+                    "worker_start_time = NULL, current_run_id = NULL, "
+                    "consecutive_failures = 0 WHERE id = ?",
+                    (row["id"],),
+                )
             _append_event(
                 conn,
                 row["id"],
@@ -7179,11 +7364,14 @@ def invalidate_descendants_for_parent_reopen(
             )
     if not caller_owns_txn:
         # Standalone call: we committed above, so the audit trail is durable
-        # — safe to kill workers now. Composed calls leave this to the
-        # caller (post-commit), preserving events-before-termination.
-        for pid, claim_lock in terminations:
-            _terminate_reclaimed_worker(pid, claim_lock)
-    return {"invalidated": invalidated, "terminations": terminations}
+        # — safe to clean workers now. The run-scoped cleanup clears claims
+        # only after exact-identity termination succeeds; survivors stay held.
+        cleanup_terminal_workers(conn)
+    return {
+        "invalidated": invalidated,
+        "terminations": [(pid, lock) for pid, lock, _start in terminations],
+        "termination_identities": terminations,
+    }
 
 
 def specify_triage_task(
@@ -7514,7 +7702,7 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_start_time = NULL "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),
         )
@@ -7527,15 +7715,19 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
+            retain_worker=True,
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
     recompute_ready(conn)
-    # Reap the workspace on archive too — tasks archived without ever
-    # completing previously kept their scratch dir / worktree forever.
-    _cleanup_workspace(conn, task_id)
+    # If a running task was archived, its ended run retains the process
+    # identity for the dispatcher's bounded cleanup pass. Do not remove a live
+    # worker's cwd underneath it.
+    archived_task = get_task(conn, task_id)
+    if archived_task is None or archived_task.worker_pid is None:
+        _cleanup_workspace(conn, task_id)
     return True
 
 
@@ -7932,7 +8124,8 @@ def schedule_task(
                SET status       = 'scheduled',
                    claim_lock   = NULL,
                    claim_expires= NULL,
-                   worker_pid   = NULL
+                   worker_pid   = NULL,
+                   worker_start_time = NULL
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
         """
@@ -8082,6 +8275,10 @@ class DispatchResult:
     spawned. ``None`` when memory was fine/unknown and the guard imposed
     no restriction. Reclaim/promotion bookkeeping still ran either way;
     deferred tasks stay queued for the next tick."""
+    cleaned_terminal: list[str] = field(default_factory=list)
+    """Task ids whose already-ended run worker was tree-terminated/reaped and
+    whose retained process claim was released this tick. Appended to preserve
+    the public legacy positional DispatchResult(...) constructor."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -8250,21 +8447,70 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _worker_identity_alive(
+    pid: Optional[int],
+    worker_start_time: Optional[int],
+    claim_lock: Optional[str] = None,
+) -> bool:
+    """Return whether the recorded worker identity is still live.
+
+    Legacy rows without a start fingerprint conservatively inherit the naked
+    PID liveness result. For current rows, a mismatched fingerprint proves PID
+    reuse and is therefore dead *for this run*. A temporarily unavailable
+    fingerprint probe fails closed while the PID exists so no claim is released
+    beside an unverifiable process.
+    """
+    if not pid or pid <= 0 or not _pid_alive(pid):
+        return False
+    expected_boot_id = _claim_boot_id(claim_lock)
+    if expected_boot_id is None:
+        # Legacy/custom claims predate the persisted boot incarnation. A live
+        # PID cannot be proven to belong to the same boot, so fail closed.
+        return True
+    live_boot_id = _worker_boot_id()
+    if live_boot_id is None:
+        # The PID exists but host incarnation cannot be verified. Preserve
+        # the claim rather than risking a duplicate writer.
+        return True
+    if live_boot_id != expected_boot_id:
+        return False
+    if worker_start_time is None:
+        return True
+    live_start_time = _worker_start_time(int(pid))
+    if live_start_time is None:
+        return True
+    return live_start_time == int(worker_start_time)
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
+    worker_start_time: Optional[int] = None,
     signal_fn=None,
+    grace_seconds: float = 5.0,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Boundedly terminate one host-local, identity-bound worker tree.
+
+    Production signaling requires both the host-incarnation value persisted in
+    modern claims and the kernel start-time fingerprint captured with the PID.
+    A missing fingerprint defers cleanup while the PID remains live; a boot or
+    start-time mismatch means the original worker is gone and the recycled PID
+    is never signalled. ``signal_fn`` remains as a deterministic unit-test hook.
+    """
     import signal
 
     info: dict[str, Any] = {
         "prev_pid": int(pid) if pid else None,
         "host_local": False,
+        "identity_verified": False,
+        "identity_mismatch": False,
+        "identity_unavailable": False,
         "termination_attempted": False,
         "terminated": False,
+        "still_alive": False,
         "sigkill": False,
+        "reaped": False,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -8273,57 +8519,132 @@ def _terminate_reclaimed_worker(
     if not str(claim_lock).startswith(host_prefix):
         return info
     info["host_local"] = True
+    pid = int(pid)
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
-    )
-    if kill is None:
-        return info
-
-    info["termination_attempted"] = True
-    try:
-        kill(int(pid), signal.SIGTERM)
-    except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
-        info["terminated"] = True
-        return info
-    except OSError:
-        return info
-
-    for _ in range(10):
-        if not _pid_alive(pid):
-            info["terminated"] = True
-            return info
-        time.sleep(0.5)
-
-    if _pid_alive(pid):
+    if signal_fn is not None:
+        info["termination_attempted"] = True
         try:
-            # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
-            # (which maps to TerminateProcess via the stdlib shim).
-            _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
-            info["sigkill"] = True
-        except (ProcessLookupError, OSError):
+            signal_fn(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            info.update(terminated=True, reaped=True)
             return info
+        except OSError:
+            info["still_alive"] = _pid_alive(pid)
+            return info
+        deadline = time.monotonic() + max(float(grace_seconds), 0.0)
+        while time.monotonic() < deadline:
+            if not _pid_alive(pid):
+                info.update(terminated=True, reaped=True)
+                return info
+            time.sleep(0.05)
+        try:
+            signal_fn(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+            info["sigkill"] = True
+        except ProcessLookupError:
+            info.update(terminated=True, reaped=True)
+            return info
+        except OSError:
+            info["still_alive"] = _pid_alive(pid)
+            return info
+        info["still_alive"] = _pid_alive(pid)
+        info["terminated"] = not info["still_alive"]
+        info["reaped"] = info["terminated"]
+        return info
 
-    info["terminated"] = not _pid_alive(pid)
+    expected_boot_id = _claim_boot_id(claim_lock)
+    if expected_boot_id is None:
+        if _pid_alive(pid):
+            info.update(identity_unavailable=True, still_alive=True)
+        else:
+            info.update(terminated=True, reaped=True)
+        return info
+    live_boot_id = _worker_boot_id()
+    if live_boot_id is None:
+        if _pid_alive(pid):
+            info.update(identity_unavailable=True, still_alive=True)
+        else:
+            info.update(terminated=True, reaped=True)
+        return info
+    if live_boot_id != expected_boot_id:
+        # The durable row belongs to a previous host incarnation. The
+        # numeric PID may now name a stranger; prove the old worker gone
+        # without sending any signal.
+        info.update(
+            identity_mismatch=True,
+            terminated=True,
+            still_alive=False,
+            reaped=True,
+            boot_mismatch=True,
+        )
+        return info
+
+    if worker_start_time is None:
+        if _pid_alive(pid):
+            info.update(identity_unavailable=True, still_alive=True)
+        else:
+            info.update(terminated=True, reaped=True)
+        return info
+
+    live_start_time = _worker_start_time(pid)
+    if live_start_time is None:
+        if _pid_alive(pid):
+            info.update(identity_unavailable=True, still_alive=True)
+        else:
+            info.update(terminated=True, reaped=True)
+        return info
+    if live_start_time != int(worker_start_time):
+        info.update(
+            identity_mismatch=True,
+            terminated=True,
+            still_alive=False,
+            reaped=True,
+        )
+        return info
+
+    info["identity_verified"] = True
+    try:
+        from agent.deadline import terminate_process_tree
+
+        result = terminate_process_tree(
+            pid,
+            expected_start_time=int(worker_start_time),
+            grace_seconds=grace_seconds,
+        )
+        info.update(result)
+    except Exception as exc:
+        info["error"] = str(exc)[:500]
+        info["still_alive"] = (
+            _worker_start_time(pid) == int(worker_start_time)
+        )
+        info["terminated"] = not info["still_alive"]
+        info["reaped"] = info["terminated"]
+    reap_worker_zombies()
+    final_start_time = _worker_start_time(pid)
+    if final_start_time is None:
+        if _pid_alive(pid):
+            info.update(
+                identity_unavailable=True,
+                terminated=False,
+                still_alive=True,
+                reaped=False,
+            )
+        else:
+            info.update(terminated=True, still_alive=False, reaped=True)
+    elif final_start_time != int(worker_start_time):
+        info.update(terminated=True, still_alive=False, reaped=True)
     return info
 
 
 def _worker_survived_termination(termination: dict) -> bool:
-    """True when we tried to kill our own host-local worker and it is still alive.
+    """True when a host-local worker identity is still alive after cleanup.
 
-    Reclaiming in this state would release the claim and let the dispatcher
-    spawn a second worker while the first is still running — the duplication
-    loop. Only host-local workers we actually signalled count: a non-local
-    claim lock or a no-op attempt (no ``os.kill`` available) must fall through
-    to the normal release path, since we cannot manage that worker anyway.
+    This includes legacy rows whose start fingerprint is unavailable: they are
+    deliberately held rather than signalled by a naked PID or released into a
+    duplicate spawn.
     """
     return bool(
-        termination.get("termination_attempted")
-        and termination.get("host_local")
+        termination.get("host_local")
+        and termination.get("still_alive")
         and not termination.get("terminated")
     )
 
@@ -8367,6 +8688,153 @@ def _defer_reclaim_for_live_worker(
         }
         payload.update(termination)
         _append_event(conn, task_id, "reclaim_deferred", payload, run_id=run_id)
+
+
+def cleanup_terminal_workers(
+    conn: sqlite3.Connection,
+    *,
+    grace_seconds: float = 5.0,
+) -> list[str]:
+    """Terminate/reap workers whose DB run already reached a handoff outcome.
+
+    Ended runs retain their claim and PID identity specifically for this pass.
+    The task claim is released only after the exact host-local process tree is
+    gone (or its start fingerprint proves the PID was recycled). Foreign-host
+    rows are left for that host's dispatcher. A surviving or unverifiable live
+    process keeps the claim, preventing dependency/ready duplicate spawns.
+    """
+    now = int(time.time())
+    rows = conn.execute(
+        """
+        SELECT r.id AS run_id,
+               r.task_id,
+               r.claim_lock,
+               r.claim_expires,
+               r.worker_pid,
+               r.worker_start_time
+          FROM task_runs r
+          JOIN tasks t ON t.id = r.task_id
+         WHERE r.ended_at IS NOT NULL
+           AND r.worker_pid IS NOT NULL
+           AND r.claim_lock IS NOT NULL
+           AND (r.claim_expires IS NULL OR r.claim_expires <= ?)
+         ORDER BY r.id
+        """,
+        (now,),
+    ).fetchall()
+    cleaned: list[str] = []
+    for row in rows:
+        termination = _terminate_reclaimed_worker(
+            row["worker_pid"],
+            row["claim_lock"],
+            worker_start_time=row["worker_start_time"],
+            grace_seconds=grace_seconds,
+        )
+        if not termination.get("host_local"):
+            continue
+        if _worker_survived_termination(termination):
+            now = int(time.time())
+            with write_txn(conn):
+                grace = now + RECLAIM_DEFER_GRACE_SECONDS
+                conn.execute(
+                    "UPDATE tasks SET claim_expires = ? "
+                    "WHERE id = ? AND claim_lock IS ? AND worker_pid IS ? "
+                    "AND worker_start_time IS ?",
+                    (
+                        grace,
+                        row["task_id"],
+                        row["claim_lock"],
+                        row["worker_pid"],
+                        row["worker_start_time"],
+                    ),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET claim_expires = ? "
+                    "WHERE id = ? AND ended_at IS NOT NULL "
+                    "AND claim_lock IS ? AND worker_pid IS ? "
+                    "AND worker_start_time IS ?",
+                    (
+                        grace,
+                        row["run_id"],
+                        row["claim_lock"],
+                        row["worker_pid"],
+                        row["worker_start_time"],
+                    ),
+                )
+                payload = {
+                    "run_id": int(row["run_id"]),
+                    "claim_lock": row["claim_lock"],
+                    "worker_pid": int(row["worker_pid"]),
+                    "worker_start_time": row["worker_start_time"],
+                    "claim_expires_now": grace,
+                }
+                payload.update(termination)
+                _append_event(
+                    conn,
+                    row["task_id"],
+                    "worker_cleanup_deferred",
+                    payload,
+                    run_id=int(row["run_id"]),
+                )
+            continue
+        if not termination.get("terminated"):
+            continue
+
+        run_cleared = False
+        cleanup_workspace = False
+        with write_txn(conn):
+            run_cur = conn.execute(
+                "UPDATE task_runs SET claim_lock = NULL, claim_expires = NULL, "
+                "worker_pid = NULL, worker_start_time = NULL "
+                "WHERE id = ? AND ended_at IS NOT NULL AND claim_lock IS ? "
+                "AND worker_pid IS ? AND worker_start_time IS ?",
+                (
+                    row["run_id"],
+                    row["claim_lock"],
+                    row["worker_pid"],
+                    row["worker_start_time"],
+                ),
+            )
+            conn.execute(
+                "UPDATE tasks SET claim_lock = NULL, claim_expires = NULL, "
+                "worker_pid = NULL, worker_start_time = NULL "
+                "WHERE id = ? AND claim_lock IS ? AND worker_pid IS ? "
+                "AND worker_start_time IS ?",
+                (
+                    row["task_id"],
+                    row["claim_lock"],
+                    row["worker_pid"],
+                    row["worker_start_time"],
+                ),
+            )
+            run_cleared = run_cur.rowcount == 1
+            if run_cleared:
+                payload = {
+                    "run_id": int(row["run_id"]),
+                    "claim_lock": row["claim_lock"],
+                    "worker_pid": int(row["worker_pid"]),
+                    "worker_start_time": row["worker_start_time"],
+                }
+                payload.update(termination)
+                _append_event(
+                    conn,
+                    row["task_id"],
+                    "worker_cleanup",
+                    payload,
+                    run_id=int(row["run_id"]),
+                )
+                cleaned.append(row["task_id"])
+                fresh_task = conn.execute(
+                    "SELECT status FROM tasks WHERE id = ?",
+                    (row["task_id"],),
+                ).fetchone()
+                cleanup_workspace = bool(
+                    fresh_task
+                    and fresh_task["status"] in {"done", "archived"}
+                )
+        if run_cleared and cleanup_workspace:
+            _cleanup_workspace(conn, row["task_id"])
+    return cleaned
 
 
 def heartbeat_worker(
@@ -8424,6 +8892,7 @@ def enforce_max_runtime(
     conn: sqlite3.Connection,
     *,
     signal_fn=None,
+    grace_seconds: float = 5.0,
 ) -> list[str]:
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
 
@@ -8437,13 +8906,12 @@ def enforce_max_runtime(
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
     test hook; defaults to ``os.kill`` on POSIX.
     """
-    import signal
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, "
+        "SELECT t.id, t.worker_pid, t.worker_start_time, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
         "       t.max_runtime_seconds, t.claim_lock "
         "FROM tasks t "
@@ -8465,50 +8933,51 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
+        termination = _terminate_reclaimed_worker(
+            pid,
+            row["claim_lock"],
+            worker_start_time=row["worker_start_time"],
+            signal_fn=signal_fn,
+            grace_seconds=grace_seconds,
         )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        if _worker_survived_termination(termination):
+            _defer_reclaim_for_live_worker(
+                conn,
+                tid,
+                row["claim_lock"],
+                now,
+                termination,
+                reason="max_runtime_worker_alive",
+            )
+            continue
+        if not termination.get("terminated"):
+            continue
 
         with write_txn(conn):
             retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
-                "last_heartbeat_at = NULL "
+                "worker_start_time = NULL, last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (retry_status, tid, pid, row["claim_lock"]),
+                "  AND worker_pid = ? AND worker_start_time IS ? "
+                "  AND claim_lock IS ?",
+                (
+                    retry_status,
+                    tid,
+                    pid,
+                    row["worker_start_time"],
+                    row["claim_lock"],
+                ),
             )
             if cur.rowcount == 1:
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
                     "limit_seconds": int(row["max_runtime_seconds"]),
-                    "sigkill": killed,
                     "retry_status": retry_status,
                 }
+                payload.update(termination)
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
@@ -8533,7 +9002,7 @@ def enforce_max_runtime(
                 end_run=False,
                 event_payload_extra={
                     "pid": pid,
-                    "sigkill": killed,
+                    "sigkill": bool(termination.get("sigkill")),
                     "retry_status": retry_status,
                 },
             )
@@ -8583,7 +9052,8 @@ def detect_stale_running(
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "SELECT t.id, t.worker_pid, t.worker_start_time, "
+        "       t.last_heartbeat_at, t.claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -8610,7 +9080,8 @@ def detect_stale_running(
 
         # Terminate the worker if it's still host-local.
         termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
+            pid, lock, worker_start_time=row["worker_start_time"],
+            signal_fn=signal_fn,
         )
 
         # Never release a claim while our own worker is still alive: that would
@@ -8627,7 +9098,7 @@ def detect_stale_running(
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
-                "last_heartbeat_at = NULL "
+                "worker_start_time = NULL, last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ?",
                 (retry_status, tid, row["claim_lock"]),
@@ -8704,14 +9175,17 @@ def reconcile_orphaned_running(
     now = int(time.time())
     reconciled: list[str] = []
     rows = conn.execute(
-        "SELECT id, claim_lock, claim_expires, worker_pid FROM tasks "
+        "SELECT id, claim_lock, claim_expires, worker_pid, worker_start_time "
+        "FROM tasks "
         "WHERE status = 'running' "
         "  AND (claim_lock IS NULL OR claim_expires IS NULL)"
     ).fetchall()
     for row in rows:
         tid = row["id"]
         pid = row["worker_pid"]
-        if pid and _pid_alive(pid):
+        if pid and _worker_identity_alive(
+            pid, row["worker_start_time"], row["claim_lock"]
+        ):
             # The recorded worker may still be doing real work — never
             # requeue beside a live process. Retry next tick.
             _log.debug(
@@ -8723,7 +9197,7 @@ def reconcile_orphaned_running(
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
-                "last_heartbeat_at = NULL "
+                "worker_start_time = NULL, last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ? AND claim_expires IS ?",
                 (tid, row["claim_lock"], row["claim_expires"]),
@@ -8892,7 +9366,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     exited_hook_payloads: list[dict] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at, assignee "
+            "SELECT id, worker_pid, worker_start_time, claim_lock, started_at, assignee "
             "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
@@ -8910,7 +9384,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 grace = _resolve_crash_grace_seconds()
                 if time.time() - started_at < grace:
                     continue
-            if _pid_alive(row["worker_pid"]):
+            if _worker_identity_alive(
+                row["worker_pid"],
+                row["worker_start_time"],
+                row["claim_lock"],
+            ):
                 continue
 
             pid = int(row["worker_pid"])
@@ -8981,7 +9459,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             event_payload["retry_status"] = retry_status
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_start_time = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
                 (retry_status, row["id"], pid, row["claim_lock"]),
@@ -9240,6 +9718,7 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
+                    "worker_start_time = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready', 'review')",
                     (failures, error[:500], task_id),
@@ -9290,6 +9769,7 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
+                    "worker_start_time = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (retry_status, failures, error[:500], task_id),
@@ -9343,25 +9823,144 @@ def _record_spawn_failure(
     )
 
 
-def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
-    """Record the spawned child's pid + emit a ``spawned`` event.
+def _worker_start_time(pid: int) -> Optional[int]:
+    """Return the durable kernel start-time fingerprint for ``pid``."""
+    try:
+        from gateway.status import get_process_identity
 
-    The event's payload carries the pid so a human reading ``hermes kanban
-    tail`` can correlate log lines with OS-level traces without opening
-    the drawer.
+        value = get_process_identity(int(pid))
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _set_worker_pid(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pid: int,
+    *,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
+) -> None:
+    """Persist a spawned PID without losing a concurrent terminal handoff.
+
+    The normal path binds the PID to the still-current open run. A worker or
+    operator can theoretically end that run between ``Popen`` and this DB write;
+    when the caller supplies the claimed run/lock, reattach the late PID to the
+    ended run and temporarily to an unclaimed task, then immediately route it
+    through run-scoped cleanup. This closes the last duplicate-spawn window.
     """
+    worker_start_time = _worker_start_time(pid)
+    # OS process metadata should be visible as soon as Popen returns, but a
+    # short bounded retry avoids creating a legacy-style naked PID row on
+    # slower Windows/macOS process tables.
+    for _ in range(4):
+        if worker_start_time is not None:
+            break
+        time.sleep(0.02)
+        worker_start_time = _worker_start_time(pid)
+    late_terminal_registration = False
+    event_run_id: Optional[int] = None
     with write_txn(conn):
-        conn.execute(
-            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
-            (int(pid), task_id),
-        )
-        run_id = _current_run_id(conn, task_id)
-        if run_id is not None:
-            conn.execute(
-                "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
-                (int(pid), run_id),
+        task_row = conn.execute(
+            "SELECT current_run_id, claim_lock FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task_row is None:
+            return
+        run_id = (
+            int(expected_run_id)
+            if expected_run_id is not None
+            else (
+                int(task_row["current_run_id"])
+                if task_row["current_run_id"] is not None
+                else None
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        )
+        run_row = (
+            conn.execute(
+                "SELECT id, ended_at, worker_pid FROM task_runs "
+                "WHERE id = ? AND task_id = ?",
+                (run_id, task_id),
+            ).fetchone()
+            if run_id is not None
+            else None
+        )
+        active_identity_matches = bool(
+            run_row is not None
+            and run_row["ended_at"] is None
+            and task_row["current_run_id"] == run_id
+            and (
+                expected_claim_lock is None
+                or task_row["claim_lock"] == expected_claim_lock
+            )
+        )
+        if active_identity_matches:
+            conn.execute(
+                "UPDATE tasks SET worker_pid = ?, worker_start_time = ? "
+                "WHERE id = ? AND current_run_id = ?",
+                (int(pid), worker_start_time, task_id, run_id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET worker_pid = ?, worker_start_time = ? "
+                "WHERE id = ? AND ended_at IS NULL",
+                (int(pid), worker_start_time, run_id),
+            )
+            event_run_id = run_id
+        elif (
+            run_row is not None
+            and run_row["ended_at"] is not None
+            and run_row["worker_pid"] is None
+            and expected_claim_lock is not None
+        ):
+            now = int(time.time())
+            cur = conn.execute(
+                "UPDATE task_runs SET claim_lock = ?, claim_expires = ?, "
+                "worker_pid = ?, worker_start_time = ? "
+                "WHERE id = ? AND ended_at IS NOT NULL AND worker_pid IS NULL",
+                (
+                    expected_claim_lock,
+                    now,
+                    int(pid),
+                    worker_start_time,
+                    run_id,
+                ),
+            )
+            if cur.rowcount == 1:
+                # Reattach to the task only if no newer run/claim won the race.
+                # The ended run remains sufficient to terminate the old writer
+                # safely when a newer current run already exists.
+                conn.execute(
+                    "UPDATE tasks SET claim_lock = ?, claim_expires = ?, "
+                    "worker_pid = ?, worker_start_time = ? "
+                    "WHERE id = ? AND current_run_id IS NULL "
+                    "AND (claim_lock IS NULL OR claim_lock IS ?) "
+                    "AND worker_pid IS NULL",
+                    (
+                        expected_claim_lock,
+                        now,
+                        int(pid),
+                        worker_start_time,
+                        task_id,
+                        expected_claim_lock,
+                    ),
+                )
+                late_terminal_registration = True
+                event_run_id = run_id
+        if event_run_id is not None:
+            _append_event(
+                conn,
+                task_id,
+                "spawned",
+                {
+                    "pid": int(pid),
+                    "worker_start_time": worker_start_time,
+                    "late_terminal_registration": late_terminal_registration,
+                },
+                run_id=event_run_id,
+            )
+    if late_terminal_registration:
+        cleanup_terminal_workers(conn)
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -9942,6 +10541,7 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    result.cleaned_terminal = cleanup_terminal_workers(conn)
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
@@ -10264,7 +10864,13 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(
+                    conn,
+                    claimed.id,
+                    int(pid),
+                    expected_run_id=claimed.current_run_id,
+                    expected_claim_lock=claimed.claim_lock,
+                )
             # Worker-lifecycle observer (RFC #58548): fires AFTER spawn_fn
             # returned and the PID (when reported) is durably persisted,
             # per the RFC timing contract. Best-effort — can never break
@@ -10396,7 +11002,13 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(
+                    conn,
+                    claimed.id,
+                    int(pid),
+                    expected_run_id=claimed.current_run_id,
+                    expected_claim_lock=claimed.claim_lock,
+                )
             # Worker-lifecycle observer (RFC #58548): same contract as the
             # ready-lane fire above — after spawn + PID persistence.
             _fire_worker_spawned_hook(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -344,7 +344,7 @@ VALID_HOOKS: Set[str] = {
     # Kwargs: board: str | None, profile_name: str, dry_run: bool,
     #   outcome: "ok" | "skipped_locked" | "idle",
     #   result: hermes_cli.kanban_db.DispatchResult (spawned, reclaimed,
-    #     promoted, reconciled_orphans, crashed, stale, timed_out,
+    #     promoted, reconciled_orphans, cleaned_terminal, crashed, stale, timed_out,
     #     auto_blocked, rate_limited, auto_assigned_default,
     #     respawn_guarded, skipped_per_profile_capped, skipped_unassigned,
     #     skipped_nonspawnable, skipped_locked).

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -224,6 +224,7 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "claim_lock": r.claim_lock,
         "claim_expires": r.claim_expires,
         "worker_pid": r.worker_pid,
+        "worker_start_time": r.worker_start_time,
         "max_runtime_seconds": r.max_runtime_seconds,
         "last_heartbeat_at": r.last_heartbeat_at,
         "started_at": r.started_at,
@@ -1099,7 +1100,9 @@ def _parents_blocking_ready(
 def _invalidate_descendants_for_parent_reopen(
     conn: sqlite3.Connection,
     parent_id: str,
-    terminations: list[tuple[Optional[int], Optional[str]]],
+    terminations: list[
+        tuple[Optional[int], Optional[str], Optional[int]]
+    ],
 ) -> None:
     """Delegate to the domain-layer implementation in :mod:`kanban_db`.
 
@@ -1109,13 +1112,13 @@ def _invalidate_descendants_for_parent_reopen(
     :func:`kanban_db.invalidate_descendants_for_parent_reopen` so every
     reopen surface shares one implementation. We run inside the caller's
     open transaction, so the domain function composes via a savepoint and
-    returns the worker terminations for us to perform post-commit (events
-    must be durable BEFORE the kill).
+    returns the worker identities that trigger run-scoped cleanup post-commit
+    (events must be durable BEFORE any signal).
     """
     result = kanban_db.invalidate_descendants_for_parent_reopen(
         conn, parent_id, author="dashboard",
     )
-    terminations.extend(result["terminations"])
+    terminations.extend(result["termination_identities"])
 
 
 def _set_status_direct(
@@ -1131,12 +1134,14 @@ def _set_status_direct(
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
-    terminations: list[tuple[Optional[int], Optional[str]]] = []
+    terminations: list[
+        tuple[Optional[int], Optional[str], Optional[int]]
+    ] = []
     effective_status = new_status
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(
-            "SELECT status, current_run_id, worker_pid, claim_lock "
+            "SELECT status, current_run_id, worker_pid, worker_start_time, claim_lock "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -1170,6 +1175,9 @@ def _set_status_direct(
                 return False
 
         was_running = prev["status"] == "running"
+        keep_process_identity = bool(
+            effective_status == "running" or prev["worker_pid"] is not None
+        )
         reopening_satisfied_parent = (
             prev["status"] in {"done", "archived"}
             and effective_status not in {"done", "archived"}
@@ -1177,15 +1185,17 @@ def _set_status_direct(
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
-            "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
-            "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
-            "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
+            "  claim_lock = CASE WHEN ? THEN claim_lock ELSE NULL END, "
+            "  claim_expires = CASE WHEN ? THEN claim_expires ELSE NULL END, "
+            "  worker_pid = CASE WHEN ? THEN worker_pid ELSE NULL END, "
+            "  worker_start_time = CASE WHEN ? THEN worker_start_time ELSE NULL END "
             "WHERE id = ?",
             (
                 effective_status,
-                effective_status,
-                effective_status,
-                effective_status,
+                keep_process_identity,
+                keep_process_identity,
+                keep_process_identity,
+                keep_process_identity,
                 task_id,
             ),
         )
@@ -1197,8 +1207,25 @@ def _set_status_direct(
                 conn, task_id,
                 outcome="reclaimed", status="reclaimed",
                 summary=f"status changed to {effective_status} (dashboard/direct)",
+                retain_worker=True,
             )
-            terminations.append((prev["worker_pid"], prev["claim_lock"]))
+            terminations.append(
+                (
+                    prev["worker_pid"],
+                    prev["claim_lock"],
+                    prev["worker_start_time"],
+                )
+            )
+        elif effective_status != "running" and keep_process_identity:
+            # The task was already in a handoff state with an ended worker.
+            # Keep and retry that run-scoped cleanup across further drag/drop.
+            terminations.append(
+                (
+                    prev["worker_pid"],
+                    prev["claim_lock"],
+                    prev["worker_start_time"],
+                )
+            )
         conn.execute(
             "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
             "VALUES (?, ?, 'status', ?, ?)",
@@ -1220,8 +1247,12 @@ def _set_status_direct(
                 task_id,
                 terminations,
             )
-    for pid, claim_lock in terminations:
-        kanban_db._terminate_reclaimed_worker(pid, claim_lock)
+    if terminations:
+        # Both direct running-task moves and descendant invalidations retain
+        # their ended-run identities. The cleanup CAS releases a claim only
+        # after the exact worker is gone, so a resistant/legacy worker cannot
+        # race a duplicate spawn.
+        kanban_db.cleanup_terminal_workers(conn)
     # If we re-opened something, children may have gone stale.
     if effective_status in {"done", "ready", "review"}:
         kanban_db.recompute_ready(conn)

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -29,6 +29,7 @@ from agent.deadline import (
     DeadlineExpired,
     clamp_timeout,
     kill_process_tree,
+    terminate_process_tree,
     resolve_timeout,
     run_bounded_async,
     run_bounded_sync,
@@ -453,6 +454,134 @@ class TestKillProcessTree:
         finally:
             if proc.poll() is None:
                 proc.kill()
+
+
+class TestTerminateProcessTreeIdentity:
+    def test_binds_process_before_final_identity_check(self, monkeypatch):
+        import psutil
+        from gateway import status as gateway_status
+
+        calls = []
+
+        class FakeProcess:
+            pid = 424_242
+
+            def create_time(self):
+                calls.append("bind")
+                return 1_800_000_000.001
+
+            def terminate(self):
+                calls.append("terminate")
+
+        parent = FakeProcess()
+
+        def _open(pid):
+            assert pid == parent.pid
+            calls.append("open")
+            return parent
+
+        def _identity(pid, *, process=None):
+            assert pid == parent.pid
+            assert process is parent
+            calls.append("identity")
+            # Simulate PID reuse between the durable record and handle bind.
+            return 888_456
+
+        monkeypatch.setattr(psutil, "Process", _open)
+        monkeypatch.setattr(gateway_status, "get_process_identity", _identity)
+
+        result = terminate_process_tree(parent.pid, expected_start_time=777_123)
+
+        assert calls == ["open", "bind", "identity"]
+        assert result["identity_mismatch"] is True
+        assert result["termination_attempted"] is False
+
+    def test_windows_kills_only_identity_bound_handles(self, monkeypatch):
+        import psutil
+        from gateway import status as gateway_status
+
+        killed = []
+
+        class FakeProcess:
+            def __init__(self, pid, created, children=()):
+                self.pid = pid
+                self._created = created
+                self._children = list(children)
+                self._alive = True
+
+            def create_time(self):
+                return self._created
+
+            def children(self, recursive=False):
+                assert recursive is True
+                return list(self._children)
+
+            def is_running(self):
+                return self._alive
+
+            def status(self):
+                return "running"
+
+            def kill(self):
+                killed.append(self.pid)
+                self._alive = False
+
+            def wait(self, timeout=0):
+                assert self._alive is False
+                return 0
+
+        child = FakeProcess(424_243, 1_800_000_000.002)
+        parent = FakeProcess(424_242, 1_800_000_000.001, [child])
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(psutil, "Process", lambda pid: parent)
+        monkeypatch.setattr(
+            gateway_status,
+            "get_process_identity",
+            lambda pid, *, process=None: 777_123,
+        )
+        monkeypatch.setattr(
+            "agent.deadline.subprocess.run",
+            lambda *a, **k: pytest.fail("identity-bound cleanup must not use taskkill"),
+        )
+
+        result = terminate_process_tree(
+            parent.pid,
+            expected_start_time=777_123,
+            grace_seconds=0,
+        )
+
+        assert killed == [parent.pid, child.pid]
+        assert result["identity_verified"] is True
+        assert result["sigkill"] is True
+        assert result["terminated"] is True
+        assert result["reaped"] is True
+
+    def test_unavailable_fingerprint_fails_closed_for_live_pid(self, monkeypatch):
+        from gateway import status as gateway_status
+
+        monkeypatch.setattr(gateway_status, "get_process_start_time", lambda _pid: None)
+        monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: True)
+
+        result = terminate_process_tree(424_242, expected_start_time=777_123)
+
+        assert result["identity_unavailable"] is True
+        assert result["termination_attempted"] is False
+        assert result["terminated"] is False
+        assert result["still_alive"] is True
+
+    def test_unavailable_fingerprint_accepts_confirmed_exit(self, monkeypatch):
+        from gateway import status as gateway_status
+
+        monkeypatch.setattr(gateway_status, "get_process_start_time", lambda _pid: None)
+        monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: False)
+
+        result = terminate_process_tree(424_242, expected_start_time=777_123)
+
+        assert result["identity_unavailable"] is False
+        assert result["termination_attempted"] is False
+        assert result["terminated"] is True
+        assert result["reaped"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -13,6 +13,23 @@ from gateway import status
 
 
 class TestGatewayPidState:
+    def test_proc_start_time_parser_handles_spaces_and_parentheses_in_comm(self):
+        suffix = ["S", *(str(field) for field in range(4, 23))]
+        raw = f"123 (worker name ) with spaces) {' '.join(suffix)}"
+
+        assert status._parse_linux_proc_start_time(raw) == 22
+
+    def test_durable_process_identity_keeps_sub_centisecond_precision(self):
+        first = 1_800_000_000.001
+        second = 1_800_000_000.004
+
+        # The compatibility PID-file representation collides; the durable
+        # worker token must not.
+        assert int(round(first * 100)) == int(round(second * 100))
+        assert status._process_create_time_token(first) != (
+            status._process_create_time_token(second)
+        )
+
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -92,5 +93,36 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
+
+
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_cli_dispatch_reports_terminal_cleanup(
+    isolated_kanban_home, monkeypatch, capsys, json_mode
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        kanban_db,
+        "dispatch_once",
+        lambda conn, **kw: kanban_db.DispatchResult(
+            cleaned_terminal=["t_ended"]
+        ),
+    )
+
+    args = argparse.Namespace(
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=json_mode,
+    )
+    assert kb_cli._cmd_dispatch(args) == 0
+    output = capsys.readouterr().out
+    if json_mode:
+        assert json.loads(output)["cleaned_terminal"] == ["t_ended"]
+    else:
+        assert "Cleaned terminal workers: 1" in output
+        assert "t_ended" in output
 
 

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -87,6 +87,13 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         lei = {r["name"]: r for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
         assert "delivery_metadata" in lei
+        run_cols = {
+            r["name"] for r in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        assert "worker_start_time" in run_cols
+        # The runtime cleanup query must remain valid after the canonical
+        # drift-rebuild pass (regression: the rebuild spec dropped this column).
+        assert kb.cleanup_terminal_workers(conn) == []
 
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2

--- a/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
+++ b/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
@@ -61,6 +61,15 @@ def test_active_tick_fires_hook_with_outcome_ok(
     result = ok_events[-1]["result"]
     assert any(row[0] == tid for row in result.spawned)
 
+
+def test_cleanup_only_tick_is_reported_as_active(captured_ticks):
+    result = kb.DispatchResult(cleaned_terminal=["t_ended"])
+
+    kb._fire_dispatch_tick_hook(result, board="default")
+
+    assert captured_ticks[-1]["outcome"] == "ok"
+    assert captured_ticks[-1]["result"].cleaned_terminal == ["t_ended"]
+
 def test_tick_hook_fires_after_dispatch_lock_released(kanban_home):
     """The #56066 sweeper finding, as a contract: subscribers run OUTSIDE
     the single-writer critical section. From the callback, acquiring the

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -81,8 +81,13 @@ def test_legacy_db_migrates_goal_columns(tmp_path, monkeypatch):
     kb.init_db()
     with kb.connect() as conn:
         cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        run_cols = {
+            r["name"] for r in conn.execute("PRAGMA table_info(task_runs)")
+        }
         assert "goal_mode" in cols
         assert "goal_max_turns" in cols
+        assert "worker_start_time" in cols
+        assert "worker_start_time" in run_cols
         task = kb.get_task(conn, "legacy1")
     # Existing row keeps the safe default.
     assert task.goal_mode is False

--- a/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
+++ b/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
@@ -113,7 +113,14 @@ def test_running_descendant_event_precedes_termination_via_reclaim_helper(
             side.close()
         assert "descendant_invalidated" in kinds
         kills.append((pid, claim_lock))
-        return {"terminated": True}
+        return {
+            "host_local": True,
+            "identity_verified": True,
+            "termination_attempted": True,
+            "terminated": True,
+            "still_alive": False,
+            "reaped": True,
+        }
 
     monkeypatch.setattr(kb, "_terminate_reclaimed_worker", fake_terminate)
 
@@ -130,6 +137,46 @@ def test_running_descendant_event_precedes_termination_via_reclaim_helper(
     assert child.current_run_id is None
     run = kb.latest_run(conn, child_id)
     assert run is not None and run.outcome == "reclaimed"
+
+
+def test_running_descendant_survivor_keeps_claim_and_blocks_duplicate_spawn(
+    conn, monkeypatch,
+):
+    parent_id = kb.create_task(conn, title="ancestor", assignee="planner")
+    assert kb.complete_task(conn, parent_id)
+    child_id = kb.create_task(
+        conn, title="running child", assignee="builder", parents=[parent_id],
+    )
+    claimed = kb.claim_task(conn, child_id, claimer=kb._claimer_id())
+    assert claimed is not None
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: None)
+    kb._set_worker_pid(conn, child_id, 424242)
+    monkeypatch.setattr(
+        kb,
+        "_terminate_reclaimed_worker",
+        lambda *_args, **_kwargs: {
+            "host_local": True,
+            "identity_verified": False,
+            "identity_unavailable": True,
+            "termination_attempted": False,
+            "terminated": False,
+            "still_alive": True,
+            "reaped": False,
+        },
+    )
+
+    _reopen_parent_directly(conn, parent_id)
+    kb.invalidate_descendants_for_parent_reopen(conn, parent_id, author="operator")
+
+    child = kb.get_task(conn, child_id)
+    assert child is not None and child.status == "todo"
+    assert child.claim_lock is not None
+    assert child.worker_pid == 424242
+    assert kb.claim_task(conn, child_id) is None
+    run = kb.latest_run(conn, child_id)
+    assert run is not None and run.ended_at is not None
+    assert run.claim_lock == child.claim_lock
+    assert run.worker_pid == child.worker_pid
 
 
 def test_counter_reset_on_invalidated_descendants(conn):

--- a/tests/hermes_cli/test_kanban_terminal_worker_cleanup.py
+++ b/tests/hermes_cli/test_kanban_terminal_worker_cleanup.py
@@ -1,0 +1,943 @@
+"""Regression coverage for run-scoped Kanban worker cleanup.
+
+A worker can make its task/run terminal before its one-shot Python process has
+actually exited.  The claim and PID must remain attached to that ended run
+until the dispatcher has proved the exact process is gone and reaped it; a
+ready/dependency task must never respawn beside the old writer.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import ANY
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claimed_with_process(conn, monkeypatch, *, goal_mode: bool = False):
+    task_id = kb.create_task(
+        conn,
+        title="terminal cleanup",
+        assignee="default",
+        goal_mode=goal_mode,
+    )
+    claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+    assert claimed is not None
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 777_123)
+    kb._set_worker_pid(conn, task_id, 424_242)
+    return task_id, claimed.current_run_id
+
+
+def test_additive_worker_fields_preserve_legacy_positional_constructors():
+    task = kb.Task(
+        "t_legacy",
+        "legacy task",
+        None,
+        "default",
+        "running",
+        1,
+        "creator",
+        10,
+        None,
+        None,
+        "scratch",
+        None,
+        "host:pid",
+        20,
+        None,
+        "branch",
+        "project",
+        "result",
+        "idempotency",
+        3,
+        424_242,
+        "legacy error",
+    )
+    assert task.worker_pid == 424_242
+    assert task.last_failure_error == "legacy error"
+    assert task.worker_start_time is None
+
+    run = kb.Run(
+        7,
+        "t_legacy",
+        "default",
+        "step",
+        "running",
+        "host:pid",
+        20,
+        424_242,
+        300,
+        11,
+        10,
+        None,
+        None,
+        None,
+        {"legacy": True},
+        "legacy run error",
+    )
+    assert run.worker_pid == 424_242
+    assert run.max_runtime_seconds == 300
+    assert run.error == "legacy run error"
+    assert run.worker_start_time is None
+
+    dispatch = kb.DispatchResult(
+        1,
+        2,
+        ["t_orphan"],
+        [("t_spawn", "default", "/workspace")],
+    )
+    assert dispatch.reconciled_orphans == ["t_orphan"]
+    assert dispatch.spawned == [("t_spawn", "default", "/workspace")]
+    assert dispatch.cleaned_terminal == []
+
+
+@pytest.mark.parametrize("goal_mode", [False, True])
+@pytest.mark.parametrize(
+    "transition",
+    ["complete", "block", "dependency", "review", "archive", "schedule"],
+)
+def test_terminal_transition_retains_process_claim_until_cleanup(
+    kanban_home, monkeypatch, goal_mode, transition,
+):
+    """Classic and goal workers keep run/claim/process identity after handoff."""
+    with kb.connect() as conn:
+        task_id, run_id = _claimed_with_process(
+            conn, monkeypatch, goal_mode=goal_mode,
+        )
+        if transition == "complete":
+            assert kb.complete_task(
+                conn, task_id, summary="done", expected_run_id=run_id,
+            )
+            expected_status = "done"
+        elif transition == "review":
+            assert kb.request_review(
+                conn,
+                task_id,
+                summary="ready for review",
+                expected_run_id=run_id,
+            )
+            expected_status = "review"
+        elif transition == "archive":
+            assert kb.archive_task(conn, task_id)
+            expected_status = "archived"
+        elif transition == "schedule":
+            assert kb.schedule_task(
+                conn,
+                task_id,
+                reason="retry later",
+                expected_run_id=run_id,
+            )
+            expected_status = "scheduled"
+        else:
+            kind = "dependency" if transition == "dependency" else "needs_input"
+            assert kb.block_task(
+                conn,
+                task_id,
+                reason="waiting",
+                kind=kind,
+                expected_run_id=run_id,
+            )
+            expected_status = "todo" if kind == "dependency" else "blocked"
+
+        task_row = conn.execute(
+            "SELECT status, claim_lock, worker_pid, worker_start_time, "
+            "current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        run_row = conn.execute(
+            "SELECT ended_at, claim_lock, worker_pid, worker_start_time "
+            "FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+
+        assert task_row["status"] == expected_status
+        assert task_row["current_run_id"] is None
+        assert task_row["claim_lock"] is not None
+        assert task_row["worker_pid"] == 424_242
+        assert task_row["worker_start_time"] == 777_123
+        assert run_row["ended_at"] is not None
+        assert run_row["claim_lock"] == task_row["claim_lock"]
+        assert run_row["worker_pid"] == 424_242
+        assert run_row["worker_start_time"] == 777_123
+
+
+def test_goal_budget_exhaustion_retains_worker_until_dispatch_cleanup(
+    kanban_home, monkeypatch,
+):
+    from hermes_cli import goals
+
+    with kb.connect() as conn:
+        task_id, run_id = _claimed_with_process(
+            conn, monkeypatch, goal_mode=True,
+        )
+        monkeypatch.setattr(
+            goals,
+            "judge_goal",
+            lambda *_args, **_kwargs: (
+                "continue", "not done", False, None, False
+            ),
+        )
+
+        result = goals.run_kanban_goal_loop(
+            task_id=task_id,
+            goal_text="finish it",
+            run_turn=lambda _prompt: pytest.fail("budget must stop another turn"),
+            task_status_fn=lambda: kb.get_task(conn, task_id).status,
+            block_fn=lambda reason: kb.block_task(
+                conn,
+                task_id,
+                reason=reason,
+                kind="needs_input",
+                expected_run_id=run_id,
+            ),
+            max_turns=1,
+            first_response="still working",
+        )
+
+        assert result["outcome"] == "blocked_budget"
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, run_id)
+        assert task is not None and task.status == "blocked"
+        assert task.worker_pid == 424_242
+        assert task.worker_start_time == 777_123
+        assert run is not None and run.ended_at is not None
+        assert run.worker_pid == 424_242
+        assert run.worker_start_time == 777_123
+
+
+def test_review_changes_handoff_retains_reviewer_process_identity(
+    kanban_home, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="review changes", assignee="implementer"
+        )
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id, claimer="reviewer")
+        assert review is not None
+        monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 777_123)
+        kb._set_worker_pid(conn, task_id, 424_242)
+
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason="fix it",
+            expected_run_id=review.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, review.current_run_id)
+        assert task is not None and task.status == "ready"
+        assert task.worker_pid == 424_242
+        assert task.worker_start_time == 777_123
+        assert run is not None and run.outcome == "changes_requested"
+        assert run.worker_pid == 424_242
+        assert run.worker_start_time == 777_123
+
+
+def test_review_reopen_cannot_drop_pending_worker_identity(
+    kanban_home, monkeypatch,
+):
+    """A fast operator reopen cannot spawn beside the implementation handoff."""
+    with kb.connect() as conn:
+        task_id, run_id = _claimed_with_process(conn, monkeypatch)
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            expected_run_id=run_id,
+        )
+        assert kb.reopen_review_task(conn, task_id)
+        reopened = kb.get_task(conn, task_id)
+        assert reopened is not None and reopened.status == "ready"
+        assert reopened.claim_lock is not None
+        assert reopened.worker_pid == 424_242
+        assert reopened.worker_start_time == 777_123
+        assert kb.claim_task(conn, task_id) is None
+
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: {
+                "prev_pid": 424_242,
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "still_alive": False,
+                "sigkill": False,
+                "reaped": True,
+            },
+        )
+        assert kb.cleanup_terminal_workers(conn) == [task_id]
+        assert kb.claim_task(conn, task_id) is not None
+
+
+def test_late_spawn_registration_after_reclaim_cannot_create_duplicate_writer(
+    kanban_home, monkeypatch,
+):
+    """A terminal transition between Popen and PID persistence stays guarded."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="spawn race", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        claim_lock = claimed.claim_lock
+        assert run_id is not None and claim_lock is not None
+
+        # Simulate an operator reclaim racing the dispatcher's post-Popen PID
+        # persistence. No PID existed yet, so the transition legitimately ends
+        # the run and clears its claim.
+        assert kb.reclaim_task(conn, task_id)
+        assert kb.get_task(conn, task_id).status == "ready"
+
+        monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 777_123)
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: {
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": False,
+                "still_alive": True,
+                "reaped": False,
+            },
+        )
+        kb._set_worker_pid(
+            conn,
+            task_id,
+            424_242,
+            expected_run_id=run_id,
+            expected_claim_lock=claim_lock,
+        )
+
+        guarded = kb.get_task(conn, task_id)
+        assert guarded is not None and guarded.status == "ready"
+        assert guarded.claim_lock == claim_lock
+        assert guarded.worker_pid == 424_242
+        assert guarded.worker_start_time == 777_123
+        assert kb.claim_task(conn, task_id) is None
+        ended = kb.get_run(conn, run_id)
+        assert ended is not None and ended.ended_at is not None
+        assert ended.claim_lock == claim_lock
+        assert ended.worker_pid == 424_242
+
+        with kb.write_txn(conn):
+            due = int(time.time()) - 1
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                (due, task_id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                (due, run_id),
+            )
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: {
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "still_alive": False,
+                "reaped": True,
+            },
+        )
+        assert kb.cleanup_terminal_workers(conn) == [task_id]
+        assert kb.claim_task(conn, task_id) is not None
+
+
+def test_terminal_cleanup_clears_claim_only_after_exact_worker_is_gone(
+    kanban_home, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed_with_process(conn, monkeypatch)
+        assert kb.complete_task(
+            conn, task_id, summary="done", expected_run_id=run_id,
+        )
+
+        calls = []
+
+        def _terminated(pid, claim_lock, worker_start_time=None, **_kwargs):
+            calls.append((pid, claim_lock, worker_start_time))
+            return {
+                "prev_pid": pid,
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "still_alive": False,
+                "sigkill": False,
+                "reaped": True,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _terminated)
+        assert kb.cleanup_terminal_workers(conn) == [task_id]
+        assert calls == [(424_242, ANY, 777_123)]
+
+        task_row = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "worker_start_time FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        run_row = conn.execute(
+            "SELECT worker_pid, worker_start_time FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        assert task_row["status"] == "done"
+        assert task_row["claim_lock"] is None
+        assert task_row["claim_expires"] is None
+        assert task_row["worker_pid"] is None
+        assert task_row["worker_start_time"] is None
+        assert run_row["worker_pid"] is None
+        assert run_row["worker_start_time"] is None
+
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'worker_cleanup' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert event is not None
+        assert json.loads(event["payload"])["run_id"] == run_id
+
+
+def test_terminal_cleanup_is_scoped_to_the_open_board(tmp_path, monkeypatch):
+    db_a = tmp_path / "board-a.db"
+    db_b = tmp_path / "board-b.db"
+    with kb.connect(db_a) as conn_a, kb.connect(db_b) as conn_b:
+        task_a, run_a = _claimed_with_process(conn_a, monkeypatch)
+        task_b, run_b = _claimed_with_process(conn_b, monkeypatch)
+        assert kb.complete_task(
+            conn_a, task_a, summary="a", expected_run_id=run_a
+        )
+        assert kb.complete_task(
+            conn_b, task_b, summary="b", expected_run_id=run_b
+        )
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda pid, claim_lock, **_kw: {
+                "prev_pid": pid,
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "still_alive": False,
+                "sigkill": False,
+                "reaped": True,
+            },
+        )
+
+        assert kb.cleanup_terminal_workers(conn_a) == [task_a]
+        assert kb.get_task(conn_a, task_a).claim_lock is None
+        untouched = kb.get_task(conn_b, task_b)
+        assert untouched is not None
+        assert untouched.claim_lock is not None
+        assert untouched.worker_pid == 424_242
+
+
+def test_dependency_handoff_cannot_respawn_while_old_worker_survives(
+    kanban_home, monkeypatch,
+):
+    """A dependency wait promoted to ready still carries the old live claim."""
+    with kb.connect() as conn:
+        task_id, run_id = _claimed_with_process(conn, monkeypatch, goal_mode=True)
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="waiting on parent",
+            kind="dependency",
+            expected_run_id=run_id,
+        )
+        kb.recompute_ready(conn)
+        promoted = kb.get_task(conn, task_id)
+        assert promoted is not None
+        assert promoted.status == "ready"
+
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *args, **kwargs: {
+                "prev_pid": 424_242,
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": False,
+                "still_alive": True,
+                "sigkill": True,
+                "reaped": False,
+            },
+        )
+        assert kb.cleanup_terminal_workers(conn) == []
+        assert kb.claim_task(conn, task_id) is None
+        held = kb.get_task(conn, task_id)
+        assert held is not None
+        assert held.status == "ready"
+        assert held.claim_lock is not None
+        assert held.worker_pid == 424_242
+
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: pytest.fail(
+                "cleanup retry must honor the deferred claim expiry"
+            ),
+        )
+        assert kb.cleanup_terminal_workers(conn) == []
+
+        # A failed kill is deferred instead of retried on every dispatcher
+        # tick. Make the retry due before modelling the next cleanup pass.
+        retry_due = int(time.time()) - 1
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                (retry_due, task_id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                (retry_due, run_id),
+            )
+
+        monkeypatch.setattr(
+            kb,
+            "_terminate_reclaimed_worker",
+            lambda *args, **kwargs: {
+                "prev_pid": 424_242,
+                "host_local": True,
+                "identity_verified": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "still_alive": False,
+                "sigkill": True,
+                "reaped": True,
+            },
+        )
+        assert kb.cleanup_terminal_workers(conn) == [task_id]
+        successor = kb.claim_task(conn, task_id)
+        assert successor is not None
+        assert successor.current_run_id != run_id
+
+
+def test_pid_reuse_mismatch_is_never_signalled(monkeypatch):
+    """A recycled PID means the original worker is gone, not a kill target."""
+    claim_lock = kb._claimer_id()
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 999_999)
+
+    def _must_not_kill(*_args, **_kwargs):
+        pytest.fail("recycled PID must not be signalled")
+
+    monkeypatch.setattr("agent.deadline.terminate_process_tree", _must_not_kill)
+    result = kb._terminate_reclaimed_worker(
+        123_456,
+        claim_lock,
+        worker_start_time=111_111,
+    )
+    assert result["identity_verified"] is False
+    assert result["identity_mismatch"] is True
+    assert result["terminated"] is True
+    assert result["still_alive"] is False
+
+
+def test_unavailable_identity_probe_holds_claim_and_never_signals(monkeypatch):
+    """A transient fingerprint failure must not turn a live PID into proof of exit."""
+    claim_lock = kb._claimer_id()
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: None)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+
+    def _must_not_kill(*_args, **_kwargs):
+        pytest.fail("an unverifiable live PID must not be signalled")
+
+    monkeypatch.setattr("agent.deadline.terminate_process_tree", _must_not_kill)
+    result = kb._terminate_reclaimed_worker(
+        123_456,
+        claim_lock,
+        worker_start_time=111_111,
+    )
+    assert result["identity_unavailable"] is True
+    assert result["termination_attempted"] is False
+    assert result["terminated"] is False
+    assert result["still_alive"] is True
+    assert kb._worker_survived_termination(result) is True
+
+
+def test_legacy_claim_without_boot_fingerprint_fails_closed(monkeypatch):
+    host = kb._claimer_id().split(":", 1)[0]
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 111_111)
+
+    def _must_not_kill(*_args, **_kwargs):
+        pytest.fail("a pre-boot-fingerprint claim must not signal a live PID")
+
+    monkeypatch.setattr("agent.deadline.terminate_process_tree", _must_not_kill)
+    result = kb._terminate_reclaimed_worker(
+        123_456,
+        f"{host}:legacy-worker",
+        worker_start_time=111_111,
+    )
+    assert result["identity_unavailable"] is True
+    assert result["termination_attempted"] is False
+    assert result["terminated"] is False
+    assert result["still_alive"] is True
+
+
+def test_reboot_incarnation_mismatch_never_signals_reused_pid(monkeypatch):
+    host = kb._claimer_id().split(":", 1)[0]
+    claim_lock = f"{host}:boot=previous-boot:worker"
+    monkeypatch.setattr(kb, "_worker_boot_id", lambda: "current-boot")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 111_111)
+
+    def _must_not_kill(*_args, **_kwargs):
+        pytest.fail("a previous-boot PID identity must never be signalled")
+
+    monkeypatch.setattr("agent.deadline.terminate_process_tree", _must_not_kill)
+    assert kb._worker_identity_alive(123_456, 111_111, claim_lock) is False
+    result = kb._terminate_reclaimed_worker(
+        123_456,
+        claim_lock,
+        worker_start_time=111_111,
+    )
+    assert result["identity_mismatch"] is True
+    assert result["boot_mismatch"] is True
+    assert result["termination_attempted"] is False
+    assert result["terminated"] is True
+    assert result["still_alive"] is False
+
+
+def test_pid_reuse_does_not_extend_expired_claim(
+    kanban_home, monkeypatch,
+):
+    """TTL recovery compares the full worker identity, not a recycled PID."""
+    with kb.connect() as conn:
+        task_id, _run_id = _claimed_with_process(conn, monkeypatch)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+                "WHERE id = ?",
+                (int(time.time()) - 10, int(time.time()), task_id),
+            )
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: 999_999)
+
+        assert kb.release_stale_claims(conn) == 1
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        kinds = [event.kind for event in kb.list_events(conn, task_id)]
+        assert "claim_extended" not in kinds
+        assert "reclaimed" in kinds
+
+
+def test_terminal_one_shot_finalizer_skips_background_linger(monkeypatch):
+    import cli as cli_mod
+    from tools.process_registry import process_registry
+
+    calls = []
+
+    class _CLI:
+        def _release_active_session(self):
+            calls.append("release")
+
+    monkeypatch.setattr(cli_mod, "_kanban_worker_run_is_terminal", lambda: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "_wait_for_oneshot_background_completions",
+        lambda _cli: pytest.fail("terminal worker must not enter the 600s linger"),
+    )
+    monkeypatch.setattr(process_registry, "kill_all", lambda **_kw: calls.append("kill_all"))
+    monkeypatch.setattr(cli_mod, "_flush_one_shot_session_store", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_shutdown_terminal_kanban_worker",
+        lambda: calls.append("hard_exit"),
+    )
+
+    cli_mod._finalize_single_query(_CLI())
+    assert calls == ["kill_all", "release", "hard_exit"]
+
+
+@pytest.mark.parametrize("failure_site", ["notify", "cleanup", "release"])
+def test_terminal_one_shot_hard_exit_runs_when_finalization_raises(
+    monkeypatch, failure_site,
+):
+    import cli as cli_mod
+    from tools.process_registry import process_registry
+
+    calls = []
+
+    def _fail(site):
+        def _raise(*_args, **_kwargs):
+            calls.append(site)
+            raise RuntimeError(site)
+
+        return _raise
+
+    class _CLI:
+        def _release_active_session(self):
+            if failure_site == "release":
+                _fail("release")()
+            calls.append("release")
+
+    monkeypatch.setattr(cli_mod, "_kanban_worker_run_is_terminal", lambda: True)
+    monkeypatch.setattr(process_registry, "kill_all", lambda **_kw: None)
+    monkeypatch.setattr(cli_mod, "_flush_one_shot_session_store", lambda _cli: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_notify_single_query_session_finalize",
+        _fail("notify") if failure_site == "notify" else lambda _cli: None,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_run_cleanup",
+        _fail("cleanup") if failure_site == "cleanup" else lambda **_kw: None,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_shutdown_terminal_kanban_worker",
+        lambda: calls.append("hard_exit"),
+    )
+
+    with pytest.raises(RuntimeError, match=failure_site):
+        cli_mod._finalize_single_query(_CLI())
+    assert calls[-1] == "hard_exit"
+    assert "release" in calls or failure_site == "release"
+
+
+def _process_gone_or_zombie(pid: int) -> bool:
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        return not proc.is_running() or proc.status() == psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return True
+
+
+@pytest.mark.linux_only
+def test_process_level_terminal_cleanup_escalates_kills_tree_and_reaps(
+    kanban_home, tmp_path,
+):
+    """Real SIGTERM-ignoring worker + detached child are gone before release."""
+    child_pid_file = tmp_path / "child.pid"
+    child_code = (
+        "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "time.sleep(120)"
+    )
+    worker_code = (
+        "import pathlib,signal,subprocess,sys,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "p=subprocess.Popen([sys.executable,'-c',sys.argv[2]], start_new_session=True); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); "
+        "time.sleep(120)"
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", worker_code, str(child_pid_file), child_code],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not child_pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert child_pid_file.exists()
+        child_pid = int(child_pid_file.read_text())
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn, title="real terminal cleanup", assignee="default"
+            )
+            task = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+            assert task is not None
+            run_id = task.current_run_id
+            kb._set_worker_pid(conn, task_id, worker.pid)
+            assert kb.complete_task(
+                conn, task_id, summary="done", expected_run_id=run_id
+            )
+
+            assert kb.cleanup_terminal_workers(
+                conn, grace_seconds=0.15
+            ) == [task_id]
+            payload = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? "
+                "AND kind = 'worker_cleanup' ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            assert payload is not None
+            cleanup = json.loads(payload["payload"])
+            assert cleanup["identity_verified"] is True
+            assert cleanup["termination_attempted"] is True
+            assert cleanup["sigkill"] is True
+            assert cleanup["reaped"] is True
+
+        worker.wait(timeout=3)
+        deadline = time.monotonic() + 3
+        while not _process_gone_or_zombie(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert _process_gone_or_zombie(child_pid)
+        assert worker.poll() is not None
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=3)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("max_retries,expected_status", [(None, "ready"), (1, "blocked")])
+def test_process_level_timeout_and_gave_up_reap_worker_tree(
+    kanban_home, tmp_path, max_retries, expected_status,
+):
+    child_pid_file = tmp_path / f"timeout-child-{max_retries}.pid"
+    child_code = (
+        "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "time.sleep(120)"
+    )
+    worker_code = (
+        "import pathlib,signal,subprocess,sys,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "p=subprocess.Popen([sys.executable,'-c',sys.argv[2]], start_new_session=True); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); "
+        "time.sleep(120)"
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", worker_code, str(child_pid_file), child_code],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not child_pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert child_pid_file.exists()
+        child_pid = int(child_pid_file.read_text())
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="timeout cleanup",
+                assignee="default",
+                max_runtime_seconds=1,
+                max_retries=max_retries,
+            )
+            task = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+            assert task is not None
+            kb._set_worker_pid(conn, task_id, worker.pid)
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                    (int(time.time()) - 20, task.current_run_id),
+                )
+
+            assert kb.enforce_max_runtime(
+                conn, grace_seconds=0.15
+            ) == [task_id]
+            updated = kb.get_task(conn, task_id)
+            assert updated is not None
+            assert updated.status == expected_status
+            assert updated.claim_lock is None
+            assert updated.worker_pid is None
+            events = [event.kind for event in kb.list_events(conn, task_id)]
+            assert "timed_out" in events
+            if max_retries == 1:
+                assert "gave_up" in events
+
+        worker.wait(timeout=3)
+        deadline = time.monotonic() + 3
+        while not _process_gone_or_zombie(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert _process_gone_or_zombie(child_pid)
+        assert worker.poll() is not None
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=3)
+
+
+@pytest.mark.linux_only
+def test_terminal_worker_hard_exit_does_not_wait_for_threads_or_children(tmp_path):
+    """The worker-side finalizer drains an untracked child then bypasses joins."""
+    child_pid_file = tmp_path / "shutdown-child.pid"
+    script = (
+        "import pathlib,signal,subprocess,sys,threading,time; "
+        "from cli import _shutdown_terminal_kanban_worker; "
+        "threading.Thread(target=lambda: time.sleep(120), daemon=False).start(); "
+        "p=subprocess.Popen([sys.executable,'-c',"
+        "'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'],"
+        "start_new_session=True); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); "
+        "_shutdown_terminal_kanban_worker()"
+    )
+    worker = subprocess.Popen([sys.executable, "-c", script, str(child_pid_file)])
+    worker.wait(timeout=10)
+    assert worker.returncode == 0
+    child_pid = int(child_pid_file.read_text())
+    deadline = time.monotonic() + 3
+    while not _process_gone_or_zombie(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert _process_gone_or_zombie(child_pid)
+
+
+@pytest.mark.windows_only
+def test_windows_terminal_cleanup_uses_identity_bound_tree_kill(kanban_home, tmp_path):
+    child_pid_file = tmp_path / "windows-child.pid"
+    worker_code = (
+        "import pathlib,subprocess,sys,time; "
+        "p=subprocess.Popen([sys.executable,'-c','import time; time.sleep(120)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(p.pid)); time.sleep(120)"
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", worker_code, str(child_pid_file)]
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not child_pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert child_pid_file.exists()
+        child_pid = int(child_pid_file.read_text())
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn, title="windows terminal cleanup", assignee="default"
+            )
+            task = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+            assert task is not None
+            kb._set_worker_pid(conn, task_id, worker.pid)
+            assert kb.complete_task(
+                conn,
+                task_id,
+                summary="done",
+                expected_run_id=task.current_run_id,
+            )
+            assert kb.cleanup_terminal_workers(
+                conn, grace_seconds=3.0
+            ) == [task_id]
+        worker.wait(timeout=5)
+        assert _process_gone_or_zombie(child_pid)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+            worker.wait(timeout=3)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -457,6 +457,36 @@ def test_dashboard_reclaim_of_active_review_preserves_review_phase(client):
         assert next_review is not None
 
 
+def test_dashboard_direct_reclaim_holds_legacy_live_worker_claim(
+    client, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy live worker", assignee="builder")
+        claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        assert claimed is not None
+        monkeypatch.setattr(kb, "_worker_start_time", lambda _pid: None)
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+        kb._set_worker_pid(conn, task_id, 424242)
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "ready"},
+    )
+    assert response.status_code == 200, response.text
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "ready"
+        assert task.claim_lock is not None
+        assert task.worker_pid == 424242
+        assert task.worker_start_time is None
+        assert kb.claim_task(conn, task_id) is None
+        run = kb.latest_run(conn, task_id)
+        assert run is not None and run.outcome == "reclaimed"
+        assert run.claim_lock == task.claim_lock
+        assert run.worker_pid == task.worker_pid
+
+
 # ---------------------------------------------------------------------------
 # DELETE /tasks/:id
 # ---------------------------------------------------------------------------
@@ -513,6 +543,7 @@ def test_dispatch_dry_run(client):
     body = r.json()
     # DispatchResult is serialized as a dataclass dict.
     assert isinstance(body, dict)
+    assert body["cleaned_terminal"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a Kanban lifecycle race where a worker could make its task/run terminal (`done`, `blocked`, dependency wait, review, timeout/give-up) while the worker process and descendants remained alive. The dispatcher previously supervised only `running` tasks, so the ended run could lose its PID identity, leak LSP/child processes, and permit a duplicate writer to respawn.

The fix retains run-scoped claim/process identity until bounded cleanup proves the exact worker tree is gone, then releases the claim with compare-and-swap guards.

## Related Issue

No public issue. Reproduced from a live goal-mode terminal transition with surviving worker/LSP processes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Retain ended-run claim, PID, start fingerprint, and host boot/incarnation identity until cleanup succeeds.
- Reap terminal workers through identity-bound process objects with bounded POSIX `SIGTERM → grace → SIGKILL` escalation; Windows uses identity-aware process handles instead of PID-only `taskkill`.
- Keep survivor/unverifiable claims held across dispatcher timeout, dashboard direct status changes, and parent-reopen descendant invalidation so duplicate claims cannot spawn.
- Make one-shot Kanban workers drain descendants and hard-exit even when notification/session cleanup raises.
- Preserve legacy positional `Task`, `Run`, and `DispatchResult` construction and expose cleanup-only dispatcher activity through hooks, CLI JSON/human output, and dashboard serialization.
- Add migration/rebuild, process-level, PID-reuse, reboot/incarnation, terminal-transition, retry/rate-limit, dashboard, and multi-board regression coverage.

## How to Test

1. Run the affected CI-parity suite:
   `scripts/run_tests.sh tests/agent/test_deadline.py tests/gateway/test_status.py tests/gateway/test_kanban_*.py tests/hermes_cli/test_kanban*.py tests/plugins/test_kanban_dashboard_plugin.py -q`
   Result: 60 files, 548 passed, 0 failed, 4 platform-only skips.
2. Run static checks:
   `.venv/bin/ruff check <affected Python files>` → all checks passed.
   `git diff --check` → clean.
3. The Linux process-level regressions launch a SIGTERM-ignoring worker plus detached child and verify SIGKILL escalation, bounded exit, and reaping before claim release.
4. Independent read-only review of the stable final diff returned **APPROVE** with no blocking, major, or minor findings.

Tested on Linux 6.8 with Python 3.13. Windows identity-bound behavior is covered by platform-simulated regression tests; native Windows validation is delegated to the repository CI lane.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing open issues and PRs for a duplicate.
- [x] This PR contains only the Kanban lifecycle fix and its regressions.
- [x] I ran the repository test wrapper on the complete affected suite.
- [x] I added regression tests for the bug and prior review blockers.
- [x] I tested on Ubuntu/Linux; Windows-specific behavior is covered in tests and CI.

### Documentation & Housekeeping

- [x] Relevant behavior is documented in code/docstrings; no user documentation change is required.
- [x] No config keys or tool schemas changed.
- [x] Cross-platform impact was explicitly reviewed and tested.
