### PR TITLE
fix(desktop-update): don't re-run a completed update on timeout (#96205)

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -607,11 +607,22 @@ if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
     FINAL_MSG="Update skipped: the git checkout is on a branch that isn't fully merged into $BRANCH. Switch to the target branch and update again (see the terminal output for the exact commands)."
     exit 8
   fi
-  log "retrying once (freshly pulled fix loads on the second run)"
-  publish_stage "Retrying update"
-  OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
-  printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
-  log "retry exit code: $CODE"
+  # A COMPLETED update is terminal (#96205): if the update printed its
+  # completion marker ("✓ Update complete!") before the process was
+  # interrupted -- killed with the timeout sentinel 124 by an outer
+  # watchdog, SIGINT, ... -- the install state is already done. Re-running
+  # it would re-apply the whole update (the retry storm that hangs the
+  # desktop updater for 70+ minutes). Surface success instead.
+  if printf '%s' "$OUT" | grep -q "Update complete!"; then
+    log "update completed before the process was interrupted (exit $CODE); treating as success, not retrying (#96205)"
+    CODE=0
+  else
+    log "retrying once (freshly pulled fix loads on the second run)"
+    publish_stage "Retrying update"
+    OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
+    printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
+    log "retry exit code: $CODE"
+  fi
 fi
 trap 'on_signal TERM' TERM
 

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -50,10 +50,11 @@ param(
     [switch]$NoMarkerCleanup,
     [switch]$SelfTestUi,
     [switch]$SelfTestPipeDrain,
+    [switch]$SelfTestRetryState,
     [switch]$SelfTestMarker
 )
 
-if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
+if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $SelfTestRetryState -and -not $InstallRoot) {
     # Mandatory in spirit; relaxed in the signature only so the self-test
     # switches can drive the UI / the pipe drain without a checkout.
     throw "-InstallRoot is required"
@@ -1119,6 +1120,55 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited); StartedAfterJobAssignment = $true }
 }
 
+# ── Update retry state machine (#96205) ────────────────────────────────────
+# `hermes update` can COMPLETE (its output shows "✓ Update complete!") and
+# still be killed by the stall watchdog: the post-update finalization
+# (gateway-restart hand-off) can stay alive and silent past the idle
+# ceiling, so Invoke-HermesStep terminates the tree and reports the timeout
+# sentinel 124. The old gate retried on ANY non-zero, non-2 exit code,
+# re-running a completed update from scratch -- the #96205 retry storm that
+# parked the Desktop popup for 70+ minutes.
+#
+# The completion marker is therefore a TERMINAL state: an update that
+# printed it is done, whatever exit code the step ended with. Terminal
+# states are never re-run.
+function Get-HermesUpdateRetryState([int]$Code, [string]$Output) {
+    if ($Code -eq 0) { return 'success' }
+    if ($Output -match 'Update complete!') { return 'completed' }
+    if ($Code -eq 2) { return 'fail-closed' }
+    return 'retryable'
+}
+
+# Run the update step through the retry state machine. Only the 'retryable'
+# state gets the single update-boundary retry (fresh code on disk, stale
+# code in memory). Exit 2 ("close all Hermes windows") is not retryable, and
+# neither is a completed update. A 'completed' state is surfaced as success
+# -- exit 0 -- with the captured output preserved so the truthful-completion
+# check below still sees a "Desktop build failed" warning if one was printed.
+function Invoke-HermesUpdateWithRetry([scriptblock]$Step) {
+    $res = & $Step
+    Write-HandoffLog "hermes update exit code: $($res.Code)"
+    $state = Get-HermesUpdateRetryState -Code $res.Code -Output $res.Output
+    if ($state -eq 'retryable') {
+        # One retry for the update-boundary class (fresh code on disk, stale
+        # code in memory).
+        Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
+        Publish-UiProgress "Retrying update"
+        $res = & $Step
+        Write-HandoffLog "retry exit code: $($res.Code)"
+        $state = Get-HermesUpdateRetryState -Code $res.Code -Output $res.Output
+    }
+    if ($state -eq 'completed') {
+        # Truthful completion: the install state is done even though the step
+        # was killed at the idle ceiling while finalizing. Report success so
+        # the hand-off relaunches the NEW build instead of re-running the
+        # update (the #96205 retry storm).
+        Write-HandoffLog "update completed but the step was killed during post-update finalization (exit $($res.Code)); treating as success, not retrying (#96205)"
+        $res = @{ Code = 0; Output = $res.Output; TreeQuiesced = $res.TreeQuiesced; StartedAfterJobAssignment = $res.StartedAfterJobAssignment }
+    }
+    return $res
+}
+
 $finalCode = 1
 $finalMsg = "update did not complete"
 $script:TreeSafeToFinalize = $true
@@ -1357,6 +1407,70 @@ exit 3
     exit 0
 }
 
+# -SelfTestRetryState: prove the retry state machine never re-runs a ------
+# completed update (#96205). Fixture states drive Get-HermesUpdateRetryState,
+# then the real gate runs with a step that "completes" and is then killed
+# with the timeout sentinel 124: the step must be invoked exactly once and
+# the result must surface as exit 0 for the downstream hand-off. Exits before
+# any marker/desktop machinery, same as the other self-test arms.
+if ($SelfTestRetryState) {
+    New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
+    $problems = @()
+    $fixtures = @(
+        @{ Name = 'clean success';             Code = 0;   Output = 'Update complete! (v0.20.5)';          Expected = 'success' }
+        @{ Name = 'fail-closed exit 2';        Code = 2;   Output = 'close all Hermes windows';               Expected = 'fail-closed' }
+        @{ Name = 'completed then timeout';    Code = 124; Output = 'Update complete! (v0.20.5) [main @ 2903a3fd]'; Expected = 'completed' }
+        @{ Name = 'completed then exit 3';     Code = 3;   Output = 'Update complete! (v0.19.0 -> v0.20.0)'; Expected = 'completed' }
+        @{ Name = 'timeout mid-update';        Code = 124; Output = 'Cloning into C:\hermes...';              Expected = 'retryable' }
+        @{ Name = 'ordinary failure';          Code = 1;   Output = 'Traceback (most recent call last)';      Expected = 'retryable' }
+        @{ Name = 'exit 9 with completion';    Code = 9;   Output = 'done. Update complete!';                 Expected = 'completed' }
+        @{ Name = 'stale output, no marker';   Code = 124; Output = 'pip install -e .';                       Expected = 'retryable' }
+        @{ Name = 'empty output timeout';      Code = 124; Output = '';                                        Expected = 'retryable' }
+    )
+    foreach ($f in $fixtures) {
+        $actual = Get-HermesUpdateRetryState -Code $f.Code -Output $f.Output
+        if ($actual -ne $f.Expected) { $problems += "$($f.Name): state '$actual', expected '$($f.Expected)'" }
+    }
+
+    # The gate itself: a step that printed the completion marker and was then
+    # killed with 124 must be invoked EXACTLY ONCE and surface as success --
+    # the exact #96205 shape (update completes, exits 124, must not re-run).
+    $ctx = @{ N = 0 }
+    $res = Invoke-HermesUpdateWithRetry {
+        $ctx.N = $ctx.N + 1
+        return @{ Code = 124; Output = 'Update complete! (v0.20.5) [main @ 2903a3fd]'; TreeQuiesced = $true; StartedAfterJobAssignment = $true }
+    }
+    if ($ctx.N -ne 1) { $problems += "completed-after-timeout step was invoked $($ctx.N) times (expected 1) -- the #96205 retry storm is back" }
+    if ($res.Code -ne 0) { $problems += "completed-after-timeout surfaced as exit $($res.Code), expected 0" }
+    if ($res.Output -notmatch 'Update complete!') { $problems += "completed-after-timeout lost the step output" }
+
+    # A genuine mid-update timeout (no completion marker) keeps the single
+    # retry, and its outcome is final.
+    $ctx2 = @{ N = 0 }
+    $res2 = Invoke-HermesUpdateWithRetry {
+        $ctx2.N = $ctx2.N + 1
+        return @{ Code = 124; Output = 'Cloning into...'; TreeQuiesced = $true; StartedAfterJobAssignment = $true }
+    }
+    if ($ctx2.N -ne 2) { $problems += "mid-update timeout was invoked $($ctx2.N) times (expected 2: first attempt + one retry)" }
+    if ($res2.Code -ne 124) { $problems += "mid-update timeout surfaced as exit $($res2.Code), expected 124" }
+
+    # Fail-closed (exit 2) is not retried either.
+    $ctx3 = @{ N = 0 }
+    $res3 = Invoke-HermesUpdateWithRetry {
+        $ctx3.N = $ctx3.N + 1
+        return @{ Code = 2; Output = 'close all Hermes windows'; TreeQuiesced = $true; StartedAfterJobAssignment = $true }
+    }
+    if ($ctx3.N -ne 1) { $problems += "fail-closed exit 2 was invoked $($ctx3.N) times (expected 1)" }
+    if ($res3.Code -ne 2) { $problems += "fail-closed exit 2 surfaced as exit $($res3.Code), expected 2" }
+
+    if ($problems.Count -gt 0) {
+        Write-Host "RETRY-STATE SELF-TEST: FAIL -- $($problems -join '; ')"
+        exit 1
+    }
+    Write-Host "RETRY-STATE SELF-TEST: PASS"
+    exit 0
+}
+
 try {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     Remove-Item -LiteralPath $ResultPath -Force -ErrorAction SilentlyContinue
@@ -1495,17 +1609,13 @@ try {
     }
     Write-HandoffLog ("running: python " + ($updateArgs -join " "))
     Publish-UiProgress "Updating code and dependencies"
-    $res = Invoke-HermesStep $pythonExe $updateArgs "update"
-    Write-HandoffLog "hermes update exit code: $($res.Code)"
-
-    if ($res.Code -ne 0 -and $res.Code -ne 2) {
-        # One retry for the update-boundary class (fresh code on disk, stale
-        # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
-        Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
-        Publish-UiProgress "Retrying update"
-        $res = Invoke-HermesStep $pythonExe $updateArgs "update"
-        Write-HandoffLog "retry exit code: $($res.Code)"
-    }
+    # The retry decision lives in Invoke-HermesUpdateWithRetry (the #96205
+    # state machine): only a genuinely failed attempt is retried once. An
+    # update that COMPLETED (its output shows "✓ Update complete!") is
+    # terminal even if the stall watchdog later kills the finalizing step
+    # with 124 -- re-running it would re-apply the whole install and hang
+    # the Desktop popup for 70+ minutes.
+    $res = Invoke-HermesUpdateWithRetry { Invoke-HermesStep $pythonExe $updateArgs "update" }
 
     # -- 4. Truthful completion: don't trust exit 0 -------------------------
     # `hermes update` treats a Desktop GUI build failure as NON-fatal (prints

--- a/tests/test_desktop_update_windows_retry_state.py
+++ b/tests/test_desktop_update_windows_retry_state.py
@@ -1,0 +1,196 @@
+"""Regression: a completed update must never be re-run by the timeout retry.
+
+#96205: on native Windows, ``hermes update`` runs to completion (its output
+shows "✓ Update complete!") but the step process does not exit cleanly — the
+post-update finalization (gateway-restart hand-off) stays alive and silent
+until the stall watchdog in ``Invoke-HermesStep`` terminates the tree with
+the timeout sentinel 124. The old retry gate re-ran the update on ANY
+non-zero, non-2 exit code, so the completed update was re-applied from
+scratch ("first attempt failed; retrying once (freshly pulled fix loads on
+the second run)") and the Desktop popup hung for 70+ minutes.
+
+The fix is a retry state machine (``Get-HermesUpdateRetryState`` +
+``Invoke-HermesUpdateWithRetry`` in ``scripts/desktop-update/windows.ps1``):
+the completion marker ("Update complete!") is a TERMINAL state. A step that
+printed it is done — the install state is updated — so it is surfaced as
+success (exit 0) instead of being re-run, whatever exit code the watchdog
+produced afterwards. ``scripts/desktop-update/posix.sh`` carries the same
+gate shape for the sibling hand-off.
+
+These are source-contract assertions, because Linux CI cannot execute the
+PowerShell hand-off; the executable proof is the ``-SelfTestRetryState`` arm
+of ``windows.ps1`` (``windows_only`` below), which drives the real gate with
+fixture steps and asserts a completed update is invoked exactly once.
+Sabotage-proof: removing the completion branch, reordering the gate so a
+completed update reaches the retry, or dropping the self-test arm each fails
+a test here.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+POSIX_SH = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+
+class TestRetryStateMachineSkipsCompletedUpdate:
+    """The windows.ps1 retry gate must treat a completed update as terminal.
+
+    The update printed "✓ Update complete!" and was THEN killed with 124 by
+    the stall watchdog while finalizing (gateway-restart hand-off). The
+    install state is done; re-running it is the #96205 retry storm.
+    """
+
+    def _src(self) -> str:
+        return WINDOWS_PS1.read_text(encoding="utf-8")
+
+    def test_state_machine_function_defines_completed_state(self):
+        src = self._src()
+        assert "function Get-HermesUpdateRetryState" in src, (
+            "the update retry decision is no longer a state machine"
+        )
+        # The completion marker must map to a terminal 'completed' state.
+        # A removed or inert completion branch fails here.
+        assert "$Output -match 'Update complete!'" in src, (
+            "the state machine no longer detects the update completion marker"
+        )
+        assert "return 'completed'" in src, (
+            "the completion marker no longer yields the terminal 'completed' state"
+        )
+
+    def test_only_retryable_state_reaches_the_retry(self):
+        src = self._src()
+        # The retry ("first attempt failed; retrying once") must be guarded
+        # by the retryable-state check, which in turn must come AFTER the
+        # completion branch in the gate so a completed update never retries.
+        msg = (
+            "the gate retries outside the 'retryable' state -- a completed "
+            "update can be re-run (the #96205 retry storm)"
+        )
+        assert "if ($state -eq 'retryable')" in src, msg
+        retryable = src.index("if ($state -eq 'retryable')")
+        assert "first attempt failed; retrying once" in src[retryable:], msg
+        completed = src.index("if ($state -eq 'completed')")
+        # Same function: the retryable branch is handled before the completed
+        # branch, and the completed branch must not contain the retry.
+        assert completed > retryable, "the retry branch must precede the completed branch"
+        assert "first attempt failed; retrying once" not in src[completed:], msg
+
+    def test_completed_timeout_surfaces_as_success(self):
+        src = self._src()
+        # A completed update must be reported as exit 0 so the hand-off
+        # relaunches the NEW build instead of failing (and instead of
+        # re-running the update).
+        completed = src.index("if ($state -eq 'completed')")
+        tail = src[completed:]
+        assert "Code = 0" in tail, (
+            "a completed-after-timeout update is not surfaced as success"
+        )
+        # The captured output must be preserved so the truthful-completion
+        # check below still sees a "Desktop build failed" warning.
+        assert "Output = $res.Output" in tail, (
+            "the completed branch drops the step output"
+        )
+
+    def test_main_flow_runs_the_update_through_the_state_machine(self):
+        src = self._src()
+        assert "Invoke-HermesUpdateWithRetry" in src, (
+            "the main update flow no longer goes through the retry state machine"
+        )
+        # The main flow's own retry gate (the pre-fix shape) must be gone:
+        # the gate now lives in the state machine function.
+        assert "if ($res.Code -ne 0 -and $res.Code -ne 2) {" not in src, (
+            "the old any-nonzero retry gate is still in the main flow"
+        )
+
+    def test_self_test_has_retry_state_arm(self):
+        src = self._src()
+        assert "[switch]$SelfTestRetryState" in src, (
+            "-SelfTestRetryState lost its switch: the executable regression "
+            "can no longer drive the gate"
+        )
+        assert "RETRY-STATE SELF-TEST: PASS" in src, (
+            "the self-test no longer has a pass line for the retry state machine"
+        )
+
+
+class TestPosixRetryGateSkipsCompletedUpdate:
+    """The posix.sh sibling must carry the same gate shape (#96205 class fix)."""
+
+    def test_completion_check_guards_the_posix_retry(self):
+        src = POSIX_SH.read_text(encoding="utf-8")
+        msg = (
+            "the posix retry gate no longer treats a completed update as "
+            "terminal -- the #96205 retry storm can re-run posix updates too"
+        )
+        assert 'grep -q "Update complete!"' in src, msg
+        gate = src.index('grep -q "Update complete!"')
+        assert "retrying once" in src[gate:], msg
+        # The completion check must sit inside the non-zero retry gate,
+        # upstream of the retry itself.
+        assert 'if [ "$CODE" -ne 0 ]' in src[:gate], msg
+
+
+@pytest.mark.windows_only
+def test_completed_update_is_invoked_exactly_once_after_timeout(
+    tmp_path: Path,
+) -> None:
+    """Execute the real retry gate against fixture steps.
+
+    ``-SelfTestRetryState`` drives ``Invoke-HermesUpdateWithRetry`` with a
+    step that "completes" (prints the marker) and is then killed with the
+    timeout sentinel 124 — the exact #96205 shape. The step must be invoked
+    exactly once and the result must surface as exit 0. A genuine mid-update
+    timeout keeps its single retry (2 invocations), and fail-closed exit 2 is
+    not retried either.
+    """
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    powershell = (
+        system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    if not powershell.is_file():
+        pytest.skip(f"Windows PowerShell not found at {powershell}")
+
+    env = {
+        **os.environ,
+        # The fixture writes its hand-off log under TEMP; point that at
+        # tmp_path so the test leaves nothing behind.
+        "TEMP": str(tmp_path),
+        "TMP": str(tmp_path),
+    }
+
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_PS1),
+            "-SelfTestRetryState",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert "RETRY-STATE SELF-TEST: PASS" in result.stdout, (
+        "The update retry state machine regressed: a completed update is "
+        "being re-run after a timeout (the #96205 retry storm that hangs the "
+        "Desktop popup for 70+ minutes), or a state maps to the wrong "
+        f"outcome. Fixture diagnosis follows.\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, (
+        f"-SelfTestRetryState exited {result.returncode}.\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )


### PR DESCRIPTION
## Problem

On native Windows, `hermes update --yes` (desktop hand-off path) runs to
completion — it prints `✓ Update complete!` — but the step process does not
exit cleanly: the post-update finalization (gateway-restart hand-off) stays
alive and silent until the stall watchdog in `Invoke-HermesStep` terminates
the tree with the timeout sentinel **124**. The old retry gate in
`scripts/desktop-update/windows.ps1` treated 124 like any other failure:

```
update| ✓ Update complete! (v0.20.5) [main @ 2903a3fd]
update| hermes update exit code: 124
update| first attempt failed; retrying once (freshly pulled fix loads on the second run)
```

That retry re-runs the **completed** update from scratch, and the Desktop
updater popup hangs for 70+ minutes (#96205). The posix hand-off
(`posix.sh`) has the same retry-gate shape.

## Fix

Introduce a **retry state machine** in `windows.ps1`:

- `Get-HermesUpdateRetryState` maps each attempt to a state:
  `success` (0), `completed` (the update printed its completion marker),
  `fail-closed` (2), `retryable` (anything else).
- `Invoke-HermesUpdateWithRetry` runs the update step through the machine.
  Only `retryable` gets the single update-boundary retry. A **completed**
  update is terminal — it is surfaced as **exit 0** (output preserved, so
  the truthful-completion check still sees a `Desktop build failed`
  warning) and the hand-off relaunches the **new** build instead of
  re-running the update.
- `posix.sh` carries the same gate shape (completion marker ⇒ no retry ⇒
  treated as success), closing the class for the sibling hand-off.

## Tests

- New `-SelfTestRetryState` arm in `windows.ps1` (executable on Windows):
  fixture states drive the state machine, then the real gate runs with a
  step that "completes" and is killed with 124 — **the step is invoked
  exactly once** and surfaces as exit 0. Genuine mid-update timeouts keep
  their single retry; exit 2 stays non-retryable.
- New `tests/test_desktop_update_windows_retry_state.py`:
  - source-contract assertions runnable on Linux CI (sabotage-proof: a
    removed completion branch, a reordered gate, or a dropped self-test
    arm each fails),
  - a `windows_only` executable test running `-SelfTestRetryState`.
- Regression proven red→green: all 7 new tests fail on the pre-fix code
  and pass post-fix.

Result: `tests/test_desktop_update_windows_retry_state.py` — 7 passed.
Related desktop-update suite — 15 passed, 2 skipped (posix executable
tests, Linux-only).

## Relationship to #96221

#96221 (by the issue author) fixes the **Rust bootstrap-installer** retry
sites (`apps/bootstrap-installer/src-tauri/src/update.rs`) for exit 124.
This PR fixes the **PowerShell hand-off layer** where the retry storm in
the issue log actually originates (`first attempt failed; retrying once`
is emitted by `windows.ps1`). The two are complementary — together they
cover both layers that can re-run a completed update.

## Risk

- `sweeper:risk-platform-windows`: touched paths are the Windows desktop
  update hand-off and its posix sibling; behavior changes only for the
  timeout-after-completion edge (was: re-run + hang; now: success + relaunch).
- No Python/Rust code changed; no config or state migration.

Closes #96205
