### PR TITLE
fix(mcp): isolate tool errors from server breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,40 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_tool_level_errors_do_not_trip_server_circuit_breaker(monkeypatch, tmp_path):
+    """A valid MCP error response proves the transport is still reachable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_not_found(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.is_error = True
+        block = MagicMock()
+        block.text = "Task not found"
+        result.content = [block]
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_not_found)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "task_detail", 10.0)
+        attempts = mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+        for _ in range(attempts):
+            parsed = json.loads(handler({}))
+            assert parsed.get("error") == "Task not found", parsed
+
+        assert call_count["n"] == attempts
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5818,7 +5818,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        rpc_response_received = False
+
         async def _call():
+            nonlocal rpc_response_received
+            rpc_response_received = False
             _mark_server_call_started(server)
             async with server._rpc_lock:
                 # Snapshot the agent's context so an elicitation callback
@@ -5830,6 +5834,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     result = await server.session.call_tool(tool_name, arguments=args)
                 finally:
                     server._pending_call_context = None
+            rpc_response_received = True
             # The RPC round-trip completed — the session is demonstrably
             # healthy at the transport level (even if the tool itself
             # returned isError). Clear the rapid-drop budget (#62212).
@@ -5969,7 +5974,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    if rpc_response_received:
+                        _reset_server_error(server_name)
+                    else:
+                        _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Summary

- Treat a valid MCP JSON-RPC response as transport health even when the tool result is an expected error.
- Keep tool-level failures visible to the model without incrementing the whole-server circuit breaker.
- Preserve breaker increments for actual transport failures.

## Why

A Deft `task_detail` miss returns a healthy MCP response with a tool error. Three such replies previously disabled the entire MCP server, so unrelated tools became unavailable even though transport remained healthy.

## Validation

- `8 passed` in `tests/tools/test_mcp_circuit_breaker.py`.
- Two live Hermes profiles continued after three tool-level `task_detail` errors; one recovered with later successful calls and neither emitted a server-unreachable breaker error.
- The follow-up Deft pilot completed both deliveries with six successful task-detail calls.