### PR TITLE
fix(computer-use): launch notarised CUA Driver from standard macOS installs

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3688,8 +3688,8 @@ DEFAULT_CONFIG = {
         # macOS only: allow launching an UNSIGNED (ad-hoc / TeamIdentifier
         # not set) CuaDriver.app for the private-session daemon. The default
         # (false) fails closed unless the bundle is signed with the official
-        # cua-driver identity (com.trycua.driver / team 4YEC26S9KF). Enable
-        # only when developing the driver locally from source.
+        # cua-driver identity (com.trycua.driver / an official signing team).
+        # Enable only when developing the driver locally from source.
         "allow_unsigned_driver": False,
         # Pre-authorize existing-profile browser attachment in standard mode
         # (cua-driver's trusted-launcher `--grant existing-profile`). When

--- a/tests/tools/test_computer_use_cua_macos_identity.py
+++ b/tests/tools/test_computer_use_cua_macos_identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 import pytest
@@ -13,16 +14,39 @@ def _codesign_proc(
     *,
     team_id: str,
     identifier: str = "com.trycua.driver",
+    returncode: int = 0,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(
         ["codesign"],
-        0,
+        returncode,
         stdout="",
         stderr=(
             f"Identifier={identifier}\n"
             f"TeamIdentifier={team_id}\n"
         ),
     )
+
+
+def _patch_codesign(monkeypatch, proc):
+    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
+    monkeypatch.setattr(cua_backend.subprocess, "run", lambda *args, **kwargs: proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="macOS bundle paths use POSIX separators")
+def test_resolve_app_path_follows_real_symlink_and_is_idempotent(tmp_path):
+    app = tmp_path / "CuaDriver.app"
+    executable = app / "Contents" / "MacOS" / "cua-driver"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    shim = tmp_path / "cua-driver"
+    try:
+        shim.symlink_to(executable)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable on this host")
+
+    assert cua_backend._resolve_cua_driver_app_path(str(shim)) == str(app)
+    assert cua_backend._resolve_cua_driver_app_path(str(executable)) == str(app)
 
 
 def test_resolve_app_path_follows_standard_driver_symlink(monkeypatch):
@@ -48,34 +72,22 @@ def test_resolve_app_path_does_not_fall_back_to_an_unrelated_bundle(monkeypatch)
 
 @pytest.mark.parametrize("team_id", ["4YEC26S9KF", "YCK386LBJ7"])
 def test_driver_signature_accepts_official_team_ids(monkeypatch, team_id):
-    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
-    monkeypatch.setattr(
-        cua_backend.subprocess,
-        "run",
-        lambda *args, **kwargs: _codesign_proc(team_id=team_id),
-    )
+    _patch_codesign(monkeypatch, _codesign_proc(team_id=team_id))
 
     cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
 
 
 def test_driver_signature_still_rejects_unrecognised_team(monkeypatch):
-    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
-    monkeypatch.setattr(
-        cua_backend.subprocess,
-        "run",
-        lambda *args, **kwargs: _codesign_proc(team_id="EVIL000000"),
-    )
+    _patch_codesign(monkeypatch, _codesign_proc(team_id="EVIL000000"))
 
     with pytest.raises(RuntimeError, match="signed by team"):
         cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
 
 
 def test_driver_signature_still_requires_exact_bundle_identifier(monkeypatch):
-    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
-    monkeypatch.setattr(
-        cua_backend.subprocess,
-        "run",
-        lambda *args, **kwargs: _codesign_proc(
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(
             team_id="YCK386LBJ7",
             identifier="com.trycua.driver.evil",
         ),
@@ -83,3 +95,84 @@ def test_driver_signature_still_requires_exact_bundle_identifier(monkeypatch):
 
     with pytest.raises(RuntimeError, match="has identifier"):
         cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_rejects_unsigned_by_default(monkeypatch):
+    _patch_codesign(monkeypatch, _codesign_proc(team_id="not set"))
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+
+    with pytest.raises(RuntimeError, match="signed by team"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_allows_unsigned_only_with_opt_in(monkeypatch):
+    _patch_codesign(monkeypatch, _codesign_proc(team_id="not set"))
+    monkeypatch.setattr(
+        cua_backend,
+        "_computer_use_cfg",
+        lambda: {"allow_unsigned_driver": True},
+    )
+
+    cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_unsigned_opt_in_still_requires_exact_bundle_identifier(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(
+            team_id="not set",
+            identifier="com.trycua.driver.evil",
+        ),
+    )
+    monkeypatch.setattr(
+        cua_backend,
+        "_computer_use_cfg",
+        lambda: {"allow_unsigned_driver": True},
+    )
+
+    with pytest.raises(RuntimeError, match="has identifier"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_requires_codesign(monkeypatch):
+    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="codesign is required"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_rejects_codesign_failure(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(team_id="", returncode=1),
+    )
+
+    with pytest.raises(RuntimeError, match="not code-signed"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_embedded_spawn_resolves_shim_and_accepts_current_team(monkeypatch):
+    executable = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+    monkeypatch.setattr(cua_backend.os.path, "realpath", lambda path: executable)
+    monkeypatch.setattr(cua_backend.os.path, "isfile", lambda path: True)
+    monkeypatch.setattr(cua_backend.os, "access", lambda path, mode: True)
+    _patch_codesign(monkeypatch, _codesign_proc(team_id="YCK386LBJ7"))
+
+    command = cua_backend._embedded_daemon_spawn_command(
+        "/Users/test/.local/bin/cua-driver",
+        ["serve", "--embedded", "--socket", "/tmp/private.sock"],
+        platform="darwin",
+    )
+
+    assert command == [
+        "/usr/bin/open",
+        "-n",
+        "-g",
+        "-a",
+        "/Applications/CuaDriver.app",
+        "--args",
+        "serve",
+        "--embedded",
+        "--socket",
+        "/tmp/private.sock",
+    ]

--- a/tests/tools/test_computer_use_cua_macos_identity.py
+++ b/tests/tools/test_computer_use_cua_macos_identity.py
@@ -1,0 +1,85 @@
+"""macOS CuaDriver.app path and signing identity contracts."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tools.computer_use import cua_backend
+
+
+def _codesign_proc(
+    *,
+    team_id: str,
+    identifier: str = "com.trycua.driver",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        ["codesign"],
+        0,
+        stdout="",
+        stderr=(
+            f"Identifier={identifier}\n"
+            f"TeamIdentifier={team_id}\n"
+        ),
+    )
+
+
+def test_resolve_app_path_follows_standard_driver_symlink(monkeypatch):
+    symlink = "/Users/test/.local/bin/cua-driver"
+    executable = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+
+    monkeypatch.setattr(cua_backend.os.path, "realpath", lambda path: executable)
+    monkeypatch.setattr(cua_backend.os.path, "isfile", lambda path: True)
+    monkeypatch.setattr(cua_backend.os, "access", lambda path, mode: True)
+
+    assert cua_backend._resolve_cua_driver_app_path(symlink) == "/Applications/CuaDriver.app"
+
+
+def test_resolve_app_path_does_not_fall_back_to_an_unrelated_bundle(monkeypatch):
+    monkeypatch.setattr(
+        cua_backend.os.path,
+        "realpath",
+        lambda path: "/usr/local/bin/cua-driver",
+    )
+
+    assert cua_backend._resolve_cua_driver_app_path("cua-driver") is None
+
+
+@pytest.mark.parametrize("team_id", ["4YEC26S9KF", "YCK386LBJ7"])
+def test_driver_signature_accepts_official_team_ids(monkeypatch, team_id):
+    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: _codesign_proc(team_id=team_id),
+    )
+
+    cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_still_rejects_unrecognised_team(monkeypatch):
+    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: _codesign_proc(team_id="EVIL000000"),
+    )
+
+    with pytest.raises(RuntimeError, match="signed by team"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_still_requires_exact_bundle_identifier(monkeypatch):
+    monkeypatch.setattr(cua_backend.shutil, "which", lambda name: "/usr/bin/codesign")
+    monkeypatch.setattr(
+        cua_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: _codesign_proc(
+            team_id="YCK386LBJ7",
+            identifier="com.trycua.driver.evil",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="has identifier"):
+        cua_backend._validate_cua_driver_app_signature("/Applications/CuaDriver.app")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -601,11 +601,12 @@ def _resolve_cua_driver_app_path(driver_cmd: str) -> Optional[str]:
     chain never validated. If the resolved driver does not live inside an
     app bundle, the caller fails closed with install guidance.
     """
+    resolved_driver_cmd = os.path.realpath(driver_cmd)
     marker = ".app/Contents/MacOS/"
-    marker_index = driver_cmd.find(marker)
+    marker_index = resolved_driver_cmd.find(marker)
     if marker_index < 0:
         return None
-    candidate = driver_cmd[: marker_index + len(".app")]
+    candidate = resolved_driver_cmd[: marker_index + len(".app")]
     executable = os.path.join(candidate, "Contents", "MacOS", "cua-driver")
     if os.path.isfile(executable) and os.access(executable, os.X_OK):
         return candidate
@@ -613,11 +614,11 @@ def _resolve_cua_driver_app_path(driver_cmd: str) -> Optional[str]:
 
 
 # The only bundle identity the private daemon may launch through, and the
-# team that signs official cua-driver releases. Exact matches only: a
+# teams that sign official cua-driver releases. Exact matches only: a
 # suffixed identifier ("com.trycua.driver.evil") or a different non-empty
 # team is an impostor bundle, not a variant.
 _CUA_DRIVER_BUNDLE_ID = "com.trycua.driver"
-_CUA_DRIVER_TEAM_ID = "4YEC26S9KF"
+_CUA_DRIVER_TEAM_IDS = ("4YEC26S9KF", "YCK386LBJ7")
 
 
 def _validate_cua_driver_app_signature(app_path: str) -> None:
@@ -626,7 +627,7 @@ def _validate_cua_driver_app_signature(app_path: str) -> None:
     Launching via ``/usr/bin/open`` hands LaunchServices whatever bundle sits
     at the path, so the TCC-identity fix must not become a launcher for
     arbitrary apps: require ``codesign -dv`` to report EXACTLY
-    ``Identifier=com.trycua.driver`` and the expected TeamIdentifier.
+    ``Identifier=com.trycua.driver`` and an expected TeamIdentifier.
     ``TeamIdentifier=not set`` (unsigned/ad-hoc dev builds) is allowed only
     when ``computer_use.allow_unsigned_driver: true`` is set in config.yaml —
     the escape hatch for local driver development, never the default. Raises
@@ -664,13 +665,13 @@ def _validate_cua_driver_app_signature(app_path: str) -> None:
             f"CuaDriver.app at {app_path} has identifier {identifier!r}, "
             f"expected {_CUA_DRIVER_BUNDLE_ID!r}; refusing to launch it."
         )
-    if team == _CUA_DRIVER_TEAM_ID:
+    if team in _CUA_DRIVER_TEAM_IDS:
         return
     if team in ("", "not set") and _computer_use_cfg().get("allow_unsigned_driver") is True:
         return
     raise RuntimeError(
-        f"CuaDriver.app at {app_path} is signed by team {team!r}, expected "
-        f"{_CUA_DRIVER_TEAM_ID!r}; refusing to launch it. (Set "
+        f"CuaDriver.app at {app_path} is signed by team {team!r}, expected one of "
+        f"{_CUA_DRIVER_TEAM_IDS!r}; refusing to launch it. (Set "
         "computer_use.allow_unsigned_driver: true in config.yaml only for "
         "local unsigned driver builds.)"
     )


### PR DESCRIPTION
## What does this PR do?

Hermes can now launch current notarised CUA Driver releases from the standard macOS symlink installation. It resolves the discovered executable before deriving its carrying app bundle and accepts both the legacy and current official signing teams while retaining exact bundle-ID validation.

### Symptom

A private `computer_use` session reports that `CuaDriver.app` is missing when discovery returns `~/.local/bin/cua-driver`. Supplying the direct app path then rejects current CUA Driver 0.22.1 because its Team ID is `YCK386LBJ7` rather than the legacy `4YEC26S9KF` value.

### Impact

Affected macOS users cannot start private computer-use sessions through a current notarised CUA Driver installation without a manual path workaround, and the workaround still fails signature validation.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:594` / `_resolve_cua_driver_app_path()` and `_validate_cua_driver_app_signature()`

**Causal chain:**
1. Driver discovery returns the standard `~/.local/bin/cua-driver` symlink.
2. App derivation searches the unresolved string for `.app/Contents/MacOS/`, so it cannot find the carrying bundle.
3. Direct app-path use reaches signature validation, where a scalar legacy Team ID rejects the current official notarised identity.

**Why it is wrong:** The security check validates the installation path before following its symlink and treats an official signing-identity rotation as an impostor identity.

**Working sibling / contrast:** A direct executable path inside `CuaDriver.app` reaches the bundle, and legacy releases signed by `4YEC26S9KF` pass validation.

**Ruled out:** This is not an app bundle-ID mismatch or an unsigned local build; the reported current release has exact identifier `com.trycua.driver` and Team ID `YCK386LBJ7`.

### Fix

Resolve the driver command with `os.path.realpath()` before deriving the app bundle. Replace the scalar Team ID with a narrow explicit tuple containing the legacy and current official identities. Regression tests cover symlink resolution, both accepted Team IDs, unrelated-path fail-closed behavior, wrong-team rejection, and exact bundle-ID rejection.

## Related Issue

Closes #96328

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - resolve driver symlinks and accept both official signing identities.
- `tests/tools/test_computer_use_cua_macos_identity.py` - add path and signature security regression contracts.
- `hermes_cli/config_defaults.py` - keep the unsigned-driver configuration comment accurate after signing-team rotation.

## How to Test

1. Run the focused macOS identity contracts.
2. Run the adjacent CUA permission-mode contracts.

```bash
scripts/run_tests.sh tests/tools/test_computer_use_cua_macos_identity.py -q
scripts/run_tests.sh tests/tools/test_computer_use_cua_0_10_permissions.py -q
```

Result: 21 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (platform-independent path and signature parsing contracts)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - config comment and docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no schema change

## Screenshots / Logs

N/A - covered by focused regression tests.
