### PR TITLE
fix(streaming): extract finish_reason/usage before content-shape continues

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4182,6 +4182,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
+            # Extract terminal chunk fields BEFORE any content-shape `continue`.
+            # Backends that merge finish_reason into the final content chunk
+            # (e.g. vLLM >= 0.1.dev20051) can have that chunk swallowed by the
+            # SSE-echo guard below when the tokenizer emits standalone ':'
+            # tokens — the finish chunk would never register and the response
+            # would be falsely flagged as truncated (#94614).
+            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
+            if chunk_finish_reason:
+                finish_reason = chunk_finish_reason
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage_obj = chunk.usage
+
             # Accumulate reasoning content
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
@@ -4314,13 +4326,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # discarding the attempted action.
                         result["partial_tool_names"].append(name)
 
-            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
-            if chunk_finish_reason:
-                finish_reason = chunk_finish_reason
-
-            # Usage in the final chunk
-            if hasattr(chunk, "usage") and chunk.usage:
-                usage_obj = chunk.usage
+            # (finish_reason/usage are now extracted at the top of the loop
+            # body. The old tail-side extraction sat after the SSE-echo
+            # guard's `continue` paths, so a merged finish chunk that tripped
+            # the guard never registered — false "stream truncated".)
 
         _close_managed_stream()
 

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -789,3 +789,67 @@ class TestSendTimePadMultimodalSafety:
         assert out[2]["content"] == ""
         # input list untouched (repair is copy-on-write)
         assert api_messages[1]["content"] == ""
+
+
+# ── Merged-finish content chunk swallowed by the SSE-echo guard (#94614) ──
+
+class TestMergedFinishChunkSurvivesSSEGuard:
+    """vLLM >= 0.1.dev20051 merges finish_reason into the final CONTENT
+    chunk instead of a separate marker-only chunk. When the SSE-echo guard
+    is engaged at that moment (GLM-family tokenizers emit standalone ':'
+    tokens mid-prose), the guard's content-shape continue paths swallow the
+    terminal chunk and finish_reason is never captured — a complete stream
+    is misclassified as a mid-stream drop. Terminal fields must be
+    extracted before any content-shape continue."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_merged_finish_chunk_after_sse_lookalike_prefix_completes(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _vllm_merged_finish_stream():
+            # ':' then ' uniform' engage the SSE-echo guard (may_be_sse True)
+            yield _make_stream_chunk(content=":")
+            yield _make_stream_chunk(content=" uniform")
+            # Merged-finish terminal content chunk, as the new vLLM emits
+            yield _make_stream_chunk(content=".", finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _vllm_merged_finish_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == ": uniform."
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_merged_finish_chunk_without_sse_trigger_still_completes(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Control: the same merged-finish shape without an SSE-lookalike
+        prefix must keep completing (guard never engages)."""
+
+        def _plain_merged_finish_stream():
+            yield _make_stream_chunk(content="Hello")
+            yield _make_stream_chunk(content=".", finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _plain_merged_finish_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "Hello."


### PR DESCRIPTION
## What does this PR do?

Second root cause behind #94614 (client-side mid-stream drop on responses that are in fact complete). This one lives in the chunk loop body, not in the accept-chunk fence:

Newer vLLM (0.1.dev20051, MTP build) merges `finish_reason:"stop"` into the final **content** chunk instead of emitting a marker-only terminal chunk. When the SSE-echo guard is engaged at that moment — GLM-family tokenizers emit standalone `':'` and `' id'` tokens, so ordinary prose trips `_provider_stream_text_may_be_sse` at a chunk boundary — the guard's content-shape `continue` paths swallow the terminal chunk and the tail-side `finish_reason` extraction never runs. The stream then ends with content delivered, usage captured, `finish_reason=None`, which the drop-guard mislabels as a mid-stream drop and retries.

Fix: extract `finish_reason`/`usage` at the top of the chunk loop body, before any content-shape `continue`; the old tail-side extraction becomes a comment. Behavior is otherwise unchanged.

Complementary to #94625 (fence gate) and #91376 (usage-side drop classification): those decide how to *classify*; this guarantees the marker is *captured* in the first place.

## Related Issue

Addresses a second mechanism behind #94614. Not marked `Fixes` since #94625 targets the same issue via the fence gate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: extract `finish_reason`/`usage` immediately after the `delta`/`model` extraction at the top of the chunk loop body — before the reasoning/content accumulation and its SSE-echo guard `continue` paths; the old tail-side extraction (after the guard) is replaced with an explanatory comment.
- `tests/run_agent/test_partial_stream_finish_reason.py`: new `TestMergedFinishChunkSurvivesSSEGuard` — (1) a merged-finish terminal content chunk arriving after an SSE-lookalike prefix (`':'`, `' uniform'`) must complete with `finish_reason == "stop"` and intact content; (2) control test: the same merged-finish shape without an SSE trigger still completes.

## How to Test

1. `uv sync --frozen && uv pip install pytest`
2. `python -m pytest tests/run_agent/test_partial_stream_finish_reason.py -q` → **19 passed**
3. Reproduce on unpatched code: `git stash push agent/chat_completion_helpers.py` → `test_merged_finish_chunk_after_sse_lookalike_prefix_completes` fails with the exact warning from #94614 (`Stream ended with no finish_reason after delivering text with no tool calls; treating as a mid-stream drop.`), the control passes; `git stash pop` → both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (this complements #91376 / #94625 rather than duplicating them)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full targeted file: 19 passed; see How to Test for scope)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Omarchy 4.0.0, Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A — behavior-affecting comments included in-code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (N/A — pure streaming-protocol handling, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)
