### PR TITLE
fix: isolate profile cron and Desktop tool ownership

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -11,12 +11,13 @@ This module provides a fail-closed, context-local secret scope:
 - ``set_secret_scope(mapping)`` installs the active profile's secrets for the
   current task (a contextvar, so it propagates into the agent's worker thread
   via ``copy_context()`` exactly like the HERMES_HOME override).
-- ``get_secret(name)`` reads from that scope. When multiplexing is **active**
-  and no scope is set, it RAISES rather than silently falling back to
-  ``os.environ`` — an un-migrated or newly-added call site fails loud at that
-  exact line instead of leaking another profile's value. When multiplexing is
-  **off** (the default), it transparently reads ``os.environ`` so the
-  single-profile gateway and every non-gateway caller behave exactly as before.
+- ``get_secret(name)`` reads from that scope. When process-wide multiplexing is
+  **active**, or a Desktop cron context marks its scope authoritative, an absent
+  scoped key never falls through to ``os.environ``. An unscoped read under
+  process-wide multiplexing RAISES instead of silently using another profile's
+  value. When neither isolation mode applies, it transparently reads
+  ``os.environ`` so the single-profile gateway and every non-gateway caller
+  behave exactly as before.
 
 Design rationale lives in ``docs/design/multiplexing-gateway.md`` (Workstream A).
 """
@@ -56,6 +57,9 @@ def is_multiplex_active() -> bool:
 _SECRET_SCOPE: ContextVar[Optional[Mapping[str, str]]] = ContextVar(
     "_SECRET_SCOPE", default=None
 )
+_SECRET_SCOPE_AUTHORITATIVE: ContextVar[bool] = ContextVar(
+    "_SECRET_SCOPE_AUTHORITATIVE", default=False
+)
 
 
 class UnscopedSecretError(RuntimeError):
@@ -85,6 +89,20 @@ def reset_secret_scope(token: Token) -> None:
 def current_secret_scope() -> Optional[Mapping[str, str]]:
     """Return the active secret mapping, or None when no scope is installed."""
     return _SECRET_SCOPE.get()
+
+
+def set_secret_scope_authoritative(authoritative: bool = True) -> Token:
+    """Make scope misses fail closed in the current execution context.
+
+    Unlike the process-global multiplex flag, this is safe for Desktop cron
+    worker contexts that coexist with ordinary single-profile work.
+    """
+    return _SECRET_SCOPE_AUTHORITATIVE.set(bool(authoritative))
+
+
+def reset_secret_scope_authoritative(token: Token) -> None:
+    """Restore the previous context-local scope-authority setting."""
+    _SECRET_SCOPE_AUTHORITATIVE.reset(token)
 
 
 # ── genuinely-global env vars (NOT per-profile secrets) ──────────────────
@@ -153,16 +171,17 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
 
     1. Genuinely-global vars (``_is_global_env``) always read ``os.environ`` —
        they are deployment settings, not profile secrets.
-    2. When a secret scope is installed (multiplexed turn), read from it. Under
-       multiplexing the scope is authoritative — an absent key returns
-       ``default`` and we do NOT fall through to ``os.environ``, because in a
-       multiplexer ``os.environ`` may hold another profile's value. When
-       multiplexing is OFF, a scope miss falls through to ``os.environ``:
-       single-profile deployments legitimately provide credentials via the
-       process environment (systemd ``Environment=``, secret-manager wrappers
-       like ``pass-cli run`` / ``op run``, plain shell exports) rather than
-       ``<home>/.env``, and the scope — installed unconditionally around e.g.
-       every cron job — must stay a ``.env`` overlay, not a blindfold.
+    2. When a secret scope is installed, read from it. Under process-wide
+       multiplexing, or when the current context explicitly marks the scope
+       authoritative, an absent key returns ``default`` and we do NOT fall
+       through to ``os.environ``, because the process environment may hold
+       another profile's value. When neither isolation mode applies, a scope
+       miss falls through to ``os.environ``: single-profile deployments
+       legitimately provide credentials via the process environment (systemd
+       ``Environment=``, secret-manager wrappers like ``pass-cli run`` /
+       ``op run``, plain shell exports) rather than ``<home>/.env``, and the
+       scope — installed unconditionally around e.g. every cron job — must stay
+       a ``.env`` overlay, not a blindfold.
     3. No scope installed:
        - multiplex INACTIVE (default deployment): read ``os.environ`` —
          identical to the legacy ``os.getenv`` behavior every caller had before.
@@ -178,7 +197,7 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
         val = scope.get(name)
         if val is not None:
             return val
-        if _MULTIPLEX_ACTIVE:
+        if _MULTIPLEX_ACTIVE or _SECRET_SCOPE_AUTHORITATIVE.get():
             return default
         # Multiplex off: the scope is an overlay over the process environment,
         # not an isolation boundary — there is no other profile to leak from.

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -30,6 +31,42 @@ from typing import Any
 # here so a still-alive-but-exhausted gateway never sleeps longer than this
 # between recovery attempts.
 _EMFILE_BACKOFF_MAX_SECONDS = 15 * 60  # 15 minutes
+
+
+@contextmanager
+def _multiplex_profile_scope(profile_home):
+    """Install one multiplex profile's home and isolated secret sources.
+
+    ``tick()`` copies this context into cron worker threads.  Home-only scoping
+    is insufficient: delivery/config reads then fall back to the backend
+    process's ambient credentials, so a Bilbo job claimed by Gollum can send via
+    Gollum's Telegram bot.
+    """
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        reset_secret_scope_authoritative,
+        set_secret_scope,
+        set_secret_scope_authoritative,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    home_token = set_hermes_home_override(str(profile_home))
+    try:
+        hydrate_profile_secret_sources(profile_home)
+        secret_token = set_secret_scope(build_profile_secret_scope(profile_home))
+        authority_token = set_secret_scope_authoritative()
+        try:
+            yield
+        finally:
+            reset_secret_scope_authoritative(authority_token)
+            reset_secret_scope(secret_token)
+    finally:
+        reset_hermes_home_override(home_token)
 
 
 def _backoff_wait_seconds(interval: float, consecutive_failures: int) -> float:
@@ -647,7 +684,6 @@ class InProcessCronScheduler(CronScheduler):
             record_ticker_heartbeat,
             use_cron_store,
         )
-        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info(
@@ -659,8 +695,7 @@ class InProcessCronScheduler(CronScheduler):
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
-            home_token = set_hermes_home_override(str(home))
-            try:
+            with _multiplex_profile_scope(home):
                 with use_cron_store(home):
                     recovered = self.recover_interrupted()
                     if recovered:
@@ -670,8 +705,6 @@ class InProcessCronScheduler(CronScheduler):
                             home,
                         )
                     record_ticker_heartbeat()
-            finally:
-                reset_hermes_home_override(home_token)
 
         consecutive_failures = 0
         while not stop_event.is_set():
@@ -683,8 +716,7 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
-                        try:
+                        with _multiplex_profile_scope(home):
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
@@ -693,8 +725,6 @@ class InProcessCronScheduler(CronScheduler):
                                     sync=False,
                                     can_dispatch=can_dispatch,
                                 )
-                        finally:
-                            reset_hermes_home_override(home_token)
                 ok = True
             except BaseException as e:
                 logger.error("Cron tick error: %s", e, exc_info=True)
@@ -706,8 +736,7 @@ class InProcessCronScheduler(CronScheduler):
             # Record per-profile heartbeat after each tick cycle.
             for entry in profile_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
-                home_token = set_hermes_home_override(str(home))
-                try:
+                with _multiplex_profile_scope(home):
                     with use_cron_store(home):
                         record_ticker_heartbeat(success=ok)
                         # Surface the failure reason (or clear it) per profile
@@ -717,8 +746,6 @@ class InProcessCronScheduler(CronScheduler):
                             clear_ticker_error()
                         elif _tick_error:
                             record_ticker_error(_tick_error)
-                finally:
-                    reset_hermes_home_override(home_token)
             if ok:
                 consecutive_failures = 0
             stop_event.wait(_backoff_wait_seconds(interval, consecutive_failures))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -294,16 +294,24 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     start_kwargs: dict = {"interval": interval}
     if isinstance(provider, InProcessCronScheduler):
         try:
-            from hermes_cli.profiles import profiles_to_serve
+            from hermes_cli.profiles import (
+                get_active_profile_name,
+                profiles_to_serve,
+            )
 
-            profile_homes = list(profiles_to_serve(multiplex=True))
-            if len(profile_homes) > 1:
-                start_kwargs["profile_homes"] = profile_homes
-                _log.info(
-                    "Desktop cron scheduler will tick %d profile(s): %s",
-                    len(profile_homes),
-                    [name for name, _home in profile_homes],
-                )
+            # Per-profile Desktop backends are pooled separately.  Only the
+            # long-lived primary/default backend may multiplex every profile;
+            # otherwise secondary backends race each other and a Gandalf
+            # process can physically claim a Bilbo execution.
+            if get_active_profile_name() == "default":
+                profile_homes = list(profiles_to_serve(multiplex=True))
+                if len(profile_homes) > 1:
+                    start_kwargs["profile_homes"] = profile_homes
+                    _log.info(
+                        "Desktop cron scheduler will tick %d profile(s): %s",
+                        len(profile_homes),
+                        [name for name, _home in profile_homes],
+                    )
         except Exception:
             # Fail open to the single-store ticker — the active profile's
             # jobs must keep firing even if profile enumeration breaks.

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,91 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_installs_each_profiles_secret_scope(tmp_path):
+    """A worker claimed by another profile must still use the job owner's secrets.
+
+    The tick context is copied into cron worker threads.  Scoping only
+    HERMES_HOME lets a documentation job be claimed by the issue-engineer
+    backend while credential and delivery lookups fall back to Gollum's ambient
+    process environment.
+    """
+    from agent import secret_scope
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "documentation-engineer"
+    for home, token in ((p1, "default-token"), (p2, "bilbo-token")):
+        (home / "cron").mkdir(parents=True)
+        (home / ".env").write_text(
+            f"TELEGRAM_BOT_TOKEN={token}\n", encoding="utf-8"
+        )
+
+    observed = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        scope = secret_scope.current_secret_scope() or {}
+        observed.append((str(get_hermes_home()), scope.get("TELEGRAM_BOT_TOKEN")))
+        if len(observed) >= 2:
+            stop.set()
+        return 0
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+             patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+            thread = threading.Thread(
+                target=InProcessCronScheduler().start,
+                args=(stop,),
+                kwargs={
+                    "interval": 0,
+                    "profile_homes": [
+                        ("default", p1),
+                        ("documentation-engineer", p2),
+                    ],
+                },
+                daemon=True,
+            )
+            thread.start()
+            thread.join(timeout=5)
+    finally:
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+    assert not thread.is_alive()
+    assert observed[:2] == [
+        (str(p1), "default-token"),
+        (str(p2), "bilbo-token"),
+    ]
+
+
+def test_multiplex_profile_scope_does_not_borrow_ambient_secret(
+    tmp_path, monkeypatch
+):
+    """A Desktop multiplexer must fail closed on a profile scope miss."""
+    from agent import secret_scope
+    from cron.scheduler_provider import _multiplex_profile_scope
+
+    profile_home = tmp_path / "documentation-engineer"
+    profile_home.mkdir()
+    (profile_home / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "ambient-default-token")
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(False)
+    try:
+        with _multiplex_profile_scope(profile_home):
+            assert secret_scope.current_secret_scope() == {}
+            assert secret_scope.get_secret("TELEGRAM_BOT_TOKEN") is None
+
+        # The authority boundary is context-local: ordinary single-profile
+        # callers still honor credentials injected into the process environment.
+        assert (
+            secret_scope.get_secret("TELEGRAM_BOT_TOKEN")
+            == "ambient-default-token"
+        )
+    finally:
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -70,6 +70,28 @@ def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path
     assert builtin.start_kwargs["profile_homes"] == homes
 
 
+def test_secondary_profile_backend_ticks_only_its_own_store(
+    monkeypatch, _providers, tmp_path
+):
+    """Only the long-lived primary backend may enumerate every profile store."""
+    _sp, builtin = _providers
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "coder")
+    monkeypatch.setattr(
+        profiles_mod,
+        "profiles_to_serve",
+        lambda **_kw: [
+            ("default", tmp_path / "root"),
+            ("coder", tmp_path / "profiles" / "coder"),
+        ],
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=8)
+
+    assert builtin.start_kwargs == {"interval": 8}
+
+
 def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
     _sp, builtin = _providers
     import hermes_cli.profiles as profiles_mod

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -112,6 +112,78 @@ class TestResolverPlumbing:
         assert "desktop_ui" in desktop
         assert "desktop_ui" not in tui
 
+    def test_global_disabled_toolsets_suppress_client_surface_injection(
+        self, no_desktop_env
+    ):
+        """A profile deny must win even when Desktop normally adds GUI tools."""
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        config = {
+            "agent": {"disabled_toolsets": ["desktop_ui", "project"]},
+            "platform_toolsets": {"cli": ["web"]},
+        }
+        no_desktop_env.setattr(config_mod, "load_config", lambda: config)
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+        assert server._load_enabled_toolsets("desktop") == ["coding"]
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: None)
+        resolved = server._load_enabled_toolsets("desktop")
+        assert resolved is not None
+        assert "web" in resolved
+        assert {"desktop_ui", "project"}.isdisjoint(resolved)
+
+    def test_make_agent_passes_global_denies_to_final_tool_assembly(
+        self, no_desktop_env
+    ):
+        """Aggregate postures cannot bypass profile-wide capability denies."""
+        from types import SimpleNamespace
+
+        import run_agent
+
+        config = {"agent": {"disabled_toolsets": ["browser"]}}
+        captured = {}
+
+        no_desktop_env.setattr(server, "_load_cfg", lambda: config)
+        no_desktop_env.setattr(
+            server,
+            "_resolve_startup_runtime",
+            lambda: ("test-model", "test-provider"),
+        )
+        no_desktop_env.setattr(
+            server,
+            "_resolve_runtime_with_fallback",
+            lambda *_a, **_k: SimpleNamespace(
+                runtime={"provider": "test-provider"},
+                used_fallback=False,
+                selected_model=None,
+            ),
+        )
+        no_desktop_env.setattr(server, "_load_provider_routing", lambda: {})
+        no_desktop_env.setattr(server, "_load_reasoning_config", lambda _model: {})
+        no_desktop_env.setattr(server, "_load_service_tier", lambda: None)
+        no_desktop_env.setattr(
+            run_agent,
+            "AIAgent",
+            lambda **kwargs: captured.update(kwargs) or SimpleNamespace(),
+        )
+
+        server._make_agent("sid", "key", session_db=object(), platform_override="desktop")
+
+        assert captured["disabled_toolsets"] == ["browser"]
+
+        from model_tools import get_tool_definitions
+
+        definitions = get_tool_definitions(
+            enabled_toolsets=captured["enabled_toolsets"],
+            disabled_toolsets=captured["disabled_toolsets"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        tool_names = {item["function"]["name"] for item in definitions}
+        assert "browser_navigate" not in tool_names
+
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5252,6 +5252,33 @@ def _gui_surface_toolsets(platform: str) -> set[str]:
     return surfaces
 
 
+def _configured_disabled_toolsets(config: dict | None = None) -> list[str]:
+    """Return the profile-wide hard-suppression list in canonical form."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    agent_cfg = config.get("agent") or {}
+    disabled = agent_cfg.get("disabled_toolsets") or []
+    if not disabled:
+        return []
+
+    from agent.skill_utils import parse_config_string_list
+
+    return sorted({
+        name.strip() for name in parse_config_string_list(disabled) if name.strip()
+    })
+
+
+def _without_disabled_toolsets(toolsets: set[str], config: dict | None = None) -> set[str]:
+    """Apply the profile-wide deny list after client-surface injection."""
+    return toolsets - set(_configured_disabled_toolsets(config))
+
+
 def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     session_platform = platform or _resolve_session_platform()
     explicit = [
@@ -5278,7 +5305,11 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
                 # coding posture returns before the fallback path that normally
                 # adds them — without this the desktop loses its pane/project
                 # tools exactly when sitting in a repo (see below).
-                return sorted({*selection, *_gui_surface_toolsets(session_platform)})
+                return sorted(
+                    _without_disabled_toolsets(
+                        {*selection, *_gui_surface_toolsets(session_platform)}
+                    )
+                )
         except Exception:
             pass
 
@@ -5395,7 +5426,11 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         # surface them. This resolver runs ONLY in the desktop/TUI gateway, so
         # folding them in here is the gate that exposes them on exactly the
         # surface that can answer them.
-        return sorted(enabled | _gui_surface_toolsets(session_platform))
+        return sorted(
+            _without_disabled_toolsets(
+                enabled | _gui_surface_toolsets(session_platform), cfg
+            )
+        )
     except Exception:
         if fallback_notice is not None:
             print(
@@ -7826,6 +7861,11 @@ def _make_agent(
             else _load_service_tier()
         ),
         enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
+        # Apply profile denies again during final schema assembly.  Exact-name
+        # subtraction above protects injected surface bundles; this second
+        # boundary strips denied capabilities nested inside aggregate postures
+        # such as ``coding`` (which directly includes browser automation).
+        disabled_toolsets=_configured_disabled_toolsets(cfg),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.


### PR DESCRIPTION
## Summary

- install both profile home and an authoritative profile-local secret scope for multiplex cron ticks
- prevent secondary pooled Desktop backends from multiplexing every profile cron store
- ensure globally disabled toolsets cannot be re-injected by Desktop/client surface discovery
- add regressions for ambient credential isolation, primary-only Desktop cron ownership, and GUI toolset denial

## Why

A documentation cron could be physically claimed by a code-review or issue-engineer Desktop backend. Although files were persisted under the target profile, process ownership and ambient credential fallback could expose the claiming backend identity. Desktop surface injection could also restore globally denied GUI toolsets.

## Verification

- independent pre-commit re-review: passed; no security concerns or logic errors
- affected secret-scope suites: 56 passed, 2 skipped
- focused runtime suites: 48 passed
- broad cron/Desktop suite: 988 passed, 10 skipped, 3 known order-dependent failures reproduced on clean HEAD
- Ruff: passed
- git diff --check: passed

## Runtime validation

A harmless one-shot documentation-engineer cron probe completed under the documentation-engineer backend PID, with no code-review record. The temporary probe job, script, and output were removed and read back as absent.