### PR TITLE
fix(clarify): require user-visible decision context

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3346,6 +3346,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     choices=next_args.get("choices"),
                     multi_select=next_args.get("multi_select", False),
                     questions=next_args.get("questions"),
+                    context=next_args.get("context", ""),
                     callback=agent.clarify_callback,
                 ),
                 next_args,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2206,6 +2206,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     choices=next_args.get("choices"),
                     multi_select=next_args.get("multi_select", False),
                     questions=next_args.get("questions"),
+                    context=next_args.get("context", ""),
                     callback=agent.clarify_callback,
                 )
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2444,7 +2444,13 @@ class TestAgentRuntimePostHookOwnershipSync:
         ("todo", {"todos": []}),
         ("session_search", {"query": "needle"}),
         ("memory", {"action": "view", "target": "memory"}),
-        ("clarify", {"question": "Continue?"}),
+        (
+            "clarify",
+            {
+                "context": "The checks finished and need a go/no-go decision.",
+                "questions": [{"question": "Continue?"}],
+            },
+        ),
         ("read_terminal", {}),
         ("read_preview", {}),
         ("drive_preview", {"action": "elements"}),
@@ -2547,6 +2553,52 @@ class TestAgentRuntimePostHookOwnershipSync:
             f"{tool_name}-sequential",
         ]
         assert all(call["tool_name"] == tool_name for call in post_calls)
+
+    def test_clarify_context_reaches_both_agent_runtime_paths(
+        self, agent, monkeypatch,
+    ):
+        seen = []
+        tool_args = {
+            "context": "The checks passed; deployment timing remains undecided.",
+            "questions": [{"question": "Deploy now?", "choices": ["Yes", "No"]}],
+        }
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *args, **kwargs: (None, None),
+        )
+        monkeypatch.setattr(
+            "tools.clarify_tool.clarify_tool",
+            lambda **kwargs: seen.append(kwargs) or '{"ok":true}',
+        )
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=AssertionError("clarify must stay in the agent runtime"),
+        ):
+            agent._invoke_tool(
+                "clarify",
+                dict(tool_args),
+                "task-concurrent",
+                tool_call_id="clarify-concurrent",
+            )
+            tool_call = _mock_tool_call(
+                name="clarify",
+                arguments=json.dumps(tool_args),
+                call_id="clarify-sequential",
+            )
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tool_call]),
+                [],
+                "task-sequential",
+            )
+
+        assert [call["context"] for call in seen] == [
+            tool_args["context"], tool_args["context"],
+        ]
+        assert [call["questions"] for call in seen] == [
+            tool_args["questions"], tool_args["questions"],
+        ]
 
     def test_post_hook_ownership_contract_lists_exercised_tools(self):
         from agent.agent_runtime_helpers import AGENT_RUNTIME_POST_HOOK_TOOL_NAMES

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -112,7 +112,10 @@ def _clarify_call(call_id: str = "clarify-1"):
         type="function",
         function=SimpleNamespace(
             name="clarify",
-            arguments='{"question": "Pick one?", "choices": ["A", "B"]}',
+            arguments=(
+                '{"context": "The checks are complete; choose how to proceed.", '
+                '"question": "Pick one?", "choices": ["A", "B"]}'
+            ),
         ),
     )
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -3,9 +3,10 @@
 import json
 from typing import List, Optional
 
+import pytest
 
 from tools.clarify_tool import (
-    clarify_tool,
+    clarify_tool as _clarify_tool,
     check_clarify_requirements,
     MAX_CHOICES,
     MAX_QUESTIONS,
@@ -14,13 +15,22 @@ from tools.clarify_tool import (
 )
 
 
+DECISION_CONTEXT = "The deployment checks passed, but the target is still undecided."
+
+
+def clarify_tool(*args, **kwargs):
+    """Exercise existing behavior with the newly required decision brief."""
+    kwargs.setdefault("context", DECISION_CONTEXT)
+    return _clarify_tool(*args, **kwargs)
+
+
 class TestClarifyToolBasics:
     """Basic functionality tests for clarify_tool."""
 
     def test_simple_question_with_callback(self):
         """Should return user response for simple question."""
         def mock_callback(question: str, choices: Optional[List[str]]) -> str:
-            assert question == "What color?"
+            assert question == f"{DECISION_CONTEXT}\n\nWhat color?"
             assert choices is None
             return "blue"
 
@@ -178,7 +188,11 @@ class TestClarifySchema:
         limit. The legacy top-level `question` shape stays handler-accepted
         but unadvertised."""
         params = CLARIFY_SCHEMA["parameters"]
-        assert params["required"] == ["questions"]
+        assert params["required"] == ["context", "questions"]
+        assert params["properties"]["context"]["type"] == "string"
+        assert params["properties"]["context"]["minLength"] == 1
+        assert "choices" not in params["properties"]
+        assert "choices" in params["properties"]["questions"]["items"]["properties"]
         assert params["properties"]["questions"]["maxItems"] == MAX_QUESTIONS
         assert params["properties"]["questions"].get("minItems") == 1
         # Legacy shape must remain accepted by the handler even though the
@@ -367,7 +381,12 @@ class TestRegistryMultiSelectPassThrough:
             return "a, b"
 
         result = json.loads(entry.handler(
-            {"question": "Pick", "choices": ["a", "b"], "multi_select": True},
+            {
+                "context": DECISION_CONTEXT,
+                "question": "Pick",
+                "choices": ["a", "b"],
+                "multi_select": True,
+            },
             callback=cb,
         ))
         assert seen["multi"] is True
@@ -383,7 +402,11 @@ class TestRegistryMultiSelectPassThrough:
             return "a"
 
         result = json.loads(entry.handler(
-            {"question": "Pick", "choices": ["a", "b"]},
+            {
+                "context": DECISION_CONTEXT,
+                "question": "Pick",
+                "choices": ["a", "b"],
+            },
             callback=cb,
         ))
         assert seen["multi"] is False
@@ -392,6 +415,24 @@ class TestRegistryMultiSelectPassThrough:
 
 class TestClarifyBatchValidation:
     """Validation of the `questions` batch parameter (issue #18450)."""
+
+    @pytest.mark.parametrize("context_kwargs", [{}, {"context": ""}, {"context": "  \n"}])
+    def test_contextless_batch_is_rejected_before_callback(self, context_kwargs):
+        calls = []
+
+        def cb(*args, **kwargs):
+            calls.append((args, kwargs))
+            return {"answers": {"q0": "yes"}}
+
+        result = json.loads(_clarify_tool(
+            "",
+            questions=[{"question": "Go?"}],
+            callback=cb,
+            **context_kwargs,
+        ))
+
+        assert "context" in result["error"].lower()
+        assert calls == []
 
     def test_batch_takes_precedence_over_question(self):
         """When both are present, `questions` wins and `question` is ignored."""
@@ -409,7 +450,21 @@ class TestClarifyBatchValidation:
         assert "responses" in result
         assert len(result["responses"]) == 1
         assert result["responses"][0]["question"] == "What color?"
-        assert seen["questions"][0]["question"] == "What color?"
+        assert seen["questions"][0]["question"] == (
+            f"{DECISION_CONTEXT}\n\nWhat color?"
+        )
+
+    def test_direct_question_renders_context_in_same_prompt(self):
+        seen = []
+
+        def cb(question, choices):
+            seen.append(question)
+            return "yes"
+
+        result = json.loads(clarify_tool("Proceed?", callback=cb))
+
+        assert seen == [f"{DECISION_CONTEXT}\n\nProceed?"]
+        assert result["question"] == "Proceed?"
 
     def test_batch_rejects_more_than_five(self):
         result = json.loads(clarify_tool(
@@ -436,7 +491,7 @@ class TestClarifyBatchValidation:
     def test_batch_empty_list_falls_back_to_single_question(self):
         """An empty questions array degrades to the single-question path."""
         def cb(question, choices):
-            assert question == "Single?"
+            assert question == f"{DECISION_CONTEXT}\n\nSingle?"
             return "yes"
 
         result = json.loads(clarify_tool("Single?", questions=[], callback=cb))
@@ -520,6 +575,28 @@ class TestClarifyBatchDispatch:
         assert len(calls) == 1
         assert [r["user_response"] for r in result["responses"]] == ["x", "y"]
 
+    @pytest.mark.parametrize(
+        "questions",
+        [
+            [{"question": "One?"}],
+            [{"question": "One?"}, {"question": "Two?"}],
+        ],
+    )
+    def test_batch_callback_renders_context_with_one_or_many_questions(
+        self, questions,
+    ):
+        seen = []
+
+        def cb(question, choices, multi_select=False, questions=None):
+            seen.extend(entry["question"] for entry in questions)
+            return {"answers": {}}
+
+        clarify_tool("", questions=questions, callback=cb)
+
+        assert seen == [
+            f"{DECISION_CONTEXT}\n\n{entry['question']}" for entry in questions
+        ]
+
     def test_batch_callback_json_string_response(self):
         """A _block-style bridge returns the answers as a JSON string."""
         def cb(question, choices, multi_select=False, questions=None):
@@ -588,7 +665,7 @@ class TestClarifyBatchDispatch:
 
         def legacy_cb(question, choices, multi_select=False):
             calls.append((question, tuple(choices or []) or None, multi_select))
-            return f"answer to {question}"
+            return f"answer {len(calls)}"
 
         result = json.loads(clarify_tool(
             "",
@@ -598,11 +675,14 @@ class TestClarifyBatchDispatch:
             ],
             callback=legacy_cb,
         ))
-        assert [c[0] for c in calls] == ["One?", "Two?"]
+        assert [c[0] for c in calls] == [
+            f"{DECISION_CONTEXT}\n\nOne?",
+            f"{DECISION_CONTEXT}\n\nTwo?",
+        ]
         assert calls[0][1] == ("a (Recommended)", "b")
         assert calls[1][1] is None
         assert [r["user_response"] for r in result["responses"]] == [
-            "answer to One?", "answer to Two?",
+            "answer 1", "answer 2",
         ]
         assert "timed_out" not in result
 
@@ -624,7 +704,10 @@ class TestClarifyBatchDispatch:
             ],
             callback=legacy_cb,
         ))
-        assert calls == ["One?", "Two?"]
+        assert calls == [
+            f"{DECISION_CONTEXT}\n\nOne?",
+            f"{DECISION_CONTEXT}\n\nTwo?",
+        ]
         assert result["timed_out"] is True
         assert [r["user_response"] for r in result["responses"]] == [
             "answered", "", "",
@@ -643,7 +726,10 @@ class TestClarifyBatchDispatch:
             questions=[{"question": "One?"}, {"question": "Two?"}],
             callback=legacy_cb,
         ))
-        assert calls == ["One?", "Two?"]
+        assert calls == [
+            f"{DECISION_CONTEXT}\n\nOne?",
+            f"{DECISION_CONTEXT}\n\nTwo?",
+        ]
         assert [r["user_response"] for r in result["responses"]] == ["", "second"]
         assert "timed_out" not in result
 
@@ -671,8 +757,11 @@ class TestRegistryBatchPassThrough:
             return {"answers": {"q0": "yes"}}
 
         result = json.loads(entry.handler(
-            {"questions": [{"question": "Go?"}]},
+            {
+                "context": DECISION_CONTEXT,
+                "questions": [{"question": "Go?"}],
+            },
             callback=cb,
         ))
-        assert seen["questions"][0]["question"] == "Go?"
+        assert seen["questions"][0]["question"] == f"{DECISION_CONTEXT}\n\nGo?"
         assert result["responses"][0]["user_response"] == "yes"

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -136,6 +136,11 @@ def _invoke_callback(callback, question, choices, multi_select):
     return callback(question, choices)
 
 
+def _render_question(context: str, question: str) -> str:
+    """Keep the decision brief and question together on every surface."""
+    return f"{context}\n\n{question}" if question else context
+
+
 def _parse_multi_select_response(raw_response) -> List[str]:
     """Parse a multi-select response into a list of cleaned choice strings.
 
@@ -276,7 +281,9 @@ def _batch_result(normalized: List[dict], answers: dict, timed_out: bool) -> str
     return json.dumps(result, ensure_ascii=False)
 
 
-def _run_batch(normalized: List[dict], callback, question: str) -> str:
+def _run_batch(
+    normalized: List[dict], callback, question: str, context: str,
+) -> str:
     """Dispatch a validated batch to the platform callback.
 
     Batch-capable callbacks (a ``questions`` kwarg, detected by signature)
@@ -292,7 +299,15 @@ def _run_batch(normalized: List[dict], callback, question: str) -> str:
     are kept either way.
     """
     if _callback_accepts_questions(callback):
-        raw = callback(question, None, questions=normalized)
+        # Current batch renderers consume the per-question text; some ignore
+        # the legacy top-level title entirely. Compose the explicit brief into
+        # every rendered question so it stays on the same form even when the
+        # user navigates among several questions.
+        rendered = [
+            {**entry, "question": _render_question(context, entry["question"])}
+            for entry in normalized
+        ]
+        raw = callback(question, None, questions=rendered)
 
         answers: dict = {}
         timed_out = False
@@ -317,7 +332,10 @@ def _run_batch(normalized: List[dict], callback, question: str) -> str:
     timed_out = False
     for entry in normalized:
         raw = _invoke_callback(
-            callback, entry["question"], entry["choices"], entry["multi_select"],
+            callback,
+            _render_question(context, entry["question"]),
+            entry["choices"],
+            entry["multi_select"],
         )
         if raw is None or (isinstance(raw, str) and raw.strip() == TIMEOUT_RESPONSE):
             timed_out = True
@@ -332,6 +350,7 @@ def clarify_tool(
     multi_select: bool = False,
     questions: Optional[List[dict]] = None,
     callback: Optional[Callable] = None,
+    context: str = "",
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.
@@ -359,10 +378,20 @@ def clarify_tool(
                       in one call; platforms without it are looped one
                       question at a time.
                       Injected by the agent runner (cli.py / gateway).
+        context:      Concise decision brief shown with every question. It
+                      should explain the relevant findings, blocker, stakes,
+                      and why the user's answer is needed.
 
     Returns:
         JSON string with the user's response(s).
     """
+    if not isinstance(context, str) or not context.strip():
+        return tool_error(
+            "context must be non-empty text explaining the decision and why "
+            "the user's answer is needed."
+        )
+    context = context.strip()
+
     if questions is not None:
         normalized, error = _normalize_questions(questions)
         if error:
@@ -373,7 +402,9 @@ def clarify_tool(
                     "Clarify tool is not available in this execution context."
                 )
             try:
-                return _run_batch(normalized, callback, str(question or "").strip())
+                return _run_batch(
+                    normalized, callback, str(question or "").strip(), context,
+                )
             except Exception as exc:
                 return tool_error(f"Failed to get user input: {exc}")
         # Empty questions array → fall through to the single-question path.
@@ -413,7 +444,9 @@ def clarify_tool(
         choices = mark_recommended(choices)
 
     try:
-        raw_response = _invoke_callback(callback, question, choices, multi_select)
+        raw_response = _invoke_callback(
+            callback, _render_question(context, question), choices, multi_select,
+        )
     except Exception as exc:
         return tool_error(f"Failed to get user input: {exc}")
 
@@ -442,7 +475,9 @@ CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
         "Ask the user one or more questions when you need a decision, "
-        "clarification, or feedback before proceeding. Pass every question "
+        "clarification, or feedback before proceeding. Include a concise "
+        "decision brief in `context`; it is shown with every question. Pass "
+        "every question "
         f"in `questions` (1-{MAX_QUESTIONS} entries) — a single question is a "
         "one-entry array, and several INDEPENDENT questions belong in ONE "
         "call (one form beats a chain of clarify calls; if one answer would "
@@ -461,6 +496,15 @@ CLARIFY_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
+            "context": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Concise user-visible decision brief: relevant findings, "
+                    "blocker, stakes, and why an answer is needed. Do not put "
+                    "answer options here; use each question's choices array."
+                ),
+            },
             "questions": {
                 "type": "array",
                 "minItems": 1,
@@ -492,7 +536,7 @@ CLARIFY_SCHEMA = {
             # at top level; a top-level `question` beside `questions` is the
             # batch form's title). One documented way to call.
         },
-        "required": ["questions"],
+        "required": ["context", "questions"],
     },
 }
 
@@ -509,6 +553,7 @@ registry.register(
         choices=args.get("choices"),
         multi_select=args.get("multi_select", False),
         questions=args.get("questions"),
+        context=args.get("context", ""),
         callback=kw.get("callback")),
     check_fn=check_clarify_requirements,
     emoji="❓",

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -46,7 +46,9 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 ### Asking multiple questions at once
 
-The `clarify` tool also accepts a `questions` array (2–5 independent questions, each with its own `choices` and `multi_select`) so the agent can batch several clarification needs into a single prompt instead of asking sequentially. The result is a `responses` array in the same order, with each question's `id` (when supplied) echoed back.
+Every `clarify` call requires a non-empty `context` decision brief explaining the relevant findings, blocker, stakes, and why the user's answer is needed. That brief is rendered with the interactive form itself; answer options belong only in each question's `choices` array.
+
+The `questions` array accepts 1–5 independent questions, each with its own `choices` and `multi_select`, so one question and multi-question batches use the same interface. The result is a `responses` array in question order.
 
 Per-surface behavior:
 
@@ -349,5 +351,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 


### PR DESCRIPTION
## What does this PR do?

Makes every `clarify` form self-contained by requiring an explicit, user-visible decision brief before the question. This fixes the case where a messaging surface displays selectable options without the findings, blocker, or stakes that prompted the decision.

The brief is model-authored through a required top-level `context` field and is rendered in the same prompt as each question. Missing or whitespace-only context fails closed before any callback runs. The existing batched `questions[]` interface, legacy callback signatures, response JSON, recommendations, multi-select, and timeout behavior remain intact.

This follows the explicit-context direction explored in #64480, adapted to the current batched `questions[]` contract on `main`.

## Related Issue

Fixes #65113

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Require non-empty `context` in the clarify schema and reject whitespace-only context at runtime.
- Render the context immediately before each question for batch-capable callbacks, legacy fallback loops, and direct single-question calls.
- Thread context through both agent runtime dispatch paths.
- Add regression coverage for schema validation, fail-closed behavior, rendering, batching, legacy callbacks, and runtime dispatch.
- Document the self-contained decision-brief contract.

## How to Test

1. Run the focused clarify and runtime suite:
   ```bash
   HERMES_PYTHON=/path/to/hermes/venv/bin/python scripts/run_tests.sh \
     tests/tools/test_clarify_tool.py \
     tests/run_agent/test_run_agent.py \
     tests/run_agent/test_sequential_tool_timeout.py \
     tests/tools/test_clarify_gateway.py \
     tests/gateway/test_telegram_clarify_buttons.py \
     tests/gateway/test_slack_clarify_buttons.py \
     tests/gateway/test_discord_clarify_buttons.py \
     tests/gateway/test_clarify_thread_followup_not_swallowed.py \
     tests/gateway/test_clarify_send_timeout_ambiguity.py \
     tests/gateway/test_clarify_progress_leak.py \
     tests/gateway/test_clarify_active_session_bypass.py \
     tests/cli/test_cli_clarify_batch.py \
     tests/plugins/platforms/photon/test_poll_clarify.py
   ```
   Result: **420 passed**.
2. Run Ruff on the changed Python files:
   ```bash
   uv run --frozen --extra dev ruff check tools/clarify_tool.py agent/tool_executor.py agent/agent_runtime_helpers.py tests/tools/test_clarify_tool.py tests/run_agent/test_run_agent.py tests/run_agent/test_sequential_tool_timeout.py
   ```
   Result: **all checks passed**.
3. Run the cross-platform static check:
   ```bash
   python scripts/check-windows-footguns.py --all
   ```
   Result: **no Windows footguns found across 1,018 files**.
4. Attempt the full repository suite:
   ```bash
   HERMES_PYTHON=/path/to/hermes/venv/bin/python scripts/run_tests.sh tests/
   ```
   The local run reported 140 failures in 35 unrelated files plus two collection/import failures. A clean `origin/main` worktree reproduced 139 failures in the same 34 unrelated files plus the same two collection/import failures. The only additional branch failure was the known timing-sensitive `tests/run_agent/test_tool_activity_heartbeat.py`, which also failed on its first baseline attempt and passed on retry on both revisions. No full-suite failure maps to a changed file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

Before this fix, a clarification can reach a messaging surface as a bare question with choices. After this fix, the callback receives one self-contained string:

```text
[decision context]

[question]
```

The choices remain separate interactive options.
