### PR TITLE
fix(desktop): timeline ticks jump to not-yet-rendered early messages

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -712,6 +712,62 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     // renderBudget covers DOM pages; groups.length covers store-window expands.
   }, [scrollRef, renderBudget, groups.length])
 
+  // Timeline jump to a not-yet-rendered early message (see timeline.tsx):
+  // raise the render budget just enough to mount the group containing the
+  // target — weights summed newest-first through the target group, matching
+  // firstVisibleGroupIndex's walk, plus one so the group lands strictly
+  // inside the window. Anchored like "Show earlier" so the on-screen
+  // position holds while the older turns prepend; the timeline polls for
+  // the node and performs the actual scroll. Ids the timeline can produce
+  // are always inside the store window (its entries come from the same
+  // thread state), so only the DOM-budget layer needs widening here.
+  useEffect(() => {
+    const el = scrollRef.current
+
+    if (!el) {
+      return
+    }
+
+    const onReveal = (event: Event) => {
+      const id = (event as CustomEvent<{ id?: string }>).detail?.id
+
+      if (!id) {
+        return
+      }
+
+      let groupIndex = weightedGroups.findIndex(group => group.id === id)
+
+      if (groupIndex < 0) {
+        const messageIndex = structuralSignature.split('\n').findIndex(line => line.split(':')[1] === id)
+
+        if (messageIndex < 0) {
+          return
+        }
+
+        groupIndex = weightedGroups.findIndex(group =>
+          group.kind === 'turn' ? group.indices.includes(messageIndex) : group.index === messageIndex
+        )
+      }
+
+      if (groupIndex < 0) {
+        return
+      }
+
+      let needed = 1
+
+      for (let i = weightedGroups.length - 1; i >= groupIndex; i--) {
+        needed += weightedGroups[i]?.weight ?? 1
+      }
+
+      anchorBeforePrepend()
+      setRenderBudget(budget => Math.max(budget, needed))
+    }
+
+    el.addEventListener('hermes:reveal-message', onReveal)
+
+    return () => el.removeEventListener('hermes:reveal-message', onReveal)
+  }, [anchorBeforePrepend, scrollRef, structuralSignature, weightedGroups])
+
   // The row array is memoized on the inputs the rows actually read. This
   // component re-renders on every isAtBottom flip — and use-stick-to-bottom
   // flips it from a ResizeObserver, so a sidebar DRAG re-renders this list per

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -112,16 +112,49 @@ export const ownViewport = (root: HTMLElement | null): HTMLElement | null =>
 
 function scrollToPrompt(root: HTMLElement | null, id: string) {
   const viewport = ownViewport(root)
-  const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
 
-  if (!viewport || !node) {
+  if (!viewport) {
     return
   }
 
-  const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
+  const find = () => viewport.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
 
-  triggerHaptic('selection')
-  jumpScroll(viewport, Math.max(0, top))
+  const jumpTo = (node: HTMLElement) => {
+    const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
+
+    triggerHaptic('selection')
+    jumpScroll(viewport, Math.max(0, top))
+  }
+
+  const node = find()
+
+  if (node) {
+    jumpTo(node)
+
+    return
+  }
+
+  // Target not rendered: the transcript is budget-windowed from the bottom
+  // (see list.tsx renderBudget), so early prompts have no DOM node yet and a
+  // plain lookup silently fails — on long transcripts most ticks were dead.
+  // Ask the list to widen its render window to this message (it listens for
+  // this event and raises the budget just enough), then poll for the node and
+  // jump once it lands. Give up after 3s if the id no longer exists.
+  viewport.dispatchEvent(new CustomEvent('hermes:reveal-message', { bubbles: true, detail: { id } }))
+
+  const deadline = performance.now() + 3000
+
+  const poll = () => {
+    const revealed = find()
+
+    if (revealed) {
+      jumpTo(revealed)
+    } else if (performance.now() < deadline) {
+      requestAnimationFrame(poll)
+    }
+  }
+
+  requestAnimationFrame(poll)
 }
 
 /**


### PR DESCRIPTION
## Problem

The transcript is budget-windowed from the bottom (`renderBudget`), so on a long/heavy session most early prompts have no DOM node. `scrollToPrompt()` bails silently when `querySelector` finds nothing — clicking most timeline ticks does nothing, and the only way back to early context is scrolling up until turns mount page by page. (Observed live: 28 ticks with only ~13 user messages in the DOM — every early tick dead.)

## Fix

- **timeline.tsx** — when the target node is missing, dispatch `hermes:reveal-message` on the viewport, then poll (rAF, 3s deadline) and jump once the node lands. Rendered targets take the exact same path as before.
- **list.tsx** — listen for that event and raise `renderBudget` just enough to mount the group containing the target: weights summed newest-first through the target group (matching `firstVisibleGroupIndex`'s walk) plus one, anchored via `anchorBeforePrepend()` like *Show earlier* so the on-screen position holds while older turns prepend. Ids the timeline can produce are always inside the store window (its entries come from the same thread state), so only the DOM-budget layer needs widening.

## Verification

Seeded a heavy session so windowing was active on open (4 ticks, 3 user nodes in DOM). Clicking the first tick mounts the missing turn (3 → 4 user nodes) and lands the first message at the top of the viewport (rect.top ≈ 38px). Light sessions (everything rendered) behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)