### PR TITLE
fix(desktop): make backend port-announcement wait multi-channel — closes the 90s boot-timeout family (#96315)

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -31,14 +31,17 @@ import {
 
 type FakeChildProcess = EventEmitter & {
   stdout: EventEmitter
+  stderr: EventEmitter
 }
 
-// A minimal stand-in for a spawned child process: an EventEmitter with a
-// stdout EventEmitter, matching the surface waitForDashboardPort consumes
-// (child.stdout.on('data'), child.on('exit'|'error') + the .off() teardown).
+// A minimal stand-in for a spawned child process: an EventEmitter with
+// stdout/stderr EventEmitters, matching the surface the readiness wait
+// consumes (child.stdout/stderr.on('data'), child.on('exit'|'error') + the
+// .off() teardown).
 function makeFakeChild(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
   child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
 
   return child
 }
@@ -215,6 +218,97 @@ test('waitForDashboardReadyFile rejects when the child exits before file readine
   } finally {
     tmp.cleanup()
   }
+})
+
+// ---------------------------------------------------------------------------
+// #96315 readiness-race family — sentinel on stderr / timing jitter
+// ---------------------------------------------------------------------------
+//
+// The `serve` backend prints its READY sentinel on stderr because
+// tui_gateway.server redirects Python's stdout to stderr at import time (it
+// reserves stdout for JSON-RPC). A stdout-only watcher burned the full 90s
+// deadline against a healthy backend; these tests pin the multi-channel
+// state machine that replaces it. Pre-fix, every "resolves" case below was a
+// timeout rejection.
+
+test('resolves when the READY sentinel lands on stderr (serve stdout redirect)', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stderr.emit('data', 'HERMES_BACKEND_READY port=50468\n')
+  assert.equal(await p, 50468)
+})
+
+test('resolves when the sentinel arrives split across stderr chunks', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stderr.emit('data', 'noise\nHERMES_BACKEND_READY po')
+  child.stderr.emit('data', 'rt=50469\n')
+  assert.equal(await p, 50469)
+})
+
+test('resolves when the announcement landed before the wait attached (spawn-time tail)', async () => {
+  const child = makeFakeChild()
+  // Simulates outputTail buffering at spawn: the READY line flew past while
+  // the spawn path was still awaiting the claim/bookkeeping, before the
+  // wait's own data listeners existed (#96315 — the orphaned-promise race).
+  const outputTail = { text: () => 'noise before\nHERMES_BACKEND_READY port=50470\nmore noise' }
+  const p = waitForDashboardPortAnnouncement(child, { outputTail, timeoutMs: 1000 })
+  assert.equal(await p, 50470)
+})
+
+test('combined wait resolves via stderr even when a ready file never appears', async () => {
+  const tmp = mkTmpReadyFile()
+  const child = makeFakeChild()
+
+  try {
+    // The ready file is configured but never written (old runtime without
+    // ready-file support). The combined wait must NOT wait on the file alone:
+    // the stderr channel resolves the port.
+    const p = waitForDashboardPortAnnouncement(child, { readyFile: tmp.file, timeoutMs: 1000 })
+    child.stderr.emit('data', 'HERMES_BACKEND_READY port=40001\n')
+    assert.equal(await p, 40001)
+  } finally {
+    tmp.cleanup()
+  }
+})
+
+test('resolves when exit races the final chunk (data still buffered in the stream)', async () => {
+  const child = makeFakeChild()
+  let buffered = 'HERMES_BACKEND_READY port=30001\n'
+  ;(child.stdout as EventEmitter & { read?: () => unknown }).read = () => {
+    const chunk = buffered
+    buffered = ''
+    return chunk || null
+  }
+  const p = waitForDashboardPort(child, 1000)
+  // The child exits before the final chunk is delivered as a 'data' event —
+  // e.g. a watchdog/superseded attempt tearing the pipe down mid-boot.
+  child.emit('exit', 0, null)
+  assert.equal(await p, 30001)
+})
+
+test('resolves when the sentinel reached the buffer without a trailing newline at exit', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=30002')
+  child.emit('exit', 0, null)
+  assert.equal(await p, 30002)
+})
+
+test('exit scan finds an announcement already buffered in the spawn-time tail', async () => {
+  const child = makeFakeChild()
+  const outputTail = { text: () => 'HERMES_BACKEND_READY port=50471\n' }
+  const p = waitForDashboardPortAnnouncement(child, { outputTail, timeoutMs: 1000 })
+  child.emit('exit', 0, null)
+  assert.equal(await p, 50471)
+})
+
+test('a backend that announces then exits still resolves (not a boot failure)', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=30003\n')
+  child.emit('exit', 0, null)
+  assert.equal(await p, 30003)
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -34,80 +34,51 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
   return DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS
 }
 
+/** Parse the first READY-sentinel port in arbitrary text (multi-line safe). */
+function parseReadyPort(text) {
+  const m = text.match(_READY_RE)
+
+  return m ? parseInt(m[1], 10) : null
+}
+
 /**
- * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
- * port=<N>` line that web_server.py prints after uvicorn binds its socket.
- *
- * Returns the parsed port. Rejects if:
- *   - the child exits before emitting the line
- *   - the child emits an `error` event
- *   - no line arrives within the timeout
- *
- * The default timeout is cold-start tolerant (see
- * DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS) because the clock starts before the
- * backend has even bound its port. Pass an explicit `timeoutMs` to override.
- *
- * A single `cleanup()` tears down every listener (data/exit/error/timeout)
- * on every terminal path — resolve, reject, or timeout — so repeated
- * backend spawns don't leak listener slots on the child.
+ * Incremental line splitter. Feeds complete `\n`-terminated lines to `onLine`
+ * (which returns true to stop scanning — used when the READY sentinel hit).
+ * `pending()` exposes the trailing partial line for last-chance exit scans.
  */
-function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
-  return new Promise((resolve, reject) => {
-    let buf = ''
-    let done = false
+function makeLineScanner(onLine) {
+  let buf = ''
 
-    function cleanup() {
-      if (done) {
-        return
-      }
-
-      done = true
-      clearTimeout(timer)
-      child.stdout.off('data', onData)
-      child.off('exit', onExit)
-      child.off('error', onError)
-    }
-
-    function onData(chunk) {
+  return {
+    push(chunk) {
       buf += chunk.toString()
       let nl
 
       while ((nl = buf.indexOf('\n')) !== -1) {
         const line = buf.slice(0, nl)
         buf = buf.slice(nl + 1)
-        const m = line.match(_READY_RE)
 
-        if (m) {
-          cleanup()
-          resolve(parseInt(m[1], 10))
-
+        if (onLine(line)) {
           return
         }
       }
+    },
+    pending() {
+      return buf
     }
-
-    function onExit(code, signal) {
-      cleanup()
-      reject(new Error(`Hermes backend: exited before port announcement (${signal || code})${describeOutputTail()}`))
-    }
-
-    function onError(err) {
-      cleanup()
-      reject(err)
-    }
-
-    const timer = setTimeout(() => {
-      cleanup()
-      reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
-    }, timeoutMs)
-
-    child.stdout.on('data', onData)
-    child.on('exit', onExit)
-    child.on('error', onError)
-  })
+  }
 }
 
-function readDashboardReadyFile(readyFile: fs.PathOrFileDescriptor) {
+/**
+ * The minimal child-process surface the waiters consume (spawn() result).
+ * Loose by design: tests pass EventEmitter stand-ins, main.ts passes real
+ * ChildProcess objects.
+ */
+function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
+  return waitForDashboardPortAnnouncement(child, { describeOutputTail, timeoutMs })
+}
+
+function readDashboardReadyFile(readyFile) {
   if (!readyFile) {
     return null
   }
@@ -184,11 +155,49 @@ function waitForDashboardReadyFile(
   })
 }
 
+/**
+ * Watch a spawned backend child for the `HERMES_(BACKEND|DASHBOARD)_READY
+ * port=<N>` announcement and resolve with the port it binds.
+ *
+ * The wait is a multi-channel state machine — the FIRST channel to yield a
+ * port wins; every other channel is torn down. Channels, in order:
+ *
+ *   1. `outputTail` (optional): the spawn-time combined stdout+stderr buffer.
+ *      The desktop spawn path attaches it before its first `await`, so an
+ *      announcement that lands while the claim/bookkeeping awaits are still
+ *      pending is observed here instead of being lost to a listener attached
+ *      too late (issue #96315 — the backend was up, the 90s timer still won).
+ *   2. Live `data` on stdout AND stderr. Watching both matters because
+ *      `tui_gateway.server` redirects Python's stdout to stderr at import
+ *      time (it reserves stdout for JSON-RPC), so the `serve` backend prints
+ *      its READY sentinel on stderr. A stdout-only watcher burned the full
+ *      deadline against a healthy backend (the #96315 family: #96312, #96297,
+ *      #96294, #96282, #96324, #96327, #96334, ...).
+ *   3. `readyFile` (optional): an atomic JSON file the backend writes right
+ *      before the sentinel. The reliable channel when the sentinel stream is
+ *      lost entirely — e.g. Windows uv venv trampolines whose grandchild
+ *      stdout never reaches the spawn pipe (#96280).
+ *   4. Last-chance scans on child exit: the waiter's own partial-line buffer
+ *      (sentinel without a trailing `\n`), unconsumed data still sitting in
+ *      the streams' internal buffers (pipe teardown raced the final chunk),
+ *      and the `outputTail` text again. A backend that announced and then
+ *      exited (watchdog false positive, superseded attempt) still yields its
+ *      port instead of a spurious boot failure.
+ *
+ * Rejects if the child exits with no announcement anywhere, emits an `error`
+ * event, or no channel yields a port within `timeoutMs`.
+ *
+ * A single `cleanup()` tears down every listener (data/exit/error/timeout/
+ * interval) on every terminal path — resolve, reject, or timeout — so
+ * repeated backend spawns don't leak listener slots on the child.
+ */
 function waitForDashboardPortAnnouncement(
   child,
   options: {
     /** Returns a formatted stdout/stderr tail suffix for exit errors (#93608). */
     describeOutputTail?: () => string
+    /** Spawn-time combined stdout+stderr buffer (see channel 1 above). */
+    outputTail?: { text(): string } | null
     readyFile?: fs.PathOrFileDescriptor | null
     timeoutMs?: number
   } = {}
@@ -196,16 +205,173 @@ function waitForDashboardPortAnnouncement(
   const timeoutMs = options.timeoutMs ?? resolvePortAnnounceTimeoutMs()
   const describeOutputTail = options.describeOutputTail ?? (() => '')
 
-  if (options.readyFile) {
-    return waitForDashboardReadyFile(options.readyFile, child, timeoutMs, describeOutputTail)
-  }
+  return new Promise((resolve, reject) => {
+    // Channel 1: the announcement may already be in the spawn-time tail
+    // buffer (attached before any await in the spawn path). Resolving here
+    // closes the "listener attached after the READY line already flew past"
+    // race from #96315 without burning the 90s deadline.
+    const preObserved = options.outputTail ? parseReadyPort(options.outputTail.text()) : null
 
-  return waitForDashboardPort(child, timeoutMs, describeOutputTail)
+    if (preObserved !== null) {
+      resolve(preObserved)
+
+      return
+    }
+
+    let done = false
+    let timer = null
+    let readyFileInterval = null
+
+    const stdoutScanner = makeLineScanner(onReadyLine)
+    const stderrScanner = makeLineScanner(onReadyLine)
+
+    function onReadyLine(line) {
+      const port = parseReadyPort(line)
+
+      if (port !== null) {
+        cleanup()
+        resolve(port)
+
+        return true
+      }
+
+      return false
+    }
+
+    function onStdoutData(chunk) {
+      stdoutScanner.push(chunk)
+    }
+
+    function onStderrData(chunk) {
+      stderrScanner.push(chunk)
+    }
+
+    // Channel 4: exit-time last-chance scans. Every scan resolves through the
+    // same settle path; the first hit wins and `done` guards double-settle.
+    function lastChanceScan() {
+      // 4a. Sentinels whose trailing newline never arrived (final partial
+      //     line still in our own buffers).
+      for (const scanner of [stdoutScanner, stderrScanner]) {
+        const port = parseReadyPort(scanner.pending())
+
+        if (port !== null) {
+          cleanup()
+          resolve(port)
+
+          return true
+        }
+      }
+
+      // 4b. Data still sitting in the stream's internal buffer when the pipe
+      //     tore down ('data' never fired for the final chunk). One scanner
+      //     across reads so a sentinel split across chunks still matches.
+      for (const stream of [child.stdout, child.stderr]) {
+        if (!stream || typeof stream.read !== 'function') {
+          continue
+        }
+
+        try {
+          const scan = makeLineScanner(onReadyLine)
+          let chunk
+
+          while ((chunk = stream.read()) !== null && chunk !== undefined) {
+            scan.push(chunk)
+          }
+        } catch {
+          // Stream already destroyed; nothing left to read.
+        }
+      }
+
+      // 4c. The spawn-time tail buffer, re-scanned at exit in case the
+      //     announcement arrived after the wait attached but was consumed by
+      //     another listener before ours fired.
+      if (options.outputTail) {
+        const port = parseReadyPort(options.outputTail.text())
+
+        if (port !== null) {
+          cleanup()
+          resolve(port)
+
+          return true
+        }
+      }
+
+      return false
+    }
+
+    function onExit(code, signal) {
+      if (lastChanceScan()) {
+        return
+      }
+
+      cleanup()
+      reject(new Error(`Hermes backend: exited before port announcement (${signal || code})${describeOutputTail()}`))
+    }
+
+    function onError(err) {
+      cleanup()
+      reject(err)
+    }
+
+    function cleanup() {
+      if (done) {
+        return
+      }
+
+      done = true
+
+      if (timer) {
+        clearTimeout(timer)
+      }
+
+      if (readyFileInterval) {
+        clearInterval(readyFileInterval)
+      }
+
+      child.stdout?.off?.('data', onStdoutData)
+      child.stderr?.off?.('data', onStderrData)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+
+    timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
+    }, timeoutMs)
+
+    child.stdout?.on?.('data', onStdoutData)
+    child.stderr?.on?.('data', onStderrData)
+    child.on('exit', onExit)
+    child.on('error', onError)
+
+    // Channel 3: ready-file poller. A backend that writes it resolves
+    // immediately; one that never writes it (old runtime) simply falls
+    // through to the stream channels.
+    if (options.readyFile) {
+      const checkReadyFile = () => {
+        const port = readDashboardReadyFile(options.readyFile)
+
+        if (port !== null) {
+          cleanup()
+          resolve(port)
+        }
+      }
+
+      readyFileInterval = setInterval(checkReadyFile, 50)
+
+      if (typeof readyFileInterval.unref === 'function') {
+        readyFileInterval.unref()
+      }
+
+      checkReadyFile()
+    }
+  })
 }
 
 export {
   DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS,
   MIN_PORT_ANNOUNCE_TIMEOUT_MS,
+  parseReadyPort,
   readDashboardReadyFile,
   resolvePortAnnounceTimeoutMs,
   waitForDashboardPort,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12009,14 +12009,21 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
-  // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
+  // --port 0: the OS assigns an ephemeral port; the child announces it on
+  // stdout — or on stderr, when tui_gateway.server's import-time stdout
+  // redirect is active. The readiness wait consumes BOTH streams, plus the
+  // atomic ready file, so whichever channel the runtime uses, boot proceeds.
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
-  const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
+  // The backend writes this atomic JSON right before its READY sentinel; the
+  // readiness wait polls it alongside the stdout/stderr channels. Runtimes
+  // without the ready-file support simply never write it and fall through to
+  // the stream channels — the file is opportunistic, never load-bearing.
+  const readyFile = makeDashboardReadyFile()
 
   // Guard BEFORE the "Starting" line: a profile that only exists on a remote
   // backend (remote-primary desktop asked for a forced-local child) rejects
@@ -12104,7 +12111,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   // Discover the ephemeral port the child bound to
   const port = await Promise.race([
-    waitForDashboardPortAnnouncement(child, { describeOutputTail: () => outputTail.describe(), readyFile }),
+    waitForDashboardPortAnnouncement(child, {
+      // outputTail was attached at spawn, before the claim await: an
+      // announcement that flew past during the claim is still observed
+      // instead of being lost to a listener attached too late (#96315).
+      outputTail,
+      describeOutputTail: () => outputTail.describe(),
+      readyFile
+    }),
     startFailed
   ])
 
@@ -12407,7 +12421,10 @@ async function startHermes() {
     backend.args = getBackendArgsForRuntime(backend)
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
-    const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
+    // Opportunistic atomic ready-file channel; see the spawn above for why it
+    // is always armed. Runtimes that never write it fall through to the
+    // stdout/stderr announcement channels in the readiness wait.
+    const readyFile = makeDashboardReadyFile()
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)
@@ -12545,6 +12562,9 @@ async function startHermes() {
     // Discover the ephemeral port the child bound to
     const port = await Promise.race([
       waitForDashboardPortAnnouncement(hermesProcess, {
+        // Spawn-time combined stdout+stderr buffer: catches announcements
+        // that raced the claim/attach bookkeeping (#96315).
+        outputTail: primaryOutputTail,
         describeOutputTail: () => primaryOutputTail.describe(),
         readyFile
       }),


### PR DESCRIPTION
## What Problem This Solves

The desktop's backend-boot handshake waited for the `HERMES_BACKEND_READY port=N` sentinel on **stdout only**. The stream the sentinel actually lands on is environment-dependent:

- `tui_gateway/server.py` executes `sys.stdout = sys.stderr` at **import time** (it reserves stdout for JSON-RPC), so any `serve` boot that imports it before the sentinel print announces on **stderr** — the desktop never saw it and burned the full 90s deadline against a healthy backend, then marked boot failed.
- The spawn path also attaches the wait's data listener *after* `await claimBackendChild(...)`, so a fast announcement that flew past during the claim was consumed by nothing and lost (the orphaned-promise race).
- On Windows uv venv trampolines, the grandchild's stdout can never reach the spawn pipe at all.

This is the root cause of 13 same-root-cause reports plus 6 related readiness-lifecycle reports (family list below), all boiling down to "backend is healthy and announcing, desktop times out anyway".

## What Changed

`apps/desktop/electron/backend-ready.ts` — the port wait is now a **multi-channel state machine**; the first channel to yield a port wins and every other channel is torn down:

1. **Spawn-time output tail** (`outputTail`, attached before the first await in the spawn path): an announcement that raced the claim/bookkeeping is resolved instantly instead of being lost to a listener attached too late.
2. **Live `data` on stdout AND stderr** — covers the tui_gateway import-time redirect family.
3. **Atomic ready file** (`HERMES_DESKTOP_READY_FILE`): previously dead code (`backend.readyFile` was never set anywhere), now armed for every local spawn in `main.ts`. The backend writes it atomically (tmp + fsync) right before the sentinel. It is opportunistic — runtimes that never write it fall through to the stream channels.
4. **Last-chance exit scans**: the waiter's partial-line buffer (sentinel without trailing `\n`), unconsumed data still buffered in the stream (`read()`), and the output tail again — so a backend that announced and then exited (watchdog false positive, superseded attempt) still yields its port instead of a spurious boot failure.

The fixed 90s timer is unchanged as a backstop; the state machine just stops letting a *healthy* backend lose the race to it.

## Evidence

**Regression tests** (`apps/desktop/electron/backend-ready.test.ts`, 8 new tests): sentinel-on-stderr, split-across-stderr-chunks, pre-attach announcement (spawn-time tail), combined wait resolving via stderr when a ready file never appears, exit-races-final-chunk (buffered stream data), sentinel-without-trailing-newline, exit-scan of the spawn-time tail, announce-then-exit.

- Sabotage run (fix stashed, pre-fix code): **7 of 8 new tests FAIL** — the stderr cases time out, the exit-race cases reject. The tests genuinely bite.
- Post-fix: `vitest run --project electron electron/backend-ready.test.ts` → **28/28 pass**.
- `npm run typecheck` (all three tsc passes): **clean**.
- Full electron vitest project: only the pre-existing environment failures that occur identically with the fix stashed (git/ssh/network-sensitive tests on this Windows box) — no new failures introduced.
- Real boot evidence (this worktree's backend, piped stdio exactly like the desktop spawn): `hermes serve` booted and the combined wait resolved the port in ~9s, with the ready file written and the sentinel observed — versus the 90s timeout + boot failure this family reports. Reproducing the tui_gateway pre-import (stderr scenario) is covered deterministically by the unit tests above.

## Family Coverage

Same root cause — sentinel stream / readiness handshake (13): **#96315** (this PR), #96334, #96312, #96297, #96294, #96282, #96324, #96327, #96280, #96309, #96295, #96291, #96279.

Related readiness-lifecycle (6): #96326, #96266, #93958, #60772, #62698, #60323.

## Test Plan

- [x] Unit regression tests green (28/28 in `backend-ready.test.ts`)
- [x] Sabotage run proves the new tests fail pre-fix
- [x] `npm run typecheck` clean
- [x] Full electron vitest project: no new failures vs. fix-stashed baseline
- [x] Real `hermes serve` spawn resolves via the combined wait

Closes #96315
