### PR TITLE
fix(tui): keep chat history visible after terminal resize

### DIFF
--- a/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
+++ b/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import { startPromptLiveSession } from '../app/useMainApp.js'
+import { buildTranscriptRows, startPromptLiveSession } from '../app/useMainApp.js'
+
+describe('buildTranscriptRows', () => {
+  it('keeps row keys stable so resize reflow preserves virtual-history anchors', () => {
+    const messages = [
+      { role: 'user' as const, text: 'hello' },
+      { role: 'assistant' as const, text: 'world' }
+    ]
+
+    const ids = new WeakMap(messages.map((message, index) => [message, `message-${index}`]))
+    const messageId = (message: (typeof messages)[number]) => ids.get(message)!
+
+    const beforeResize = buildTranscriptRows(messages, messageId)
+    const afterResize = buildTranscriptRows(messages, messageId)
+
+    expect(afterResize.map(row => row.key)).toEqual(beforeResize.map(row => row.key))
+  })
+})
 
 describe('startPromptLiveSession', () => {
   it('starts a kept-live session with generated id/title, applies selected model, then dispatches the prompt', async () => {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -145,6 +145,10 @@ export async function startPromptLiveSession({
   return sid
 }
 
+export function buildTranscriptRows(historyItems: readonly Msg[], messageId: (msg: Msg) => string): TranscriptRow[] {
+  return historyItems.map((msg, index) => ({ index, key: messageId(msg), msg }))
+}
+
 export function useMainApp(gw: GatewayClient) {
   const { exit } = useApp()
   const { stdout } = useStdout()
@@ -338,15 +342,13 @@ export function useMainApp(gw: GatewayClient) {
     return next
   }, [])
 
-  // Wrapped row heights are width-dependent. Cached layout outlives a resize
-  // and lands sticky-scroll at the stale max, cutting off the tail. The
-  // hook's "scale heights by oldCols/newCols" path is too approximate for
-  // mixed markdown — we deliberately remount every row so yoga re-measures
-  // off live geometry. Cost: per-row local state (e.g. systemOpen toggles)
-  // resets on resize; small UX hit for a hard correctness win.
+  // Keep logical row identity stable across width changes. useVirtualHistory
+  // invalidates width-dependent measurements and remeasures the mounted rows;
+  // remounting every row here discards that anchor state during SIGWINCH and
+  // can leave the transcript viewport in an empty spacer.
   const virtualRows = useMemo<TranscriptRow[]>(
-    () => historyItems.map((msg, index) => ({ index, key: `${messageId(msg)}:c${cols}`, msg })),
-    [cols, historyItems, messageId]
+    () => buildTranscriptRows(historyItems, messageId),
+    [historyItems, messageId]
   )
 
   const detailsLayoutKey = useMemo(() => {


### PR DESCRIPTION
## What does this PR do?

Preserves TUI transcript history across terminal resize reflow. Transcript rows now keep their logical React identity while `useVirtualHistory` invalidates width-dependent measurements and remeasures mounted content, preventing resize-driven remounts from discarding virtual-history anchor state and leaving only the composer visible.

### Symptom

After a terminal resize, previously visible TUI chat messages can disappear while the composer remains usable and subsequent messages still render.

### Impact

Users lose access to the visible context of an active conversation whenever they resize, maximize, or restore the terminal window.

### Bug Cause

**Trigger:** `ui-tui/src/app/useMainApp.ts` / `virtualRows` on a terminal column change.

**Causal chain:**
1. A terminal resize updates `cols`.
2. Every transcript row key includes `cols`, so React treats all historical rows as different elements and remounts the complete virtualized window.
3. The remount drops the stable row identity used by virtual-history measurement and anchoring, allowing the viewport to land in an empty spacer after reflow.

**Why it is wrong:** Terminal width changes affect row measurements, not message identity. `useVirtualHistory` already invalidates width-dependent measurements, scales the provisional cache, freezes the mounted range, and remeasures rows after layout.

**Working sibling / contrast:** Width-resize coverage in `virtualHistoryOffsetCache.test.ts` and `scrollBoxRendererBounds.test.ts` keeps stable item keys while remeasuring and preserves mounted viewport coverage.

**Ruled out:** The Ink alt-screen erase/repaint path is not the state-loss source; focused resize tests confirm it erases and repaints committed content. The failure is in application-level row identity during virtualized reflow.

### Fix

Build transcript rows from stable message IDs only, independent of terminal columns. Add a regression contract that repeated row projections preserve keys across resize reflow.

## Related Issue

Closes #96372

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/useMainApp.ts` - keep transcript row keys stable across width changes while retaining width-aware remeasurement.
- `ui-tui/src/__tests__/orchestratorPromptSession.test.ts` - verify transcript row identity remains stable across repeated projections.

## How to Test

1. Start `hermes` in TUI mode and create several visible conversation turns.
2. Resize, maximize, and restore the terminal window.
3. Confirm previous messages remain visible and rewrap while the composer remains usable.
4. Run the focused automated checks:

```bash
cd ui-tui
npx vitest run src/__tests__/orchestratorPromptSession.test.ts src/__tests__/virtualHistoryOffsetCache.test.ts src/__tests__/scrollBoxRendererBounds.test.ts packages/hermes-ink/src/ink/ink-resize.test.ts
npm run typecheck
npx eslint src/app/useMainApp.ts src/__tests__/orchestratorPromptSession.test.ts
```

Focused result: 4 files and 27 tests passed; TypeScript and focused ESLint checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant TUI test suite and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the automated path on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] Config example update is N/A
- [x] Architecture/workflow documentation update is N/A
- [x] I've considered cross-platform impact; the change uses platform-independent React identity and virtual-history logic
- [x] Tool description/schema update is N/A

## Screenshots / Logs

Focused automated checks are listed above; real-terminal verification is part of review because the reported symptom depends on PTY resize behavior.
