### PR TITLE
fix(cron,kanban): close fd-leak residuals from #96290 — gated-run SessionDB open, kanban PRAGMA-failure abandon

### DIFF
--- a/contributors/emails/hjharris1@gmail.com
+++ b/contributors/emails/hjharris1@gmail.com
@@ -1,0 +1,2 @@
+Hjharris1
+# PR #96290 salvage

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3984,6 +3984,40 @@ def _get_media_send_timeout() -> int:
     return _DEFAULT_MEDIA_SEND_TIMEOUT
 
 
+def _get_session_db_timeout() -> float:
+    """Resolve the bound on run_job's SessionDB init from env/config.
+
+    Mirrors the ``script_timeout_seconds`` resolution pattern: the
+    HERMES_CRON_SESSION_DB_TIMEOUT env var wins, then
+    ``cron.session_db_timeout_seconds`` in config.yaml (present in
+    DEFAULT_CONFIG, so ``load_config()``'s deep-merge supplies it), then
+    10s. Unlike the sibling timeouts, 0 is meaningful (unlimited — legacy
+    behavior, opt-in for debugging), so values are passed through untouched.
+    """
+    env_value = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+    if env_value:
+        try:
+            return float(env_value)
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                env_value,
+            )
+
+    try:
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        configured = cron_cfg.get("session_db_timeout_seconds")
+        if configured is not None:
+            return float(configured)
+    except Exception as exc:
+        logger.debug(
+            "Failed to load cron.session_db_timeout_seconds from config: %s", exc
+        )
+
+    return 10.0
+
+
 def _read_windows_pyvenv_cfg(venv_dir: Path) -> dict[str, str]:
     cfg_path = venv_dir / "pyvenv.cfg"
     try:
@@ -6305,48 +6339,13 @@ def run_job(
         # which only watches the agent's run_conversation below):
         # SessionDB.__init__ opens/migrates state.db synchronously and has no
         # timeout of its own against a wedged sqlite3.connect (e.g. a stale
-        # flock left by a crashed sibling process). An unbounded hang here is
-        # invisible to every other cron safeguard, because it happens BEFORE
-        # _submit_with_guard's future exists — the finally block that releases
-        # the job from _running_job_ids never runs, so the job stays wedged
-        # "running" until the whole gateway process is restarted, silently
-        # skipping every scheduled fire in between with
-        # "already running — skipping".
-        _session_db_timeout: float | None = None
+        # flock left by a crashed sibling process). An unbounded hang here
+        # would wedge the job's worker thread, so the init is bounded and a
+        # timeout proceeds without a session store instead of blocking the
+        # run forever.
+        _session_db_timeout = _get_session_db_timeout()
         try:
             from hermes_state import SessionDB
-
-            # Resolve timeout: env override → config.yaml → default 10s.
-            # Mirrors the script_timeout_seconds resolution pattern.
-            _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-            if _raw_env_timeout:
-                try:
-                    _session_db_timeout = float(_raw_env_timeout)
-                except (ValueError, TypeError):
-                    logger.warning(
-                        "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                        _raw_env_timeout,
-                    )
-            if _session_db_timeout is None:
-                try:
-                    # _cfg was already loaded above for model/toolset routing.
-                    _cron_cfg_for_db = (
-                        _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                    )
-                    _configured = (
-                        _cron_cfg_for_db.get("session_db_timeout_seconds")
-                        if isinstance(_cron_cfg_for_db, dict)
-                        else None
-                    )
-                    if _configured is not None:
-                        _session_db_timeout = float(_configured)
-                except Exception as exc:
-                    logger.debug(
-                        "Failed to load cron.session_db_timeout_seconds from config: %s",
-                        exc,
-                    )
-            if _session_db_timeout is None:
-                _session_db_timeout = 10.0
 
             if _session_db_timeout > 0:
                 _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5602,81 +5602,12 @@ def run_job(
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
-    # Initialize SQLite session store so cron job messages are persisted
-    # and discoverable via session_search (same pattern as gateway/run.py).
-    #
-    # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT, which
-    # only watches the agent's run_conversation below): SessionDB.__init__
-    # opens/migrates state.db synchronously and has no timeout of its own
-    # against a wedged sqlite3.connect (e.g. a stale flock left by a crashed
-    # sibling process). An unbounded hang here is invisible to every other
-    # cron safeguard, because it happens BEFORE _submit_with_guard's future
-    # exists — the finally block that releases the job from
-    # _running_job_ids never runs, so the job stays wedged "running" until
-    # the whole gateway process is restarted, silently skipping every
-    # scheduled fire in between with "already running — skipping".
-    _session_db = None
-    try:
-        from hermes_state import SessionDB
-
-        # Resolve timeout: env override → config.yaml → default 10s.
-        # Mirrors the script_timeout_seconds resolution pattern.
-        _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-        if _raw_env_timeout:
-            try:
-                _session_db_timeout = float(_raw_env_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                    _raw_env_timeout,
-                )
-        if _session_db_timeout is None:
-            try:
-                from hermes_cli.config import load_config
-                _cfg = load_config() or {}
-                _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                _configured = _cron_cfg.get("session_db_timeout_seconds")
-                if _configured is not None:
-                    _session_db_timeout = float(_configured)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to load cron.session_db_timeout_seconds from config: %s",
-                    exc,
-                )
-        if _session_db_timeout is None:
-            _session_db_timeout = 10.0
-
-        if _session_db_timeout > 0:
-            _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            _session_db_future = _session_db_pool.submit(SessionDB)
-            try:
-                _session_db = _session_db_future.result(timeout=_session_db_timeout)
-            except concurrent.futures.TimeoutError:
-                # The worker is abandoned (shutdown below doesn't wait for it).
-                # If SessionDB() later completes inside it, the future's result
-                # would be orphaned and its SQLite FDs (.db, WAL, SHM) leak
-                # until process exit.  Register a done-callback that retrieves
-                # and closes any eventual late result (#72782).
-                _session_db_future.add_done_callback(_close_late_session_db_result)
-                raise
-            finally:
-                # Don't wait for a wedged connect() to unwind — abandon the
-                # worker thread (same pattern as the agent inactivity timeout
-                # further down) rather than blocking shutdown on it too.
-                _session_db_pool.shutdown(wait=False)
-        else:
-            # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
-    except concurrent.futures.TimeoutError:
-        logger.error(
-            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
-            "without a session store for this run instead of blocking it "
-            "forever",
-            job.get("id", "?"), _session_db_timeout,
-        )
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+    # NOTE: the SQLite session store used to be initialized here, BEFORE the
+    # wake-gate and prompt-validation early returns below. Every gated run
+    # (``wakeAgent: false``, blocked prompt) opened state.db and returned
+    # without reaching the finally that closes it, relying on GC to release
+    # the handle. Init now happens inside the main try, right before the
+    # agent is constructed — after every early-return path (#96290).
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -5848,6 +5779,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _session_db = None
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -6362,6 +6294,92 @@ def run_job(
                 "Job '%s': MCP initialization failed (non-fatal): %s",
                 job_id, _mcp_exc,
             )
+
+        # Initialize the SQLite session store so cron job messages are
+        # persisted and discoverable via session_search (same pattern as
+        # gateway/run.py) — only now, after every early-return path
+        # (wake-gate, prompt validation, drift skip) has passed, so a gated
+        # run never opens state.db just to abandon the handle (#96290).
+        #
+        # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT,
+        # which only watches the agent's run_conversation below):
+        # SessionDB.__init__ opens/migrates state.db synchronously and has no
+        # timeout of its own against a wedged sqlite3.connect (e.g. a stale
+        # flock left by a crashed sibling process). An unbounded hang here is
+        # invisible to every other cron safeguard, because it happens BEFORE
+        # _submit_with_guard's future exists — the finally block that releases
+        # the job from _running_job_ids never runs, so the job stays wedged
+        # "running" until the whole gateway process is restarted, silently
+        # skipping every scheduled fire in between with
+        # "already running — skipping".
+        _session_db_timeout: float | None = None
+        try:
+            from hermes_state import SessionDB
+
+            # Resolve timeout: env override → config.yaml → default 10s.
+            # Mirrors the script_timeout_seconds resolution pattern.
+            _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+            if _raw_env_timeout:
+                try:
+                    _session_db_timeout = float(_raw_env_timeout)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                        _raw_env_timeout,
+                    )
+            if _session_db_timeout is None:
+                try:
+                    # _cfg was already loaded above for model/toolset routing.
+                    _cron_cfg_for_db = (
+                        _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
+                    )
+                    _configured = (
+                        _cron_cfg_for_db.get("session_db_timeout_seconds")
+                        if isinstance(_cron_cfg_for_db, dict)
+                        else None
+                    )
+                    if _configured is not None:
+                        _session_db_timeout = float(_configured)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to load cron.session_db_timeout_seconds from config: %s",
+                        exc,
+                    )
+            if _session_db_timeout is None:
+                _session_db_timeout = 10.0
+
+            if _session_db_timeout > 0:
+                _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                _session_db_future = _session_db_pool.submit(SessionDB)
+                try:
+                    _session_db = _session_db_future.result(timeout=_session_db_timeout)
+                except concurrent.futures.TimeoutError:
+                    # The worker is abandoned (shutdown below doesn't wait for
+                    # it). If SessionDB() later completes inside it, the
+                    # future's result would be orphaned and its SQLite FDs
+                    # (.db, WAL, SHM) leak until process exit.  Register a
+                    # done-callback that retrieves and closes any eventual
+                    # late result (#72782).
+                    _session_db_future.add_done_callback(_close_late_session_db_result)
+                    raise
+                finally:
+                    # Don't wait for a wedged connect() to unwind — abandon the
+                    # worker thread (same pattern as the agent inactivity
+                    # timeout further down) rather than blocking shutdown on
+                    # it too.
+                    _session_db_pool.shutdown(wait=False)
+            else:
+                # 0 = unlimited (legacy behavior, opt-in for debugging)
+                _session_db = SessionDB()
+        except concurrent.futures.TimeoutError:
+            logger.error(
+                "Job '%s': SessionDB init did not return within %.0fs — proceeding "
+                "without a session store for this run instead of blocking it "
+                "forever",
+                job.get("id", "?"), _session_db_timeout,
+            )
+        except Exception as e:
+            logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
         agent = AIAgent(
             model=model,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1589,10 +1589,21 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
         isolation_level=None,
         timeout=busy_timeout_ms / 1000.0,
     )
-    # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
-    # the PRAGMA explicitly so it is observable and survives future wrapper
-    # changes. Parameter binding is not supported for PRAGMA assignments.
-    conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    try:
+        # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
+        # the PRAGMA explicitly so it is observable and survives future wrapper
+        # changes. Parameter binding is not supported for PRAGMA assignments.
+        conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    except BaseException:
+        # A half-open connection abandoned here would leak its fd AND leave a
+        # stale entry in the connect_tracked live-connection registry (which
+        # only clears on close), permanently blocking byte-level probes of
+        # this database file. Close before re-raising.
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
     return conn
 
 

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -345,3 +345,38 @@ class TestLateSessionDbClosedAfterTimeout:
             "The SessionDB that completed after the timeout must be closed by "
             "the done-callback — otherwise its SQLite FDs leak until process exit (#72782)"
         )
+
+
+# ===========================================================================
+# #96290: gated runs must not open the session store at all
+# ===========================================================================
+
+class TestSessionDbInitAfterEarlyReturns:
+    """SessionDB init moved AFTER the wake-gate / prompt-validation early
+    returns (#96290): a run that never reaches the agent must never open
+    state.db, so there is no handle for a gated return path to abandon."""
+
+    def test_wake_gate_false_never_opens_session_db(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_SESSION_DB_TIMEOUT", raising=False)
+        job = {
+            "id": "gated-no-db",
+            "name": "gated-no-db",
+            "prompt": "hello",
+            "script": "gate.py",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB") as mock_db_cls, \
+             patch(
+                 "cron.scheduler._run_job_script_with_claim_heartbeat",
+                 return_value=(True, '{"wakeAgent": false}'),
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        mock_db_cls.assert_not_called()
+        mock_agent_cls.assert_not_called()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1007,6 +1007,39 @@ def test_connect_works_when_wal_is_silently_refused(tmp_path, monkeypatch, caplo
     )
 
 
+def test_sqlite_connect_closes_tracked_conn_on_setup_failure(tmp_path, monkeypatch):
+    """A PRAGMA failure after connect must not abandon a tracked kanban fd."""
+    from hermes_cli import sqlite_safe_read
+
+    db_path = tmp_path / "kanban.db"
+    real_connect = sqlite3.connect
+    opened = []
+
+    class _BusyTimeoutFailure(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if str(sql).startswith("PRAGMA busy_timeout="):
+                raise sqlite3.OperationalError("simulated setup failure")
+            return super().execute(sql, *args, **kwargs)
+
+    def failing_connect(*args, **kwargs):
+        kwargs.pop("factory", None)
+        conn = real_connect(*args, factory=_BusyTimeoutFailure, **kwargs)
+        opened.append(conn)
+        return conn
+
+    key = sqlite_safe_read._key(db_path)
+    with sqlite_safe_read._live_lock:
+        before = sqlite_safe_read._live_connections.get(key, 0)
+    monkeypatch.setattr(kb.sqlite3, "connect", failing_connect)
+
+    with pytest.raises(sqlite3.OperationalError, match="simulated setup failure"):
+        kb._sqlite_connect(db_path)
+
+    with sqlite_safe_read._live_lock:
+        after = sqlite_safe_read._live_connections.get(key, 0)
+    assert after == before
+
+
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):
     """Regression test for issue #22459.
 


### PR DESCRIPTION
## Summary

Salvages the two fixes from #96290 that are still live on current `main` — the rest of that PR (read-conn pool, /dev/null sink close, mcp/insights/session_search/react close paths) already landed independently via #83226, 87aedbe7b6/0472c31aa1, 3d73821e9d, and #72782.

Contributor commits cherry-picked with @Hjharris1's authorship preserved.

## Changes

- `hermes_cli/kanban_db.py`: `_sqlite_connect` closes the half-open tracked connection before re-raising when the `busy_timeout` PRAGMA fails. Previously the abandoned connection leaked its fd AND left a stale entry in the `sqlite_safe_read` live-connection registry (only cleared on close), permanently blocking byte-level probes of the kanban database.
- `cron/scheduler.py`: SessionDB init moved from the top of `run_job` to inside the main try, right before `AIAgent` construction — after the wake-gate (`wakeAgent: false`), prompt-injection-block, and drift-skip early returns. A gated run no longer opens state.db (full read pool + token-writer machinery + .db/-wal/-shm handles) just to abandon the handle to GC.
- `cron/scheduler.py` (follow-up): the inline env→config→default timeout ladder — the third copy of the pattern — is extracted as `_get_session_db_timeout()` next to `_get_script_timeout`/`_get_media_send_timeout`. Using `load_config()`'s deep-merge means `cron.session_db_timeout_seconds` resolves from DEFAULT_CONFIG instead of a hardcoded fallback that had to stay in sync with it, and drops one redundant `load_config()` from every non-gated job run relative to main.
- Tests: kanban PRAGMA-failure regression test (from #96290, registry-count assertion); new cron gated-run test (mutation-checked: fails on unmodified main where the gated path opens SessionDB, passes with the reorder).

## Validation

| | Before | After |
|---|---|---|
| kanban `busy_timeout` PRAGMA raises | fd + registry entry leaked | connection closed, registry count unchanged |
| cron `wakeAgent: false` run | SessionDB opened + abandoned to GC | SessionDB never constructed |
| `tests/cron/` + `tests/hermes_cli/test_kanban_db.py` | — | 1018 passed; only pre-existing `test_monitor_kind.py` failures (reproduced on unmodified `origin/main`, local-env) |

Closes #96290 residuals; credit to @Hjharris1 for both fixes.
