### PR TITLE
fix(process-registry): stop failed waits from reporting clean exits

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -313,6 +313,85 @@ def test_reader_loop_streams_incremental_chunks_from_read1(registry, monkeypatch
     assert moved == ["proc_reader_live"]
 
 
+def test_reader_loop_force_terminates_and_reaps_after_wait_timeout(
+    registry, monkeypatch, caplog
+):
+    class _FakeStdout:
+        def read(self, _n):
+            return ""
+
+    class _FakeProcess:
+        pid = 4321
+        returncode = None
+
+        def __init__(self):
+            self.stdout = _FakeStdout()
+            self.wait_calls = 0
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired("child", timeout)
+            self.returncode = -9
+            return self.returncode
+
+    session = _make_session(sid="proc_wait_timeout")
+    session.process = _FakeProcess()
+    registry._running[session.id] = session
+    terminated = []
+    monkeypatch.setattr(
+        registry,
+        "_terminate_host_pid",
+        lambda pid, expected_start: terminated.append((pid, expected_start)),
+    )
+
+    registry._reader_loop(session)
+
+    assert session.process.wait_calls == 2
+    assert terminated == [(4321, None)]
+    assert session.exited is True
+    assert session.exit_code == -9
+    assert session.completion_reason == "exited"
+    assert session.id not in registry._running
+    assert session.id in registry._finished
+    assert "force-terminating" in caplog.text
+
+
+def test_reader_loop_keeps_session_running_when_forced_reap_fails(
+    registry, monkeypatch, caplog
+):
+    class _FakeStdout:
+        def read(self, _n):
+            return ""
+
+    class _FakeProcess:
+        pid = 4321
+        returncode = None
+        stdout = _FakeStdout()
+
+        def wait(self, timeout=None):
+            raise RuntimeError("wait handle unavailable")
+
+    session = _make_session(sid="proc_wait_failed")
+    session.process = _FakeProcess()
+    registry._running[session.id] = session
+    terminated = []
+    monkeypatch.setattr(
+        registry,
+        "_terminate_host_pid",
+        lambda pid, expected_start: terminated.append((pid, expected_start)),
+    )
+
+    registry._reader_loop(session)
+
+    assert terminated == [(4321, None)]
+    assert session.exited is False
+    assert session.exit_code is None
+    assert session.id in registry._running
+    assert session.id not in registry._finished
+    assert "could not be reaped after forced termination" in caplog.text
+
+
 # =========================================================================
 # Incremental UTF-8 decoding across chunk boundaries
 # (ported from openclaw/openclaw#112325)
@@ -412,6 +491,41 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
 
     assert session.output_buffer == "café\n"
     assert "\ufffd" not in session.output_buffer
+
+
+def test_pty_reader_loop_force_terminates_and_reaps_after_wait_failure(registry):
+    class _FakePty:
+        exitstatus = None
+
+        def __init__(self):
+            self.wait_calls = 0
+            self.terminate_calls = []
+
+        def isalive(self):
+            return False
+
+        def wait(self):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise RuntimeError("PTY wait failed")
+            self.exitstatus = -9
+            return self.exitstatus
+
+        def terminate(self, force=False):
+            self.terminate_calls.append(force)
+
+    session = _make_session(sid="proc_pty_wait_failed")
+    session._pty = _FakePty()
+    registry._running[session.id] = session
+
+    registry._pty_reader_loop(session)
+
+    assert session._pty.wait_calls == 2
+    assert session._pty.terminate_calls == [True]
+    assert session.exited is True
+    assert session.exit_code == -9
+    assert session.id not in registry._running
+    assert session.id in registry._finished
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1496,16 +1496,79 @@ class ProcessRegistry:
                     _append_chunk(tail)
             except Exception:
                 pass
-            # Always reap the child to prevent zombie processes.
+            self._reap_and_finish_local_process(
+                session,
+                wait=lambda: session.process.wait(timeout=5),
+                force_terminate=lambda: self._terminate_host_pid(
+                    session.process.pid, session.host_start_time
+                ),
+                exit_code=lambda: session.process.returncode,
+                kind="pipe",
+            )
+
+    def _reap_and_finish_local_process(
+        self,
+        session: ProcessSession,
+        *,
+        wait,
+        force_terminate,
+        exit_code,
+        kind: str,
+    ) -> bool:
+        """Reap a local child before publishing its terminal state.
+
+        Reader completion does not prove that the child was reaped. If the
+        first wait fails, force-terminate the owned process tree and wait once
+        more. A child that still cannot be reaped remains in ``_running`` with
+        its runtime handle intact instead of being reported as a clean exit.
+        """
+        try:
+            wait()
+        except Exception as first_error:
+            if isinstance(first_error, subprocess.TimeoutExpired):
+                logger.warning(
+                    "%s process %s did not exit during wait; force-terminating: %s",
+                    kind,
+                    session.id,
+                    first_error,
+                )
+            else:
+                logger.error(
+                    "%s process %s wait failed; force-terminating: %s",
+                    kind,
+                    session.id,
+                    first_error,
+                )
             try:
-                session.process.wait(timeout=5)
-            except Exception as e:
-                logger.debug("Process wait timed out or failed: %s", e)
+                force_terminate()
+                if session.systemd_unit:
+                    _stop_systemd_unit(session.systemd_unit)
+                wait()
+            except Exception as reap_error:
+                logger.error(
+                    "%s process %s could not be reaped after forced termination: %s",
+                    kind,
+                    session.id,
+                    reap_error,
+                )
+                return False
+
+        with session._lock:
             session.exited = True
             if session.completion_reason != "killed":
-                session.exit_code = session.process.returncode
+                try:
+                    session.exit_code = exit_code()
+                except Exception as status_error:
+                    logger.error(
+                        "%s process %s was reaped but its exit status is unavailable: %s",
+                        kind,
+                        session.id,
+                        status_error,
+                    )
+                    session.exit_code = -1
                 session.completion_reason = "exited"
-            self._move_to_finished(session)
+        self._move_to_finished(session)
+        return True
 
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
@@ -1605,16 +1668,13 @@ class ProcessRegistry:
         except Exception:
             pass
 
-        # Process exited
-        try:
-            pty.wait()
-        except Exception as e:
-            logger.debug("PTY wait timed out or failed: %s", e)
-        session.exited = True
-        if session.completion_reason != "killed":
-            session.exit_code = pty.exitstatus if hasattr(pty, 'exitstatus') else -1
-            session.completion_reason = "exited"
-        self._move_to_finished(session)
+        self._reap_and_finish_local_process(
+            session,
+            wait=pty.wait,
+            force_terminate=lambda: pty.terminate(force=True),
+            exit_code=lambda: pty.exitstatus if hasattr(pty, "exitstatus") else -1,
+            kind="PTY",
+        )
 
     def _move_to_finished(self, session: ProcessSession):
         """Move a session from running to finished.


### PR DESCRIPTION
## What does this PR do?

Background terminal sessions no longer report a clean exit when their child process could not be reaped. Pipe and PTY readers now force-terminate and retry the wait after an initial failure, and they keep the runtime handle in the running registry with an error log if the second wait also fails.

### Symptom

A failed local pipe or PTY wait was logged only at debug level, but the session was still moved to the finished registry with `completion_reason="exited"` and a missing or invalid exit code.

### Impact

Operators could receive a false clean-exit status while the child remained unreaped, and the registry discarded the only runtime handle that could be used for later cleanup.

### Bug Cause

**Trigger:** `tools/process_registry.py` in `_reader_loop` and `_pty_reader_loop` when the final child wait raises or times out.

**Causal chain:**
1. A local reader reaches output completion and calls the child handle's wait method.
2. The wait raises, but the exception handler only emits a debug log and execution continues through unconditional finalization.
3. The registry marks the session exited, publishes an unavailable exit status, and moves the child handle out of the running registry.

**Why it is wrong:** Reader completion does not prove that the child has been reaped, so terminal state must not be published until wait succeeds.

**Working sibling / contrast:** The orphaned-pipe reconciliation path has a concrete return code from `Popen.poll()` before it marks a session exited. This change applies the same requirement for definitive process state to both reader finalization paths.

**Ruled out:** Remote environment polling is not affected because it determines process liveness and exit status through the backend wrapper rather than a local process handle.

### Fix

A shared local finalizer now retries reaping after force-terminating the owned pipe process tree or PTY handle. Timeout failures are warnings, other wait failures and failed second waits are errors, and a session whose second wait fails remains tracked as running instead of being published as a clean exit.

## Related Issue

Closes #96362

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` - make pipe and PTY completion conditional on successful child reaping, with forced termination and a second wait after failure.
- `tests/tools/test_process_registry.py` - cover pipe timeout escalation, persistent reap failure state, and PTY wait escalation.

## How to Test

1. Run the focused local reader regression tests.
2. Confirm an initial mocked wait failure force-terminates and waits again before publishing exit state.
3. Confirm a repeated wait failure leaves the session in the running registry and emits an error.

```bash
scripts/run_tests.sh tests/tools/test_process_registry.py -k 'reader_loop'
```

Result: 9 passed on Windows 11. The three new regression tests were also run against the pre-fix implementation and failed as expected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the tool schema is unchanged
