### PR TITLE
fix(desktop): route HERMES_(BACKEND|DASHBOARD)_READY sentinel to fd 1

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19888,17 +19888,20 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # HERMES_DESKTOP_SPAWN_STDOUT_FIX: write directly to fd 1 instead of
+            # print() — the Electron desktop spawn matches on a regex against
+            # child.stdout, and an in-process sys.stdout hijack (caused by some
+            # import-side-effect chain inside start_server's setup) was routing
+            # these sentinels to fd 2 (stderr), making every Desktop boot hit the
+            # 90s 'Timed out waiting for Hermes backend port announcement' error
+            # even though the backend was actually up and serving. os.write(1,...)
+            # is fd-level and immune to sys.stdout being replaced.
+            import os as _os
+            _os.write(1, (f"{ready_token} port={actual_port}" + "\n").encode())
             if headless:
-                # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
-                # advertise a paste-and-connect URL, just announce the bind.
-                # flush: on a piped stdout (Desktop spawn) this line is
-                # block-buffered and can surface MINUTES after the flushed
-                # READY sentinel above, which reads as a slow boot in
-                # support bundles when the backend was actually up.
-                print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
+                _os.write(1, (f"  Hermes backend listening on {host}:{actual_port}" + "\n").encode())
             else:
-                print(f"  Hermes Web UI → http://{host}:{actual_port}")
+                _os.write(1, (f"  Hermes Web UI \xe2\x86\x92 http://{host}:{actual_port}" + "\n").encode())
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop


### PR DESCRIPTION
## Problem

The Electron desktop spawn parses the `HERMES_(?:BACKEND|DASHBOARD)_READY port=N` sentinel out of `child.stdout` (`waitForDashboardPort` in `electron-main.mjs:1943`). When `hermes serve` ran inside that spawn, an in-process `sys.stdout` hijack (somewhere in `start_server`'s import/setup chain — I haven't fully traced it yet, suspect uvicorn's lifespan or a `logging.basicConfig(stream=sys.stderr)` call) silently replaced `sys.stdout` with a new `TextIOWrapper` wrapping fd 2. The sentinel `print(f"{ready_token} port={actual_port}", flush=True)` then went to stderr, where Electron never listens.

## Symptom

Every Desktop boot hit the 90 s "Timed out waiting for Hermes backend port announcement" recovery overlay (this lives in the same neighborhood as #74874), even though the backend was actually up and serving on `/api/health` and `/api/status`. The renderer's "primary backend process still alive (likely transient stall)" self-heal path then SIGTERM'd the healthy child and retried, which surfaced as the 2–3 rapid repair cycles per launch — also a known false-positive mode of #74874.

## Fix

Write the three sentinels directly to fd 1 via `os.write(1, ...)`. fd-level writes bypass any later reassignment of `sys.stdout`, so the sentinel is delivered to the same pipe Electron is reading regardless of what the import chain does to the Python-level stream. The two human banner lines that share the same code path get the same treatment for consistency.

## Verification

End-to-end on macOS (Hermes.app 0.20.5, parent commit `a588685fb` at time of fix):

- spawn → regex match on stdout resolves in ~1 s (was 90 s timeout before)
- subsequent `/api/health`, `/api/status`, and the WebSocket probe all pass
- no repair cycle is triggered
- confirmed via a Node.js spawn harness: STDOUT receives `HERMES_BACKEND_READY port=NNNNN\n  Hermes backend listening on 127.0.0.1:NNNNN\n` and STDERR is empty (was: STDOUT empty, STDERR carried the full banner)

## Open question

I haven't isolated which import in `start_server` (uvicorn? a plugin? a logging init?) is reassigning `sys.stdout`. The fd-level workaround is robust but if someone wants to actually fix the root cause that's the thing to chase.
