### PR TITLE
fix(agent): rebuild gateway-restored system prompt missing USER.md/MEMORY.md blocks (#96134)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -863,6 +863,43 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
         return False
 
 
+def _stored_prompt_reflects_builtin_memory(agent, stored_prompt: str) -> bool:
+    """Whether a stored system prompt already embeds the store's current blocks.
+
+    The gateway restores the persisted system prompt verbatim on every turn
+    (fresh ``AIAgent`` per turn, byte-stable prefix cache). The stored bytes
+    are only rejected when the runtime identity (model/provider/cwd/platform)
+    drifts — memory content was never part of that check, so a prompt
+    persisted while ``USER.md``/``MEMORY.md`` were empty (or before memory was
+    enabled, or by an older build) was reused forever, even across restarts:
+    the gateway resolves the same session_id from its SessionDB, so the
+    memory blocks never entered the system prompt again (issue #96134).
+
+    Reuse the compression path's retention check
+    (``_cached_prompt_reflects_builtin_memory``): it renders the CURRENT
+    frozen blocks from the agent's store and verifies they appear verbatim in
+    the stored prompt (and that no block header lingers for a now-empty or
+    disabled target). A mismatch means the stored prompt would silently miss
+    memory the fresh build would inject — the restore must rebuild once; the
+    rebuilt prompt is persisted, so the check converges and the cache stays
+    warm from the next turn.
+
+    Agents without a built-in memory store (or test fakes whose store is not
+    a real ``MemoryStore``) pass through unchanged — the check only fires for
+    real stores, and any unexpected render failure fails OPEN to reuse so a
+    probe hiccup can never force a per-turn cache miss.
+    """
+    store = getattr(agent, "_memory_store", None)
+    if store is None:
+        return True
+    try:
+        from agent.conversation_compression import _cached_prompt_reflects_builtin_memory
+
+        return _cached_prompt_reflects_builtin_memory(agent, stored_prompt)
+    except Exception:
+        return True
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -912,7 +949,11 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 agent.session_id, exc,
             )
 
-    if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
+    if (
+        stored_prompt
+        and _stored_prompt_matches_runtime(agent, stored_prompt)
+        and _stored_prompt_reflects_builtin_memory(agent, stored_prompt)
+    ):
         # Bot Chat capability epoch: an eternal bot session must adopt
         # user-initiated capability changes (skills/toolsets/MCP/SOUL/roster)
         # on the next message, not at /new or compression. The stored prompt
@@ -1016,14 +1057,25 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         reconstruct_static_prefix(agent, system_message=system_message)
         return
     if stored_prompt:
-        stored_state = "stale_runtime"
-        logger.info(
-            "Stored system prompt for session %s has stale runtime identity; "
-            "rebuilding for model=%s provider=%s.",
-            agent.session_id,
-            getattr(agent, "model", "") or "",
-            getattr(agent, "provider", "") or "",
-        )
+        if not _stored_prompt_reflects_builtin_memory(agent, stored_prompt):
+            stored_state = "stale_memory"
+            logger.info(
+                "Stored system prompt for session %s is missing built-in memory "
+                "blocks that the current MemoryStore would inject (USER.md/"
+                "MEMORY.md changed or became non-empty since the prompt was "
+                "persisted); rebuilding once. Prefix cache will miss for this "
+                "turn only (#96134).",
+                agent.session_id,
+            )
+        else:
+            stored_state = "stale_runtime"
+            logger.info(
+                "Stored system prompt for session %s has stale runtime identity; "
+                "rebuilding for model=%s provider=%s.",
+                agent.session_id,
+                getattr(agent, "model", "") or "",
+                getattr(agent, "provider", "") or "",
+            )
 
     if conversation_history and stored_state in ("null", "empty"):
         # Continuing session whose stored prompt is unusable.  The

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -115,6 +115,124 @@ class TestStoredPromptReuse:
 
 
 # ---------------------------------------------------------------------------
+# #96134: stored prompts that miss built-in memory blocks must rebuild once
+# ---------------------------------------------------------------------------
+
+
+class TestStoredPromptMemoryRefresh:
+    """Regression for #96134 — gateway restores stale memory-less prompts.
+
+    The gateway persists the built system prompt in the SessionDB and
+    restores it byte-for-byte on every turn (fresh ``AIAgent`` per turn). The
+    runtime-identity check (model/provider/cwd/platform) never looked at
+    memory, so a prompt persisted while ``USER.md``/``MEMORY.md`` were empty
+    (or before memory was enabled) was reused forever — even across gateway
+    restarts, because the same session_id resolves from the same DB. The
+    fresh build *would* inject the blocks; the restore just never noticed.
+    """
+
+    @staticmethod
+    def _memory_store(tmp_path, monkeypatch, user_text: str, memory_text: str):
+        """A real MemoryStore loaded from a profile home with real files."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True, exist_ok=True)
+        (mem_dir / "USER.md").write_text(user_text, encoding="utf-8")
+        (mem_dir / "MEMORY.md").write_text(memory_text, encoding="utf-8")
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore(memory_enabled=True, user_profile_enabled=True)
+        store.load_from_disk()
+        return store
+
+    def test_stored_prompt_missing_memory_blocks_rebuilds(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """#96134: stored prompt without memory blocks → rebuild, don't reuse.
+
+        Pre-fix this reused the stale stored bytes verbatim (the bug); the
+        fresh build embeds USER.md/MEMORY.md content, so the rebuilt prompt
+        is persisted and the next turn restores byte-stable again.
+        """
+        store = self._memory_store(
+            tmp_path, monkeypatch,
+            user_text="Preferred name: Jackie\n",
+            memory_text="User likes concise answers.\n",
+        )
+        db = MagicMock()
+        db.get_session.return_value = {
+            "system_prompt": "Stale prompt persisted before USER.md existed."
+        }
+        agent = _make_agent(session_db=db, prebuilt_prompt="FRESH_BUILT_PROMPT")
+        agent._memory_store = store
+        agent._memory_enabled = True
+        agent._user_profile_enabled = True
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+
+        assert agent._cached_system_prompt == "FRESH_BUILT_PROMPT"
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, agent._cached_system_prompt
+        )
+        assert any(
+            "missing built-in memory blocks" in r.getMessage()
+            for r in caplog.records
+        ), "rebuild must be logged distinctly from runtime staleness"
+
+    def test_stored_prompt_with_current_memory_blocks_still_reused_verbatim(
+        self, tmp_path, monkeypatch
+    ):
+        """Byte-stable restore still wins when the blocks are current.
+
+        The prefix-cache contract must survive the fix: a stored prompt that
+        already embeds the store's rendered blocks is reused byte-for-byte.
+        """
+        store = self._memory_store(
+            tmp_path, monkeypatch,
+            user_text="Preferred name: Jackie\n",
+            memory_text="User likes concise answers.\n",
+        )
+        mem_block = store.format_for_system_prompt("memory")
+        user_block = store.format_for_system_prompt("user")
+        assert mem_block and user_block, "precondition: blocks render"
+
+        stored = f"HEADER\n\n{mem_block}\n\n{user_block}"
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent._memory_store = store
+        agent._memory_enabled = True
+        agent._user_profile_enabled = True
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_no_memory_store_keeps_reusing_stored_prompt(self):
+        """Agents without a built-in store are untouched by the new gate."""
+        stored = "Plain stored prompt, no memory surface anywhere"
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent._memory_store = None
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Legitimate fresh-build paths (no history, no DB)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #96134 — gateway sessions (Weixin/WeCom etc.) never saw `USER.md`/`MEMORY.md` content in the system prompt, while CLI did.

**Root cause (reproduced):** the gateway persists the built system prompt in the shared `SessionDB` and restores it **byte-for-byte on every turn** (fresh `AIAgent` per turn, byte-stable prefix cache). `_restore_or_build_system_prompt` only rejected a stored prompt when the *runtime identity* drifted (model/provider/cwd/platform). Memory content was never part of that check — so a prompt persisted while `USER.md`/`MEMORY.md` were empty (or before memory was enabled, or by an older build) was reused forever, **even across gateway restarts**, because the same `session_id` resolves from the same DB row. The memory blocks the fresh build *would* inject never entered the system prompt again.

This matches every reporter observation: `/memory` works and manual `read_file` works (the store and files are fine), only the system-prompt injection is missing; clearing `sessions.json`/`gateway_routing` doesn't help because the stale prompt lives in the `sessions.system_prompt` column of `state.db`.

## Fix

- `agent/conversation_loop.py`: gate the stored-prompt reuse on `_stored_prompt_reflects_builtin_memory` — a thin wrapper reusing the compression path's existing retention check `_cached_prompt_reflects_builtin_memory` (agent/conversation_compression.py), which renders the store's **current** frozen blocks and verifies they appear verbatim in the stored prompt (and that no block header lingers for a now-empty/disabled target).
- On mismatch the restore **rebuilds once** with a distinct `stale_memory` log line; the rebuilt prompt is persisted via `update_system_prompt`, so the prefix cache stays warm from the next turn.
- Agents without a built-in `MemoryStore` are untouched; probe failures fail open to reuse (no per-turn cache misses).

## Tests

- New regression tests in `tests/agent/test_system_prompt_restore.py`:
  - `test_stored_prompt_missing_memory_blocks_rebuilds` — the #96134 case: stored prompt without memory blocks + store with content → rebuild (proven RED on pre-fix code via stash/sabotage run, GREEN post-fix).
  - `test_stored_prompt_with_current_memory_blocks_still_reused_verbatim` — byte-stable restore preserved when blocks are current.
  - `test_no_memory_store_keeps_reusing_stored_prompt` — no-store agents unaffected.
- Related suites: 135 passed (test_system_prompt_restore, test_system_prompt, test_turn_context, test_skip_memory_store_65429, test_builtin_memory_disabled_surface, test_73297_memory_flush_on_reset, test_memory_tool). The 1 failure (`test_coding_prompt_preserves_legacy_workspace_order`) is a pre-existing baseline failure — fails identically on unmodified `main`.

Closes #96134