### PR TITLE
feat(gateway): support persistent room model profiles

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -344,6 +344,7 @@ class Platform(Enum):
     SMS = "sms"
     DINGTALK = "dingtalk"
     API_SERVER = "api_server"
+    NEXTDO = "nextdo"
     WEBHOOK = "webhook"
     MSGRAPH_WEBHOOK = "msgraph_webhook"
     FEISHU = "feishu"
@@ -596,7 +597,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, reasoning, and system prompt.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -605,6 +606,7 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    reasoning: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -614,6 +616,8 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.reasoning is not None:
+            out["reasoning"] = self.reasoning
         return out
 
     @classmethod
@@ -624,6 +628,7 @@ class ChannelOverride:
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            reasoning=data.get("reasoning"),
         )
 
 

--- a/gateway/room_profiles.py
+++ b/gateway/room_profiles.py
@@ -1,0 +1,153 @@
+"""Durable exact-room model profiles, independent of config.yaml."""
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+_VERSION = 1
+_locks_guard = threading.Lock()
+_locks: dict[Path, threading.RLock] = {}
+
+@dataclass(frozen=True)
+class RoomModelProfile:
+    model: str
+    provider: str
+    reasoning: str
+
+
+def exact_room_id(source: Any) -> str | None:
+    thread = str(getattr(source, "thread_id", "") or "").strip()
+    chat = str(getattr(source, "chat_id", "") or "").strip()
+    return thread or chat or None
+
+
+def _platform(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").strip()
+
+
+def _lock_for(path: Path) -> threading.RLock:
+    path = path.resolve()
+    with _locks_guard:
+        return _locks.setdefault(path, threading.RLock())
+
+@contextmanager
+def _sibling_lock(path: Path):
+    lock_path = path.with_name(path.name + ".lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+", encoding="utf-8") as f:
+        windows_lock = False
+        try:
+            import fcntl
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        except ImportError:  # pragma: no cover - Windows
+            import msvcrt
+            f.seek(0)
+            if not f.read(1):
+                f.seek(0); f.write(" "); f.flush()
+            f.seek(0)
+            msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+            windows_lock = True
+        try:
+            yield
+        finally:
+            if windows_lock:
+                import msvcrt
+                f.seek(0); msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+class RoomProfileStore:
+    def __init__(self, path: Path | str | None = None):
+        if path is None:
+            from hermes_constants import get_hermes_home
+            path = Path(get_hermes_home()) / "room_profiles.json"
+        self.path = Path(path).expanduser()
+        self._snapshot: dict[str, Any] | None = None
+        self._invalid = False
+        self.load()
+
+    @staticmethod
+    def _empty() -> dict[str, Any]:
+        return {"version": _VERSION, "profiles": {}}
+
+    @staticmethod
+    def _entry(value: Any) -> RoomModelProfile | None:
+        if not isinstance(value, dict): return None
+        vals = [value.get(k) for k in ("model", "provider", "reasoning")]
+        if not all(isinstance(v, str) and v.strip() for v in vals): return None
+        return RoomModelProfile(*(v.strip() for v in vals))
+
+    def _read(self) -> dict[str, Any]:
+        if not self.path.exists(): return self._empty()
+        try:
+            with self.path.open(encoding="utf-8") as f: raw = json.load(f)
+        except Exception as exc:
+            logger.warning("Cannot read room profile sidecar %s: %s", self.path, exc)
+            raise ValueError("invalid room profile sidecar") from exc
+        if not isinstance(raw, dict) or raw.get("version") != _VERSION or not isinstance(raw.get("profiles"), dict):
+            logger.warning("Unsupported room profile sidecar schema: %s", self.path)
+            raise ValueError("unsupported room profile sidecar")
+        return raw
+
+    def _valid_snapshot(self, raw: dict[str, Any]) -> dict[str, Any]:
+        # Preserve unknown root/platform/entry fields for forward compatibility,
+        # but only expose valid typed entries.
+        result = copy.deepcopy(raw)
+        result["profiles"] = {}
+        for plat, rooms in raw["profiles"].items():
+            if not isinstance(plat, str) or not isinstance(rooms, dict): continue
+            valid = {}
+            for room, value in rooms.items():
+                if isinstance(room, str) and room.strip() and self._entry(value): valid[room] = copy.deepcopy(value)
+                elif value is not None: logger.warning("Ignoring invalid room profile %s/%s", plat, room)
+            if valid: result["profiles"][plat] = valid
+        return result
+
+    def load(self) -> None:
+        try:
+            self._snapshot = self._valid_snapshot(self._read())
+            self._invalid = False
+        except ValueError:
+            self._snapshot = self._empty()
+            self._invalid = True
+
+    def get(self, platform: Any, room_id: str) -> RoomModelProfile | None:
+        if self._invalid: return None
+        room = str(room_id or "").strip()
+        if not room: return None
+        # Reloading here makes external edits visible and keeps fail-closed semantics.
+        self.load()
+        value = (self._snapshot or {}).get("profiles", {}).get(_platform(platform), {}).get(room)
+        return self._entry(value)
+
+    def upsert(self, platform: Any, room_id: str, profile: RoomModelProfile) -> RoomModelProfile:
+        if not isinstance(profile, RoomModelProfile) or self._entry(profile.__dict__) is None:
+            raise ValueError("invalid room model profile")
+        plat, room = _platform(platform), str(room_id or "").strip()
+        if not plat or not room: raise ValueError("platform and room_id are required")
+        with _lock_for(self.path):
+            with _sibling_lock(self.path):
+                raw = self._read()  # authoritative read inside both locks
+                updated = copy.deepcopy(raw)
+                profiles = updated.setdefault("profiles", {})
+                rooms = profiles.setdefault(plat, {})
+                old = rooms.get(room)
+                replacement = {"model": profile.model, "provider": profile.provider, "reasoning": profile.reasoning}
+                if isinstance(old, dict):
+                    replacement = {**old, **replacement}
+                rooms[room] = replacement
+                atomic_json_write(self.path, updated, indent=2)
+                self._snapshot = self._valid_snapshot(updated)
+                self._invalid = False
+        return profile

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,7 @@ from agent.turn_context import (
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.room_profiles import RoomModelProfile, RoomProfileStore, exact_room_id
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -3790,6 +3791,9 @@ def _channel_override_lookup_keys(
     """
     keys: list[str] = []
     seen: set[str] = set()
+    # A trusted thread id is the exact channel identity.  Chat is only the
+    # fallback for messages without a thread; parent remains the final
+    # inheritance fallback for forum/channel adapters.
     for key in (chat_id, thread_id, parent_id):
         if not key:
             continue
@@ -6871,6 +6875,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("could not set multiplex-active flag", exc_info=True)
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self._room_profile_stores: Dict[Path, RoomProfileStore] = {}
+        self._room_profile_stores_lock = threading.Lock()
         # When non-None, SessionDB init failed — the gateway broadcasts a
         # one-time warning to the home channel(s) after connecting, so the
         # user knows persistence is broken instead of discovering it later
@@ -8062,6 +8068,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return source
         return dataclasses.replace(source, thread_id=recovered)
 
+    def _room_profile_store(self) -> RoomProfileStore:
+        from hermes_constants import get_hermes_home
+        path = (Path(get_hermes_home()) / "room_profiles.json").resolve()
+        stores = self.__dict__.setdefault("_room_profile_stores", {})
+        lock = self.__dict__.setdefault("_room_profile_stores_lock", threading.Lock())
+        with lock:
+            return stores.setdefault(path, RoomProfileStore(path))
+
+    def _dynamic_room_profile(self, source: Optional[SessionSource]) -> RoomModelProfile | None:
+        if source is None: return None
+        room = exact_room_id(source)
+        return self._room_profile_store().get(source.platform, room) if room else None
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -8141,6 +8160,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             model = runtime_model
 
+        dynamic = self._dynamic_room_profile(source)
+        if dynamic:
+            model = dynamic.model
+            runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(dynamic.provider)
+            runtime_kwargs["provider"] = dynamic.provider
+
         cfg = getattr(self, "config", None)
         if cfg and source is not None:
             chat_id = str(source.chat_id) if source.chat_id else ""
@@ -8159,7 +8184,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 thread_id=thread_id,
                 parent_id=parent_id,
             )
-            if ch:
+            if ch and not dynamic:
                 if ch.model:
                     model = ch.model
                 if ch.provider:
@@ -9441,6 +9466,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         from hermes_cli.model_switch import resolve_effective_model
 
+        dynamic = self._dynamic_room_profile(SessionSource(platform=platform, chat_id=chat_id, user_id="", thread_id=thread_id))
+        if dynamic: return dynamic.model
         override = None
         config = getattr(self, "config", None)
         if config:
@@ -9555,6 +9582,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
+
+        dynamic = self._dynamic_room_profile(source)
+        if dynamic:
+            from hermes_constants import parse_reasoning_effort
+            parsed = parse_reasoning_effort(dynamic.reasoning)
+            if parsed is not None: return parsed
+
+        # Channel reasoning follows the same trusted platform/chat lookup as
+        # model/provider resolution.  Missing ``reasoning`` is a legacy config
+        # and must fall through to per-model/global resolution.
+        if source is not None:
+            cfg = getattr(self, "config", None)
+            if cfg is not None:
+                channel = _get_channel_override(
+                    cfg, source.platform, str(source.chat_id or ""),
+                    thread_id=str(source.thread_id) if getattr(source, "thread_id", None) else None,
+                    parent_id=str(source.parent_chat_id) if getattr(source, "parent_chat_id", None) else None,
+                )
+                if channel is not None and channel.reasoning is not None:
+                    from hermes_constants import parse_reasoning_effort
+                    parsed = parse_reasoning_effort(channel.reasoning)
+                    if parsed is not None:
+                        return parsed
         return self._load_reasoning_config(model)
 
     def _set_session_reasoning_override(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1748,6 +1748,70 @@ class GatewaySlashCommandsMixin:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
+    # Exact room presets are intentionally duplicated from the adapter picker
+    # as a small, closed allowlist.  Never accept arbitrary values from event
+    # metadata: the adapter supplies only the key, while Hermes owns the tuple.
+    _ROOM_MODEL_PRESETS = {
+        "sol-max": ("gpt-5.6-sol", "openai-codex", "max"),
+        "sol-xhigh": ("gpt-5.6-sol", "openai-codex", "xhigh"),
+        "sol-high": ("gpt-5.6-sol", "openai-codex", "high"),
+        "sol-medium": ("gpt-5.6-sol", "openai-codex", "medium"),
+        "sol-1m-xhigh": ("gpt-5.6-sol-1m-local", "cliproxy", "xhigh"),
+        "luna-max": ("gpt-5.6-luna", "openai-codex", "max"),
+        "luna-xhigh": ("gpt-5.6-luna", "openai-codex", "xhigh"),
+        "55-xhigh": ("gpt-5.5", "openai-codex", "xhigh"),
+        "55-high": ("gpt-5.5", "openai-codex", "high"),
+        "55-medium": ("gpt-5.5", "openai-codex", "medium"),
+    }
+
+    async def _handle_room_model_request(self, event: MessageEvent, request, *, config_path=None) -> Optional[str]:
+        """Persist a trusted NextDo room preset in the profile sidecar."""
+        from hermes_cli.model_switch import switch_model
+        from hermes_constants import parse_reasoning_effort
+        from gateway.room_profiles import RoomModelProfile, exact_room_id
+        source = event.source
+        metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        if (source is None or source.platform != Platform.NEXTDO or
+                metadata.get("route_kind") != "internal_room_model_preset" or
+                metadata.get("synthetic") is not True):
+            return "❌ Room model presets are available only from a trusted NextDo picker event."
+        room = exact_room_id(source)
+        preset_key = metadata.get("preset_key")
+        preset = self._ROOM_MODEL_PRESETS.get(preset_key)
+        if not room: return "❌ Room model preset requires a room chat id."
+        if preset is None: return "❌ Invalid room model preset."
+        model, provider, effort = preset
+        if request.target != model or request.explicit_provider != provider or request.reasoning != effort:
+            return "❌ Room model preset does not match its signed request."
+        if parse_reasoning_effort(effort) is None: return "❌ Invalid reasoning effort."
+        try:
+            result = await asyncio.to_thread(switch_model, raw_input=model,
+                current_provider="openrouter", current_model="", current_base_url="",
+                current_api_key="", is_global=False, explicit_provider=provider,
+                user_providers=None, custom_providers=None)
+            if not result.success or (result.new_model, result.target_provider) != (model, provider):
+                return "❌ Room model preset failed provider/model validation."
+            store = await asyncio.to_thread(self._room_profile_store)
+            await asyncio.to_thread(store.upsert, source.platform, room,
+                RoomModelProfile(model, provider, effort))
+        except Exception as exc:
+            logger.warning("Room model preset sidecar write/validation failed: %s", exc)
+            return "❌ Room model preset was not pinned; runtime is unchanged."
+        # Converge transient state only after durable sidecar success.
+        session_source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
+        session_key = self._session_key_for_source(session_source)
+        try:
+            await self.async_session_store.set_model_override(session_key, None)
+        except Exception as exc:
+            logger.warning("Room preset session override clear failed: %s", exc)
+            return f"❌ Room model preset was saved, but session override clear failed ({exc}); state is partial. Retry the same preset to converge."
+        state = self._session_state(session_key)
+        state.conversation.model_override = None
+        state.conversation.reasoning_override = None
+        getattr(self, "_pending_model_notes", {}).pop(session_key, None)
+        self._evict_cached_agent(session_key)
+        return f"✅ Pinned profile: {preset_key} ({model} / {provider} / reasoning {effort}) for this NextDo room."
+
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model.
 
@@ -1789,6 +1853,8 @@ class GatewaySlashCommandsMixin:
         if request.errors:
             # Gateway decoration: "❌ " prefix over the canonical error copy.
             return f"❌ {request.error_messages()[0]}"
+        if request.is_room:
+            return await self._handle_room_model_request(event, request)
         persist_global = resolve_persist_behavior(
             is_global_flag,
             is_session,

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1434,6 +1434,7 @@ def run_import(args) -> None:
 _QUICK_STATE_FILES = (
     "state.db",
     "config.yaml",
+    "room_profiles.json",
     ".env",
     "auth.json",
     "cron/jobs.json",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -639,6 +639,8 @@ class ModelFlagParseResult:
     force_refresh: bool = False
     is_session: bool = False
     is_once: bool = False
+    reasoning: str = ""
+    is_room: bool = False
 # ---------------------------------------------------------------------------
 # Flag parsing
 # ---------------------------------------------------------------------------
@@ -671,11 +673,13 @@ def parse_model_flags_detailed(raw_args: str) -> ModelFlagParseResult:
     force_refresh = False
     is_session = False
     is_once = False
+    reasoning = ""
+    is_room = False
 
     # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
     # A single Unicode dash before a flag keyword becomes "--"
     import re as _re
-    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|session|refresh|once)', r'--\1', raw_args)
+    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|session|refresh|once|reasoning|room)', r'--\1', raw_args)
 
     # Keep this hand-rolled because model IDs may contain colons/slashes and
     # the historical parser did not require shell quoting.
@@ -695,6 +699,12 @@ def parse_model_flags_detailed(raw_args: str) -> ModelFlagParseResult:
         elif parts[i] == "--once":
             is_once = True
             i += 1
+        elif parts[i] == "--room":
+            is_room = True
+            i += 1
+        elif parts[i] == "--reasoning" and i + 1 < len(parts):
+            reasoning = parts[i + 1].strip().lower()
+            i += 2
         elif parts[i] == "--provider" and i + 1 < len(parts):
             explicit_provider = parts[i + 1]
             i += 2
@@ -710,6 +720,8 @@ def parse_model_flags_detailed(raw_args: str) -> ModelFlagParseResult:
         force_refresh=force_refresh,
         is_session=is_session,
         is_once=is_once,
+        reasoning=reasoning,
+        is_room=is_room,
     )
 
 
@@ -820,6 +832,8 @@ class ModelSwitchRequest:
     is_global: bool = False
     is_session: bool = False
     is_once: bool = False
+    reasoning: str = ""
+    is_room: bool = False
     force_refresh: bool = False
     scope: str = "default"
     errors: tuple = ()
@@ -839,6 +853,8 @@ class ModelSwitchRequest:
             force_refresh=self.force_refresh,
             is_session=self.is_session,
             is_once=self.is_once,
+            reasoning=self.reasoning,
+            is_room=self.is_room,
         )
 
     def error_messages(self) -> list:
@@ -889,6 +905,8 @@ def parse_model_switch_args(raw: str) -> ModelSwitchRequest:
         is_global=parsed.is_global,
         is_session=parsed.is_session,
         is_once=parsed.is_once,
+        reasoning=parsed.reasoning,
+        is_room=parsed.is_room,
         force_refresh=parsed.force_refresh,
         scope=scope,
         errors=tuple(errors),

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -101,6 +101,7 @@ DEFAULT_DIST_OWNED: Tuple[str, ...] = (
 USER_OWNED_EXCLUDE: frozenset = frozenset({
     # Credentials & runtime secrets
     "auth.json", ".env",
+    "room_profiles.json",
     # Databases & runtime state
     "state.db", "state.db-shm", "state.db-wal",
     "hermes_state.db", "response_store.db",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -239,7 +239,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
 # (#58394). Add new artifacts here when introduced in ``hermes_constants``.
 _DEFAULT_EXPORT_INCLUDE_ROOT = frozenset({
     # Configuration / persona
-    "config.yaml", "SOUL.md", "MEMORY.md", "USER.md", "todo.json",
+    "config.yaml", "room_profiles.json", "SOUL.md", "MEMORY.md", "USER.md", "todo.json",
     "system_prompt.md", "AGENTS.md", "CLAUDE.md", ".cursorrules",
     # Desktop appearance/interface overlay (written by the desktop app's
     # profile export; applied by its import — see desktop.json handling).

--- a/tests/gateway/test_room_model_profiles.py
+++ b/tests/gateway/test_room_model_profiles.py
@@ -1,0 +1,97 @@
+"""Room profile persistence and resolver coverage."""
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import json
+import multiprocessing
+import pytest
+
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.room_profiles import RoomModelProfile, RoomProfileStore, exact_room_id
+from gateway.run import GatewayRunner, _get_channel_override
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
+from hermes_cli.model_switch import parse_model_switch_args
+
+P = RoomModelProfile("m", "p", "high")
+def src(platform=Platform.NEXTDO, chat_id="chat", thread_id=None):
+    return SessionSource(platform=platform, chat_id=chat_id, user_id="u", thread_id=thread_id)
+def runner(config=None):
+    r=object.__new__(GatewayRunner); r.config=config or GatewayConfig(); r._sessions={}; r._pending_model_notes={}; r._agent_cache={}; r._room_profile_stores={}; r._room_profile_stores_lock=__import__('threading').Lock(); r._session_key_for_source=lambda s:f'{s.platform.value}:{s.chat_id}'; r._normalize_source_for_session_key=lambda s:s; r._evict_cached_agent=lambda k:r._agent_cache.pop(k,None); r._async_session_store=SimpleNamespace(set_model_override=AsyncMock()); return r
+
+def test_missing_create_reload_and_exact_identity(tmp_path):
+    path=tmp_path/'room_profiles.json'; s=RoomProfileStore(path)
+    assert s.get('nextdo','r') is None
+    s.upsert('nextdo','r',P)
+    assert json.loads(path.read_text())['version']==1
+    assert RoomProfileStore(path).get('nextdo','r') == P
+    assert exact_room_id(src(thread_id=' t '))=='t' and exact_room_id(src())=='chat'
+
+def test_siblings_platforms_threads_and_unknown_fields_preserved(tmp_path):
+    path=tmp_path/'room_profiles.json'; s=RoomProfileStore(path)
+    s.upsert('nextdo','a',P); s.upsert('nextdo','b',RoomModelProfile('b','p','low')); s.upsert('discord','a',P)
+    raw=json.loads(path.read_text()); raw['future']=42; raw['profiles']['nextdo']['a']['future_entry']='x'; path.write_text(json.dumps(raw))
+    s.upsert('nextdo','c',P); raw=json.loads(path.read_text())
+    assert set(raw['profiles']['nextdo'])=={'a','b','c'} and set(raw['profiles']['discord'])=={'a'} and raw['future']==42
+
+def test_thread_concurrency_preserves_every_room(tmp_path):
+    path=tmp_path/'room_profiles.json'; s=RoomProfileStore(path)
+    with ThreadPoolExecutor(8) as pool: list(pool.map(lambda i:s.upsert('nextdo',str(i),P), range(20)))
+    assert len(json.loads(path.read_text())['profiles']['nextdo'])==20
+
+def _mp_upsert(args):
+    path, room=args; RoomProfileStore(path).upsert('nextdo', room, P)
+
+def test_multiprocess_lock_preserves_every_room(tmp_path):
+    path=str(tmp_path/'room_profiles.json')
+    with multiprocessing.get_context('fork').Pool(4) as pool: pool.map(_mp_upsert, [(path,str(i)) for i in range(8)])
+    assert len(json.loads(open(path).read())['profiles']['nextdo'])==8
+
+def test_corrupt_unsupported_and_invalid_entry_fail_closed(tmp_path, caplog):
+    path=tmp_path/'room_profiles.json'; path.write_text('{bad')
+    s=RoomProfileStore(path); assert s.get('nextdo','x') is None
+    with pytest.raises(ValueError): s.upsert('nextdo','x',P)
+    path.write_text(json.dumps({'version':2,'profiles':{}})); s.load(); assert s.get('nextdo','x') is None
+    path.write_text(json.dumps({'version':1,'profiles':{'nextdo':{'bad':{},'good':P.__dict__}}})); s.load(); assert s.get('nextdo','good')==P
+
+def test_atomic_failure_preserves_bytes_and_cache(tmp_path, monkeypatch):
+    path=tmp_path/'room_profiles.json'; s=RoomProfileStore(path); s.upsert('nextdo','old',P); before=path.read_bytes(); old=s.get('nextdo','old')
+    monkeypatch.setattr('gateway.room_profiles.atomic_json_write', lambda *a,**k: (_ for _ in ()).throw(OSError('full')))
+    with pytest.raises(OSError): s.upsert('nextdo','new',P)
+    assert path.read_bytes()==before and s.get('nextdo','old')==old and s.get('nextdo','new') is None
+
+@pytest.mark.asyncio
+async def test_trusted_command_persists_sidecar_and_clears_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kw: SimpleNamespace(success=True, new_model=kw["raw_input"], target_provider=kw["explicit_provider"]))
+    r = runner()
+    source = src()
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    key = store.get_or_create_session(source).session_key
+    r._session_key_for_source = lambda s: key
+    r.session_store = store
+    r._async_session_store = AsyncSessionStore(store)
+    store.set_model_override(key, {"model": "old"})
+    state = r._session_state(key)
+    state.conversation.model_override = {"model": "old"}; state.conversation.reasoning_override = {"enabled": True, "effort": "low"}; r._agent_cache[key] = object()
+    event = MessageEvent(text="/model", source=source, metadata={"route_kind":"internal_room_model_preset", "synthetic":True, "preset_key":"sol-max"})
+    result = await r._handle_room_model_request(event, parse_model_switch_args("gpt-5.6-sol --provider openai-codex --reasoning max --room"))
+    assert result.startswith("✅")
+    profile_path = tmp_path / "room_profiles.json"
+    assert profile_path.is_file()
+    assert RoomProfileStore(profile_path).get("nextdo", "chat") == RoomModelProfile("gpt-5.6-sol", "openai-codex", "max")
+    assert SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig()).get_model_override(key) is None
+    assert state.conversation.model_override is None and state.conversation.reasoning_override is None and key not in r._agent_cache
+
+def test_full_precedence_and_static_prompt_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME',str(tmp_path)); r=runner(GatewayConfig(platforms={Platform.NEXTDO:PlatformConfig(channel_overrides={'chat':ChannelOverride(model='static',reasoning='medium',system_prompt='prompt')})}))
+    RoomProfileStore(tmp_path/'room_profiles.json').upsert('nextdo','chat',RoomModelProfile('dynamic','p','high'))
+    assert r._resolve_model_for_channel(Platform.NEXTDO,'chat')=='dynamic'
+    assert r._resolve_session_reasoning_config(source=src(),model='global')['effort']=='high'
+    assert r._get_system_prompt_for_channel(Platform.NEXTDO,'chat')=='prompt'
+    r._session_state('nextdo:chat').conversation.model_override={'model':'session','provider':'p','api_key':'k'}
+    assert r._resolve_session_agent_runtime(source=src())[0]=='session'
+
+def test_static_lookup_remains_upstream_chat_first():
+    c=GatewayConfig.from_dict({'platforms':{'nextdo':{'channel_overrides':{'chat':{'model':'chat'},'thread':{'model':'thread'}}}}})
+    assert _get_channel_override(c,Platform.NEXTDO,'chat',thread_id='thread').model=='chat'


### PR DESCRIPTION
## Summary
- add profile-scoped persistent room model profiles for model, provider, and reasoning
- resolve dynamic room profiles across new/reset/compression/restart while preserving static room prompts
- add a trusted `/model ... --reasoning ... --room` path for authenticated platform presets
- keep temporary session overrides (including Fast/service tier) separate
- include `room_profiles.json` in backup/profile handling

## Safety
- exact platform + thread/chat identity; no user-supplied target
- fixed allowlist for trusted NextDo presets
- feature-owned versioned sidecar with locked read-modify-write and atomic replacement
- runtime/session state changes only after durable persistence; partial convergence is reported, not claimed as success

## Tests
- `python3 -m pytest -q tests/gateway/test_room_model_profiles.py` — 9 passed
- related gateway/CLI/profile suites — 324 passed, 2 skipped
- `python3 -m compileall -q gateway hermes_cli tests/gateway/test_room_model_profiles.py`
- `git diff --check`

The companion Next Do PR changes `/m` to emit one authenticated room-preset request. Fast remains session-only.
