### PR TITLE
fix(mcp): tolerate OAuth iss path-suffix mismatch

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1112,3 +1112,106 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# RFC 9207 iss suffix tolerance (#96107)
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceOAuthResponseIss:
+    def test_monday_path_suffix_uses_advertised_issuer(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        assert (
+            coerce_oauth_response_iss(
+                "https://auth.monday.com",
+                "https://auth.monday.com/mcp",
+            )
+            == "https://auth.monday.com/mcp"
+        )
+
+    def test_trailing_slash_only_uses_advertised(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        assert (
+            coerce_oauth_response_iss(
+                "https://auth.example.com",
+                "https://auth.example.com/",
+            )
+            == "https://auth.example.com/"
+        )
+
+    def test_exact_match_unchanged(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        assert (
+            coerce_oauth_response_iss(
+                "https://auth.example.com/mcp",
+                "https://auth.example.com/mcp",
+            )
+            == "https://auth.example.com/mcp"
+        )
+
+    def test_different_host_is_not_rewritten(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        emitted = "https://evil.example"
+        assert (
+            coerce_oauth_response_iss(emitted, "https://auth.monday.com/mcp")
+            == emitted
+        )
+
+    def test_emitted_longer_than_advertised_is_not_rewritten(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        emitted = "https://auth.monday.com/mcp/extra"
+        assert (
+            coerce_oauth_response_iss(emitted, "https://auth.monday.com/mcp")
+            == emitted
+        )
+
+    def test_empty_sides_pass_through(self):
+        from tools.mcp_oauth import coerce_oauth_response_iss
+
+        assert coerce_oauth_response_iss(None, "https://auth.monday.com/mcp") is None
+        assert coerce_oauth_response_iss("https://auth.monday.com", None) == (
+            "https://auth.monday.com"
+        )
+
+
+@pytest.mark.asyncio
+async def test_iss_suffix_coerce_rewrites_callback_result():
+    pytest.importorskip("mcp.shared.auth")
+    from tools.mcp_oauth import (
+        coerce_oauth_response_iss,
+        install_oauth_iss_suffix_coerce,
+        _authorization_code_result,
+    )
+
+    class _Meta:
+        issuer = "https://auth.monday.com/mcp"
+
+    class _Ctx:
+        oauth_metadata = _Meta()
+        storage = None
+        callback_handler = None
+
+    class _Provider:
+        context = _Ctx()
+
+    async def _inner():
+        return _authorization_code_result(
+            "auth-code", "state-1", "https://auth.monday.com"
+        )
+
+    provider = _Provider()
+    provider.context.callback_handler = _inner
+    install_oauth_iss_suffix_coerce(provider)
+    result = await provider.context.callback_handler()
+    expected = coerce_oauth_response_iss(
+        "https://auth.monday.com", "https://auth.monday.com/mcp"
+    )
+    assert getattr(result, "iss", None) == expected
+    assert getattr(result, "code", None) == "auth-code"
+    assert getattr(result, "state", None) == "state-1"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -744,6 +744,98 @@ def _authorization_code_result(code: str, state: "str | None", iss: "str | None"
     return AuthorizationCodeResult(code=code, state=state, iss=iss)
 
 
+def coerce_oauth_response_iss(
+    emitted: "str | None", advertised: "str | None"
+) -> "str | None":
+    """Return the ``iss`` the MCP SDK should validate against metadata.
+
+    monday.com (and similar hosted MCP servers) advertise
+    ``issuer: https://auth.monday.com/mcp`` but emit
+    ``iss=https://auth.monday.com`` on the authorization redirect. The SDK's
+    RFC 9207 §2.4 check is a strict string compare, so that suffix-only
+    mismatch rejects the callback after the user already granted consent.
+
+    Coerce only when the advertised issuer is the emitted value plus a path
+    suffix (same origin), or the two differ only by a trailing slash.
+    Different hosts, a longer emitted value, or an empty side are left
+    untouched. See #96107.
+    """
+    if not emitted or not advertised:
+        return emitted
+    emitted_s = str(emitted).rstrip("/")
+    advertised_s = str(advertised).rstrip("/")
+    if not emitted_s or not advertised_s:
+        return emitted
+    if emitted_s == advertised_s:
+        return str(advertised)
+    if advertised_s.startswith(emitted_s + "/"):
+        return str(advertised)
+    return emitted
+
+
+def _oauth_result_field(result: Any, name: str, tuple_index: int) -> Any:
+    if result is None:
+        return None
+    if isinstance(result, tuple):
+        if len(result) > tuple_index:
+            return result[tuple_index]
+        return None
+    return getattr(result, name, None)
+
+
+def _advertised_oauth_issuer(provider: Any) -> "str | None":
+    ctx = getattr(provider, "context", None)
+    if ctx is None:
+        return None
+    meta = getattr(ctx, "oauth_metadata", None)
+    issuer = getattr(meta, "issuer", None) if meta is not None else None
+    if issuer:
+        return str(issuer)
+    storage = getattr(ctx, "storage", None)
+    load = getattr(storage, "load_oauth_metadata", None) if storage is not None else None
+    if callable(load):
+        stored = load()
+        issuer = getattr(stored, "issuer", None) if stored is not None else None
+        if issuer:
+            return str(issuer)
+    return None
+
+
+def install_oauth_iss_suffix_coerce(provider: Any) -> None:
+    """Wrap ``context.callback_handler`` so monday-style iss suffixes pass RFC 9207.
+
+    Discovery stores the advertised issuer on ``context.oauth_metadata``
+    before the browser redirect. The callback still carries the shorter
+    emitted ``iss``; rewriting it here (same-origin path suffix only) lets
+    the SDK's strict compare succeed without skipping issuer validation.
+    """
+    ctx = getattr(provider, "context", None)
+    if ctx is None:
+        return
+    inner = getattr(ctx, "callback_handler", None)
+    if inner is None or getattr(inner, "_hermes_iss_suffix_coerced", False):
+        return
+
+    async def _callback():
+        result = await inner()
+        advertised = _advertised_oauth_issuer(provider)
+        emitted = _oauth_result_field(result, "iss", 2)
+        coerced = coerce_oauth_response_iss(
+            str(emitted) if emitted is not None else None,
+            advertised,
+        )
+        if coerced == emitted or coerced is emitted:
+            return result
+        return _authorization_code_result(
+            _oauth_result_field(result, "code", 0),
+            _oauth_result_field(result, "state", 1),
+            coerced,
+        )
+
+    _callback._hermes_iss_suffix_coerced = True  # type: ignore[attr-defined]
+    ctx.callback_handler = _callback
+
+
 def _make_callback_handler() -> tuple[type, dict]:
     """Create a per-flow callback HTTP handler class with its own result dict.
 
@@ -1184,11 +1276,17 @@ def _get_hermes_oauth_provider_class() -> type | None:
         ``token_user_agent`` (from ``oauth.user_agent``) is stamped onto the
         token-endpoint requests the SDK builds — some authorization servers
         and WAFs reject httpx's default User-Agent there (#75576).
+
+        monday.com advertises ``issuer`` with a ``/mcp`` path suffix but
+        emits a suffix-less ``iss`` on the redirect (#96107). The callback
+        is rewritten to the advertised issuer when the mismatch is that
+        path suffix only, so the SDK's RFC 9207 check can complete.
         """
 
         def __init__(self, *args: Any, token_user_agent: "str | None" = None, **kwargs: Any):
             super().__init__(*args, **kwargs)
             self._hermes_token_user_agent = token_user_agent
+            install_oauth_iss_suffix_coerce(self)
 
         def _stamp_token_user_agent(self, request):
             ua = getattr(self, "_hermes_token_user_agent", None)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -147,6 +147,9 @@ def _make_hermes_provider_class() -> Optional[type]:
             import anyio
 
             self.context.lock = anyio.Semaphore(1, max_value=1)
+            from tools.mcp_oauth import install_oauth_iss_suffix_coerce
+
+            install_oauth_iss_suffix_coerce(self)
             self._hermes_server_name = server_name
             self._hermes_home = ""
             # When the client_id comes from config.yaml (pre-registered), an


### PR DESCRIPTION
## What does this PR do?

`hermes mcp login monday` fails after the browser consent step: monday.com advertises `issuer: https://auth.monday.com/mcp` but emits `iss=https://auth.monday.com` on the redirect. The MCP SDK's RFC 9207 check is a strict string compare, so token exchange never runs.

Hermes already carries provider shims on `HermesOAuthClientProvider` (Supabase `client_secret_post`, token User-Agent). This adds the same kind of fixup: if the advertised issuer is the emitted `iss` plus a path suffix (same origin), rewrite the callback `iss` to the advertised value. Different hosts, a longer emitted value, or an empty side are left untouched — we do not skip issuer validation.

Wired on both construction paths (`build_oauth_auth` and `MCPOAuthManager`).

## Related Issue

Fixes #96107

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth.py`: `coerce_oauth_response_iss` + `install_oauth_iss_suffix_coerce` wrapping `context.callback_handler`
- `tools/mcp_oauth_manager.py`: same wrap on `HermesMCPOAuthProvider`
- `tests/tools/test_mcp_oauth.py`: monday suffix, trailing slash, different host, longer emitted, empty sides, and a callback rewrite test

## How to Test

1. `python -m pytest tests/tools/test_mcp_oauth.py::TestCoerceOAuthResponseIss tests/tools/test_mcp_oauth.py::test_iss_suffix_coerce_rewrites_callback_result tests/tools/test_mcp_oauth.py::TestBuildOAuthAuth tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_user_agent.py tests/tools/test_mcp_oauth_integration.py -q` — 44 passed
2. Not live-tested against monday.com (no tenant here). The unit cases use the exact issuer pair from the report.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
