### PR TITLE
fix(gateway): restore stdout before announcing READY port to desktop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19581,6 +19581,15 @@ def start_server(
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 
+    # Snapshot the real stdout early: importing tui_gateway.server below (for
+    # install_exit_flush_signal_handlers) runs its module-level
+    # ``sys.stdout = sys.stderr`` (JSON-RPC stdout protection for the stdio
+    # gateway). That redirect must NOT apply here — this is the HTTP/serve
+    # backend, and the HERMES_BACKEND_READY port announcement below is the
+    # desktop's only port-discovery channel, read from the spawn's stdout
+    # pipe. Restore the real stdout right before the announcement.
+    _real_process_stdout = sys.stdout
+
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through
     # the `serve` path in main.py (which applies the same floor). Canonical
     # policy lives in resource_limits; #81547's motivating leak (iterdir fds)
@@ -19915,6 +19924,14 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
+
+            # Restore the real stdout pipe before the announcement: the
+            # tui_gateway.server import above redirected sys.stdout to stderr
+            # (JSON-RPC protection), which would otherwise swallow this
+            # sentinel and make the desktop time out waiting for the port.
+            if sys.stdout is not _real_process_stdout:
+                sys.stdout = _real_process_stdout
+            
             # tui_gateway.server (imported above for the flush-on-SIGTERM
             # handlers, #94724) redirects sys.stdout→sys.stderr at import time
             # to keep stray prints off the JSON-RPC protocol stream. fd 1 is


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

Fixes #96346

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Importing tui_gateway.server during start_server() runs its module-level
`sys.stdout = sys.stderr` (JSON-RPC stdout protection for the stdio
gateway). The serve/dashboard backend then announced HERMES_BACKEND_READY
on stderr instead of stdout, so the desktop spawn never saw the port and
timed out after 90s with "Timed out waiting for Hermes backend port
announcement".

Snapshot the real stdout at start_server() entry and restore it right
before printing the READY sentinel. The HTTP/serve backend does not speak
JSON-RPC on stdout, so the redirect must not apply to it.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. installing hermes
2. run `hermes deskop`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Error occurred in handler for 'hermes:api': Error: Timed out waiting for Hermes backend port announcement (90000ms)
    at Timeout.<anonymous> (file:///home/xiaoji/.hermes/hermes-agent/apps/desktop/release/linux-unpacked/resources/app.asar/dist/electron-main.mjs:1981:14)
    at listOnTimeout (node:internal/timers:605:17)
    at process.processTimers (node:internal/timers:541:7)
```