### PR TITLE
feat(desktop): persist accent picker selections

### DIFF
--- a/apps/desktop/src/plugins/accent/picker.tsx
+++ b/apps/desktop/src/plugins/accent/picker.tsx
@@ -14,7 +14,7 @@
 //
 // It drives `$accentOverride`, which the theme context feeds through
 // `retintTheme`, so the whole app repaints against the REAL derivation on every
-// pointer move. Nothing persists: reload and you're back on the authored theme.
+// pointer move. The plugin provides an explicit Save action for persistence.
 //
 // Sizing note: the statusbar is `h-5` (20px). The TRIGGER must live inside that
 // band or it clips to a sliver; the panel is a popover and can be any size.
@@ -198,7 +198,7 @@ function HueRail({ lch, onPick }: { lch: Oklch; onPick: (h: number) => void }) {
   )
 }
 
-function AccentPicker() {
+function AccentPicker({ onSave }: { onSave: () => void }) {
   const { theme, renderedMode } = useTheme()
   const override = useValue($accentOverride)
   const painted = theme.colors.primary
@@ -253,6 +253,13 @@ function AccentPicker() {
         >
           reset
         </button>
+        <button
+          className="shrink-0 rounded-sm border border-(--dt-border) px-1.5 py-0.5 text-[11px]"
+          onClick={onSave}
+          type="button"
+        >
+          save
+        </button>
       </div>
 
       <div className="grid grid-cols-8 gap-1">
@@ -294,7 +301,7 @@ function AccentPicker() {
   )
 }
 
-export function AccentPickerTrigger() {
+export function AccentPickerTrigger({ onSave }: { onSave: () => void }) {
   const { theme } = useTheme()
 
   return (
@@ -318,7 +325,7 @@ export function AccentPickerTrigger() {
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-auto p-0" side="top">
-        <AccentPicker />
+        <AccentPicker onSave={onSave} />
       </PopoverContent>
     </Popover>
   )

--- a/apps/desktop/src/plugins/accent/plugin.tsx
+++ b/apps/desktop/src/plugins/accent/plugin.tsx
@@ -5,7 +5,8 @@
  * one color, and it works on any theme with any accent; this plugin is only the
  * control surface for it. That split is deliberate: the retint is core behavior
  * that Appearance settings and ⌘K should be able to drive too, while the
- * statusbar picker is an authoring tool most users never need.
+ * statusbar picker is an authoring tool most users never need. The picker can
+ * explicitly save its current accent through the plugin-scoped storage API.
  *
  * Ships OFF (`defaultEnabled: false`): it inventories in Settings ▸ Plugins and
  * registers nothing until the switch is flipped. With it off, `$accentOverride`
@@ -22,12 +23,20 @@ const plugin: HermesPlugin = {
   id: 'accent',
   name: 'Accent Picker',
   description:
-    'Pick the theme accent from an OKLCH color picker in the status bar; the palette re-derives live. Authoring tool — the color is not persisted.',
+    'Pick the theme accent from an OKLCH color picker in the status bar; the palette re-derives live. Press Save to persist the selected accent.',
   defaultEnabled: false,
   register(ctx) {
-    // The override is a scratch value, not a setting. Dropping it on unregister
-    // means disabling the plugin (or reloading) returns every surface to the
-    // authored theme instead of stranding a color with no control to clear it.
+    const savedAccent = ctx.storage.get<string | null>('savedAccent', null)
+
+    // Restore only an explicitly saved accent. Live changes remain previews
+    // until the user presses Save.
+    if (savedAccent) {
+      setAccentOverride(savedAccent)
+    }
+
+    // Dropping the override on unregister means disabling the plugin (or
+    // reloading) returns every surface to the authored theme. The saved value
+    // remains in plugin storage and is restored when the plugin is enabled.
     ctx.onDispose(() => setAccentOverride(null))
 
     ctx.registerMany([
@@ -35,7 +44,7 @@ const plugin: HermesPlugin = {
         id: 'picker',
         area: STATUSBAR_AREAS.right,
         order: 90,
-        render: () => <AccentPickerTrigger />
+        render: () => <AccentPickerTrigger onSave={() => ctx.storage.set('savedAccent', $accentOverride.get())} />
       },
       {
         id: 'reset',


### PR DESCRIPTION
## What does this PR do?

Adds an explicit **Save** action to the Desktop Accent Picker.

Previously, accent changes were preview-only and reset when the plugin was reloaded.
This change keeps live picker adjustments temporary until the user clicks **save**.
The explicitly saved accent is persisted in plugin-scoped storage and restored when
the Accent Picker plugin is enabled or reloaded.

## Related Issue

Related to #91107: this PR implements explicit saved Accent Picker persistence while keeping unsaved adjustments transient.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a **save** button to `apps/desktop/src/plugins/accent/picker.tsx`.
- Passed an `onSave` callback from the Accent Picker plugin to the picker UI.
- Persisted the explicitly saved override under the plugin-scoped `savedAccent` key.
- Restored a saved accent when `apps/desktop/src/plugins/accent/plugin.tsx` registers.
- Kept unsaved picker changes as transient live previews.

## How to Test

1. Run Hermes Desktop in development mode and enable the **Accent Picker** plugin.
2. Open the picker from the status bar, choose a noticeably different accent color,
   then click **save**.
3. Restart/reload the Desktop app or disable and re-enable the plugin.
4. Confirm that the saved accent is restored.
5. Change a color without clicking **save**, reload the plugin, and confirm that
   the unsaved preview is not persisted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual verification completed on Windows 11:

- `npm run typecheck` passed.
- `git diff --check` passed.
- Selected an accent, clicked **save**, restarted the Desktop development build,
  and confirmed the saved accent persisted.