### PR TITLE
fix(desktop): keep busy tile transcripts stable

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -14,9 +14,11 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionTiles,
   $stalledSessionIds,
   $workingSessionIds,
   clearAllSessionStates,
+  publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
@@ -158,6 +160,7 @@ afterEach(() => {
   vi.clearAllMocks()
   vi.restoreAllMocks()
   clearAllSessionStates()
+  $sessionTiles.set([])
   resetTypingActivityTracking()
 })
 
@@ -218,9 +221,12 @@ describe('active transcript refresh', () => {
     const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
       (sessionId, updater) => {
         updaterCallCount += 1
-        const current = {} as Parameters<typeof updater>[0]
+        const current = states.get(sessionId) ?? createClientSessionState(TILE_STORED_ID)
+        const next = updater(current)
 
-        return updater(current)
+        states.set(sessionId, next)
+
+        return next
       }
     )
 
@@ -228,7 +234,6 @@ describe('active transcript refresh', () => {
 
     const signatureRef = { current: new Map<string, string>() }
     const requestSequenceRef = { current: 0 }
-    const busyRef = { current: false }
 
     vi.mocked(getLatestSessionMessages).mockImplementation(async (storedId: string) => {
       if (storedId === TILE_STORED_ID) {
@@ -250,7 +255,6 @@ describe('active transcript refresh', () => {
     await act(async () => {
       await reconcileTileTranscriptsForTest({
         tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
-        busyRef,
         requestSequenceRef,
         signatureRef,
         updateSessionState
@@ -260,6 +264,160 @@ describe('active transcript refresh', () => {
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
     expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+    expect(states.get(TILE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'background delivery answer'
+    })
+  })
+
+  it('reconciles an idle tile while the main pane is busy', async () => {
+    const runtimeId = 'runtime-idle-tile'
+    const storedId = 'stored-idle-tile'
+    const idleState = createClientSessionState(storedId)
+
+    setBusy(true)
+    publishSessionState(runtimeId, idleState)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('idle tile update', storedId) as never)
+
+    const updateSessionState = vi.fn((sessionId: string, updater: (state: typeof idleState) => typeof idleState) => {
+      expect(sessionId).toBe(runtimeId)
+
+      return updater(idleState)
+    })
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId)
+    expect(updateSessionState).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reconcile a busy tile when the main pane is idle', async () => {
+    const runtimeId = 'runtime-busy-tile'
+    const storedId = 'stored-busy-tile'
+    const liveState = createClientSessionState(storedId)
+
+    liveState.busy = true
+    liveState.messages = [
+      {
+        id: 'live-assistant',
+        parts: [{ text: 'streaming answer', type: 'text' }],
+        pending: true,
+        role: 'assistant'
+      }
+    ]
+    publishSessionState(runtimeId, liveState)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: storedId } as never)
+
+    const updateSessionState = vi.fn()
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('discards a tile snapshot when the tile becomes busy during the read', async () => {
+    const runtimeId = 'runtime-racing-tile'
+    const storedId = 'stored-racing-tile'
+    const idleState = createClientSessionState(storedId)
+    let resolveRead: (value: unknown) => void = () => undefined
+
+    publishSessionState(runtimeId, idleState)
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveRead = resolve
+      }) as never
+    )
+
+    const updateSessionState = vi.fn()
+
+    const reconcile = reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    publishSessionState(runtimeId, {
+      ...idleState,
+      busy: true,
+      messages: [
+        {
+          id: 'live-assistant',
+          parts: [{ text: 'new live output', type: 'text' }],
+          pending: true,
+          role: 'assistant'
+        }
+      ],
+      turnLive: true
+    })
+    resolveRead({ messages: [], session_id: storedId })
+    await reconcile
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('discards a tile snapshot when the tile closes during the read', async () => {
+    const runtimeId = 'runtime-closing-tile'
+    const storedId = 'stored-closing-tile'
+    let resolveRead: (value: unknown) => void = () => undefined
+
+    $sessionTiles.set([{ runtimeId, storedSessionId: storedId }])
+    publishSessionState(runtimeId, createClientSessionState(storedId))
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveRead = resolve
+      }) as never
+    )
+
+    const updateSessionState = vi.fn()
+
+    const reconcile = reconcileTileTranscriptsForTest({
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    $sessionTiles.set([])
+    resolveRead(transcript('stale tile answer', storedId))
+    await reconcile
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('prunes the cached signature after a reconciled tile closes', async () => {
+    const runtimeId = 'runtime-closed-after-reconcile'
+    const storedId = 'stored-closed-after-reconcile'
+    const signatureRef = { current: new Map<string, string>() }
+
+    $sessionTiles.set([{ runtimeId, storedSessionId: storedId }])
+    publishSessionState(runtimeId, createClientSessionState(storedId))
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('reconciled answer', storedId) as never)
+
+    await reconcileTileTranscriptsForTest({
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState: vi.fn((_, updater) => updater(createClientSessionState(storedId)))
+    })
+    expect(signatureRef.current.has(`tile:${storedId}`)).toBe(true)
+
+    $sessionTiles.set([])
+    await reconcileTileTranscriptsForTest({
+      requestSequenceRef: { current: 0 },
+      signatureRef,
+      updateSessionState: vi.fn()
+    })
+
+    expect(signatureRef.current.has(`tile:${storedId}`)).toBe(false)
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
@@ -287,13 +445,11 @@ describe('active transcript refresh', () => {
     signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
 
     const updateSessionState = vi.fn()
-    const busyRef = { current: false }
     const requestSequenceRef = { current: 0 }
 
     await act(async () => {
       await reconcileTileTranscriptsForTest({
         tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
-        busyRef,
         requestSequenceRef,
         signatureRef,
         updateSessionState

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -66,6 +66,12 @@ export interface ActiveTranscriptRefreshDeps {
   ) => ClientSessionState
 }
 
+function tileRuntimeOwnsLiveState(runtimeId: string): boolean {
+  const state = $sessionStates.get()[runtimeId]
+
+  return Boolean(state && (state.busy || state.awaitingResponse || state.needsInput || state.turnLive))
+}
+
 /**
  * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
  * slice 1). Bot canonical chats live here — never in $sessions /
@@ -84,12 +90,10 @@ export interface ActiveTranscriptRefreshDeps {
  */
 export async function reconcileTileTranscripts({
   requestSequenceRef,
-  busyRef,
   signatureRef,
   updateSessionState,
   tiles: tilesOverride
 }: {
-  busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
   tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
@@ -100,6 +104,13 @@ export async function reconcileTileTranscripts({
   ) => ClientSessionState
 }): Promise<void> {
   const tiles = tilesOverride ?? $sessionTiles.get()
+  const openSignatureKeys = new Set(tiles.map(tile => `tile:${tile.storedSessionId}`))
+
+  for (const signatureKey of signatureRef.current.keys()) {
+    if (!openSignatureKeys.has(signatureKey)) {
+      signatureRef.current.delete(signatureKey)
+    }
+  }
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
@@ -110,7 +121,7 @@ export async function reconcileTileTranscripts({
       continue
     }
 
-    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+    if (!storedSessionId || !runtimeSessionId || tileRuntimeOwnsLiveState(runtimeSessionId)) {
       continue
     }
 
@@ -123,14 +134,15 @@ export async function reconcileTileTranscripts({
 
     // With a tiles override (test path), the live $sessionTiles check can't
     // see the synthetic tile — treat override tiles as present.
-    const stillPresent = tilesOverride
-      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
-      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+    const tileStillPresent = () =>
+      tilesOverride
+        ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+        : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
 
     try {
       const latest = await getLatestSessionMessages(storedSessionId)
 
-      if (requestId !== requestSequenceRef.current || busyRef.current || !stillPresent) {
+      if (requestId !== requestSequenceRef.current || tileRuntimeOwnsLiveState(runtimeSessionId) || !tileStillPresent()) {
         // Tile closed or superseded mid-read — discard AND prune its
         // signature so the map doesn't grow one entry per ever-opened tile
         // for the app's lifetime (#94255 review point 3).
@@ -547,10 +559,8 @@ export function useBackgroundSync({
   // transcript signatures, so no-change ticks and closed tiles cost nothing.
   const tileRequestSequenceRef = useRef(0)
   const tileSignatureRef = useRef(new Map<string, string>())
-  // Read $busy.get() directly inside the reconcile loop instead of mirroring
-  // the atom into a ref (lint: no-restricted-syntax — refs synced from atoms
-  // lag one render). The reconcile runs on tick, not render, so .get() is
-  // always current.
+  // Tile reconciliation reads each runtime's live state directly from
+  // $sessionStates; the primary chat's $busy atom has no authority over tiles.
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -697,11 +707,6 @@ export function useBackgroundSync({
       // (#93942 scenario A). Signature-gated per tile, so no-change ticks
       // cost nothing.
       void reconcileTileTranscripts({
-        busyRef: {
-          get current() {
-            return $busy.get()
-          }
-        },
         requestSequenceRef: tileRequestSequenceRef,
         signatureRef: tileSignatureRef,
         updateSessionState


### PR DESCRIPTION
## What does this PR do?

Hardens the workspace-tile transcript reconciliation introduced by #95600 / #94255 so a persisted snapshot cannot replace a tile's live output or make unrelated tabs jump.

`reconcileTileTranscripts()` currently gates every tile with the main pane's global `$busy` state. That produces both failure directions:

- an idle tile is not reconciled while the main pane is busy;
- a busy tile is still reconciled while the main pane is idle, so a stale persisted snapshot can overwrite its live transcript.

The async read also captures tile presence before `getLatestSessionMessages()`, allowing a result to land after the tile becomes busy, closes, or is rebound.

## Changes

- decide liveness per tile runtime from `$sessionStates` (`busy`, `awaitingResponse`, `needsInput`, or `turnLive`);
- check that runtime-specific liveness both before and after the async storage read;
- re-read the live stored-session/runtime pair after the await so closed or rebound tiles discard stale results;
- prune signature entries for tiles that have closed, including after a successful earlier reconciliation;
- preserve idle-tile refresh while the main pane is busy;
- leave the main-pane backfill and empty-transcript behavior unchanged.

This is complementary to #95770 (cheap no-change fetch gating) and #96215 (warm-cache refresh on explicit Bot Chat reopen); neither protects an active tile from an in-flight persisted snapshot.

## Regression proof

On current `origin/main` / `v0.20.6`, with only a test-harness compatibility default for the old `busyRef` signature:

```text
use-background-sync.test.ts: 5 failed, 26 passed
```

The five failures are the intended contracts:

1. idle tile still reconciles while the main pane is busy;
2. busy tile is skipped while the main pane is idle;
3. tile becoming busy during the read rejects the snapshot;
4. tile closing during the read rejects the snapshot;
5. closed-tile signature is pruned.

On this branch:

```text
use-background-sync.test.ts: 31 passed
TypeScript typecheck (all three desktop tsconfigs): passed
Scoped ESLint: passed
Production desktop build + assert-dist-built: passed
git diff --check: passed
```

## Scope

Only these files change:

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts`
