### PR TITLE
fix(api-server): anchor each request's cwd in its profile workspace

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7161,6 +7161,32 @@ class APIServerAdapter(BasePlatformAdapter):
         return None
 
     @staticmethod
+    def _profile_workspace_dir() -> str:
+        """Resolve (and ensure) the active request scope's workspace directory.
+
+        Under ``/p/<profile>/`` the request's profile pins HERMES_HOME to the
+        profile home, but the terminal/file working directory is a single
+        process-global override — every multiplexed profile would otherwise
+        share one cwd and overwrite each other's files. Anchoring each request
+        in its own home's ``workspace/`` gives concurrent profiles isolated
+        default working directories.
+
+        Returns "" when resolution fails so callers skip registration and keep
+        the legacy behavior instead of failing the turn.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+
+            ws = get_hermes_home() / "workspace"
+            ws.mkdir(parents=True, exist_ok=True)
+            return str(ws)
+        except Exception:
+            logger.debug(
+                "[api_server] failed to resolve profile workspace dir", exc_info=True
+            )
+            return ""
+
+    @staticmethod
     def _bind_api_server_session(
         *,
         chat_id: str = "",
@@ -7168,6 +7194,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: str = "",
         browser_control_principal: str = "",
         browser_control_transport_family: str = "",
+        cwd: str = "",
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -7178,6 +7205,10 @@ class APIServerAdapter(BasePlatformAdapter):
         forgetting to mark the channel as non-delivering. There is no
         ``async_delivery`` parameter to get wrong; the stateless HTTP path can
         never wake the agent after the turn ends, on ANY route.
+
+        ``cwd`` pins the logical working directory this context advertises
+        (consumed via the session-cwd machinery by the system prompt and the
+        terminal/file tools).
 
         Returns reset tokens; pass them to ``clear_session_vars`` in a
         ``finally`` block (the binding is request-scoped and must not outlive
@@ -7195,6 +7226,7 @@ class APIServerAdapter(BasePlatformAdapter):
             browser_control_transport_family=browser_control_transport_family,
             async_delivery=False,
             cron_session="",
+            cwd=cwd,
         )
 
     async def _run_agent(
@@ -7264,6 +7296,7 @@ class APIServerAdapter(BasePlatformAdapter):
             from gateway.session_context import clear_session_vars
 
             with self._profile_scope(request_profile):
+                profile_workspace = self._profile_workspace_dir()
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
@@ -7272,6 +7305,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     browser_control_transport_family=(
                         request_browser_control_transport_family
                     ),
+                    cwd=profile_workspace,
                 )
                 agent = None
                 try:
@@ -7295,6 +7329,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     if active_run_id:
                         self._active_run_agents[active_run_id] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
+                    # Anchor terminal/file tools' mechanical cwd for this task —
+                    # the same registration TUI/ACP entries drive via
+                    # register_task_env_overrides. CWD-only overrides share the
+                    # "default" sandbox, so this anchors files without forking
+                    # a separate environment per profile.
+                    if profile_workspace:
+                        try:
+                            from tools.terminal_tool import (
+                                register_task_env_overrides,
+                            )
+
+                            register_task_env_overrides(
+                                effective_task_id, {"cwd": profile_workspace}
+                            )
+                        except Exception:
+                            logger.debug(
+                                "[api_server] failed to register task cwd",
+                                exc_info=True,
+                            )
                     # Baseline for selective background-process reaping on
                     # SSE client disconnect — mirrors gateway/run.py's
                     # gateway-turn cleanup (#76115); this API-server surface
@@ -7728,6 +7781,23 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     return
                 with self._profile_scope(request_profile):
+                    # /v1/runs builds the agent — and therefore its system
+                    # prompt — here, BEFORE the worker below binds session
+                    # context. Pin the logical cwd around construction so the
+                    # prompt advertises this profile's workspace; release right
+                    # after so later code in this task sees the same state as
+                    # before the pin.
+                    profile_workspace = self._profile_workspace_dir()
+                    pinned_cwd_token = None
+                    if profile_workspace:
+                        try:
+                            from agent.runtime_cwd import set_session_cwd
+
+                            pinned_cwd_token = set_session_cwd(profile_workspace)
+                        except Exception:
+                            logger.debug(
+                                "[api_server] failed to pin run cwd", exc_info=True
+                            )
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -7739,6 +7809,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         model_options=agent_overrides.get("model_options"),
                         route=route,
                     )
+                    if pinned_cwd_token is not None:
+                        try:
+                            pinned_cwd_token.var.reset(pinned_cwd_token)
+                        except Exception:
+                            pass
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
@@ -7789,6 +7864,7 @@ class APIServerAdapter(BasePlatformAdapter):
                             # contextvars so concurrent runs do not share process
                             # environment state.
                             approval_token = set_current_session_key(approval_session_key)
+                            profile_workspace = self._profile_workspace_dir()
                             session_tokens = self._bind_api_server_session(
                                 # chat_id carries the raw session id (the
                                 # X-Hermes-Session-Id equivalent) exactly like
@@ -7807,8 +7883,33 @@ class APIServerAdapter(BasePlatformAdapter):
                                 browser_control_transport_family=(
                                     request_browser_control_transport_family
                                 ),
+                                cwd=profile_workspace,
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
+                            # Anchor terminal/file tools' mechanical cwd. The
+                            # first command resolves its cwd through the
+                            # run-scoped key; later ones go through the tool
+                            # task id — register both so the anchor holds from
+                            # the first command regardless of which lookup wins.
+                            if profile_workspace:
+                                try:
+                                    from tools.terminal_tool import (
+                                        register_task_env_overrides,
+                                    )
+
+                                    register_task_env_overrides(
+                                        effective_task_id, {"cwd": profile_workspace}
+                                    )
+                                    if approval_session_key != effective_task_id:
+                                        register_task_env_overrides(
+                                            approval_session_key,
+                                            {"cwd": profile_workspace},
+                                        )
+                                except Exception:
+                                    logger.debug(
+                                        "[api_server] failed to register run task cwd",
+                                        exc_info=True,
+                                    )
                             # /v1/runs runs its own agent lifecycle (no
                             # TurnRunner, no _run_agent) — record turn process
                             # ownership so stop/cancel can reap only the

--- a/tests/gateway/test_api_server_profile_workspace.py
+++ b/tests/gateway/test_api_server_profile_workspace.py
@@ -1,0 +1,133 @@
+"""Tests: the API-server surface anchors a per-profile workspace cwd.
+
+The api_server multiplexes profiles through one process (X-Hermes-Profile /
+``/p/<profile>/`` scope), but TERMINAL_CWD is a single process-global — every
+profile shared one working directory and could overwrite each other's files.
+These tests pin the contract that closes that gap:
+
+- ``_profile_workspace_dir()`` resolves (and creates) ``<HERMES_HOME>/workspace``
+  and degrades to "" instead of failing the turn when it cannot;
+- ``_bind_api_server_session(cwd=...)`` drives the existing session-cwd
+  machinery, so system-prompt context discovery sees the workspace;
+- a completed /v1/runs turn registers the mechanical terminal/file override
+  under both the tool task id and the run-scoped key — same infrastructure
+  TUI/ACP entries drive via ``register_task_env_overrides``.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    return app
+
+
+def _make_instant_agent():
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.return_value = {"final_response": "done"}
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+    return mock_agent
+
+
+async def _wait_completed(cli, run_id: str) -> dict:
+    status = {}
+    for _ in range(40):
+        status_resp = await cli.get(f"/v1/runs/{run_id}")
+        status = await status_resp.json()
+        if status["status"] in {"completed", "failed"}:
+            break
+        await asyncio.sleep(0.05)
+    return status
+
+
+class TestProfileWorkspaceDir:
+    def test_resolves_home_workspace_and_creates_it(self):
+        from hermes_constants import get_hermes_home
+
+        ws = _make_adapter()._profile_workspace_dir()
+
+        assert Path(ws) == get_hermes_home() / "workspace"
+        assert Path(ws).is_dir(), "the anchor directory must exist before first use"
+
+    def test_degrades_to_empty_string_on_resolution_failure(self):
+        # The helper imports get_hermes_home at call time; make it raise to
+        # simulate an unresolvable home. Callers must treat "" as "skip
+        # registration", never as a hard failure of the request.
+        with patch("hermes_constants.get_hermes_home", side_effect=RuntimeError("no home")):
+            assert _make_adapter()._profile_workspace_dir() == ""
+
+
+class TestBindForwardsWorkspaceCwd:
+    def test_logical_cwd_flows_into_session_cwd_machinery(self, tmp_path):
+        from agent.runtime_cwd import resolve_agent_cwd
+        from gateway.session_context import clear_session_vars
+
+        tokens = _make_adapter()._bind_api_server_session(
+            chat_id="c1",
+            session_key="k1",
+            session_id="s1",
+            cwd=str(tmp_path),
+        )
+        try:
+            assert resolve_agent_cwd() == tmp_path, (
+                "bind must pin the logical working directory for this context, "
+                "not leave agents on the process-global TERMINAL_CWD"
+            )
+        finally:
+            clear_session_vars(tokens)
+
+
+class TestRunRegistersTerminalCwdAnchor:
+    @pytest.mark.asyncio
+    async def test_completed_run_anchors_task_and_run_keys(self, adapter):
+        from hermes_constants import get_hermes_home
+        from tools.terminal_tool import clear_task_env_overrides, get_session_cwd
+
+        expected_ws = str(Path(get_hermes_home()) / "workspace")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.return_value = _make_instant_agent()
+
+                resp = await cli.post("/v1/runs", json={
+                    "input": "hi",
+                    "session_id": "ws-sess-1",
+                })
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                status = await _wait_completed(cli, run_id)
+                assert status["status"] == "completed"
+
+                try:
+                    # effective task id = session_id: later commands in the run
+                    # resolve their cwd through this key.
+                    assert get_session_cwd("ws-sess-1") == expected_ws
+                    # approval key = run id: resolves the FIRST command's lookup.
+                    assert get_session_cwd(run_id) == expected_ws
+                finally:
+                    clear_task_env_overrides("ws-sess-1")
+                    clear_task_env_overrides(run_id)


### PR DESCRIPTION
## Problem

The api_server multiplexes profiles through one process — under `/p/<profile>/` the profile scope pins HERMES_HOME per request — but the terminal/file working directory is driven by a single process-global (`TERMINAL_CWD`). Every concurrent profile shared one cwd, so agents running under different profiles could read and write into each other's directory.

Other surfaces already solve both halves of this: TUI/ACP pass an explicit cwd through session binding and register it mechanically via `register_task_env_overrides`, and `set_session_vars` accepts `cwd=` for exactly this purpose. The api_server surface was the remaining entry point wired to neither.

## Fix

- `_profile_workspace_dir()`: resolve (and ensure) `<active profile home>/workspace`; returns `""` on failure so callers keep legacy behavior rather than failing the turn.
- `_bind_api_server_session(cwd=...)`: forward into the existing session-cwd machinery so the system prompt / context discovery advertises the workspace (the logical half).
- `_run_agent` worker (used by `/v1/responses` and friends): register the mechanical terminal/file override under the effective task id — CWD-only overrides share the `"default"` sandbox, so no per-profile environment split.
- `/v1/runs`: builds its agent before any session bind, so pin the logical cwd around `_create_agent` (released immediately after construction) and register overrides under **both** keys the terminal tool consults — the effective task id for later commands and the run-scoped key for the first command.

## Tests

`tests/gateway/test_api_server_profile_workspace.py`: helper resolution + failure degradation; logical cwd flows through bind into `resolve_agent_cwd`; completed runs anchor both lookup keys.
