### PR TITLE
fix(desktop): unwrap Mistral Voxtral JSON in client-direct STT

### DIFF
--- a/apps/desktop/src/lib/voice-client-direct.test.ts
+++ b/apps/desktop/src/lib/voice-client-direct.test.ts
@@ -8,7 +8,8 @@ import {
   type DirectTtsConfig,
   fetchVoiceClientConfig,
   synthesizeSpeechClientDirect,
-  transcribeAudioClientDirect
+  transcribeAudioClientDirect,
+  transcriptFromOpenAiMultipartBody
 } from './voice-client-direct'
 
 const directStt = {
@@ -115,6 +116,35 @@ describe('transcribeAudioClientDirect', () => {
     expect(form.get('model')).toBe('whisper-large-v3-turbo')
     expect(form.get('language')).toBe('en')
     expect(form.get('response_format')).toBe('text')
+  })
+
+  it('unwraps Mistral Voxtral JSON instead of dumping it into the composer', async () => {
+    mockDesktopApi({
+      ok: true,
+      stt: {
+        ...directStt,
+        provider: 'mistral',
+        base_url: 'https://api.mistral.ai/v1',
+        model: 'voxtral-mini-latest',
+        language: null
+      },
+      tts: relay
+    })
+
+    const voxtral = {
+      model: 'voxtral-mini-latest',
+      text: 'Hallo, bist du da?',
+      language: null,
+      segments: [],
+      usage: { prompt_audio_seconds: 4, total_tokens: 388 },
+      finish_reason: null
+    }
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(voxtral), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await transcribeAudioClientDirect(new Blob(['x'], { type: 'audio/webm' }))).toBe(
+      'Hallo, bist du da?'
+    )
   })
 
   it('returns null (relay) when the provider is not client-callable', async () => {
@@ -243,6 +273,36 @@ describe('synthesizeSpeechClientDirect', () => {
     )
 
     await expect(synthesizeSpeechClientDirect(openaiTts, 'Hi.')).rejects.toThrow(/openai TTS error.*429/)
+  })
+})
+
+describe('transcriptFromOpenAiMultipartBody', () => {
+  it('keeps Groq/OpenAI plain-text bodies', () => {
+    expect(transcriptFromOpenAiMultipartBody('  hello world  ')).toBe('hello world')
+  })
+
+  it('extracts .text from a Voxtral JSON envelope', () => {
+    expect(
+      transcriptFromOpenAiMultipartBody(
+        JSON.stringify({
+          model: 'voxtral-mini-latest',
+          text: 'Hallo, bist du da?',
+          language: null,
+          segments: [],
+          usage: { prompt_audio_seconds: 4 }
+        })
+      )
+    ).toBe('Hallo, bist du da?')
+  })
+
+  it('treats a JSON envelope with empty text as silence', () => {
+    expect(transcriptFromOpenAiMultipartBody(JSON.stringify({ text: '  ', model: 'voxtral-mini-latest' }))).toBe(
+      ''
+    )
+  })
+
+  it('leaves a non-envelope JSON object intact', () => {
+    expect(transcriptFromOpenAiMultipartBody('{"error":"nope"}')).toBe('{"error":"nope"}')
   })
 })
 

--- a/apps/desktop/src/lib/voice-client-direct.ts
+++ b/apps/desktop/src/lib/voice-client-direct.ts
@@ -141,6 +141,36 @@ async function providerErrorText(response: Response): Promise<string> {
 }
 
 /**
+ * Normalize an OpenAI-compatible transcription HTTP body to spoken text.
+ *
+ * Groq and OpenAI honor `response_format=text` and return a bare string.
+ * Mistral Voxtral ignores that flag and returns JSON
+ * `{ text, model, usage, ... }` — dumping that object into the Desktop
+ * composer is the dictation regression (plain speech becomes raw JSON).
+ */
+export function transcriptFromOpenAiMultipartBody(body: string): string {
+  const trimmed = String(body || '').trim()
+
+  if (!trimmed) {
+    return ''
+  }
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as { text?: unknown }
+
+      if (typeof parsed?.text === 'string') {
+        return parsed.text.trim()
+      }
+    } catch {
+      // Not JSON — treat the body as the transcript.
+    }
+  }
+
+  return trimmed
+}
+
+/**
  * Transcribe provider-direct. Returns the transcript ('' = silence), or null
  * when the profile's provider isn't client-callable — the caller relays.
  * Provider REJECTIONS throw: the configured provider said no, and silently
@@ -179,7 +209,7 @@ export async function transcribeAudioClientDirect(audio: Blob): Promise<null | s
       throw new Error(`${stt.provider} STT error (HTTP ${response.status}): ${await providerErrorText(response)}`)
     }
 
-    return (await response.text()).trim()
+    return transcriptFromOpenAiMultipartBody(await response.text())
   }
 
   if (stt.wire === 'xai-stt') {


### PR DESCRIPTION
## Summary
- Desktop dictation with Mistral Voxtral was pasting the raw transcription JSON into the prompt instead of the spoken words (`"Hallo, bist du da?"` lived in `.text`, but the composer showed the whole object).
- Client-direct STT asks for `response_format=text` (OpenAI/Groq honor that). Voxtral ignores it and returns `{ text, model, usage, ... }`. The openai-multipart path now unwraps `.text` when the body is that envelope, and still keeps plain-text Groq/OpenAI bodies as-is.

## Test plan
- [ ] `npm run test --workspace apps/desktop -- src/lib/voice-client-direct.test.ts`
- [ ] Desktop Settings → STT provider `mistral` (`voxtral-mini-latest`), dictate a short phrase, confirm the composer shows the spoken text (not JSON).
- [ ] Repeat with Groq/OpenAI STT and confirm plain-text transcripts are unchanged.
- [ ] Optional: `voice.client_direct: false` still relays through `/api/audio/transcribe` without dumping JSON.