### PR TITLE
fix(gateway): bind HERMES_SESSION_PROFILE per /p/<profile>/ api request

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7166,6 +7166,7 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        profile: str = "",
         browser_control_principal: str = "",
         browser_control_transport_family: str = "",
     ) -> list:
@@ -7179,6 +7180,13 @@ class APIServerAdapter(BasePlatformAdapter):
         ``async_delivery`` parameter to get wrong; the stateless HTTP path can
         never wake the agent after the turn ends, on ANY route.
 
+        ``profile`` names the multiplex profile serving this request
+        (the ``/p/<profile>/`` prefix, or ``""`` for the default profile).
+        It must reach ``set_session_vars`` so ``HERMES_SESSION_PROFILE`` is
+        bound per request: without it every API-server session collapses to
+        the default container key and org-profile turns can reuse the
+        default profile's sandbox (cross-profile SSH/secret exposure).
+
         Returns reset tokens; pass them to ``clear_session_vars`` in a
         ``finally`` block (the binding is request-scoped and must not outlive
         the turn — a session resumed later on a delivering interface, e.g. the
@@ -7191,6 +7199,7 @@ class APIServerAdapter(BasePlatformAdapter):
             chat_id=chat_id,
             session_key=session_key,
             session_id=session_id,
+            profile=profile,
             browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
             async_delivery=False,
@@ -7268,6 +7277,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    profile=request_profile or "",
                     browser_control_principal=request_browser_control_principal,
                     browser_control_transport_family=(
                         request_browser_control_transport_family

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -93,3 +93,72 @@ class TestApiServerModelsUnderProfile:
             assert adapter._resolve_model_name("") == "coder"
         finally:
             _api_request_profile.reset(token_prof)
+
+
+class TestApiServerSessionProfileBinding:
+    """HERMES_SESSION_PROFILE must be bound per /p/<profile>/ request.
+
+    Regression guard for cross-profile sandbox reuse: before the fix,
+    _bind_api_server_session never passed ``profile`` to set_session_vars,
+    so every API-server turn bound HERMES_SESSION_PROFILE="" and the
+    terminal tool collapsed ALL api_server sessions (default AND org
+    profiles) onto the shared "default" container key — letting org-profile
+    turns reuse the default profile's sandbox (SSH key / secrets exposure).
+    """
+
+    def test_profile_is_bound_into_session_vars(self):
+        from gateway.session_context import clear_session_vars, get_session_env
+
+        adapter = _make_adapter(multiplex=True)
+        tokens = adapter._bind_api_server_session(
+            chat_id="chat",
+            session_key="key",
+            session_id="sess",
+            profile="nm-media",
+        )
+        try:
+            assert get_session_env("HERMES_SESSION_PROFILE") == "nm-media"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_default_profile_binds_empty_profile(self):
+        from gateway.session_context import clear_session_vars, get_session_env
+
+        adapter = _make_adapter(multiplex=True)
+        tokens = adapter._bind_api_server_session(
+            chat_id="chat",
+            session_key="key",
+            session_id="sess",
+            profile="",
+        )
+        try:
+            assert get_session_env("HERMES_SESSION_PROFILE") == ""
+        finally:
+            clear_session_vars(tokens)
+
+    def test_bound_profile_selects_profile_scoped_container_key(self, monkeypatch):
+        """Terminal container resolution honours the api_server-bound profile."""
+        import tools.terminal_tool as tt
+        from gateway.session_context import clear_session_vars, get_session_env
+
+        adapter = _make_adapter(multiplex=True)
+        monkeypatch.setattr(tt, "_ensure_terminal_env_bridged", lambda: None)
+        monkeypatch.setattr(
+            tt, "_docker_persistent_profile_scoped", lambda: True
+        )
+        monkeypatch.setattr(tt, "_current_session_key", lambda: "sess-key")
+        monkeypatch.setattr(
+            tt, "_current_session_profile",
+            lambda: get_session_env("HERMES_SESSION_PROFILE", ""),
+        )
+
+        tokens = adapter._bind_api_server_session(
+            chat_id="chat",
+            session_key="key",
+            session_id="sess",
+            profile="nm-media",
+        )
+        try:
+            assert tt._resolve_container_task_id(None) == "profile:nm-media"
+        finally:
+            clear_session_vars(tokens)


### PR DESCRIPTION
## What

`APIServerAdapter._bind_api_server_session()` never forwarded the request's multiplex profile to `set_session_vars()`, so every `/v1/chat/completions` turn — including `/p/<profile>/` requests on a multiplexed gateway — bound `HERMES_SESSION_PROFILE=""`.

## Why it matters

The terminal tool resolves the persistent Docker container key per session:

```python
profile = _current_session_profile() or "default"
return f"profile:{profile}"
```

With `HERMES_SESSION_PROFILE` always empty on the API-server path, **every** API-server session (default profile AND secondary org profiles) collapses onto the shared `"default"` container key (`_active_environments` cache). On a multiplexed gateway the first caller after process start therefore wins that slot, and secondary-profile turns can end up reusing the **default profile's sandbox container** — including its home directory (SSH keys, secrets, host mounts). Observed live: an org-profile turn executed tools inside the default profile's container and read the default profile's private SSH key.

The same `HERMES_SESSION_PROFILE` ContextVar is already bound correctly by the TUI gateway and WebUI paths; only the API-server chokepoint omitted it.

## Fix

Pass the request profile through `_bind_api_server_session()` → `set_session_vars(profile=...)`:

- no `/p/<profile>/` prefix → `profile=""` → container key `"default"` (unchanged behaviour)
- `/p/<profile>/x` → `profile="<profile>"` → container key `"profile:<profile>"` → its own profile-scoped container, never the default profile's

## Tests

Added `TestApiServerSessionProfileBinding` to `tests/gateway/test_multiplex_api_server_routing.py`:
- profile is bound into session vars for a `/p/<profile>/` request
- default (no prefix) binds empty profile
- bound profile yields the profile-scoped container key (`profile:nm-media`)

Verified against `main` (v0.20.6): 116 passed, ruff clean.
