### PR TITLE
fix(serve): write machine sentinels to real fd 1 so the desktop handshake survives the stdout redirect (#96282)

### DIFF
--- a/contributors/emails/me@kitsonkelly.com
+++ b/contributors/emails/me@kitsonkelly.com
@@ -1,0 +1,2 @@
+kitsonk
+# PR #96284 salvage

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19515,9 +19515,27 @@ def _port_bind_conflict(host: str, port: int) -> bool:
     return False
 
 
+def _write_machine_sentinel_line(line: str) -> None:
+    """Write a machine-parsed sentinel line to the REAL stdout (fd 1).
+
+    The serve startup path imports ``tui_gateway.server`` (flush-on-SIGTERM
+    handlers, #94724) which redirects ``sys.stdout`` to ``sys.stderr`` at
+    import time to keep stray prints off the JSON-RPC protocol stream. Any
+    machine-readable sentinel printed after that import via ``print()`` lands
+    on stderr — invisible to consumers that parse the child's stdout pipe
+    (the Desktop spawn, scripts). fd 1 is untouched by the Python-level
+    redirect, so write there; fall back to ``print`` for exotic environments
+    where fd 1 isn't writable (e.g. closed).
+    """
+    try:
+        os.write(1, (line + "\n").encode())
+    except OSError:
+        print(line, flush=True)
+
+
 def _report_port_in_use(host: str, port: int) -> None:
     """Print the machine sentinel + a human hint naming likely holders."""
-    print(_PORT_IN_USE_SENTINEL.format(port=port), flush=True)
+    _write_machine_sentinel_line(_PORT_IN_USE_SENTINEL.format(port=port))
     print(
         f"  Port {port} on {host} is already in use — likely another "
         "'hermes serve' / 'hermes dashboard' backend or the Hermes gateway. "
@@ -19894,12 +19912,8 @@ def start_server(
             # still the real stdout — and the Desktop spawn watches
             # child.stdout for this sentinel — so write to the fd, not to the
             # (redirected) sys.stdout, or the desktop times out after 90s
-            # against a perfectly healthy backend.
-            _ready_line = f"{ready_token} port={actual_port}\n"
-            try:
-                os.write(1, _ready_line.encode())
-            except OSError:
-                print(_ready_line, end="", flush=True)
+            # against a perfectly healthy backend (#96282).
+            _write_machine_sentinel_line(f"{ready_token} port={actual_port}")
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19524,13 +19524,22 @@ def _write_machine_sentinel_line(line: str) -> None:
     machine-readable sentinel printed after that import via ``print()`` lands
     on stderr — invisible to consumers that parse the child's stdout pipe
     (the Desktop spawn, scripts). fd 1 is untouched by the Python-level
-    redirect, so write there; fall back to ``print`` for exotic environments
-    where fd 1 isn't writable (e.g. closed).
+    redirect, so write there.
+
+    Best-effort by design: if fd 1 is unwritable (closed; invalid under
+    pythonw.exe), fall back to ``print()`` for human visibility only — the
+    redirected stream can't reach stdout-parsing consumers, and pythonw
+    Desktop spawns rely on ``_write_dashboard_ready_file()`` (the
+    HERMES_DESKTOP_READY_FILE channel) for port discovery instead. Never
+    raises: a sentinel-delivery failure must not kill a healthy serve.
     """
     try:
         os.write(1, (line + "\n").encode())
     except OSError:
-        print(line, flush=True)
+        try:
+            print(line, flush=True)
+        except Exception:
+            pass
 
 
 def _report_port_in_use(host: str, port: int) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19888,7 +19888,18 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # tui_gateway.server (imported above for the flush-on-SIGTERM
+            # handlers, #94724) redirects sys.stdout→sys.stderr at import time
+            # to keep stray prints off the JSON-RPC protocol stream. fd 1 is
+            # still the real stdout — and the Desktop spawn watches
+            # child.stdout for this sentinel — so write to the fd, not to the
+            # (redirected) sys.stdout, or the desktop times out after 90s
+            # against a perfectly healthy backend.
+            _ready_line = f"{ready_token} port={actual_port}\n"
+            try:
+                os.write(1, _ready_line.encode())
+            except OSError:
+                print(_ready_line, end="", flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -114,7 +114,12 @@ def _spawn_serve(port: int, tmp_path: Path, merge_stderr: bool = True) -> subpro
         cwd=str(REPO_ROOT),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
+        # merge_stderr=False: the caller only asserts on stdout. Discard
+        # stderr instead of piping it — with the serve-path stdout redirect
+        # active ALL server logging lands on stderr, and an unread stderr
+        # pipe can fill (~64KB) and block the child before it ever emits
+        # the READY sentinel, turning the test into a timeout flake.
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL,
         text=True,
     )
 
@@ -237,10 +242,3 @@ def test_ready_sentinel_arrives_on_stdout_not_stderr(tmp_path):
             proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
             proc.kill()
-        # Drain stderr after exit so the pipe doesn't fill and block the child
-        # on platforms with small pipe buffers.
-        if proc.stderr is not None:
-            try:
-                proc.stderr.read()
-            except Exception:
-                pass

--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -91,7 +91,7 @@ def test_exit_code_is_distinct_tempfail():
 # ---------------------------------------------------------------------------
 
 
-def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
+def _spawn_serve(port: int, tmp_path: Path, merge_stderr: bool = True) -> subprocess.Popen:
     home = tmp_path / "hermes_home"
     home.mkdir(exist_ok=True)
     env = dict(os.environ)
@@ -114,7 +114,7 @@ def _spawn_serve(port: int, tmp_path: Path) -> subprocess.Popen:
         cwd=str(REPO_ROOT),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
         text=True,
     )
 
@@ -201,3 +201,46 @@ def test_ephemeral_port_zero_unaffected(tmp_path):
             proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+def test_ready_sentinel_arrives_on_stdout_not_stderr(tmp_path):
+    """#96282 — the Desktop spawn watches child.stdout for the READY sentinel.
+
+    ``tui_gateway.server`` (imported on the serve startup path since 6d4e851d8
+    for the flush-on-SIGTERM handlers) redirects ``sys.stdout`` to
+    ``sys.stderr`` at import time. If the sentinel is printed through the
+    redirected ``sys.stdout``, it lands on stderr and the desktop times out
+    after 90s against a perfectly healthy backend. The sentinel must reach
+    the real stdout (fd 1).
+
+    The other E2E tests here merge stderr into stdout, which is exactly how
+    the regression slipped past CI — this test keeps the streams separate.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    proc = _spawn_serve(port, tmp_path, merge_stderr=False)
+    try:
+        # stdout only: the sentinel MUST arrive here (desktop watches this pipe)
+        ready, lines = _read_until(proc, "HERMES_BACKEND_READY")
+        out = "".join(lines)
+        assert ready, (
+            f"READY sentinel not on stdout (desktop boot would time out); "
+            f"stdout:\n{out}"
+        )
+        assert f"HERMES_BACKEND_READY port={port}" in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        # Drain stderr after exit so the pipe doesn't fill and block the child
+        # on platforms with small pipe buffers.
+        if proc.stderr is not None:
+            try:
+                proc.stderr.read()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

Desktop boot no longer times out at 90s against a healthy backend: the machine-parsed startup sentinels (`HERMES_BACKEND_READY` / `HERMES_DASHBOARD_READY`, and the sibling `BACKEND_PORT_IN_USE`) are now written to the real stdout file descriptor (fd 1), which the Python-level `sys.stdout` redirect cannot reroute.

Fixes #96282. Also resolves the symptom wave in #96279 and #96291.

Salvage of #96284 by @kitsonk (authorship preserved via cherry-pick) + a follow-up commit widening the fix to the sibling sentinel site.

## Root cause

`tui_gateway/server.py` swaps `sys.stdout = sys.stderr` at import time (legitimate: keeps stray prints off its JSON-RPC protocol stream). Since 6d4e851d8 (#94724 item 2) the serve startup path imports `tui_gateway.server` for the flush-on-SIGTERM handlers **before** printing the READY sentinel — so the sentinel landed on stderr, while the Electron desktop spawn (`apps/desktop/electron/backend-ready.ts`, `waitForDashboardPort`) watches **child.stdout only**. Healthy backend announces in ~2s; desktop times out at 90s, SIGTERMs it, and the renderer loops `refreshProfiles failed`.

CI missed it because the existing serve E2E tests spawn with `stderr=subprocess.STDOUT`, merging the streams.

## Changes

- `hermes_cli/web_server.py`: new `_write_machine_sentinel_line()` — `os.write(1, ...)` with a `print()` fallback if fd 1 is unwritable; used for the READY sentinel (contributor commit) and for `BACKEND_PORT_IN_USE` in `_report_port_in_use()` (follow-up — same bug class, both callers run after the redirect). Human-facing hint lines stay on `print()`.
- `tests/hermes_cli/test_serve_port_in_use.py`: `test_ready_sentinel_arrives_on_stdout_not_stderr` — spawns a real serve with stdout/stderr captured **separately** and asserts the sentinel arrives on stdout (the exact gap that let this slip past CI).

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_serve_port_in_use.py` (9 tests, real subprocess spawns) | pass |
| Mutation check: prod file reverted to origin/main, regression test | fails (times out waiting for stdout sentinel) — test genuinely pins the fix |
| E2E split-stream: `HERMES_BACKEND_READY port=<n>` on stdout | pass |
| E2E split-stream: second serve on the same port → `BACKEND_PORT_IN_USE` on stdout, exit 75, count==1 | pass |
| ruff on both touched files | clean |

## Credit

Root cause analysis, fix, and regression test by @kitsonk (#96284, issue #96282). Competing PRs #96289 (@jamesxia1988) and #92631 (@thanhdtr) identified the same fd-1 approach — #92631 notably pre-diagnosed the bug class on Aug 23 via a different import path, before 6d4e851d8 made it unconditional.

Closes #96284.
