### PR TITLE
fix(agent): cap tool_search calls per turn

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -179,6 +179,7 @@ class ToolCallGuardrailConfig:
 # pathological, so the defaults are deliberately low.
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
+_DEFAULT_MAX_TOOL_SEARCHES_PER_TURN = 50
 
 
 @dataclass(frozen=True)
@@ -190,8 +191,8 @@ class LoopCapConfig:
     loops. Here the caps count *within a single agent loop* (one turn): the
     counters reset in ``reset_for_turn`` at the start of every
     ``run_conversation``, so a legitimate multi-turn session is never starved,
-    but a single turn that spirals into an unbounded search / delegation loop
-    is stopped.
+    but a single turn that spirals into an unbounded search / delegation /
+    tool-discovery loop is stopped.
 
     Semantics differ from the per-turn loop *detector* above (which keys on
     repeated identical/failing calls): these caps are a hard ceiling on the
@@ -201,6 +202,7 @@ class LoopCapConfig:
 
     max_web_searches: int = _DEFAULT_MAX_WEB_SEARCHES_PER_TURN
     max_subagents: int = _DEFAULT_MAX_SUBAGENTS_PER_TURN
+    max_tool_searches: int = _DEFAULT_MAX_TOOL_SEARCHES_PER_TURN
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "LoopCapConfig":
@@ -214,6 +216,9 @@ class LoopCapConfig:
             ),
             max_subagents=_non_negative_int(
                 data.get("max_subagents"), defaults.max_subagents
+            ),
+            max_tool_searches=_non_negative_int(
+                data.get("max_tool_searches"), defaults.max_tool_searches
             ),
         )
 
@@ -367,6 +372,7 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        self._turn_tool_search_count = 0
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -719,6 +725,27 @@ class ToolCallGuardrailController:
                 self._halt_decision = decision
                 return decision
             self._turn_subagent_count += spawn_count
+            return None
+
+        if tool_name == "tool_search":
+            cap = caps.max_tool_searches
+            if cap and self._turn_tool_search_count >= cap:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="loop_tool_search_cap",
+                    message=(
+                        f"Blocked tool_search: this turn has already made {cap} "
+                        "tool searches, the per-turn limit. This looks like a "
+                        "runaway discovery loop. Use the tools you already "
+                        "found, or answer the user with what you have."
+                    ),
+                    tool_name=tool_name,
+                    count=self._turn_tool_search_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+            self._turn_tool_search_count += 1
             return None
 
         return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -518,6 +518,13 @@ tool_loop_guardrails:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+  # Per-turn ceilings. Always on; 0 = unlimited. tool_search is capped
+  # because successful identical catalog queries never trip the failure
+  # hard-stops and the identical-call stub is advisory only.
+  loop_caps:
+    max_web_searches: 50
+    max_subagents: 50
+    max_tool_searches: 50
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -780,10 +780,13 @@ DEFAULT_CONFIG = {
         # is never starved. They are always-on and fire regardless of the
         # warn/hard-stop thresholds above. A single turn issuing dozens of web
         # searches or spawning dozens of subagents is already pathological, so
-        # the defaults are low. Set either to 0 to disable that cap (unlimited).
+        # the defaults are low. Set any of them to 0 to disable that cap
+        # (unlimited). max_tool_searches covers successful identical
+        # tool_search loops that the failure-keyed hard stops never see.
         "loop_caps": {
             "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
+            "max_tool_searches": 50,  # max tool_search calls per turn (0 = unlimited)
         },
     },
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -149,6 +149,8 @@ def test_loop_cap_zero_disables_and_junk_falls_back():
     assert LoopCapConfig.from_mapping({"max_web_searches": 0}).max_web_searches == 0
     assert LoopCapConfig.from_mapping({"max_web_searches": -5}).max_web_searches == 50
     assert LoopCapConfig.from_mapping({"max_subagents": "nope"}).max_subagents == 50
+    assert LoopCapConfig.from_mapping({"max_tool_searches": 0}).max_tool_searches == 0
+    assert LoopCapConfig.from_mapping({"max_tool_searches": -1}).max_tool_searches == 50
 
 
 def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
@@ -167,6 +169,38 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
+
+
+def test_tool_search_cap_blocks_successful_repeats_regardless_of_hard_stop():
+    # tool_search hits still count: the failure-keyed hard stops never fire
+    # on a successful catalog query, and the identical-call stub is advisory.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_tool_searches=3),
+        )
+    )
+    for i in range(3):
+        assert controller.before_call(
+            "tool_search", {"query": f"q{i}"}
+        ).action == "allow"
+    decision = controller.before_call("tool_search", {"query": "q4"})
+    assert decision.action == "block"
+    assert decision.code == "loop_tool_search_cap"
+    assert decision.should_halt is True
+
+
+def test_tool_search_cap_zero_disables_limit():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_tool_searches=0),
+        )
+    )
+    for i in range(8):
+        assert controller.before_call(
+            "tool_search", {"query": "same"}
+        ).action == "allow"
 
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1723,13 +1723,14 @@ tool_loop_guardrails:
   loop_caps:
     max_web_searches: 50       # max web_search calls per turn (0 = unlimited)
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)
+    max_tool_searches: 50      # max tool_search calls per turn (0 = unlimited)
 ```
 
 `hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
 
 ### Per-turn runaway-loop caps
 
-Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on how many `web_search` calls and subagent spawns a single agent loop (turn) may make. The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — but a single turn that spirals into an unbounded search or delegation loop is stopped. These are always on and fire regardless of `hard_stop_enabled`. A single turn issuing dozens of web searches or spawning dozens of subagents is already pathological, so the defaults are low. When a cap is reached, the offending tool call is blocked with an explanatory message and the turn stops cleanly instead of burning the rest of the budget. Set either value to `0` to disable that cap entirely.
+Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on how many `web_search` calls, `tool_search` calls, and subagent spawns a single agent loop (turn) may make. The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — but a single turn that spirals into an unbounded search, tool-discovery, or delegation loop is stopped. These are always on and fire regardless of `hard_stop_enabled`. A single turn issuing dozens of web searches, tool searches, or spawning dozens of subagents is already pathological, so the defaults are low. When a cap is reached, the offending tool call is blocked with an explanatory message and the turn stops cleanly instead of burning the rest of the budget. Set any of the values to `0` to disable that cap entirely. The `tool_search` cap is what stops a model that keeps re-issuing the same successful catalog query: the identical-call stub in `agent.stall_guards` is advisory prose and the failure-keyed hard stops never increment on a hit.
 
 A single `delegate_task` batch counts each task toward `max_subagents` (a batch of 3 spends 3), so the cap tracks real subagents spawned rather than `delegate_task` invocations.
 


### PR DESCRIPTION
## What does this PR do?

A single turn issued 1,523 successful `tool_search` calls, filled the context, and died. Every search returned hits, so the failure-keyed hard stops never incremented. The identical-call stub fired 1,088 times and was ignored because it is prose in the tool result, not a block. `loop_caps` already ceilings `web_search` and `delegate_task`; `tool_search` had no cap.

Add `loop_caps.max_tool_searches` (default 50, `0` = unlimited). Same semantics as the other loop caps: always on, per turn, independent of `hard_stop_enabled`. The identical-call stub stays advisory (pollers like `process` still need that). A turn that re-issues the same successful catalog query now stops at 50 instead of 1,523.

## Related Issue

Fixes #96247

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_guardrails.py`: `LoopCapConfig.max_tool_searches` + `_check_loop_cap` for `tool_search` (`loop_tool_search_cap`)
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`, `website/docs/user-guide/configuration.md`
- `tests/agent/test_tool_guardrails.py`: cap blocks after 3, `0` disables

## How to Test

1. `python -m pytest tests/agent/test_tool_guardrails.py tests/tools/test_delegate_control_actions.py -q` — 48 passed
2. With `loop_caps.max_tool_searches: 3`, the 4th `tool_search` in a turn is blocked even when every prior call succeeded

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
