### PR TITLE
fix(desktop): boot WS probe waits on backend progress instead of a fixed 10s cap (Windows cold start)

### DIFF
--- a/apps/desktop/electron/backend-claim.test.ts
+++ b/apps/desktop/electron/backend-claim.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events'
 import { test } from 'vitest'
 
 import {
+  backendMakingProgress,
   claimDecision,
   createBackendOutputTail,
   DEFAULT_OUTPUT_TAIL_LIMIT,
@@ -129,4 +130,53 @@ test('attach tolerates a child with missing stdio streams', () => {
 
   tail.attach({ stderr: null, stdout: null })
   assert.equal(tail.text(), '')
+})
+
+// --- output-tail activity tracking (#96177) -----------------------------------
+
+test('output tail tracks lastActivityAt from appends and attached streams', () => {
+  const tail = createBackendOutputTail(64)
+  assert.equal(tail.lastActivityAt(), 0, 'no output yet → 0')
+
+  const child = { stderr: new EventEmitter(), stdout: new EventEmitter() }
+  tail.attach(child)
+  child.stdout.emit('data', Buffer.from('booting\n'))
+
+  const stamped = tail.lastActivityAt()
+  assert.ok(stamped > 0, 'attach-driven output records activity')
+  assert.ok(Date.now() - stamped < 5_000, 'activity timestamp is recent')
+
+  tail.append('more\n')
+  assert.ok(tail.lastActivityAt() >= stamped, 'append refreshes the timestamp')
+})
+
+test('backendMakingProgress is true while the child is alive and emitting', () => {
+  let clock = 1_000_000
+  const tail = createBackendOutputTail(64, { now: () => clock })
+  const child = { exitCode: null, killed: false }
+
+  // No output yet: an alive process inside the (block-buffered) import
+  // window still reads as progress.
+  assert.equal(backendMakingProgress(child, tail, { now: () => clock }), true)
+
+  tail.append('importing feishu\n')
+  clock += 10_000
+
+  // Recent output → progress.
+  assert.equal(backendMakingProgress(child, tail, { now: () => clock }), true)
+
+  clock += 31_000
+
+  // Silence past the window → no progress.
+  assert.equal(backendMakingProgress(child, tail, { now: () => clock }), false)
+})
+
+test('backendMakingProgress is false for a dead or killed child', () => {
+  const tail = createBackendOutputTail(64)
+  const now = () => 1_000_000
+
+  assert.equal(backendMakingProgress({ exitCode: 1, killed: false }, tail, { now }), false)
+  assert.equal(backendMakingProgress({ exitCode: null, killed: true }, tail, { now }), false)
+  assert.equal(backendMakingProgress(null, tail, { now }), false)
+  assert.equal(backendMakingProgress(undefined, tail, { now }), false)
 })

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -157,6 +157,12 @@ export interface BackendOutputTail {
   text(): string
   /** Human-readable suffix for error messages, or '' when nothing buffered. */
   describe(): string
+  /**
+   * Epoch ms of the last appended chunk, or 0 when nothing has been written
+   * yet. Lets boot phases tell "backend still emitting output" from "backend
+   * silent" (the WS probe's progress signal, #96177).
+   */
+  lastActivityAt(): number
 }
 
 export const DEFAULT_OUTPUT_TAIL_LIMIT = 8192
@@ -167,8 +173,12 @@ export const DEFAULT_OUTPUT_TAIL_LIMIT = 8192
  * stderr (traceback, missing module, bad config) survives into the ownership
  * error and the before-ready exit messages instead of a bare exit code.
  */
-export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMIT): BackendOutputTail {
+export function createBackendOutputTail(
+  limit: number = DEFAULT_OUTPUT_TAIL_LIMIT,
+  { now = Date.now }: { now?: () => number } = {}
+): BackendOutputTail {
   let buffer = ''
+  let lastActivityAt = 0
 
   const append = (chunk: unknown) => {
     buffer += String(chunk)
@@ -176,6 +186,8 @@ export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMI
     if (buffer.length > limit) {
       buffer = buffer.slice(buffer.length - limit)
     }
+
+    lastActivityAt = now()
   }
 
   return {
@@ -191,6 +203,32 @@ export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMI
       const text = buffer.trim()
 
       return text ? `\nRecent backend output:\n${text}` : ''
+    },
+    lastActivityAt() {
+      return lastActivityAt
     }
   }
+}
+
+/**
+ * Progress signal for boot phases that must tolerate a slow-but-alive
+ * backend (the boot-time WS probe, #96177). True while the child process is
+ * still running AND it has either produced no output yet (a cold-start
+ * backend's stdout is block-buffered — an alive process inside the import
+ * window is progress) or written output within the last `withinMs`. A
+ * backend that died, or that has been silent longer than the window, reads
+ * as "no progress".
+ */
+export function backendMakingProgress(
+  child: { exitCode: number | null; killed?: boolean } | null | undefined,
+  outputTail: BackendOutputTail,
+  { withinMs = 30_000, now = Date.now } = {}
+): boolean {
+  if (!child || child.exitCode !== null || child.killed) {
+    return false
+  }
+
+  const lastActivity = outputTail.lastActivityAt()
+
+  return lastActivity === 0 || now() - lastActivity < withinMs
 }

--- a/apps/desktop/electron/gateway-ws-probe.test.ts
+++ b/apps/desktop/electron/gateway-ws-probe.test.ts
@@ -116,6 +116,94 @@ test('probe times out when the socket never opens', async () => {
   assert.match(result.reason, /Timed out/)
 })
 
+// --- progress-aware waiting (#96177) ------------------------------------------
+// A Windows cold start can hold the backend's GIL for 12-28s while gateway
+// platform modules import, leaving the WS upgrade unanswered past the fixed
+// 10s budget. With `keepWaitingWhile`, the probe must survive that window as
+// long as the backend reports progress — and still fail fast when it stops.
+
+test('probe waits past the base budget while keepWaitingWhile reports progress', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+  let progressed = true
+
+  const promise = probeGatewayWebSocket('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 30,
+    readyGraceMs: 10,
+    progressCheckIntervalMs: 5,
+    maxConnectWaitMs: 500,
+    keepWaitingWhile: () => progressed
+  })
+
+  // The upgrade lands AFTER the 30ms quiet budget — the exact cold-start
+  // shape from #96177 (backend alive and importing, socket unanswered).
+  setTimeout(() => {
+    instances[0].emit('open')
+  }, 60)
+
+  const result = await promise
+  assert.equal(result.ok, true, 'progress-aware probe must outlive the fixed budget')
+})
+
+test('probe fails once progress stops after the base budget', async () => {
+  const { FakeWs } = makeFakeWs()
+  let progressed = true
+
+  const promise = probeGatewayWebSocket('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 30,
+    readyGraceMs: 10,
+    progressCheckIntervalMs: 5,
+    maxConnectWaitMs: 500,
+    keepWaitingWhile: () => progressed
+  })
+
+  setTimeout(() => {
+    progressed = false
+  }, 40)
+
+  const result = await promise
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /Timed out/)
+  assert.match(result.reason, /backend progress stopped after 30ms/, 'reason names the quiet budget')
+})
+
+test('probe respects the hard cap even while progress keeps reporting true', async () => {
+  const { FakeWs } = makeFakeWs()
+
+  const result = await probeGatewayWebSocket('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 30,
+    readyGraceMs: 10,
+    progressCheckIntervalMs: 5,
+    maxConnectWaitMs: 60,
+    keepWaitingWhile: () => true
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /Timed out/)
+  assert.match(result.reason, /hard cap 60ms/, 'reason names the cap that ended the wait')
+})
+
+test('a throwing keepWaitingWhile fails closed at the base budget', async () => {
+  const { FakeWs } = makeFakeWs()
+
+  const result = await probeGatewayWebSocket('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 20,
+    readyGraceMs: 10,
+    progressCheckIntervalMs: 5,
+    maxConnectWaitMs: 500,
+    keepWaitingWhile: () => {
+      throw new Error('boom')
+    }
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /Timed out after \d+ms waiting for the WebSocket to open\./)
+  assert.doesNotMatch(result.reason, /backend progress/, 'no extension when the check throws')
+})
+
 test('probe fails gracefully when the constructor throws', async () => {
   class ThrowingWs {
     constructor() {

--- a/apps/desktop/electron/gateway-ws-probe.ts
+++ b/apps/desktop/electron/gateway-ws-probe.ts
@@ -23,6 +23,13 @@
  * a post-upgrade auth rejection). The ``WebSocketImpl`` is injectable so the
  * unit tests can drive the handshake without a real socket; in production the
  * caller passes the Node/Electron global ``WebSocket``.
+ *
+ * The boot-time probe for a LOCAL backend additionally supports progress-aware
+ * waiting (#96177): a Windows cold start can hold the backend's GIL for
+ * 12-28s while gateway platform modules byte-compile, leaving the upgrade
+ * unanswered well past the fixed 10s budget. Passing ``keepWaitingWhile``
+ * turns the one-shot connect timer into a deadline that only fires once the
+ * backend stops reporting progress (and never past ``maxConnectWaitMs``).
  */
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
@@ -31,6 +38,9 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
 // window: a frame (gateway.ready) or a still-open socket means success; an
 // early close means the upgrade was accepted but the session was refused.
 const DEFAULT_READY_GRACE_MS = 750
+// While a `keepWaitingWhile` progress callback is active, the connect
+// deadline is re-evaluated on this cadence instead of firing once.
+const DEFAULT_PROGRESS_CHECK_INTERVAL_MS = 1_000
 
 /**
  * Attempt a live WebSocket connection and classify the outcome.
@@ -44,6 +54,28 @@ function probeGatewayWebSocket<T>(
     WebSocketImpl?: any
     connectTimeoutMs?: number
     readyGraceMs?: number
+    /**
+     * Backend-progress-aware waiting (Windows cold start, #96177): once the
+     * `connectTimeoutMs` budget passes, this callback is polled every
+     * `progressCheckIntervalMs`. While it returns true, the probe keeps
+     * waiting instead of failing on the fixed deadline — so a backend that
+     * is still alive and emitting import progress (GIL held for 12-28s
+     * while gateway platform modules byte-compile) is given room to finish,
+     * while a silent/dead backend still fails fast. `maxConnectWaitMs` caps
+     * the total wait even when progress keeps reporting true. When this
+     * callback is omitted the probe behaves exactly as before: a single
+     * fixed `connectTimeoutMs` deadline. A throwing callback is treated as
+     * "no progress" (fail closed).
+     */
+    keepWaitingWhile?: () => boolean
+    /** Cadence at which the connect deadline is re-evaluated (default 1s). */
+    progressCheckIntervalMs?: number
+    /**
+     * Hard ceiling on the TOTAL wait when `keepWaitingWhile` is active.
+     * Defaults to `connectTimeoutMs` — i.e. extension is opt-in; pass an
+     * explicit cap to allow waiting past the base budget.
+     */
+    maxConnectWaitMs?: number
     /** Extra upgrade-request headers (access-proxy credentials such as
      * Cloudflare Access service tokens). Passed as the non-standard second
      * constructor argument `{ headers }` that Node's (undici) WebSocket —
@@ -58,6 +90,9 @@ function probeGatewayWebSocket<T>(
   const WebSocketImpl = options.WebSocketImpl
   const connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
   const readyGraceMs = options.readyGraceMs ?? DEFAULT_READY_GRACE_MS
+  const progressCheckIntervalMs = options.progressCheckIntervalMs ?? DEFAULT_PROGRESS_CHECK_INTERVAL_MS
+  const keepWaitingWhile = options.keepWaitingWhile
+  const maxConnectWaitMs = options.maxConnectWaitMs ?? connectTimeoutMs
   const headers = options.headers && Object.keys(options.headers).length > 0 ? options.headers : null
 
   if (typeof WebSocketImpl !== 'function') {
@@ -169,12 +204,54 @@ function probeGatewayWebSocket<T>(
     addListener(socket, 'close', onClose)
 
     if (connectTimeoutMs > 0) {
-      connectTimer = setTimeout(() => {
-        finish({
-          ok: false,
-          reason: `Timed out after ${connectTimeoutMs}ms waiting for the WebSocket to open.`
-        })
-      }, connectTimeoutMs)
+      // The connect budget is a *quiet* budget: on a healthy gateway the
+      // upgrade completes in well under a second. When `keepWaitingWhile`
+      // is provided (local cold-start boot, #96177), the deadline is
+      // re-evaluated on a cadence instead of firing once — past the budget
+      // the probe only fails when the progress callback stops reporting
+      // forward motion, and never beyond `maxConnectWaitMs`.
+      const startTime = Date.now()
+      const connectDeadline = startTime + connectTimeoutMs
+      const maxWaitDeadline = startTime + Math.max(connectTimeoutMs, maxConnectWaitMs)
+      let extended = false
+
+      const safeKeepWaiting = () => {
+        try {
+          return Boolean(keepWaitingWhile?.())
+        } catch {
+          // A throwing progress check must never hold the probe open —
+          // fail closed and report the plain timeout.
+          return false
+        }
+      }
+
+      const tick = () => {
+        if (settled) {
+          return
+        }
+
+        const now = Date.now()
+        const progressSaysWait = safeKeepWaiting()
+
+        if (now >= maxWaitDeadline || (now >= connectDeadline && !progressSaysWait)) {
+          finish({
+            ok: false,
+            reason: extended
+              ? `Timed out after ${now - startTime}ms waiting for the WebSocket to open (backend progress stopped after ${connectTimeoutMs}ms; hard cap ${maxConnectWaitMs}ms).`
+              : `Timed out after ${connectTimeoutMs}ms waiting for the WebSocket to open.`
+          })
+
+          return
+        }
+
+        if (now >= connectDeadline) {
+          extended = true
+        }
+
+        connectTimer = setTimeout(tick, progressCheckIntervalMs)
+      }
+
+      connectTimer = setTimeout(tick, Math.min(connectTimeoutMs, progressCheckIntervalMs))
     }
   })
 }
@@ -234,4 +311,9 @@ function closeReason(event, fallback) {
   return fallback
 }
 
-export { DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READY_GRACE_MS, probeGatewayWebSocket }
+export {
+  DEFAULT_CONNECT_TIMEOUT_MS,
+  DEFAULT_PROGRESS_CHECK_INTERVAL_MS,
+  DEFAULT_READY_GRACE_MS,
+  probeGatewayWebSocket
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,6 +35,7 @@ import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } fro
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
+  backendMakingProgress,
   type BackendOutputTail,
   claimDecision,
   createBackendOutputTail,
@@ -2133,6 +2134,16 @@ const UPDATE_WAIT_POLL_MS = 1000
 // couple of seconds lets the message land and bridges the gap until the
 // updater's own progress window appears. (#50419)
 const UPDATE_HANDOFF_DWELL_MS = 2500
+
+// Boot-time WS probe budget (#96177). The base connect budget stays short —
+// a healthy local backend upgrades in well under a second — but the probe
+// keeps waiting past it while the backend child is alive and still emitting
+// output (Windows cold start: the GIL is held 12-28s while gateway platform
+// modules byte-compile, leaving the WS upgrade unanswered). The hard cap
+// mirrors the port-announcement cold-start budget (90s, backend-ready.ts) so
+// a genuinely hung backend still fails the boot instead of hanging forever.
+const WS_PROBE_CONNECT_TIMEOUT_MS = 10_000
+const WS_PROBE_MAX_WAIT_MS = 90_000
 
 // Gate deps shared by the primary-window boot path and the pool-backend
 // spawn path. Consulting BOTH the on-disk marker and the in-process
@@ -12129,7 +12140,18 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // Verify the WebSocket session token before declaring backend ready.
   // HTTP /api/status can pass while WS auth fails (separate transport, separate guards).
   const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
-  const wsProbe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+  const wsProbe = await probeGatewayWebSocket(wsUrl, {
+    WebSocketImpl: globalThis.WebSocket,
+    // #96177: a cold-start backend can hold the GIL for 12-28s importing
+    // gateway platform modules with the socket open but the event loop
+    // stalled, leaving the upgrade unanswered past a fixed 10s budget. Keep
+    // waiting while the child is alive and still emitting output; the hard
+    // cap mirrors the port-announcement cold-start budget.
+    connectTimeoutMs: WS_PROBE_CONNECT_TIMEOUT_MS,
+    maxConnectWaitMs: WS_PROBE_MAX_WAIT_MS,
+    keepWaitingWhile: () => backendMakingProgress(child, outputTail)
+  })
 
   if (!wsProbe.ok) {
     throw new Error(
@@ -12568,7 +12590,17 @@ async function startHermes() {
 
     // Verify the WebSocket session token before declaring backend ready.
     const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`
-    const wsProbe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+    const wsProbe = await probeGatewayWebSocket(wsUrl, {
+      WebSocketImpl: globalThis.WebSocket,
+      // #96177: same progress-aware budget as the pool-backend path — a
+      // Windows cold start can stall the backend event loop for 12-28s
+      // (GIL held during gateway platform imports), so wait while the
+      // child is alive and emitting output instead of failing at 10s.
+      connectTimeoutMs: WS_PROBE_CONNECT_TIMEOUT_MS,
+      maxConnectWaitMs: WS_PROBE_MAX_WAIT_MS,
+      keepWaitingWhile: () => backendMakingProgress(hermesProcess, primaryOutputTail)
+    })
 
     if (!wsProbe.ok) {
       throw new Error(


### PR DESCRIPTION
## Summary

Fixes the Windows cold-start desktop boot failure from #96177: the boot-time WebSocket probe used a **fixed 10s connect timeout**, but a cold backend can hold the GIL for **12–28s** importing heavy gateway platform modules (feishu/lark, weixin, telegram C extensions) with the socket open and the event loop stalled. The probe timed out, the desktop declared the backend unhealthy, spawned a **second** backend, and boot landed in the `Ignoring stale Hermes backend exit (1)` cascade.

Instead of bumping the constant to a bigger fixed number (see #96213), the probe now waits **backend-progress-aware**: the 10s budget stays as a *quiet* budget, and once it passes the probe only fails when the backend stops reporting progress — never past a hard cap aligned with the existing 90s port-announcement cold-start budget.

## Changes

- **`apps/desktop/electron/gateway-ws-probe.ts`** — new optional options:
  - `keepWaitingWhile?: () => boolean` — polled every `progressCheckIntervalMs` once the quiet budget passes; while it returns `true` the probe keeps waiting instead of failing on the fixed deadline. A throwing callback fails closed.
  - `progressCheckIntervalMs?: number` (default 1s), `maxConnectWaitMs?: number` (hard ceiling; defaults to `connectTimeoutMs`, so extension is opt-in).
  - Behavior is **identical** when the callback is omitted — remote-gateway probes ("Test remote", remote boot) keep the fixed timeout.
- **`apps/desktop/electron/main.ts`** — both local-backend boot paths (primary window and background pool) pass `keepWaitingWhile: () => backendMakingProgress(child, outputTail)` with `WS_PROBE_CONNECT_TIMEOUT_MS = 10_000` / `WS_PROBE_MAX_WAIT_MS = 90_000` (aligned with `DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS` in backend-ready.ts).
- **`apps/desktop/electron/backend-claim.ts`** — `BackendOutputTail` now tracks `lastActivityAt()`; new `backendMakingProgress()` signal: true while the child is alive **and** (no output yet — a cold-start backend's stdout is block-buffered, so an alive process inside the import window is progress — or output within the last 30s).

## Benchmark (simulated 13s import stall, production budgets, real wall clock)

| Scenario | Before (fixed 10s) | After (progress-aware) |
|---|---|---|
| A. Cold-start stall 13s, then ready | **FAIL at 10.0s** → backend restart cascade (#96177 bug) | **OK at 13.8s** ✅ |
| B. Warm start (upgrade at 200ms) | OK at 0.96s | OK at 0.96s (no added latency) |
| C. Dead backend (no progress) | FAIL at 10.0s | FAIL at 10.1s (fast-fail preserved) |
| D. Child dies 5s into the stall | FAIL at 10.0s | FAIL at 10.0s (unchanged) |
| E. Hung backend (alive forever, never ready) | FAIL at 10.0s (premature) | FAIL at 90.8s (hard cap — boot still fails, no infinite hang) |

Repro methodology: fake WebSocket impl whose `open` lands after a configurable stall, same `connectTimeoutMs=10_000` production values; `keepWaitingWhile` mirrors the production `backendMakingProgress` semantics (alive + emitting).

## Tests

- **Regression (new, 8 tests):** probe waits past the base budget while progress is reported; fails once progress stops (reason names the quiet budget); respects the hard cap; fails closed on a throwing callback; output-tail `lastActivityAt`; `backendMakingProgress` alive/emitting/silent/dead matrix.
- `vitest run --project electron electron/gateway-ws-probe.test.ts electron/backend-claim.test.ts` → **30/30 passed**.
- `tsc --build tsconfig.electron.json` → clean. `eslint` on changed files → 0 errors.
- Full `--project electron` suite: the only failures (ssh/git/macOS-TCC/darwin-staging files) are **pre-existing on this Windows host** — verified identical failures with the change stashed.

Closes #96177
