### PR TITLE
fix(cron): stop a NUL byte skipping the lifecycle scan of remote script text

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -847,22 +847,35 @@ def _sanitize_remote_script_text(
     text: Optional[str], *, max_bytes: Optional[int] = None
 ) -> tuple[Optional[str], bool]:
     """Apply the local-read contract to text from an untrusted ``read_remote_script`` callback: NUL
-    means binary (nothing to scan, checked first); oversized fails closed. Size compares re-encoded
-    *bytes* (matching the ``head -c`` wire bound): a >1 MiB multibyte file truncated at the byte cap
-    decodes to fewer chars, and a char count would scan instead of failing.
+    padded text is still scanned after NUL stripping; oversized fails closed. Size compares
+    re-encoded *bytes* (matching the ``head -c`` wire bound): a >1 MiB multibyte file truncated at
+    the byte cap decodes to fewer chars, and a char count would scan instead of failing.
 
     The recursion boundary must not trust its callbacks: any backend (SSH, Modal, Daytona, or a future one)
-    can hand back raw binary bytes decoded as text, or arbitrarily large output. Enforced here rather than
-    inside each callback so the guarantee holds for every callback, not just the ones we hardened. See
-    #76762, #77703.
+    can hand back raw binary bytes decoded as text, or arbitrarily large output. Mirror
+    ``_read_referenced_script``'s semantics exactly — binaries are identified by magic number and
+    skipped (#77703), oversized text fails closed like an oversized local file (#76762), and a
+    NUL-bearing *text* payload has its NULs stripped and is then scanned — so remote and local reads
+    can never diverge again.
+
+    The magic check runs against the encoded bytes, because a signature is a byte-level fact; the
+    callback's decode leaves ASCII-range magic (``MZ``, ``\\x7fELF``, ``!<arch>``, ``PK\\x03\\x04``)
+    intact, and anything it mangled beyond recognition is text as far as this boundary can tell and
+    gets scanned rather than skipped. Enforced here rather than inside each callback so the guarantee
+    holds for every callback, not just the ones we hardened.
     """
-    if not text or "\x00" in text:
+    if not text:
         return None, False
     byte_limit = _capped_read_limit(max_bytes)
-    if len(text) > byte_limit:
-        return None, True  # chars <= bytes: over the cap without encoding
-    if len(text.encode("utf-8", errors="replace")) > byte_limit:
+    encoded = text.encode("utf-8", errors="replace")
+    if _has_binary_magic(encoded):
+        return None, False
+    # Size before stripping, for the same reason as the local read: stripping
+    # shrinks the buffer and would let an oversized payload duck this branch.
+    if len(encoded) > byte_limit:
         return None, True
+    if "\x00" in text:
+        text = text.replace("\x00", "")
     return text, False
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1398,6 +1398,35 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_nul_padded_remote_text_is_scanned_not_skipped(self):
+        """A NUL in remote callback text is not a binary signature.
+
+        The local read stopped equating "contains a NUL" with "is a compiled
+        binary" — `bash` runs a text script straight past an embedded NUL, so
+        a single pad byte used to skip the scan of a file that still executes
+        its lifecycle command. The recursion boundary kept the old rule, which
+        left the same bypass reachable through every `read_remote_script`
+        backend: one NUL anywhere in the returned text made the whole payload
+        unscannable AND safe, hiding the command sitting next to it.
+
+        No magic signature here, so this is text: strip the NULs and scan.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        for payload in (
+            "pad\x00 hermes gateway restart\n",
+            "hermes gateway restart\n\x00trailing junk",
+            "her\x00mes gateway restart\n",
+        ):
+            result = contains_gateway_lifecycle_command_or_referenced_script(
+                "bash /nonexistent/dir/helper.sh",
+                cwd="/tmp",
+                read_remote_script=lambda _path, _p=payload: _p,
+            )
+            assert result is True, payload
+
     def test_oversized_remote_callback_text_fails_closed(self):
         """T4: >1 MiB of NUL-free text from a remote callback must follow the
         local-read contract (oversized regular file → fail closed, #76762)


### PR DESCRIPTION
## Problem

`_read_referenced_script` recently stopped equating "contains a NUL" with "is a compiled binary" — `bash` executes a text script straight past an embedded NUL, so a single pad byte made the guard skip a file that still runs its lifecycle command. It now identifies binaries by magic number and strips NULs out of text before scanning.

`_sanitize_remote_script_text` did not follow. Its docstring still promises to *"Mirror `_read_referenced_script`'s semantics exactly … so remote and local reads can never diverge again"*, but the code kept the old rule:

```python
if "\x00" in text:
    return None, False        # unscannable AND safe
```

So the bypass that was closed locally stayed reachable through every `read_remote_script` backend (SSH, Modal, Daytona, any future one) — which is precisely the exposure the boundary sanitizer was introduced to cover.

## Reproduction against `main` (5fc308a707, v0.20.6)

```python
from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script as chk

chk("bash /nonexistent/dir/helper.sh", cwd="/tmp",
    read_remote_script=lambda _p: "hermes gateway restart\n")
# True  — detected

chk("bash /nonexistent/dir/helper.sh", cwd="/tmp",
    read_remote_script=lambda _p: "pad\x00 hermes gateway restart\n")
# False — one NUL and the command is invisible
```

The NUL can sit before, after, or inside the command. The cron job is then created and schedules exactly the SIGTERM-respawn loop (#30719) the guard exists to prevent.

## Fix

Mirror the local contract, in the same order: magic number → skip; oversized → fail closed; otherwise strip NULs and scan.

The magic check runs against the encoded bytes, because a signature is a byte-level fact. The callback's decode leaves ASCII-range magic (`MZ`, `\x7fELF`, `!<arch>`, `PK\x03\x04`) intact, and anything it mangled past recognition is text as far as this boundary can tell, so it gets scanned rather than skipped. Size is still checked *before* stripping, since stripping shrinks the buffer.

## Tests

Adds `test_nul_padded_remote_text_is_scanned_not_skipped` next to the existing T3/T4 remote-callback cases, covering a NUL before, after and inside the command.

- Fails on unmodified `main` (`1 failed, 297 deselected`).
- Whole file passes with the fix: **298 passed**.
- T3 (`MZ`-prefixed binary from a callback must not false-positive) and T4 (oversized remote text fails closed) are unchanged and still pass — the `MZ` payload in T3 is caught by the magic check, not by the NUL rule.

## Related, deliberately not fixed here

`_BINARY_MAGICS` contains `b"MZ"`, two printable ASCII characters, and `_has_binary_magic` only overrides it for a shebang. A local shell script whose first line is `MZ; hermes gateway restart` is therefore classified as a PE binary and never scanned:

```python
Path("/tmp/x.sh").write_bytes(b"MZ; hermes gateway restart\n")
chk("source /tmp/x.sh", cwd="/tmp")   # False
```

That predates this change and affects the local path too, so it belongs in its own PR. Happy to send one (corroborating the `MZ` signature with the NULs a real DOS header carries in its first bytes, or dropping `b"MZ"` and letting those files fail closed) if you'd like it separately.
