### PR TITLE
fix(desktop): preserve Bot workspace when resuming sessions

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -94,7 +94,7 @@ import { useKeybinds } from '../hooks/use-keybinds'
 import { useHudHandoff } from '../hud/handoff'
 import { ModelPickerOverlay } from '../model-picker-overlay'
 import { ModelVisibilityOverlay } from '../model-visibility-overlay'
-import { mainChatOccupied, openSession } from '../open-session'
+import { mainChatOccupied, openSession, openSessionFromPicker } from '../open-session'
 import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
 import { FileActionDialogs } from '../right-sidebar/file-actions'
 import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
@@ -1157,7 +1157,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         />
       )}
       <ModelPickerOverlay gateway={gateway || undefined} onSelect={selectModel} profile={activeGatewayProfile} />
-      <SessionPickerOverlay onResume={sessionId => openSession(sessionId, navigate)} />
+      <SessionPickerOverlay onResume={sessionId => openSessionFromPicker(sessionId, navigate)} />
       <ModelVisibilityOverlay
         gateway={gateway || undefined}
         onOpenProviders={openProviderSettings}

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -4,6 +4,9 @@ const focusOpenSession = vi.fn()
 const openSessionTile = vi.fn()
 const reuseBlankDraftTile = vi.fn()
 const setSessionTileWorkspaceScope = vi.fn()
+const focusedSessionWorkspaceScope = vi.fn<
+  () => { workspaceMode: 'bots' | 'sessions'; workspaceOwnerKey?: string }
+>(() => ({ workspaceMode: 'sessions' }))
 const openSessionInNewWindow = vi.fn()
 const canOpenSessionWindow = vi.fn(() => true)
 const workspaceIsPageGet = vi.fn(() => false)
@@ -11,6 +14,7 @@ const workspaceIsPageGet = vi.fn(() => false)
 vi.mock('@/store/session-states', () => ({
   focusedSessionNeedsRoute: (focused: 'main' | 'tile' | null, workspaceIsPage: boolean) =>
     !focused || (focused === 'main' && workspaceIsPage),
+  focusedSessionWorkspaceScope: () => focusedSessionWorkspaceScope(),
   focusOpenSession: (...args: unknown[]) => focusOpenSession(...args),
   openSessionTile: (...args: unknown[]) => openSessionTile(...args),
   reuseBlankDraftTile: (...args: unknown[]) => reuseBlankDraftTile(...args),
@@ -29,7 +33,7 @@ vi.mock('./routes', () => ({
 
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 
-import { mainChatOccupied, openSession, openSessionIntentFromModifiers } from './open-session'
+import { mainChatOccupied, openSession, openSessionFromPicker, openSessionIntentFromModifiers } from './open-session'
 
 /**
  * The question behind both the sidebar "+" and a palette open: is there a
@@ -92,6 +96,8 @@ describe('openSession', () => {
     workspaceIsPageGet.mockReturnValue(false)
     reuseBlankDraftTile.mockReset()
     setSessionTileWorkspaceScope.mockReset()
+    focusedSessionWorkspaceScope.mockReset()
+    focusedSessionWorkspaceScope.mockReturnValue({ workspaceMode: 'sessions' })
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
   })
@@ -204,6 +210,42 @@ describe('openSession', () => {
     openSession('s1', navigate, 'stack')
     expect(navigate).toHaveBeenCalledWith('/c/s1')
     expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('stack spends the focused Bot-scoped blank draft even when main is empty', () => {
+    const scope = { workspaceMode: 'bots' as const, workspaceOwnerKey: 'connection-a::default' }
+
+    focusOpenSession.mockReturnValue(null)
+    reuseBlankDraftTile.mockReturnValue(true)
+    openSession('s1', navigate, 'stack', scope)
+
+    expect(reuseBlankDraftTile).toHaveBeenCalledWith('s1', scope)
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('picker resumes into the focused Bot workspace instead of the Sessions main', () => {
+    const scope = { workspaceMode: 'bots' as const, workspaceOwnerKey: 'connection-a::default' }
+
+    focusedSessionWorkspaceScope.mockReturnValue(scope)
+    focusOpenSession.mockReturnValue(null)
+    reuseBlankDraftTile.mockReturnValue(true)
+    openSessionFromPicker('s1', navigate)
+
+    expect(focusedSessionWorkspaceScope).toHaveBeenCalledOnce()
+    expect(reuseBlankDraftTile).toHaveBeenCalledWith('s1', scope)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('picker keeps its existing in-place behavior in the Sessions workspace', () => {
+    $activeSessionId.set('runtime-current')
+    focusedSessionWorkspaceScope.mockReturnValue({ workspaceMode: 'sessions' })
+    focusOpenSession.mockReturnValue(null)
+
+    openSessionFromPicker('s1', navigate)
+
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
   })
 
   it('window pops out when the bridge supports it', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -19,6 +19,7 @@ import { $activeSessionId, $selectedStoredSessionId, markSessionRead } from '@/s
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   focusedSessionNeedsRoute,
+  focusedSessionWorkspaceScope,
   focusOpenSession,
   openSessionTile,
   reuseBlankDraftTile,
@@ -75,6 +76,15 @@ export function openSessionIntentFromModifiers(
   return base
 }
 
+/** Picker selection preserves the workspace of the tab that opened it without
+ * changing the established Sessions behavior. */
+export function openSessionFromPicker(storedSessionId: string, navigate: OpenSessionNavigate): void {
+  const workspaceScope = focusedSessionWorkspaceScope()
+  const intent = workspaceScope.workspaceMode === 'bots' ? 'stack' : 'in-place'
+
+  openSession(storedSessionId, navigate, intent, workspaceScope)
+}
+
 /**
  * @param navigate Required for `in-place` (route into main when not on screen).
  *   `tab` / `window` ignore it — pass a no-op when you don't have a router handle.
@@ -126,7 +136,13 @@ export function openSession(
   let spendBlankDraft = false
 
   if (resolved === 'stack') {
-    spendBlankDraft = mainChatOccupied($activeSessionId.get(), $selectedStoredSessionId.get())
+    // A Bot-scoped picker is already inside a session tab, so its blank draft
+    // is the surface the user expects `/resume` to replace. Main may be empty
+    // or hidden behind the Bots workspace; treating that as an in-place open
+    // routes the saved chat elsewhere while leaving the visible blank tab
+    // active. Force the tab path so it first focuses an existing target, then
+    // spends the scoped blank draft before stacking a new tab.
+    spendBlankDraft = Boolean(botWorkspaceScope) || mainChatOccupied($activeSessionId.get(), $selectedStoredSessionId.get())
     resolved = spendBlankDraft ? 'tab' : 'in-place'
   }
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -13,6 +13,7 @@ import {
   clearAllSessionStates,
   closeAllOpenSessionTiles,
   focusedSessionNeedsRoute,
+  focusedSessionWorkspaceScope,
   focusOpenSession,
   foregroundSessionScopes,
   isSessionRemote,
@@ -271,6 +272,20 @@ describe('SessionTile workspace scope', () => {
       })
     ])
     expect(focusOpenSession('bot-chat', scope)).toBe('tile')
+  })
+
+  it('reports the workspace scope of the focused Bot session tab', () => {
+    const scope = {
+      ownerRoute: { connectionId: 'connection-a', profile: 'default' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'connection-a::default',
+      workspaceTabTitle: 'Bot Chat'
+    }
+
+    openSessionTile('bot-chat', 'center', undefined, undefined, scope)
+    $layoutTree.set(group(['workspace', tilePane('bot-chat')], { active: tilePane('bot-chat'), id: 'main' }))
+
+    expect(focusedSessionWorkspaceScope()).toEqual(scope)
   })
 
   it('keeps Bot tabs while a profile publication swaps the Sessions bucket', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1449,6 +1449,29 @@ export function focusedSessionNeedsRoute(focused: 'main' | 'tile' | null, worksp
   return !focused || (focused === 'main' && workspaceIsPage)
 }
 
+/** Presentation scope of the session tab the user is currently acting from.
+ * Picker actions must preserve this scope: a `/resume` opened from Bot Mode is
+ * still a Bot tab with its exact owner route, not a Sessions-main navigation. */
+export function focusedSessionWorkspaceScope(): SessionTileWorkspaceScope {
+  const paneId = focusedSessionTabAnchor()
+
+  if (paneId?.startsWith(TILE_PANE_PREFIX)) {
+    const storedSessionId = paneId.slice(TILE_PANE_PREFIX.length)
+    const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+    if (tile?.workspaceMode === 'bots') {
+      return {
+        ...(tile.ownerRoute ? { ownerRoute: tile.ownerRoute } : {}),
+        workspaceMode: 'bots',
+        ...(tile.workspaceOwnerKey ? { workspaceOwnerKey: tile.workspaceOwnerKey } : {}),
+        ...(tile.workspaceTabTitle ? { workspaceTabTitle: tile.workspaceTabTitle } : {})
+      }
+    }
+  }
+
+  return { workspaceMode: 'sessions' }
+}
+
 /** The open tab that's still an empty "New session" draft, if there is one.
  *  That tab is the one the user would have typed into, so an open-from-nowhere
  *  spends it instead of stacking a second blank tab beside it. Most recent


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop `/resume` when it is invoked from a focused Bot workspace. The session picker previously dropped the focused workspace scope and called `openSession` with its default Sessions scope, so a selected session could open in Sessions/main or leave the empty Bot draft visible.

The picker now preserves the focused Bot workspace and reuses its blank draft when possible, while keeping the existing in-place behavior for the normal Sessions workspace.

## Related Issue

Fixes #96363

Refs #94726. Related to #91740, but deliberately does not change the broader Bot-session browsing model.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-states.ts`
  - Add `focusedSessionWorkspaceScope()` to recover the focused tab's presentation scope.
- `apps/desktop/src/app/open-session.ts`
  - Add `openSessionFromPicker()`.
  - Use Bot-scoped `stack` behavior and preserve Sessions `in-place` behavior.
  - Thread Bot scope through blank-draft reuse.
- `apps/desktop/src/app/contrib/wiring.tsx`
  - Route `SessionPickerOverlay` through the picker-specific open helper.
- Add regression coverage in `open-session.test.ts` and `session-states.test.ts`.

## User Impact

A user can open `/resume` from a Bot tab, choose an existing session, and stay in the correct Bot workspace. A focused empty Bot draft is reused instead of leaving it visible or redirecting the conversation to Sessions/main.

## Relationship to Existing Work

Recent owner-routing changes determine which gateway/profile owns an already-opened session. This patch operates one boundary earlier: it preserves the presentation workspace at the Desktop picker → `openSession` handoff. It does not alter gateway ownership or session identity.

## How to Test

1. In Desktop, open Bots and focus a Bot workspace with an empty `New session` draft.
2. Invoke `/resume` and choose an existing session.
3. Confirm the selected session replaces/reuses the Bot draft and remains in the same Bot workspace.
4. Confirm invoking `/resume` from Sessions retains the previous in-place behavior.
5. Run:

```bash
npm run test:ui -- src/store/session-states.test.ts src/app/open-session.test.ts
npm run test:ui
npm run typecheck
```

## Evidence

Validated after applying the patch cleanly to `main` at `5fc308a70719a83cccdbba4c0e39c23f5a8239d5`:

- Focused suite: **2 test files, 79 tests passed**.
- Full Desktop UI suite: **617 test files, 6082 tests passed**.
- Desktop TypeScript typecheck: passed.
- `git diff --check`: passed.
- Live macOS Desktop canary: passed.
- Structured autoreview: clean; no accepted/actionable findings (`overall: patch is correct (0.98)`).

## Known Boundary

This PR does not expose hidden Bot sessions in the Sessions sidebar, add a per-Bot history browser, or change backend owner resolution. Those are separate concerns tracked by #91740 and the wider Bot Mode tracker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test suites
- [x] I've added tests for the bug fix
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing contract or config changed
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no workflow or architecture policy changed
- [x] Cross-platform impact considered; the change is renderer state/navigation logic with no platform-specific API
- [x] Tool descriptions/schemas — N/A
