### PR TITLE
fix(desktop): keep restarted sessions on their owner

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -30,6 +30,7 @@ import {
 } from './backend-ready'
 
 type FakeChildProcess = EventEmitter & {
+  stderr: EventEmitter
   stdout: EventEmitter
 }
 
@@ -38,6 +39,7 @@ type FakeChildProcess = EventEmitter & {
 // (child.stdout.on('data'), child.on('exit'|'error') + the .off() teardown).
 function makeFakeChild(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
+  child.stderr = new EventEmitter()
   child.stdout = new EventEmitter()
 
   return child
@@ -96,6 +98,24 @@ test('resolves with a HERMES_BACKEND_READY port (headless `serve`)', async () =>
   const child = makeFakeChild()
   const p = waitForDashboardPort(child, 1000)
   child.stdout.emit('data', 'HERMES_BACKEND_READY port=43210\n')
+  assert.equal(await p, 43210)
+})
+
+test('resolves when the runtime announces readiness on stderr', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stderr.emit('data', 'HERMES_BACKEND_READY port=43210\n')
+  assert.equal(await p, 43210)
+})
+
+test('resolves from output buffered before the watcher attached', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(
+    child,
+    1000,
+    () => '',
+    () => 'HERMES_BACKEND_READY port=43210\n'
+  )
   assert.equal(await p, 43210)
 })
 

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -35,7 +35,7 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
 }
 
 /**
- * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
+ * Watch a child process's output for the `HERMES_(BACKEND|DASHBOARD)_READY
  * port=<N>` line that web_server.py prints after uvicorn binds its socket.
  *
  * Returns the parsed port. Rejects if:
@@ -51,7 +51,12 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  * on every terminal path — resolve, reject, or timeout — so repeated
  * backend spawns don't leak listener slots on the child.
  */
-function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
+function waitForDashboardPort(
+  child,
+  timeoutMs = resolvePortAnnounceTimeoutMs(),
+  describeOutputTail = () => '',
+  bufferedOutput = () => ''
+) {
   return new Promise((resolve, reject) => {
     let buf = ''
     let done = false
@@ -64,6 +69,7 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
       done = true
       clearTimeout(timer)
       child.stdout.off('data', onData)
+      child.stderr?.off('data', onData)
       child.off('exit', onExit)
       child.off('error', onError)
     }
@@ -102,8 +108,10 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
     }, timeoutMs)
 
     child.stdout.on('data', onData)
+    child.stderr?.on('data', onData)
     child.on('exit', onExit)
     child.on('error', onError)
+    onData(bufferedOutput())
   })
 }
 
@@ -189,6 +197,8 @@ function waitForDashboardPortAnnouncement(
   options: {
     /** Returns a formatted stdout/stderr tail suffix for exit errors (#93608). */
     describeOutputTail?: () => string
+    /** Returns output captured before this watcher attached. */
+    bufferedOutput?: () => string
     readyFile?: fs.PathOrFileDescriptor | null
     timeoutMs?: number
   } = {}
@@ -200,7 +210,7 @@ function waitForDashboardPortAnnouncement(
     return waitForDashboardReadyFile(options.readyFile, child, timeoutMs, describeOutputTail)
   }
 
-  return waitForDashboardPort(child, timeoutMs, describeOutputTail)
+  return waitForDashboardPort(child, timeoutMs, describeOutputTail, options.bufferedOutput)
 }
 
 export {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12104,7 +12104,11 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   // Discover the ephemeral port the child bound to
   const port = await Promise.race([
-    waitForDashboardPortAnnouncement(child, { describeOutputTail: () => outputTail.describe(), readyFile }),
+    waitForDashboardPortAnnouncement(child, {
+      bufferedOutput: () => outputTail.text(),
+      describeOutputTail: () => outputTail.describe(),
+      readyFile
+    }),
     startFailed
   ])
 
@@ -12545,6 +12549,7 @@ async function startHermes() {
     // Discover the ephemeral port the child bound to
     const port = await Promise.race([
       waitForDashboardPortAnnouncement(hermesProcess, {
+        bufferedOutput: () => primaryOutputTail.text(),
         describeOutputTail: () => primaryOutputTail.describe(),
         readyFile
       }),

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
 import { setSessionOwnerHint, setSessions } from '@/store/session'
-import { sessionTileDelegate } from '@/store/session-states'
+import {
+  $sessionTiles,
+  _resetSessionOwnerHoldsForTests,
+  foregroundSessionScopes,
+  sessionTileDelegate
+} from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
 import { useSessionTileDelegate } from './use-session-tile-delegate'
@@ -64,11 +69,15 @@ function renderTile(
 describe('useSessionTileDelegate resumeTile', () => {
   beforeEach(() => {
     setSessions([])
+    $sessionTiles.set([])
+    _resetSessionOwnerHoldsForTests()
     vi.mocked(getLatestSessionMessages).mockClear()
   })
 
   afterEach(() => {
     setSessions([])
+    $sessionTiles.set([])
+    _resetSessionOwnerHoldsForTests()
   })
 
   it('carries the owning profile into a cold tile resume so it cannot fork profiles', async () => {
@@ -149,6 +158,22 @@ describe('useSessionTileDelegate resumeTile', () => {
       profile: 'default'
     })
     expect(ambientRequest).not.toHaveBeenCalled()
+  })
+
+  it('pins a resolved tile owner until the resumed runtime becomes foreground', async () => {
+    $sessionTiles.set([{ storedSessionId: 'stored-routed' }])
+    setSessions([row({ connection_id: 'source-b', id: 'stored-routed', profile: 'default' })])
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockImplementationOnce(async () => {
+      expect(foregroundSessionScopes()).toEqual(new Set(['conn:source-b::default']))
+
+      return { session_id: 'runtime-routed' } as never
+    })
+
+    renderTile(ambientRequest)
+
+    await expect(sessionTileDelegate()!.resumeTile('stored-routed')).resolves.toBe('runtime-routed')
   })
 
   it('routes a Bot tile prefetch and resume through its exact connection owner', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -16,7 +16,12 @@ import {
 import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
-import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
+import {
+  holdSessionOwnerUntilForeground,
+  publishSessionState,
+  sessionTileOwnerRoute,
+  setSessionTileDelegate
+} from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
@@ -204,6 +209,7 @@ export function useSessionTileDelegate({
         // launch-profile DB and fork the conversation into the wrong profile —
         // the same cross-profile bleed the recovery resumes had (#67603).
         const owner = await ownerForStoredSession(storedSessionId)
+        const releaseOwnerHold = holdSessionOwnerUntilForeground(storedSessionId, owner)
 
         const restScope =
           owner && typeof owner === 'object'
@@ -240,7 +246,10 @@ export function useSessionTileDelegate({
 
             return stored
           }
-        )
+        ).catch(error => {
+          releaseOwnerHold()
+          throw error
+        })
 
         const prefetch = await prefetchPromise
 
@@ -257,13 +266,13 @@ export function useSessionTileDelegate({
             }),
             storedSessionId
           )
-
           notify({
             kind: 'info',
             title: translateNow('desktop.readOnlyTranscriptTitle'),
             message: translateNow('desktop.readOnlyTranscriptBody')
           })
 
+          releaseOwnerHold()
           return readOnlyId
         }
 
@@ -272,6 +281,7 @@ export function useSessionTileDelegate({
         const runtimeId = resumed?.session_id
 
         if (!runtimeId) {
+          releaseOwnerHold()
           throw new Error('resume returned no session id')
         }
 

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -62,13 +62,13 @@ describe('selectProfile', () => {
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
 
-  it('keeps the legacy profile-only path when the explicit local source is live', async () => {
+  it('keeps the pick on the explicit local registry source', async () => {
     activeGatewayConnectionId.mockReturnValue('local')
 
     selectProfile('override-profile')
 
-    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
-    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'override-profile'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 })
 
@@ -82,13 +82,13 @@ describe('newSessionInProfile', () => {
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 
-  it('keeps the legacy profile-only path for a new chat on the explicit local source', async () => {
+  it('keeps a new chat on the explicit local registry source', async () => {
     activeGatewayConnectionId.mockReturnValue('local')
 
     newSessionInProfile('override-profile')
 
-    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
-    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'override-profile'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,4 +1,3 @@
-import { LOCAL_CONNECTION_ID } from '@hermes/shared'
 import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -268,8 +267,7 @@ export const $newChatRoute = atom<AgentProfileRoute | null>(null)
 // string "omar", and every follow-up RPC dialed requestGatewayForProfile
 // ("omar") — a DIFFERENT socket than the one that created the session —
 // and 4001'd "session not found" (#94071). null = the intent dials the legacy
-// profile-only path (a v1 primary with no registry identity, or a profile
-// pick on the explicit `local` source — see profilePickConnectionId).
+// profile-only path for a v1 primary with no registry identity.
 export const $newChatConnectionId = atom<null | string>(null)
 
 /** Capture the registry source a new-chat profile intent lands on — by
@@ -281,17 +279,13 @@ export function captureNewChatSource(connectionId: null | string = activeGateway
 
 /**
  * The registry source a PROFILE PICK dials, mirroring activateOnCurrentSource:
- * a live remote registry source keeps its connection id, while the primary and
- * the explicit `local` source take the legacy profile-only path (null) so the
- * main process can resolve a per-profile remote override before falling back
- * to a local backend. The draft's owner must name the socket that activation
- * dials — capturing `local` for a pick would mint the session on the registry
- * entry local::x while the window shows the override's socket.
+ * every live registry source keeps its connection id. In particular, the
+ * explicit `local` source means This device and must not fall through the v1
+ * global route, which may point at a remote primary. Only a primary with no
+ * registry identity uses the legacy profile-only path.
  */
 function profilePickConnectionId(): null | string {
-  const connectionId = activeGatewayConnectionId()
-
-  return connectionId && connectionId !== LOCAL_CONNECTION_ID ? connectionId : null
+  return activeGatewayConnectionId()
 }
 
 /**

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -4,8 +4,10 @@ import {
   $selectedStoredSessionId,
   _resetSessionOwnerHintsForTests,
   setActiveSessionId,
-  setSessionOwnerHint
+  setSessionOwnerHint,
+  setSessions
 } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
 
 import {
   $sessionOwnerHoldRevision,
@@ -30,6 +32,7 @@ afterEach(() => {
   $selectedStoredSessionId.set(null)
   _resetSessionOwnerHoldsForTests()
   _resetSessionOwnerHintsForTests({ storage: true })
+  setSessions([])
   vi.useRealTimers()
 })
 
@@ -84,6 +87,27 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     holdSessionOwnerUntilForeground('stored-c', omar)
     vi.advanceTimersByTime(60_000 + 1)
     expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('keeps an ownerless session tile pinned after its transition hold expires', () => {
+    vi.useFakeTimers()
+    setSessions([{ id: 'stored-mali', profile: 'mali' } as SessionInfo])
+    $sessionTiles.set([{ storedSessionId: 'stored-mali' }])
+    holdSessionOwnerUntilForeground('stored-mali', 'mali')
+
+    vi.advanceTimersByTime(60_000 + 1)
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['mali']))
+  })
+
+  it.each([
+    [{ id: 'stored-mali', profile: 'mali' }, 'mali'],
+    [{ id: 'stored-upwork', connection_id: 'local', profile: 'default' }, 'conn:local::default']
+  ])('keeps a selected session owner pinned after restart (%s)', (session, expectedScope) => {
+    setSessions([session as SessionInfo])
+    $selectedStoredSessionId.set(session.id)
+
+    expect(foregroundSessionScopes()).toEqual(new Set([expectedScope]))
   })
 
   it('publishes hold release and TTL expiry so pending gateway redials can drain without unrelated UI state', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -191,7 +191,7 @@ export function _resetSessionOwnerHoldsForTests(): void {
  * is cleared, so the primary runtime must survive that handoff. Open panes have
  * the same ownership contract: a non-focused idle tile is still user-visible
  * state and must not be evicted just because another pane has focus. Prefer the
- * live event scope, with the tile's persisted route as the pre-bind fallback.
+ * live event scope, with the tile's known owner as the pre-bind fallback.
  *
  * A just-created session's owner is named by its create → foreground hold
  * (holdSessionOwnerUntilForeground) until the selected/tiled publication or
@@ -209,9 +209,15 @@ export function foregroundSessionScopes(): Set<string> {
     }
   }
 
-  const addRouteScope = (route: SessionOwnerRoute | undefined) => {
-    const connectionId = route?.connectionId?.trim()
-    const profile = route?.profile?.trim()
+  const addOwnerScope = (owner: SessionOwnerScope) => {
+    if (typeof owner === 'string') {
+      scopes.add(normalizeProfileKey(owner))
+
+      return
+    }
+
+    const connectionId = owner?.connectionId?.trim()
+    const profile = owner?.profile?.trim()
 
     if (connectionId && profile) {
       scopes.add(registryBackendScopeKey(connectionId, profile))
@@ -219,10 +225,11 @@ export function foregroundSessionScopes(): Set<string> {
   }
 
   addRuntimeScope($activeSessionId.get() ?? undefined)
+  addOwnerScope(knownOwnerForSession($selectedStoredSessionId.get()))
 
   for (const tile of $sessionTiles.get()) {
     addRuntimeScope(tile.runtimeId)
-    addRouteScope(tile.ownerRoute)
+    addOwnerScope(knownOwnerForSession(tile.storedSessionId))
   }
 
   // Create → foreground holds. A hold whose scope the rungs above already


### PR DESCRIPTION
## What

- Keep selected and tiled stored-session owner scopes foregrounded after restart.
- Retain a cold-resume owner until the runtime publishes foreground state.
- Keep explicit local profile selections on This device.
- Accept backend READY announcements from stderr or buffered output.

## Why

After restart, a stored session in All Profiles can have no live runtime scope yet. The idle pruner then closes its owner socket, causing repeated loader flashes. The previous hold only delayed that failure. The current `hermes serve` process can also emit READY on stderr, and local profile picks could fall through the legacy remote primary route.

## Verification

- 69 targeted desktop tests passed.
- Desktop type-check passed.
- Signed macOS build passed `codesign --verify --deep --strict`.
- Exact-head UI checks: default, Daniela, Dexter, James, and Mali stayed on This device with zero post-ready anomalies.
- Exact-head All Profiles persisted-session watch: 25 of 25 clean samples.
- Longer All Profiles watch before the final upstream rebase: 85 of 85 clean samples.

No new dependencies.