### PR TITLE
fix(desktop): accept READY sentinel on stderr without splicing streams

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -31,14 +31,16 @@ import {
 
 type FakeChildProcess = EventEmitter & {
   stdout: EventEmitter
+  stderr: EventEmitter
 }
 
 // A minimal stand-in for a spawned child process: an EventEmitter with a
 // stdout EventEmitter, matching the surface waitForDashboardPort consumes
-// (child.stdout.on('data'), child.on('exit'|'error') + the .off() teardown).
+// (child.stdout/stderr.on('data'), child.on('exit'|'error') + the .off() teardown).
 function makeFakeChild(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
   child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
 
   return child
 }
@@ -99,12 +101,57 @@ test('resolves with a HERMES_BACKEND_READY port (headless `serve`)', async () =>
   assert.equal(await p, 43210)
 })
 
+test('resolves when HERMES_BACKEND_READY arrives on stderr', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stderr.emit('data', 'HERMES_BACKEND_READY port=60184\n')
+  assert.equal(await p, 60184)
+})
+
 test('parses the port even when the line arrives split across chunks', async () => {
   const child = makeFakeChild()
   const p = waitForDashboardPort(child, 1000)
   child.stdout.emit('data', 'HERMES_DASHBOARD_READY po')
   child.stdout.emit('data', 'rt=8080\n')
   assert.equal(await p, 8080)
+})
+
+// The three tests below pin the per-stream line buffering (#96282 review).
+// A single shared buffer across stdout+stderr passes the happy paths above
+// but corrupts these: it splices partial lines from one pipe onto the other.
+
+test('an unterminated stderr fragment does not corrupt a later stdout READY line', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  // No trailing newline: this fragment stays in the stderr buffer forever.
+  child.stderr.emit('data', 'INFO uvicorn: partial log line with no newline')
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=51515\n')
+  // Shared buffer => the stdout line becomes
+  // '...no newlineHERMES_BACKEND_READY port=51515', which the ^-anchored
+  // _READY_RE cannot match, so this would hang until the timeout.
+  assert.equal(await p, 51515)
+})
+
+test('READY split across stdout chunks survives an interleaved stderr line', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stdout.emit('data', 'HERMES_BACKEND_READY po')
+  // A complete stderr line lands between the two stdout halves. With a
+  // shared buffer it is appended into the middle of the pending stdout
+  // fragment and the port is lost.
+  child.stderr.emit('data', 'WARNING uvicorn: reload disabled\n')
+  child.stdout.emit('data', 'rt=52525\n')
+  assert.equal(await p, 52525)
+})
+
+test('a READY token torn across stdout and stderr must NOT resolve', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 30)
+  // Neither pipe ever carries a complete sentinel line. Only a shared
+  // buffer would glue these halves into a bogus announcement.
+  child.stdout.emit('data', 'HERMES_BACKEND_READY po')
+  child.stderr.emit('data', 'rt=53535\n')
+  await assert.rejects(p, /Timed out waiting for Hermes backend port announcement/)
 })
 
 test('rejects when the child exits before announcing', async () => {

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -35,8 +35,16 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
 }
 
 /**
- * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
- * port=<N>` line that web_server.py prints after uvicorn binds its socket.
+ * Watch a child process's stdout AND stderr for the
+ * `HERMES_(BACKEND|DASHBOARD)_READY port=<N>` line that web_server.py prints
+ * after uvicorn binds its socket.
+ *
+ * Both streams are watched because a `hermes serve` runtime that imports
+ * tui_gateway.server has sys.stdout redirected to stderr, so an older or
+ * partially patched backend can announce on either stream. Each stream keeps
+ * its OWN line buffer: sharing one buffer would let a half-written stderr
+ * fragment splice onto a stdout chunk (fabricating or destroying a READY
+ * token) and would let a token torn across the two pipes look whole.
  *
  * Returns the parsed port. Rejects if:
  *   - the child exits before emitting the line
@@ -53,7 +61,8 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  */
 function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
   return new Promise((resolve, reject) => {
-    let buf = ''
+    // Independent per-stream line buffers. Never share one across streams.
+    const buffers = { stdout: '', stderr: '' }
     let done = false
 
     function cleanup() {
@@ -63,13 +72,18 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
 
       done = true
       clearTimeout(timer)
-      child.stdout.off('data', onData)
+      child.stdout.off('data', onStdout)
+      child.stderr?.off?.('data', onStderr)
       child.off('exit', onExit)
       child.off('error', onError)
     }
 
-    function onData(chunk) {
-      buf += chunk.toString()
+    function consume(chunk, stream: 'stdout' | 'stderr') {
+      if (done) {
+        return
+      }
+
+      let buf = buffers[stream] + chunk.toString()
       let nl
 
       while ((nl = buf.indexOf('\n')) !== -1) {
@@ -78,12 +92,23 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
         const m = line.match(_READY_RE)
 
         if (m) {
+          buffers[stream] = buf
           cleanup()
           resolve(parseInt(m[1], 10))
 
           return
         }
       }
+
+      buffers[stream] = buf
+    }
+
+    function onStdout(chunk) {
+      consume(chunk, 'stdout')
+    }
+
+    function onStderr(chunk) {
+      consume(chunk, 'stderr')
     }
 
     function onExit(code, signal) {
@@ -101,7 +126,8 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
       reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
     }, timeoutMs)
 
-    child.stdout.on('data', onData)
+    child.stdout.on('data', onStdout)
+    child.stderr?.on?.('data', onStderr)
     child.on('exit', onExit)
     child.on('error', onError)
   })


### PR DESCRIPTION
## What does this PR do?

The serve-side READY-on-fd-1 fix already landed (#96311). Desktop still times out against older or mixed-version hermes serve runtimes that announce HERMES_BACKEND_READY on stderr because tui_gateway.server redirects stdout.

This watches both stdout and stderr for the sentinel, with independent line buffers. Sharing one buffer lets a partial stderr log splice onto a stdout chunk and either fabricate a port or hide a real one.

## Related Issue

Follow-up to #96282 (server sentinel path already merged).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- apps/desktop/electron/backend-ready.ts: parse READY on stdout and stderr with per-stream buffers
- apps/desktop/electron/backend-ready.test.ts: stderr READY, interleaved stderr noise, and torn-token-must-not-resolve cases

## How to Test

1. cd apps/desktop && npx --no-install vitest run electron/backend-ready.test.ts (24 passed locally)
2. Desktop against current main serve: still boots from stdout READY
3. Desktop against a pre-fd-1 serve that prints READY only on stderr: should now connect instead of 90s timeout

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched existing PRs; the fd-1 server fix is already merged. This is the Desktop consumer half only
- [x] This PR contains only changes related to this fix
- [x] Desktop vitest for this change passed
- [x] Tests added for the change
- [x] Tested on macOS arm64

### Documentation and Housekeeping

- [x] Documentation N/A
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING.md / AGENTS.md N/A
- [x] Cross-platform: Electron pipes are LF-split; trailing CR is tolerated because the regex is not end-anchored
- [x] Tool schemas N/A
