### PR TITLE
chore: release v0.20.6 (2026.8.27)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.20.5"
-__release_date__ = "2026.8.19"
+__version__ = "0.20.6"
+__release_date__ = "2026.8.27"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.20.5"
+version = "0.20.6"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.5"
+version = "0.20.6"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release commit for Hermes Agent v0.20.6 (v2026.8.27) — rollup patch tag covering the ~525 PRs / ~1,313 commits merged since v0.20.5 (v2026.8.19). Full curated notes for this window ship with v0.21.0.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.20.5 → 0.20.6, `__release_date__` 2026.8.19 → 2026.8.27
- `pyproject.toml`: version 0.20.6
- `uv.lock`: regenerated for the version bump (`uv lock --check` clean)

## Validation
| Gate | Result |
|---|---|
| `uv lock --check` | clean |
| Anchored stale-version grep (`0.20.5`) | zero hits |
| Installer squash-rewrite scan | small incremental fixes only, no rewrites |

## Infographic

![v0.20.6 rollup patch](https://v3b.fal.media/files/b/0aa803de/goquUw7gqJftZc2lXD7Le_2to4xm8X.png)
