### PR TITLE
fix(desktop): detect backend ready marker on stderr

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -31,14 +31,15 @@ import {
 
 type FakeChildProcess = EventEmitter & {
   stdout: EventEmitter
+  stderr: EventEmitter
 }
 
-// A minimal stand-in for a spawned child process: an EventEmitter with a
-// stdout EventEmitter, matching the surface waitForDashboardPort consumes
-// (child.stdout.on('data'), child.on('exit'|'error') + the .off() teardown).
+// A minimal stand-in for a spawned child process: an EventEmitter with stdout
+// and stderr streams, matching the surface waitForDashboardPort consumes.
 function makeFakeChild(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
   child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
 
   return child
 }
@@ -92,11 +93,13 @@ test('resolves with the announced port', async () => {
   assert.equal(await p, 54321)
 })
 
-test('resolves with a HERMES_BACKEND_READY port (headless `serve`)', async () => {
+test('resolves with a HERMES_BACKEND_READY port emitted on stderr', async () => {
   const child = makeFakeChild()
   const p = waitForDashboardPort(child, 1000)
-  child.stdout.emit('data', 'HERMES_BACKEND_READY port=43210\n')
+  child.stderr.emit('data', 'HERMES_BACKEND_READY port=43210\r\n')
   assert.equal(await p, 43210)
+  assert.equal(child.stdout.listenerCount('data'), 0)
+  assert.equal(child.stderr.listenerCount('data'), 0)
 })
 
 test('parses the port even when the line arrives split across chunks', async () => {
@@ -105,6 +108,22 @@ test('parses the port even when the line arrives split across chunks', async () 
   child.stdout.emit('data', 'HERMES_DASHBOARD_READY po')
   child.stdout.emit('data', 'rt=8080\n')
   assert.equal(await p, 8080)
+})
+
+test('parses a stderr announcement split across chunks', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+  child.stderr.emit('data', 'HERMES_BACKEND_READY po')
+  child.stderr.emit('data', 'rt=8081\r\n')
+  assert.equal(await p, 8081)
+})
+
+test('does not combine fragments from stdout and stderr', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 20)
+  child.stdout.emit('data', 'HERMES_BACKEND_READY po')
+  child.stderr.emit('data', 'rt=8082\n')
+  await assert.rejects(p, /Timed out/)
 })
 
 test('rejects when the child exits before announcing', async () => {
@@ -132,10 +151,13 @@ test('rejects with the timeout message after the deadline', async () => {
 test('a late announcement after timeout does not throw (listeners torn down)', async () => {
   const child = makeFakeChild()
   await assert.rejects(waitForDashboardPort(child, 20), /Timed out/)
+  assert.equal(child.stdout.listenerCount('data'), 0)
+  assert.equal(child.stderr.listenerCount('data'), 0)
   // The orphaned backend may still print its READY line later; the watcher
   // must have detached so this emit is a no-op rather than a double-settle.
   assert.doesNotThrow(() => {
     child.stdout.emit('data', 'HERMES_DASHBOARD_READY port=9999\n')
+    child.stderr.emit('data', 'HERMES_BACKEND_READY port=9998\n')
   })
 })
 

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -35,7 +35,7 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
 }
 
 /**
- * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
+ * Watch a child process's stdout and stderr for the `HERMES_(BACKEND|DASHBOARD)_READY
  * port=<N>` line that web_server.py prints after uvicorn binds its socket.
  *
  * Returns the parsed port. Rejects if:
@@ -53,7 +53,8 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  */
 function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
   return new Promise((resolve, reject) => {
-    let buf = ''
+    let stdoutBuf = ''
+    let stderrBuf = ''
     let done = false
 
     function cleanup() {
@@ -63,18 +64,24 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
 
       done = true
       clearTimeout(timer)
-      child.stdout.off('data', onData)
+      child.stdout.off('data', onStdoutData)
+      child.stderr.off('data', onStderrData)
       child.off('exit', onExit)
       child.off('error', onError)
     }
 
-    function onData(chunk) {
-      buf += chunk.toString()
-      let nl
+    function consume(chunk, stream) {
+      const combined = (stream === 'stdout' ? stdoutBuf : stderrBuf) + chunk.toString()
+      const lines = combined.split('\n')
+      const remainder = lines.pop() ?? ''
 
-      while ((nl = buf.indexOf('\n')) !== -1) {
-        const line = buf.slice(0, nl)
-        buf = buf.slice(nl + 1)
+      if (stream === 'stdout') {
+        stdoutBuf = remainder
+      } else {
+        stderrBuf = remainder
+      }
+
+      for (const line of lines) {
         const m = line.match(_READY_RE)
 
         if (m) {
@@ -84,6 +91,14 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
           return
         }
       }
+    }
+
+    function onStdoutData(chunk) {
+      consume(chunk, 'stdout')
+    }
+
+    function onStderrData(chunk) {
+      consume(chunk, 'stderr')
     }
 
     function onExit(code, signal) {
@@ -101,7 +116,8 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
       reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
     }, timeoutMs)
 
-    child.stdout.on('data', onData)
+    child.stdout.on('data', onStdoutData)
+    child.stderr.on('data', onStderrData)
     child.on('exit', onExit)
     child.on('error', onError)
   })


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows Desktop startup failure where the Hermes backend successfully started and announced its listening port, but Desktop ignored the announcement and timed out after 90 seconds.

`HERMES_BACKEND_READY port=<port>` can be emitted on stderr. `waitForDashboardPort()` monitored only stdout, even though the general backend logger consumed both streams. The readiness watcher now monitors stdout and stderr with independent buffers, preventing fragments from different streams from being combined while preserving the existing timeout and child-process failure behavior.

## Related Issue

No linked issue. Reproduced from a Windows 11 Desktop startup failure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/electron/backend-ready.ts` to monitor both stdout and stderr for readiness markers.
- Kept independent line buffers for each stream so cross-stream fragments cannot form a false marker.
- Removed both data listeners during resolve, exit, error, and timeout cleanup.
- Updated `apps/desktop/electron/backend-ready.test.ts` with stderr, Windows CRLF, split-chunk, cross-stream isolation, and listener-cleanup regression coverage.
- Updated the readiness watcher documentation to describe both streams.

## How to Test

1. On Windows 11, start Hermes Desktop in an environment where `hermes serve` emits `HERMES_BACKEND_READY port=<port>` on stderr. Before this change, the backend starts and logs its port, but Desktop fails after `Timed out waiting for Hermes backend port announcement (90000ms)`.
2. Run `npm exec vitest run apps/desktop/electron/backend-ready.test.ts`; all 22 tests should pass.
3. Run `npm exec tsc -- -p apps/desktop/tsconfig.electron.json --noEmit` and `npm exec eslint -- apps/desktop/electron/backend-ready.ts apps/desktop/electron/backend-ready.test.ts`.
4. Build and launch the Windows Desktop package. Confirm the log reaches `Hermes backend is ready. Finalizing desktop startup` and `GET /api/status` succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the function documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdout behavior remains covered; stderr uses independent buffering
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

Before:

```text
HERMES_BACKEND_READY port=57287
Hermes backend listening on 127.0.0.1:57287
Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

After:

```text
HERMES_BACKEND_READY port=45486
Hermes backend is ready. Finalizing desktop startup
GET /api/status -> 200 OK
```
