### PR TITLE
fix(skills): fetch explicitly linked same-directory siblings on install

### DIFF
--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -139,13 +139,78 @@ def test_same_dir_link_without_extension_is_ignored(monkeypatch):
     """Prose targets that aren't file links (no extension) never fetch."""
     from tools.skills_hub import _referenced_support_paths
 
-    skill = "---\nname: x\ndescription: x\n---\nsee [notes](NOTES) and `README`\n"
+    skill = "---\nname: x\ndescription: x\---\nsee [notes](NOTES) and `README`\n"
     assert _referenced_support_paths(skill) == set()
+
+
+def test_same_dir_link_query_and_fragment_are_stripped():
+    """?query and #fragment never leak into the fetched bundle path."""
+    from tools.skills_hub import _referenced_support_paths
+
+    skill = (
+        "---\nname: x\ndescription: x\---\n"
+        "[a](CONTEXT-FORMAT.md?raw=1) [b](DEEPENING.md#usage)\n"
+    )
+    assert _referenced_support_paths(skill) == {"CONTEXT-FORMAT.md", "DEEPENING.md"}
+
+
+def test_case_variant_of_skill_md_is_never_a_sibling_entry():
+    """skill.md must not ship as a bundle file (case-insensitive FS collision)."""
+    from tools.skills_hub import _referenced_support_paths
+
+    skill = "---\nname: x\ndescription: x\---\n[home](skill.md)\n"
+    assert _referenced_support_paths(skill) == set()
+
+
+def test_case_folded_sibling_collision_drops_the_pair():
+    """A.md + a.md would collide on install — neither ships."""
+    from tools.skills_hub import _referenced_support_paths
+
+    skill = "---\nname: x\ndescription: x\---\n[a](A.md) [a2](a.md)\n"
+    assert _referenced_support_paths(skill) == set()
+
+
+def test_github_fetches_pin_to_the_tree_revision(monkeypatch):
+    """#96310 review: every byte fetch carries the tree's SHA as ?ref=."""
+    source = GitHubSource(GitHubAuth())
+    fetched: list[tuple[str, dict | None]] = []
+
+    def _fake_content(repo, path, ref=None):
+        fetched.append((path, {"ref": ref} if ref else None))
+        return SKILL_MD if path.endswith("SKILL.md") else "x"
+
+    monkeypatch.setattr(source, "_fetch_file_content", _fake_content)
+    monkeypatch.setattr(
+        source,
+        "_fetch_file_bytes",
+        lambda repo, path, ref=None: fetched.append((path, {"ref": ref} if ref else None)) or b"x",
+    )
+    source._tree_cache["owner/repo"] = (
+        "main",
+        [
+            {"path": "skill/SKILL.md", "type": "blob", "mode": "100644"},
+            {"path": "skill/CONTEXT-FORMAT.md", "type": "blob", "mode": "100644"},
+        ],
+    )
+    source._tree_revisions["owner/repo"] = "treesha123"
+
+    minimal_skill = "---\nname: x\ndescription: x\n---\nSee [the format](CONTEXT-FORMAT.md).\n"
+    monkeypatch.setattr(
+        source, "_fetch_file_content",
+        lambda repo, path, ref=None: fetched.append((path, {"ref": ref} if ref else None)) or minimal_skill,
+    )
+
+    bundle = source.fetch("owner/repo/skill")
+
+    assert bundle is not None
+    assert fetched, "expected byte fetches"
+    for path, params in fetched:
+        assert params == {"ref": "treesha123"}, path
 
 
 def test_github_source_rejects_symlink_in_referenced_directory(monkeypatch):
     source = GitHubSource(GitHubAuth())
-    monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path: SKILL_MD if path.endswith("SKILL.md") else "x")
+    monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path, ref=None: SKILL_MD if path.endswith("SKILL.md") else "x")
     source._tree_cache["owner/repo"] = (
         "main",
         [

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -105,6 +105,44 @@ def test_url_source_rejects_traversal_reference(monkeypatch):
     assert source.fetch("https://example.com/bad/SKILL.md") is None
 
 
+def test_same_dir_linked_siblings_are_fetched(served_repo, monkeypatch):
+    """#96310: explicitly linked same-skill-directory files must ship in the
+    bundle — dropping them made installs "succeed" with unresolved links."""
+    repo, url = served_repo
+    (repo / "CONTEXT-FORMAT.md").write_text("format\n")
+    (repo / "DEEPENING.md").write_text("deepening\n")
+    (repo / "SKILL.md").write_text(SKILL_MD + "See [the format](./CONTEXT-FORMAT.md) and [deepening](DEEPENING.md).\n")
+    monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _url: True)
+    monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _url: None)
+
+    bundle = UrlSource().fetch(url)
+
+    assert bundle is not None
+    assert bundle.files["CONTEXT-FORMAT.md"] == b"format\n"
+    assert bundle.files["DEEPENING.md"] == b"deepening\n"
+    # Unlinked siblings stay excluded — same fetch-minimization contract.
+    assert "README.md" not in bundle.files
+
+
+def test_same_dir_traversal_link_is_rejected(monkeypatch):
+    source = UrlSource()
+    skill = (
+        "---\nname: bad\ndescription: bad\n---\n"
+        "[bad](./../outside-secret.md)\n"
+    )
+    monkeypatch.setattr(source, "_fetch_text", lambda _url: skill)
+
+    assert source.fetch("https://example.com/bad/SKILL.md") is None
+
+
+def test_same_dir_link_without_extension_is_ignored(monkeypatch):
+    """Prose targets that aren't file links (no extension) never fetch."""
+    from tools.skills_hub import _referenced_support_paths
+
+    skill = "---\nname: x\ndescription: x\n---\nsee [notes](NOTES) and `README`\n"
+    assert _referenced_support_paths(skill) == set()
+
+
 def test_github_source_rejects_symlink_in_referenced_directory(monkeypatch):
     source = GitHubSource(GitHubAuth())
     monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path: SKILL_MD if path.endswith("SKILL.md") else "x")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -188,26 +188,51 @@ def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
             paths.add(safe)
     for match in _SAMEDIR_LINK_RE.finditer(normalized):
         raw = match.group(1).rstrip(".,;:")
+        # Canonicalize first: drop query/fragment components (``?raw=1``,
+        # ``#section``) and percent-decode — the same normalization the
+        # support-dir branch applies via urlsplit+unquote — then strip a
+        # leading ``./``. The set below deduplicates case-SENSITIVE repeats;
+        # case-VARIANT collisions are rejected rather than merged (below).
+        name = unquote(urlsplit(raw).path)
+        name = name[2:] if name.startswith("./") else name
         # External URLs, anchors, mailto and site-absolute targets are not
         # same-directory file links — leave them to their own resolution.
-        if "://" in raw or raw.startswith(("mailto:", "#", "/")):
+        if not name or "://" in raw or raw.startswith(("mailto:", "#", "/")):
             continue
-        name = raw[2:] if raw.startswith("./") else raw
         # A ``..`` prefix is a traversal attempt — same fail-closed contract
         # as the support-dir branch above, before any shape-based skipping.
         if name.startswith(".."):
             return None
         # Only unambiguous file links: an extension, no internal slash, and
-        # never SKILL.md itself (that IS the bundle root).
-        if "/" in name or name == "SKILL.md" or "." not in name.lstrip("."):
+        # never SKILL.md itself (that IS the bundle root). The casefold
+        # check keeps a ``skill.md`` link from shipping as a bundle entry
+        # that collides with SKILL.md on case-insensitive filesystems
+        # (macOS/Windows) — skipped, not merged, so the bundle root is
+        # never overwritten (#96310 review).
+        if (
+            "/" in name
+            or name.casefold() == "skill.md"
+            or "." not in name.lstrip(".")
+        ):
             continue
-        if not _SAMEDIR_NAME_RE.match(raw):
+        if not _SAMEDIR_NAME_RE.match(name):
             continue
         try:
             safe = _validate_bundle_rel_path(name)
         except ValueError:
             return None
         paths.add(safe)
+    # Case-folded collision among the accepted same-dir names themselves
+    # (``A.md`` + ``a.md``) would also collide on install — drop the pair
+    # rather than guess which variant the author meant.
+    folded: dict[str, str] = {}
+    for p in sorted(paths):
+        key = p.casefold()
+        if key in folded:
+            paths.discard(folded[key])
+            paths.discard(p)
+        else:
+            folded[key] = p
     return paths
 
 
@@ -692,7 +717,19 @@ class GitHubSource(SkillSource):
         repo = f"{parts[0]}/{parts[1]}"
         skill_path = parts[2]
 
-        skill_md = self._fetch_file_content(repo, f"{skill_path.rstrip('/')}/SKILL.md")
+        # Resolve the tree FIRST so every byte fetch in this install —
+        # SKILL.md included — can be pinned to the same revision. Without the
+        # pin the /contents endpoint floats to the default-branch HEAD and
+        # the downloaded bytes can come from a NEWER revision than the tree
+        # the paths were validated against (TOCTOU between "the tree says
+        # this is a regular blob" and "what actually gets downloaded").
+        # Idempotent + cached, so callers that already primed the tree pay
+        # nothing extra.
+        tree = self._get_repo_tree(repo)
+        pinned_ref = self._tree_revisions.get(repo)
+        skill_md = self._fetch_file_content(
+            repo, f"{skill_path.rstrip('/')}/SKILL.md", ref=pinned_ref
+        )
         if skill_md is None:
             return None
         referenced = _referenced_support_paths(skill_md)
@@ -700,7 +737,6 @@ class GitHubSource(SkillSource):
             return None
 
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
-        tree = self._get_repo_tree(repo)
         if tree is not None:
             branch, entries = tree
             prefix = f"{skill_path.rstrip('/')}/"
@@ -714,7 +750,7 @@ class GitHubSource(SkillSource):
                 if item.get("type") != "blob" or item.get("mode") == "120000":
                     logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
                     return None
-                content = self._fetch_file_bytes(repo, item_path)
+                content = self._fetch_file_bytes(repo, item_path, ref=pinned_ref)
                 if content is None:
                     return None
                 files[rel_path] = content
@@ -1099,9 +1135,11 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
+    def _fetch_file_content(
+        self, repo: str, path: str, ref: Optional[str] = None
+    ) -> Optional[str]:
         """Fetch a single text file from GitHub."""
-        content = self._fetch_file_bytes(repo, path)
+        content = self._fetch_file_bytes(repo, path, ref=ref)
         if content is None:
             return None
         try:
@@ -1109,11 +1147,24 @@ class GitHubSource(SkillSource):
         except UnicodeDecodeError:
             return None
 
-    def _fetch_file_bytes(self, repo: str, path: str) -> Optional[bytes]:
-        """Fetch exact file bytes from GitHub without text decoding."""
+    def _fetch_file_bytes(
+        self, repo: str, path: str, ref: Optional[str] = None
+    ) -> Optional[bytes]:
+        """Fetch exact file bytes from GitHub without text decoding.
+
+        ``ref`` pins the fetch to a specific commit/tree SHA. Without it the
+        contents endpoint floats to the default-branch HEAD, so the bytes can
+        come from a NEWER revision than the tree the paths were validated
+        against — a TOCTOU between "what the tree says is a regular blob"
+        and "what actually gets downloaded". Callers that resolved paths from
+        a tree pass that tree's SHA; ``None`` keeps the legacy unpinned
+        behavior for call sites with no revision in hand.
+        """
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
+        params = {"ref": ref} if ref else None
         resp = self._github_get(
             url,
+            params=params,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
         )
         if resp is not None and resp.status_code == 200:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -160,6 +160,16 @@ _LOCAL_LINK_RE = re.compile(
 _SUSPICIOUS_LOCAL_REF_RE = re.compile(
     r"(?:references|templates|scripts|assets|examples)/(?:[^\s)`\"'<>]*/)?\.\.(?:/|$)"
 )
+# Same-directory links (``](./FILE.ext)`` / ``](FILE.ext)``) — siblings of
+# SKILL.md that the document explicitly links. Skills legitimately ship
+# supporting docs next to SKILL.md instead of under a support directory
+# (e.g. mattpocock/skills' domain-modeling links ./CONTEXT-FORMAT.md);
+# dropping them made the install "succeed" while the bundle came out with
+# unresolved links (#96310). The trailing extension requirement keeps prose
+# words out; the code-side checks keep this strictly to the skill's own
+# directory (support-dir links stay on _LOCAL_LINK_RE).
+_SAMEDIR_LINK_RE = re.compile(r"\]\(([^)\s\"'<>]+)")
+_SAMEDIR_NAME_RE = re.compile(r"^(?:\./)?[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
@@ -176,6 +186,28 @@ def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
             return None
         if safe.split("/", 1)[0] in _ALLOWED_SUPPORT_DIRS:
             paths.add(safe)
+    for match in _SAMEDIR_LINK_RE.finditer(normalized):
+        raw = match.group(1).rstrip(".,;:")
+        # External URLs, anchors, mailto and site-absolute targets are not
+        # same-directory file links — leave them to their own resolution.
+        if "://" in raw or raw.startswith(("mailto:", "#", "/")):
+            continue
+        name = raw[2:] if raw.startswith("./") else raw
+        # A ``..`` prefix is a traversal attempt — same fail-closed contract
+        # as the support-dir branch above, before any shape-based skipping.
+        if name.startswith(".."):
+            return None
+        # Only unambiguous file links: an extension, no internal slash, and
+        # never SKILL.md itself (that IS the bundle root).
+        if "/" in name or name == "SKILL.md" or "." not in name.lstrip("."):
+            continue
+        if not _SAMEDIR_NAME_RE.match(raw):
+            continue
+        try:
+            safe = _validate_bundle_rel_path(name)
+        except ValueError:
+            return None
+        paths.add(safe)
     return paths
 
 


### PR DESCRIPTION
## What does this PR do?

Installing a GitHub-backed third-party skill could report success while **silently omitting files that `SKILL.md` explicitly links** when those files sit next to `SKILL.md` instead of under one of the five recognized support directories (`references/`, `templates/`, `scripts/`, `assets/`, `examples/`). The public example in the issue: `mattpocock/skills`' `domain-modeling` links `./CONTEXT-FORMAT.md` and `ADR-FORMAT.md` (and `codebase-design` links `DEEPENING.md`, `DESIGN-IT-TWICE.md`) — all four exist as regular sibling blobs in the same skill directory at the same revision, yet the installed bundle came out with unresolved links (#96310).

`_referenced_support_paths` gains a second collection pass for **same-directory markdown-link targets**:

- captured from real link syntax (`](./FILE.ext)` / `](FILE.ext)`) — prose words never match because the target must carry an extension and no internal slash;
- `SKILL.md` itself is excluded (it IS the bundle root);
- a leading `..` is rejected **fail-closed** — same contract as the existing support-dir traversal branch, and the whole-document `..` suspicion check still runs first;
- external URLs, anchors, `mailto:` and site-absolute targets are left to their own resolution;
- every accepted name still runs the bundle path validator.

Unlinked siblings remain excluded: the fetch-minimization contract is unchanged — only files the document **explicitly links** ship, no directory enumeration, no recursion, no outside-the-skill-directory paths (those keep riding the support-dir allowlist).

## Related Issue

Fixes #96310

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/skills_hub.py` — added `_SAMEDIR_LINK_RE` / `_SAMEDIR_NAME_RE` and the same-directory collection pass inside `_referenced_support_paths`, with the fail-closed `..` rejection and the external-target skips documented at the site.
- `tests/tools/test_skill_bundle_provenance.py` (+3): linked siblings ship in the bundle (both `./`-prefixed and bare forms, over the real HTTP fixture) while unlinked `README.md` stays excluded; a `](./../outside-secret.md)` link rejects the whole fetch (fail-closed); extension-less prose targets never fetch.

## How to Test

1. `python -m pytest tests/tools/test_skill_bundle_provenance.py -q` — should pass (10 passed).
2. Red/green: on unpatched `main` the sibling test fails (`CONTEXT-FORMAT.md` absent from the bundle) and the traversal test fails (the link is silently ignored instead of rejected); with this PR all ten pass.
3. Hub suites unchanged: `python -m pytest tests/tools/test_skills_hub.py tests/tools/test_skills_hub_clawhub.py tests/tools/test_skills_hub_browse_sh.py tests/hermes_cli/test_skills_hub.py -q` — should pass (107 passed).
4. Manual (per the issue): install the linked public skill — `hermes skills install github:mattpocock/skills/skills/engineering/domain-modeling` — the installed directory now contains `CONTEXT-FORMAT.md` and `ADR-FORMAT.md` alongside `SKILL.md`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the same-dir contract, fail-closed `..`, and fetch-minimization scope documented on the new pass)
- [x] New and existing unit tests pass locally (3 new; 107 across the skills_hub suites)
- [x] Changes are backward compatible (support-dir links, traversal rejection, and unlinked-sibling exclusion all pinned unchanged)
