### PR TITLE
feat(matrix): add Element X command surface

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -116,7 +116,7 @@ _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _MATRIX_CODE_COMMAND_RE = re.compile(
-    r"`/([A-Za-z0-9][A-Za-z0-9_-]*)(?=[\s`])"
+    r"^/([A-Za-z0-9][A-Za-z0-9_-]*)(?=\s|$)"
 )
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
@@ -1107,10 +1107,66 @@ def _platformize_command_mentions(text: str, platform: Any) -> str:
     platform_value = getattr(platform, "value", platform)
     if platform_value != "matrix":
         return rendered
-    return _MATRIX_CODE_COMMAND_RE.sub(
-        lambda match: f"`!{match.group(1)}",
-        rendered,
-    )
+
+    from agent.skill_commands import get_skill_commands
+    from hermes_cli.commands import is_gateway_known_command
+
+    skill_command_names = {
+        str(command).removeprefix("/") for command in get_skill_commands()
+    }
+
+    def _replace_single_backtick_spans(line: str) -> str:
+        parts: list[str] = []
+        cursor = 0
+        while cursor < len(line):
+            opening = line.find("`", cursor)
+            if opening < 0:
+                parts.append(line[cursor:])
+                break
+            parts.append(line[cursor:opening])
+            run_end = opening
+            while run_end < len(line) and line[run_end] == "`":
+                run_end += 1
+            delimiter = line[opening:run_end]
+            closing = line.find(delimiter, run_end)
+            if closing < 0:
+                parts.append(line[opening:])
+                break
+
+            content = line[run_end:closing]
+            match = _MATRIX_CODE_COMMAND_RE.match(content)
+            if len(delimiter) == 1 and match:
+                command_name = match.group(1)
+                if (
+                    is_gateway_known_command(command_name)
+                    or command_name in skill_command_names
+                ):
+                    content = f"!{command_name}{content[match.end():]}"
+            parts.extend((delimiter, content, delimiter))
+            cursor = closing + len(delimiter)
+        return "".join(parts)
+
+    lines: list[str] = []
+    fence: tuple[str, int] | None = None
+    for line in rendered.splitlines(keepends=True):
+        stripped = line.lstrip(" \t")
+        if fence is not None:
+            lines.append(line)
+            marker, minimum_length = fence
+            marker_length = len(stripped) - len(stripped.lstrip(marker))
+            if marker_length >= minimum_length and not stripped[marker_length:].strip():
+                fence = None
+            continue
+
+        opening_fence = re.match(r"(`{3,}|~{3,})", stripped)
+        if opening_fence:
+            marker = opening_fence.group(1)
+            fence = (marker[0], len(marker))
+            lines.append(line)
+            continue
+        lines.append(_replace_single_backtick_spans(line))
+
+    return "".join(lines)
 
 
 # Only auto-continue interrupted gateway turns while the interruption is fresh.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -115,6 +115,9 @@ _USER_BOUNDARY_END_REASONS = (
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_MATRIX_CODE_COMMAND_RE = re.compile(
+    r"`/([A-Za-z0-9][A-Za-z0-9_-]*)(?=[\s`])"
+)
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -1091,6 +1094,23 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
         return f"/{sanitized}" if sanitized else match.group(0)
 
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
+
+
+def _platformize_command_mentions(text: str, platform: Any) -> str:
+    """Render command mentions using syntax the target client can send.
+
+    Dispatch remains slash-based internally. Telegram receives its existing
+    name sanitization; Matrix receives bang-prefixed command tokens because
+    Element clients may reserve slash commands locally.
+    """
+    rendered = _telegramize_command_mentions(text, platform)
+    platform_value = getattr(platform, "value", platform)
+    if platform_value != "matrix":
+        return rendered
+    return _MATRIX_CODE_COMMAND_RE.sub(
+        lambda match: f"`!{match.group(1)}",
+        rendered,
+    )
 
 
 # Only auto-continue interrupted gateway turns while the interruption is fresh.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1722,7 +1722,10 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _platformize_command_mentions
         from hermes_cli.slash_exec import CommandContext, execute_command
 
-        reply = execute_command("help", CommandContext(surface="gateway"))
+        reply = execute_command(
+            "help",
+            CommandContext(surface="gateway", args=event.get_command_args()),
+        )
         return _platformize_command_mentions(
             reply.text,
             getattr(getattr(event, "source", None), "platform", None),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1719,17 +1719,17 @@ class GatewaySlashCommandsMixin:
 
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""
-        from gateway.run import _telegramize_command_mentions
+        from gateway.run import _platformize_command_mentions
         from hermes_cli.slash_exec import CommandContext, execute_command
 
         reply = execute_command("help", CommandContext(surface="gateway"))
-        return _telegramize_command_mentions(
+        return _platformize_command_mentions(
             reply.text,
             getattr(getattr(event, "source", None), "platform", None),
         )
 
     async def _handle_commands_command(self, event: MessageEvent) -> str:
-        from gateway.run import _telegramize_command_mentions
+        from gateway.run import _platformize_command_mentions
         from hermes_cli.slash_exec import CommandContext, execute_command
         from gateway.config import Platform
 
@@ -1743,7 +1743,7 @@ class GatewaySlashCommandsMixin:
                 options={"page_size": page_size},
             ),
         )
-        return _telegramize_command_mentions(
+        return _platformize_command_mentions(
             reply.text,
             getattr(getattr(event, "source", None), "platform", None),
         )

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -160,6 +160,19 @@ def _exec_help(ctx: CommandContext) -> CommandReply:
     from agent.i18n import t
     from hermes_cli.commands import gateway_help_lines
 
+    if (ctx.args or "").strip().lower() == "skills":
+        try:
+            from agent.skill_commands import get_skill_commands
+
+            skill_cmds = get_skill_commands()
+        except Exception:
+            skill_cmds = {}
+        lines = [t("gateway.help.skill_header", count=len(skill_cmds))]
+        for cmd in sorted(skill_cmds):
+            description = skill_cmds[cmd].get("description", "").strip()
+            lines.append(f"`{cmd}` — {description}")
+        return CommandReply("\n".join(lines), format="markdown")
+
     lines = [
         t("gateway.help.header"),
         *gateway_help_lines(),

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -63,3 +63,50 @@ async def test_commands_sanitizes_slash_command_mentions_for_telegram(monkeypatc
     assert "`/Linear`" not in result
 
 
+@pytest.mark.asyncio
+async def test_help_uses_matrix_safe_bang_command_mentions(monkeypatch):
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/arxiv": {"description": "Search arXiv"}},
+    )
+
+    result = await _make_runner()._handle_help_command(
+        _make_event("/help", Platform.MATRIX)
+    )
+
+    assert "`!model" in result
+    assert "`!commands" in result
+    assert "`!arxiv`" in result
+    assert "`/model" not in result
+    assert "`/commands" not in result
+    assert "`/arxiv`" not in result
+
+
+@pytest.mark.asyncio
+async def test_commands_uses_matrix_safe_bang_entries_and_navigation(monkeypatch):
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/arxiv": {"description": "Search arXiv"}},
+    )
+
+    result = await _make_runner()._handle_commands_command(
+        _make_event("/commands 1", Platform.MATRIX)
+    )
+
+    assert "`!" in result
+    assert "`!commands 2`" in result
+    assert "`/commands 2`" not in result
+
+
+@pytest.mark.asyncio
+async def test_commands_keeps_slash_prefix_on_non_matrix_gateway(monkeypatch):
+    monkeypatch.setattr("agent.skill_commands.get_skill_commands", lambda: {})
+
+    result = await _make_runner()._handle_commands_command(
+        _make_event("/commands 1", Platform.DISCORD)
+    )
+
+    assert "`/start" in result
+    assert "`!start" not in result
+
+

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -110,3 +110,16 @@ async def test_commands_keeps_slash_prefix_on_non_matrix_gateway(monkeypatch):
     assert "`!start" not in result
 
 
+def test_matrix_command_rendering_preserves_paths_and_multi_backtick_code():
+    from gateway.run import _platformize_command_mentions
+
+    source = (
+        "Use `/tmp` and `/tmp/file`; keep ``/commands`` and "
+        "`` `/commands` `` unchanged.\n"
+        "```text\n`/commands`\n```\n"
+        "```/commands``` also stays unchanged."
+    )
+
+    assert _platformize_command_mentions(source, Platform.MATRIX) == source
+
+

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -83,6 +83,26 @@ async def test_help_uses_matrix_safe_bang_command_mentions(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_matrix_help_skills_lists_all_installed_skill_commands(monkeypatch):
+    skill_commands = {
+        f"/skill-{index:02d}": {"description": f"Skill {index:02d}"}
+        for index in range(12)
+    }
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: skill_commands,
+    )
+
+    result = await _make_runner()._handle_help_command(
+        _make_event("/help skills", Platform.MATRIX)
+    )
+
+    assert "`!skill-00`" in result
+    assert "`!skill-11`" in result
+    assert "`!model" not in result
+
+
+@pytest.mark.asyncio
 async def test_commands_uses_matrix_safe_bang_entries_and_navigation(monkeypatch):
     monkeypatch.setattr(
         "agent.skill_commands.get_skill_commands",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -530,6 +530,26 @@ class TestMatrixBangCommandAlias:
         )
         assert _normalize_matrix_bang_command("!tasks") == "/tasks"
 
+    def test_every_gateway_registry_name_and_alias_has_bang_alias(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+        from plugins.platforms.matrix.adapter import _normalize_matrix_bang_command
+
+        for name in sorted(GATEWAY_KNOWN_COMMANDS):
+            assert _normalize_matrix_bang_command(f"!{name} probe") == f"/{name} probe"
+
+    def test_plugin_bang_command_normalizes(self):
+        import hermes_cli.plugins as plugins_mod
+        from plugins.platforms.matrix.adapter import _normalize_matrix_bang_command
+
+        with patch.object(
+            plugins_mod,
+            "get_plugin_commands",
+            return_value={"plugin-check": {"description": "Test plugin command"}},
+        ):
+            assert (
+                _normalize_matrix_bang_command("!plugin-check value")
+                == "/plugin-check value"
+            )
 
     @pytest.mark.asyncio
     async def test_unknown_bang_text_stays_normal_text(self):

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -20,7 +20,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Rooms** | By default, Hermes requires an `@mention` to respond. Set `MATRIX_REQUIRE_MENTION=false` or add room IDs to `MATRIX_FREE_RESPONSE_ROOMS` for free-response rooms. Room invites are auto-accepted. |
 | **Threads** | Hermes supports Matrix threads (MSC3440). If you reply in a thread, Hermes keeps the thread context isolated from the main room timeline. Threads where the bot has already participated do not require a mention. |
 | **Auto-threading** | By default, Hermes auto-creates a thread for each message it responds to in a room. This keeps conversations isolated. Set `MATRIX_AUTO_THREAD=false` to disable. Set `MATRIX_DM_AUTO_THREAD=true` (default false) to also auto-create threads for DM messages — this is distinct from `MATRIX_DM_MENTION_THREADS`, which only starts a thread when the bot is `@mentioned` in a DM. |
-| **Commands** | Hermes accepts normal `/commands` when your Matrix client sends them. If your client reserves `/` for local commands, use `!commands` instead; Hermes normalizes known `!command` aliases to `/command`. |
+| **Commands** | Element X may consume `/command` as a local client command. Use `!command` for Hermes commands. Hermes keeps `/` internally and rewrites known `!command` messages before gateway dispatch. Generated help and command-directory replies also use `!` on Matrix. |
 | **Interactive controls** | Dangerous-command approval and `/model` selection can use Matrix reactions. Approval reactions can be limited to the user who requested the action. |
 | **Thinking and tool activity** | Matrix uses threaded, editable thinking/tool-activity panes when gateway progress is enabled, so updates do not flood the main room timeline. |
 | **Shared rooms with multiple users** | By default, Hermes isolates session history per user inside the room. Two people talking in the same room do not share one transcript unless you explicitly disable that. |
@@ -551,26 +551,38 @@ To find a Room ID: in Element, go to the room → **Settings** → **Advanced** 
 
 ## Commands in Matrix
 
-Hermes supports the same gateway commands in Matrix that it supports on other
-messaging platforms, including `/commands`, `/model`, `/stop`, `/queue`,
-`/steer`, `/goal`, `/subgoal`, `/background`, `/bg`, `/btw`, `/tasks`, and
-`/yolo`.
+Hermes supports the same gateway-compatible commands in Matrix that it supports
+on other messaging platforms. Element X may consume `/command` as a local
+client command before it reaches the room, so use the Matrix-safe `!command`
+form. Hermes keeps `/` internally and rewrites known `!command` messages before
+gateway dispatch.
 
-Some Matrix clients reserve leading `/` for local client commands and may not
-send unknown slash commands to the room. In that case, use `!` as a Matrix-safe
-alias:
+Start with the generated command directory rather than relying on a static list:
 
 ```text
-!commands
-!model
-!model gpt-5.5 --provider openrouter
-!queue continue with the next task
-!stop
+!commands          # page 1 of all gateway-compatible commands and skills
+!commands 2        # next page
+!help              # concise command help
+!help skills       # installed skill commands
+!whoami            # verify admin/user command access
 ```
+
+The generated Matrix replies also advertise `!command`, including pagination
+instructions such as `!commands 2`, so the examples can be sent directly from
+Element X.
+
+Other examples include `!model`, `!stop`, `!queue`, `!steer`, `!goal`,
+`!background`, `!bg`, `!btw`, and `!tasks`.
 
 Hermes only normalizes `!command` when the command is known to the gateway, a
 registered plugin command, or an installed skill command. Ordinary exclamations
 such as `!important` remain normal chat messages.
+
+Here, the “full list” means every gateway-compatible built-in command and alias,
+registered plugin command, and installed skill command. CLI-only commands remain
+available only in the CLI/TUI. Matrix and Element X do not currently provide a
+Telegram Bot API-style remote command menu or autocomplete, so `!commands` is
+the authoritative in-room directory.
 
 ## Troubleshooting
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -578,11 +578,13 @@ Hermes only normalizes `!command` when the command is known to the gateway, a
 registered plugin command, or an installed skill command. Ordinary exclamations
 such as `!important` remain normal chat messages.
 
-Here, the “full list” means every gateway-compatible built-in command and alias,
-registered plugin command, and installed skill command. CLI-only commands remain
-available only in the CLI/TUI. Matrix and Element X do not currently provide a
-Telegram Bot API-style remote command menu or autocomplete, so `!commands` is
-the authoritative in-room directory.
+The generated directory includes every gateway-compatible built-in command and alias
+plus installed skill commands. Registered plugin commands can also be invoked with
+`!command` when installed, but they are not currently enumerated by `!commands`.
+CLI-only commands remain available only in the CLI/TUI. Matrix and Element X do
+not currently provide a Telegram Bot API-style remote command menu or autocomplete,
+so `!commands` is the primary in-room discovery surface rather than a complete
+inventory of installed plugin commands.
 
 ## Troubleshooting
 


### PR DESCRIPTION
1|## Summary
2|
3|- render Matrix gateway help and command-directory replies with Element X-safe `!command` tokens
4|- preserve Telegram sanitization and slash-command output on non-Matrix platforms
5|- verify built-in names/aliases, plugin commands, installed skills, pagination, and unknown `!text`
6|- document the generated Matrix command directory and honest Element/Element X limitations
7|
8|## Test plan
9|
10|- [x] RED observed for Matrix help and paginated command output before implementation
11|- [x] `scripts/run_tests.sh tests/gateway/test_gateway_command_help.py tests/gateway/test_matrix.py tests/hermes_cli/test_commands.py tests/hermes_cli/test_commands_execute.py -v --tb=long` — 175 passed
12|- [x] `npm ci && npm run build` in `website/`
13|- [x] Ruff, `git diff --check`, and added-line security scan
14|- [x] Final full-suite baseline comparison — 0 feature-only failures (feature: 98 existing/environmental failures; clean HEAD: the same set plus 3 additional failures)
15|- [x] Independent fail-closed review found Markdown/path overreach; corrective RED-GREEN cycle added coverage for `/tmp`, nested multi-backticks, and fenced code
16|- [x] Final hash-validated independent review — no security concerns or logic errors
17|
18|## Scope
19|
20|This changes reply presentation only. Canonical dispatch still uses `/command`, and Matrix `!command` acceptance remains registry-derived rather than maintaining a second command list.
21|