### PR TITLE
fix: emit Hermes backend READY sentinel to real stdout on serve

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19874,7 +19874,14 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # tui_gateway.server reassigns sys.stdout -> sys.stderr at import time
+            # (to keep its stdio JSON-RPC protocol clean). `serve` imports that
+            # module, so a plain print() here would emit the port announcement to
+            # STDERR — but the Desktop's port-waiter parses only STDOUT and would
+            # time out. Route the sentinel to the real stdout (sys.__stdout__),
+            # falling back to stderr if the original was detached.
+            _announce_stream = sys.__stdout__ if sys.__stdout__ is not None else sys.stderr
+            print(f"{ready_token} port={actual_port}", file=_announce_stream, flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.


### PR DESCRIPTION
## Summary

`hermes serve` announces its port with the sentinel line `HERMES_BACKEND_READY port=<port>`. This line was being emitted on **stderr**, not stdout.

**Root cause:** `tui_gateway/server.py` reassigns `sys.stdout -> sys.stderr` at import time (module-level) to keep its stdio JSON-RPC protocol clean. `hermes serve` imports that module, so by the time `web_server.py` print()s the READY announcement, Python's `sys.stdout` has already been replaced by `sys.stderr`.

The desktop app's port-waiter (`waitForDashboardPort`) parses **only `child.stdout`** — so it never sees the sentinel and always fails boot after 90s with:

```
Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

Effectively, the packaged desktop app could never boot on Windows: each launch spawned the backend, the backend announced READY (visible in `desktop.log` via the stderr relay), then the desktop timed out and re-spawned forever.

## Fix

Route the announcement to the real stdout (`sys.__stdout__`), falling back to stderr only if the original stdout was detached:

```python
_announce_stream = sys.__stdout__ if sys.__stdout__ is not None else sys.stderr
print(f"{ready_token} port={actual_port}", file=_announce_stream, flush=True)
```

`sys.__stdout__` preserves the true stdout even though `tui_gateway` reassigns `sys.stdout`.

Note: `serve` already has a ready-file side channel (`HERMES_DESKTOP_READY_FILE`) that the desktop does use in some code paths — but the local (non-SSH) path goes through `waitForDashboardPort` (stdout), so this fix is what makes the common local boot succeed.

## Verification

- Before: `serve` printed READY to **stderr** (stdout empty) — reproduced with `python -m hermes_cli.main serve ...` splitting streams.
- After: READY appears on **stdout**.
- End-to-end: launching the packaged desktop app now logs `Hermes backend is ready. Finalizing desktop startup` with no timeout, and the backend is reachable (established connection from renderer).

## Test Plan
- [x] `serve` announces READY on stdout (split-stream check)
- [x] Packaged desktop app boots past the 90s window
- [ ] Downstream CI passes
