### PR TITLE
feat(gateway): add /todo to show the session task list

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16788,6 +16788,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "background": self._handle_background_command,
                 "kanban": self._handle_kanban_command,
                 "subgoal": self._handle_subgoal_command,
+                "todo": self._handle_todo_command,
                 "heartbeat": self._handle_heartbeat_command,
                 "yolo": self._handle_yolo_command,
                 "verbose": self._handle_verbose_command,
@@ -18249,6 +18250,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "subgoal":
             return await self._handle_subgoal_command(event)
+
+        if canonical == "todo":
+            return await self._handle_todo_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3140,6 +3140,42 @@ class GatewaySlashCommandsMixin:
         idx = len(mgr.state.subgoals) if mgr.state else 0
         return f"✓ Added subgoal {idx}: {text}"
 
+    async def _handle_todo_command(self, event: "MessageEvent") -> str:
+        """Handle /todo — show the agent's task list for this session.
+
+        The list lives on the AIAgent instance (``_todo_store``), so this
+        resolves the running agent first (mid-turn, which is when the list is
+        most useful) and falls back to the cached agent between turns. This is
+        read-only, so it is safe to invoke while the agent is running.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        session_key = self._session_key_for_source(event.source)
+
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            cache = getattr(self, "_agent_cache", None)
+            if cache_lock is not None and cache is not None:
+                try:
+                    with cache_lock:
+                        cached = cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+                except Exception:
+                    agent = None
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            return "📋 No task list yet — no agent is resident for this session."
+
+        store = getattr(agent, "_todo_store", None)
+        if store is None:
+            return "📋 No task list yet — this session has no todo store."
+
+        rendered = store.format_for_display()
+        if not rendered:
+            return "📋 No task list yet."
+        return f"📋 Task list\n\n{rendered}"
+
     async def _get_loop_manager_for_event(self, event: "MessageEvent"):
         """Return a LoopManager bound to the session for this gateway event.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -221,6 +221,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<prompt>", busy_policy="reject", busy_handler="moa"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]", busy_policy="dispatch"),
+    CommandDef("todo", "Show the agent's task list for this session", "Session",
+               aliases=("todos", "plan"), gateway_only=True, busy_policy="dispatch"),
     CommandDef("status", "Show session, model, token, and context info", "Session",
                busy_policy="dispatch"),
     CommandDef("egress", "Show Docker egress proxy status", "Session",
@@ -467,6 +469,7 @@ HELP_SESSION_SUBGROUPS: dict[str, tuple[str, ...]] = {
         "background", "bg", "btw", "agents", "tasks", "queue", "q", "steer",
         "goal", "subgoal", "heartbeat", "hb", "refine", "loop", "proactive",
         "moa", "journey", "learning", "memory-graph",
+        "todo", "todos", "plan",
     ),
 }
 

--- a/tests/gateway/test_todo_command.py
+++ b/tests/gateway/test_todo_command.py
@@ -1,0 +1,163 @@
+"""Tests for the /todo gateway slash command.
+
+Covers the registry contract (the command dispatches mid-run rather than
+hitting the busy-reject catch-all) and the handler's agent-resolution
+cascade: running agent → cached agent → no agent.
+"""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.commands import (
+    ACTIVE_SESSION_BYPASS_COMMANDS,
+    COMMAND_REGISTRY,
+    GATEWAY_KNOWN_COMMANDS,
+)
+from tools.todo_tool import TodoStore
+
+
+def _todo_def():
+    return next(c for c in COMMAND_REGISTRY if c.name == "todo")
+
+
+def test_todo_is_gateway_known_with_aliases():
+    for name in ("todo", "todos", "plan"):
+        assert name in GATEWAY_KNOWN_COMMANDS
+
+
+def test_todo_dispatches_while_agent_is_busy():
+    # The list is most useful mid-turn, so /todo must not fall through to the
+    # "Agent is running" busy-reject catch-all.
+    assert _todo_def().busy_policy == "dispatch"
+    assert "todo" in ACTIVE_SESSION_BYPASS_COMMANDS
+
+
+def test_todo_has_no_busy_handler():
+    # busy_policy="dispatch" with no busy_handler routes to the plain-handler
+    # table in _dispatch_busy_slash_command, which is where "todo" is wired.
+    assert _todo_def().busy_handler is None
+
+
+# --- TodoStore.format_for_display -----------------------------------------
+
+
+def test_format_for_display_empty_returns_none():
+    assert TodoStore().format_for_display() is None
+
+
+def test_format_for_display_keeps_completed_and_cancelled():
+    # Unlike format_for_injection (which drops finished work so the model does
+    # not redo it), the user-facing render must show progress.
+    store = TodoStore()
+    store.write(
+        [
+            {"id": "1", "content": "read source", "status": "completed"},
+            {"id": "2", "content": "write test", "status": "in_progress"},
+            {"id": "3", "content": "open PR", "status": "pending"},
+            {"id": "4", "content": "abandoned idea", "status": "cancelled"},
+        ]
+    )
+    out = store.format_for_display()
+    assert "[x] read source" in out
+    assert "[>] write test" in out
+    assert "[ ] open PR" in out
+    assert "[~] abandoned idea" in out
+    assert "1/4 done" in out
+
+
+def test_format_for_display_omits_injection_header():
+    from tools.todo_tool import TODO_INJECTION_HEADER
+
+    store = TodoStore()
+    store.write([{"id": "1", "content": "task", "status": "pending"}])
+    assert TODO_INJECTION_HEADER not in store.format_for_display()
+
+
+# --- handler --------------------------------------------------------------
+
+
+class _Runner:
+    """Minimal stand-in exposing only what _handle_todo_command reads."""
+
+    def __init__(self, running=None, cached=None):
+        self._running_agents = running or {}
+        self._agent_cache = cached
+        self._agent_cache_lock = threading.Lock()
+
+    def _session_key_for_source(self, source):
+        return "sess"
+
+    async def handle(self, event):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        return await GatewaySlashCommandsMixin._handle_todo_command(self, event)
+
+
+def _event():
+    return SimpleNamespace(source=SimpleNamespace(platform=None))
+
+
+def _agent_with(items):
+    store = TodoStore()
+    if items:
+        store.write(items)
+    return SimpleNamespace(_todo_store=store)
+
+
+@pytest.mark.asyncio
+async def test_no_resident_agent():
+    out = await _Runner().handle(_event())
+    assert "No task list yet" in out
+
+
+@pytest.mark.asyncio
+async def test_pending_sentinel_is_not_an_agent():
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _Runner(running={"sess": _AGENT_PENDING_SENTINEL})
+    out = await runner.handle(_event())
+    assert "No task list yet" in out
+
+
+@pytest.mark.asyncio
+async def test_reads_the_running_agent():
+    runner = _Runner(
+        running={"sess": _agent_with([{"id": "1", "content": "ship it", "status": "in_progress"}])}
+    )
+    out = await runner.handle(_event())
+    assert "[>] ship it" in out
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_cached_agent_between_turns():
+    agent = _agent_with([{"id": "1", "content": "cached task", "status": "pending"}])
+    runner = _Runner(cached={"sess": (agent, object())})
+    out = await runner.handle(_event())
+    assert "[ ] cached task" in out
+
+
+@pytest.mark.asyncio
+async def test_running_agent_wins_over_cache():
+    runner = _Runner(
+        running={"sess": _agent_with([{"id": "1", "content": "live", "status": "pending"}])},
+        cached={"sess": (_agent_with([{"id": "1", "content": "stale", "status": "pending"}]), object())},
+    )
+    out = await runner.handle(_event())
+    assert "live" in out
+    assert "stale" not in out
+
+
+@pytest.mark.asyncio
+async def test_agent_without_todo_store():
+    runner = _Runner(running={"sess": SimpleNamespace()})
+    out = await runner.handle(_event())
+    assert "No task list yet" in out
+
+
+@pytest.mark.asyncio
+async def test_empty_list_on_a_resident_agent():
+    runner = _Runner(running={"sess": _agent_with([])})
+    out = await runner.handle(_event())
+    assert "No task list yet" in out

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -149,6 +149,31 @@ class TodoStore:
 
         return "\n".join(lines)
 
+    def format_for_display(self) -> Optional[str]:
+        """Render the whole list for a user-facing surface such as ``/todo``.
+
+        Unlike ``format_for_injection``, this keeps completed and cancelled
+        items so the reader sees progress, and it omits the compression
+        header. Returns ``None`` when the list is empty.
+        """
+        if not self._items:
+            return None
+
+        markers = {
+            "completed": "[x]",
+            "in_progress": "[>]",
+            "pending": "[ ]",
+            "cancelled": "[~]",
+        }
+        lines = []
+        for item in self._items:
+            marker = markers.get(item["status"], "[?]")
+            lines.append(f"{marker} {item['content']}")
+
+        done = sum(1 for i in self._items if i["status"] == "completed")
+        lines.append(f"\n{done}/{len(self._items)} done")
+        return "\n".join(lines)
+
     @staticmethod
     def _cap_content(content: str) -> str:
         """Truncate oversized todo content to MAX_TODO_CONTENT_CHARS.


### PR DESCRIPTION
## Problem

On Telegram and other gateway platforms, the `todo` tool renders only a count. `agent/display.py` maps the tool to the verb `"Updating tasks"` and returns `f"planning {len(todos_arg)} task(s)"`, so a plan of five steps shows as:

```
📋 Updating tasks 5 task(s)
```

The list content itself is unreachable from chat. There is no `/todo` command, and `TodoStore` lives on the `AIAgent` instance, so the only existing render is `format_for_injection`, which the context compressor consumes.

## Change

Add a read-only `/todo` command (aliases `/todos`, `/plan`) that prints the session task list with status markers:

```
📋 Task list

[x] Read the source
[>] Write the tests
[ ] Open the PR
[~] Abandoned idea

1/4 done
```

- `TodoStore.format_for_display()` renders the whole list. It keeps completed and cancelled items, unlike `format_for_injection`, which drops them so the model does not redo finished work after compression.
- `CommandDef("todo", …, gateway_only=True, busy_policy="dispatch")`. The `dispatch` policy matters: the list is most useful **while the agent is running**, and without it the command falls through to the "Agent is running" busy-reject catch-all. `gateway_only=True` keeps it out of the CLI and TUI surfaces, where the transcript already shows every `todo` call.
- `_handle_todo_command` resolves the running agent first, then the cached agent between turns, mirroring the cascade `_handle_context_command` already uses.

No change to the `todo` tool schema, so per-conversation prompt caching is untouched.

## Why a command instead of richer progress output

Rendering the list inline in the progress preview was the alternative. It fires on writes only, so you would see the plan at creation and after each status flip but could never ask "where are we now?" — and the preview is capped by `tool_preview_length` (default 40 chars), so it would truncate anyway.

## Verification

Test radius, run with `scripts/run_tests.sh`:

```
=== Summary: 6 files, 57 tests passed, 0 failed (100% complete) in 4.0s (28 workers) ===
```

Covering `tests/gateway/test_todo_command.py` (13 new), `tests/tools/test_todo_tool.py`, `tests/tools/test_todo_tool_type_coercion.py`, `tests/hermes_cli/test_busy_policy_invariants.py` (the derived-bypass-set invariant), `tests/cli/test_command_palette.py` (help subgrouping), and `tests/gateway/test_status_command.py` (the sibling handler using the same agent-resolution cascade).

Gate teeth check — with `format_for_display` severed to filter finished items the way `format_for_injection` does, the suite fails as intended:

```
FAILED tests/gateway/test_todo_command.py::test_format_for_display_keeps_completed_and_cancelled
E  AssertionError: assert '[x] read source' in '[>] write test\n[ ] open PR\n\n1/4 done'
=== Summary: 1 files, 12 tests passed, 1 failed ===
```

Lint and platform checks:

```
$ ruff check gateway/run.py gateway/slash_commands.py hermes_cli/commands.py tools/todo_tool.py tests/gateway/test_todo_command.py
All checks passed!

$ python scripts/check-windows-footguns.py tools/todo_tool.py gateway/slash_commands.py
✓ No Windows footguns found (2 file(s) scanned).
```

Registration confirmed against the built registry:

```
$ python -c "from hermes_cli.commands import gateway_help_lines; ..."
`/todo` -- Show the agent's task list for this session (alias: `/todos`, `/plan`)
```

Sibling sweep: `format_for_injection` has one production caller (`agent/conversation_compression.py:3407`) and is unmodified; the new method is additive. No duplicate command names or aliases in `COMMAND_REGISTRY`. The `_ALWAYS_ALLOWED_FOR_USERS` floor is unchanged, so `/todo` follows normal slash gating.

## Known / out of scope

- **No rendered-surface screenshots.** The change produces chat text, not UI. The exact output is quoted above and asserted in the tests.
- **CLI and TUI keep the count preview.** `gateway_only=True` is deliberate: the CLI transcript already shows each `todo` call, so a command there would duplicate visible state. Extending to the CLI is a separate change if wanted.
- **Read-only.** `/todo` does not edit the list. Mutating the plan from chat would race the running agent's own writes to the same store.
