### PR TITLE
fix(serve): announce port sentinels on the real stdout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19461,6 +19461,26 @@ PORT_IN_USE_EXIT_CODE = 75
 _PORT_IN_USE_SENTINEL = "BACKEND_PORT_IN_USE port={port}"
 
 
+def _announce_stream():
+    """The process's real stdout, for machine-readable launch sentinels.
+
+    ``tui_gateway.server`` reassigns ``sys.stdout`` to stderr at import time so
+    stray library ``print()`` can't corrupt its JSON-RPC stdio transport, and
+    ``start_server`` imports that module during startup. Every plain ``print()``
+    after that import lands on stderr — including the port sentinels, which the
+    desktop watches for on *stdout* only. The backend then boots fine while
+    Electron times out on the port announcement and calls the launch failed.
+    Sentinels therefore address the original stdout explicitly.
+
+    ``sys.__stdout__`` is None under pythonw (Windows Desktop); that launch path
+    announces the port through HERMES_DESKTOP_READY_FILE instead.
+    """
+    stream = getattr(sys, "__stdout__", None)
+    if stream is None or getattr(stream, "closed", False):
+        return sys.stdout
+    return stream
+
+
 def _is_addr_in_use_error(exc: OSError) -> bool:
     """True when ``exc`` is the platform's address-in-use bind failure."""
     import errno
@@ -19517,12 +19537,14 @@ def _port_bind_conflict(host: str, port: int) -> bool:
 
 def _report_port_in_use(host: str, port: int) -> None:
     """Print the machine sentinel + a human hint naming likely holders."""
-    print(_PORT_IN_USE_SENTINEL.format(port=port), flush=True)
+    announce = _announce_stream()
+    print(_PORT_IN_USE_SENTINEL.format(port=port), file=announce, flush=True)
     print(
         f"  Port {port} on {host} is already in use — likely another "
         "'hermes serve' / 'hermes dashboard' backend or the Hermes gateway. "
         "Stop the other process, or pass --port <other> "
         "(--port 0 picks a free ephemeral port).",
+        file=announce,
         flush=True,
     )
 
@@ -19888,7 +19910,8 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            announce = _announce_stream()
+            print(f"{ready_token} port={actual_port}", file=announce, flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.
@@ -19896,9 +19919,13 @@ def start_server(
                 # block-buffered and can surface MINUTES after the flushed
                 # READY sentinel above, which reads as a slow boot in
                 # support bundles when the backend was actually up.
-                print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
+                print(
+                    f"  Hermes backend listening on {host}:{actual_port}",
+                    file=announce,
+                    flush=True,
+                )
             else:
-                print(f"  Hermes Web UI → http://{host}:{actual_port}")
+                print(f"  Hermes Web UI → http://{host}:{actual_port}", file=announce)
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -91,7 +91,9 @@ def test_exit_code_is_distinct_tempfail():
 # ---------------------------------------------------------------------------
 
 
-def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
+def _spawn_serve(
+    port: int, tmp_path: Path, merge_streams: bool = True
+) -> subprocess.Popen:
     home = tmp_path / "hermes_home"
     home.mkdir(exist_ok=True)
     env = dict(os.environ)
@@ -114,7 +116,7 @@ def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
         cwd=str(REPO_ROOT),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.STDOUT if merge_streams else subprocess.DEVNULL,
         text=True,
     )
 
@@ -176,6 +178,28 @@ def test_free_port_boots_and_announces_ready(tmp_path):
         assert ready, f"no READY sentinel; output:\n{out}"
         assert f"HERMES_BACKEND_READY port={port}" in out
         assert "BACKEND_PORT_IN_USE" not in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_ready_sentinel_lands_on_real_stdout(tmp_path):
+    """The sentinel must reach fd 1, not drift onto stderr.
+
+    ``tui_gateway.server`` reassigns ``sys.stdout`` to stderr at import time and
+    ``start_server`` imports it during startup, so a plain ``print()`` puts the
+    announcement on the wrong stream. The desktop watches the child's *stdout*
+    only: a drifted sentinel boots a perfectly healthy backend that Electron
+    still declares dead after its 90s port-announcement timeout. Every other
+    test in this file merges the two streams and cannot see the difference.
+    """
+    proc = _spawn_serve(0, tmp_path, merge_streams=False)
+    try:
+        ready, lines = _read_until(proc, "HERMES_BACKEND_READY", timeout=90.0)
+        assert ready, "READY sentinel never reached stdout:\n" + "".join(lines)
     finally:
         proc.terminate()
         try:


### PR DESCRIPTION
## What does this PR do?

The desktop app stopped booting for me on current main. It dies with:

```
[boot] Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

The backend itself is fine. It binds a port in about two seconds and answers HTTP the whole time. The problem is which stream the announcement goes out on.

`tui_gateway/server.py` does this at import time:

```python
_real_stdout = sys.stdout
sys.stdout = sys.stderr
```

That's there so a stray `print()` from some library can't corrupt the JSON-RPC stream, which is reasonable on its own. The catch is that `start_server` now imports that module during startup to get `install_exit_flush_signal_handlers`, and that import runs before the port is announced. After it, every `print()` in the process goes to stderr, including this one:

```python
print(f"{ready_token} port={actual_port}", flush=True)
```

The Electron side only reads `child.stdout` (`waitForDashboardPort` in `apps/desktop/electron/backend-ready.ts`), so it waits the full 90 seconds, gives up, and SIGTERMs a backend that had been ready since second two. The renderer is then stuck looping on `refreshProfiles failed after 3 attempt(s)`.

The logs look self-contradictory until you spot this, because `rememberLog` is attached to stdout and stderr both. The READY line sits in `desktop.log` a few lines above a timeout claiming it never showed up.

The `BACKEND_PORT_IN_USE` sentinel has the same problem, since it's printed after that import too. A genuine port conflict would come out as the generic 90 second timeout instead of the sentinel plus exit 75, which defeats what #93608 added.

So both sentinels now write to `sys.__stdout__`, the interpreter's original stdout, which still points at fd 1 no matter what `sys.stdout` has been reassigned to.

The issue suggests `os.write(1, ...)`. That hits the same descriptor and would work. I went with `sys.__stdout__` because it keeps the text mode and encoding of the prints around it, and because it degrades sensibly under pythonw on Windows, where `sys.__stdout__` is None and there's no console to write to anyway. That launch path already gets the port through `HERMES_DESKTOP_READY_FILE`.

## Related Issue

Fixes #96282

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: new `_announce_stream()` helper. Returns `sys.__stdout__`, or falls back to `sys.stdout` if that's None or closed.
- `hermes_cli/web_server.py`: `_report_port_in_use()` writes its sentinel and the human hint through that stream.
- `hermes_cli/web_server.py`: the ready sentinel and the "listening on" / "Web UI" line after it go through the same stream.
- `tests/hermes_cli/test_serve_port_in_use.py`: `_spawn_serve` takes a `merge_streams` argument, defaulting to True so the existing tests behave exactly as before, plus a new test that spawns with the two streams kept apart.

Nothing else is touched. The redirect in `tui_gateway/server.py` stays as it is, since other callers rely on it.

## How to Test

On main, run serve with the streams separated and watch the sentinel land on the wrong one:

```
$ python -m hermes_cli.main serve --host 127.0.0.1 --port 0 > out.log 2> err.log
$ cat out.log      # empty
$ cat err.log
HERMES_BACKEND_READY port=57533
  Hermes backend listening on 127.0.0.1:57533
```

On this branch the same command puts it in `out.log`.

For the test:

```
$ pytest tests/hermes_cli/test_serve_port_in_use.py -q
9 passed in 2.88s
```

Keep the new test and revert `hermes_cli/web_server.py` on its own, and you get the desktop's exact failure mode, a 90 second wait and then nothing on stdout:

```
FAILED tests/hermes_cli/test_serve_port_in_use.py::test_ready_sentinel_lands_on_real_stdout
AssertionError: READY sentinel never reached stdout
1 failed in 90.37s
```

Worth noting why CI never caught this: `_spawn_serve` was passing `stderr=subprocess.STDOUT`, so the sentinel passed the assertions no matter which stream it came out of.

Last check is the desktop app itself, launched before and after on the same machine. Logs below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on Apple Silicon (Darwin 25.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - the new helper carries a docstring explaining the import ordering trap, so the next person who adds a print here knows why it's not a plain `print()`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - fixed on macOS, and the Windows pythonw path is unaffected because `sys.__stdout__` is None there and the fallback keeps the old behavior, with the port still travelling through the ready file
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

`~/.hermes/logs/desktop.log` before:

```
[boot] Waiting for Hermes backend to launch
HERMES_BACKEND_READY port=57166
  Hermes backend listening on 127.0.0.1:57166
Ignoring stale Hermes backend exit (SIGTERM)
[boot] Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

After:

```
[boot] Waiting for Hermes backend to launch
HERMES_BACKEND_READY port=58086
  Hermes backend listening on 127.0.0.1:58086
[boot] Waiting for Hermes backend to become ready
[boot] Hermes backend is ready. Finalizing desktop startup
```

Ready in about a second, and `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:58086/api/status` gives 200.
