### PR TITLE
fix(gateway): preserve exception type when error string is empty — stop duplicate delivery on httpx timeouts (salvage #78249)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -519,7 +519,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
             return SendResult(success=True, message_id=str(msg_id), raw_response=res)
         except Exception as exc:
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     # ------------------------------------------------------------------
     # Text sending
@@ -582,7 +582,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     success=True, message_id=str(msg_id), raw_response=res
                 )
             except Exception as exc:
-                return SendResult(success=False, error=str(exc))
+                return SendResult(success=False, error=str(exc) or type(exc).__name__)
         return last
 
     # ------------------------------------------------------------------

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2545,7 +2545,7 @@ class QQAdapter(BasePlatformAdapter):
                     )
                     await asyncio.sleep(delay)
 
-        error_msg = str(last_exc) if last_exc else "Unknown error"
+        error_msg = (str(last_exc) or type(last_exc).__name__) if last_exc else "Unknown error"
         logger.error("[%s] Send failed: %s", self._log_tag, error_msg)
         retryable = not any(
             k in error_msg.lower() for k in ("invalid", "forbidden", "not found")
@@ -2661,7 +2661,7 @@ class QQAdapter(BasePlatformAdapter):
             logger.error(
                 "[%s] send_with_keyboard failed: %s", self._log_tag, exc
             )
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     async def send_approval_request(
             self,
@@ -3013,7 +3013,7 @@ class QQAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("[%s] Media send failed: %s", self._log_tag, exc)
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     async def _upload_local_file(
             self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -552,7 +552,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 resp = await self._http_client.post(url, headers=headers, json=payload)
             except Exception as exc:
                 logger.exception("[whatsapp_cloud] send failed")
-                return SendResult(success=False, error=str(exc))
+                return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
             if resp.status_code != 200:
                 # Meta returns structured errors in the body — surface them
@@ -710,7 +710,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             resp = await self._http_client.post(url, headers=headers, json=payload)
         except Exception as exc:
             logger.exception("[whatsapp_cloud] interactive send failed")
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
         if resp.status_code != 200:
             try:
@@ -1086,7 +1086,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             resp = await self._http_client.post(url, headers=headers, json=payload)
         except Exception as exc:
             logger.exception("[whatsapp_cloud] media send failed")
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
         if resp.status_code != 200:
             try:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3897,7 +3897,7 @@ class MediaSendHandler(ABC):
                 "[%s] %s.handle() failed: %s",
                 adapter.name, handler_name, exc, exc_info=True,
             )
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
 
 class ImageUrlHandler(MediaSendHandler):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -2,9 +2,11 @@
 import asyncio
 import json
 
+import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -477,5 +479,91 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert len(deleted_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# Regression for #78183: httpx timeout exceptions stringify to "" which
+# defeats _is_timeout_error, causing the plain-text fallback to re-send an
+# already-delivered message (duplicate delivery).
+# ---------------------------------------------------------------------------
+
+class TestBlueBubblesTimeoutErrorNormalization:
+    """When an httpx timeout has an empty string representation, the adapter
+    must fall back to the exception type name so the base-layer timeout guard
+    can still recognise it."""
+
+    @pytest.mark.asyncio
+    async def test_send_read_timeout_produces_matchable_error(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise httpx.ReadTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert result.error, "error must not be empty"
+        assert BasePlatformAdapter._is_timeout_error(result.error), (
+            f"_is_timeout_error must recognise {result.error!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_write_timeout_produces_matchable_error(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise httpx.WriteTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert result.error
+        assert BasePlatformAdapter._is_timeout_error(result.error)
+
+    @pytest.mark.asyncio
+    async def test_create_chat_for_handle_timeout_produces_matchable_error(
+        self, monkeypatch,
+    ):
+        """Sibling call path — _create_chat_for_handle has the same
+        error=str(exc) pattern and must also preserve the exception type."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            raise httpx.ReadTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter._create_chat_for_handle("test@example.com", "hi")
+
+        assert not result.success
+        assert result.error
+        assert BasePlatformAdapter._is_timeout_error(result.error)
+
+    @pytest.mark.asyncio
+    async def test_non_empty_error_string_is_unchanged(self, monkeypatch):
+        """A normal exception with a message must keep its original text."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise RuntimeError("Server error '500 Internal Server Error'")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert "500 Internal Server Error" in (result.error or "")
 
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -440,6 +440,55 @@ class TestWaitForReconnection:
 
 
 # ---------------------------------------------------------------------------
+# Regression for #78183: httpx timeout empty-string defeats _is_timeout_error
+# ---------------------------------------------------------------------------
+
+class TestQQTimeoutErrorNormalization:
+    """When an httpx timeout has an empty string representation, qqbot's send
+    paths must preserve the exception type name so the base-layer timeout guard
+    (_is_timeout_error) can still recognise it and suppress the duplicate-
+    delivery plain-text fallback."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_preserves_read_timeout_type(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter = self._make_adapter()
+
+        async def _boom(*args, **kwargs):
+            raise httpx.ReadTimeout("")
+
+        adapter._send_c2c_text = _boom
+
+        result = await adapter._send_chunk("test_openid", "hello world")
+
+        assert not result.success
+        assert result.error, "error must not be empty"
+        assert BasePlatformAdapter._is_timeout_error(result.error), (
+            f"_is_timeout_error must recognise {result.error!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_non_empty_error_unchanged(self):
+        """A normal exception with a message must keep its original text."""
+        adapter = self._make_adapter()
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("Server error '500 Internal Server Error'")
+
+        adapter._send_c2c_text = _boom
+
+        result = await adapter._send_chunk("test_openid", "hello world")
+
+        assert not result.success
+        assert "500 Internal Server Error" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
 # ChunkedUploader
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Salvage of #78249 by @Tranquil-Flow (authorship preserved via cherry-pick). Fixes #78183.

## What happens today (real-world impact)

A BlueBubbles (iMessage) user asks Hermes something; the BlueBubbles server is slow and the HTTP request times out AFTER the message was already delivered to the device. The user then receives the same reply TWICE — the second copy prefixed `(Response formatting failed, plain text:)`.

Verbatim from a production gateway log (note the empty error after `Send failed:`):

```
16:35:03,878 INFO    gateway.platforms.base: [Bluebubbles] Sending response (412 chars) to <chat>
16:35:41,536 WARNING gateway.platforms.base: [Bluebubbles] Send failed:  — trying plain-text fallback
```

## Why

`httpx` timeout exceptions stringify to the empty string (`str(httpx.ReadTimeout('')) == ''`). Adapters store `error=str(exc)`, and `_is_timeout_error()` (`gateway/platforms/base.py:5552`) short-circuits on its first line — `if not error: return False` — so the guard that exists precisely to prevent duplicate delivery (`base.py:5646`, "Timeout errors are NOT retryable... the request may have already been delivered") never fires, and the plain-text fallback re-sends the full message.

## Fix

At every httpx-based adapter error boundary: `error=str(exc) or type(exc).__name__`. This yields `"ReadTimeout"` / `"WriteTimeout"`, which the EXISTING matcher already recognises — no change to `base.py`. Non-empty error strings are byte-identical to before (`or` short-circuits).

Sites: `gateway/platforms/bluebubbles.py` (send + `_create_chat_for_handle`), `qqbot/adapter.py` (3 sites), `whatsapp_cloud.py` (3 sites), `yuanbao.py` (handler funnel). `ConnectTimeout` intentionally remains retryable — if the connection never opened, the message was not delivered, so retry is correct (matches the existing `connecttimeout` retryable pattern).

Whole-class note: weixin/feishu use aiohttp/urllib (not httpx) and their `asyncio.TimeoutError` also stringifies empty, but those adapters funnel errors through different paths; kept out of scope here to stay behavior-parity-verifiable per site.

## Provenance / verification

- Cherry-picked cbc81bb372 from #78249; clean pick onto current main, no conflicts.
- `tests/gateway/test_bluebubbles.py` + `test_qqbot.py`: 86 + 51 passed.
- Mutation check: reverting only `gateway/platforms/bluebubbles.py` to main fails the 3 new regression tests (load-bearing).
- 3-angle review: 0 HIGH. One pre-existing (NOT introduced here) gap noted for follow-up: qqbot's `_send_chunk` sets `retryable=True` for timeout errors, and `send_with_retries` checks `retryable` before the timeout guard — so qqbot retains a residual duplicate-delivery window it had before this PR.

## Related

#85125 flagged this issue as a ride-along that never landed; this closes that gap. Same symptom family as #14061 (WeCom, non-empty-string variant) — different defeat mechanism, not addressed here.
