### PR TITLE
fix: scope Windows SCM pending-service checks

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -871,6 +871,13 @@ def find_windows_gateway_services(
         if profile_processes is None:
             profile_processes = find_profile_gateway_processes(strict=True)
         service_names_by_pid: dict[int, set[str]] = {}
+        transitional_services_by_pid: dict[int, dict[str, str]] = {}
+        pending_service_statuses = {
+            "continue_pending",
+            "pause_pending",
+            "start_pending",
+            "stop_pending",
+        }
         for service in psutil_module.win_service_iter():
             try:
                 if all(
@@ -896,9 +903,24 @@ def find_windows_gateway_services(
             if service_status == "stopped":
                 continue
             if service_status != "running":
-                raise RuntimeError(
-                    f"SCM service {service_name} has indeterminate status: {service_status}"
-                )
+                if service_status not in pending_service_statuses:
+                    raise RuntimeError(
+                        f"SCM service {service_name} has indeterminate status: "
+                        f"{service_status}"
+                    )
+                # Transitional services are relevant only when their live PID
+                # is in a validated gateway's ancestor chain. Windows commonly
+                # leaves unrelated per-user services in STOP_PENDING; failing
+                # the entire scan on one would block every Desktop update.
+                if service_pid <= 0:
+                    raise RuntimeError(
+                        f"SCM service {service_name}={service_status} "
+                        "has no valid process ID"
+                    )
+                transitional_services_by_pid.setdefault(service_pid, {})[
+                    service_name
+                ] = str(service_status)
+                continue
             if service_pid <= 0:
                 raise RuntimeError(
                     f"Running SCM service {service_name} has no valid process ID"
@@ -917,6 +939,21 @@ def find_windows_gateway_services(
             ) > 0.001:
                 raise RuntimeError("Gateway process identity changed during SCM discovery")
             ancestor_pids = [int(parent.pid) for parent in gateway_process.parents()]
+            transitional_ancestors = [
+                pid for pid in ancestor_pids if pid in transitional_services_by_pid
+            ]
+            if transitional_ancestors:
+                details = ", ".join(
+                    f"{name}={status}"
+                    for pid in transitional_ancestors
+                    for name, status in sorted(
+                        transitional_services_by_pid[pid].items()
+                    )
+                )
+                raise RuntimeError(
+                    "SCM service in gateway ancestor chain has indeterminate status: "
+                    + details
+                )
             shared_service_pids = [
                 pid
                 for pid in ancestor_pids

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -872,6 +872,7 @@ def find_windows_gateway_services(
             profile_processes = find_profile_gateway_processes(strict=True)
         service_names_by_pid: dict[int, set[str]] = {}
         transitional_services_by_pid: dict[int, dict[str, str]] = {}
+        transitional_create_times_by_pid: dict[int, float] = {}
         pending_service_statuses = {
             "continue_pending",
             "pause_pending",
@@ -917,6 +918,26 @@ def find_windows_gateway_services(
                         f"SCM service {service_name}={service_status} "
                         "has no valid process ID"
                     )
+                try:
+                    service_create_time = float(
+                        psutil_module.Process(service_pid).create_time()
+                    )
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"SCM service {service_name}={service_status} could not "
+                        f"validate PID {service_pid}"
+                    ) from exc
+                previous_create_time = transitional_create_times_by_pid.get(
+                    service_pid
+                )
+                if previous_create_time is not None and abs(
+                    service_create_time - previous_create_time
+                ) > 0.001:
+                    raise RuntimeError(
+                        "Transitional SCM service process identity changed during "
+                        f"SCM discovery: PID {service_pid}"
+                    )
+                transitional_create_times_by_pid[service_pid] = service_create_time
                 transitional_services_by_pid.setdefault(service_pid, {})[
                     service_name
                 ] = str(service_status)
@@ -1004,6 +1025,23 @@ def find_windows_gateway_services(
                 "Could not determine SCM ownership for gateway profile "
                 f"{profile_process.profile}"
             ) from exc
+    for service_pid, expected_create_time in sorted(
+        transitional_create_times_by_pid.items()
+    ):
+        try:
+            current_create_time = float(
+                psutil_module.Process(service_pid).create_time()
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Transitional SCM service process disappeared during SCM discovery: "
+                f"PID {service_pid}"
+            ) from exc
+        if abs(current_create_time - expected_create_time) > 0.001:
+            raise RuntimeError(
+                "Transitional SCM service process identity changed during SCM "
+                f"discovery: PID {service_pid}"
+            )
     return [found[name] for name in sorted(found)]
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -7,6 +7,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -1066,6 +1067,130 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
             gateway_create_time=300.0,
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("service_name", "service_pid", "expected_error"),
+    [
+        pytest.param(
+            "BcastDVRUserService_abcde", 900, None, id="unrelated-service"
+        ),
+        pytest.param(
+            "HermesGateway",
+            200,
+            "HermesGateway=stop_pending",
+            id="gateway-ancestor",
+        ),
+    ],
+)
+def test_find_windows_gateway_services_scopes_transitional_status_to_ancestry(
+    monkeypatch,
+    service_name,
+    service_pid,
+    expected_error,
+):
+    """Only a transitional service in the gateway ancestry blocks discovery."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = gateway.ProfileGatewayProcess(
+        profile="default", path=Path("profile"), pid=300, create_time=300.0
+    )
+
+    class FakeService:
+        def as_dict(self):
+            return {
+                "name": service_name,
+                "pid": service_pid,
+                "status": "stop_pending",
+            }
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            assert self.pid == 300
+            return [FakeProcess(200)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService()],
+        Process=FakeProcess,
+    )
+
+    if expected_error:
+        with pytest.raises(RuntimeError, match=expected_error):
+            gateway.find_windows_gateway_services(
+                psutil_module=fake_psutil,
+                profile_processes=[profile],
+            )
+    else:
+        assert (
+            gateway.find_windows_gateway_services(
+                psutil_module=fake_psutil,
+                profile_processes=[profile],
+            )
+            == []
+        )
+
+
+def test_find_windows_gateway_services_rejects_transitional_service_without_pid(
+    monkeypatch,
+):
+    """A transitional service with no PID has ambiguous ownership."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+
+    class FakeService:
+        def as_dict(self):
+            return {
+                "name": "UnknownPending",
+                "pid": 0,
+                "status": "start_pending",
+            }
+
+    fake_psutil = SimpleNamespace(win_service_iter=lambda: [FakeService()])
+
+    with pytest.raises(RuntimeError, match="SCM service enumeration failed") as excinfo:
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[],
+        )
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "UnknownPending=start_pending has no valid process ID" in str(
+        excinfo.value.__cause__
+    )
+
+
+@pytest.mark.parametrize("service_status", ["paused", "unknown"])
+def test_find_windows_gateway_services_rejects_non_pending_indeterminate_status(
+    monkeypatch,
+    service_status,
+):
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+
+    class FakeService:
+        def as_dict(self):
+            return {
+                "name": "UnexpectedState",
+                "pid": 900,
+                "status": service_status,
+            }
+
+    fake_psutil = SimpleNamespace(win_service_iter=lambda: [FakeService()])
+
+    with pytest.raises(RuntimeError, match="SCM service enumeration failed") as excinfo:
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[],
+        )
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert (
+        f"UnexpectedState has indeterminate status: {service_status}"
+        in str(excinfo.value.__cause__)
+    )
 
 
 def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypatch):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1164,6 +1164,62 @@ def test_find_windows_gateway_services_rejects_transitional_service_without_pid(
     )
 
 
+@pytest.mark.parametrize(
+    ("create_times", "expected_error"),
+    [
+        pytest.param(
+            [ProcessLookupError("gone")],
+            "could not validate PID 900",
+            id="stale-pid",
+        ),
+        pytest.param(
+            [900.0, 901.0],
+            "identity changed during SCM discovery",
+            id="reused-pid",
+        ),
+    ],
+)
+def test_find_windows_gateway_services_validates_transitional_process_identity(
+    monkeypatch,
+    create_times,
+    expected_error,
+):
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    remaining_create_times = iter(create_times)
+
+    class FakeService:
+        def as_dict(self):
+            return {
+                "name": "UnrelatedPending",
+                "pid": 900,
+                "status": "stop_pending",
+            }
+
+    class FakeProcess:
+        def __init__(self, pid):
+            assert pid == 900
+
+        def create_time(self):
+            value = next(remaining_create_times)
+            if isinstance(value, BaseException):
+                raise value
+            return value
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService()],
+        Process=FakeProcess,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[],
+        )
+
+    errors = [str(excinfo.value), str(excinfo.value.__cause__)]
+    assert any(expected_error in error for error in errors)
+
+
 @pytest.mark.parametrize("service_status", ["paused", "unknown", None])
 def test_find_windows_gateway_services_rejects_non_pending_indeterminate_status(
     monkeypatch,

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1016,15 +1016,16 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
 
     class FakeService:
-        def __init__(self, name, pid):
+        def __init__(self, name, pid, status="running"):
             self.name = name
             self.pid = pid
+            self._status = status
 
         def as_dict(self):
             return {
                 "name": self.name,
                 "pid": self.pid,
-                "status": "running",
+                "status": self._status,
             }
 
     class FakeProcess:
@@ -1045,7 +1046,7 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     fake_psutil = SimpleNamespace(
         win_service_iter=lambda: [
             FakeService("HermesGateway", 100),
-            FakeService("UnrelatedService", 900),
+            FakeService("BcastDVRUserService_abcde", 900, "stop_pending"),
         ],
         Process=FakeProcess,
     )
@@ -1076,9 +1077,9 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
             "BcastDVRUserService_abcde", 900, None, id="unrelated-service"
         ),
         pytest.param(
-            "HermesGateway",
+            "UnrelatedPendingService",
             200,
-            "HermesGateway=stop_pending",
+            "UnrelatedPendingService=stop_pending",
             id="gateway-ancestor",
         ),
     ],
@@ -1163,7 +1164,7 @@ def test_find_windows_gateway_services_rejects_transitional_service_without_pid(
     )
 
 
-@pytest.mark.parametrize("service_status", ["paused", "unknown"])
+@pytest.mark.parametrize("service_status", ["paused", "unknown", None])
 def test_find_windows_gateway_services_rejects_non_pending_indeterminate_status(
     monkeypatch,
     service_status,
@@ -1177,6 +1178,9 @@ def test_find_windows_gateway_services_rejects_non_pending_indeterminate_status(
                 "pid": 900,
                 "status": service_status,
             }
+
+        def status(self):
+            return service_status
 
     fake_psutil = SimpleNamespace(win_service_iter=lambda: [FakeService()])
 


### PR DESCRIPTION
## What does this PR do?

Scopes Windows SCM transitional-state failures to services that could actually own a validated Hermes gateway process.

A native Windows Desktop update failed before fetch because the unrelated per-user GameDVR service `BcastDVRUserService_<suffix>` was stuck in `STOP_PENDING`. `find_windows_gateway_services()` raised on every non-`running`/non-`stopped` service before checking process ancestry, so an unrelated Windows component became a global update blocker.

The fix records transitional services by validated process identity while scanning SCM. It ignores them when their PID is outside every validated gateway ancestor chain, after rechecking that the pending service's PID still identifies the same live process. It remains fail-closed when a transitional service is in the gateway ancestry, has no PID, has a stale/unqueryable PID, or changes process identity during discovery. Existing fail-closed handling for SCM inspection/enumeration errors and shared service-host ambiguity is unchanged.

## Related Issue

Fixes #96360

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: defer transitional-service rejection only when a live, identity-stable service process permits an ancestry check; ignore it only when that PID is outside every validated gateway ancestry.
- `tests/hermes_cli/test_gateway.py`: cover the ownership invariant—an unrelated `stop_pending` service coexists with discovery of a valid running gateway service, while a non-Hermes-named gateway-ancestor transition, missing/stale/reused PIDs, and non-pending/missing states remain fail-closed.

## How to Test

1. On current `main`, run the new unrelated-service parameter case; it fails with `SCM service BcastDVRUserService_abcde has indeterminate status: stop_pending`.
2. Apply this patch and run:

   ```bash
   HERMES_PYTHON=/path/to/dev/python scripts/run_tests.sh \
     tests/hermes_cli/test_gateway.py \
     tests/hermes_cli/test_update_concurrent_quarantine.py -q -j 2
   ```

3. Confirm the unrelated-service case still returns the valid running gateway service and the name-independent gateway-ancestor case raises with `UnrelatedPendingService=stop_pending`.
4. Confirm missing, stale, and reused pending-service PIDs remain fail-closed, as do stable/unknown nonterminal states such as `paused` and malformed status values.

Focused result: **71 passed, 3 skipped, 0 failed**. `py_compile`, `ruff check`, and `uv pip check` also pass.

Live Windows evidence: the Desktop update failed twice before fetch while `BcastDVRUserService_<suffix>` was `STOP_PENDING`; Windows respawned the service under a new PID after termination and the retry failed identically. After proving no Hermes SCM service or Desktop/backend process remained, the same update without `--gateway` completed v0.20.5 → v0.20.6. This confirms the checkout/dependency update path was healthy and isolates the failure to SCM ownership discovery.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 live reproduction/recovery; hermetic regression tests on WSL2/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal bug fix with explanatory source comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Sanitized live failure shape:

```text
RuntimeError: SCM service BcastDVRUserService_<suffix> has indeterminate status: stop_pending
RuntimeError: SCM service enumeration failed
RuntimeError: Could not determine Windows gateway service ownership: SCM service enumeration failed
```

The updater failed before `Fetching updates...`; the confirmed no-`--gateway` recovery completed with:

```text
Update complete! (v0.20.5 → v0.20.6)
```
