### PR TITLE
fix(approval): restore plugin-registered skip_container_guards consult

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -368,6 +368,57 @@ class TestDockerHostBindApproval:
         assert A._should_skip_container_guards("daytona") is True
         assert A._should_skip_container_guards("local") is False
 
+    def test_should_skip_container_guards_honors_plugin_flag(self):
+        """Regression: a plugin-registered backend's declared
+        skip_container_guards flag must actually be consulted here.
+
+        This exact wiring (added by 0484910787) was accidentally reverted
+        to a hardcoded tuple by an unrelated commit (c8c3f4c448) the very
+        next day -- nothing caught it because no test exercised a
+        plugin-registered backend through this function. Guards against
+        that regression recurring for any plugin backend (e.g. a
+        TerminalEnvironmentProvider shipped as a standalone plugin, per
+        PR #94400 -- this is exactly the mechanism third-party cloud
+        sandboxes are meant to use instead of hardcoded built-in entries).
+        """
+        import tools.approval as A
+        from agent import terminal_env_registry as reg
+        from agent.terminal_env_provider import TerminalEnvironmentProvider
+
+        class _Isolated(TerminalEnvironmentProvider):
+            name = "isolatedbox"
+            is_container = True  # skip_container_guards defaults to this
+
+            def is_available(self):
+                return True
+
+            def create_environment(self, **kwargs):
+                raise NotImplementedError
+
+        class _NotIsolated(TerminalEnvironmentProvider):
+            name = "openbox"
+
+            @property
+            def skip_container_guards(self):
+                return False
+
+            def is_available(self):
+                return True
+
+            def create_environment(self, **kwargs):
+                raise NotImplementedError
+
+        reg._reset_for_tests()
+        try:
+            reg.register_provider(_Isolated())
+            reg.register_provider(_NotIsolated())
+            assert A._should_skip_container_guards("isolatedbox") is True
+            assert A._should_skip_container_guards("openbox") is False
+            # Unregistered/unknown backend fails soft to False (approval ON).
+            assert A._should_skip_container_guards("nosuchbackend") is False
+        finally:
+            reg._reset_for_tests()
+
     def test_isolated_docker_keeps_fast_path(self, monkeypatch):
         """Isolated Docker still bypasses dangerous-command approval."""
         import tools.approval as A

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3980,7 +3980,18 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     """
     if env_type == "docker":
         return not has_host_access
-    return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
+    if env_type in ("singularity", "modal", "daytona", "vercel_sandbox"):
+        return True
+    if env_type in ("local", "ssh"):
+        return False
+    # Plugin-registered backends: honor their declarative flag. Fail-soft
+    # to False — an unknown backend keeps the approval layer ON.
+    try:
+        from agent.terminal_env_registry import provider_flag
+
+        return bool(provider_flag(env_type, "skip_container_guards", False))
+    except Exception:
+        return False
 
 
 def check_dangerous_command(command: str, env_type: str,


### PR DESCRIPTION
## What changed since the original version of this PR

Per @andrexibiza's review below, the original approach (adding `deepinfra` as a hardcoded built-in) went against exactly what #94400's `TerminalEnvironmentProvider` ABI was merged to eliminate, and against `AGENTS.md`'s "no new third-party-product plugins in-tree" policy. That's correct — the DeepInfra sandbox backend has moved to a standalone plugin: **[deepinfra/deepinfra-hermes-sandbox](https://github.com/deepinfra/deepinfra-hermes-sandbox)**, following the same path #93523 (Sprites) took.

What's left in **this** PR is the one genuine core gap the standalone plugin surfaced: `tools/approval.py`'s `_should_skip_container_guards()` was wired to consult the plugin registry when #94400 landed, but an unrelated commit the very next day (`c8c3f4c448`) reverted that hunk back to a hardcoded tuple as incidental collateral from an unrelated diff in the same file. No test exercised a plugin-registered backend through this function, so it went unnoticed — any `TerminalEnvironmentProvider` plugin declaring `skip_container_guards=True` has had that flag silently ignored since. This restores the consult and adds a regression test.

## Summary

- `tools/approval.py`: restore the `provider_flag(env_type, "skip_container_guards", False)` fallback for non-built-in backends.
- `tests/tools/test_modal_sandbox_fixes.py`: regression test registering a fake plugin provider through the real registry and confirming its `skip_container_guards` flag is actually honored (and that an unregistered backend still fails safe to `False`).

## Test plan

- [x] `pytest tests/tools/test_modal_sandbox_fixes.py tests/tools/test_approval.py tests/agent/test_terminal_env_registry.py` green
- [x] `ruff check` clean
- [x] Verified with the real `deepinfra-hermes-sandbox` provider registered through the actual registry (not just a fake test double): `check_dangerous_command()` returns `approved: True` for a normally-dangerous command once the plugin is registered, confirming the fix closes the gap end-to-end, not just in isolation

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>