### PR TITLE
fix(desktop): reseed a remote draft's workspace cwd after a profile switch

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -14,6 +14,7 @@ import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEff
 import { useLocation, useNavigate } from 'react-router'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { draftNeedsReseed, seedDefaultCwd } from '@/app/session/seed-default-cwd'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { ConfirmHost } from '@/components/confirm-host'
@@ -542,6 +543,34 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     void refreshActiveProfile()
     resetProjectTreeState()
   }, [gatewayScope, refreshCurrentModel, refreshHermesConfig])
+
+  // A remote profile switch can leave the fresh draft with no workspace: the
+  // draft is created before the swapped descriptor is published, so it read
+  // the OUTGOING profile's remembered cwd (see draftNeedsReseed). Once the
+  // descriptor for the new scope lands, reseed a detached, un-targeted draft
+  // the same way boot does. Keyed on the published descriptor rather than
+  // $activeGatewayProfile because the remembered-cwd lookup reads
+  // $connection.profile.
+  const publishedConnection = useStore($connection)
+  const draftSeedScope = `${publishedConnection?.connectionId ?? ''}\0${publishedConnection?.profile ?? ''}\0${publishedConnection?.baseUrl ?? ''}`
+  const lastDraftSeedScopeRef = useRef(draftSeedScope)
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    if (draftSeedScope === lastDraftSeedScopeRef.current) {
+      return
+    }
+
+    lastDraftSeedScopeRef.current = draftSeedScope
+
+    if (!draftNeedsReseed(publishedConnection)) {
+      return
+    }
+
+    const stillCurrent = () => lastDraftSeedScopeRef.current === draftSeedScope
+
+    seedDefaultCwd(stillCurrent).catch(err => console.warn('Failed to reseed the workspace cwd after a profile switch', err))
+  }, [draftSeedScope, publishedConnection])
 
   // New session anchored to a workspace. Seeds cwd + branch from the clicked
   // workspace; an explicit worktree path also drills the sidebar into that

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,11 +1,11 @@
 import { isGatewayReauthRequired, JsonRpcGatewayError, resolveGatewayWsUrl } from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
+import { seedDefaultCwd } from '@/app/session/seed-default-cwd'
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
 import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
-import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
@@ -54,14 +54,11 @@ import {
 import {
   $activeSessionId,
   $connection,
-  $currentCwd,
   $selectedStoredSessionId,
   $sessions,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
   setConnection,
-  setCurrentBranch,
-  setCurrentCwd,
   setSessionsLoading
 } from '@/store/session'
 import {
@@ -545,23 +542,6 @@ export function useGatewayBoot({
       }
 
       return true
-    }
-
-    // Seed the working dir from the backend default on a fresh view (nothing
-    // open yet). Shared by boot + soft switch.
-    async function seedDefaultCwd(shouldPublish: () => boolean = () => true) {
-      await ensureDefaultWorkspaceCwd(shouldPublish)
-
-      if (!shouldPublish()) {
-        return
-      }
-
-      const remoteDefault = await desktopDefaultCwd().catch(() => null)
-
-      if (shouldPublish() && remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
-        setCurrentCwd(remoteDefault.cwd)
-        setCurrentBranch(remoteDefault.branch || '')
-      }
     }
 
     // Soft gateway-mode apply: main tore down the primary without reloading.

--- a/apps/desktop/src/app/session/seed-default-cwd.test.ts
+++ b/apps/desktop/src/app/session/seed-default-cwd.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeSessionId, $connection, $currentCwd, $newChatWorkspaceTarget, setCurrentCwdTransient } from '@/store/session'
+
+import { draftNeedsReseed, seedDefaultCwd } from './seed-default-cwd'
+
+const { desktopDefaultCwd } = vi.hoisted(() => ({
+  desktopDefaultCwd: vi.fn<() => Promise<{ branch: string; cwd: string } | null>>()
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({ desktopDefaultCwd }))
+
+const HOST = 'http://gganbu:9119'
+
+function remote(profile: string) {
+  return { baseUrl: HOST, mode: 'remote', profile } as never
+}
+
+function rememberedKey(profile: string) {
+  return `hermes.desktop.workspace-cwd.remote.${encodeURIComponent(HOST)}.${encodeURIComponent(profile)}`
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  $connection.set(null)
+  $activeSessionId.set(null)
+  $newChatWorkspaceTarget.set(undefined)
+  setCurrentCwdTransient('')
+  desktopDefaultCwd.mockReset()
+  desktopDefaultCwd.mockResolvedValue(null)
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    sanitizeWorkspaceCwd: vi.fn(async (cwd: string) => ({ cwd, sanitized: false })),
+    settings: { getDefaultProjectDir: vi.fn(async () => ({ dir: '' })) }
+  }
+})
+
+afterEach(() => {
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  $connection.set(null)
+  setCurrentCwdTransient('')
+})
+
+describe('draftNeedsReseed', () => {
+  it('is true only for a detached, un-targeted draft on a remote connection', () => {
+    expect(draftNeedsReseed(remote('default'))).toBe(true)
+  })
+
+  it('leaves local drafts alone — a bare local chat is detached by design', () => {
+    expect(draftNeedsReseed({ mode: 'local' } as never)).toBe(false)
+    expect(draftNeedsReseed(null)).toBe(false)
+  })
+
+  it('never touches an open session, an attached draft, or an explicitly detached one', () => {
+    $activeSessionId.set('20260827_050914_0009ee')
+    expect(draftNeedsReseed(remote('default'))).toBe(false)
+    $activeSessionId.set(null)
+
+    setCurrentCwdTransient('/home/user/repo')
+    expect(draftNeedsReseed(remote('default'))).toBe(false)
+    setCurrentCwdTransient('')
+
+    // workspaceTarget === null is the "start detached" request (startFreshSessionDraft).
+    $newChatWorkspaceTarget.set(null)
+    expect(draftNeedsReseed(remote('default'))).toBe(false)
+  })
+})
+
+describe('seedDefaultCwd', () => {
+  it('seeds the remembered workspace of the PUBLISHED profile after a switch (#49293)', async () => {
+    // The fresh draft was created while $connection still named the outgoing
+    // profile, which never had a remembered workspace → it resolved to ''.
+    localStorage.setItem(rememberedKey('default'), '/home/user/repo')
+    $connection.set(remote('researcher'))
+    setCurrentCwdTransient('')
+
+    // The swap resolves and the descriptor for the target profile lands.
+    $connection.set(remote('default'))
+    expect(draftNeedsReseed($connection.get())).toBe(true)
+
+    await seedDefaultCwd()
+
+    expect($currentCwd.get()).toBe('/home/user/repo')
+  })
+
+  it('falls back to the backend default when the profile has no remembered workspace', async () => {
+    desktopDefaultCwd.mockResolvedValue({ branch: 'main', cwd: '/home/user/default-project' })
+    $connection.set(remote('researcher'))
+
+    await seedDefaultCwd()
+
+    expect($currentCwd.get()).toBe('/home/user/default-project')
+  })
+
+  it('does nothing once the caller has been superseded', async () => {
+    localStorage.setItem(rememberedKey('default'), '/home/user/repo')
+    desktopDefaultCwd.mockResolvedValue({ branch: 'main', cwd: '/home/user/default-project' })
+    $connection.set(remote('default'))
+
+    await seedDefaultCwd(() => false)
+
+    expect($currentCwd.get()).toBe('')
+  })
+})

--- a/apps/desktop/src/app/session/seed-default-cwd.ts
+++ b/apps/desktop/src/app/session/seed-default-cwd.ts
@@ -1,0 +1,48 @@
+import type { HermesConnection } from '@/global'
+import { desktopDefaultCwd } from '@/lib/desktop-fs'
+import {
+  $activeSessionId,
+  $currentCwd,
+  $newChatWorkspaceTarget,
+  ensureDefaultWorkspaceCwd,
+  setCurrentBranch,
+  setCurrentCwd
+} from '@/store/session'
+
+// Seed the working dir on a fresh view (nothing open yet): the remembered
+// per-(connection, profile) workspace first (ensureDefaultWorkspaceCwd), then
+// the backend's own default (/api/fs/default-cwd on remote). Shared by boot,
+// the soft connection switch, and the post-profile-swap reseed in wiring.
+// `shouldPublish` lets a superseded caller bail before touching live state.
+export async function seedDefaultCwd(shouldPublish: () => boolean = () => true): Promise<void> {
+  await ensureDefaultWorkspaceCwd(shouldPublish)
+
+  if (!shouldPublish()) {
+    return
+  }
+
+  const remoteDefault = await desktopDefaultCwd().catch(() => null)
+
+  if (shouldPublish() && remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
+    setCurrentCwd(remoteDefault.cwd)
+    setCurrentBranch(remoteDefault.branch || '')
+  }
+}
+
+// A profile switch drops to a fresh draft BEFORE the swapped connection is
+// published (selectProfile fires requestFreshSession synchronously; the
+// descriptor lands once the swap resolves). A REMOTE draft therefore resolved
+// its cwd under the OUTGOING profile's remembered workspace — the key is
+// per-(host, profile) — which is blank whenever that profile never had one, and
+// nothing reseeded it afterwards; boot and the soft connection switch both do.
+// Local drafts are unaffected: a bare local chat is detached by design and
+// every local profile shares one remembered key, so the lookup can't drift.
+// True when the draft on `connection` should be reseeded the way boot seeds it.
+export function draftNeedsReseed(connection: HermesConnection | null | undefined): boolean {
+  return (
+    connection?.mode === 'remote' &&
+    !$activeSessionId.get() &&
+    !$currentCwd.get().trim() &&
+    $newChatWorkspaceTarget.get() === undefined
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the "No project open" workspace pane after switching profiles on a **remote** desktop connection.

A profile switch drops to a fresh draft *before* the swapped connection is published — `selectProfile` fires `requestFreshSession()` synchronously, while the new `$connection` descriptor only lands once `ensureGatewayProfile` resolves. The draft therefore resolves its cwd under the **outgoing** profile's remembered workspace (`hermes.desktop.workspace-cwd.remote.<host>.<profile>`), which is blank for any profile that never had a session. Nothing reseeds it afterwards: boot and the soft connection switch both seed the draft through `seedDefaultCwd` (remembered cwd → `/api/fs/default-cwd`), a profile swap did not.

Measured on the switch `researcher → default` (researcher had no remembered workspace; default did):

```
def+0    gw=default  connProfile=researcher  cwd="/home/…/hermes-rh"   ← draft created here
def+300  gw=default  connProfile=default     cwd=""                     ← resolved under researcher's key
def+2500 gw=default  connProfile=default     cwd=""                     ← nothing reseeds → "No project open"
```

**Fix:** extract `seedDefaultCwd` from `use-gateway-boot` into `app/session/seed-default-cwd.ts` (no behavior change for boot / soft switch) and have `ContribWiring` reseed a detached, un-targeted draft once the published `$connection` scope changes. It is keyed on the published descriptor rather than `$activeGatewayProfile` because the remembered-cwd lookup reads `$connection.profile`.

**Scope:** remote connections only (`draftNeedsReseed`). A bare local chat is detached by design (`workspaceCwdForNewSession` → configured default dir only) and every local profile shares one remembered key, so the outgoing-profile lookup cannot drift there.

Not in this PR: the separate "tree stuck on skeleton after a store reset" defect (#90229 / #91245) — #90334 covers that, and #96329 (stacked on it) closes the remaining profile-switch gap.

## Related Issue

Fixes #49293 (canonical: #49291 — root cause 1 "ordering race in selectProfile" and 3 "missing cwd reset on `$activeGatewayProfile` change"; #39837 covered only the send-routing side)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/seed-default-cwd.ts` (new): `seedDefaultCwd` (moved verbatim from `use-gateway-boot.ts`) + `draftNeedsReseed` predicate
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: import the shared helper instead of the inline closure; drop now-unused imports
- `apps/desktop/src/app/contrib/wiring.tsx`: effect keyed on the published `$connection` scope that reseeds a detached, un-targeted remote draft (with a `stillCurrent` guard so a superseded switch never publishes)
- `apps/desktop/src/app/session/seed-default-cwd.test.ts` (new): 6 tests — predicate scoping (remote-only, open session / attached / explicitly-detached drafts untouched), reseed from the published profile's remembered workspace after a switch, fallback to the backend default, superseded-caller no-op

## How to Test

1. Desktop in remote mode (Settings → connection → Remote URL) against a backend with ≥2 profiles; make sure one profile (e.g. `researcher`) has never had a session opened on this desktop (no `hermes.desktop.workspace-cwd.remote.<host>.researcher` key in localStorage).
2. Start on `default` with a workspace showing in the right rail. Switch to `researcher`, then back to `default`.
3. **Before:** right rail shows "No project open"; `$currentCwd` is `""`. **After:** the rail shows `default`'s remembered workspace (or the backend's `/api/fs/default-cwd`) within ~1 s, on every hop.
4. `cd apps/desktop && npx vitest run src/app/session/seed-default-cwd.test.ts` (6 pass), `npm run check:lint`, `npm run test:ui`.

Tested on macOS 15 (Darwin 24.6, Apple Silicon) desktop dev build at `a588685fb9` against a Fedora x86_64 backend (`hermes serve`, v0.20.5+1168) over HTTP/oauth with 5 profiles; verified live via CDP across a 5-hop switch cycle. Python tests untouched (desktop-only change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#39837 closed as superseded on the routing side; #90334 covers the separate tree-reset defect)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, no Python changes; `npm run check:lint` + `npm run test:ui` in `apps/desktop` pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (client) + Fedora (backend)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only; no path/process handling
