### PR TITLE
feat(matrix): make per-message read receipts and lifecycle reactions configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -349,7 +349,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
-    "MATRIX_READ_RECEIPTS",
+    "MATRIX_READ_RECEIPTS", "MATRIX_REACTIONS",
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -349,6 +349,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
+    "MATRIX_READ_RECEIPTS",
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2447,6 +2447,11 @@ DEFAULT_CONFIG = {
         #   after_processing  — mark read only once the agent finishes the turn
         #   disabled          — never send read receipts
         "read_receipts": "immediate",
+        # Lifecycle reactions on processed messages: an eyes reaction when the
+        # agent starts and a checkmark/cross when it finishes. On Beeper these
+        # propagate to every bridged network, so each incoming message visibly
+        # gets a checkmark. Set false to disable (eyes + checkmark/cross).
+        "reactions": True,
     },
 
     # Approval mode for dangerous commands:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2439,6 +2439,14 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in rooms
         "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
         "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        # When to send an m.read receipt / fully-read marker for an incoming
+        # message. On Beeper the receipt propagates to every bridged network
+        # (Messenger/Instagram/WhatsApp/...), so marking read on ingestion makes
+        # all of them show the message as read the instant the gateway sees it.
+        #   immediate         — mark read on arrival (default; historical behavior)
+        #   after_processing  — mark read only once the agent finishes the turn
+        #   disabled          — never send read receipts
+        "read_receipts": "immediate",
     },
 
     # Approval mode for dangerous commands:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1311,6 +1311,20 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
         ).lower() not in {"false", "0", "no"}
+
+        # Read receipts: configurable via config.yaml ``matrix.read_receipts``
+        # (env ``MATRIX_READ_RECEIPTS`` as legacy fallback; YAML wins when set).
+        # Three modes control when an ``m.read`` receipt / fully-read marker is
+        # sent for an incoming message:
+        #   - "immediate" (default): mark read the instant the event arrives
+        #     (historical behavior).
+        #   - "after_processing": mark read only once the agent finishes the
+        #     turn, so the receipt reflects an actual reply rather than mere
+        #     ingestion.
+        #   - "disabled": never send read receipts. On Beeper this stops every
+        #     bridged network (Messenger/Instagram/WhatsApp/...) from showing
+        #     messages as read the instant the gateway processes them.
+        self._read_receipts_mode: str = self._parse_read_receipts_mode(config)
         self._pending_reactions: dict[tuple[str, str], str] = {}
         # Delay before redacting reactions so Matrix homeservers have time to
         # deliver the final message event without tripping "missing event"
@@ -1432,6 +1446,47 @@ class MatrixAdapter(BasePlatformAdapter):
         return os.getenv(
             "MATRIX_THREAD_REQUIRE_MENTION", "false"
         ).lower() in {"true", "1", "yes", "on"}
+
+    @staticmethod
+    def _parse_read_receipts_mode(config) -> str:
+        """Resolve read-receipt mode from config.yaml ``matrix.read_receipts``.
+
+        Falls back to the legacy ``MATRIX_READ_RECEIPTS`` env var; the YAML
+        value always wins when set. Returns one of ``"immediate"``,
+        ``"after_processing"``, or ``"disabled"``.
+
+        Back-compat: earlier releases exposed only a boolean env var, so
+        boolean / ``"true"`` / ``"false"`` / ``"on"`` / ``"off"`` / ``"1"`` /
+        ``"0"`` values are still accepted — truthy maps to ``"immediate"`` and
+        falsy to ``"disabled"``. Unrecognized values fall back to the default.
+        """
+        default = "immediate"
+        valid = {"immediate", "after_processing", "disabled"}
+
+        def _coerce(raw) -> Optional[str]:
+            if raw is None:
+                return None
+            if isinstance(raw, bool):
+                return "immediate" if raw else "disabled"
+            token = str(raw).strip().lower()
+            if not token:
+                return None
+            if token in valid:
+                return token
+            # Legacy boolean spellings (the pre-mode env flag).
+            if token in {"true", "1", "yes", "on", "enabled"}:
+                return "immediate"
+            if token in {"false", "0", "no", "off"}:
+                return "disabled"
+            return default
+
+        configured = _coerce(config.extra.get("read_receipts"))
+        if configured is not None:
+            return configured
+        env_mode = _coerce(os.getenv("MATRIX_READ_RECEIPTS"))
+        if env_mode is not None:
+            return env_mode
+        return default
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -3460,7 +3515,10 @@ class MatrixAdapter(BasePlatformAdapter):
         if thread_id:
             self._threads.mark(thread_id)
 
-        self._background_read_receipt(room_id, event_id)
+        # "immediate" marks read on arrival; "after_processing" defers the
+        # receipt to on_processing_complete; "disabled" never sends one.
+        if self._read_receipts_mode == "immediate":
+            self._background_read_receipt(room_id, event_id)
 
         return body, is_dm, chat_type, thread_id, display_name, source
 
@@ -3982,11 +4040,28 @@ class MatrixAdapter(BasePlatformAdapter):
         event: MessageEvent,
         outcome: ProcessingOutcome,
     ) -> None:
-        """Replace eyes with checkmark (success) or cross (failure)."""
-        if not self._reactions_enabled:
-            return
+        """Replace eyes with checkmark (success) or cross (failure).
+
+        Also emits a deferred read receipt when ``read_receipts`` is set to
+        ``after_processing`` — the message is marked read once the turn is
+        done rather than the instant it arrived.
+        """
         msg_id = event.message_id
         room_id = event.source.chat_id
+
+        # Deferred read receipt ("after_processing" mode). Independent of the
+        # reaction lifecycle below, and skipped on cancellation so a cancelled
+        # turn doesn't mark the triggering message read.
+        if (
+            self._read_receipts_mode == "after_processing"
+            and msg_id
+            and room_id
+            and outcome != ProcessingOutcome.CANCELLED
+        ):
+            self._background_read_receipt(room_id, msg_id)
+
+        if not self._reactions_enabled:
+            return
         if not msg_id or not room_id:
             return
         if outcome == ProcessingOutcome.CANCELLED:
@@ -5406,6 +5481,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_SESSION_SCOPE"] = str(matrix_cfg["session_scope"]).lower()
     if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
         os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
+    if "read_receipts" in matrix_cfg and not os.getenv("MATRIX_READ_RECEIPTS"):
+        os.environ["MATRIX_READ_RECEIPTS"] = str(matrix_cfg["read_receipts"]).lower()
     if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1307,10 +1307,14 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_PROCESS_NOTICES", "false"
         ).lower() in ("true", "1", "yes")
 
-        # Reactions: configurable via MATRIX_REACTIONS (default: true).
-        self._reactions_enabled: bool = os.getenv(
-            "MATRIX_REACTIONS", "true"
-        ).lower() not in {"false", "0", "no"}
+        # Lifecycle reactions: configurable via config.yaml ``matrix.reactions``
+        # (env ``MATRIX_REACTIONS`` as legacy fallback; YAML wins when set).
+        # When enabled (default), the adapter annotates every processed message
+        # with an eyes reaction on start and a checkmark/cross on completion. On
+        # Beeper those reactions propagate to each bridged network, so every
+        # incoming message visibly gets a checkmark — set ``reactions: false``
+        # to stop that.
+        self._reactions_enabled: bool = self._parse_reactions_enabled(config)
 
         # Read receipts: configurable via config.yaml ``matrix.read_receipts``
         # (env ``MATRIX_READ_RECEIPTS`` as legacy fallback; YAML wins when set).
@@ -1487,6 +1491,34 @@ class MatrixAdapter(BasePlatformAdapter):
         if env_mode is not None:
             return env_mode
         return default
+
+    @staticmethod
+    def _parse_reactions_enabled(config) -> bool:
+        """Resolve lifecycle-reaction toggle from ``matrix.reactions``.
+
+        Falls back to the legacy ``MATRIX_REACTIONS`` env var; the YAML value
+        always wins when set. Defaults to enabled. A value is falsy when it is
+        the boolean ``False`` or one of ``"false"`` / ``"0"`` / ``"no"`` /
+        ``"off"`` (case-insensitive); everything else is truthy.
+        """
+
+        def _coerce(raw) -> Optional[bool]:
+            if raw is None:
+                return None
+            if isinstance(raw, bool):
+                return raw
+            token = str(raw).strip().lower()
+            if not token:
+                return None
+            return token not in {"false", "0", "no", "off"}
+
+        configured = _coerce(config.extra.get("reactions"))
+        if configured is not None:
+            return configured
+        env_val = _coerce(os.getenv("MATRIX_REACTIONS"))
+        if env_val is not None:
+            return env_val
+        return True
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -5483,6 +5515,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
     if "read_receipts" in matrix_cfg and not os.getenv("MATRIX_READ_RECEIPTS"):
         os.environ["MATRIX_READ_RECEIPTS"] = str(matrix_cfg["read_receipts"]).lower()
+    if "reactions" in matrix_cfg and not os.getenv("MATRIX_REACTIONS"):
+        os.environ["MATRIX_REACTIONS"] = str(matrix_cfg["reactions"]).lower()
     if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3342,3 +3342,154 @@ class TestCryptoPickleKeyMigration:
         # start still sees a legacy-key account and retries the migration.
         store.put_account.assert_not_awaited()
         assert "retried on the next start" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Read-receipt mode (matrix.read_receipts: immediate / after_processing / disabled)
+# ---------------------------------------------------------------------------
+
+class TestMatrixReadReceiptsMode:
+    """Read receipts are configurable via config.yaml ``matrix.read_receipts``.
+
+    Three modes gate when an ``m.read`` receipt is sent for an inbound message:
+    ``immediate`` (on arrival, the historical default), ``after_processing``
+    (once the agent finishes the turn), and ``disabled`` (never). A legacy
+    ``MATRIX_READ_RECEIPTS`` env var is honored as a fallback; the YAML value
+    wins when both are present.
+    """
+
+    @staticmethod
+    def _parse(extra=None, env=None):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+        cfg = PlatformConfig(enabled=True, token="t", extra=dict(extra or {}))
+        with patch.dict("os.environ", env or {}, clear=False):
+            # Ensure a stray real env var can't perturb the extra-only cases.
+            if not env:
+                import os
+                os.environ.pop("MATRIX_READ_RECEIPTS", None)
+            return MatrixAdapter._parse_read_receipts_mode(cfg)
+
+    def test_default_is_immediate(self):
+        assert self._parse() == "immediate"
+
+    def test_explicit_modes_from_yaml(self):
+        assert self._parse({"read_receipts": "immediate"}) == "immediate"
+        assert self._parse({"read_receipts": "after_processing"}) == "after_processing"
+        assert self._parse({"read_receipts": "disabled"}) == "disabled"
+
+    def test_case_and_whitespace_insensitive(self):
+        assert self._parse({"read_receipts": "  DISABLED "}) == "disabled"
+        assert self._parse({"read_receipts": "After_Processing"}) == "after_processing"
+
+    def test_legacy_boolean_spellings(self):
+        # Pre-mode releases exposed a boolean; truthy → immediate, falsy → disabled.
+        assert self._parse({"read_receipts": True}) == "immediate"
+        assert self._parse({"read_receipts": False}) == "disabled"
+        assert self._parse({"read_receipts": "false"}) == "disabled"
+        assert self._parse({"read_receipts": "no"}) == "disabled"
+        assert self._parse({"read_receipts": "on"}) == "immediate"
+
+    def test_unrecognized_value_falls_back_to_default(self):
+        assert self._parse({"read_receipts": "sometimes"}) == "immediate"
+
+    def test_env_var_fallback_when_yaml_unset(self):
+        assert self._parse(env={"MATRIX_READ_RECEIPTS": "disabled"}) == "disabled"
+        assert self._parse(env={"MATRIX_READ_RECEIPTS": "after_processing"}) == "after_processing"
+
+    def test_yaml_wins_over_env(self):
+        assert self._parse(
+            {"read_receipts": "disabled"},
+            env={"MATRIX_READ_RECEIPTS": "immediate"},
+        ) == "disabled"
+
+    # --- behavior: immediate marks read on arrival -------------------------
+
+    async def _dispatch(self, adapter, is_dm=True):
+        adapter._is_dm_room = AsyncMock(return_value=is_dm)
+        adapter._get_display_name = AsyncMock(return_value="Alice")
+        adapter._require_mention = True
+        adapter._free_rooms = set()
+        adapter.handle_message = AsyncMock()
+        await adapter._handle_text_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$rr-test",
+            event_ts=0.0,
+            source_content={"msgtype": "m.text", "body": "hello"},
+            relates_to={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_immediate_sends_receipt_on_arrival(self):
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "immediate"
+        adapter._background_read_receipt = MagicMock()
+        await self._dispatch(adapter)
+        adapter._background_read_receipt.assert_called_once_with(
+            "!room:example.org", "$rr-test"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disabled_never_sends_receipt_on_arrival(self):
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "disabled"
+        adapter._background_read_receipt = MagicMock()
+        await self._dispatch(adapter)
+        adapter._background_read_receipt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_after_processing_defers_receipt_from_arrival(self):
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "after_processing"
+        adapter._background_read_receipt = MagicMock()
+        await self._dispatch(adapter)
+        # Not sent on arrival — the deferred path handles it later.
+        adapter._background_read_receipt.assert_not_called()
+
+    # --- behavior: after_processing marks read on completion ---------------
+
+    @staticmethod
+    def _completion_event():
+        event = MagicMock()
+        event.message_id = "$rr-test"
+        event.source.chat_id = "!room:example.org"
+        return event
+
+    @pytest.mark.asyncio
+    async def test_after_processing_sends_receipt_on_success(self):
+        from plugins.platforms.matrix.adapter import ProcessingOutcome
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "after_processing"
+        adapter._reactions_enabled = False  # isolate the receipt path
+        adapter._background_read_receipt = MagicMock()
+        await adapter.on_processing_complete(
+            self._completion_event(), ProcessingOutcome.SUCCESS
+        )
+        adapter._background_read_receipt.assert_called_once_with(
+            "!room:example.org", "$rr-test"
+        )
+
+    @pytest.mark.asyncio
+    async def test_after_processing_skips_receipt_on_cancel(self):
+        from plugins.platforms.matrix.adapter import ProcessingOutcome
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "after_processing"
+        adapter._reactions_enabled = False
+        adapter._background_read_receipt = MagicMock()
+        await adapter.on_processing_complete(
+            self._completion_event(), ProcessingOutcome.CANCELLED
+        )
+        adapter._background_read_receipt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_immediate_mode_does_not_double_send_on_completion(self):
+        from plugins.platforms.matrix.adapter import ProcessingOutcome
+        adapter = _make_adapter()
+        adapter._read_receipts_mode = "immediate"
+        adapter._reactions_enabled = False
+        adapter._background_read_receipt = MagicMock()
+        await adapter.on_processing_complete(
+            self._completion_event(), ProcessingOutcome.SUCCESS
+        )
+        # The completion path is only for after_processing mode.
+        adapter._background_read_receipt.assert_not_called()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3493,3 +3493,106 @@ class TestMatrixReadReceiptsMode:
         )
         # The completion path is only for after_processing mode.
         adapter._background_read_receipt.assert_not_called()
+
+
+class TestMatrixReactionsToggle:
+    """Lifecycle reactions are configurable via config.yaml ``matrix.reactions``.
+
+    When enabled (default), the adapter annotates every processed message with
+    an eyes reaction on start and a checkmark/cross on completion. Setting
+    ``reactions: false`` disables both. A legacy ``MATRIX_REACTIONS`` env var is
+    honored as a fallback; the YAML value wins when both are present.
+    """
+
+    @staticmethod
+    def _parse(extra=None, env=None):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+        cfg = PlatformConfig(enabled=True, token="t", extra=dict(extra or {}))
+        with patch.dict("os.environ", env or {}, clear=False):
+            if not env:
+                import os
+                os.environ.pop("MATRIX_REACTIONS", None)
+            return MatrixAdapter._parse_reactions_enabled(cfg)
+
+    def test_default_is_enabled(self):
+        assert self._parse() is True
+
+    def test_explicit_bool_from_yaml(self):
+        assert self._parse({"reactions": True}) is True
+        assert self._parse({"reactions": False}) is False
+
+    def test_string_spellings(self):
+        assert self._parse({"reactions": "false"}) is False
+        assert self._parse({"reactions": "off"}) is False
+        assert self._parse({"reactions": "no"}) is False
+        assert self._parse({"reactions": "0"}) is False
+        assert self._parse({"reactions": "true"}) is True
+        assert self._parse({"reactions": "on"}) is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert self._parse({"reactions": "  FALSE "}) is False
+        assert self._parse({"reactions": "Off"}) is False
+
+    def test_env_var_fallback_when_yaml_unset(self):
+        assert self._parse(env={"MATRIX_REACTIONS": "false"}) is False
+        assert self._parse(env={"MATRIX_REACTIONS": "true"}) is True
+
+    def test_yaml_wins_over_env(self):
+        assert self._parse(
+            {"reactions": False},
+            env={"MATRIX_REACTIONS": "true"},
+        ) is False
+        assert self._parse(
+            {"reactions": True},
+            env={"MATRIX_REACTIONS": "false"},
+        ) is True
+
+    # --- behavior: reactions gate the eyes/checkmark lifecycle -------------
+
+    @staticmethod
+    def _event():
+        event = MagicMock()
+        event.message_id = "$react-test"
+        event.source.chat_id = "!room:example.org"
+        return event
+
+    @pytest.mark.asyncio
+    async def test_enabled_adds_eyes_on_start(self):
+        adapter = _make_adapter()
+        adapter._reactions_enabled = True
+        adapter._send_reaction = AsyncMock(return_value="$eyes")
+        await adapter.on_processing_start(self._event())
+        adapter._send_reaction.assert_awaited_once_with(
+            "!room:example.org", "$react-test", "\U0001f440"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_eyes_on_start(self):
+        adapter = _make_adapter()
+        adapter._reactions_enabled = False
+        adapter._send_reaction = AsyncMock()
+        await adapter.on_processing_start(self._event())
+        adapter._send_reaction.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_adds_checkmark_on_success(self):
+        from plugins.platforms.matrix.adapter import ProcessingOutcome
+        adapter = _make_adapter()
+        adapter._reactions_enabled = True
+        adapter._read_receipts_mode = "disabled"  # isolate the reaction path
+        adapter._send_reaction = AsyncMock(return_value="$check")
+        await adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
+        adapter._send_reaction.assert_awaited_once_with(
+            "!room:example.org", "$react-test", "\u2705"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disabled_no_checkmark_on_success(self):
+        from plugins.platforms.matrix.adapter import ProcessingOutcome
+        adapter = _make_adapter()
+        adapter._reactions_enabled = False
+        adapter._read_receipts_mode = "disabled"
+        adapter._send_reaction = AsyncMock()
+        await adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
+        adapter._send_reaction.assert_not_called()
+


### PR DESCRIPTION
## Summary

The Matrix adapter automatically annotates **every** incoming message the moment the gateway processes it, in two independent ways, and neither could be configured from `config.yaml`:

1. **Read receipts** — an `m.read` receipt / fully-read marker is sent on arrival (`_resolve_message_context`).
2. **Lifecycle reactions** — an eyes reaction (👀) is added when the agent starts a turn and a checkmark/cross (✅/❌) when it finishes (`on_processing_start` / `on_processing_complete`).

This is especially disruptive on Beeper: both signals propagate through the bridge to the underlying network (Messenger / Instagram / WhatsApp / …). So every bridged conversation gets marked read **and** stamped with a visible checkmark the instant the bot ingests a message — regardless of whether the human operator has actually seen or replied to it. For a bot that passively watches many rooms, this silently annotates everything, everywhere.

This PR makes both behaviors configurable under the `matrix` config namespace, per the repository policy that non-secret behavioral configuration belongs in `config.yaml` rather than an environment variable.

## `matrix.read_receipts` (three modes)

| Mode | Behavior |
|------|----------|
| `immediate` (default) | Mark read on arrival — **historical behavior, no change for existing deployments** |
| `after_processing` | Mark read only once the agent finishes the turn, so the receipt reflects an actual reply rather than mere ingestion |
| `disabled` | Never send read receipts |

`after_processing` defers the receipt to `on_processing_complete`, independent of the reaction lifecycle and skipped on cancellation. The legacy `MATRIX_READ_RECEIPTS` env var is honored as a fallback; the YAML value wins when both are set. Legacy boolean spellings map truthy → `immediate`, falsy → `disabled`.

> This supersedes the read-receipt portion of the closed #4441, which added `MATRIX_READ_RECEIPTS` as an environment variable. That approach was declined in review because the config belongs in `config.yaml`; this PR implements it there, on the current mautrix adapter, with coverage for all modes.

## `matrix.reactions` (boolean, default `true`)

Promotes the previously env-only `MATRIX_REACTIONS` toggle to a `config.yaml` boolean. `true` (default) keeps the historical eyes/checkmark lifecycle; `false` disables both the 👀 on start and the ✅/❌ on completion. The legacy `MATRIX_REACTIONS` env var remains a fallback, with YAML winning.

Both settings are bridged through the existing `_apply_yaml_config` hook (`matrix:` YAML → `MATRIX_*` env, env taking precedence), the same mechanism already used by `auto_thread`, `session_scope`, etc.

## Files changed

| File | Change |
|------|--------|
| `plugins/platforms/matrix/adapter.py` | `_parse_read_receipts_mode` + `_parse_reactions_enabled` helpers; gate immediate receipt; deferred receipt in `on_processing_complete`; `matrix.read_receipts` / `matrix.reactions` → env bridges in `_apply_yaml_config` |
| `hermes_cli/config_defaults.py` | Register `matrix.read_receipts` (`immediate`) and `matrix.reactions` (`true`) defaults |
| `hermes_cli/config.py` | Keep `MATRIX_READ_RECEIPTS` / `MATRIX_REACTIONS` in the known-env allowlist so `doctor` doesn't flag the internal bridge vars |
| `tests/gateway/test_matrix.py` | 23 regression tests |

## Tests

23 new tests, all passing (`TestMatrixReadReceiptsMode` ×13, `TestMatrixReactionsToggle` ×10):
- **Read receipts** — parser: default, explicit modes, case/whitespace tolerance, legacy booleans, unrecognized-value fallback, env fallback, YAML-wins-over-env; behavior: `immediate` sends on arrival, `disabled` never sends, `after_processing` defers and sends on success but is skipped on cancellation, `immediate` does not double-send at completion.
- **Reactions** — parser: default enabled, explicit bool, string spellings (`off`/`no`/`0`/…), case/whitespace tolerance, env fallback, YAML-wins-over-env; behavior: eyes on start / checkmark on success only when enabled, nothing when disabled.

(The Matrix backend has no `pytest` in the venv here; tests were run via a standalone runner importing the classes and executing sync + async methods — 23 passed, 0 failed.)

## Compatibility

- Defaults reproduce current behavior exactly (`read_receipts: immediate`, `reactions: true`) — no change for existing deployments.
- Env vars and legacy boolean forms still work.
- Matrix-specific; no cross-platform impact.
