### PR TITLE
fix(desktop): expanded thinking block swallows wheel scroll (#96094)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -237,10 +237,12 @@ const ThinkingDisclosure: FC<{
           className={cn(
             // Body sits flush with the "Thinking" header — no left indent —
             // and inherits the disclosure-level opacity fade defined in
-            // styles.css (~0.67 at rest, 1 on hover/focus). overflow-auto so
-            // the max-h-40 preview is a real scroller, not a clip.
-            'mt-0.5 w-full min-w-0 max-w-full overflow-auto overscroll-contain wrap-anywhere pb-1',
-            isPreview && 'max-h-40'
+            // styles.css (~0.67 at rest, 1 on hover/focus). overflow-auto +
+            // overscroll-contain are preview-only so the expanded body (no
+            // max-h) doesn't become a dead scroll container that swallows the
+            // wheel instead of chaining it to the thread viewport (#96094).
+            'mt-0.5 w-full min-w-0 max-w-full wrap-anywhere pb-1',
+            isPreview && 'max-h-40 overflow-auto overscroll-contain'
           )}
           data-slot="aui_thinking-body"
           ref={scrollRef}

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -1,5 +1,6 @@
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { useEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -641,6 +642,30 @@ describe('assistant-ui streaming renderer', () => {
     expect(settled).toContain('max-h-40')
     expect(settled).toMatch(/\boverflow-auto\b/)
     expect(settled).not.toMatch(/\boverflow-hidden\b/)
+  })
+
+  it('expanded thinking body does not swallow the wheel (#96094)', async () => {
+    // Manually expanded (not preview): the body has no max-h, so it must not be
+    // a scroll container — otherwise overscroll-contain swallows the wheel
+    // instead of chaining it to the thread viewport.
+    const { container, settle } = renderSettlingReasoning()
+
+    // Collapse the live preview first, then manually expand it (userOpen=true, isPreview=false).
+    const toggle = within(container).getByRole('button', { name: /thought/i })
+    await userEvent.click(toggle)
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    })
+    await userEvent.click(toggle)
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    const expanded = container.querySelector('[data-slot="aui_thinking-body"]')?.className ?? ''
+
+    expect(expanded).not.toMatch(/\boverflow-auto\b/)
+    expect(expanded).not.toMatch(/\boverscroll-contain\b/)
+    expect(expanded).not.toMatch(/\bmax-h-40\b/)
   })
 
   it('does not collapse a live thinking preview when the turn settles', async () => {


### PR DESCRIPTION
## Summary

Manually expanded thinking blocks swallow the wheel scroll — the body becomes a dead `overflow:auto` container whose `overscroll-behavior: contain` chains the wheel to itself instead of the thread viewport.

Root cause is PR #95783 (`be7eefec8d`), which added `overflow-auto overscroll-contain` unconditionally while `max-h-40` is gated on `isPreview`. When expanded (`isPreview=false`), the body has no height cap → `scrollHeight === clientHeight` → no internal scroll, yet it still swallows the wheel. Same trap documented for the session list in #84964.

Fix scopes `overflow-auto overscroll-contain` to the preview only. The expanded body reverts to a normal block — wheel chains to the transcript.

Closes #96094.

## Test plan

- [x] Expanded body no longer carries `overflow-auto` or `overscroll-contain` (new test)
- [x] Preview path unchanged — still carries `max-h-40 overflow-auto overscroll-contain`
- [x] Existing `streaming.test.tsx` tests still pass
- [x] Branch based on current `upstream/main`

🤖 Generated with [natural-language-commit](https://github.com/mparsia/natural-language-commit)