### PR TITLE
fix(credential-pool): stop a false-positive Codex quota probe hot-looping a 429

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -738,6 +738,11 @@ class CredentialPool:
         # loop runs unbounded and non-interruptible.  Reset whenever a real
         # entry is identified or an escape path returns None.
         self._unmatched_rotation_streak: int = 0
+        # entry.id -> wall-clock time at which a positive Codex quota-restored
+        # probe was last acted on by lifting that entry's cooldown.  Guards the
+        # probe against its own false positives; see
+        # ``_codex_quota_restored_upstream``.
+        self._codex_probe_honored_at: Dict[str, float] = {}
 
     def has_credentials(self) -> bool:
         with self._lock:
@@ -1799,6 +1804,27 @@ class CredentialPool:
         Only fires for openai-codex entries frozen by a 429/quota-shaped
         error.  The underlying probe is throttled per token (5 min) so this
         is safe on the hot selection path.
+
+        The probe can be WRONG, and a false positive here is expensive.  It
+        reads ``/usage`` window utilisation, which reports below 100% while the
+        account is still being refused for a limit that endpoint does not
+        expose (burst caps, per-model windows).  Because a positive result both
+        lifts the cooldown and is cached for
+        ``CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS``, every selection during that
+        window hands the benched credential straight back: the pool never
+        reaches "no available entries", ``rotate()`` never returns None, and
+        the provider fallback chain (``fallback_providers`` — nous first) is
+        never reached.  Observed 2026-08-26: ~8,000 requests over 2.5h against
+        an ``openai-codex`` pool of one entry, hot-looping the same 429 at
+        roughly one request per second until the real quota window reopened.
+
+        So a positive probe buys exactly ONE optimistic retry per entry.  If
+        the account 429s again after we acted on the probe, the probe is
+        demonstrably wrong about this account and we keep the bench, letting
+        the pool empty and provider fallback take over.  The marker is dropped
+        when the entry legitimately returns to ``OK`` (see
+        ``_available_entries``), so a genuine early reopen in a later quota
+        window is still detected.
         """
         if self.provider != "openai-codex" or entry.last_status != STATUS_EXHAUSTED:
             return False
@@ -1811,8 +1837,14 @@ class CredentialPool:
         token = entry.access_token or ""
         if not token:
             return False
+        honored_at = self._codex_probe_honored_at.get(entry.id)
+        if honored_at is not None and (entry.last_status_at or 0.0) >= honored_at:
+            # We already lifted this entry's cooldown on a positive probe and
+            # it was re-benched by a later failure.  Do not spend another live
+            # request on the same wrong answer.
+            return False
         try:
-            return bool(
+            restored = bool(
                 auth_mod._probe_codex_quota_restored(
                     token,
                     base_url=entry.base_url,
@@ -1821,6 +1853,9 @@ class CredentialPool:
         except Exception:
             logger.debug("Codex quota-restored probe failed", exc_info=True)
             return False
+        if restored:
+            self._codex_probe_honored_at[entry.id] = time.time()
+        return restored
 
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
         if entry.auth_type != AUTH_TYPE_OAUTH:
@@ -1992,6 +2027,9 @@ class CredentialPool:
                 continue
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry, sole_credential=sole_credential)
+                # True when the cooldown below is being lifted on the strength
+                # of a live probe rather than because it actually elapsed.
+                lifted_by_probe = False
                 if exhausted_until is not None and now < exhausted_until:
                     # Codex quota windows can reopen EARLY: the user redeems a
                     # banked rate-limit reset (Codex CLI / ChatGPT UI), upgrades
@@ -2005,6 +2043,7 @@ class CredentialPool:
                         and self._codex_quota_restored_upstream(entry)
                     ):
                         continue
+                    lifted_by_probe = True
                 if clear_expired:
                     cleared = replace(
                         entry,
@@ -2018,6 +2057,12 @@ class CredentialPool:
                     self._replace_entry(entry, cleared)
                     entry = cleared
                     cleared_any = True
+                    if not lifted_by_probe:
+                        # The cooldown actually elapsed, so this entry is
+                        # genuinely healthy again: forget any one-shot Codex
+                        # probe marker and let the next quota window get its
+                        # own early-reopen detection.
+                        self._codex_probe_honored_at.pop(entry.id, None)
             if refresh and self._entry_needs_refresh(entry):
                 if self.provider in ("openai-codex", "xai-oauth"):
                     # Defer single-use-token refresh to avoid holding the

--- a/tests/agent/test_credential_pool_codex_quota_probe_loop.py
+++ b/tests/agent/test_credential_pool_codex_quota_probe_loop.py
@@ -1,0 +1,174 @@
+"""A false-positive Codex quota probe must not hot-loop a benched credential.
+
+The ``/usage`` quota probe lifts an ``openai-codex`` cooldown when the upstream
+window looks reopened.  It reports window utilisation only, so it can read
+"restored" while the account is still refused for a limit that endpoint does
+not expose.  A positive result is also cached for 5 minutes, so before this
+guard every selection during that window handed the benched credential straight
+back: the pool never reached "no available entries", ``rotate()`` never returned
+None, and the ``fallback_providers`` chain was never reached.
+
+Observed 2026-08-26: ~8,000 requests over 2.5h against a one-entry
+``openai-codex`` pool, replaying the same 429 at ~1 req/s until the real quota
+window reopened.
+
+The probe now buys exactly one optimistic retry per entry per quota window.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+RESET_AT_FAR_FUTURE_SECONDS = 3 * 60 * 60
+
+
+def _load(tmp_path, monkeypatch, *, last_status_at: float, reset_at: float):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "455eb2",
+                    "label": "device_code",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual",
+                    "access_token": "***",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "last_status": "exhausted",
+                    "last_status_at": last_status_at,
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_message": "The usage limit has been reached",
+                    "last_error_reset_at": reset_at,
+                }
+            ]
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent.credential_pool import load_pool
+
+    return load_pool("openai-codex")
+
+
+@pytest.fixture
+def always_restored(monkeypatch):
+    """Force the probe to insist the quota is restored, and count the calls."""
+    import agent.credential_pool as cp
+
+    calls: list[int] = []
+
+    def _probe(token, *, base_url=None, **kwargs):
+        calls.append(1)
+        return True
+
+    monkeypatch.setattr(cp.auth_mod, "_probe_codex_quota_restored", _probe)
+    monkeypatch.setattr(
+        cp.auth_mod,
+        "_is_codex_rate_limit_shaped",
+        lambda code, reason, message: True,
+    )
+    return calls
+
+
+def test_positive_probe_still_grants_one_optimistic_retry(tmp_path, monkeypatch, always_restored):
+    """The #43747 early-reopen behaviour is preserved for the first attempt."""
+    now = time.time()
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        last_status_at=now - 5,
+        reset_at=now + RESET_AT_FAR_FUTURE_SECONDS,
+    )
+
+    entry = pool.select()
+
+    assert entry is not None, "a positive probe should lift the stale cooldown once"
+    assert entry.id == "455eb2"
+    assert entry.last_status == "ok"
+    assert len(always_restored) == 1
+
+
+def test_probe_is_not_retrusted_after_the_account_429s_again(
+    tmp_path, monkeypatch, always_restored
+):
+    """The loop terminates: pool empties, so provider fallback can engage."""
+    now = time.time()
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        last_status_at=now - 5,
+        reset_at=now + RESET_AT_FAR_FUTURE_SECONDS,
+    )
+
+    assert pool.select() is not None  # optimistic retry granted
+
+    # ...and upstream refuses it anyway, exactly as it did for 2.5 hours.
+    rotated = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id="455eb2",
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "reset_at": now + RESET_AT_FAR_FUTURE_SECONDS,
+        },
+    )
+
+    assert rotated is None, (
+        "a one-entry pool whose only credential just 429'd must report no "
+        "rotation target so the caller falls through to fallback_providers"
+    )
+    # Every subsequent selection stays empty rather than replaying the 429.
+    for _ in range(25):
+        assert pool.select() is None
+    assert len(always_restored) == 1, (
+        "the discredited probe must not be consulted again for this window"
+    )
+
+
+def test_marker_clears_once_the_real_cooldown_elapses(tmp_path, monkeypatch, always_restored):
+    """A later quota window gets its own early-reopen detection."""
+    import agent.credential_pool as cp
+
+    now = time.time()
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        last_status_at=now - 5,
+        reset_at=now + RESET_AT_FAR_FUTURE_SECONDS,
+    )
+    assert pool.select() is not None
+    assert (
+        pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="455eb2",
+            error_context={"reason": "usage_limit_reached"},
+        )
+        is None
+    )
+    assert pool._codex_probe_honored_at
+
+    # The genuine reset lands: cooldown elapsed, entry recovers on its own.
+    with pool._lock:
+        stale = pool._entries[0]
+        pool._replace_entry(
+            stale,
+            cp.replace(
+                stale,
+                last_status_at=now - RESET_AT_FAR_FUTURE_SECONDS,
+                last_error_reset_at=now - 60,
+            ),
+        )
+
+    entry = pool.select()
+    assert entry is not None
+    assert entry.last_status == "ok"
+    assert not pool._codex_probe_honored_at, "marker should not survive a real recovery"


### PR DESCRIPTION
## Summary

A false-positive Codex quota probe can pin a single-entry `openai-codex` pool into an
unbounded 429 retry loop, and — because the pool never converges to "no available entries" —
the configured `fallback_providers` chain is never reached.

## The loop

`_codex_quota_restored_upstream()` live-checks the Codex `/usage` endpoint to detect a quota
window reopening early (#43747). That endpoint reports *window utilisation only*, so it can
report below 100% while the account is still being refused for a limit it does not expose
(burst caps, per-model windows).

A positive result does two things: it lifts the entry's cooldown, and it is cached for
`CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS` (5 min). So for the whole cache window, every call to
`_available_entries()` clears the benched credential back to `STATUS_OK` and returns it.

On a pool with one entry that never converges:

- `_available_entries()` never returns empty
- so `_select_unlocked()` never returns `None`
- so `mark_exhausted_and_rotate()` reports a *successful rotation to the credential that just
  failed*

The caller reads that as a healthy rotation and retries, rather than falling through to
provider fallback. The `fallback_providers` chain is never consulted, no matter how it is
configured.

## Observed

2026-08-26, on a one-entry `openai-codex` pool: roughly 8,000 requests over 2.5 hours,
replaying the same `usage_limit_reached` 429 at about one request per second, until the real
quota window reopened. `nous` was sitting first in `fallback_providers` the entire time and
never got a turn. The persisted `last_error_reset_at` was ~3h in the future and was correctly
honoured by `_exhausted_until()` — the probe was overriding it on every selection.

Log signature:

```
credential pool: marking device_code exhausted (status=429), rotating
credential pool: rotated to device_code
Credential 429 (rate limit) — rotated to pool entry 455eb2
```

Note that it rotates *to the same entry it just benched*.

## Fix

A positive probe now buys exactly **one** optimistic retry per entry. If a failure lands after
we acted on the probe, the probe is demonstrably wrong about this account, so the bench holds
— the pool can empty and provider fallback takes over.

The marker is keyed by entry id and dropped when the cooldown *genuinely* elapses (as opposed
to being lifted by the probe), so early-reopen detection still works normally in the next quota
window. The #43747 behaviour this guards is preserved for the first attempt, which is the case
it was written for.

## Tests

`tests/agent/test_credential_pool_codex_quota_probe_loop.py`, three cases:

1. a positive probe still grants the one optimistic retry (#43747 preserved)
2. after a subsequent 429, `mark_exhausted_and_rotate()` returns `None` and stays empty across
   25 further selections — the discredited probe is not consulted again
3. the marker clears once the real cooldown elapses, restoring early-reopen detection

All three fail on `main` and pass with the fix. Case 2 reproduces the production loop exactly:
pre-fix, `mark_exhausted_and_rotate()` hands back the same entry.

Full `-k credential_pool` suite: 122 passed against `main` at v0.20.6.

## Notes

Only the `openai-codex` provider has this probe, so the blast radius is limited to that path.
No behaviour change for pools with more than one usable entry, since those already converge by
rotating to a different credential.
