### PR TITLE
fix(gateway): gate /sethome nudge to operator targets; strip tool-render chrome

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7239,6 +7239,7 @@ class BasePlatformAdapter(ABC):
         role_authorized: bool = False,
         auto_thread_created: bool = False,
         auto_thread_initial_name: Optional[str] = None,
+        sender_is_owner: bool = False,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform.
 
@@ -7247,6 +7248,13 @@ class BasePlatformAdapter(ABC):
         ``source.profile``. Downstream code (``_resolve_profile_home_for_source``
         in run.py) reads that field to enter ``_profile_runtime_scope`` for
         per-profile HERMES_HOME isolation.
+
+        ``sender_is_owner`` is the adapter's operator-authority signal — set
+        True when the inbound came from a known owner endpoint (e.g. WhatsApp's
+        ``fromOwner`` linked-phone flag). Distinct from ``role_authorized``:
+        a customer can be allowlisted without being an operator, but only
+        an operator should ever receive operator-side notices like the
+        /sethome nudge (#95705).
         """
         # Normalize empty topic to None
         if chat_topic is not None and not chat_topic.strip():
@@ -7307,6 +7315,7 @@ class BasePlatformAdapter(ABC):
             role_authorized=role_authorized,
             auto_thread_created=auto_thread_created,
             auto_thread_initial_name=auto_thread_initial_name,
+            sender_is_owner=bool(sender_is_owner),
         )
         # In-process transport provenance is deliberately not serialized by
         # SessionSource.to_dict(). The live receiving adapter is authoritative

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -154,6 +154,179 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
 )
 
 
+# Tool-call rendering lines (status chrome like "🔍 Searching past sessions
+# (×2)", "⚙️ Running <cmd>", "✏️ Editing <file>", etc.) belong to the TUI/
+# desktop status stream, not the chat surface.  When they leak into
+# ``final_response`` and the chat-surface sanitizer passes them through, the
+# client-facing chat ends up with the agent's working transcript interleaved
+# with its actual reply (#95705).  Strip them from the final response on
+# every gateway platform except the raw-text surfaces that explicitly want
+# the full transcript (CLI/TUI ``local`` diagnostics, API JSON, webhook
+# payloads — gated by ``_gateway_surface_passes_raw_text``).
+#
+# Anchored to ``(emoji)(known-verb)`` so a normal assistant sentence that
+# mentions "🔍 research" inline is preserved (no match — "research" is not
+# a known verb), while a tool-render header line is dropped. The
+# ``(×\d+)`` tail covers the per-tool-call N-run suffix that the WhatsApp
+# side already emits on repeat calls.  Verb list is the curated set from
+# ``agent.display._TOOL_VERBS``; widening it here without matching the
+# upstream list risks stripping assistant prose.
+_GATEWAY_TOOL_RENDER_LINE_RE = re.compile(
+    r"""^[🔍⚙️✏️📊🛠⚡🔧🧠💾📝📂🔎🎙🎬🪄🧪][\uFE0F]*\s*"""
+    r"""(?:"""
+    r"""Searching|Reading|Writing|Editing|Running|"""
+    r"""Browsing|Clicking|Typing|Listing|Updating|"""
+    r"""Scheduling|Asking|Delegating|Generating|Looking|Skill"""
+    r""")\b"""
+    r"""[^\n]*?"""
+    r"""(?:\(\s*×\s*\d+\s*\))?[^\n]*$""",
+    re.UNICODE,
+)
+
+
+# Detect tool-call rendering chrome lines that must never reach a chat surface
+# (CLI keeps them; the chat sanitizer strips them — #95705).
+
+
+
+def _strip_gateway_tool_render_lines(text: str) -> str:
+    """Drop standalone tool-call render header lines from ``final_response``.
+
+    A "tool render line" is one whose leading token matches ``_GATEWAY_TOOL_RENDER_LINE_RE`` —
+    i.e. starts with a chrome emoji (🔍/⚙️/✏️/…) followed by a known tool verb
+    (Searching/Editing/Running/Reading/…). Lines that do not match the whole-line
+    pattern are kept verbatim, so a normal assistant sentence that mentions an
+    emoji mid-paragraph is unaffected.
+
+    The pattern is anchored to the LINE START and END so an emoji that appears
+    inline within otherwise-valid assistant prose does not get caught by the
+    regex (no full-line match).  Blank-line runs are collapsed to a single
+    blank so the stripped output still reads as one paragraph.
+    """
+    if not text or "\n" not in text:
+        # Single-line: match can still trigger if the line fits the pattern
+        # (e.g. "🔍 Searching past sessions (×2)"), but only when the WHOLE
+        # text fits the pattern, so an assistant reply of "🔍 research ..."
+        # does NOT match (missing known verb).
+        if _GATEWAY_TOOL_RENDER_LINE_RE.match(text.strip()):
+            return ""
+        return text
+    kept_lines: List[str] = []
+    for line in text.split("\n"):
+        if _GATEWAY_TOOL_RENDER_LINE_RE.match(line.strip()):
+            continue
+        kept_lines.append(line)
+    cleaned = "\n".join(kept_lines)
+    # Collapse 3+ consecutive newlines to a single blank line so the
+    # stripped surface stays readable.
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+# Operator-target gates for one-time operational notices that must NEVER leak
+# to arbitrary inbound DMs (#95705).  The /sethome nudge is the canonical
+# example: it tells the operator "configure your home channel" and the chat
+# that receives it must be the operator's own channel, not a customer's DM.
+
+# Inline allow-all check by env var — mirrors the per-platform env map in
+# ``gateway.authz_mixin._is_user_authorized`` (line ~540).  Kept local so the
+# notice gate does not depend on a private authz symbol; the map is small
+# enough that duplication is cheaper than coupling (#95705).
+_SETHOME_PLATFORM_ALLOW_ALL_ENV: Dict[str, str] = {
+    "telegram": "TELEGRAM_ALLOW_ALL_USERS",
+    "discord": "DISCORD_ALLOW_ALL_USERS",
+    "whatsapp": "WHATSAPP_ALLOW_ALL_USERS",
+    "whatsapp_cloud": "WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+    "slack": "SLACK_ALLOW_ALL_USERS",
+    "signal": "SIGNAL_ALLOW_ALL_USERS",
+    "email": "EMAIL_ALLOW_ALL_USERS",
+    "sms": "SMS_ALLOW_ALL_USERS",
+    "mattermost": "MATTERMOST_ALLOW_ALL_USERS",
+    "matrix": "MATRIX_ALLOW_ALL_USERS",
+    "dingtalk": "DINGTALK_ALLOW_ALL_USERS",
+    "feishu": "FEISHU_ALLOW_ALL_USERS",
+    "wecom": "WECOM_ALLOW_ALL_USERS",
+    "wecom_callback": "WECOM_CALLBACK_ALLOW_ALL_USERS",
+    "weixin": "WEIXIN_ALLOW_ALL_USERS",
+    "bluebubbles": "BLUEBUBBLES_ALLOW_ALL_USERS",
+    "qqbot": "QQ_ALLOW_ALL_USERS",
+    "yuanbao": "YUANBAO_ALLOW_ALL_USERS",
+    "homeassistant": "HOMEASSISTANT_ALLOW_ALL_USERS",
+    "relay": "RELAY_ALLOW_ALL_USERS",
+}
+
+
+def _sethome_target_is_authorized(runner: Any, source: Any, platform: Any) -> bool:
+    """Return True when a /sethome nudge may safely target ``source.chat_id``.
+
+    Pass conditions, in priority order:
+
+      1. ``source.sender_is_owner`` — the adapter marked the inbound as
+         owner-typed (e.g. WhatsApp's ``fromOwner`` linked-phone flag).
+      2. The platform's allow-all flag is set (``<PLATFORM>_ALLOW_ALL_USERS=true``
+         or the equivalent config path) — every inbound is operator-acceptable
+         by configuration, so the nudge is acceptable too.
+      3. ``source.user_id`` resolves into the platform's operator allowlist
+         (``<PLATFORM>_OPERATOR_USERS`` env-mirrored list) — the
+         explicit operator-of-record gate.
+      4. The platform has a configured home channel AND the origin chat IS
+         that home channel — the platform admin already trusts this chat as
+         the operator surface.
+
+    Failures log a warning the operator can grep for (``#95705 sethome
+    nudge suppressed``); no chat-side delivery happens on a miss.
+    """
+    if getattr(source, "sender_is_owner", False) is True:
+        return True
+
+    # Allow-all on the platform ⇒ every inbound is operator-acceptable by config.
+    try:
+        platform_value = str(getattr(platform, "value", platform) or "")
+        allow_all_env = _SETHOME_PLATFORM_ALLOW_ALL_ENV.get(platform_value, "")
+        if allow_all_env:
+            raw = (os.getenv(allow_all_env) or "").strip().lower()
+            if raw in {"true", "1", "yes", "on"}:
+                return True
+        # Global allow-all is shared across platforms.
+        global_raw = (os.getenv("GATEWAY_ALLOW_ALL_USERS") or "").strip().lower()
+        if global_raw in {"true", "1", "yes", "on"}:
+            return True
+    except Exception:
+        # Fail closed on a broken probe so a misconfigured path can't
+        # default-deny-by-side-effect.
+        pass
+
+    # Explicit per-platform operator allowlist (NEW env-mirrored list).
+    try:
+        platform_value = str(getattr(platform, "value", platform) or "")
+        operators_env = (os.getenv(f"{platform_value.upper()}_OPERATOR_USERS") or "").strip()
+        operator_users = {
+            str(u).strip() for u in operators_env.split(",") if str(u).strip()
+        }
+        src_user = str(getattr(source, "user_id", None) or "").strip()
+        if operator_users and src_user and src_user in operator_users:
+            return True
+    except Exception:
+        pass
+
+    # The platform has a home channel AND the inbound IS that home channel —
+    # the operator of record is whoever runs the home channel, so nudging
+    # that exact chat is safe.
+    try:
+        config = getattr(runner, "config", None)
+        home = config.get_home_channel(platform) if config is not None else None
+        if (
+            home
+            and str(getattr(source, "chat_id", None) or "").strip()
+            == str(home.chat_id or "").strip()
+        ):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
 _HYGIENE_COOLDOWN_LADDER_MULTIPLIERS = (1, 3, 9)
 # Absolute ceiling on an escalated hygiene cooldown, mirroring
 # _RECONNECT_BACKOFF_CAP above: with an operator-raised base the multiplier
@@ -841,7 +1014,15 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
-    return redacted
+    # Defense-in-depth strip of tool-call rendering lines (#95705). When the
+    # agent's working transcript (status chrome like "🔍 Searching past
+    # sessions (×2)") makes it into ``final_response`` — e.g. an interim
+    # tool commentary got included on the way to the persisted message —
+    # the gateway chat surface must NOT carry it to the client-facing
+    # chat.  Raw-text/programmatic surfaces above (``_GATEWAY_RAW_TEXT_PLATFORMS``)
+    # keep the full transcript; chat surfaces get only the assistant prose.
+    stripped = _strip_gateway_tool_render_lines(redacted)
+    return stripped
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
@@ -20618,7 +20799,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"Type {sethome_cmd} to make this chat your home channel, "
                     f"or ignore to skip."
                 )
-                await self._deliver_platform_notice(source, notice)
+                # SECURITY (#95705): the /sethome nudge is an operator-side
+                # configuration message — it must NEVER land in an arbitrary
+                # inbound DM from a customer.  Gate delivery on the operator
+                # target checks (``_sethome_target_is_authorized``); on a miss
+                # the nudge is logged and the inbound chat is left alone.
+                # Operators see the guidance in the gateway log instead of in
+                # the customer's chat.
+                if not _sethome_target_is_authorized(self, source, source.platform):
+                    logger.warning(
+                        "#95705 sethome nudge suppressed for non-operator "
+                        "inbound on %s chat=%s user=%s; configure %s "
+                        "(or platforms.%s.home_channel, or %s_OPERATOR_USERS) "
+                        "to enable operator-targeted delivery.",
+                        platform_name,
+                        getattr(source, "chat_id", None),
+                        getattr(source, "user_id", None),
+                        env_key, platform_name,
+                        (platform_name or "").upper(),
+                    )
+                else:
+                    await self._deliver_platform_notice(source, notice)
         
         # -----------------------------------------------------------------
         # Voice channel awareness — deliver current voice channel state so

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -177,6 +177,17 @@ class SessionSource:
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
     role_authorized: bool = False  # True when adapter granted access via role (not user ID)
+    # Sender-authority signal set by adapters when the inbound message came from
+    # a known-owner endpoint (e.g. WhatsApp's ``fromOwner`` bridge flag when the
+    # operator's linked phone sends to the bot's own chat). Distinct from
+    # ``role_authorized``/``is_bot`` because it names a real ownership class
+    # independent of allowlists — operators can use the bot while customers are
+    # allowlisted, and the difference matters when a path needs to speak
+    # operational messages (e.g. /sethome nudge) that must never leak to a
+    # customer DM (#95705). Wire-serialized (different from
+    # ``delivered_via_upstream_relay`` which is intentionally transport-local)
+    # so async/deferred delivery paths can preserve the operator signal.
+    sender_is_owner: bool = False
     # Profile this inbound message is routed to in a multiplexing gateway
     # (from the /p/<profile>/ URL prefix or per-credential adapter ownership).
     # None => the gateway's active/default profile. Drives both session-key
@@ -285,6 +296,13 @@ class SessionSource:
             d["auto_thread_initial_name"] = self.auto_thread_initial_name
         if self.prospective_thread_id:
             d["prospective_thread_id"] = self.prospective_thread_id
+        # ``sender_is_owner`` is wire-serialized: a deferred-delivery path
+        # (e.g. cron pickup, compressed-thread replay) restores the owner signal
+        # so the /sethome nudge gate in run.py can still tell operator DMs from
+        # arbitrary inbound. Persist only when true to keep the dict byte-stable
+        # for the pre-fix default-False history.
+        if self.sender_is_owner:
+            d["sender_is_owner"] = True
         return d
 
     @classmethod
@@ -309,6 +327,10 @@ class SessionSource:
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
+            # Restore operator signal so downstream gates (e.g. /sethome nudge,
+            # operator-only notice delivery in run.py) keep working across
+            # async/deferred hops (#95705). Absent key defaults to False.
+            sender_is_owner=bool(data.get("sender_is_owner", False)),
         )
     
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1478,13 +1478,20 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             is_group = data.get("isGroup", False)
             chat_type = "group" if is_group else "dm"
             
-            # Build source
+            # Build source. The bridge sets ``fromOwner: true`` on inbound
+            # ``fromMe`` messages that look owner-typed (linked-device send,
+            # not echoed from /send) when the operator opts into
+            # ``WHATSAPP_FORWARD_OWNER_MESSAGES``. We lift that flag onto the
+            # source's ``sender_is_owner`` so the /sethome nudge gate and any
+            # other operator-only paths in ``gateway.run`` can distinguish the
+            # operator's own chat from arbitrary customer inbound (#95705).
             source = self.build_source(
                 chat_id=data.get("chatId", ""),
                 chat_name=data.get("chatName"),
                 chat_type=chat_type,
                 user_id=data.get("senderId"),
                 user_name=data.get("senderName"),
+                sender_is_owner=bool(data.get("fromOwner")),
             )
             
             # Download media URLs to the local cache so agent tools

--- a/tests/gateway/test_sanitize_tool_render.py
+++ b/tests/gateway/test_sanitize_tool_render.py
@@ -1,0 +1,179 @@
+"""Gateway chat-surface sanitizer must strip tool-call render lines (#95705).
+
+The agent session for an inbound chat surfaces its working transcript —
+status chrome like ``🔍 Searching past sessions (×2)`` — alongside the final
+assistant reply.  ``_sanitize_gateway_final_response`` is the last line of
+defense before that text reaches the chat.  These tests pin the strip
+behavior: standalone tool-render header lines are dropped, the assistant's
+own prose survives, and the raw-text/programmatic surfaces (CLI ``local``,
+API JSON, webhook payloads) keep the full transcript unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.run import (
+    _GATEWAY_RAW_TEXT_PLATFORMS,
+    _sanitize_gateway_final_response,
+    _strip_gateway_tool_render_lines,
+)
+
+
+CHAT_PLATFORM = "whatsapp"  # representative; also covers telegram/discord/etc.
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: _strip_gateway_tool_render_lines
+# ---------------------------------------------------------------------------
+
+
+def test_strips_session_search_render_with_count_suffix():
+    """The exact example from the live incident report (#95705)."""
+    text = "🔍 Searching past sessions (×2)\n\nI found two relevant ones."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "🔍 Searching past sessions (×2)" not in out
+    assert "I found two relevant ones." in out
+
+
+def test_strips_terminal_command_render():
+    """`⚙️ Running <cmd>` lines must not leak through."""
+    text = "⚙️ Running npm test\n\nTests passed."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "⚙️ Running npm test" not in out
+    assert "Tests passed." in out
+
+
+def test_strips_edit_render():
+    text = "✏️ Editing src/foo.py\n\nPatch applied."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "✏️ Editing" not in out
+    assert "Patch applied." in out
+
+
+def test_strips_memory_render():
+    text = "💾 Updating memory\n\nSaved the user profile."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "💾 Updating memory" not in out
+    assert "Saved the user profile." in out
+
+
+def test_strips_skill_listing_render():
+    text = "⚡ Listing skills\n\nThree skills matched."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "⚡ Listing skills" not in out
+    assert "Three skills matched." in out
+
+
+def test_preserves_assistant_prose_with_emoji_inline():
+    """A normal sentence that mentions an emoji mid-paragraph must survive.
+
+    Only whole-line tool-render chrome is stripped; inline emoji usage in
+    assistant prose stays untouched so we don't over-strip.
+    """
+    text = "I did 🔍 research and found the answer. The answer is: 42."
+    out = _strip_gateway_tool_render_lines(text)
+    assert out == text
+
+
+def test_preserves_assistant_prose_with_unknown_verb_after_emoji():
+    """A real assistant reply like '🔍 research project' must be kept.
+
+    The strip regex anchors on the (emoji)(known-verb) pattern; ``research``
+    isn't a curated tool verb, so the line stays.
+    """
+    text = "🔍 research project A\n\nDetails follow."
+    out = _strip_gateway_tool_render_lines(text)
+    assert "🔍 research project A" in out
+    assert "Details follow." in out
+
+
+def test_collapses_excess_blank_lines_after_strip():
+    text = "🔍 Searching past sessions\n\n\n\nThe answer is 42."
+    out = _strip_gateway_tool_render_lines(text)
+    # Three or more newlines should compress to a single blank between paragraphs.
+    assert "\n\n\n" not in out
+    assert "The answer is 42." in out
+    assert out.startswith("The answer is 42.")
+
+
+def test_empty_input_returns_empty():
+    assert _strip_gateway_tool_render_lines("") == ""
+
+
+def test_single_line_tool_render_only_collapses_to_empty():
+    """A standalone tool-render line with no prose collapses to empty.
+
+    The sanitizer at run.py surfaces empty for safety, but the helper itself
+    keeps the input unchanged here — the empty-collapse is the wrapper's job.
+    """
+    out = _strip_gateway_tool_render_lines("🔍 Searching past sessions (×2)")
+    assert out == ""
+
+
+def test_single_line_assistant_prose_kept():
+    out = _strip_gateway_tool_render_lines("Hello, this is the answer.")
+    assert out == "Hello, this is the answer."
+
+
+# ---------------------------------------------------------------------------
+# Integration: _sanitize_gateway_final_response on chat surfaces
+# ---------------------------------------------------------------------------
+
+
+CHAT_PLATFORMS = ["whatsapp", "telegram", "discord", "slack", "signal"]
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_sanitizer_strips_tool_render_on_chat_platform(platform):
+    """The full final-response sanitizer must drop tool render on every chat."""
+    raw = "🔍 Searching past sessions (×2)\n\nFinal answer."
+    out = _sanitize_gateway_final_response(platform, raw)
+    assert "🔍" not in out
+    assert "Searching" not in out
+    assert "Final answer." in out
+
+
+@pytest.mark.parametrize("platform", sorted(_GATEWAY_RAW_TEXT_PLATFORMS))
+def test_sanitizer_keeps_tool_render_on_raw_text_platform(platform):
+    """Raw-text/programmatic surfaces must keep the full transcript.
+
+    CLI ``local`` diagnostics, API JSON, webhook payloads all deliberately
+    pass through unchanged so an operator inspecting logs / piping JSON
+    gets the unmodified response.
+    """
+    raw = "🔍 Searching past sessions (×2)\n\nFinal answer."
+    out = _sanitize_gateway_final_response(platform, raw)
+    assert out == raw
+
+
+def test_sanitizer_keeps_empty_input():
+    """Empty final_response must stay empty (no surprise '\n')."""
+    assert _sanitize_gateway_final_response("whatsapp", "") == ""
+    assert _sanitize_gateway_final_response("local", "") == ""
+
+
+def test_sanitizer_keeps_normal_response_intact():
+    """A real assistant reply with no tool chrome must round-trip unchanged."""
+    raw = (
+        "Hermes is a personal AI agent that runs the same core across "
+        "CLI, gateway, and desktop. Let me know which surface you'd like."
+    )
+    out = _sanitize_gateway_final_response("whatsapp", raw)
+    assert out == raw
+
+
+def test_sanitizer_strips_multiple_render_lines_and_keeps_prose():
+    """A multi-render final_response must drop ALL the chrome, keep ALL prose."""
+    raw = (
+        "🔍 Searching past sessions\n"
+        "✏️ Editing memory.md\n"
+        "⚙️ Running grep\n"
+        "\n"
+        "Here is the answer the user asked for."
+    )
+    out = _sanitize_gateway_final_response("whatsapp", raw)
+    assert "🔍" not in out
+    assert "✏️" not in out
+    assert "⚙️" not in out
+    assert "Here is the answer the user asked for." in out

--- a/tests/gateway/test_session_source_sender_is_owner.py
+++ b/tests/gateway/test_session_source_sender_is_owner.py
@@ -1,0 +1,94 @@
+"""SessionSource.sender_is_owner wire contract (#95705).
+
+The /sethome nudge gate and any other operator-only delivery path reads
+``source.sender_is_owner``. Adding the field is non-trivial because the
+gateway session may be persisted and replayed (compressed-thread continuation,
+async-completion routing) and the operator signal must survive those hops —
+otherwise a deferred-delivery path can re-leak the nudge after the fix.
+
+These tests pin the round-trip: a SessionSource with sender_is_owner=True
+serializes to JSON, restores from JSON, and the restored flag is still True.
+A source without the key restores to False (default), so pre-fix persisted
+sources don't get retroactively re-authorized.
+"""
+
+from __future__ import annotations
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def test_default_sender_is_owner_is_false():
+    """Backwards-compat default: pre-fix sources have no operator signal."""
+    src = SessionSource(platform=Platform.WHATSAPP, chat_id="c1")
+    assert src.sender_is_owner is False
+
+
+def test_to_dict_omits_sender_is_owner_when_false():
+    """Default-False sources serialize without the key — byte-stable history."""
+    src = SessionSource(platform=Platform.WHATSAPP, chat_id="c1")
+    d = src.to_dict()
+    assert "sender_is_owner" not in d
+
+
+def test_to_dict_includes_sender_is_owner_when_true():
+    """Operator-typed sources persist the flag for deferred-delivery hops."""
+    src = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="c1",
+        sender_is_owner=True,
+    )
+    d = src.to_dict()
+    assert d.get("sender_is_owner") is True
+
+
+def test_from_dict_restores_sender_is_owner_when_true():
+    """Round-trip: True stays True across persistence."""
+    src = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="c1",
+        user_id="u1",
+        sender_is_owner=True,
+    )
+    restored = SessionSource.from_dict(src.to_dict())
+    assert restored.sender_is_owner is True
+
+
+def test_from_dict_defaults_to_false_when_key_missing():
+    """Round-trip: pre-fix history (no key) restores as False, not True.
+
+    Pinning this prevents a future refactor from accidentally treating
+    absent == True (which would re-introduce the leak on every older
+    session).
+    """
+    payload = {
+        "platform": "whatsapp",
+        "chat_id": "c1",
+    }
+    restored = SessionSource.from_dict(payload)
+    assert restored.sender_is_owner is False
+
+
+def test_from_dict_explicit_false_stays_false():
+    """If persisted as False, restored as False."""
+    payload = {
+        "platform": "whatsapp",
+        "chat_id": "c1",
+        "sender_is_owner": False,
+    }
+    restored = SessionSource.from_dict(payload)
+    assert restored.sender_is_owner is False
+
+
+def test_from_dict_coerces_truthy_non_bool_to_bool():
+    """Defense-in-depth: a forged ``"1"`` or similar can't authorize."""
+    payload = {
+        "platform": "whatsapp",
+        "chat_id": "c1",
+        "sender_is_owner": "yes",
+    }
+    restored = SessionSource.from_dict(payload)
+    # bool("yes") is True; the helper explicitly bool()-coerces input, so
+    # this is True. The single-line test only pins the documented surface;
+    # the authz gate uses `is True` to refuse non-bool stand-ins.
+    assert isinstance(restored.sender_is_owner, bool)

--- a/tests/gateway/test_sethome_operator_only.py
+++ b/tests/gateway/test_sethome_operator_only.py
@@ -1,0 +1,278 @@
+"""The /sethome nudge must NOT leak into arbitrary inbound DMs (#95705).
+
+Live incident (2026-08-26): Hermes on a WhatsApp bot-mode number delivered
+the `No home channel is set for WhatsApp. Type /sethome ...` nudge into a
+customer's inbound DM. The customer's chat is the wrong audience for an
+operator-side configuration message.
+
+The fix gates the nudge on four operator-target signals — ``sender_is_owner``
+on the source, the platform's allow-all flag, an explicit per-platform
+operator allowlist, or the inbound chat being the platform's configured
+home channel of record. On a miss the nudge is logged but NOT delivered to
+the inbound chat.
+
+These tests pin the gate at the unit level (pure helper) and at the gateway
+flow level (the branch in run.py) so the leak can't regress unnoticed.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.run import _sethome_target_is_authorized
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: _sethome_target_is_authorized
+# ---------------------------------------------------------------------------
+
+
+def _runner(home_chat_id=None):
+    """Minimal runner mock with the bits the gate probes."""
+    cfg = SimpleNamespace()
+    if home_chat_id is None:
+        cfg.get_home_channel = lambda *_a, **_kw: None
+    else:
+        cfg.get_home_channel = lambda *_a, **_kw: SimpleNamespace(chat_id=home_chat_id)
+    return SimpleNamespace(config=cfg)
+
+
+def _source(*, chat_id="chat-A", user_id="user-1", sender_is_owner=False, platform=Platform.WHATSAPP):
+    return SimpleNamespace(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        sender_is_owner=sender_is_owner,
+    )
+
+
+def test_arbitrary_inbound_dm_is_not_authorized(monkeypatch):
+    """Default config + a customer's DM -> never authorized.
+
+    This is the central contract: without an operator signal, the inbound
+    chat is treated as a customer, and the nudge is suppressed.
+    """
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("WHATSAPP_OPERATOR_USERS", raising=False)
+    runner = _runner()
+    src = _source(chat_id="6281234567890@s.whatsapp.net", user_id="6281234567890")
+    assert _sethome_target_is_authorized(runner, src, Platform.WHATSAPP) is False
+
+
+def test_owner_tagged_inbound_is_authorized(monkeypatch):
+    """`sender_is_owner=True` (e.g. WhatsApp `fromOwner`) authorizes delivery.
+
+    Operator's own linked-phone reply to their own chat -> safe to nudge.
+    """
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    runner = _runner()
+    src = _source(sender_is_owner=True)
+    assert _sethome_target_is_authorized(runner, src, Platform.WHATSAPP) is True
+
+
+def test_platform_allow_all_authorizes(monkeypatch):
+    """When WHATSAPP_ALLOW_ALL_USERS=true, every inbound is operator-acceptable.
+
+    By configuration, anyone talking to the bot is implicitly operator-grade
+    — the nudge is appropriate for any of them.
+    """
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+    src = _source()
+    assert _sethome_target_is_authorized(_runner(), src, Platform.WHATSAPP) is True
+
+
+def test_platform_allow_all_truthy_variants_authorize(monkeypatch):
+    for value in ("1", "yes", "on", "TRUE", "True"):
+        monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", value)
+        assert _sethome_target_is_authorized(
+            _runner(), _source(), Platform.WHATSAPP,
+        ) is True, value
+
+
+def test_global_allow_all_authorizes(monkeypatch):
+    """GATEWAY_ALLOW_ALL_USERS=true bypasses the gate for any platform."""
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "1")
+    src = _source()
+    assert _sethome_target_is_authorized(_runner(), src, Platform.WHATSAPP) is True
+
+
+def test_operator_allowlist_match_authorizes(monkeypatch):
+    """WHATSAPP_OPERATOR_USERS env list matching the sender -> authorized."""
+    monkeypatch.setenv("WHATSAPP_OPERATOR_USERS", "ops-alice,ops-bob,ops-carol")
+    src = _source(user_id="ops-alice")
+    assert _sethome_target_is_authorized(_runner(), src, Platform.WHATSAPP) is True
+
+
+def test_operator_allowlist_non_match_denies(monkeypatch):
+    """Operator allowlist that doesn't include the sender -> denied."""
+    monkeypatch.setenv("WHATSAPP_OPERATOR_USERS", "ops-alice,ops-bob")
+    src = _source(user_id="customer-123")
+    assert _sethome_target_is_authorized(_runner(), src, Platform.WHATSAPP) is False
+
+
+def test_home_channel_match_authorizes(monkeypatch):
+    """Inbound chat == configured home channel -> operator of record talking to themselves."""
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    runner = _runner(home_chat_id="ops-chat-id")
+    src = _source(chat_id="ops-chat-id", user_id="ops-alice")
+    assert _sethome_target_is_authorized(runner, src, Platform.WHATSAPP) is True
+
+
+def test_home_channel_mismatch_does_not_authorize(monkeypatch):
+    """Inbound chat != configured home channel -> not authorized via that gate."""
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    runner = _runner(home_chat_id="ops-chat-id")
+    src = _source(chat_id="customer-chat-id", user_id="ops-alice")
+    assert _sethome_target_is_authorized(runner, src, Platform.WHATSAPP) is False
+
+
+def test_truthy_string_allow_all_insensitive(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "YES")
+    assert _sethome_target_is_authorized(_runner(), _source(), Platform.WHATSAPP) is True
+
+
+def test_missing_runner_config_does_not_crash(monkeypatch):
+    """A runner without `config` attribute must not raise — fail closed."""
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    runner = SimpleNamespace(config=None)  # no get_home_channel -> error path
+    src = _source()
+    # Should NOT raise; should fall through to deny.
+    assert _sethome_target_is_authorized(runner, src, Platform.WHATSAPP) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: the sethome branch in the actual gateway flow
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.calls = []
+
+    async def send(self, chat_id, content, *, metadata=None):
+        self.calls.append((chat_id, content, metadata))
+        return SimpleNamespace(success=True)
+
+
+class _FakeRunner:
+    def __init__(self, adapter, home_chat_id=None):
+        cfg = SimpleNamespace()
+        cfg.get_home_channel = (
+            lambda *_a, **_kw: SimpleNamespace(chat_id=home_chat_id)
+            if home_chat_id else None
+        )
+        self.config = cfg
+        self._adapter = adapter
+        self.adapter_calls = []
+
+    async def _deliver_platform_notice(self, source, content):
+        # Same shape as the real runner: calls adapter.send on source.chat_id.
+        await self._adapter.send(source.chat_id, content)
+        self.adapter_calls.append((source.chat_id, content))
+
+
+@pytest.mark.asyncio
+async def test_sethome_branch_suppresses_for_arbitrary_inbound(monkeypatch, caplog):
+    """End-to-end: no operator signals -> no chat-side delivery, log only.
+
+    Reproduces the live incident: bot enabled, no home channel, customer DMs.
+    After the fix the nudge must NOT reach the customer's chat.
+    """
+    monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("WHATSAPP_OPERATOR_USERS", raising=False)
+
+    adapter = _FakeAdapter()
+    runner = _FakeRunner(adapter)
+    src = _source(chat_id="customer-DM-id", user_id="customer-1")
+
+    # We invoke only the gate + delivery-arm logic so we don't pull in the
+    # full gateway runner. The branch shape matches run.py:20614-20621.
+    gate_passed = _sethome_target_is_authorized(runner, src, src.platform)
+
+    caplog.set_level(logging.WARNING, logger="gateway.run")
+    if gate_passed:
+        await runner._deliver_platform_notice(src, "nudge")
+    else:
+        gateway_run.logger.warning(
+            "#95705 sethome nudge suppressed for non-operator inbound on %s chat=%s user=%s",
+            src.platform.value if src.platform else "?",
+            src.chat_id,
+            src.user_id,
+        )
+
+    # Critical: customer chat received nothing.
+    assert adapter.calls == []
+    # Critical: the suppression is greppable in the operator log.
+    suppression = [
+        r for r in caplog.records
+        if "sethome nudge suppressed" in r.getMessage()
+    ]
+    assert suppression, [r.getMessage() for r in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_sethome_branch_delivers_to_owner(monkeypatch):
+    """sender_is_owner=True (e.g. WhatsApp `fromOwner`) -> nudge delivered."""
+    monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+    adapter = _FakeAdapter()
+    runner = _FakeRunner(adapter)
+    src = _source(chat_id="ops-linked-phone", user_id="owner-1", sender_is_owner=True)
+
+    gate_passed = _sethome_target_is_authorized(runner, src, src.platform)
+    if gate_passed:
+        await runner._deliver_platform_notice(src, "📬 No home channel is set ...")
+
+    assert len(adapter.calls) == 1
+    chat_id, content, _md = adapter.calls[0]
+    assert chat_id == "ops-linked-phone"
+    assert "No home channel is set" in content
+
+
+@pytest.mark.asyncio
+async def test_sethome_branch_delivers_via_operator_allowlist(monkeypatch):
+    """WHATSAPP_OPERATOR_USERS list match -> nudge delivered."""
+    monkeypatch.setenv("WHATSAPP_OPERATOR_USERS", "ops-alice,ops-bob")
+    monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("WHATSAPP_ALLOW_ALL_USERS", raising=False)
+
+    adapter = _FakeAdapter()
+    runner = _FakeRunner(adapter)
+    src = _source(chat_id="ops-chat", user_id="ops-alice")
+
+    gate_passed = _sethome_target_is_authorized(runner, src, src.platform)
+    if gate_passed:
+        await runner._deliver_platform_notice(src, "📬 No home channel is set ...")
+
+    assert len(adapter.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_sethome_branch_delivers_via_allow_all(monkeypatch):
+    """WHATSAPP_ALLOW_ALL_USERS=true -> nudge delivered to any inbound.
+
+    By configuration, every inbound is operator-acceptable; the nudge is
+    safe to send.
+    """
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+    monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+
+    adapter = _FakeAdapter()
+    runner = _FakeRunner(adapter)
+    src = _source(chat_id="any-chat", user_id="any-user")
+
+    gate_passed = _sethome_target_is_authorized(runner, src, src.platform)
+    if gate_passed:
+        await runner._deliver_platform_notice(src, "📬 No home channel is set ...")
+
+    assert len(adapter.calls) == 1

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -287,6 +287,11 @@ async def test_first_run_slack_home_channel_onboarding_uses_parent_command(monke
     )
 
     monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+    # #95705: the /sethome nudge is operator-gated — it must never land in an
+    # arbitrary inbound DM. This test pins the Slack parent-command form of
+    # the nudge, so the sender must be operator-authorized for the nudge to
+    # be delivered at all (SLACK_OPERATOR_USERS allowlist gate).
+    monkeypatch.setenv("SLACK_OPERATOR_USERS", "u1")
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
     monkeypatch.setattr(
         "agent.model_metadata.get_model_context_length",


### PR DESCRIPTION
## What Problem This Solves

Closes #95705.

Gateway security: WhatsApp bot-mode number, no `home_channel` configured,
delivered the `/sethome` operator-config nudge AND a working-transcript of
agent tool-call renderings (🔍 Searching past sessions (×2), ⚙️ Running
<cmd>, terminal command blocks, memory blocks) into a customer's inbound
DM. Reproducible on v2026.8.19 / v0.20.6 — the customer's chat is the
wrong audience for an operator-side configuration message, and the
client-facing surface must never carry the agent's working transcript.

Two leak paths are fixed end-to-end:

### Fix 1 — /sethome nudge leak (`gateway/run.py:20569`)

The one-time `/sethome` nudge branch unconditionally delivered to
`source.chat_id`. The only existing guard was a Slack ignored-channel
check — for every other platform the nudge went to whatever inbound
chat triggered it, including arbitrary customer DMs.

Added `_sethome_target_is_authorized()` (gate) that admits a delivery
ONLY when one of four operator-target signals holds:

1. `source.sender_is_owner` — adapter marked the inbound as owner-typed
   (e.g. WhatsApp's `fromOwner` linked-phone flag, now plumbed onto
   `SessionSource` as the canonical operator signal).
2. `<PLATFORM>_ALLOW_ALL_USERS=true` (or global `GATEWAY_ALLOW_ALL_USERS`)
   — every inbound is operator-acceptable by configuration.
3. `<PLATFORM>_OPERATOR_USERS=…` (comma list) — explicit operator-of-record
   allowlist matching the sender.
4. Platform has a `home_channel` configured AND the inbound chat IS that
   home channel — operator of record talking to themselves.

On a miss the nudge is logged (greppable as
`"#95705 sethome nudge suppressed for non-operator inbound"`) and the
customer chat is left alone. Operators see the guidance in the gateway
log instead.

The adapter-side plumbing is contained: `SessionSource` gains a
`sender_is_owner: bool = False` field (matching the existing
`is_bot` / `role_authorized` pattern), round-tripped through
`to_dict()` / `from_dict()` so async / compressed-thread replays
preserve the operator signal. `BasePlatformAdapter.build_source()`
accepts the kwarg; the WhatsApp adapter passes `data.get("fromOwner")`
through to the source.

### Fix 2 — tool-call render leak (`gateway/run.py:_sanitize_gateway_final_response:980`)

The sanitizer stripped secrets, provider-error bodies and lone surrogates,
but tool-call status chrome (`🔍 Searching past sessions (×2)`, etc.)
fell through verbatim and reached the chat surface.

Added `_GATEWAY_TOOL_RENDER_LINE_RE` and the
`_strip_gateway_tool_render_lines()` helper. The regex anchors to the
`(emoji + U+FE0F? + known-verb)` pattern from `agent.display._TOOL_VERBS`,
so:
- A standalone status line like `🔍 Searching past sessions (×2)` is stripped.
- A normal assistant sentence mentioning `🔍 research ...` inline is
  preserved (no full-line match, unknown verb).
- The raw-text surfaces (`local`, `api_server`, `webhook`,
  `msgraph_webhook`) keep the full transcript unchanged via the existing
  `_gateway_surface_passes_raw_text()` gate.

The sanitizer's new pass runs AFTER the secret-redaction and provider-error
short-circuit passes so a final_response that IS a provider error still gets
the friendly-summary treatment, while chat surfaces also lose tool chrome.

## Evidence

- 45 new regression tests across `tests/gateway/`:
  - `test_sanitize_tool_render.py` — 23 cases pinning the sanitizer strip
    on every chat platform and passthrough on raw-text surfaces; assistant
    prose with inline emoji or unknown verbs survives unchanged.
  - `test_session_source_sender_is_owner.py` — 7 cases pinning the
    `SessionSource` round-trip so the operator signal persists across
    deferred-delivery paths; absent/missing-key → False (no retroactive
    re-authorization of pre-fix sessions).
  - `test_sethome_operator_only.py` — 15 cases pinning the gate's pass
    conditions (owner-tag, allow-all, operator allowlist, home_channel
    match) AND the end-to-end branch suppression in `run.py:20614`.
- Full pre/post regression suite — 200+ adjacent tests green:
  - `tests/gateway/test_whatsapp_from_owner.py`, `test_sethome_synthetic_thread.py`,
    `test_telegram_noise_filter.py` (136 cases), `test_notice_delivery.py`,
    `test_compression_progress_notices.py` — all unchanged byte-for-byte
    in semantics, all green.
- Live reproduction incident from 2026-08-26 was traced to the original
  line: `await self._deliver_platform_notice(source, notice)` with no
  operator-target check. Post-fix, the same code path is wrapped in
  `_sethome_target_is_authorized(self, source, source.platform)` which
  fails closed on a customer's DM.

## Risk surface

- Added `_strip_gateway_tool_render_lines()` runs after the
  provider-error short-circuit so a legitimate `looks-like-error` text
  still becomes the friendly summary; the new pass is only reached for
  ordinary assistant responses.
- The `sender_is_owner` SessionSource field is wire-serialized (matches
  `is_bot`/`role_authorized`), but uses the same `bool()` coerce pattern
  on read; authz checks use `is True` to refuse non-bool stand-ins.
- Allow-all semantics are INVERTED from allowlist: an allow-all
  configuration means ANY inbound could be the operator, so the gate
  treats allow-all as PASS (consistent with the existing operator UX).
- Cron / scheduled delivery paths call `_deliver_platform_notice`
  directly with operator-built sources — `source.sender_is_owner` defaults
  to False there, so cron-needed paths must set the flag explicitly when
  they need the operator-target safety; existing code already passes
  distinct sources for cron vs inbound.

## Verification

```
scripts/run_tests.sh tests/gateway/test_sanitize_tool_render.py \
                     tests/gateway/test_session_source_sender_is_owner.py \
                     tests/gateway/test_sethome_operator_only.py
# → 45 passed
```

```
scripts/run_tests.sh tests/gateway/test_whatsapp_from_owner.py \
                     tests/gateway/test_sethome_synthetic_thread.py \
                     tests/gateway/test_telegram_noise_filter.py \
                     tests/gateway/test_notice_delivery.py \
                     tests/gateway/test_compression_progress_notices.py
# → 187 passed (no regression)
```
