### PR TITLE
fix(desktop): allow sole local registry owner fallback

### DIFF
--- a/apps/desktop/src/store/session-owner-resolution.test.ts
+++ b/apps/desktop/src/store/session-owner-resolution.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $connectionsRegistry } from './connections'
+import { $connectionsRegistry } from './connection-registry-state'
 import { $profiles } from './profile'
 import {
   ambientGatewayOwnsEverySession,
@@ -8,12 +8,12 @@ import {
   sessionOwnerIsKnown
 } from './session-owner-resolution'
 
-const registry = (...ids: string[]) =>
+const registry = (...connections: Array<{ id: string; kind: string }>) =>
   ({
-    connections: ids.map(id => ({ id })),
-    lastUsed: ids[0] ?? null,
+    connections,
+    lastUsed: connections[0]?.id ?? null,
     launchMode: 'primary',
-    primary: ids[0] ?? null
+    primary: connections[0]?.id ?? null
   }) as never
 
 beforeEach(() => {
@@ -43,32 +43,46 @@ describe('session owner topology', () => {
     )
   })
 
-  it('fails closed on an unknown owner in registry topology while preserving legacy profile routes', () => {
-    // A connection registry means the ambient gateway is never provably the
-    // sole backend, even with one profile listed: an unknown owner fails
-    // closed. A bare profile still names a backend — the legacy profile door
-    // (a pick on the primary / explicit `local` source) mints sessions owned
-    // by that profile's pool socket in every topology.
-    $connectionsRegistry.set(registry('local'))
+  it('uses the ambient gateway only when a loaded registry proves a sole local backend', () => {
+    $connectionsRegistry.set(registry({ id: 'local', kind: 'local' }))
     $profiles.set([{ name: 'default' }] as never)
 
     expect(sessionOwnerIsKnown('default')).toBe(true)
-    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(ambientGatewayOwnsEverySession()).toBe(true)
     expect(() =>
-      assertSessionOwnerResolved('default', { method: 'session.resume', sessionId: 'registry-profile' })
+      assertSessionOwnerResolved(null, { method: 'approval.respond', sessionId: 'sole-local' })
     ).not.toThrow()
-    expect(() => assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'unknown-owner' })).toThrow(
+
+    $connectionsRegistry.set(registry({ id: 'remote', kind: 'remote' }))
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() => assertSessionOwnerResolved(null, { method: 'approval.respond', sessionId: 'remote-only' })).toThrow(
       /could not be resolved/i
     )
 
-    $connectionsRegistry.set(registry('local', 'homelab'))
+    $connectionsRegistry.set(
+      registry(
+        { id: 'local', kind: 'local' },
+        { id: 'homelab', kind: 'remote' }
+      )
+    )
     expect(sessionOwnerIsKnown(null)).toBe(false)
     expect(ambientGatewayOwnsEverySession()).toBe(false)
     expect(() => assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'unknown-owner' })).toThrow(
       /could not be resolved/i
     )
 
+    $connectionsRegistry.set(registry({ id: 'local', kind: 'local' }))
+    $profiles.set([{ name: 'default' }, { name: 'loki' }] as never)
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() => assertSessionOwnerResolved(null, { method: 'approval.respond', sessionId: 'multi-profile' })).toThrow(
+      /could not be resolved/i
+    )
+  })
+
+  it('preserves legacy profile-only owner routing', () => {
     $connectionsRegistry.set(null)
+    $profiles.set([{ name: 'default' }] as never)
+
     expect(sessionOwnerIsKnown('default')).toBe(true)
     expect(ambientGatewayOwnsEverySession()).toBe(true)
     expect(() =>

--- a/apps/desktop/src/store/session-owner-resolution.ts
+++ b/apps/desktop/src/store/session-owner-resolution.ts
@@ -13,12 +13,12 @@
  * session is left untouched for the next correctly-routed attempt.
  *
  * The ONE case where the ambient gateway is not a fallback but the owner by
- * construction: no registry topology exists (legacy v1 primary) AND at most
- * one profile exists — a single backend serves every session, so there is
- * nothing to misroute to. Older single-profile backends omit `profile` on
+ * construction: the loaded topology proves there is only one local backend
+ * and at most one profile. Legacy v1 primary installs with no registry also
+ * satisfy that contract. Older single-profile backends omit `profile` on
  * their rows entirely; those users keep working unchanged.
  */
-import { hasRegistryTopology } from './connection-registry-state'
+import { $connectionsRegistry, hasRegistryTopology } from './connection-registry-state'
 import { $profiles } from './profile'
 import { isSessionOwnerRoute, type SessionOwnerScope } from './session-request-router'
 
@@ -44,11 +44,26 @@ export function isSessionOwnerResolutionError(error: unknown): error is SessionO
 }
 
 /** True when the ambient gateway is provably the only backend any session
- *  can live on (legacy single-backend Desktop): Electron has published no
- *  connection registry and there is at most one profile. The active route is
- *  presentation state; a null active connection does not prove sole topology. */
+ *  can live on. Legacy profile-only Desktop qualifies with at most one
+ *  profile. In modern registry topology, only a loaded registry containing
+ *  exactly one local connection qualifies; the async pre-load window and any
+ *  remote/multi-connection topology continue to fail closed. */
 export function ambientGatewayOwnsEverySession(): boolean {
-  return !hasRegistryTopology() && $profiles.get().length <= 1
+  if ($profiles.get().length > 1) {
+    return false
+  }
+
+  if (!hasRegistryTopology()) {
+    return true
+  }
+
+  const registry = $connectionsRegistry.get()
+  if (!registry) {
+    return false
+  }
+
+  const connections = registry.connections ?? []
+  return connections.length === 1 && connections[0]?.kind === 'local'
 }
 
 /** True when `owner` names a backend: an exact connection route, or a bare


### PR DESCRIPTION
⚠️ **DO NOT MERGE YET** — follow-up review found a routing-safety gap in this implementation. `$profiles` is lazy-loaded and may retain stale data after a failed refresh, so `length <= 1` does not prove the current backend/profile topology is authoritative. The safe fix needs explicit authoritative/epoch state, invalidation on backend changes, fail-closed behavior after refresh failure, and regression coverage for unloaded, failed-refresh, and stale-cache cases.

Fixes #96394.

## Problem

Desktop owner resolution intentionally fails closed when a session has no explicit owner route. The modern connection-registry capability made that guard too broad, though: even after the registry has loaded and proves there is exactly one local connection, `ambientGatewayOwnsEverySession()` still returns false because `hasRegistryTopology()` is true.

That leaves single-connection/single-profile installs unable to answer approval prompts when the owner ladder misses, despite there being no second backend to misroute to.

## Fix

- preserve fail-closed behavior while the registry is still loading;
- preserve fail-closed behavior for a sole remote connection, multiple connections, or multiple profiles;
- allow the ambient gateway only when the loaded registry contains exactly one `local` connection and there is at most one profile;
- preserve the existing legacy profile-only fallback;
- keep the focused test on the same canonical `connection-registry-state` store used by production owner resolution;
- add focused regression coverage for sole-local approval routing and the ambiguous cases above.

## Validation

- refreshed again onto current upstream `main` (`8dbf07e950d0c404052456fde2758ef2fe157fb6`);
- branch is exactly one focused commit ahead and zero commits behind, touching only the owner-resolution source and focused test;
- the previous head (`22e06db1040ff57c1675b1cf0e54399254ccd955`) passed CI, Docker Build/Test/Publish, and Nix after the canonical-store test fix;
- final duplicate search still finds no other open PR covering #96394 / this sole-local owner fallback;
- fresh hosted checks are the execution gate for head `41f1db3169c9d84568165331cda81b567254892a`.