### PR TITLE
fix(dashboard): let explicit ws_ping config outrank the loopback gate

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19855,6 +19855,48 @@ def start_server(
         except (TypeError, ValueError):
             return default
 
+    # A loopback bind is not proof of a local client. Behind a reverse proxy
+    # the server binds 127.0.0.1 while the browser is arbitrarily far away —
+    # the exact shape the dashboard docs recommend ("Public URL override":
+    # `hermes dashboard --host 127.0.0.1`, point the TLS proxy at it, and the
+    # Tailscale Serve example). There an intermediary keeps answering TCP on
+    # the server leg after the client is gone, so no FIN/RST arrives and no
+    # OS-level signal reveals the death; the protocol ping, which the browser
+    # itself must answer, is the only end-to-end liveness check available.
+    # Without it the session stays `attached` forever and PtySessionRegistry
+    # .reap_idle skips it (attached sessions are exempt by design), leaking one
+    # `hermes --tui` child per dead client until the host runs out of memory.
+    #
+    # The default is unchanged — a loopback bind still disables the ping, so an
+    # event-loop stall can never false-kill a genuinely local client — but an
+    # operator who has explicitly configured a cadence is describing their
+    # topology, which is better evidence than the bind address.
+    #
+    # Explicitness MUST be read from the raw config: load_config() deep-merges
+    # DEFAULT_CONFIG, so `"ws_ping_interval" in _dash_cfg` is True on every
+    # install and would enable the ping for all loopback binds. This is the
+    # presence-sensitive read that read_user_config_raw's docstring warns
+    # about. Managed scope is overlaid so an administrator-pinned value counts
+    # as explicit too. Values still come from the merged config, so setting
+    # only one key leaves its sibling at the documented default.
+    #
+    # read_raw_config() and NOT read_raw_config_readonly(): the overlay mutates
+    # the dict it is handed, and the readonly variant returns the shared cache
+    # object itself (its docstring: "Mutating the returned dict corrupts the
+    # in-process cache for every subsequent caller").
+    try:
+        from hermes_cli.managed_scope import apply_managed_overlay
+
+        _raw_dash_cfg = (
+            apply_managed_overlay(read_raw_config()).get("dashboard") or {}
+        )
+    except Exception:
+        _raw_dash_cfg = {}
+    _ws_ping_configured = any(
+        key in _raw_dash_cfg for key in ("ws_ping_interval", "ws_ping_timeout")
+    )
+    _use_ws_ping = (not _is_loopback) or _ws_ping_configured
+
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -19871,12 +19913,15 @@ def start_server(
         # metadata without accepting spoofed X-Forwarded-* headers from every
         # caller.
         forwarded_allow_ips=_dashboard_forwarded_allow_ips(_dash_cfg),
-        # Half-open detection for public binds only (see above). Loopback
-        # disables the protocol ping (None) so an event-loop stall can never
-        # trigger a false disconnect; a genuinely dead local client is still
-        # reaped via the WebSocketDisconnect → disconnect/reap path.
-        ws_ping_interval=None if _is_loopback else _ws_ping_setting("ws_ping_interval"),
-        ws_ping_timeout=None if _is_loopback else _ws_ping_setting("ws_ping_timeout"),
+        # Half-open detection. On for public binds; off for loopback so an
+        # event-loop stall can never trigger a false disconnect, where a
+        # genuinely dead local client is still reaped via the
+        # WebSocketDisconnect → disconnect/reap path. An explicit
+        # dashboard.ws_ping_* setting turns it on either way, for the
+        # reverse-proxied loopback deployments where the client is remote and
+        # a half-open socket is otherwise undetectable (see above).
+        ws_ping_interval=_ws_ping_setting("ws_ping_interval") if _use_ws_ping else None,
+        ws_ping_timeout=_ws_ping_setting("ws_ping_timeout") if _use_ws_ping else None,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
     )
     server = uvicorn.Server(config)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -109,6 +109,113 @@ def test_start_server_disables_ws_ping_on_loopback(monkeypatch):
     assert captured["ws_ping_timeout"] is None
 
 
+def _write_dashboard_config(tmp_path, monkeypatch, body: str):
+    """Point HERMES_HOME at a fresh dir holding the given config.yaml."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_start_server_keeps_ws_ping_off_on_loopback_for_default_config(
+    tmp_path, monkeypatch
+):
+    """The loopback default must survive the explicit-config escape hatch.
+
+    Regression guard for the obvious-but-wrong implementation of
+    test_start_server_enables_ws_ping_on_loopback_when_configured below:
+    probing ``load_config()["dashboard"]`` for the keys does NOT detect an
+    operator's intent, because load_config() deep-merges DEFAULT_CONFIG and
+    that already carries ws_ping_interval/ws_ping_timeout. Every install
+    would look "explicitly configured" and the ping would come back on for
+    all loopback binds — the exact false-disconnect regression #53773 the
+    loopback gate exists to prevent. Explicitness must be read from the raw
+    config; this test fails if that ever regresses to the merged one.
+    """
+    _write_dashboard_config(
+        tmp_path, monkeypatch, "dashboard:\n  theme: midnight\n"
+    )
+    captured = _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] is None
+    assert captured["ws_ping_timeout"] is None
+
+
+def test_start_server_enables_ws_ping_on_loopback_when_configured(
+    tmp_path, monkeypatch
+):
+    """An explicit dashboard.ws_ping_* setting outranks the loopback default.
+
+    A loopback bind is not proof of a local client: the documented
+    reverse-proxy deployment binds 127.0.0.1 with the browser arbitrarily
+    far away. There the proxy keeps answering TCP on the server leg after
+    the client is gone, so the protocol ping is the only end-to-end
+    liveness signal, and without it the PTY session stays `attached`
+    forever and leaks its child.
+    """
+    _write_dashboard_config(
+        tmp_path,
+        monkeypatch,
+        "dashboard:\n  ws_ping_interval: 20\n  ws_ping_timeout: 25\n",
+    )
+    captured = _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 20.0
+    assert captured["ws_ping_timeout"] == 25.0
+
+
+def test_start_server_ws_ping_on_loopback_defaults_the_unset_sibling(
+    tmp_path, monkeypatch
+):
+    """Setting one key enables the ping; the other stays at its default."""
+    _write_dashboard_config(
+        tmp_path, monkeypatch, "dashboard:\n  ws_ping_interval: 30\n"
+    )
+    captured = _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 30.0
+    assert captured["ws_ping_timeout"] == 20.0
+
+
+def test_start_server_ws_ping_on_loopback_honours_managed_scope(
+    tmp_path, monkeypatch
+):
+    """An administrator-pinned ws_ping counts as explicit configuration.
+
+    Managed scope is the enterprise equivalent of the operator editing
+    config.yaml, so it has to clear the same bar; reading only the user's
+    raw config would silently ignore it.
+    """
+    _write_dashboard_config(
+        tmp_path, monkeypatch, "dashboard:\n  theme: midnight\n"
+    )
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "dashboard:\n  ws_ping_interval: 45\n  ws_ping_timeout: 50\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    from hermes_cli.managed_scope import invalidate_managed_cache
+
+    invalidate_managed_cache()
+    captured = _stub_uvicorn(monkeypatch)
+    try:
+        web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+    finally:
+        invalidate_managed_cache()
+
+    assert captured["ws_ping_interval"] == 45.0
+    assert captured["ws_ping_timeout"] == 50.0
+
+
 def test_start_server_accepts_base64_desktop_attachments_above_preview_limit(monkeypatch):
     """The gateway frame cap must fit the Desktop attachment default after
     base64 expansion and JSON framing; uvicorn's 16 MiB default would reject


### PR DESCRIPTION
## What does this PR do?

A loopback bind is not proof of a local client. `start_server` disables uvicorn's WebSocket ping whenever the bind is loopback, on the stated reasoning that half-open connections "cannot happen on loopback: there is no network or proxy in the path". That holds for `hermes serve` on a laptop. It does not hold for the deployment `website/docs/user-guide/features/web-dashboard.md` recommends under **Public URL override** — `hermes dashboard --host 127.0.0.1 --port 9119 --no-open` behind a TLS reverse proxy, with Tailscale Serve given as an example of "this deployment shape".

There the server binds loopback while the browser is arbitrarily far away, across intermediaries that keep answering TCP on the server leg after the client is gone. TCP keepalive cannot help — the server's peer is the proxy, and the proxy is alive. The WebSocket ping, which the *browser* must answer, is the only end-to-end liveness signal. Without it the session stays `attached` forever, `PtySessionRegistry.reap_idle` skips it (attached sessions are exempt by design), and one `hermes --tui` child leaks per dead client until the host OOMs.

**The default is unchanged.** A loopback bind still disables the ping, so an event-loop stall can never false-kill a genuinely local client (#53773). Only an explicitly configured `dashboard.ws_ping_interval` / `ws_ping_timeout` now outranks the heuristic: an operator who sets a cadence is describing their topology, which is better evidence than the bind address.

### The subtle part

Explicitness is read from the **raw** config, not `load_config()`. `load_config()` deep-merges `DEFAULT_CONFIG`, which already carries `ws_ping_interval: 20.0` / `ws_ping_timeout: 20.0` — so `"ws_ping_interval" in _dash_cfg` is `True` on *every* install, and the obvious implementation would silently enable the ping for all loopback binds and fail `test_start_server_disables_ws_ping_on_loopback`. `read_user_config_raw`'s docstring already names this trap for "presence-sensitive" reads. `test_start_server_keeps_ws_ping_off_on_loopback_for_default_config` is a guard against it coming back.

Two smaller notes: managed scope is overlaid so an administrator-pinned value also counts as explicit, and it uses `read_raw_config()` rather than `read_raw_config_readonly()` because `apply_managed_overlay` mutates the dict it is handed while the readonly variant returns the shared cache object.

## Related Issue

Refs #96418

Deliberately *not* `Fixes` — that issue also reports a second defect (`reap_idle` has no notion of an in-flight turn) which this PR does not address, because fixing it properly needs a `busy` signal plumbed out of the session and that API call should be yours. Please close #96418 manually if you'd rather track the remainder separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — in `start_server`, gate the uvicorn `ws_ping_interval` / `ws_ping_timeout` kwargs on `_use_ws_ping = (not _is_loopback) or _ws_ping_configured`, where `_ws_ping_configured` is a presence check against the raw config plus the managed-scope overlay. Values still resolve through the existing `_ws_ping_setting` against the merged config, so setting one key leaves its sibling at the documented default.
- `tests/test_web_server.py` — four tests: explicit config on loopback, unset-sibling defaulting, the managed-scope path, and the regression guard described above.

## How to Test

`pytest tests/test_web_server.py tests/test_ws_keepalive_config.py tests/test_pty_keepalive_ws.py tests/test_pty_session.py tests/test_web_server_sessiondb_eventloop.py tests/test_web_server_status_topology_cache.py tests/test_managed_runtime_resolution.py tests/test_install_ps1_web_server_syntax_probe.py`

- Base `cced6fa360`: **40 passed, 3 skipped**
- With this PR: **44 passed, 3 skipped** (same 40, plus the 4 new)

Behaviour across every host × config combination, each row exercised against the real `load_config()` / `read_raw_config()` rather than a hand-built dict:

| host | `dashboard` config | ws_ping_interval | ws_ping_timeout | |
|---|---|---|---|---|
| `0.0.0.0` | *(none)* | 20.0 | 20.0 | unchanged |
| `0.0.0.0` | `interval: 5, timeout: 7` | 5.0 | 7.0 | unchanged |
| `127.0.0.1` | *(none)* | `None` | `None` | unchanged — the safe default |
| `127.0.0.1` | `theme: midnight` (no ws_ping) | `None` | `None` | unchanged — merged defaults must not count |
| `127.0.0.1` | `interval: 20, timeout: 25` | 20.0 | 25.0 | **the fix** |
| `127.0.0.1` | `interval: 30` only | 30.0 | 20.0 | **the fix** — sibling defaults |
| `127.0.0.1` | managed scope pins `45 / 50` | 45.0 | 50.0 | **the fix** — admin-pinned |
| `127.0.0.1` | `interval: nonsense` | 20.0 | 20.0 | never crashes |
| `localhost` | *(none)* | `None` | `None` | unchanged |
| `::1` | *(none)* | `None` | `None` | unchanged |

The four new tests were mutation-tested: reverting the presence check to the merged config fails two of them (plus your existing loopback test), and dropping the managed overlay fails a third — so none of them pass vacuously.

`ruff check` clean on both files; `scripts/check-windows-footguns.py` clean on both files.

## Checklist

- [x] Default behaviour is unchanged for every existing configuration
- [x] Existing tests pass unmodified (no test was edited to accommodate the change)
- [x] New tests added, and verified non-vacuous by mutation
- [x] Conventional Commit message
- [x] `ruff` and the Windows-footgun checker pass on the changed files
