### PR TITLE
fix(cli): restart hermes-webui* units after hermes update

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -29,7 +29,7 @@ _FLEET_RESTART_PENDING_NAME = "fleet_restart_pending"
 _FRESH_RESTART_SUPERVISORS = frozenset({"systemd", "launchd", "service", "s6"})
 
 _SYSTEMD_SCOPES = (("user", ["systemctl", "--user"]), ("system", ["systemctl"]))
-_LIST_GATEWAY_UNITS = ["list-units", "hermes-gateway*", "hermes-serve*", "--plain", "--no-legend", "--no-pager"]
+_LIST_GATEWAY_UNITS = ["list-units", "hermes-gateway*", "hermes-serve*", "hermes-webui*", "--plain", "--no-legend", "--no-pager"]
 
 
 def _write_gateway_update_exit_code(ok: bool) -> None:
@@ -240,7 +240,7 @@ def _needs_sudo(scope: str) -> bool:
 
 
 def _restart_systemd_gateway_units_best_effort(failed: list, listings) -> None:
-    """Best-effort ``systemctl restart`` of every hermes-gateway/serve unit."""
+    """Best-effort ``systemctl restart`` of every hermes-gateway/serve/webui unit."""
     answered = set()
     for scope, scope_cmd, result in listings:
         answered.add(scope)
@@ -310,7 +310,7 @@ def _run_pending_fleet_restart() -> bool:
                     kill_gateway_processes(all_profiles=True)
                     _wait_for_gateway_exit(timeout=5.0, force_after=None)
         # --- Systemd services (Linux) --- Discover all hermes-gateway* units (default + profiles) plus
-        # hermes-serve* units (the Desktop app's backend, #83438).
+        # hermes-serve* units (the Desktop app's backend, #83438) and companion hermes-webui* units.
         if systemd_listings is not None:
             _restart_systemd_gateway_units_best_effort(failed, systemd_listings)
         # --- Launchd services (macOS) --- Restart EVERY ai.hermes.gateway* LaunchAgent, not only the
@@ -421,17 +421,19 @@ def _is_hermes_gateway_unit(unit: str) -> bool:
     """Exact base unit or hyphenated profile family only: ``startswith("hermes-serve")``
     would accept ``hermes-server.service``."""
     return (
-        # list-units is already pattern-filtered, but keep the name gate so a stray non-gateway/serve line
+        # list-units is already pattern-filtered, but keep the name gate so a stray non-gateway/serve/webui line
         # cannot enter the restart path. See #83595.
         unit == "hermes-gateway.service"
         or unit.startswith("hermes-gateway-")
         or unit == "hermes-serve.service"
         or unit.startswith("hermes-serve-")
+        or unit == "hermes-webui.service"
+        or unit.startswith("hermes-webui-")
     )
 
 
 def _for_each_systemd_gateway_unit(list_units_stdout: str, *, process_unit, on_unit_timeout) -> None:
-    """Process each hermes-gateway*/hermes-serve* unit from ``systemctl list-units``.
+    """Process each hermes-gateway*/hermes-serve*/hermes-webui* unit from ``systemctl list-units``.
 
     ``TimeoutExpired`` from ``process_unit`` is isolated per unit via ``on_unit_timeout``
     so one wedged systemctl call cannot abort the rest of the fleet.
@@ -789,7 +791,7 @@ def _restart_one_systemd_gateway_unit(
     svc_name: str, *, scope: str, scope_cmd: list, drain_budget: float, _manage_cmd_cache: dict,
     restarted_services: list, failed_or_stale_units: list,
 ) -> None:
-    """Restart one active systemd gateway/serve unit: graceful SIGUSR1 drain, then forced restart.
+    """Restart one active systemd gateway/serve/webui unit: graceful SIGUSR1 drain, then forced restart.
 
     Appends settled names to ``restarted_services`` and failures to ``failed_or_stale_units``.
     """
@@ -889,7 +891,7 @@ def _restart_one_systemd_gateway_unit(
 
 
 def _restart_systemd_gateway_units(restarted_services, failed_or_stale_units, restarted_scoped_units, drain_budget):
-    """Restart every active hermes-gateway*/hermes-serve* systemd unit (user + system).
+    """Restart every active hermes-gateway*/hermes-serve*/hermes-webui* systemd unit (user + system).
 
     Settled units → ``restarted_services`` (bare) and ``restarted_scoped_units``
     (``scope/name``); failures → ``failed_or_stale_units``. Per-unit timeouts isolated.

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -108,6 +108,47 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == ["hermes-serve", "hermes-serve-work", "hermes-gateway"]
 
+    def test_hermes_webui_units_are_included(self):
+        # #95882 — hermes update restarted hermes-gateway* and hermes-serve*
+        # units but left companion hermes-webui* (sharing the source tree) on
+        # stale pre-update code, producing HTTP 409 until a manual restart.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            "\n".join(
+                [
+                    "ssh.service loaded active running",
+                    "hermes-webui.service loaded active running",
+                    "hermes-webui-prod.service loaded active running",
+                    "hermes-serve.service loaded active running",
+                    "hermes-gateway.service loaded active running",
+                    "",
+                ]
+            ),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == [
+            "hermes-webui",
+            "hermes-webui-prod",
+            "hermes-serve",
+            "hermes-gateway",
+        ]
+
+    def test_hermes_webui_near_prefix_is_rejected(self):
+        # Keep the exact/hyphenated gate: a bare prefix would also accept
+        # the unrelated ``hermes-webuictl.service``.
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            _list_units_stdout(["hermes-webuictl", "hermes-webui-coder"]),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-webui-coder"]
+
     def test_hermes_server_near_prefix_is_rejected(self):
         # Review on #83595: a bare ``startswith("hermes-serve")`` gate also
         # accepts the unrelated ``hermes-server.service``. Only the exact
@@ -137,6 +178,59 @@ class TestFleetRestartTimeoutIsolation:
         assert seen == ["hermes-gateway-coder"]
 
 
+class TestFleetRestartBestEffort:
+    def test_discovers_and_restarts_hermes_webui_units(self, monkeypatch):
+        # #95882 — the user-facing boundary is that ``hermes update`` runs
+        # ``systemctl list-units`` with the right globs and restarts the units.
+        # Mock the subprocess boundary so this is testable on macOS/CI.
+        from hermes_cli.update_cmd_fleet import (
+            _restart_systemd_gateway_units_best_effort,
+            _systemd_gateway_unit_listings,
+        )
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "list-units" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="\n".join(
+                        [
+                            "hermes-webui.service loaded active running",
+                            "hermes-serve.service loaded active running",
+                        ]
+                    )
+                )
+            stdout = "active\n" if "is-active" in cmd else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        failed: list[str] = []
+        listings = list(_systemd_gateway_unit_listings())
+        _restart_systemd_gateway_units_best_effort(failed, listings)
+
+        list_units_calls = [c for c in calls if "list-units" in c]
+        assert list_units_calls == [
+            prefix + [
+                "list-units", "hermes-gateway*", "hermes-serve*",
+                "hermes-webui*", "--plain", "--no-legend", "--no-pager",
+            ]
+            for prefix in (["systemctl", "--user"], ["systemctl"])
+        ]
+
+        restart_calls = [
+            c for c in calls if "restart" in c and "hermes-webui" in c
+        ]
+        assert len(restart_calls) == 2
+        assert "--user" in restart_calls[0]
+        assert "--user" not in restart_calls[1]
+        assert [c for c in calls if c[-2:] == ["is-active", "hermes-webui"]] == [
+            ["systemctl", "--user", "is-active", "hermes-webui"],
+            ["systemctl", "is-active", "hermes-webui"],
+        ]
+        assert failed == []
+
+
 class TestGracefulSigusr1Eligibility:
     def test_gateway_units_are_eligible(self):
         assert _service_unit_supports_graceful_sigusr1_restart("hermes-gateway")
@@ -152,6 +246,10 @@ class TestGracefulSigusr1Eligibility:
         assert not _service_unit_supports_graceful_sigusr1_restart(
             "hermes-serve-work"
         )
+
+    def test_webui_units_are_not_eligible(self):
+        assert not _service_unit_supports_graceful_sigusr1_restart("hermes-webui")
+        assert not _service_unit_supports_graceful_sigusr1_restart("hermes-webui-prod")
 
     def test_process_errors_other_than_timeout_still_propagate(self):
         def process_unit(_svc_name: str) -> None:


### PR DESCRIPTION
## What does this PR do?

`hermes update` already restarts `hermes-gateway*` and `hermes-serve*` systemd units after a code update, but it had no awareness of companion `hermes-webui*` units. On deployments where the WebUI backend runs as a systemd unit sharing the Hermes source tree, the WebUI keeps serving pre-update Python/JS after the update and returns HTTP 409 until it is manually restarted.

This PR adds `hermes-webui*` to the `systemctl list-units` patterns and to the unit-name gate, mirroring the existing treatment of `hermes-serve*` (#83438) so the fleet-restart phase restarts the WebUI backend alongside the other Hermes services.

## Related Issue

Fixes #95882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_fleet.py`: Add the WebUI discovery pattern and accept only the exact base unit or hyphenated profile family. Preserve current upstream's pre-stop listings and restart verification.
- `tests/hermes_cli/test_update_fleet_restart_timeout.py`: Cover base/profile WebUI names, near-prefix rejection, discovery and restart in both systemd scopes, activation readback, and exclusion from gateway-only SIGUSR1 handling.

## How to Test

Run the focused suite from the upstream repository root:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_timeout.py
```

The paired regression check runs identical committed test bytes on current main and this branch. The WebUI inclusion, near-prefix-with-valid-profile, and discovery/restart cases must fail on main and pass on the branch. The complete focused suite also preserves timeout isolation and gateway/serve behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the canonical project checker (`scripts/check.sh --project hermes-agent --worktree <path>`) against the changed test files and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated docstrings in `hermes_cli/update_cmd_fleet.py`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Linux/systemd-only change; macOS/Windows paths unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A