### PR TITLE
fix(api-server): retry EADDRINUSE briefly across gateway restart handoff

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8446,15 +8446,42 @@ class APIServerAdapter(BasePlatformAdapter):
             #   - Linux: SO_REUSEADDR only permits rebinding past TIME_WAIT
             #     (a second live listener needs SO_REUSEPORT, never set), so
             #     keep the default (enabled) for instant restart rebinds.
-            self._site = web.TCPSite(
-                self._runner,
-                self._host,
-                self._port,
-                reuse_address=False if sys.platform == "darwin" else None,
-            )
-            try:
-                await self._site.start()
-            except OSError as exc:
+            # Local patch 0009: across a gateway restart the predecessor's
+            # socket can linger for a few seconds (kickstart -k gives no
+            # gap; reuse_address is deliberately OFF on macOS above). A
+            # single bind attempt turned that handoff race into a dead API
+            # port until the NEXT restart (observed on 3 of 4 restarts,
+            # 2026-08-25/26). Retry EADDRINUSE briefly before declaring the
+            # fatal config error — the genuinely-held-port case (#52132)
+            # still goes fatal, just ~30s later.
+            bind_exc = None
+            for _bind_attempt in range(10):
+                self._site = web.TCPSite(
+                    self._runner,
+                    self._host,
+                    self._port,
+                    reuse_address=False if sys.platform == "darwin" else None,
+                )
+                try:
+                    await self._site.start()
+                    bind_exc = None
+                    break
+                except OSError as exc:
+                    bind_exc = exc
+                    self._site = None
+                    if getattr(exc, "errno", None) != errno.EADDRINUSE:
+                        break
+                    if _bind_attempt < 9:
+                        logger.warning(
+                            "[%s] bind %s:%d busy (attempt %d/10) — "
+                            "predecessor socket may be lingering; retrying "
+                            "in 3s",
+                            self.name, self._host, self._port,
+                            _bind_attempt + 1,
+                        )
+                        await asyncio.sleep(3.0)
+            if bind_exc is not None:
+                exc = bind_exc
                 await self._runner.cleanup()
                 self._runner = None
                 self._site = None


### PR DESCRIPTION
## Problem
Across a gateway restart the predecessor's socket can linger for a few seconds (`launchctl kickstart -k` and similar supervisors give no gap; `reuse_address` is deliberately OFF on macOS per the adjacent comment). The single bind attempt turns that handoff race into a dead API port until the NEXT restart — observed on 3 of 4 production restarts (macOS arm64).

## Fix
Retry `EADDRINUSE` up to 10×/3s before the existing fatal non-retryable path. A genuinely-held port (#52132's case) still goes fatal with the same operator guidance, just ~30s later. Non-EADDRINUSE errors break immediately as before.

## Testing
Full api_server gateway suite passes on main (the one `TestHealthDetailedEndpoint` failure is pre-existing on main without this change). Live-verified across 5 production restarts since: port bound every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)