### PR TITLE
fix(desktop): name pasted composer images with local time, not UTC

### DIFF
--- a/apps/desktop/electron/composer-image-name.test.ts
+++ b/apps/desktop/electron/composer-image-name.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for electron/composer-image-name.ts.
+ *
+ * Run with: vitest run --project electron composer-image-name
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * Regression (issue #96403): pasted composer screenshots were named with a
+ * UTC timestamp (Date.toISOString()), so the filename disagreed with the
+ * file's mtime, which the OS shows in local time — e.g. 8 hours off for
+ * UTC+8 users. The stamp must be built from the date's LOCAL components.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { composerImageTimestamp } from './composer-image-name'
+
+// A duck-typed Date whose local and UTC readings deliberately differ, so the
+// test distinguishes local-time formatting from toISOString() on any host,
+// regardless of the machine's own timezone (CI runners often run in UTC,
+// where a real Date could not tell the two apart).
+const LOCAL_VS_UTC_SKEWED = {
+  getFullYear: () => 2026,
+  getMonth: () => 7, // August, 0-based
+  getDate: () => 18,
+  getHours: () => 20,
+  getMinutes: () => 52,
+  getSeconds: () => 56,
+  getMilliseconds: () => 282,
+  toISOString: () => '2026-08-18T12:52:56.282Z'
+} as unknown as Date
+
+test('composerImageTimestamp renders local wall-clock components, not UTC', () => {
+  // Local reading is 20:52:56.282; the UTC reading (what a toISOString()-based
+  // stamp would produce) is 12:52:56.282. The filename must carry the local
+  // one so it agrees with the file's mtime.
+  assert.equal(composerImageTimestamp(LOCAL_VS_UTC_SKEWED), '2026-08-18_20-52-56-282')
+})
+
+test('composerImageTimestamp zero-pads every component', () => {
+  const singleDigitComponents = {
+    getFullYear: () => 2026,
+    getMonth: () => 0, // January
+    getDate: () => 3,
+    getHours: () => 4,
+    getMinutes: () => 5,
+    getSeconds: () => 6,
+    getMilliseconds: () => 7
+  } as unknown as Date
+
+  assert.equal(composerImageTimestamp(singleDigitComponents), '2026-01-03_04-05-06-007')
+})
+
+test('composerImageTimestamp keeps the legacy filename shape for real dates', () => {
+  // Same shape the toISOString()-based stamp produced, so existing tooling
+  // that parses composer_* filenames keeps working.
+  assert.match(composerImageTimestamp(), /^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}$/)
+})

--- a/apps/desktop/electron/composer-image-name.ts
+++ b/apps/desktop/electron/composer-image-name.ts
@@ -1,0 +1,30 @@
+/**
+ * Filename stamping for pasted composer images (composer-images/).
+ *
+ * The timestamp embedded in a composer image filename must be the user's
+ * LOCAL wall-clock time: these files are browsed and sorted by humans
+ * alongside their filesystem mtimes, which the OS displays in local time.
+ * Rendering the stamp with Date.toISOString() writes UTC into the filename,
+ * so for anyone off UTC the name disagrees with the file's mtime by the zone
+ * offset (issue #96403 — e.g. 8 hours off for UTC+8 users).
+ *
+ * Machine-facing artifacts (run logs, emergency backups) intentionally keep
+ * UTC stamps; this helper is for the user-facing composer-images/ directory
+ * only.
+ */
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0')
+}
+
+/**
+ * Format `date` as `YYYY-MM-DD_HH-MM-SS-mmm` in LOCAL time — the same shape
+ * the previous toISOString()-based stamp produced, but in the user's timezone.
+ */
+export function composerImageTimestamp(date: Date = new Date()): string {
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1, 2)}-${pad(date.getDate(), 2)}` +
+    `_${pad(date.getHours(), 2)}-${pad(date.getMinutes(), 2)}-${pad(date.getSeconds(), 2)}` +
+    `-${pad(date.getMilliseconds(), 3)}`
+  )
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -87,6 +87,7 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
+import { composerImageTimestamp } from './composer-image-name'
 import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
@@ -5859,7 +5860,7 @@ async function writeComposerImage(buffer, ext = '.png') {
   const safeExt = /^\.[a-z0-9]{1,5}$/.test(normalizedExt) ? normalizedExt : '.png'
   const dir = path.join(app.getPath('userData'), 'composer-images')
   await fs.promises.mkdir(dir, { recursive: true })
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').replace('Z', '')
+  const stamp = composerImageTimestamp()
   const random = crypto.randomBytes(3).toString('hex')
   const filePath = path.join(dir, `composer_${stamp}_${random}${safeExt}`)
   await fs.promises.writeFile(filePath, buffer)


### PR DESCRIPTION
## Problem

`writeComposerImage` (`apps/desktop/electron/main.ts`) stamps pasted composer image filenames via `Date.toISOString()`, which is UTC. The file's filesystem mtime is shown in local time, so the filename disagrees with the mtime by the user's zone offset — e.g. a screenshot taken at 20:52 local (UTC+8) is named `composer_2026-08-18_12-52-56-282_….png`. Confusing when browsing/sorting `composer-images/`.

Closes #96403

## Approach

- Extract the stamp into `composerImageTimestamp()` in a new small module `electron/composer-image-name.ts`, built from the date's **local** wall-clock components.
- Keep the exact legacy filename shape (`YYYY-MM-DD_HH-MM-SS-mmm`), so anything parsing `composer_*` names keeps working.

## Sibling sites (class sweep) — intentionally unchanged

The same `toISOString().replace(...)` pattern exists at three other places, all **machine-facing** artifacts where a UTC stamp is the right choice for cross-timezone log/backup correlation:

- `electron/bootstrap-runner.ts:848` — per-run bootstrap log filename
- `electron/main.ts:4127` — emergency `state.db` pre-update backup
- `electron/main.ts:9139` — corrupt connections-registry sidecar

Only the user-facing `composer-images/` filename switches to local time.

## Tests

New `electron/composer-image-name.test.ts` (3 tests, vitest `electron` project):

- pins local-time rendering with a duck-typed Date whose local and UTC readings deliberately differ — distinguishes local formatting from `toISOString()` **on any host timezone** (CI runners often run in UTC, where a real Date cannot tell the two apart)
- pins zero-padding of every component
- pins the legacy filename shape for real dates

Verification:

- Sabotage run: temporarily restoring the `toISOString()` implementation makes 2 of 3 tests fail (the shape test passes both ways, as intended); restored fix → 3/3 green.
- `tsc -p tsconfig.electron.json --noEmit` clean.
- Full electron project: 1936 passed, 1 failed — `managed-ssh-update.test.ts > POSIX managed launcher…` fails **identically on clean main** on this machine (exit 127, environment issue, unrelated to this diff).

## Risk

Cosmetic-only change to a filename string. Existing files keep their UTC names; only new pastes get local-time names. No migration needed.