### PR TITLE
fix(search): carry macOS protected exclusions into the zero-match probes

### DIFF
--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -209,3 +209,28 @@ def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypat
     paths = [match.path for match in result.matches]
     assert any("visible.txt" in path for path in paths)
     assert all("protected.txt" not in path for path in paths)
+
+
+def test_zero_match_probes_keep_protected_globs(tmp_path, monkeypatch):
+    """The zero-match probes re-scan the root (the hidden probe with
+    --hidden --no-ignore) — they must carry the same protected exclusions
+    as the primary engines, or a zero-result broad search still descends
+    into protected app data and fires the unattended TCC prompt."""
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
+
+    ops._zero_match_probe("needle.[0-9]", str(home), None)
+
+    probe_commands = [c for c in env.commands if c.startswith("rg ")]
+    assert probe_commands, "probes issued no rg commands"
+    assert any("--hidden --no-ignore" in c for c in probe_commands)
+    for command in probe_commands:
+        for dirname in PROTECTED_NAMES:
+            assert f"!{dirname}/**" in command, (
+                f"probe missing exclusion for {dirname}: {command}"
+            )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2988,6 +2988,13 @@ class ShellFileOperations(FileOperations):
             return shown + (f" (+{extra} more)" if extra > 0 else "")
 
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        # Apply the same macOS TCC-protected exclusions the main engines use.
+        # The probes re-scan the root — the hidden probe even with --hidden
+        # --no-ignore — so without this a ZERO-RESULT broad search still
+        # descends into protected app data and fires the unattended prompt
+        # the primary exclusion just avoided.
+        for _item in self._macos_search_exclusions(path):
+            glob_expr += f" --glob {self._escape_shell_arg(f'!{_item}/**')}"
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "


### PR DESCRIPTION
## Problem

The macOS protected-search exclusions added in 0.20.6 (`_macos_search_exclusions`) cover the four primary search engines, but not `_zero_match_probe`.

A **zero-result** broad content search re-scans the search root up to three times — including the hidden probe with `--hidden --no-ignore` — without the exclusion globs. On macOS 26 that descends into protected app data (`~/Library/Containers` etc.) and fires the unattended `kTCCServiceSystemPolicyAppData` prompt the primary exclusions just avoided. That prompt is allow-once for CLI clients, so it recurs forever.

Observed on a production agent (macOS 26, arm64): TCC prompt lands <2s after a broad sweep whose *visible* engines were already excluded — the probes were the remaining trigger. Related context: #49110, and the same trigger class as hermes-webui#1485.

## Fix

Append the existing `_macos_search_exclusions` globs to the shared `glob_expr` used by all three probe invocations. No behavior change on non-macOS or for explicitly-targeted protected paths (same policy as the primary engines).

## Testing

New test `test_zero_match_probes_keep_protected_globs` exercises all three probes and asserts every protected dir is excluded from each; full `test_macos_protected_search.py` suite passes (12/12) on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)