### PR TITLE
fix(docker): forwarded env values leave world-readable argv

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -172,6 +172,7 @@ def _make_execute_only_env(forward_env=None):
     env._snapshot_ready = True
     env._last_sync_time = None
     env._init_env_args = []
+    env._init_env_values = {}
     return env
 
 
@@ -184,10 +185,12 @@ def test_init_env_args_uses_hermes_dotenv_for_allowlisted_env(monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {"DATABASE_URL": "value_from_dotenv"})
 
-    args = env._build_init_env_args()
-    args_str = " ".join(args)
+    args, values = env._build_init_env_args()
 
-    assert "DATABASE_URL=value_from_dotenv" in args_str
+    # Name-only argv (#96268): the value never appears in the command line.
+    assert "-e" in args and "DATABASE_URL" in args
+    assert "DATABASE_URL=value_from_dotenv" not in " ".join(args)
+    assert values["DATABASE_URL"] == "value_from_dotenv"
 
 
 def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
@@ -197,11 +200,10 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "value_from_shell")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {"DATABASE_URL": "value_from_dotenv"})
 
-    args = env._build_init_env_args()
-    args_str = " ".join(args)
+    _args, values = env._build_init_env_args()
 
-    assert "DATABASE_URL=value_from_shell" in args_str
-    assert "value_from_dotenv" not in args_str
+    assert values["DATABASE_URL"] == "value_from_shell"
+    assert "value_from_dotenv" not in values.values()
 
 
 def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
@@ -216,12 +218,12 @@ def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
     monkeypatch.setenv("MY_SECRET", "")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {"MY_SECRET": "value_from_dotenv"})
 
-    args = env._build_init_env_args()
+    args, values = env._build_init_env_args()
 
-    # Assert on the resolved value, not the printed -e flag: the disk value
-    # must win and a blank "MY_SECRET=" flag must never be emitted.
-    assert "MY_SECRET=value_from_dotenv" in args
-    assert "MY_SECRET=" not in args
+    # Assert on the resolved value, not a printed -e flag: the disk value
+    # must win and the argv never carries values at all (#96268).
+    assert values["MY_SECRET"] == "value_from_dotenv"
+    assert all(arg != "MY_SECRET=" for arg in args)
 
 
 def test_init_env_args_uses_active_profile_for_forwarded_env(monkeypatch):
@@ -234,13 +236,13 @@ def test_init_env_args_uses_active_profile_for_forwarded_env(monkeypatch):
     ss.set_multiplex_active(True)
     token = ss.set_secret_scope({"SERVICE_TOKEN": "token-for-routed-profile"})
     try:
-        args = env._build_init_env_args()
+        _args, values = env._build_init_env_args()
     finally:
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    assert "SERVICE_TOKEN=token-for-routed-profile" in args
-    assert "SERVICE_TOKEN=token-for-default" not in args
+    assert values["SERVICE_TOKEN"] == "token-for-routed-profile"
+    assert "token-for-default" not in values.values()
 
 
 def test_init_env_args_omits_missing_scoped_forwarded_env(monkeypatch):
@@ -253,12 +255,12 @@ def test_init_env_args_omits_missing_scoped_forwarded_env(monkeypatch):
     ss.set_multiplex_active(True)
     token = ss.set_secret_scope({})
     try:
-        args = env._build_init_env_args()
+        args, values = env._build_init_env_args()
     finally:
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    assert "SERVICE_TOKEN=token-for-default" not in args
+    assert "SERVICE_TOKEN" not in values
     assert "SERVICE_TOKEN" not in args
 
 
@@ -273,7 +275,7 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
     monkeypatch.setattr(
         docker_env,
         "_popen_bash",
-        lambda cmd, stdin_data=None: calls.append((cmd, stdin_data)) or object(),
+        lambda cmd, stdin_data=None, **kwargs: calls.append((cmd, kwargs)) or object(),
     )
     ss.set_multiplex_active(True)
     token = ss.set_secret_scope({"SERVICE_TOKEN": "token-for-profile-a"})
@@ -289,11 +291,16 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    first_cmd = calls[0][0]
-    assert "SERVICE_TOKEN=token-for-profile-a" in first_cmd
-    second_cmd = calls[1][0]
-    assert "SERVICE_TOKEN=token-for-profile-a" not in second_cmd
+    first_cmd, first_kwargs = calls[0]
+    # The value reaches the docker client through the subprocess environment,
+    # never through argv (#96268).
+    assert "-e" in first_cmd and "SERVICE_TOKEN" in first_cmd
+    assert "SERVICE_TOKEN=token-for-profile-a" not in first_cmd
+    assert first_kwargs["env"]["SERVICE_TOKEN"] == "token-for-profile-a"
+    second_cmd, second_kwargs = calls[1]
+    assert "SERVICE_TOKEN" not in second_cmd
     assert "unset SERVICE_TOKEN" in second_cmd[-1]
+    assert "SERVICE_TOKEN" not in (second_kwargs.get("env") or {})
 
 
 def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, tmp_path):
@@ -312,15 +319,18 @@ def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, t
     monkeypatch.setenv("EXPLICIT_TOKEN", "token-for-default")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
 
-    def _run_fake_docker_exec(cmd, stdin_data=None):
+    def _run_fake_docker_exec(cmd, stdin_data=None, **kwargs):
         """Execute the generated docker exec command in a real local bash."""
         container_index = cmd.index(env._container_id)
         child_env = os.environ.copy()
+        child_env.update(kwargs.get("env") or {})
         index = 2
         while index < container_index:
             assert cmd[index] == "-e"
-            key, value = cmd[index + 1].split("=", 1)
-            child_env[key] = value
+            # Name-only flags (#96268): the value arrives via the client
+            # subprocess env, never through argv.
+            assert "=" not in cmd[index + 1]
+            assert cmd[index + 1] in child_env
             index += 2
         assert cmd[container_index + 1 : container_index + 3] == ["bash", "-c"]
         return subprocess.Popen(
@@ -414,11 +424,10 @@ def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     monkeypatch.setenv("MY_KEY", "dynamic_value")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
 
-    args = env._build_init_env_args()
-    args_str = " ".join(args)
+    _args, values = env._build_init_env_args()
 
-    assert "MY_KEY=dynamic_value" in args_str
-    assert "MY_KEY=static_value" not in args_str
+    assert values["MY_KEY"] == "dynamic_value"
+    assert "static_value" not in values.values()
 
 
 def test_normalize_env_dict_filters_invalid_keys():

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1552,16 +1552,24 @@ class DockerEnvironment(BaseEnvironment):
             logger.info("Started container %s (%s)", container_name, self._container_id[:12])
 
         # Build the init-time env forwarding args used to seed the snapshot.
-        self._init_env_args = self._build_init_env_args()
+        self._init_env_args, self._init_env_values = self._build_init_env_args()
 
         # Initialize session snapshot inside the container
         self.init_session()
 
-    def _build_init_env_args(self) -> list[str]:
-        """Build -e KEY=VALUE args for injecting host env vars into init_session.
+    def _build_init_env_args(self) -> tuple[list[str], dict[str, str]]:
+        """Build name-only -e KEY argv plus the values for the client env.
 
         These are used during init_session() so that export -p captures the
         configured environment and the current profile's forwarded values.
+
+        The argv carries NAMES only; the values travel through the docker
+        client subprocess's own environment (``_run_bash`` merges them into
+        ``env=``). A valueless ``-e KEY`` makes the CLI resolve the value from
+        its own environment (docker 29.x and podman alike), so behavior inside
+        the container is unchanged — but the values move out of
+        ``/proc/<pid>/cmdline``, which any local user can read, into
+        ``/proc/<pid>/environ``, which is owner-restricted (#96268).
         """
         passthrough_env, unset_names = self._resolve_passthrough_env()
         exec_env: dict[str, str] = dict(self._env)
@@ -1572,8 +1580,8 @@ class DockerEnvironment(BaseEnvironment):
 
         args = []
         for key in sorted(exec_env):
-            args.extend(["-e", f"{key}={exec_env[key]}"])
-        return args
+            args.extend(["-e", key])
+        return args, exec_env
 
     def _build_passthrough_env(self) -> dict[str, str]:
         """Resolve forwarded host variables through the active profile scope."""
@@ -1619,17 +1627,23 @@ class DockerEnvironment(BaseEnvironment):
                 unset_names.add(key)
         return exec_env, unset_names
 
-    def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], tuple[str, ...]]:
-        """Build runtime forwarding args plus names absent from the active scope."""
+    def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], dict[str, str], tuple[str, ...]]:
+        """Build runtime forwarding args plus names absent from the active scope.
+
+        Same name-only argv contract as :meth:`_build_init_env_args` — the
+        returned values dict is merged into the docker client's environment by
+        the caller so secrets never appear in ``/proc/<pid>/cmdline`` (#96268).
+        """
         passthrough_env, unset_names = self._resolve_passthrough_env()
         args = []
         for key in sorted(passthrough_env):
-            args.extend(["-e", f"{key}={passthrough_env[key]}"])
-        return args, tuple(sorted(unset_names))
+            args.extend(["-e", key])
+        return args, passthrough_env, tuple(sorted(unset_names))
 
-    def _build_runtime_env_args(self) -> list[str]:
+    def _build_runtime_env_args(self) -> tuple[list[str], dict[str, str]]:
         """Build only dynamic forwarded values for a non-login command."""
-        return self._build_runtime_env_args_with_unsets()[0]
+        args, values, _unset = self._build_runtime_env_args_with_unsets()
+        return args, values
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
@@ -1644,10 +1658,12 @@ class DockerEnvironment(BaseEnvironment):
         # injected on every later command because this container can be shared
         # by multiple routed profiles in one gateway process.
         unset_names: tuple[str, ...] = ()
+        exec_env: dict[str, str] = {}
         if login:
             cmd.extend(self._init_env_args)
+            exec_env = dict(self._init_env_values)
         elif self._profile_scoped_passthrough:
-            runtime_args, unset_names = self._build_runtime_env_args_with_unsets()
+            runtime_args, exec_env, unset_names = self._build_runtime_env_args_with_unsets()
             cmd.extend(runtime_args)
 
         if login:
@@ -1663,7 +1679,13 @@ class DockerEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        return _popen_bash(cmd, stdin_data)
+        # The docker client resolves valueless ``-e KEY`` flags from its own
+        # environment, so the forwarded values ride the subprocess env
+        # (owner-only /proc/<pid>/environ) instead of world-readable argv
+        # (#96268). Inheriting os.environ keeps every non-forwarded variable
+        # the client itself may need (DOCKER_HOST, config, PATH).
+        client_env = {**os.environ, **exec_env} if exec_env else None
+        return _popen_bash(cmd, stdin_data, env=client_env)
 
     # ------------------------------------------------------------------
     # "No such container" recovery (issue #36266)


### PR DESCRIPTION
## What does this PR do?

The docker backend's `docker exec` transport emitted `-e KEY=VALUE` pairs into the argv for **every forwarded/passthrough variable on every terminal command** the agent runs. On Linux, `/proc/<pid>/cmdline` is readable by **any local user** regardless of the process owner (unlike `/proc/<pid>/environ`, which is owner-restricted) — so every allowlisted secret (e.g. a `GITLAB_TOKEN` passed through so the sandbox can reach a CI API) was visible in plain `ps aux` output to all local accounts for the duration of every call. The reporter caught this live: the same `-e GITLAB_TOKEN=<value>` wrapper showed up in `ps` around completely unrelated inner commands (#96268).

This is orthogonal to #30103 / GHSA-rhgp-j443-p4rf (those govern **which names** may pass through); this fixes the **transport of the values**:

- `_build_init_env_args` / `_build_runtime_env_args_with_unsets` now emit **name-only** `-e KEY` flags and return the values separately.
- `_run_bash` merges the values into the docker-client subprocess's own environment (`env=`), inheriting `os.environ` so non-forwarded variables the client needs (DOCKER_HOST, PATH, config) keep working.
- The docker CLI (29.x; podman behaves the same) resolves a valueless `-e KEY` from its own environment, so **behavior inside the container is unchanged** while the values move from world-readable `cmdline` to owner-restricted `environ`.

## Related Issue

Fixes #96268

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/environments/docker.py`
  - `_build_init_env_args` returns `(name-only argv, values dict)`; `init_session` stores both (`_init_env_args`, `_init_env_values`).
  - `_build_runtime_env_args_with_unsets` returns `(name-only argv, values, unset_names)`; `_build_runtime_env_args` mirrors.
  - `_run_bash` merges the values into the client subprocess env; the bash `unset` prefix for out-of-scope names is unchanged.
- `tests/tools/test_docker_environment.py`: the six existing env-arg pins moved to the new contract (value in the returned values dict / subprocess env, never in argv — `"KEY=value" not in cmd`); the real-bash exec emulator resolves name-only flags from the captured client env.

## How to Test

1. `python -m pytest tests/tools/test_docker_environment.py -q` — should pass (61 passed).
2. Adjacent suites unchanged: `python -m pytest tests/tools/test_docker_session_isolation.py tests/tools/test_docker_network_config.py tests/tools/test_env_passthrough.py -q` — should pass (55 passed).
3. Manual (per the issue): with a forwarded secret (`docker_forward_env: [GITLAB_TOKEN]`), run any terminal command and inspect `ps aux` — the docker exec argv now shows `-e GITLAB_TOKEN` (name only) while the value is absent from `/proc/<client-pid>/cmdline`; inside the container `echo "$GITLAB_TOKEN"` still prints the value.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the name-only/env= transport contract and its /proc rationale documented on the builders and in `_run_bash`)
- [x] New and existing unit tests pass locally (61 docker env + 55 adjacent)
- [x] Changes are backward compatible (container-visible environment identical — the CLI resolves valueless -e from the client env on docker 29.x and podman; argv alone changes shape)
