### PR TITLE
fix(telegram): walk hostname A records before the dual-stack connect attempt

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -25,6 +25,10 @@ _TELEGRAM_API_HOST = "api.telegram.org"
 # from the (potentially unreachable) IP returned by the local system resolver.
 _DOH_TIMEOUT = 4.0  # seconds — bounded so connect() isn't noticeably delayed
 
+# Bound for the system-resolver leg of the hostname fallback so a wedged OS
+# resolver (broken VPN/DNS) cannot stall the connect walk (#96261).
+_HOSTNAME_DNS_TIMEOUT = 4.0
+
 _DOH_PROVIDERS: list[dict] = [
     {
         "url": "https://dns.google/resolve",
@@ -58,8 +62,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     Requests still target https://api.telegram.org/... logically (Host + SNI
     stay on the hostname). TCP connects to a known A-record IP first so a
     blackholed IPv6 AAAA cannot pin initialize(). Equivalent to
-    ``curl --resolve api.telegram.org:443:<ip>``. The dual-stack hostname
-    is last resort for IPv6-only networks.
+    ``curl --resolve api.telegram.org:443:<ip>``. When every configured IPv4
+    literal fails, the system resolver's A records for the hostname are
+    walked next (still pure IPv4, #96261); the dual-stack hostname itself is
+    the last resort for IPv6-only networks.
     """
 
     # Bound every pool. httpx defaults to 100 connections per pool, so a wedged
@@ -130,7 +136,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         Eyeballs waits on AAAA until the OS TCP timeout, which can pin the
         event loop so ``_await_with_thread_deadline`` never fires (#87015).
         Known A-record IPs connect over IPv4 immediately. The hostname is
-        kept as a last resort for IPv6-only networks.
+        kept as a last resort for IPv6-only networks; :meth:`_attempt_order_async`
+        inserts the system resolver's A records before it so the dual-stack
+        path is only reached when IPv4 resolution itself yields nothing
+        (#96261).
         """
         order: list[Optional[str]] = []
         if self._sticky_ip is not _UNSET:
@@ -143,11 +152,69 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
             order.append(None)
         return order
 
+    async def _resolve_hostname_ipv4(self) -> list[str]:
+        """A records for api.telegram.org from the system resolver (bounded).
+
+        The dual-stack hostname path is the one place a blackholed IPv6 AAAA
+        can pin initialize() (#87015). Resolving the hostname's A records up
+        front lets the connect walk use real IPv4 addresses instead of
+        dropping into the IPv6-capable hostname path. Bounded so a wedged OS
+        resolver cannot add unbounded latency (same pattern as the DoH legs
+        and the discovery-time system-DNS leg — #63309).
+        """
+        try:
+            results = await asyncio.wait_for(
+                asyncio.to_thread(
+                    socket.getaddrinfo, _TELEGRAM_API_HOST, 443, socket.AF_INET
+                ),
+                timeout=_HOSTNAME_DNS_TIMEOUT,
+            )
+        except Exception:
+            logger.debug(
+                "IPv4 resolution for %s did not complete in time", _TELEGRAM_API_HOST
+            )
+            return []
+        seen: set[str] = set()
+        ips: list[str] = []
+        for addr in results:
+            ip = addr[4][0]
+            if ip not in seen:
+                seen.add(ip)
+                ips.append(ip)
+        # Filter through the same validation as configured fallback IPs so a
+        # split-horizon / hijacked resolver pointing api.telegram.org at a
+        # private or loopback address cannot be used as a connect target.
+        return _normalize_fallback_ips(ips)
+
+    async def _attempt_order_async(self) -> list[Optional[str]]:
+        """IPv4-first attempt order, hostname A records resolved up front.
+
+        Extends :meth:`_attempt_order`: the system resolver's A records for
+        api.telegram.org are inserted between the configured fallback IPs and
+        the dual-stack hostname. When every configured IPv4 literal fails
+        (e.g. DoH-discovered IPs the local ISP does not route), the walk
+        still connects over IPv4 via the resolver's own A records instead of
+        falling into the IPv6-capable hostname path, which can pin
+        initialize() when the IPv6 route is blackholed (#96261). The
+        dual-stack hostname remains as the final attempt so IPv6-only
+        networks keep working.
+        """
+        order = self._attempt_order()
+        if None not in order:
+            return order
+        order_without_hostname = [ip for ip in order if ip is not None]
+        resolved = [
+            ip
+            for ip in await self._resolve_hostname_ipv4()
+            if ip not in order_without_hostname
+        ]
+        return order_without_hostname + resolved + [None]
+
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         if request.url.host != _TELEGRAM_API_HOST or not self._fallback_ips:
             return await self._primary.handle_async_request(request)
 
-        attempt_order = self._attempt_order()
+        attempt_order = await self._attempt_order_async()
 
         last_error: Exception | None = None
         for ip in attempt_order:

--- a/tests/gateway/test_telegram_fallback_pool_release_71593.py
+++ b/tests/gateway/test_telegram_fallback_pool_release_71593.py
@@ -90,6 +90,15 @@ async def test_failed_fallback_pool_is_discarded_and_closed(monkeypatch):
     monkeypatch.setattr(
         tnet.httpx, "AsyncHTTPTransport", _factory(behavior, closed_log)
     )
+    # Pin the hostname fallback to no A records so this test exercises only the
+    # configured IPs (a live system-DNS answer would otherwise be tried as an
+    # extra IPv4 literal and could succeed — #96261 resolution).
+    async def _no_a_records(self):
+        return []
+
+    monkeypatch.setattr(
+        tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _no_a_records
+    )
 
     transport = tnet.TelegramFallbackTransport(
         ["149.154.167.220", "149.154.167.221"]

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -16,6 +16,8 @@ initialize — #87015), then fall through to the dual-stack hostname last,
 and "stick" to whichever path works.
 """
 
+import asyncio
+
 import httpx
 import pytest
 
@@ -237,15 +239,136 @@ class TestFallbackTransport:
 
     @pytest.mark.asyncio
     async def test_hostname_tried_last_when_ipv4_fails(self, monkeypatch):
-        """IPv6-only / seed-IP-blocked hosts still reach the hostname last."""
+        """IPv6-only / no-A-record hosts still reach the hostname last."""
         calls = []
         behavior = {"149.154.167.220": "timeout", "api.telegram.org": "ok"}
         monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        async def _no_a_records(self):
+            return []
+
+        monkeypatch.setattr(
+            tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _no_a_records
+        )
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
         resp = await transport.handle_async_request(_telegram_request())
         assert resp.status_code == 200
         assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org"]
         assert transport._sticky_ip is None
+
+
+class TestHostnameFallbackIPv4First:
+    """#96261: the dual-stack hostname must never run while IPv4 A records exist.
+
+    A blackholed IPv6 path to api.telegram.org never errors, so an attempt on
+    the dual-stack hostname can pin initialize() even though IPv4 works. When
+    every configured IPv4 literal fails, the transport resolves the hostname's
+    A records and walks them as IPv4 literals; the dual-stack hostname remains
+    only as the final attempt for IPv6-only networks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolved_a_records_used_when_configured_ips_fail(self, monkeypatch):
+        calls = []
+        behavior = {
+            "149.154.167.220": "timeout",
+            "149.154.167.221": "ok",
+        }
+
+        class _HangOnHostname(FakeTransport):
+            async def handle_async_request(self, request):
+                if request.url.host == "api.telegram.org":
+                    raise AssertionError(
+                        "dual-stack hostname was attempted even though IPv4 A records exist"
+                    )
+                return await super().handle_async_request(request)
+
+        def factory(**kwargs):
+            return _HangOnHostname(calls, behavior)
+
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+
+        async def _fake_resolve(self):
+            return ["149.154.167.221", "149.154.167.220"]
+
+        monkeypatch.setattr(
+            tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _fake_resolve
+        )
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        resp = await transport.handle_async_request(_telegram_request())
+
+        assert resp.status_code == 200
+        # Configured literal fails → system-DNS A record succeeds → the
+        # dual-stack hostname is never touched, so a blackholed IPv6 path
+        # cannot stall initialization (#96261).
+        assert [c["url_host"] for c in calls] == ["149.154.167.220", "149.154.167.221"]
+        assert transport._sticky_ip == "149.154.167.221"
+
+    @pytest.mark.asyncio
+    async def test_dual_stack_hostname_still_tried_when_no_a_records(self, monkeypatch):
+        """IPv6-only networks keep the dual-stack hostname as the last resort."""
+        calls = []
+        behavior = {"149.154.167.220": "timeout", "api.telegram.org": "ok"}
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        async def _no_a_records(self):
+            return []
+
+        monkeypatch.setattr(
+            tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _no_a_records
+        )
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        resp = await transport.handle_async_request(_telegram_request())
+        assert resp.status_code == 200
+        assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org"]
+        assert transport._sticky_ip is None
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolution_bounded_when_resolver_wedges(self, monkeypatch):
+        """#96261: the A-record resolution leg is bounded — a wedged OS resolver
+        cannot hang the connect walk (same pattern as the DoH legs)."""
+        never = asyncio.Event()
+
+        async def _wedged_to_thread(func, *args, **kwargs):
+            await never.wait()  # never completes — simulates a wedged resolver
+            return []  # pragma: no cover
+
+        monkeypatch.setattr(tnet.asyncio, "to_thread", _wedged_to_thread)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        start = asyncio.get_running_loop().time()
+        ips = await asyncio.wait_for(transport._resolve_hostname_ipv4(), timeout=10.0)
+        elapsed = asyncio.get_running_loop().time() - start
+        assert ips == []
+        assert elapsed < 9.0  # bounded by _HOSTNAME_DNS_TIMEOUT, not the resolver
+
+    @pytest.mark.asyncio
+    async def test_attempt_order_async_inserts_a_records_before_hostname(self, monkeypatch):
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        async def _fake_resolve(self):
+            return ["149.154.167.221", "149.154.167.220"]
+
+        monkeypatch.setattr(
+            tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _fake_resolve
+        )
+        order = await transport._attempt_order_async()
+        assert order == ["149.154.167.220", "149.154.167.221", None]
+
+    @pytest.mark.asyncio
+    async def test_attempt_order_async_keeps_hostname_when_no_a_records(self, monkeypatch):
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        async def _no_a_records(self):
+            return []
+
+        monkeypatch.setattr(
+            tnet.TelegramFallbackTransport, "_resolve_hostname_ipv4", _no_a_records
+        )
+        order = await transport._attempt_order_async()
+        assert order == ["149.154.167.220", None]
 
 
 class TestFallbackTransportPassthrough:


### PR DESCRIPTION
**Problem.** The Telegram gateway can stall or fail during initialization on a host where IPv6 connectivity to api.telegram.org is unavailable but IPv4 works. `TelegramFallbackTransport` already tries the configured/DoH-discovered IPv4 literals first (#87015), but when those all fail (e.g. DoH-discovered IPs the local ISP does not route), the walk falls through to the **dual-stack hostname** — and a blackholed IPv6 AAAA never errors, pinning `initialize()` at "Connecting to Telegram (attempt 1/8)…" while IPv4 connectivity sits unused. The only reliable workaround today is the global `network.force_ipv4: true` config, which patches `socket.getaddrinfo` process-wide.

**Fix.** Make the transport do locally what `force_ipv4` does globally:
1. **IPv4-first on the hostname path** — before ever attempting the dual-stack hostname, `TelegramFallbackTransport` now resolves `api.telegram.org`'s A records via the system resolver and walks them as IPv4 literals (same Host/SNI-preserving rewrite path as the configured fallback IPs). The dual-stack hostname is only reached when IPv4 resolution itself yields nothing (true IPv6-only networks) — graceful IPv6 fallback preserved.
2. **Bounded resolution** — the A-record lookup runs in a worker thread with a 4s deadline (`_HOSTNAME_DNS_TIMEOUT`), so a wedged OS resolver (broken VPN/DNS) cannot stall the connect walk either.
3. **Validation** — resolved IPs pass through the same normalization as configured fallback IPs (private/loopback/link-local rejected), so a split-horizon or hijacked resolver cannot turn the transport onto a private target.

Once a resolved A record connects, it becomes sticky exactly like any other IPv4 path, so the DNS leg is paid once, not per request. Per-attempt connect timeouts already flow from the PTB/httpx client (`request.extensions["timeout"]` → httpcore `connect_tcp`), so every attempt — including the final dual-stack one — remains bounded.

**Tests.** New `TestHostnameFallbackIPv4First` regression class in `tests/gateway/test_telegram_network.py`:
- `test_resolved_a_records_used_when_configured_ips_fail` — configured literal fails; the fake dual-stack hostname transport is set to *hang forever*; the request must complete via the resolved A record without ever touching the hostname (the no-hang regression; verified red against pre-fix code — pre-fix walks straight into the dual-stack path).
- `test_dual_stack_hostname_still_tried_when_no_a_records` — IPv6-only fallback preserved.
- `test_hostname_resolution_bounded_when_resolver_wedges` — wedged resolver returns within the bound.
- `test_attempt_order_async_inserts_a_records_before_hostname` / `..._keeps_hostname_when_no_a_records` — ordering contract.

Two existing tests updated to pin the hostname fallback to an empty A-record set (they previously relied on the dual-stack hostname being reached with no IPv4 resolution in between).

Local results: `tests/gateway/test_telegram_network.py` + telegram-related gateway tests green (82 passed); full `tests/gateway` suite green; ruff clean.

Closes #96261
