### PR TITLE
i18n(zh): localize sidebar filter menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -71,45 +71,47 @@ interface Option<T extends string = string> {
   label: string
 }
 
-const GROUPINGS: Option<SidebarGrouping>[] = [
-  { icon: 'clock', id: 'date', label: 'Updated' },
-  { icon: 'root-folder', id: 'project', label: 'Project' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
+// The label strings live in i18n (see `t.sidebar.filterMenu`); the arrays
+// below are built per-render from `fm` so they pick up the active locale.
+const GROUPING_DEFS: { icon: string; id: SidebarGrouping }[] = [
+  { icon: 'clock', id: 'date' },
+  { icon: 'root-folder', id: 'project' },
+  { icon: 'pulse', id: 'status' },
+  { icon: 'account', id: 'profile' }
 ]
 
-const ORDERINGS: Option<SidebarOrdering>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'add', id: 'created', label: 'Created' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'list-ordered', id: 'manual', label: 'Manual' }
+const ORDERING_DEFS: { icon: string; id: SidebarOrdering }[] = [
+  { icon: 'clock', id: 'updated' },
+  { icon: 'add', id: 'created' },
+  { icon: 'pulse', id: 'status' },
+  { icon: 'symbol-numeric', id: 'tokens' },
+  { icon: 'credit-card', id: 'cost' },
+  { icon: 'list-ordered', id: 'manual' }
 ]
 
-const ROW_META: Option<SidebarRowMeta>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'comment', id: 'preview', label: 'Preview' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'git-pull-request', id: 'pr', label: 'PR' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
+const ROW_META_DEFS: { icon: string; id: SidebarRowMeta }[] = [
+  { icon: 'clock', id: 'updated' },
+  { icon: 'comment', id: 'preview' },
+  { icon: 'symbol-numeric', id: 'tokens' },
+  { icon: 'credit-card', id: 'cost' },
+  { icon: 'git-pull-request', id: 'pr' },
+  { icon: 'account', id: 'profile' }
 ]
 
-const PR_FILTERS: Option<PullRequestBucket>[] = [
-  { icon: 'git-pull-request', id: 'open', label: 'Open' },
-  { icon: 'git-pull-request-draft', id: 'draft', label: 'Draft' },
-  { icon: 'git-merge', id: 'merged', label: 'Merged' },
-  { icon: 'git-pull-request-closed', id: 'closed', label: 'Closed' },
-  { icon: 'circle-slash', id: 'none', label: 'No PR' }
+const PR_FILTER_DEFS: { icon: string; id: PullRequestBucket }[] = [
+  { icon: 'git-pull-request', id: 'open' },
+  { icon: 'git-pull-request-draft', id: 'draft' },
+  { icon: 'git-merge', id: 'merged' },
+  { icon: 'git-pull-request-closed', id: 'closed' },
+  { icon: 'circle-slash', id: 'none' }
 ]
 
-const STATUS_FILTERS: Option<SessionStatusBucket>[] = [
-  { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: 'Needs input' },
-  { dot: sessionDotClassName('working'), id: 'working', label: 'Working' },
-  { dot: sessionDotClassName('unread'), id: 'unread', label: 'Unread' },
-  { dot: sessionDotClassName('draft'), id: 'draft', label: 'Draft' },
-  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: 'Idle' }
+const STATUS_FILTER_DEFS: { icon?: string; dot?: string; id: SessionStatusBucket }[] = [
+  { dot: sessionDotClassName('needs-input'), id: 'needs-input' },
+  { dot: sessionDotClassName('working'), id: 'working' },
+  { dot: sessionDotClassName('unread'), id: 'unread' },
+  { dot: sessionDotClassName('draft'), id: 'draft' },
+  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle' }
 ]
 
 function OptionGlyph({ option }: { option: Option }) {
@@ -176,6 +178,38 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   // been explicitly shut.
   const projectsCollapsed = projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
 
+  // Build the option lists with localized labels (the label strings live in
+  // i18n at `t.sidebar.filterMenu`, keyed by each option's `id`).
+  const fm = t.sidebar.filterMenu
+  const OPTION_LABEL: Record<string, string> = {
+    date: fm.updated,
+    project: fm.project,
+    status: fm.status,
+    profile: fm.profile,
+    updated: fm.updated,
+    created: fm.created,
+    tokens: fm.tokens,
+    cost: fm.cost,
+    manual: fm.manual,
+    preview: fm.preview,
+    pr: fm.pr,
+    open: fm.open,
+    draft: fm.draft,
+    merged: fm.merged,
+    closed: fm.closed,
+    none: fm.noPr,
+    'needs-input': fm.needsInput,
+    working: fm.workingStatus,
+    unread: fm.unread,
+    idle: fm.idle
+  }
+
+  const GROUPINGS = GROUPING_DEFS.map(def => ({ ...def, label: OPTION_LABEL[def.id] }))
+  const ORDERINGS = ORDERING_DEFS.map(def => ({ ...def, label: OPTION_LABEL[def.id] }))
+  const ROW_META = ROW_META_DEFS.map(def => ({ ...def, label: OPTION_LABEL[def.id] }))
+  const PR_FILTERS = PR_FILTER_DEFS.map(def => ({ ...def, label: OPTION_LABEL[def.id] }))
+  const STATUS_FILTERS = STATUS_FILTER_DEFS.map(def => ({ ...def, label: OPTION_LABEL[def.id] }))
+
   const groupingLabel = GROUPINGS.find(option => option.id === grouping)?.label
 
   // Two options are conditional: dragging a row is what picks manual, so it
@@ -227,7 +261,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
         <DropdownMenuGroup>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger hideChevron>
-              Grouping
+              {fm.grouping}
               <span className="ml-auto flex items-center gap-1 pl-4 text-(--ui-text-tertiary)">
                 {groupingLabel}
                 <Codicon name="chevron-right" size="1rem" />
@@ -246,7 +280,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Ordering</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.ordering}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
                 onValueChange={value => setSidebarOrdering(value as SidebarOrdering)}
@@ -260,7 +294,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Show</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.show}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {rowMetaOptions.map(option => (
                 <OptionCheckbox
@@ -278,17 +312,17 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           <OptionCheckbox
             checked={cardRows}
             onCheck={() => setSidebarCardRows(!cardRows)}
-            option={{ icon: 'inbox', id: 'card-rows', label: 'Inbox style' }}
+            option={{ icon: 'inbox', id: 'card-rows', label: fm.inboxStyle }}
           />
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Filters</DropdownMenuLabel>
+          <DropdownMenuLabel>{fm.filters}</DropdownMenuLabel>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.status}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {STATUS_FILTERS.map(option => (
                 <OptionCheckbox
@@ -305,7 +339,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               this submenu never appears rather than filtering everything out. */}
           {prAvailable && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Pull request</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{fm.pullRequest}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 {PR_FILTERS.map(option => (
                   <OptionCheckbox
@@ -320,7 +354,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           )}
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Profile</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.profile}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
               {/* Scoped to one profile the rail is already the filter, so the
                   per-profile boxes only appear where they can narrow something.
@@ -347,7 +381,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
 
           {projects.length > 1 && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Project</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{fm.project}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
                 {projects.map(project => (
                   <OptionCheckbox
@@ -382,12 +416,12 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           <OptionCheckbox
             checked={showArchived}
             onCheck={() => setSidebarShowArchived(!showArchived)}
-            option={{ id: 'archived', label: 'Archived' }}
+            option={{ id: 'archived', label: fm.archived }}
           />
 
           {/* One way back rather than two near-identical ones: this drops the
               grouping and sort too, which "clear filters" left behind. */}
-          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>Reset to defaults</DropdownMenuItem>}
+          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>{fm.resetToDefaults}</DropdownMenuItem>}
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
@@ -405,11 +439,11 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               )
             }
           >
-            {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+            {projectsCollapsed ? fm.expandAll : fm.collapseAll}
           </DropdownMenuItem>
         )}
         <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>
-          Mark all as read
+          {t.sidebar.markAllRead}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2318,7 +2318,39 @@ export const en: Translations = {
       working: 'Working',
       done: 'Done'
     },
-    markAllRead: 'Mark all as read'
+    markAllRead: 'Mark all as read',
+    filterMenu: {
+      grouping: 'Grouping',
+      ordering: 'Ordering',
+      show: 'Show',
+      filters: 'Filters',
+      status: 'Status',
+      pullRequest: 'Pull request',
+      profile: 'Profile',
+      project: 'Project',
+      resetToDefaults: 'Reset to defaults',
+      expandAll: 'Expand all',
+      collapseAll: 'Collapse all',
+      updated: 'Updated',
+      created: 'Created',
+      tokens: 'Tokens',
+      cost: 'Cost',
+      manual: 'Manual',
+      preview: 'Preview',
+      pr: 'PR',
+      open: 'Open',
+      draft: 'Draft',
+      merged: 'Merged',
+      closed: 'Closed',
+      noPr: 'No PR',
+      needsInput: 'Needs input',
+      workingStatus: 'Working',
+      unread: 'Unread',
+      draftStatus: 'Draft',
+      idle: 'Idle',
+      archived: 'Archived',
+      inboxStyle: 'Inbox style'
+    }
   },
 
   composer: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1980,6 +1980,39 @@ export interface Translations {
       done: string
     }
     markAllRead: string
+    filterMenu: {
+      grouping: string
+      ordering: string
+      show: string
+      filters: string
+      status: string
+      pullRequest: string
+      profile: string
+      project: string
+      resetToDefaults: string
+      expandAll: string
+      collapseAll: string
+      // Option labels (the per-row text inside each submenu).
+      updated: string
+      created: string
+      tokens: string
+      cost: string
+      manual: string
+      preview: string
+      pr: string
+      open: string
+      draft: string
+      merged: string
+      closed: string
+      noPr: string
+      needsInput: string
+      workingStatus: string
+      unread: string
+      draftStatus: string
+      idle: string
+      archived: string
+      inboxStyle: string
+    }
   }
 
   composer: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2498,7 +2498,39 @@ export const zh: Translations = {
       working: '进行中',
       done: '已完成'
     },
-    markAllRead: '全部标记为已读'
+    markAllRead: '全部标记为已读',
+    filterMenu: {
+      grouping: '分组方式',
+      ordering: '排序方式',
+      show: '显示',
+      filters: '筛选',
+      status: '状态',
+      pullRequest: '拉取请求',
+      profile: '配置文件',
+      project: '项目',
+      resetToDefaults: '恢复默认',
+      expandAll: '全部展开',
+      collapseAll: '全部折叠',
+      updated: '更新时间',
+      created: '创建时间',
+      tokens: '令牌数',
+      cost: '花费',
+      manual: '手动',
+      preview: '预览',
+      pr: 'PR',
+      open: '开启',
+      draft: '草稿',
+      merged: '已合并',
+      closed: '已关闭',
+      noPr: '无 PR',
+      needsInput: '需要输入',
+      workingStatus: '进行中',
+      unread: '未读',
+      draftStatus: '草稿',
+      idle: '空闲',
+      archived: '已归档',
+      inboxStyle: '收件箱样式'
+    }
   },
 
   composer: {


### PR DESCRIPTION
Title: i18n(zh): localize sidebar filter menu

Description: The sidebar filter menu (the funnel icon next to the session list) hardcoded all its English labels directly in apps/desktop/src/app/chat/sidebar/filter-menu.tsx — Grouping, Ordering, Show, Filters, Status, Pull request, Profile, Project, Archived, Mark all as read, Inbox style, and every per-option label (Updated, Created, Tokens, Cost, Manual, Open, Draft, Merged, Closed, No PR, Needs input, Working, Unread, Idle, etc.).

These ignored the active display.language, so even with language: zh set, that menu stayed English.

Changes:

types.ts: add sidebar.filterMenu to the Translations contract.
en.ts / zh.ts: fill sidebar.filterMenu (English source + Simplified Chinese).
filter-menu.tsx: replace the hardcoded label constants with i18n lookups from t.sidebar.filterMenu, building option lists per-render so labels follow the locale.
Type-checked clean (npx tsc --noEmit -p tsconfig.json).

侧边栏筛选菜单原本硬编码英文，忽略 display.language 设置。本 PR 将其接入 i18n 体系，中文环境下显示「分组方式/排序方式/显示/筛选/状态/拉取请求/配置文件/项目/已归档/全部标记为已读/收件箱样式」及对应选项，跟随系统语言切换。