### PR TITLE
fix(desktop): a project-tree root load only satisfies its own connection (follow-up to #90334)

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -462,4 +462,83 @@ describe('useProjectTree', () => {
     await waitFor(() => expect(result.current.rootError).toBe('no-bridge'))
     expect(result.current.data).toEqual([])
   })
+  it('reloads the root after a mid-flight reset instead of sticking on the skeleton', async () => {
+    // #90229. A gateway boot calls resetProjectTreeState() from
+    // useGatewayBoot({ beforeConnectionSwitch }), which can land while the
+    // first root read is still in flight. The completion is then correctly
+    // abandoned -- the store no longer owns this cwd -- but nothing re-armed a
+    // replacement, so the tree waited forever.
+    let release: (result: HermesReadDirResult) => void = () => {}
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          release = resolve
+        })
+    )
+    readDir.mockResolvedValue(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+    expect(result.current.rootLoading).toBe(true)
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await act(async () => {
+      release(ok([{ name: 'stale', path: '/p/stale', isDirectory: false }]))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.data.map(n => n.name)).toEqual(['src']))
+    // rootLoading feeds `disabled` on the sidebar's Refresh button, so a stuck
+    // `true` is what left the user with no way out.
+    expect(result.current.rootLoading).toBe(false)
+    expect(result.current.rootError).toBeNull()
+  })
+
+  it('reloads the root after a reset that lands once the tree is already loaded', async () => {
+    // Same defect without the race: the load effect depends only on
+    // [connectionKey, cwd], and a reset changes neither, so a reset at any
+    // moment orphaned the tree until one of those happened to change.
+    readDir.mockResolvedValue(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(1))
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await waitFor(() => expect(result.current.data.map(n => n.name)).toEqual(['src']))
+    expect(result.current.rootLoading).toBe(false)
+    expect(readDir).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-arm when a different cwd owns the store', async () => {
+    // The re-arm keys on the CLEARED store (cwd: ''), not on any mismatch. The
+    // atom is global, so two mounted consumers with different cwds would
+    // otherwise each keep re-claiming it and loop forever.
+    readDir.mockImplementation(async path => ok([{ name: `in-${path}`, path: `${path}/x`, isDirectory: false }]))
+
+    const first = renderHook(() => useProjectTree('/a'))
+
+    await waitFor(() => expect(first.result.current.data.length).toBe(1))
+
+    const second = renderHook(() => useProjectTree('/b'))
+
+    await waitFor(() => expect(second.result.current.data.length).toBe(1))
+
+    const settled = readDir.mock.calls.length
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20))
+    })
+
+    expect(readDir.mock.calls.length).toBe(settled)
+    expect(second.result.current.data.map(n => n.name)).toEqual(['in-/b'])
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -6,7 +6,12 @@ import { $connection } from '@/store/session'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
-import { resetProjectTreeState, useProjectTree } from './use-project-tree'
+import {
+  isUnownedProjectTree,
+  readProjectTreeState,
+  resetProjectTreeState,
+  useProjectTree
+} from './use-project-tree'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 
@@ -540,5 +545,31 @@ describe('useProjectTree', () => {
 
     expect(readDir.mock.calls.length).toBe(settled)
     expect(second.result.current.data.map(n => n.name)).toEqual(['in-/b'])
+  })
+})
+
+describe('the reset contract', () => {
+  // The re-arm effect fires on "the store is unowned". Nothing else in the
+  // module asserts that a reset actually PRODUCES an unowned store, so a
+  // change to how the reset represents that state would disarm the re-arm
+  // and every behavioural test above would still pass: they all reset first,
+  // so they would agree with each other about a broken shape.
+  it('leaves the store unowned', () => {
+    resetProjectTreeState()
+
+    expect(isUnownedProjectTree(readProjectTreeState())).toBe(true)
+  })
+
+  it('does not call a store owned by a live cwd unowned', async () => {
+    readDir.mockResolvedValue(ok([]))
+
+    const view = renderHook(() => useProjectTree('/repo'))
+
+    await waitFor(() => {
+      expect(view.result.current.rootLoading).toBe(false)
+    })
+
+    expect(readProjectTreeState().cwd).toBe('/repo')
+    expect(isUnownedProjectTree(readProjectTreeState())).toBe(false)
   })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -523,6 +523,51 @@ describe('useProjectTree', () => {
     expect(readDir).toHaveBeenCalledTimes(2)
   })
 
+  it('reloads under the new connection when the re-armed read was issued under the old one', async () => {
+    // Profile switch on current main: resetProjectTreeState() runs on the
+    // gateway-scope change BEFORE the swapped $connection is published, so the
+    // re-arm issues its read under the OLD connection key. The stale-connection
+    // guard rightly discards that read — but the reset also blanked
+    // lastConnectionKey, so the connection change is not seen as a change and
+    // the non-forced reload declined because a load was "in flight". Net: a
+    // store that owns the cwd, rootLoading stuck true, Refresh disabled.
+    readDir.mockResolvedValue(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+    $connection.set({ connectionId: 'gateway', mode: 'local', profile: 'a' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(1))
+
+    let release: (value: HermesReadDirResult) => void = () => {}
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          release = resolve
+        })
+    )
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    // The re-arm's read is pending under connection "a" when "b" publishes.
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      $connection.set({ connectionId: 'gateway', mode: 'local', profile: 'b' } as never)
+    })
+
+    await act(async () => {
+      release(ok([{ name: 'stale', path: '/p/stale', isDirectory: false }]))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.data.map(n => n.name)).toEqual(['src']))
+    expect(result.current.rootLoading).toBe(false)
+    expect(readDir).toHaveBeenCalledTimes(3)
+  })
+
   it('does not re-arm when a different cwd owns the store', async () => {
     // The re-arm keys on the CLEARED store (cwd: ''), not on any mismatch. The
     // atom is global, so two mounted consumers with different cwds would

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -473,6 +473,28 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     void loadRoot(cwd, { connectionKey })
   }, [connectionKey, cwd])
 
+  // Re-arm after the store is reset out from under us. `resetProjectTreeState`
+  // fires on gateway boot / connection switch, and can land while a root read
+  // is in flight: the completion above is then correctly abandoned (the store
+  // no longer owns this cwd), but nothing starts a replacement. The effect
+  // above only depends on [connectionKey, cwd], neither of which a reset
+  // changes, and both self-heal effects below are gated on `state.cwd === cwd`
+  // -- the very condition the reset broke. The tree then reports
+  // `rootLoading: Boolean(cwd)` forever, which also disables the Refresh
+  // button, so there is no way back (#90229).
+  //
+  // Keyed on the CLEARED store (`cwd: ''`), not on any mismatch: the atom is
+  // global, so a mismatch against a different non-empty cwd means another
+  // consumer owns it, and re-claiming that would ping-pong. Converges because
+  // `loadRoot` writes its cwd into the store before its first await.
+  useEffect(() => {
+    if (!cwd || state.cwd !== '') {
+      return
+    }
+
+    void loadRoot(cwd)
+  }, [cwd, state.cwd, state.requestId])
+
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the
   // timer; a success clears rootError and stops it.

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -110,7 +110,7 @@ export interface UseProjectTreeResult {
   setNodeOpen: (id: string, open: boolean) => void
 }
 
-interface ProjectTreeState {
+export interface ProjectTreeState {
   collapseNonce: number
   cwd: string
   data: TreeNode[]
@@ -153,6 +153,27 @@ function clearProjectTree() {
   nextRootRequestId += 1
   inflight.clear()
   $projectTree.set({ ...initialState, requestId: nextRootRequestId })
+}
+
+/** True when the store belongs to no consumer: `clearProjectTree` has wiped
+ *  it and nothing has claimed a cwd since.
+ *
+ *  This is the reset contract, and it lives here rather than at the one place
+ *  that reads it so a caller never has to know *how* "unowned" is spelled.
+ *  Today it is `cwd: ''` straight out of `initialState`, which is also what
+ *  `clearProjectTree` writes -- the two cannot drift because they name the
+ *  same object. If the representation ever becomes a generation counter or an
+ *  explicit null owner, this function changes and the re-arm effect keeps
+ *  working, instead of silently going quiet again (#90229). */
+export function isUnownedProjectTree(state: ProjectTreeState): boolean {
+  return state.cwd === initialState.cwd
+}
+
+/** Read-only view of the store, exported for the reset-contract test.
+ *  The re-arm effect's correctness depends on what a reset LEAVES BEHIND, and
+ *  a test that can only see the hook's rendered output cannot assert that. */
+export function readProjectTreeState(): ProjectTreeState {
+  return $projectTree.get()
 }
 
 /** Sessions record their launch cwd; deleted worktrees and remote-backend
@@ -483,17 +504,20 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   // `rootLoading: Boolean(cwd)` forever, which also disables the Refresh
   // button, so there is no way back (#90229).
   //
-  // Keyed on the CLEARED store (`cwd: ''`), not on any mismatch: the atom is
-  // global, so a mismatch against a different non-empty cwd means another
-  // consumer owns it, and re-claiming that would ping-pong. Converges because
+  // Keyed on the CLEARED store, not on any mismatch: the atom is global, so a
+  // mismatch against a different non-empty cwd means another consumer owns it,
+  // and re-claiming that would ping-pong. What "cleared" means is
+  // `isUnownedProjectTree`'s to say, not this effect's. Converges because
   // `loadRoot` writes its cwd into the store before its first await.
+  const treeIsUnowned = isUnownedProjectTree(state)
+
   useEffect(() => {
-    if (!cwd || state.cwd !== '') {
+    if (!cwd || !treeIsUnowned) {
       return
     }
 
     void loadRoot(cwd)
-  }, [cwd, state.cwd, state.requestId])
+  }, [cwd, treeIsUnowned, state.requestId])
 
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -112,6 +112,12 @@ export interface UseProjectTreeResult {
 
 export interface ProjectTreeState {
   collapseNonce: number
+  /** desktopFsCacheKey() the root load was issued under. A load — in flight
+   *  or complete — only satisfies its own connection: a reset that lands
+   *  before the swapped $connection publishes re-arms a read under the OLD
+   *  key, which the stale-connection guard then rightly discards, so a fresh
+   *  load for the new key must not be declined as "already in flight". */
+  connectionKey: string
   cwd: string
   data: TreeNode[]
   loaded: boolean
@@ -125,6 +131,7 @@ export interface ProjectTreeState {
 
 const initialState: ProjectTreeState = {
   collapseNonce: 0,
+  connectionKey: '',
   cwd: '',
   data: [],
   loaded: false,
@@ -213,7 +220,7 @@ async function loadRoot(
 
   const current = $projectTree.get()
 
-  if (!force && current.cwd === cwd && (current.loaded || current.rootLoading)) {
+  if (!force && current.cwd === cwd && current.connectionKey === connectionKey && (current.loaded || current.rootLoading)) {
     return
   }
 
@@ -227,6 +234,7 @@ async function loadRoot(
 
   $projectTree.set({
     collapseNonce: current.collapseNonce,
+    connectionKey,
     cwd,
     data: [],
     loaded: false,


### PR DESCRIPTION
## What does this PR do?

**Stacked on #90334** — the first two commits are that PR's, unchanged; only the last commit (`fix(desktop): a project-tree root load only satisfies its own connection`) is new. Rebase drops the first two once #90334 merges.

With #90334 applied on current `main`, the right-rail file tree can still wedge on a **profile switch**. Reproduced on macOS 15 (Apple Silicon) at `a588685fb9`, desktop in global-remote mode (one `hermes serve` host, 5 profiles). Trace from the renderer (temporary `console.debug` in `loadRoot`, the reset, and the load effect), switching `engineer → default`:

```
4.20s RESET
4.22s loadRoot START req=5 force=false key=connection:<host>:engineer storeCwd=EMPTY   ← #90334 re-arm, under the OLD key
4.23s mainEffect connectionChanged=false last= key=connection:<host>:default            ← reset blanked lastConnectionKey
4.23s loadRoot SKIP loaded=false loading=true req=5                                     ← non-forced reload declined
4.94s loadRoot DROP req=5 latestReq=5 latestCwd=set keyNow=…:default keyThen=…:engineer ← stale-connection guard
```

`resetProjectTreeState()` runs on the gateway-scope change *before* the swapped `$connection` is published (`selectProfile` → `ensureGatewayProfile` resolves later), so the re-arm issues its read under the outgoing connection key. When the new descriptor lands, the load effect sees `lastConnectionKey === ''` (the reset blanked it), so it is not a `connectionChanged`, and its non-forced `loadRoot` returns early because req 5 is "in flight". Req 5 then completes and is — correctly — discarded by the `desktopFsCacheKey() !== connectionKey` guard from 9abeb89a49, which landed after #90334 was cut. Net: the store owns the cwd with `rootLoading` stuck `true`, Refresh is `disabled={loading}`, and the tree shows the skeleton until the next switch. It only bites when the read outlives the swap (occluded window → throttled timers, slow remote, large directory), which matches the "roughly 1 in 3 boots" wording in #90229.

**Fix:** record the connection key a root load was issued under in `ProjectTreeState`, and let `loadRoot`'s early return treat a load as "in flight" only when it is for the **same** key:

```ts
if (!force && current.cwd === cwd && current.connectionKey === connectionKey && (current.loaded || current.rootLoading)) {
  return
}
```

With that the same trace ends `loadRoot DONE req=7 n=20` on every hop.

## Related Issue

Refs #90229, #91245, #90672 (follow-up to #90334)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/files/use-project-tree.ts`: `ProjectTreeState.connectionKey` (set by `loadRoot`, cleared by the reset); the in-flight/loaded early return now also requires the same key
- `apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts`: regression test — reset re-arms a read under connection "a", "b" publishes while it is pending, the stale read is discarded and the tree loads under "b" (red on #90334 alone, green with this commit)

## How to Test

1. Desktop with ≥2 profiles (remote mode makes it easy to hit: switch while the window is occluded, or against a slow host).
2. On #90334 alone: switch profiles a few times; when the read outlives the swap the rail stays on the skeleton with Refresh disabled. With this commit: the tree loads on every switch.
3. `cd apps/desktop && npx vitest run src/app/right-sidebar` (16 files / 117 tests), `npm run check:lint`.

Tested on macOS 15 (Darwin 24.6, Apple Silicon) desktop dev build against a Fedora x86_64 backend (`hermes serve`, v0.20.5) with 5 profiles; verified live via CDP across a 6-hop switch cycle.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#90334 — this stacks on it rather than competing)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — the two carried commits are #90334
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only; `npm run check:lint` + `npm run test:ui` in `apps/desktop` pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (client) + Fedora (backend)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — renderer-only state change; no path/process handling
