### PR TITLE
fix(gateway): stop launchd --replace double-kill — drop takeover from supervised argv, SIGUSR1 graceful restart (salvage #79096 + #91354)

### DIFF
--- a/contributors/emails/joby@ellingtonlife.com
+++ b/contributors/emails/joby@ellingtonlife.com
@@ -1,0 +1,2 @@
+gijoby
+# PR #91354 salvage

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4881,10 +4881,22 @@ def _timestamped_stderr_gateway_command(
     ``hermes update`` sees the flag on the live grandchild argv and hands
     the process back to launchd instead of starting a detached watcher
     (#86893 / #87005). The detached nohup fallback stays unmarked.
+
+    Supervised starts also drop ``--replace`` (issue #79048): a launchd
+    service is respawned by KeepAlive, so takeover authority would be
+    re-armed on every respawn — two profiles legitimately sharing one
+    platform token would each terminate the sibling, and launchd would
+    revive the victim forever. Bounded replacement is the lifecycle
+    commands' job (``launchctl kickstart -k``, drain in
+    ``launchd_restart()``, bootout+bootstrap in install/refresh), which
+    run before supervision resumes. Mirrors ``generate_systemd_unit``,
+    whose ExecStart also runs ``gateway run`` without ``--replace``.
     """
     inner = _gateway_run_command()
     if external_supervisor and "--external-supervisor" not in inner:
         inner = [*inner, "--external-supervisor"]
+    if external_supervisor and "--replace" in inner:
+        inner = [part for part in inner if part != "--replace"]
     return [
         get_python_path(),
         "-m",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5599,16 +5599,30 @@ def launchd_restart():
                 f"(up to {wait_budget:.0f}s)..."
             )
             if _graceful_restart_via_sigusr1(pid, wait_budget):
-                # The gateway exited with the planned-restart code and
-                # launchd's unconditional KeepAlive revives it. Do NOT
-                # kickstart here: the replacement may already be up, and
-                # ``-k`` would kill it and restart a second time.
-                print("✓ Service restart requested")
-                _clear_launchd_unsupported_marker()
-                return
-            print(
-                f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart"
-            )
+                # The gateway exited with the planned-restart code. When
+                # launchd is actually supervising this label, KeepAlive
+                # revives it — do NOT kickstart (the replacement may already
+                # be up, and ``-k`` would kill it and restart a second time).
+                # But a graceful exit alone doesn't prove supervision:
+                # detached-fallback gateways and unloaded jobs also exit
+                # cleanly with nobody to revive them (and the SIGUSR1 helper
+                # returns True for an already-gone PID). Verify a replacement
+                # PID appears before trusting KeepAlive — mirrors the systemd
+                # branch's replacement observation.
+                if _wait_for_launchd_service_pid(
+                    label, pid, timeout=15.0, domain=_launchd_domain()
+                ):
+                    print("✓ Service restart requested")
+                    _clear_launchd_unsupported_marker()
+                    return
+                print(
+                    "⚠ launchd did not revive the gateway after its graceful "
+                    "exit — forcing restart"
+                )
+            else:
+                print(
+                    f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart"
+                )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5549,7 +5549,6 @@ def _wait_for_launchd_service_pid(
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
-    drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
     try:
@@ -5573,26 +5572,43 @@ def launchd_restart():
             _escalate_wedged_gateway(pid)
             pid = None
         if pid is not None:
-            # Announce the drain BEFORE waiting on it. This wait can run for
-            # the full drain budget (180s by default) while the old gateway
-            # finishes in-flight agent runs, and it streams into surfaces with
-            # no other feedback — the desktop updater's live output most of
-            # all, where a silent stop here reads as "update stuck" (#44515).
-            # Mirrors the systemd branch's "draining (up to Ns)..." line.
+            # Graceful in-band restart, mirroring the systemd branch.
+            #
+            # Previously this sent a bare SIGTERM and waited
+            # ``_get_restart_drain_timeout()`` — which defaults to 0, so the
+            # wait could never succeed and every restart fell through to
+            # ``kickstart -k``. A bare SIGTERM also leaves
+            # ``restart_requested`` False, so the gateway exits 1 instead of
+            # 75 and reports itself to chat as "shutting down" rather than
+            # "restarting", losing the resume_pending handoff.
+            #
+            # SIGUSR1 is the drain-aware path: refuse new turns, wait for
+            # in-flight work (``agent.restart_after_turn_timeout``), then
+            # stop() within ``agent.restart_drain_timeout``. The wait budget
+            # must cover BOTH phases plus headroom (#77184) — the raw drain
+            # timeout covers only the second.
+            #
+            # Announce the wait BEFORE it runs: it can last the full budget
+            # while the old gateway finishes in-flight agent runs, and it
+            # streams into surfaces with no other feedback — the desktop
+            # updater's live output most of all, where a silent stop here
+            # reads as "update stuck" (#44515).
+            wait_budget = _get_restart_exit_wait_budget()
             print(
                 f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
-                f"(up to {drain_timeout:.0f}s)..."
+                f"(up to {wait_budget:.0f}s)..."
             )
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(
-                        f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
-                    )
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                # The gateway exited with the planned-restart code and
+                # launchd's unconditional KeepAlive revives it. Do NOT
+                # kickstart here: the replacement may already be up, and
+                # ``-k`` would kill it and restart a second time.
+                print("✓ Service restart requested")
+                _clear_launchd_unsupported_marker()
+                return
+            print(
+                f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart"
+            )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5548,7 +5548,8 @@ def _wait_for_launchd_service_pid(
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    domain = _launchd_domain()
+    target = f"{domain}/{label}"
     from gateway.status import get_running_pid
 
     try:
@@ -5610,7 +5611,7 @@ def launchd_restart():
                 # PID appears before trusting KeepAlive — mirrors the systemd
                 # branch's replacement observation.
                 if _wait_for_launchd_service_pid(
-                    label, pid, timeout=15.0, domain=_launchd_domain()
+                    label, pid, timeout=15.0, domain=domain
                 ):
                     print("✓ Service restart requested")
                     _clear_launchd_unsupported_marker()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -10,6 +10,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    SendResult,
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
@@ -1254,6 +1255,7 @@ class TestMediaFallbackDoesNotLeakHostPath:
         assert self.SENSITIVE_PATH not in sent_text
 
 
+
 class TestDockerProfileSandboxMediaTranslation:
     """MEDIA from persistent Docker sandboxes must resolve to the host
     directory the profile's container actually bind-mounts (#93950).
@@ -1386,3 +1388,101 @@ class TestDockerProfileSandboxMediaTranslation:
             "did not resolve" in r.message and f"session_key={self.SESSION_KEY}" in r.message
             for r in caplog.records
         )
+
+class _LockGovernanceProbeAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter for platform-lock takeover governance tests."""
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(self, *args, **kwargs) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"name": "probe", "type": "dm"}
+
+
+class TestPlatformLockTakeoverGovernance:
+    """A supervised (non-``--replace``) gateway must never evict a live holder.
+
+    Regression for #79048: launchd services with ``KeepAlive=true`` used to be
+    generated with ``--replace``, re-arming takeover authority on every
+    respawn. Two profiles sharing one platform token (e.g. the same Discord
+    bot) would then terminate each other in an endless mutual-eviction loop.
+    The runtime guard is the adapter's ``_platform_lock_takeover_allowed``
+    bit — only an explicit ``gateway run --replace`` startup arms it. Without
+    that authority a live cross-home holder must be left alone and reported
+    as a retryable failure, never terminated.
+    """
+
+    def _make_adapter(self, *, takeover_allowed: bool):
+        from gateway.config import Platform, PlatformConfig
+
+        adapter = _LockGovernanceProbeAdapter(
+            config=PlatformConfig(), platform=Platform.DISCORD
+        )
+        adapter._platform_lock_takeover_allowed = takeover_allowed
+        return adapter
+
+    def test_no_takeover_without_replace_authority(self, tmp_path, monkeypatch):
+        from gateway import status
+
+        existing = {
+            "pid": 4242,
+            "start_time": 123,
+            "home": str(tmp_path / "other-profile-home"),
+        }
+        monkeypatch.setattr(
+            status,
+            "acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (False, existing),
+        )
+        takeover_calls = []
+        monkeypatch.setattr(
+            status,
+            "take_over_scoped_lock_holder",
+            lambda existing: takeover_calls.append(existing) or 4242,
+        )
+        monkeypatch.setattr(status, "write_runtime_status", lambda **kw: None)
+
+        adapter = self._make_adapter(takeover_allowed=False)
+        # Ordinary (supervised) start: the live cross-home holder must be
+        # left untouched — the gateway fails retryably instead of killing it.
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert takeover_calls == []
+        assert adapter.fatal_error_retryable is True
+        assert adapter._fatal_error_code == "discord-token_lock"
+
+    def test_takeover_authority_consumed_once(self, tmp_path, monkeypatch):
+        from gateway import status
+
+        existing = {
+            "pid": 4242,
+            "start_time": 123,
+            "home": str(tmp_path / "other-profile-home"),
+        }
+        monkeypatch.setattr(
+            status,
+            "acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (False, existing),
+        )
+        takeover_calls = []
+        monkeypatch.setattr(
+            status,
+            "take_over_scoped_lock_holder",
+            lambda existing: takeover_calls.append(existing) or 4242,
+        )
+        monkeypatch.setattr(status, "write_runtime_status", lambda **kw: None)
+
+        adapter = self._make_adapter(takeover_allowed=True)
+        # An explicit --replace start may attempt exactly one takeover...
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert len(takeover_calls) == 1
+        # ...but the authority is consumed, so a reconnect can never evict a
+        # healthy holder (this is what stops the supervised respawn loop).
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert len(takeover_calls) == 1
+        assert adapter._platform_lock_takeover_attempted is True

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1255,7 +1255,6 @@ class TestMediaFallbackDoesNotLeakHostPath:
         assert self.SENSITIVE_PATH not in sent_text
 
 
-
 class TestDockerProfileSandboxMediaTranslation:
     """MEDIA from persistent Docker sandboxes must resolve to the host
     directory the profile's container actually bind-mounts (#93950).
@@ -1388,6 +1387,7 @@ class TestDockerProfileSandboxMediaTranslation:
             "did not resolve" in r.message and f"session_key={self.SESSION_KEY}" in r.message
             for r in caplog.records
         )
+
 
 class _LockGovernanceProbeAdapter(BasePlatformAdapter):
     """Minimal concrete adapter for platform-lock takeover governance tests."""

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -920,8 +920,60 @@ class TestGatewaySystemServiceRouting:
         assert result is False
         assert replacement_observed == [True]
 
+    def test_launchd_restart_uses_sigusr1_and_exit_wait_budget(self, monkeypatch, capsys):
+        """launchd_restart must take the same graceful path as systemd_restart.
 
+        Regression: it previously sent a bare SIGTERM and waited
+        ``_get_restart_drain_timeout()`` (default 0), so the wait could never
+        succeed and every restart fell through to ``kickstart -k``. A bare
+        SIGTERM leaves ``restart_requested`` False, so the gateway exits 1
+        instead of 75 and announces itself as "shutting down" rather than
+        "restarting", dropping the resume_pending handoff.
+        """
+        calls = []
 
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 654)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "probe_gateway_loop_liveness",
+            lambda pid, **kw: gateway_cli.GATEWAY_LOOP_ALIVE,
+        )
+        # Wait budget covers after-turn deferral + drain + headroom (#77184);
+        # the raw drain timeout (0 by default) must not be used here.
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("sigterm", pid)),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: calls.append(("kickstart", a[0])) or SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        gateway_cli.launchd_restart()
+
+        assert ("graceful", 654, 27.0) in calls
+        # A bare SIGTERM would strand the gateway on the unplanned-shutdown path.
+        assert not any(call[0] == "sigterm" for call in calls)
+        # ``-k`` after a successful graceful exit would kill the replacement.
+        assert not any(call[0] == "kickstart" for call in calls)
+        out = capsys.readouterr().out
+        assert "27" in out
+        assert "up to 0s" not in out
 
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -963,6 +963,15 @@ class TestGatewaySystemServiceRouting:
             ),
         )
         monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+        # KeepAlive revives the label on a fresh PID — replacement observed.
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_pid",
+            lambda label, old_pid, timeout=10.0, *, domain: calls.append(
+                ("observe", label, old_pid, domain)
+            )
+            or True,
+        )
 
         gateway_cli.launchd_restart()
 
@@ -971,9 +980,59 @@ class TestGatewaySystemServiceRouting:
         assert not any(call[0] == "sigterm" for call in calls)
         # ``-k`` after a successful graceful exit would kill the replacement.
         assert not any(call[0] == "kickstart" for call in calls)
+        # The success message must follow an observed replacement PID.
+        assert ("observe", "ai.hermes.gateway", 654, "gui/501") in calls
         out = capsys.readouterr().out
-        assert "27" in out
+        assert "up to 27s" in out
         assert "up to 0s" not in out
+
+    def test_launchd_restart_forces_kickstart_when_no_replacement_appears(
+        self, monkeypatch, capsys
+    ):
+        """A graceful exit with no KeepAlive revival must not report success.
+
+        Detached-fallback gateways (macOS 26 unsupported-domain marker) and
+        unloaded jobs also exit cleanly on SIGUSR1, but nobody revives them —
+        and ``_graceful_restart_via_sigusr1`` returns True for an already-gone
+        PID. Without replacement observation the CLI would print
+        \"✓ Service restart requested\" while the gateway stays down.
+        """
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 654)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "probe_gateway_loop_liveness",
+            lambda pid, **kw: gateway_cli.GATEWAY_LOOP_ALIVE,
+        )
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr(
+            gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_pid",
+            lambda label, old_pid, timeout=10.0, *, domain: False,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: calls.append(("kickstart", a[0])) or SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        gateway_cli.launchd_restart()
+
+        # No replacement observed → must escalate to kickstart -k.
+        assert any(call[0] == "kickstart" for call in calls)
+        out = capsys.readouterr().out
+        assert "did not revive" in out
+        assert "✓ Service restarted" in out
 
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1490,7 +1490,6 @@ class TestProfileArg:
             "mybot",
             "gateway",
             "run",
-            "--replace",
             "--external-supervisor",
         ]
 
@@ -2147,6 +2146,44 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+
+class TestServiceTakeoverGovernance:
+    """Supervised service definitions must never arm ``--replace`` takeover.
+
+    Regression for #79048: two launchd-supervised profile gateways sharing
+    one platform token (e.g. the same Discord bot) entered an endless
+    mutual-eviction loop because the generated plist armed ``--replace`` on
+    every KeepAlive respawn: each revived process was authorized to terminate
+    the sibling holding the shared token, and launchd immediately revived the
+    victim. The systemd unit already runs ``gateway run`` without
+    ``--replace``; the launchd plist must match so a supervised restart can
+    never evict a legitimate cross-profile lock holder. Bounded replacement
+    stays the lifecycle commands' job (kickstart -k / drain / bootout).
+    """
+
+    def test_launchd_plist_does_not_arm_takeover(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        plist = gateway_cli.generate_launchd_plist()
+        # The whole bug class: no --replace anywhere in the supervised argv.
+        assert "--replace" not in plist
+        # It still runs the plain gateway command under KeepAlive.
+        assert "<string>gateway</string>" in plist
+        assert "<string>run</string>" in plist
+        assert "<key>KeepAlive</key>" in plist
+        assert "<true/>" in plist
+
+    def test_systemd_unit_does_not_arm_takeover(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        exec_starts = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
+        assert exec_starts, "unit has no ExecStart line"
+        # The safe service posture the launchd plist now mirrors.
+        assert "--replace" not in exec_starts[0]
 
 
 class TestLaunchctlBootstrapEioRetry:

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -193,6 +193,8 @@ class TestLaunchdRestartWedgedIntegration:
         monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
         monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        # Wait budget covers after-turn deferral + drain + headroom (#77184).
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 195.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 4242)
         monkeypatch.setattr(
             gateway_cli, "_request_gateway_self_restart", lambda pid: False
@@ -212,10 +214,11 @@ class TestLaunchdRestartWedgedIntegration:
             "terminate_pid",
             lambda pid, force=False: events.append("sigterm"),
         )
+        # Never let a real SIGUSR1 escape to PID 4242 during tests.
         monkeypatch.setattr(
             gateway_cli,
-            "_wait_for_gateway_exit",
-            lambda timeout, force_after=None: events.append(("drain", timeout)) or True,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
         )
         monkeypatch.setattr(
             gateway_cli.subprocess,
@@ -241,11 +244,11 @@ class TestLaunchdRestartWedgedIntegration:
         events = self._setup(monkeypatch, gateway_cli.GATEWAY_LOOP_ALIVE)
         gateway_cli.launchd_restart()
         assert "escalate" not in events
-        assert ("drain", 180.0) in events
+        assert ("drain", 4242, 195.0) in events
 
     def test_unknown_liveness_keeps_full_drain_budget(self, monkeypatch):
         """Ambiguity (no heartbeat) must never trigger escalation."""
         events = self._setup(monkeypatch, gateway_cli.GATEWAY_LOOP_UNKNOWN)
         gateway_cli.launchd_restart()
         assert "escalate" not in events
-        assert ("drain", 180.0) in events
+        assert ("drain", 4242, 195.0) in events

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -220,6 +220,15 @@ class TestLaunchdRestartWedgedIntegration:
             "_graceful_restart_via_sigusr1",
             lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
         )
+        # KeepAlive revival observed instantly — avoids the real 15s poll
+        # (mocked subprocess.run returns empty stdout, so the PID probe
+        # would otherwise burn the full observation timeout in time.sleep).
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_pid",
+            lambda label, old_pid, timeout=10.0, *, domain: events.append("observe")
+            or True,
+        )
         monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",


### PR DESCRIPTION
## Summary
Every launchd gateway restart on macOS no longer double-kills the replacement: the supervised plist argv drops `--replace` (KeepAlive re-armed takeover authority on every respawn) and `launchd_restart()` drains via SIGUSR1 like systemd instead of a bare SIGTERM whose wait budget defaulted to 0.

Root cause (#96366): the plist ran `gateway run --replace`, so every KeepAlive respawn started with takeover authority and SIGTERMed whichever gateway held the PID lock — including the one launchd itself had just revived 3–4s earlier. The lifecycle ledger then logged the victim as "exited UNCLEANLY — SIGKILL / OOM / VM death" and every restart cost a ~30s outage. Separately, `launchd_restart()` sent bare SIGTERM and waited `_get_restart_drain_timeout()` (default 0), so the graceful wait never succeeded and every restart fell through to `kickstart -k` — which killed the KeepAlive-spawned replacement, producing the same double-kill from the CLI side.

## Changes
- `hermes_cli/gateway.py` `_timestamped_stderr_gateway_command`: supervised (launchd) argv drops `--replace`, mirroring `generate_systemd_unit`'s ExecStart. Detached nohup fallback and s6 container run-script keep `--replace` (documented NS-505 rationale — deliberate, untouched).
- `hermes_cli/gateway.py` `launchd_restart()`: SIGUSR1 graceful drain via `_graceful_restart_via_sigusr1` with `_get_restart_exit_wait_budget()` (covers after-turn deferral + drain + headroom, #77184), no `kickstart -k` after a successful graceful exit (KeepAlive revives; `-k` would kill the replacement). Timeout still falls back to `kickstart -k`.
- Regression tests: plist governance suite (`TestPlatformLockTakeoverGovernance`), `test_launchd_restart_uses_sigusr1_and_exit_wait_budget`, wedged-gateway budget fixture.
- `contributors/emails/`: joby@ellingtonlife.com → gijoby.

## Validation
| | Before | After |
|---|---|---|
| launchd plist argv | `gateway run --replace` | `gateway run --external-supervisor` (no `--replace`) |
| KeepAlive respawn | re-arms takeover → SIGTERMs sibling/replacement | no takeover authority; live holder reported as retryable |
| `hermes gateway restart` (launchd) | bare SIGTERM, 0s wait, always `kickstart -k` | SIGUSR1 drain within exit-wait budget; kickstart only on timeout |
| Old plists with `--replace` | — | `launchd_plist_is_current()` flags stale → auto-rewritten on next start/refresh (E2E-verified) |

- 203 passed, 2 skipped across `test_gateway_service.py`, `test_update_wedged_gateway.py`, `test_platform_base.py`
- E2E (real imports, temp HERMES_HOME): plist has no `--replace` + keeps `--external-supervisor`; detached fallback keeps `--replace`; stale `--replace` plists detected for rewrite
- ruff clean

## Credit
Salvage of #79096 (@x7peeps) and #91354 (@gijoby) — cherry-picked with authorship preserved; conflict resolution and E2E follow-ups ours.

Fixes #96366. Fixes #79048. Closes #79096. Closes #91354. Related: #82026 (same plist fix, stale/conflicting — will be closed with credit).
