### PR TITLE
fix(bootstrap): unify Windows Path so npm pack can see tsc

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -7,6 +7,7 @@
 //! On Unix we shell out to `bash <script>` since install.sh expects bash.
 
 use anyhow::{Context, Result};
+use std::ffi::OsString;
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
@@ -299,6 +300,15 @@ pub async fn run_script(
         cmd.current_dir(cwd);
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        let mut extra = Vec::new();
+        if let Some(home) = hermes_home_override {
+            extra.push(("HERMES_HOME".to_string(), OsString::from(home)));
+        }
+        apply_windows_child_env(&mut cmd, &extra);
+    }
+    #[cfg(not(target_os = "windows"))]
     if let Some(home) = hermes_home_override {
         cmd.env("HERMES_HOME", home);
     }
@@ -510,6 +520,65 @@ pub fn parse_manifest(stdout: &str) -> Option<crate::events::Manifest> {
         }
     }
     None
+}
+
+/// Default PATHEXT when a parent env block dropped it. cmd.exe uses this
+/// list to resolve ``tsc`` to ``tsc.cmd`` (#96112).
+pub(crate) const WINDOWS_DEFAULT_PATHEXT: &str =
+    ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
+
+/// Collapse duplicate ``Path``/``PATH`` entries in a Windows environment block.
+///
+/// Windows env lookup is case-insensitive, but the block can still carry
+/// both keys as distinct entries (Rust ``Command.env("PATH", ...)`` on top
+/// of an inherited ``Path``). Node and npm iterate the block as a list and
+/// may pick the stale/empty one, so ``tsc.cmd`` is "not recognized" even
+/// though TypeScript is installed (#96112).
+pub(crate) fn collapse_windows_path_env(
+    entries: Vec<(String, OsString)>,
+) -> Vec<(String, OsString)> {
+    let mut canonical_path: Option<OsString> = None;
+    let mut other_path: Option<OsString> = None;
+    let mut pathext: Option<OsString> = None;
+    let mut rest: Vec<(String, OsString)> = Vec::new();
+    for (k, v) in entries {
+        if k == "Path" {
+            canonical_path = Some(v);
+            continue;
+        }
+        if k.eq_ignore_ascii_case("path") {
+            other_path = Some(v);
+            continue;
+        }
+        if k.eq_ignore_ascii_case("pathext") {
+            pathext = Some(v);
+            continue;
+        }
+        rest.push((k, v));
+    }
+    if let Some(v) = canonical_path.or(other_path) {
+        rest.push(("Path".to_string(), v));
+    }
+    rest.push((
+        "PATHEXT".to_string(),
+        pathext.unwrap_or_else(|| OsString::from(WINDOWS_DEFAULT_PATHEXT)),
+    ));
+    rest
+}
+
+/// Replace the child env block with a Path/PATH-collapsed copy of the
+/// current process env plus *extra* (last ``Path`` wins).
+#[cfg(target_os = "windows")]
+pub(crate) fn apply_windows_child_env(cmd: &mut Command, extra: &[(String, OsString)]) {
+    let mut collected: Vec<(String, OsString)> = std::env::vars_os()
+        .map(|(k, v)| (k.to_string_lossy().into_owned(), v))
+        .collect();
+    collected.extend(extra.iter().cloned());
+    let collapsed = collapse_windows_path_env(collected);
+    cmd.env_clear();
+    for (k, v) in collapsed {
+        cmd.env(k, v);
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -838,5 +907,77 @@ info line
         assert_eq!(lines, vec!["bye"], "output written before EOF must survive");
         // Far below the child's 30s: a pass cannot be it exiting on its own.
         assert!(elapsed < Duration::from_secs(10), "took {elapsed:?}");
+    }
+
+    #[test]
+    fn collapse_windows_path_env_keeps_a_single_path_key() {
+        let out = collapse_windows_path_env(vec![
+            ("Path".to_string(), OsString::from(r"C:\Windows\system32")),
+            ("PATH".to_string(), OsString::from(r"C:\empty")),
+            (
+                "HERMES_HOME".to_string(),
+                OsString::from(r"C:\Users\x\.hermes"),
+            ),
+        ]);
+        let path_keys: Vec<_> = out
+            .iter()
+            .filter(|(k, _)| k.eq_ignore_ascii_case("path"))
+            .collect();
+        assert_eq!(path_keys.len(), 1);
+        assert_eq!(path_keys[0].0, "Path");
+        // Last exact `Path` wins; a later `PATH` is the fallback only.
+        assert_eq!(
+            path_keys[0].1,
+            OsString::from(r"C:\Windows\system32")
+        );
+        assert!(out.iter().any(|(k, _)| k == "HERMES_HOME"));
+    }
+
+    #[test]
+    fn collapse_windows_path_env_last_exact_path_wins() {
+        let out = collapse_windows_path_env(vec![
+            ("Path".to_string(), OsString::from(r"C:\Windows\system32")),
+            (
+                "Path".to_string(),
+                OsString::from(r"C:\hermes\node;C:\Windows\system32"),
+            ),
+        ]);
+        let path = out
+            .iter()
+            .find(|(k, _)| k == "Path")
+            .expect("collapsed Path");
+        assert_eq!(
+            path.1,
+            OsString::from(r"C:\hermes\node;C:\Windows\system32")
+        );
+    }
+
+    #[test]
+    fn collapse_windows_path_env_seeds_pathext_when_missing() {
+        let out = collapse_windows_path_env(vec![(
+            "Path".to_string(),
+            OsString::from(r"C:\Windows\system32"),
+        )]);
+        let pe = out
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("pathext"))
+            .expect("PATHEXT");
+        assert!(
+            pe.1.to_string_lossy().to_ascii_uppercase().contains(".CMD"),
+            "cmd.exe must be able to resolve tsc.cmd shims"
+        );
+    }
+
+    #[test]
+    fn collapse_windows_path_env_preserves_existing_pathext() {
+        let out = collapse_windows_path_env(vec![
+            ("Path".to_string(), OsString::from(r"C:\Windows\system32")),
+            ("PATHEXT".to_string(), OsString::from(".EXE;.CMD")),
+        ]);
+        let pe = out
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("pathext"))
+            .expect("PATHEXT");
+        assert_eq!(pe.1, OsString::from(".EXE;.CMD"));
     }
 }

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -948,8 +948,13 @@ async fn run_streamed(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    for (key, value) in envs {
-        cmd.env(key, value);
+    #[cfg(target_os = "windows")]
+    crate::powershell::apply_windows_child_env(&mut cmd, envs);
+    #[cfg(not(target_os = "windows"))]
+    {
+        for (key, value) in envs {
+            cmd.env(key, value);
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -1056,7 +1061,11 @@ fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
         hermes_home.join("node").join("bin"),
         venv_bin_dir(install_root),
     ]) {
-        envs.push(("PATH".to_string(), path));
+        // Windows CreateProcess env blocks can carry both Path and PATH as
+        // distinct entries. Prefer the canonical `Path` key so collapse in
+        // apply_windows_child_env keeps the prepended value (#96112).
+        let key = if cfg!(windows) { "Path" } else { "PATH" };
+        envs.push((key.to_string(), path));
     }
     envs
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -884,6 +884,50 @@ function Ensure-NodeExeOnPath {
     return $true
 }
 
+# npm lifecycle scripts spawn cmd.exe, which resolves `tsc` via PATHEXT + PATH.
+# The bootstrap installer (Rust Command) can hand the child both Path and PATH
+# as distinct env-block entries; Node/npm then pick the wrong one and tsc.cmd
+# is "not recognized" even though TypeScript is already in node_modules\.bin
+# (#96112). Collapse to a single Path, keep PATHEXT, and prepend the workspace
+# shim dirs so pack can see tsc even if npm's own PATH rewrite is confused.
+function Ensure-NpmLifecyclePath {
+    param([string]$RepoRoot)
+
+    $path = [Environment]::GetEnvironmentVariable("Path", "Process")
+    if (-not $path) {
+        $path = [Environment]::GetEnvironmentVariable("PATH", "Process")
+    }
+    if (-not $path) { $path = "" }
+
+    $bins = @(
+        (Join-Path $RepoRoot "node_modules\.bin"),
+        (Join-Path $RepoRoot "apps\desktop\node_modules\.bin")
+    )
+    foreach ($bin in $bins) {
+        if ((Test-Path -LiteralPath $bin) -and ($path -notlike "*${bin}*")) {
+            $path = "$bin;$path"
+        }
+    }
+
+    [Environment]::SetEnvironmentVariable("Path", $path, "Process")
+    [Environment]::SetEnvironmentVariable("PATH", $path, "Process")
+
+    $pathext = [Environment]::GetEnvironmentVariable("PATHEXT", "Process")
+    if (-not $pathext) {
+        [Environment]::SetEnvironmentVariable(
+            "PATHEXT",
+            ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC",
+            "Process"
+        )
+    }
+}
+
+function Test-DesktopBuildIsMissingTsc {
+    param([string]$LogText)
+    if ([string]::IsNullOrEmpty($LogText)) { return $false }
+    return $LogText -match "tsc['"" ]?\s*is not recognized" -or $LogText -match "'tsc' is not recognized"
+}
+
 # Put the Hermes-managed Node dir at the FRONT of the persisted User PATH.
 #
 # Appending is not enough: it leaves a pre-existing system Node ahead of the
@@ -4040,6 +4084,8 @@ function Install-Desktop {
     } else {
         Write-Warn "Could not resolve a git commit for the desktop stamp -- write-build-stamp will use its non-git fallback"
     }
+    Ensure-NodeExeOnPath | Out-Null
+    Ensure-NpmLifecyclePath -RepoRoot $InstallDir
     Push-Location $desktopDir
     $prevEAP = $ErrorActionPreference
     $prevCSCAuto = $env:CSC_IDENTITY_AUTO_DISCOVERY
@@ -4053,20 +4099,25 @@ function Install-Desktop {
         & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
         $code = $LASTEXITCODE
         if ($code -ne 0) {
-            $purged = @()
-            $restored = $false
-            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
-                $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
-                $restored = Restore-ElectronDist -InstallDir $InstallDir
-            }
-            if ($restored) {
-                Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
-                foreach ($p in $purged) { Write-Info "  - $p" }
-                & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
-                $code = $LASTEXITCODE
+            $errSoFar = Get-Content $buildLog -Raw -ErrorAction SilentlyContinue
+            if (Test-DesktopBuildIsMissingTsc $errSoFar) {
+                Write-Warn "Desktop build failed because tsc was not on PATH for npm lifecycle scripts (not an Electron download problem)."
+            } else {
+                $purged = @()
+                $restored = $false
+                if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                    $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
+                    $restored = Restore-ElectronDist -InstallDir $InstallDir
+                }
+                if ($restored) {
+                    Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
+                    foreach ($p in $purged) { Write-Info "  - $p" }
+                    & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+                    $code = $LASTEXITCODE
+                }
             }
         }
-        if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
+        if ($code -ne 0 -and -not $env:ELECTRON_MIRROR -and -not (Test-DesktopBuildIsMissingTsc (Get-Content $buildLog -Raw -ErrorAction SilentlyContinue))) {
             $mirror = $script:DesktopElectronFallbackMirror
             Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
             Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"

--- a/tests/test_install_ps1_desktop_tsc_path.py
+++ b/tests/test_install_ps1_desktop_tsc_path.py
@@ -1,0 +1,45 @@
+"""Regression tests for #96112: installer-spawned npm pack must see tsc.cmd.
+
+TypeScript is already on disk after workspace npm install; the failure is the
+environment the bootstrap installer hands to npm/cmd.exe (duplicate Path/PATH
+keys, missing PATHEXT, node_modules\\.bin not on PATH).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_install_ps1_defines_npm_lifecycle_path_helper() -> None:
+    text = _install_ps1()
+    assert "function Ensure-NpmLifecyclePath" in text
+    assert "function Test-DesktopBuildIsMissingTsc" in text
+    assert re.search(
+        r'\[Environment\]::SetEnvironmentVariable\(\s*"Path"',
+        text,
+    ), "Ensure-NpmLifecyclePath must write the Process Path key"
+    assert ".CMD" in text, "PATHEXT default must include .CMD so tsc.cmd resolves"
+
+
+def test_install_desktop_unifies_path_before_npm_pack() -> None:
+    text = _install_ps1()
+    assert re.search(
+        r"function Install-Desktop \{[\s\S]*?Ensure-NpmLifecyclePath[\s\S]*?\$npmExe run pack",
+        text,
+    ), "Install-Desktop must unify Path before npm run pack"
+
+
+def test_install_desktop_does_not_blame_electron_for_missing_tsc() -> None:
+    text = _install_ps1()
+    assert re.search(
+        r"Test-DesktopBuildIsMissingTsc[\s\S]{0,400}ELECTRON_MIRROR",
+        text,
+    ), "tsc-not-on-PATH failures must skip the Electron-mirror retry"


### PR DESCRIPTION
## What does this PR do?

Windows bootstrap desktop pack fails with `'tsc' is not recognized` even though `node_modules\.bin\tsc.cmd` was just installed, and the same `npm run pack` succeeds from a normal terminal. The remaining variable is the env block the installer hands to npm/cmd.exe: duplicate `Path`/`PATH` keys (Rust `Command.env("PATH")` on top of inherited `Path`) and a missing `PATHEXT`, so cmd.exe never resolves the `.cmd` shim.

Collapse the child env to a single `Path`, seed `PATHEXT` when absent, and prepend workspace `node_modules\.bin` before `npm run pack`. When the log is `tsc is not recognized`, skip the Electron-mirror retry — that diagnosis was wrong and delayed the real error.

## Related Issue

Fixes #96112

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/powershell.rs`: `collapse_windows_path_env` / `apply_windows_child_env` on the install-script child
- `apps/bootstrap-installer/src-tauri/src/update.rs`: emit canonical `Path` on Windows; collapse before spawn
- `scripts/install.ps1`: `Ensure-NpmLifecyclePath` before `npm run pack`; `Test-DesktopBuildIsMissingTsc` skips the Electron retry
- `tests/test_install_ps1_desktop_tsc_path.py`: source-scan for the helper and the skip

## How to Test

1. `python -m pytest tests/test_install_ps1_desktop_tsc_path.py tests/test_install_ps1_ascii_only.py tests/test_install_ps1_node_path_for_npm.py -q` — 7 passed
2. Rust unit tests for `collapse_windows_path_env` (single Path key, last exact Path wins, PATHEXT default). Not compiled here: this host has no `libdbus-1-dev` for the Tauri crate. They will run in CI.
3. Not reproduced on a real Windows 11 box (no Windows runner here)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (source-scan + Path collapse unit tests; Windows runtime not available)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
