### PR TITLE
fix(update): prevent unrelated Windows services from blocking updates

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -871,6 +871,7 @@ def find_windows_gateway_services(
         if profile_processes is None:
             profile_processes = find_profile_gateway_processes(strict=True)
         service_names_by_pid: dict[int, set[str]] = {}
+        indeterminate_services_by_pid: dict[int, list[tuple[str, object]]] = {}
         for service in psutil_module.win_service_iter():
             try:
                 if all(
@@ -896,9 +897,11 @@ def find_windows_gateway_services(
             if service_status == "stopped":
                 continue
             if service_status != "running":
-                raise RuntimeError(
-                    f"SCM service {service_name} has indeterminate status: {service_status}"
-                )
+                if service_pid > 0:
+                    indeterminate_services_by_pid.setdefault(service_pid, []).append(
+                        (service_name, service_status)
+                    )
+                continue
             if service_pid <= 0:
                 raise RuntimeError(
                     f"Running SCM service {service_name} has no valid process ID"
@@ -917,6 +920,14 @@ def find_windows_gateway_services(
             ) > 0.001:
                 raise RuntimeError("Gateway process identity changed during SCM discovery")
             ancestor_pids = [int(parent.pid) for parent in gateway_process.parents()]
+            for pid in ancestor_pids:
+                indeterminate_services = indeterminate_services_by_pid.get(pid, [])
+                if indeterminate_services:
+                    service_name, service_status = indeterminate_services[0]
+                    raise RuntimeError(
+                        f"SCM service {service_name} has indeterminate status: "
+                        f"{service_status}"
+                    )
             shared_service_pids = [
                 pid
                 for pid in ancestor_pids

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1015,15 +1015,16 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
 
     class FakeService:
-        def __init__(self, name, pid):
+        def __init__(self, name, pid, status="running"):
             self.name = name
             self.pid = pid
+            self.status = status
 
         def as_dict(self):
             return {
                 "name": self.name,
                 "pid": self.pid,
-                "status": "running",
+                "status": self.status,
             }
 
     class FakeProcess:
@@ -1044,7 +1045,7 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     fake_psutil = SimpleNamespace(
         win_service_iter=lambda: [
             FakeService("HermesGateway", 100),
-            FakeService("UnrelatedService", 900),
+            FakeService("UnrelatedService", 900, "stop_pending"),
         ],
         Process=FakeProcess,
     )
@@ -1066,6 +1067,37 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
             gateway_create_time=300.0,
         )
     ]
+
+
+def test_find_windows_gateway_services_rejects_transitional_ancestor(monkeypatch):
+    """A transitional service in the gateway ancestry remains fail-closed."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def as_dict(self):
+            return {"name": "HermesGateway", "pid": 100, "status": "stop_pending"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService()],
+        Process=FakeProcess,
+    )
+
+    with pytest.raises(RuntimeError, match="indeterminate status: stop_pending"):
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[profile],
+        )
 
 
 def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Prevents an unrelated transitional Windows SCM service from aborting `hermes update --gateway` before code is fetched. Transitional status remains fail-closed when the service PID is actually in a validated Hermes gateway's ancestor chain.

### Symptom

A Windows Desktop update exits with `SCM service enumeration failed` when an unrelated service such as `BcastDVRUserService_*` is in `STOP_PENDING`.

### Impact

Affected Windows users cannot update Hermes while any unrelated SCM service remains transitional, even when that service does not supervise a Hermes gateway.

### Bug Cause

**Trigger:** `hermes_cli/gateway.py:find_windows_gateway_services` rejects every status other than `running` or `stopped` during global SCM enumeration.

**Causal chain:**
1. Desktop starts `hermes update --gateway` while an unrelated SCM service reports `stop_pending` with a live PID.
2. SCM enumeration raises before comparing that PID with validated gateway process ancestry.
3. The updater aborts before fetching new code.

**Why it is wrong:** Transitional status is ownership-relevant only when that service can supervise a validated Hermes gateway process. Rejecting it before ancestry filtering turns an unrelated Windows component into a global update blocker.

**Working sibling / contrast:** Running unrelated services already survive discovery because only a service PID found in the validated gateway ancestry is returned.

**Ruled out:** This is not a gateway process-identification failure. The failure occurs first during service enumeration, and the reported service PID is absent from the validated gateway ancestry.

### Fix

Record transitional services by PID during SCM enumeration, then reject them only when their PID appears in a validated gateway's ancestor chain. SCM enumeration and inspection errors, running services without valid PIDs, shared service hosts, and transitional gateway ancestors remain fail-closed.

## Related Issue

Fixes #96360

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - defer transitional-service rejection until validated gateway ancestry is known.
- `tests/hermes_cli/test_gateway.py` - cover unrelated and gateway-ancestor `stop_pending` services.

## How to Test

1. Run the focused Windows SCM ownership tests.
2. Confirm an unrelated `stop_pending` service is ignored.
3. Confirm a `stop_pending` service in the gateway ancestry still raises.

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway.py -q
```

Result: 33 passed, 5 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test file and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by deterministic regression tests for SCM service status and ancestry.
