### PR TITLE
fix(gateway): keep sessions.json route when startup recovery succeeds with the same session id (salvage #95963)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1618,6 +1618,26 @@ class SessionStore:
                         recovered_keys += 1
                         continue
 
+                    # A non-None recovery with the SAME session id is a successful
+                    # resume: _recover_session_from_db only returns non-None after
+                    # passing all safety gates (recoverable end reason, reset
+                    # boundary NOT EXISTS, source-scope match, active-profile
+                    # check, _should_reset). Keep the routing entry in place — it
+                    # is still valid, not a dead route. The `!=` guard above is
+                    # only for the compression-rotation case where a newer live
+                    # child session exists; a same-id recovery must NOT fall
+                    # through to the prune branch (#95957).
+                    if recovered_entry is not None:
+                        logger.warning(
+                            "gateway.session: keeping stale sessions.json entry "
+                            "%r -> %s (end_reason=%r); recovery succeeded with "
+                            "same session id",
+                            key, entry.session_id, row["end_reason"],
+                        )
+                        self._entries[key] = recovered_entry
+                        recovered_keys += 1
+                        continue
+
                     logger.warning(
                         "gateway.session: pruning stale sessions.json entry "
                         "%r -> %s (end_reason=%r); left by a crashed gateway",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1618,24 +1618,22 @@ class SessionStore:
                         recovered_keys += 1
                         continue
 
-                    # A non-None recovery with the SAME session id is a successful
-                    # resume: _recover_session_from_db only returns non-None after
-                    # passing all safety gates (recoverable end reason, reset
-                    # boundary NOT EXISTS, source-scope match, active-profile
-                    # check, _should_reset). Keep the routing entry in place — it
-                    # is still valid, not a dead route. The `!=` guard above is
-                    # only for the compression-rotation case where a newer live
-                    # child session exists; a same-id recovery must NOT fall
-                    # through to the prune branch (#95957).
+                    # A non-None recovery with the SAME session id is a
+                    # successful resume (all recovery gates passed, row
+                    # reopened): keep the routing entry — it is proven valid,
+                    # not a dead route (#95957). Keep the ORIGINAL entry
+                    # object, not the recovered one: the recovered entry is
+                    # rebuilt minimal from the DB row and would silently drop
+                    # live state the existing entry carries (token/cost
+                    # counters, model_override, resume_pending/queued-work
+                    # markers, metadata). Nothing in sessions.json changes,
+                    # so no save is needed for this branch.
                     if recovered_entry is not None:
-                        logger.warning(
-                            "gateway.session: keeping stale sessions.json entry "
-                            "%r -> %s (end_reason=%r); recovery succeeded with "
-                            "same session id",
-                            key, entry.session_id, row["end_reason"],
+                        logger.info(
+                            "gateway.session: reopened ended session %s for "
+                            "sessions.json entry %r (end_reason=%r); keeping route",
+                            entry.session_id, key, row["end_reason"],
                         )
-                        self._entries[key] = recovered_entry
-                        recovered_keys += 1
                         continue
 
                     logger.warning(

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -104,6 +104,41 @@ class TestPruneStaleSessionsLocked:
         assert key in store._entries
         assert store._entries[key].session_id == "sid_parent"
 
+    def test_keeps_stale_entry_when_recovery_returns_same_session_id(self, tmp_path):
+        """A successful same-id recovery must NOT prune the routing entry.
+
+        When the startup sweep finds a stale entry whose session has ended in
+        state.db but ``_recover_session_from_db`` succeeds and returns the SAME
+        session id (proving the route is still resumable — the ``!=`` repoint
+        guard only exists for the compression-rotation child case), the entry
+        must be kept in place. The old code fell through to the prune branch
+        whenever the recovered id did not differ, deleting a perfectly valid
+        resumable mapping (#95957).
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning(
+            {"sid_parent": {"end_reason": "agent_close", "id": "sid_parent"}}
+        )
+        # Recovery returns the row for sid_parent itself — same id as the entry.
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_parent",
+            "started_at": (datetime.now() - timedelta(hours=5)).timestamp(),
+            "last_activity_at": (
+                datetime.now() - timedelta(hours=4)
+            ).timestamp(),
+        }
+        store = _make_store_with_db(tmp_path, db)  # default mode="none"
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        with patch.object(store, "_save") as mock_save:
+            store._prune_stale_sessions_locked()
+
+        # The successfully-recovered route must survive the sweep.
+        assert key in store._entries
+        assert store._entries[key].session_id == "sid_parent"
+        mock_save.assert_called_once()
+
+
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
         with patch("gateway.session.SessionStore._ensure_loaded"):

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -128,7 +128,10 @@ class TestPruneStaleSessionsLocked:
             ).timestamp(),
         }
         store = _make_store_with_db(tmp_path, db)  # default mode="none"
-        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+        original_entry = _make_entry_with_origin(key, "sid_parent")
+        original_entry.model_override = {"model": "custom/model", "provider": "openrouter"}
+        original_entry.resume_pending = True
+        store._entries[key] = original_entry
 
         with patch.object(store, "_save") as mock_save:
             store._prune_stale_sessions_locked()
@@ -136,8 +139,17 @@ class TestPruneStaleSessionsLocked:
         # The successfully-recovered route must survive the sweep.
         assert key in store._entries
         assert store._entries[key].session_id == "sid_parent"
-        mock_save.assert_called_once()
-
+        # The ORIGINAL entry object is kept — a rebuilt entry would silently
+        # drop live state (model_override, resume_pending, token counters).
+        assert store._entries[key] is original_entry
+        assert store._entries[key].model_override == {
+            "model": "custom/model", "provider": "openrouter"
+        }
+        assert store._entries[key].resume_pending is True
+        # The row is reopened in state.db by recovery.
+        db.reopen_session.assert_called_once_with("sid_parent")
+        # Nothing in sessions.json changed, so no rewrite is needed.
+        mock_save.assert_not_called()
 
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))


### PR DESCRIPTION
## Summary
The startup routing sweep no longer deletes a user's chat routing after a gateway crash: when `_prune_stale_sessions_locked` finds a stale sessions.json entry but recovery succeeds with the SAME session id, the entry is kept (and the row reopened) instead of falling through to the prune branch.

Root cause (#95957, the residual half of #61993): `_recover_session_from_db` only had its result honored in the `recovered.session_id != entry.session_id` compression-repoint branch. A same-id recovery — the common case after a crash leaves an `agent_close` row plus a live sessions.json entry — passed every safety gate (recoverable end reason, reset-policy check, scope check), reopened the row, and was then discarded; the sweep logged "pruning stale sessions.json entry … left by a crashed gateway" and dropped the routing key, so queued/resume-pending work disappeared until the user's next message rebuilt the route.

## Changes
- `gateway/session.py` `_prune_stale_sessions_locked`: same-id successful recovery keeps the ORIGINAL routing entry (INFO log) instead of falling through to the prune. The original entry object is kept — a rebuilt one would silently drop live state (token/cost counters, `model_override`, `resume_pending`/queued-work markers, metadata). Routing is unchanged, so no sessions.json rewrite.
- `tests/gateway/test_session_store_stale_prune.py`: regression test — same-id recovery survives the sweep, live entry state preserved, row reopened, no save.

Explicit boundaries are unaffected: `session_reset` rows are not recoverable (`_RECOVERABLE_END_REASONS`), so user `/new` resets still prune and never resurrect (#65783's contract holds — verified in E2E below).

## Validation
| Scenario (real SessionDB + SessionStore, temp HERMES_HOME) | Before (main) | After |
|---|---|---|
| Crash → `agent_close` row + live routing entry | route pruned ("left by a crashed gateway"), row left reopened+orphaned | route kept, row reopened, mapping intact |
| Explicit `session_reset` row + stale entry | pruned | still pruned — never resurrected |

- 9/9 `test_session_store_stale_prune.py` (incl. new regression test)
- ruff clean

## Credit
Salvage of #95963 by @Jackal991 — cherry-picked with authorship preserved; review follow-up (keep original entry object to preserve live session state, INFO log, no redundant save) ours.

Fixes #95957. Closes #95963. Related: #61993 (the resurrection half was fixed by #65783; this closes the inverse route-loss residual).
