### PR TITLE
test(serve): cover BACKEND_PORT_IN_USE sentinel stream, not just its text

### DIFF
--- a/tests/hermes_cli/test_serve_port_in_use.py
+++ b/tests/hermes_cli/test_serve_port_in_use.py
@@ -11,6 +11,9 @@ Contract under test:
 * conflict → single stdout sentinel ``BACKEND_PORT_IN_USE port=<port>`` +
   a human hint line + exit code 75 (EX_TEMPFAIL, the repo's existing
   transient-condition convention) — and NO ``HERMES_BACKEND_READY``.
+* that conflict sentinel must land on **stdout specifically**, not merely
+  "somewhere in the merged output" — see
+  ``test_conflict_sentinel_is_on_stdout_not_stderr``.
 * free explicit port → boots and announces ``HERMES_BACKEND_READY`` exactly
   as before (contract untouched).
 * ``--port 0`` (ephemeral) → probe skipped, boots, announces the
@@ -242,3 +245,42 @@ def test_ready_sentinel_arrives_on_stdout_not_stderr(tmp_path):
             proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+def test_conflict_sentinel_is_on_stdout_not_stderr(tmp_path):
+    """The conflict sentinel must reach STDOUT, the pipe consumers watch.
+
+    Regression guard for the sibling half of the #96282 class of bug. Importing
+    ``tui_gateway.server`` (done in ``start_server`` for the flush-on-SIGTERM
+    handlers) rebinds ``sys.stdout`` to stderr, so a plain ``print()`` of a
+    machine sentinel silently changes channel. The READY sentinel was fixed in
+    f2dd32d3e and the conflict sentinel in 42e1aa39f — but that second fix
+    shipped with no test, and every other case here spawns with
+    ``stderr=subprocess.STDOUT``, which merges the streams and passes whether
+    the sentinel goes to fd 1 or fd 2.
+
+    Verified to have teeth: reverting ``_report_port_in_use`` to a bare
+    ``print()`` leaves the rest of this module green and fails only this test.
+    """
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("127.0.0.1", 0))
+    holder.listen(1)
+    port = holder.getsockname()[1]
+    try:
+        # stderr discarded, NOT merged: an assertion on this stdout text is
+        # then a real statement about which fd the sentinel was written to.
+        proc = _spawn_serve(port, tmp_path, merge_stderr=False)
+        try:
+            out, _ = proc.communicate(timeout=180)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            pytest.fail("serve did not exit on a port conflict")
+    finally:
+        holder.close()
+
+    assert proc.returncode == 75, f"exit={proc.returncode}\nstdout:\n{out}"
+    assert f"BACKEND_PORT_IN_USE port={port}" in out, (
+        "conflict sentinel missing from STDOUT — a stdout-parsing consumer "
+        f"(desktop spawn, scripts) would see no reason for the exit.\n"
+        f"stdout was:\n{out}"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds the missing regression test for the **second half** of the #96282 fix. That fix landed in two commits: f2dd32d3e moved the READY sentinel to fd 1 and added a split-stream test, then 42e1aa39f applied the same fix to the `BACKEND_PORT_IN_USE` sibling site — with no test.

Every other case in `test_serve_port_in_use.py` spawns with `stderr=subprocess.STDOUT`, so the merged output contains the sentinel whether it went to fd 1 or fd 2. The existing assertions are therefore blind to the exact regression #96282 was about: `start_server` imports `tui_gateway.server`, which rebinds `sys.stdout` to stderr, so a bare `print()` of a machine sentinel silently changes channel while the suite stays green.

## Related Issue

Follow-up test coverage for #96282 (fixed in f2dd32d3e / 42e1aa39f / 8d95ab1b3).

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/hermes_cli/test_serve_port_in_use.py`: add `test_conflict_sentinel_is_on_stdout_not_stderr`, spawning with `merge_stderr=False` so an assertion on stdout is a real statement about which fd was written. Reuses the existing helper's `merge_stderr` parameter — no new scaffolding.

## How to Test

1. `pytest tests/hermes_cli/test_serve_port_in_use.py -q` → 10 passed.
2. Confirm the test has teeth — revert the sibling fix in `hermes_cli/web_server.py`:
   ```python
   def _report_port_in_use(host: str, port: int) -> None:
       print(_PORT_IN_USE_SENTINEL.format(port=port), flush=True)  # was _write_machine_sentinel_line
   ```
3. Re-run: **only** the new test fails (`assert 'BACKEND_PORT_IN_USE port=NNNNN' in ''`); the other 9 still pass — which is the coverage gap this closes.

Verified on macOS 26.6.2 (arm64), Python 3.13, at `cced6fa360`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open or closed PR covers this sentinel's stream
- [x] My PR contains **only** changes related to this fix (a single test function; no production code touched)
- [x] I've run the affected suite and all tests pass
- [x] I've added tests for my changes — the PR *is* the test
- [x] I've tested on my platform: macOS 26.6.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (test-only; the contract is documented in the module docstring, which this PR extends)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the test asserts only on stdout and discards stderr, so it carries no shell or path assumptions; the existing module already guards `sys.platform == "win32"` behavior at the same layer

## Note on scope

This is deliberately a **behavior-contract** test (which fd the sentinel reaches), not a change-detector on the message text, per the testing guidance in `AGENTS.md`.

