### PR TITLE
fix(desktop): allow HTML fullscreen in the permission request handler

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6930,7 +6930,11 @@ function installDownloadHandling() {
 function installMediaPermissions() {
   // Async request handler: the prompt-style path (most platforms).
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback, details) => {
-    callback(isMediaCapturePermission(permission, details))
+    // HTML fullscreen (e.g. the native fullscreen button on a <video> in the
+    // transcript) also goes through the permission request handler. Answering
+    // false leaves the renderer's requestFullscreen() promise permanently
+    // pending — the click just does nothing, with no error anywhere.
+    callback(permission === 'fullscreen' || isMediaCapturePermission(permission, details))
   })
 
   // Synchronous check handler: Chromium consults this for getUserMedia on
@@ -6939,6 +6943,7 @@ function installMediaPermissions() {
   // handler ever runs.
   session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
     return (
+      permission === 'fullscreen' ||
       permission === 'media' ||
       permission === ('audioCapture' as any) /* todo: is this needed? */ ||
       permission === ('videoCapture' as any)


### PR DESCRIPTION
## Problem

The session-wide `setPermissionRequestHandler` answers **every** permission request with `isMediaCapturePermission()`, so a `fullscreen` permission request is always denied. Chromium then leaves the renderer's `requestFullscreen()` promise **permanently pending** — clicking the fullscreen button on a `<video>` in the transcript (or any element-fullscreen request) silently does nothing: no error, no rejection, no fullscreen.

## Repro

1. Have the agent produce a video file in chat (any `<video>` in the transcript).
2. Click the player's fullscreen button → nothing happens.
3. Via devtools, a trusted-gesture `video.requestFullscreen()` returns a promise that never settles.

## Fix

Explicitly allow `'fullscreen'` in both the request handler and the synchronous check handler; media-capture logic unchanged. All other permissions are still denied as before.

## Verification

CDP trusted click calling `requestFullscreen()`: previously the promise never settled; with this change it resolves and `document.fullscreenElement` is set (and exits normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)