### PR TITLE
fix(deadline): remove the dead second SuspectableBackend class shadowing the Phase 3a Protocol (salvage #95599)

### DIFF
--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -648,32 +648,3 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
         except Exception:
             continue
     return signalled
-
-
-class SuspectableBackend:
-    """Protocol for backends whose connection state can be *poisoned* by a
-    race (teardown-vs-keepalive, auth-lock corruption) without the backend
-    itself being dead.
-
-    The contract is **cheap-mark, lazy-verify**: noticing a poisoned state
-    must never do I/O — ``mark_suspect`` just latches a reason string. The
-    NEXT caller pays for verification once, via ``ensure_healthy``: a cheap
-    health probe that either clears the suspicion (backend was fine) or
-    forces a reconnect/recycle before the call proceeds. This is what keeps
-    a single race from permanently parking a connection (#81051/#77765/
-    #84132): instead of parking on the ambiguous event, the backend is
-    marked suspect and recycled exactly once on next use.
-    """
-
-    def mark_suspect(self, reason: str) -> None:
-        """Latch a suspicion about this backend. Must be cheap (no I/O)."""
-        raise NotImplementedError
-
-    async def ensure_healthy(self, timeout: float = 5.0) -> bool:
-        """Verify a suspect backend before reuse.
-
-        Returns True when the backend is healthy (clearing the suspicion);
-        returns False after forcing a reconnect/recycle so the caller's
-        normal no-session path handles the rebuild. Must not raise.
-        """
-        raise NotImplementedError

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -545,6 +545,26 @@ class TestSequentialToolTimeoutResolver:
 # ---------------------------------------------------------------------------
 
 
+def test_suspectable_backend_name_is_not_shadowed():
+    """`agent.deadline.SuspectableBackend` must resolve to the Phase 3a
+    Protocol (sync `ensure_healthy(self) -> bool`), not a second, unrelated
+    `class SuspectableBackend` defined later in the module. A later Phase 3b
+    adopter independently redefined the same name as a concrete async class
+    (`ensure_healthy(self, timeout=5.0)`), which silently shadowed the
+    Protocol at module scope — nothing subclasses or imports either by name
+    today, so the collision caused no runtime breakage yet, but it would
+    hand the wrong (and differently-shaped) type to the next `from
+    agent.deadline import SuspectableBackend` consumer.
+    """
+    import inspect
+
+    from agent.deadline import SuspectableBackend
+
+    assert getattr(SuspectableBackend, "_is_protocol", False) is True
+    assert not inspect.iscoroutinefunction(SuspectableBackend.ensure_healthy)
+    assert "timeout" not in inspect.signature(SuspectableBackend.ensure_healthy).parameters
+
+
 class _RecordingBackend:
     """Minimal SuspectableBackend: records mark_suspect calls."""
 


### PR DESCRIPTION
Salvage of #95599 by @nftpoetrist (authorship preserved via cherry-pick). Cleans up cruft from the #85125 deadline campaign.

## What

`agent/deadline.py` defined `class SuspectableBackend` **twice**:

- The Phase 3a Protocol (#93796): sync `ensure_healthy(self) -> bool`, `_is_protocol=True` — the documented contract.
- A second concrete class at the bottom of the module (added by the Phase 3b MCP adopter, #94184): async `ensure_healthy(self, timeout: float = 5.0)`, raising `NotImplementedError` — written independently without noticing the name collision, silently shadowing the Protocol at module scope.

## Impact

No runtime breakage today — both Phase 3b adopters (`tools/mcp_tool.py:2913`, `tools/browser_tool.py:1996`) implement the contract structurally and never import the symbol by name. But the next `from agent.deadline import SuspectableBackend` consumer would get the wrong, differently-shaped type (async + timeout param vs the documented sync Protocol).

## Fix

Delete the dead second class; add a regression test pinning that `agent.deadline.SuspectableBackend` resolves to the Protocol (`_is_protocol`, sync `ensure_healthy`, no `timeout` param).

## Verification

- Clean cherry-pick of 1777d1b531 onto current main.
- `tests/agent/test_deadline.py`: 54 passed.
- Mutation check: restoring main's `agent/deadline.py` (with the duplicate class) fails the new test; with the fix it passes — load-bearing.
- Import probe: `tools.mcp_tool` + `tools.browser_tool` import clean; `SuspectableBackend._is_protocol is True`, `ensure_healthy` is sync.
- Confirmed zero by-name importers/subclassers outside `agent/deadline.py` (grep: only docstring/comment references in the two adopters).
