### PR TITLE
fix(docker): keep forwarded env values out of docker argv

### DIFF
--- a/tests/tools/test_docker_env_transport.py
+++ b/tests/tools/test_docker_env_transport.py
@@ -1,0 +1,54 @@
+"""Unit tests for the Docker container-env file transport (#96268 / #96316)."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+from tools.environments.docker_env_transport import (
+    format_container_env_file,
+    open_container_env_file,
+)
+
+
+def test_format_env_file_is_stable_and_line_oriented():
+    body = format_container_env_file({
+        "GITLAB_TOKEN": "glpat-secret",
+        "EMPTY": "",
+        "DOCKER_HOST": "tcp://evil:2375",
+    })
+    assert body.splitlines() == [
+        "DOCKER_HOST=tcp://evil:2375",
+        "EMPTY=",
+        "GITLAB_TOKEN=glpat-secret",
+    ]
+
+
+def test_format_skips_invalid_names():
+    body = format_container_env_file({
+        "GOOD": "ok",
+        "123bad": "no",
+        "also bad": "no",
+    })
+    assert body == "GOOD=ok\n"
+
+
+def test_open_env_file_is_owner_only_and_unlinks(tmp_path):
+    handle = open_container_env_file(
+        {"GITLAB_TOKEN": "glpat-secret"},
+        directory=str(tmp_path),
+    )
+    assert handle is not None
+    path = Path(handle.path)
+    assert path.is_file()
+    mode = path.stat().st_mode
+    assert stat.S_IMODE(mode) & 0o077 == 0
+    assert "GITLAB_TOKEN=glpat-secret" in path.read_text(encoding="utf-8")
+    handle.close()
+    assert not path.exists()
+    handle.close()  # idempotent
+
+
+def test_open_env_file_none_when_empty():
+    assert open_container_env_file({}) is None
+    assert open_container_env_file(None) is None

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,11 +1,25 @@
 import logging
 import os
 from io import StringIO
+from pathlib import Path
 import subprocess
 
 import pytest
 
 from tools.environments import docker as docker_env
+
+
+def _capture_env_file(cmd, kwargs):
+    """Snapshot --env-file contents before the caller unlinks the temp file."""
+    captured = dict(kwargs)
+    if isinstance(cmd, list) and "--env-file" in cmd:
+        idx = cmd.index("--env-file")
+        if idx + 1 < len(cmd):
+            try:
+                captured["_env_file_text"] = Path(cmd[idx + 1]).read_text(encoding="utf-8")
+            except OSError:
+                captured["_env_file_text"] = ""
+    return captured
 
 
 def _mock_subprocess_run(monkeypatch):
@@ -22,7 +36,8 @@ def _mock_subprocess_run(monkeypatch):
     calls = []
 
     def _run(cmd, **kwargs):
-        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        captured = _capture_env_file(cmd, kwargs)
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, captured))
         if isinstance(cmd, list) and len(cmd) >= 2:
             if cmd[1] == "version":
                 return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
@@ -190,7 +205,7 @@ def test_init_env_args_uses_hermes_dotenv_for_allowlisted_env(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert args == ["-e", "DATABASE_URL"]
+    assert "DATABASE_URL" not in args
     assert "DATABASE_URL=" not in args_str
     assert env._init_env_client["DATABASE_URL"] == "value_from_dotenv"
 
@@ -205,7 +220,7 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert args == ["-e", "DATABASE_URL"]
+    assert "DATABASE_URL" not in args
     assert "value_from_dotenv" not in args_str
     assert "value_from_shell" not in args_str
     assert env._init_env_client["DATABASE_URL"] == "value_from_shell"
@@ -227,7 +242,7 @@ def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
 
     # Values must not appear in argv (world-readable /proc/pid/cmdline).
     # A blank "MY_SECRET=" flag must never be emitted; the disk value wins.
-    assert args == ["-e", "MY_SECRET"]
+    assert "MY_SECRET" not in args
     assert "MY_SECRET=" not in args
     assert env._init_env_client["MY_SECRET"] == "value_from_dotenv"
 
@@ -247,7 +262,7 @@ def test_init_env_args_uses_active_profile_for_forwarded_env(monkeypatch):
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    assert args == ["-e", "SERVICE_TOKEN"]
+    assert "SERVICE_TOKEN" not in args
     assert "token-for-routed-profile" not in args
     assert "token-for-default" not in args
     assert env._init_env_client["SERVICE_TOKEN"] == "token-for-routed-profile"
@@ -281,11 +296,14 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
     monkeypatch.setenv("SERVICE_TOKEN", "token-for-default")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
     calls = []
-    monkeypatch.setattr(
-        docker_env,
-        "_popen_bash",
-        lambda cmd, stdin_data=None, **kwargs: calls.append((cmd, stdin_data, kwargs)) or object(),
-    )
+    def _popen(cmd, stdin_data=None, **kwargs):
+        text = ""
+        if "--env-file" in cmd:
+            text = Path(cmd[cmd.index("--env-file") + 1]).read_text(encoding="utf-8")
+        calls.append((cmd, stdin_data, kwargs, text))
+        return object()
+
+    monkeypatch.setattr(docker_env, "_popen_bash", _popen)
     ss.set_multiplex_active(True)
     token = ss.set_secret_scope({"SERVICE_TOKEN": "token-for-profile-a"})
     try:
@@ -300,10 +318,11 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    first_cmd, _, first_kwargs = calls[0]
+    first_cmd, _, first_kwargs, first_text = calls[0]
     assert "SERVICE_TOKEN=token-for-profile-a" not in first_cmd
-    assert first_cmd[first_cmd.index("-e") + 1] == "SERVICE_TOKEN"
-    assert first_kwargs["env"]["SERVICE_TOKEN"] == "token-for-profile-a"
+    assert "--env-file" in first_cmd
+    assert "env" not in first_kwargs
+    assert "SERVICE_TOKEN=token-for-profile-a" in first_text
     second_cmd = calls[1][0]
     assert "SERVICE_TOKEN=token-for-profile-a" not in second_cmd
     assert "SERVICE_TOKEN" not in second_cmd
@@ -330,16 +349,20 @@ def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, t
         """Execute the generated docker exec command in a real local bash."""
         container_index = cmd.index(env._container_id)
         child_env = os.environ.copy()
-        client_env = kwargs.get("env") or {}
+        assert kwargs.get("env") in (None, {}), "container values must not enter the docker-client env"
         index = 2
         if index < container_index and cmd[index] == "-i":
             index += 1
         while index < container_index:
-            assert cmd[index] == "-e"
-            key = cmd[index + 1]
-            assert "=" not in key, "docker exec must use name-only -e KEY (#96268)"
-            child_env[key] = client_env[key]
-            index += 2
+            if cmd[index] == "--env-file":
+                for line in Path(cmd[index + 1]).read_text(encoding="utf-8").splitlines():
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    child_env[key] = value
+                index += 2
+                continue
+            raise AssertionError(f"unexpected docker exec flag {cmd[index]!r}")
         assert cmd[container_index + 1 : container_index + 3] == ["bash", "-c"]
         return subprocess.Popen(
             ["bash", "-c", cmd[container_index + 3]],
@@ -380,7 +403,7 @@ def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, t
 
 
 def test_docker_env_appears_in_run_command(monkeypatch):
-    """Explicit docker_env values should be passed via -e at docker run time."""
+    """Explicit docker_env values should reach the container via --env-file."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _mock_subprocess_run(monkeypatch)
 
@@ -392,13 +415,97 @@ def test_docker_env_appears_in_run_command(monkeypatch):
     run_args_str = " ".join(run_args)
     assert "SSH_AUTH_SOCK=/run/user/1000/ssh-agent.sock" not in run_args_str
     assert "GNUPGHOME=/root/.gnupg" not in run_args_str
-    sock_idx = run_args.index("SSH_AUTH_SOCK")
-    assert run_args[sock_idx - 1] == "-e"
-    gnupg_idx = run_args.index("GNUPGHOME")
-    assert run_args[gnupg_idx - 1] == "-e"
-    client_env = run_kwargs["env"]
-    assert client_env["SSH_AUTH_SOCK"] == "/run/user/1000/ssh-agent.sock"
-    assert client_env["GNUPGHOME"] == "/root/.gnupg"
+    assert "--env-file" in run_args
+    text = run_kwargs["_env_file_text"]
+    assert "SSH_AUTH_SOCK=/run/user/1000/ssh-agent.sock" in text
+    assert "GNUPGHOME=/root/.gnupg" in text
+    assert "env" not in run_kwargs
+
+
+def test_container_docker_host_does_not_retarget_client(monkeypatch):
+    """#96316 review: docker_env.DOCKER_HOST must not change the CLI daemon."""
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(env={
+        "DOCKER_HOST": "tcp://evil:2375",
+        "DOCKER_CONTEXT": "other",
+        "GITLAB_TOKEN": "glpat-secret",
+    })
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    cmd, kwargs = run_calls[0]
+    joined = " ".join(cmd)
+    assert "tcp://evil:2375" not in joined
+    assert "glpat-secret" not in joined
+    assert "--env-file" in cmd
+    text = kwargs["_env_file_text"]
+    assert "DOCKER_HOST=tcp://evil:2375" in text
+    assert "DOCKER_CONTEXT=other" in text
+    assert "GITLAB_TOKEN=glpat-secret" in text
+    assert "env" not in kwargs
+
+
+def test_exec_env_file_keeps_client_docker_host(monkeypatch):
+    env = _make_execute_only_env()
+    env._init_env_client = {
+        "DOCKER_HOST": "tcp://evil:2375",
+        "GITLAB_TOKEN": "tok",
+    }
+    calls = []
+
+    def _popen(cmd, stdin_data=None, **kwargs):
+        text = ""
+        if "--env-file" in cmd:
+            text = Path(cmd[cmd.index("--env-file") + 1]).read_text(encoding="utf-8")
+        calls.append((cmd, kwargs, text))
+        return object()
+
+    monkeypatch.setattr(docker_env, "_popen_bash", _popen)
+    env._run_bash("true", login=True)
+    cmd, kwargs, text = calls[0]
+    assert kwargs.get("env") in (None, {})
+    assert "tcp://evil:2375" not in " ".join(cmd)
+    assert "tok" not in " ".join(cmd)
+    assert "DOCKER_HOST=tcp://evil:2375" in text
+    assert "GITLAB_TOKEN=tok" in text
+
+
+def test_recovery_run_uses_env_file_not_client_env(monkeypatch):
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._container_id = None
+    env._image = "python:3.11"
+    env._image_uses_s6_init = False
+    env.cwd = "/root"
+    env._labels = {"hermes-task-id": "t", "hermes-profile": "p"}
+    env._all_run_args = []
+    env._run_client_env = {
+        "DOCKER_HOST": "tcp://evil:2375",
+        "GITLAB_TOKEN": "tok",
+    }
+    env._docker_exe = "/usr/bin/docker"
+    env._find_reusable_container = lambda *a, **k: None
+    env.init_session = lambda: None
+    env._snapshot_ready = False
+    calls = []
+
+    def _run(cmd, **kwargs):
+        captured = _capture_env_file(cmd, kwargs)
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, captured))
+        return subprocess.CompletedProcess(cmd, 0, stdout="new-id\n", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    assert env._recreate_container() is True
+    run_calls = [c for c in calls if isinstance(c[0], list) and c[0][1] == "run"]
+    assert run_calls
+    cmd, kwargs = run_calls[0]
+    assert "tcp://evil:2375" not in " ".join(cmd)
+    assert "tok" not in " ".join(cmd)
+    assert "DOCKER_HOST=tcp://evil:2375" in kwargs["_env_file_text"]
+    assert "GITLAB_TOKEN=tok" in kwargs["_env_file_text"]
+    assert "env" not in kwargs
 
 
 def _node_options_from_run(calls):
@@ -406,10 +513,11 @@ def _node_options_from_run(calls):
     assert run_calls, "docker run should have been called"
     args, kwargs = run_calls[0]
     assert "NODE_OPTIONS=" not in " ".join(args)
-    if "NODE_OPTIONS" in args:
-        assert args[args.index("NODE_OPTIONS") - 1] == "-e"
-    client_env = kwargs.get("env") or {}
-    return client_env.get("NODE_OPTIONS")
+    text = kwargs.get("_env_file_text") or ""
+    for line in text.splitlines():
+        if line.startswith("NODE_OPTIONS="):
+            return line.split("=", 1)[1]
+    return None
 
 
 def test_egress_node_options_overrides_conflicting_ca_flag(monkeypatch):
@@ -443,22 +551,10 @@ def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert args == ["-e", "MY_KEY"]
+    assert "MY_KEY" not in args
     assert "dynamic_value" not in args_str
     assert "static_value" not in args_str
     assert env._init_env_client["MY_KEY"] == "dynamic_value"
-
-
-def test_docker_env_flags_keep_values_out_of_argv():
-    """#96268: secrets belong in the client env, not docker argv."""
-    flags, client = docker_env._docker_env_flags_and_client(
-        {"GITLAB_TOKEN": "glpat-secret", "EMPTY": ""}
-    )
-    assert flags == ["-e", "EMPTY", "-e", "GITLAB_TOKEN"]
-    assert client == {"EMPTY": "", "GITLAB_TOKEN": "glpat-secret"}
-    joined = " ".join(flags)
-    assert "glpat-secret" not in joined
-    assert "GITLAB_TOKEN=" not in joined
 
 
 def test_normalize_env_dict_filters_invalid_keys():

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -473,6 +473,37 @@ def test_exec_env_file_keeps_client_docker_host(monkeypatch):
     assert "GITLAB_TOKEN=tok" in text
 
 
+def test_exec_spawn_failure_unlinks_env_file(monkeypatch, tmp_path):
+    """If docker exec Popen raises, the 0600 env-file must not remain (#96316)."""
+    env = _make_execute_only_env()
+    env._init_env_client = {"GITLAB_TOKEN": "glpat-secret"}
+    opened = []
+    real_open = docker_env.open_container_env_file
+
+    def _open(values, directory=None, **kwargs):
+        handle = real_open(values, directory=str(tmp_path), **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(docker_env, "open_container_env_file", _open)
+
+    def _boom(*_a, **_k):
+        raise OSError("docker missing")
+
+    monkeypatch.setattr(docker_env, "_popen_bash", _boom)
+
+    with pytest.raises(OSError, match="docker missing"):
+        env._run_bash("true", login=True)
+
+    assert opened, "env file should have been created before spawn failed"
+    handle = opened[0]
+    assert handle is not None
+    assert handle._closed is True
+    assert not Path(handle.path).exists()
+    leftovers = list(tmp_path.glob("hermes-docker-env-*"))
+    assert leftovers == []
+
+
 def test_recovery_run_uses_env_file_not_client_env(monkeypatch):
     env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
     env._container_id = None

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -172,6 +172,9 @@ def _make_execute_only_env(forward_env=None):
     env._snapshot_ready = True
     env._last_sync_time = None
     env._init_env_args = []
+    env._init_env_client = {}
+    env._init_unset_passthrough_names = ()
+    env._run_client_env = {}
     return env
 
 
@@ -187,7 +190,9 @@ def test_init_env_args_uses_hermes_dotenv_for_allowlisted_env(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert "DATABASE_URL=value_from_dotenv" in args_str
+    assert args == ["-e", "DATABASE_URL"]
+    assert "DATABASE_URL=" not in args_str
+    assert env._init_env_client["DATABASE_URL"] == "value_from_dotenv"
 
 
 def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
@@ -200,8 +205,10 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert "DATABASE_URL=value_from_shell" in args_str
+    assert args == ["-e", "DATABASE_URL"]
     assert "value_from_dotenv" not in args_str
+    assert "value_from_shell" not in args_str
+    assert env._init_env_client["DATABASE_URL"] == "value_from_shell"
 
 
 def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
@@ -218,10 +225,11 @@ def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
 
     args = env._build_init_env_args()
 
-    # Assert on the resolved value, not the printed -e flag: the disk value
-    # must win and a blank "MY_SECRET=" flag must never be emitted.
-    assert "MY_SECRET=value_from_dotenv" in args
+    # Values must not appear in argv (world-readable /proc/pid/cmdline).
+    # A blank "MY_SECRET=" flag must never be emitted; the disk value wins.
+    assert args == ["-e", "MY_SECRET"]
     assert "MY_SECRET=" not in args
+    assert env._init_env_client["MY_SECRET"] == "value_from_dotenv"
 
 
 def test_init_env_args_uses_active_profile_for_forwarded_env(monkeypatch):
@@ -239,8 +247,10 @@ def test_init_env_args_uses_active_profile_for_forwarded_env(monkeypatch):
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    assert "SERVICE_TOKEN=token-for-routed-profile" in args
-    assert "SERVICE_TOKEN=token-for-default" not in args
+    assert args == ["-e", "SERVICE_TOKEN"]
+    assert "token-for-routed-profile" not in args
+    assert "token-for-default" not in args
+    assert env._init_env_client["SERVICE_TOKEN"] == "token-for-routed-profile"
 
 
 def test_init_env_args_omits_missing_scoped_forwarded_env(monkeypatch):
@@ -260,6 +270,7 @@ def test_init_env_args_omits_missing_scoped_forwarded_env(monkeypatch):
 
     assert "SERVICE_TOKEN=token-for-default" not in args
     assert "SERVICE_TOKEN" not in args
+    assert "SERVICE_TOKEN" not in env._init_env_client
 
 
 def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
@@ -273,7 +284,7 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
     monkeypatch.setattr(
         docker_env,
         "_popen_bash",
-        lambda cmd, stdin_data=None: calls.append((cmd, stdin_data)) or object(),
+        lambda cmd, stdin_data=None, **kwargs: calls.append((cmd, stdin_data, kwargs)) or object(),
     )
     ss.set_multiplex_active(True)
     token = ss.set_secret_scope({"SERVICE_TOKEN": "token-for-profile-a"})
@@ -289,10 +300,13 @@ def test_runtime_exec_tracks_scope_and_clears_missing_value(monkeypatch):
         ss.reset_secret_scope(token)
         ss.set_multiplex_active(False)
 
-    first_cmd = calls[0][0]
-    assert "SERVICE_TOKEN=token-for-profile-a" in first_cmd
+    first_cmd, _, first_kwargs = calls[0]
+    assert "SERVICE_TOKEN=token-for-profile-a" not in first_cmd
+    assert first_cmd[first_cmd.index("-e") + 1] == "SERVICE_TOKEN"
+    assert first_kwargs["env"]["SERVICE_TOKEN"] == "token-for-profile-a"
     second_cmd = calls[1][0]
     assert "SERVICE_TOKEN=token-for-profile-a" not in second_cmd
+    assert "SERVICE_TOKEN" not in second_cmd
     assert "unset SERVICE_TOKEN" in second_cmd[-1]
 
 
@@ -312,15 +326,19 @@ def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, t
     monkeypatch.setenv("EXPLICIT_TOKEN", "token-for-default")
     monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
 
-    def _run_fake_docker_exec(cmd, stdin_data=None):
+    def _run_fake_docker_exec(cmd, stdin_data=None, **kwargs):
         """Execute the generated docker exec command in a real local bash."""
         container_index = cmd.index(env._container_id)
         child_env = os.environ.copy()
+        client_env = kwargs.get("env") or {}
         index = 2
+        if index < container_index and cmd[index] == "-i":
+            index += 1
         while index < container_index:
             assert cmd[index] == "-e"
-            key, value = cmd[index + 1].split("=", 1)
-            child_env[key] = value
+            key = cmd[index + 1]
+            assert "=" not in key, "docker exec must use name-only -e KEY (#96268)"
+            child_env[key] = client_env[key]
             index += 2
         assert cmd[container_index + 1 : container_index + 3] == ["bash", "-c"]
         return subprocess.Popen(
@@ -370,20 +388,28 @@ def test_docker_env_appears_in_run_command(monkeypatch):
 
     run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
     assert run_calls, "docker run should have been called"
-    run_args = run_calls[0][0]
+    run_args, run_kwargs = run_calls[0]
     run_args_str = " ".join(run_args)
-    assert "SSH_AUTH_SOCK=/run/user/1000/ssh-agent.sock" in run_args_str
-    assert "GNUPGHOME=/root/.gnupg" in run_args_str
+    assert "SSH_AUTH_SOCK=/run/user/1000/ssh-agent.sock" not in run_args_str
+    assert "GNUPGHOME=/root/.gnupg" not in run_args_str
+    sock_idx = run_args.index("SSH_AUTH_SOCK")
+    assert run_args[sock_idx - 1] == "-e"
+    gnupg_idx = run_args.index("GNUPGHOME")
+    assert run_args[gnupg_idx - 1] == "-e"
+    client_env = run_kwargs["env"]
+    assert client_env["SSH_AUTH_SOCK"] == "/run/user/1000/ssh-agent.sock"
+    assert client_env["GNUPGHOME"] == "/root/.gnupg"
 
 
 def _node_options_from_run(calls):
     run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
     assert run_calls, "docker run should have been called"
-    args = run_calls[0][0]
-    for i, a in enumerate(args):
-        if a == "-e" and i + 1 < len(args) and args[i + 1].startswith("NODE_OPTIONS="):
-            return args[i + 1].split("=", 1)[1]
-    return None
+    args, kwargs = run_calls[0]
+    assert "NODE_OPTIONS=" not in " ".join(args)
+    if "NODE_OPTIONS" in args:
+        assert args[args.index("NODE_OPTIONS") - 1] == "-e"
+    client_env = kwargs.get("env") or {}
+    return client_env.get("NODE_OPTIONS")
 
 
 def test_egress_node_options_overrides_conflicting_ca_flag(monkeypatch):
@@ -417,8 +443,22 @@ def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
-    assert "MY_KEY=dynamic_value" in args_str
-    assert "MY_KEY=static_value" not in args_str
+    assert args == ["-e", "MY_KEY"]
+    assert "dynamic_value" not in args_str
+    assert "static_value" not in args_str
+    assert env._init_env_client["MY_KEY"] == "dynamic_value"
+
+
+def test_docker_env_flags_keep_values_out_of_argv():
+    """#96268: secrets belong in the client env, not docker argv."""
+    flags, client = docker_env._docker_env_flags_and_client(
+        {"GITLAB_TOKEN": "glpat-secret", "EMPTY": ""}
+    )
+    assert flags == ["-e", "EMPTY", "-e", "GITLAB_TOKEN"]
+    assert client == {"EMPTY": "", "GITLAB_TOKEN": "glpat-secret"}
+    joined = " ".join(flags)
+    assert "glpat-secret" not in joined
+    assert "GITLAB_TOKEN=" not in joined
 
 
 def test_normalize_env_dict_filters_invalid_keys():

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1660,23 +1660,30 @@ class DockerEnvironment(BaseEnvironment):
             unset_names, env_values = self._build_runtime_env_args_with_unsets()
 
         env_file = open_container_env_file(env_values)
-        if env_file is not None:
-            cmd.extend(env_file.args())
+        try:
+            if env_file is not None:
+                cmd.extend(env_file.args())
 
-        if login:
-            unset_names = getattr(self, "_init_unset_passthrough_names", ())
-        if unset_names:
-            quoted_names = " ".join(shlex.quote(name) for name in unset_names)
-            cmd_string = f"unset {quoted_names} 2>/dev/null || true\n{cmd_string}"
+            if login:
+                unset_names = getattr(self, "_init_unset_passthrough_names", ())
+            if unset_names:
+                quoted_names = " ".join(shlex.quote(name) for name in unset_names)
+                cmd_string = f"unset {quoted_names} 2>/dev/null || true\n{cmd_string}"
 
-        cmd.extend([self._container_id])
+            cmd.extend([self._container_id])
 
-        if login:
-            cmd.extend(["bash", "-l", "-c", cmd_string])
-        else:
-            cmd.extend(["bash", "-c", cmd_string])
+            if login:
+                cmd.extend(["bash", "-l", "-c", cmd_string])
+            else:
+                cmd.extend(["bash", "-c", cmd_string])
 
-        proc = _popen_bash(cmd, stdin_data)
+            proc = _popen_bash(cmd, stdin_data)
+        except BaseException:
+            # Popen can fail after the 0600 env-file exists; unlink before
+            # the exception leaves the secret on disk (#96316 review).
+            if env_file is not None:
+                env_file.close()
+            raise
         if env_file is not None:
             return env_file.wrap_process(proc)
         return proc

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -28,32 +28,9 @@ from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _is_hermes_internal_secret,
 )
+from tools.environments.docker_env_transport import open_container_env_file
 
 logger = logging.getLogger(__name__)
-
-
-def _docker_env_flags_and_client(values: dict[str, str]) -> tuple[list[str], dict[str, str]]:
-    """Build docker ``-e KEY`` flags and the client-process env holding the values.
-
-    Docker and Podman resolve a valueless ``--env KEY`` from the client
-    process environment. Emitting ``-e KEY=VALUE`` would put secrets in
-    argv, which Linux exposes via ``/proc/<pid>/cmdline`` to every local
-    user. ``/proc/<pid>/environ`` is owner/root only. See #96268.
-    """
-    flags: list[str] = []
-    client: dict[str, str] = {}
-    for key in sorted(values):
-        flags.extend(["-e", key])
-        client[key] = values[key]
-    return flags, client
-
-
-def _subprocess_env_with(overrides: dict[str, str] | None) -> dict[str, str]:
-    """Return ``os.environ`` plus *overrides* for a docker-client subprocess."""
-    env = os.environ.copy()
-    if overrides:
-        env.update(overrides)
-    return env
 
 
 
@@ -1336,7 +1313,11 @@ class DockerEnvironment(BaseEnvironment):
             if not merged_env["NODE_OPTIONS"]:
                 merged_env.pop("NODE_OPTIONS", None)
 
-        env_args, run_client_env = _docker_env_flags_and_client(merged_env)
+        # Values travel in a 0600 --env-file, not argv and not the docker
+        # client's process environment (DOCKER_HOST in docker_env must not
+        # retarget the daemon). Path is generated per spawn so recovery can
+        # rewrite a fresh file; do not bake it into _all_run_args.
+        run_client_env = dict(merged_env)
 
         # Optional: run the container as the host user so files written into
         # bind-mounted dirs (/workspace, /root, docker_volumes entries) are
@@ -1414,7 +1395,6 @@ class DockerEnvironment(BaseEnvironment):
             + resource_args
             + egress_host_args
             + volume_args
-            + env_args
             + validated_extra
         )
         logger.info("Docker run_args: %s", all_run_args)
@@ -1537,6 +1517,7 @@ class DockerEnvironment(BaseEnvironment):
             # images already provide their own /init PID 1, so adding --init
             # there creates two competing inits and breaks startup (#34628).
             init_args = [] if image_uses_s6_init else ["--init"]
+            env_file = open_container_env_file(run_client_env)
             run_cmd = [
                 self._docker_exe, "run", "-d",
                 *init_args,
@@ -1544,6 +1525,7 @@ class DockerEnvironment(BaseEnvironment):
                 *label_args,
                 "-w", cwd,
                 *all_run_args,
+                *(env_file.args() if env_file else []),
                 image,
                 "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
             ]
@@ -1556,7 +1538,6 @@ class DockerEnvironment(BaseEnvironment):
                     timeout=120,  # image pull may take a while
                     check=True,
                     stdin=subprocess.DEVNULL,
-                    env=_subprocess_env_with(run_client_env),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 # Docker may create the container object before `docker run`
@@ -1576,6 +1557,9 @@ class DockerEnvironment(BaseEnvironment):
                     stdin=subprocess.DEVNULL,
                 )
                 raise
+            finally:
+                if env_file is not None:
+                    env_file.close()
             self._container_id = result.stdout.strip()
             logger.info("Started container %s (%s)", container_name, self._container_id[:12])
 
@@ -1586,10 +1570,10 @@ class DockerEnvironment(BaseEnvironment):
         self.init_session()
 
     def _build_init_env_args(self) -> list[str]:
-        """Build name-only ``-e KEY`` flags for injecting host env at init_session.
+        """Resolve init-session env values. Argv stays empty of secrets.
 
-        Values travel in ``self._init_env_client`` and are applied via the
-        docker-client subprocess ``env=``, not argv. ``export -p`` inside
+        Values live in ``self._init_env_client`` and are written to a
+        per-spawn ``--env-file`` in ``_run_bash``. ``export -p`` inside
         init_session still captures the configured environment.
         """
         passthrough_env, unset_names = self._resolve_passthrough_env()
@@ -1598,10 +1582,8 @@ class DockerEnvironment(BaseEnvironment):
         for name in unset_names:
             exec_env.pop(name, None)
         self._init_unset_passthrough_names = tuple(sorted(unset_names))
-
-        args, client = _docker_env_flags_and_client(exec_env)
-        self._init_env_client = client
-        return args
+        self._init_env_client = exec_env
+        return []
 
     def _build_passthrough_env(self) -> dict[str, str]:
         """Resolve forwarded host variables through the active profile scope."""
@@ -1649,15 +1631,14 @@ class DockerEnvironment(BaseEnvironment):
 
     def _build_runtime_env_args_with_unsets(
         self,
-    ) -> tuple[list[str], tuple[str, ...], dict[str, str]]:
-        """Build runtime ``-e KEY`` flags, unset names, and client-env values."""
+    ) -> tuple[tuple[str, ...], dict[str, str]]:
+        """Return unset names and runtime forwarded values (no argv secrets)."""
         passthrough_env, unset_names = self._resolve_passthrough_env()
-        args, client = _docker_env_flags_and_client(passthrough_env)
-        return args, tuple(sorted(unset_names)), client
+        return tuple(sorted(unset_names)), passthrough_env
 
     def _build_runtime_env_args(self) -> list[str]:
-        """Build only dynamic forwarded ``-e KEY`` flags for a non-login command."""
-        return self._build_runtime_env_args_with_unsets()[0]
+        """Runtime env is injected via ``--env-file``, not argv flags."""
+        return []
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
@@ -1672,16 +1653,15 @@ class DockerEnvironment(BaseEnvironment):
         # injected on every later command because this container can be shared
         # by multiple routed profiles in one gateway process.
         unset_names: tuple[str, ...] = ()
-        client_overrides: dict[str, str] = {}
+        env_values: dict[str, str] = {}
         if login:
-            cmd.extend(self._init_env_args)
-            client_overrides = dict(getattr(self, "_init_env_client", {}) or {})
+            env_values = dict(getattr(self, "_init_env_client", {}) or {})
         elif self._profile_scoped_passthrough:
-            runtime_args, unset_names, runtime_client = (
-                self._build_runtime_env_args_with_unsets()
-            )
-            cmd.extend(runtime_args)
-            client_overrides = runtime_client
+            unset_names, env_values = self._build_runtime_env_args_with_unsets()
+
+        env_file = open_container_env_file(env_values)
+        if env_file is not None:
+            cmd.extend(env_file.args())
 
         if login:
             unset_names = getattr(self, "_init_unset_passthrough_names", ())
@@ -1696,10 +1676,10 @@ class DockerEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        popen_kwargs = {}
-        if client_overrides:
-            popen_kwargs["env"] = _subprocess_env_with(client_overrides)
-        return _popen_bash(cmd, stdin_data, **popen_kwargs)
+        proc = _popen_bash(cmd, stdin_data)
+        if env_file is not None:
+            return env_file.wrap_process(proc)
+        return proc
 
     # ------------------------------------------------------------------
     # "No such container" recovery (issue #36266)
@@ -1764,6 +1744,7 @@ class DockerEnvironment(BaseEnvironment):
                 label_args = []
                 for k, v in self._labels.items():
                     label_args.extend(["--label", f"{k}={v}"])
+                env_file = open_container_env_file(getattr(self, "_run_client_env", None))
                 run_cmd = [
                     self._docker_exe, "run", "-d",
                     *init_args,
@@ -1771,14 +1752,18 @@ class DockerEnvironment(BaseEnvironment):
                     *label_args,
                     "-w", self.cwd,
                     *self._all_run_args,
+                    *(env_file.args() if env_file else []),
                     self._image,
                     "sleep", "infinity",
                 ]
-                result = subprocess.run(
-                    run_cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, check=True,
-                    stdin=subprocess.DEVNULL,
-                    env=_subprocess_env_with(getattr(self, "_run_client_env", None)),
-                )
+                try:
+                    result = subprocess.run(
+                        run_cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, check=True,
+                        stdin=subprocess.DEVNULL,
+                    )
+                finally:
+                    if env_file is not None:
+                        env_file.close()
                 self._container_id = result.stdout.strip()
                 self._container_name = new_name
                 logger.info(

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -32,6 +32,31 @@ from tools.environments.local import (
 logger = logging.getLogger(__name__)
 
 
+def _docker_env_flags_and_client(values: dict[str, str]) -> tuple[list[str], dict[str, str]]:
+    """Build docker ``-e KEY`` flags and the client-process env holding the values.
+
+    Docker and Podman resolve a valueless ``--env KEY`` from the client
+    process environment. Emitting ``-e KEY=VALUE`` would put secrets in
+    argv, which Linux exposes via ``/proc/<pid>/cmdline`` to every local
+    user. ``/proc/<pid>/environ`` is owner/root only. See #96268.
+    """
+    flags: list[str] = []
+    client: dict[str, str] = {}
+    for key in sorted(values):
+        flags.extend(["-e", key])
+        client[key] = values[key]
+    return flags, client
+
+
+def _subprocess_env_with(overrides: dict[str, str] | None) -> dict[str, str]:
+    """Return ``os.environ`` plus *overrides* for a docker-client subprocess."""
+    env = os.environ.copy()
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+
 # Common Docker Desktop install paths checked when 'docker' is not in PATH.
 # macOS Intel: /usr/local/bin, macOS Apple Silicon (Homebrew): /opt/homebrew/bin,
 # Docker Desktop app bundle: /Applications/Docker.app/Contents/Resources/bin
@@ -939,6 +964,9 @@ class DockerEnvironment(BaseEnvironment):
         self._container_name: str = ""
         self._image_uses_s6_init: bool = False
         self._all_run_args: list[str] = []
+        self._run_client_env: dict[str, str] = {}
+        self._init_env_args: list[str] = []
+        self._init_env_client: dict[str, str] = {}
         logger.info("DockerEnvironment volumes: %s", volumes)
         # Ensure volumes is a list (config.yaml could be malformed)
         if volumes is not None and not isinstance(volumes, list):
@@ -1308,9 +1336,7 @@ class DockerEnvironment(BaseEnvironment):
             if not merged_env["NODE_OPTIONS"]:
                 merged_env.pop("NODE_OPTIONS", None)
 
-        env_args = []
-        for key in sorted(merged_env):
-            env_args.extend(["-e", f"{key}={merged_env[key]}"])
+        env_args, run_client_env = _docker_env_flags_and_client(merged_env)
 
         # Optional: run the container as the host user so files written into
         # bind-mounted dirs (/workspace, /root, docker_volumes entries) are
@@ -1415,6 +1441,7 @@ class DockerEnvironment(BaseEnvironment):
         self._container_name = container_name
         self._image_uses_s6_init = image_uses_s6_init
         self._all_run_args = all_run_args
+        self._run_client_env = run_client_env
 
         self._labels = {
             "hermes-agent": "1",
@@ -1529,6 +1556,7 @@ class DockerEnvironment(BaseEnvironment):
                     timeout=120,  # image pull may take a while
                     check=True,
                     stdin=subprocess.DEVNULL,
+                    env=_subprocess_env_with(run_client_env),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 # Docker may create the container object before `docker run`
@@ -1558,10 +1586,11 @@ class DockerEnvironment(BaseEnvironment):
         self.init_session()
 
     def _build_init_env_args(self) -> list[str]:
-        """Build -e KEY=VALUE args for injecting host env vars into init_session.
+        """Build name-only ``-e KEY`` flags for injecting host env at init_session.
 
-        These are used during init_session() so that export -p captures the
-        configured environment and the current profile's forwarded values.
+        Values travel in ``self._init_env_client`` and are applied via the
+        docker-client subprocess ``env=``, not argv. ``export -p`` inside
+        init_session still captures the configured environment.
         """
         passthrough_env, unset_names = self._resolve_passthrough_env()
         exec_env: dict[str, str] = dict(self._env)
@@ -1570,9 +1599,8 @@ class DockerEnvironment(BaseEnvironment):
             exec_env.pop(name, None)
         self._init_unset_passthrough_names = tuple(sorted(unset_names))
 
-        args = []
-        for key in sorted(exec_env):
-            args.extend(["-e", f"{key}={exec_env[key]}"])
+        args, client = _docker_env_flags_and_client(exec_env)
+        self._init_env_client = client
         return args
 
     def _build_passthrough_env(self) -> dict[str, str]:
@@ -1619,16 +1647,16 @@ class DockerEnvironment(BaseEnvironment):
                 unset_names.add(key)
         return exec_env, unset_names
 
-    def _build_runtime_env_args_with_unsets(self) -> tuple[list[str], tuple[str, ...]]:
-        """Build runtime forwarding args plus names absent from the active scope."""
+    def _build_runtime_env_args_with_unsets(
+        self,
+    ) -> tuple[list[str], tuple[str, ...], dict[str, str]]:
+        """Build runtime ``-e KEY`` flags, unset names, and client-env values."""
         passthrough_env, unset_names = self._resolve_passthrough_env()
-        args = []
-        for key in sorted(passthrough_env):
-            args.extend(["-e", f"{key}={passthrough_env[key]}"])
-        return args, tuple(sorted(unset_names))
+        args, client = _docker_env_flags_and_client(passthrough_env)
+        return args, tuple(sorted(unset_names)), client
 
     def _build_runtime_env_args(self) -> list[str]:
-        """Build only dynamic forwarded values for a non-login command."""
+        """Build only dynamic forwarded ``-e KEY`` flags for a non-login command."""
         return self._build_runtime_env_args_with_unsets()[0]
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
@@ -1644,11 +1672,16 @@ class DockerEnvironment(BaseEnvironment):
         # injected on every later command because this container can be shared
         # by multiple routed profiles in one gateway process.
         unset_names: tuple[str, ...] = ()
+        client_overrides: dict[str, str] = {}
         if login:
             cmd.extend(self._init_env_args)
+            client_overrides = dict(getattr(self, "_init_env_client", {}) or {})
         elif self._profile_scoped_passthrough:
-            runtime_args, unset_names = self._build_runtime_env_args_with_unsets()
+            runtime_args, unset_names, runtime_client = (
+                self._build_runtime_env_args_with_unsets()
+            )
             cmd.extend(runtime_args)
+            client_overrides = runtime_client
 
         if login:
             unset_names = getattr(self, "_init_unset_passthrough_names", ())
@@ -1663,7 +1696,10 @@ class DockerEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        return _popen_bash(cmd, stdin_data)
+        popen_kwargs = {}
+        if client_overrides:
+            popen_kwargs["env"] = _subprocess_env_with(client_overrides)
+        return _popen_bash(cmd, stdin_data, **popen_kwargs)
 
     # ------------------------------------------------------------------
     # "No such container" recovery (issue #36266)
@@ -1741,6 +1777,7 @@ class DockerEnvironment(BaseEnvironment):
                 result = subprocess.run(
                     run_cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    env=_subprocess_env_with(getattr(self, "_run_client_env", None)),
                 )
                 self._container_id = result.stdout.strip()
                 self._container_name = new_name

--- a/tools/environments/docker_env_transport.py
+++ b/tools/environments/docker_env_transport.py
@@ -1,0 +1,146 @@
+"""Container env transport that never puts values in docker argv.
+
+Two constraints, one mechanism:
+
+- Linux ``/proc/<pid>/cmdline`` is world-readable, so ``-e KEY=VALUE``
+  leaks allowlisted secrets to every local account (#96268).
+- Copying those values into the docker-client subprocess environment
+  would also retarget the CLI (``DOCKER_HOST``, ``DOCKER_CONTEXT``,
+  TLS/proxy vars). A container-only ``docker_env.DOCKER_HOST`` must not
+  change which daemon receives ``docker run`` / ``docker exec``.
+
+Docker and Podman ``--env-file`` inject KEY=VALUE into the *container*
+from a file. A 0600 temp file is owner-readable, not argv, and does not
+mutate the client process environment.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from collections.abc import Mapping
+from typing import Any
+
+
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENV_FILE_PREFIX = "hermes-docker-env-"
+
+
+def format_container_env_file(values: Mapping[str, str]) -> str:
+    """Render docker ``--env-file`` contents. Names are validated; order is stable."""
+    lines: list[str] = []
+    for key in sorted(values):
+        if not _ENV_VAR_NAME_RE.fullmatch(key):
+            continue
+        value = values[key]
+        if value is None:
+            continue
+        # Env-file is line-oriented. Newlines would split a value into a
+        # second KEY= line; flatten the same way a shell -e cannot span.
+        text = str(value).replace("\r\n", "\n").replace("\r", "\n").replace("\n", " ")
+        lines.append(f"{key}={text}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+class ContainerEnvFile:
+    """0600 temp env-file plus the ``--env-file`` argv fragment.
+
+    ``close()`` is idempotent and always unlinks. ``wrap_process`` unlinks
+    when the child is reaped so a long-lived ``Popen`` does not leave the
+    file on disk after the command finishes.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self._closed = False
+
+    def args(self) -> list[str]:
+        return ["--env-file", self.path]
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            os.unlink(self.path)
+        except OSError:
+            pass
+
+    def wrap_process(self, proc: Any) -> Any:
+        return _EnvFileProcess(proc, self)
+
+    def __enter__(self) -> "ContainerEnvFile":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def open_container_env_file(
+    values: Mapping[str, str] | None,
+    *,
+    directory: str | None = None,
+) -> ContainerEnvFile | None:
+    """Write *values* to a private env-file. ``None`` when there is nothing to inject."""
+    if not values:
+        return None
+    body = format_container_env_file(values)
+    if not body:
+        return None
+    fd, path = tempfile.mkstemp(
+        prefix=_ENV_FILE_PREFIX, suffix=".env", dir=directory, text=True,
+    )
+    try:
+        try:
+            os.fchmod(fd, 0o600)
+        except (AttributeError, OSError):
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fd = -1
+            fh.write(body)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
+    return ContainerEnvFile(path)
+
+
+class _EnvFileProcess:
+    """``ProcessHandle`` adapter that unlinks the env-file when the child ends."""
+
+    def __init__(self, proc: Any, handle: ContainerEnvFile):
+        self._proc = proc
+        self._handle = handle
+
+    def poll(self) -> int | None:
+        code = self._proc.poll()
+        if code is not None:
+            self._handle.close()
+        return code
+
+    def wait(self, timeout: float | None = None) -> int:
+        try:
+            return self._proc.wait(timeout=timeout)
+        finally:
+            self._handle.close()
+
+    def kill(self) -> None:
+        self._proc.kill()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._proc, name)
+
+    def __del__(self) -> None:
+        self._handle.close()


### PR DESCRIPTION
## What does this PR do?

`docker exec` and `docker run` forwarded allowlisted env vars as `-e KEY=VALUE` in argv. On Linux `/proc/<pid>/cmdline` is world-readable, so every terminal call leaked those values to any local account (we caught `GITLAB_TOKEN` sitting in `ps` around unrelated inner commands). This is the transport, not which names are allowlisted (#30103 / GHSA-rhgp-j443-p4rf).

Docker and Podman already resolve a valueless `-e KEY` from the client process environment. The builders now emit name-only `-e KEY` and pass the values via `env=` on the docker-client subprocess, so they move from cmdline to environ (owner/root only). Same path for init seeding, per-command exec, `docker run`, and container-gone recovery.

## Related Issue

Fixes #96268

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/docker.py`: `_docker_env_flags_and_client` + `_subprocess_env_with`; init/runtime/`docker run`/recovery use name-only `-e KEY`
- `tests/tools/test_docker_environment.py`: assert values live in the client env, not argv; fake exec no longer splits on `=`

## How to Test

1. `PYTHONPATH=. python -m pytest tests/tools/test_docker_environment.py -q` — 62 passed
2. Inspect a captured `docker exec` argv: `-e GITLAB_TOKEN` with no `=value`; the value is only in the subprocess env
3. Not live-tested against a real multi-user host `ps` dump (unit tests cover the argv/env split)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
