### PR TITLE
feat(kanban): allow scheduled initial tasks

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -398,7 +398,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           default="running",
                           help="Initial card status. Use 'blocked' for cards "
                                "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+                               "to skip the brief running-to-blocked transition, "
+                               "or 'scheduled' to park outside the dispatcher "
+                               "until explicit release.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -100,7 +100,7 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
-VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_INITIAL_STATUSES = {"running", "blocked", "scheduled"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -3203,6 +3203,9 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
+    ``initial_status="scheduled"`` atomically parks a task outside the
+    dispatcher queue until a caller explicitly releases it.
+
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
     creating a duplicate. Useful for retried webhooks / automation that
@@ -3450,10 +3453,10 @@ def create_task(
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
                 # Determine task status from parent status, unless the caller
-                # parks it directly in blocked for human-ops review or in
-                # triage for a specifier.
-                if initial_status == "blocked":
-                    task_status = "blocked"
+                # parks it directly in blocked for human-ops review,
+                # scheduled for deferred release, or triage for a specifier.
+                if initial_status in {"blocked", "scheduled"}:
+                    task_status = initial_status
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -40,6 +40,32 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 
+def test_kanban_create_help_explains_scheduled_dispatch_hold(kanban_home):
+    output = kc.run_slash("create --help")
+
+    assert "scheduled" in output
+    assert "outside the dispatcher" in output
+    assert "explicit release" in output
+
+
+def test_run_slash_create_scheduled_stays_outside_dispatch_queue(kanban_home):
+    payload = json.loads(
+        kc.run_slash(
+            "create 'route before dispatch' --assignee ops "
+            "--initial-status scheduled --json"
+        )
+    )
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, payload["id"])
+        promoted = kb.recompute_ready(conn)
+
+        assert task is not None
+        assert task.status == "scheduled"
+        assert kb.claim_task(conn, payload["id"]) is None
+        assert promoted == 0
+
+
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -188,7 +188,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 
 
 
-def test_create_task_can_start_scheduled_without_entering_dispatch_queue(kanban_home):
+def test_create_task_can_start_scheduled_until_explicit_release(kanban_home):
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -199,12 +199,112 @@ def test_create_task_can_start_scheduled_without_entering_dispatch_queue(kanban_
 
         task = kb.get_task(conn, task_id)
         promoted = kb.recompute_ready(conn)
+        after_recompute = kb.get_task(conn, task_id)
+        claimed_while_scheduled = kb.claim_task(conn, task_id)
+        released = kb.unblock_task(conn, task_id)
+        after_release = kb.get_task(conn, task_id)
 
         assert task is not None
+        assert after_recompute is not None
+        assert after_release is not None
         assert task.status == "scheduled"
-        assert kb.claim_task(conn, task_id) is None
+        assert claimed_while_scheduled is None
         assert promoted == 0
-        assert kb.get_task(conn, task_id).status == "scheduled"
+        assert after_recompute.status == "scheduled"
+        assert released is True
+        assert after_release.status == "ready"
+
+
+def test_create_scheduled_unblock_waits_for_unfinished_parent(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", assignee="ops")
+        child_id = kb.create_task(
+            conn,
+            title="held child",
+            assignee="ops",
+            parents=[parent_id],
+            initial_status="scheduled",
+        )
+
+        assert kb.unblock_task(conn, child_id) is True
+        assert kb.get_task(conn, child_id).status == "todo"
+
+        assert kb.complete_task(conn, parent_id, summary="parent complete") is True
+        assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_create_scheduled_unblock_is_ready_when_parent_done(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", assignee="ops")
+        assert kb.complete_task(conn, parent_id, summary="parent complete") is True
+        child_id = kb.create_task(
+            conn,
+            title="held child",
+            assignee="ops",
+            parents=[parent_id],
+            initial_status="scheduled",
+        )
+
+        assert kb.unblock_task(conn, child_id) is True
+        assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_create_scheduled_child_is_atomic_inside_outer_transaction(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    writer = kb.connect(db_path)
+    reader = kb.connect(db_path)
+    try:
+        with kb.write_txn(writer):
+            parent_id = kb.create_task(writer, title="parent", assignee="ops")
+            child_id = kb.create_task(
+                writer,
+                title="held child",
+                assignee="ops",
+                parents=[parent_id],
+                initial_status="scheduled",
+            )
+
+            assert kb.get_task(writer, child_id).status == "scheduled"
+            assert reader.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+        child = kb.get_task(reader, child_id)
+        assert child is not None
+        assert child.status == "scheduled"
+        assert kb.parent_ids(reader, child_id) == [parent_id]
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_dispatch_once_does_not_spawn_scheduled_task(
+    kanban_home, all_assignees_spawnable,
+):
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kb.connect() as conn:
+        scheduled_id = kb.create_task(
+            conn,
+            title="route before dispatch",
+            assignee="ops",
+            initial_status="scheduled",
+        )
+        ready_id = kb.create_task(
+            conn,
+            title="dispatcher control",
+            assignee="ops",
+        )
+
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=2)
+        scheduled = kb.get_task(conn, scheduled_id)
+
+    assert spawns == [ready_id]
+    assert [item[0] for item in result.spawned] == [ready_id]
+    assert scheduled is not None
+    assert scheduled.status == "scheduled"
 
 
 def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -188,6 +188,25 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 
 
 
+def test_create_task_can_start_scheduled_without_entering_dispatch_queue(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="route before dispatch",
+            assignee="ops",
+            initial_status="scheduled",
+        )
+
+        task = kb.get_task(conn, task_id)
+        promoted = kb.recompute_ready(conn)
+
+        assert task is not None
+        assert task.status == "scheduled"
+        assert kb.claim_task(conn, task_id) is None
+        assert promoted == 0
+        assert kb.get_task(conn, task_id).status == "scheduled"
+
+
 def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="delayed recheck", assignee="ops")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -399,8 +399,15 @@ def test_create_schema_exposes_scheduled_initial_status():
     from tools.kanban_tools import KANBAN_CREATE_SCHEMA
 
     initial_status = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["initial_status"]
-    assert set(initial_status["enum"]) == {"running", "blocked", "scheduled"}
+    assert "scheduled" in initial_status["enum"]
     assert "outside the dispatcher" in initial_status["description"]
+
+
+def test_list_schema_exposes_scheduled_status_filter():
+    from tools.kanban_tools import KANBAN_LIST_SCHEMA
+
+    status = KANBAN_LIST_SCHEMA["parameters"]["properties"]["status"]
+    assert "scheduled" in status["enum"]
 
 
 def test_create_scheduled_stays_outside_dispatch_queue(worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -395,6 +395,36 @@ def test_comment_ignores_caller_supplied_author(worker_env):
         conn.close()
 
 
+def test_create_schema_exposes_scheduled_initial_status():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    initial_status = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["initial_status"]
+    assert set(initial_status["enum"]) == {"running", "blocked", "scheduled"}
+    assert "outside the dispatcher" in initial_status["description"]
+
+
+def test_create_scheduled_stays_outside_dispatch_queue(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    payload = json.loads(
+        kt._handle_create(
+            {
+                "title": "route before dispatch",
+                "assignee": "peer",
+                "initial_status": "scheduled",
+            }
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "scheduled"
+    with kb.connect_closing() as conn:
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, payload["task_id"]) is None
+        assert kb.get_task(conn, payload["task_id"]).status == "scheduled"
+
+
 def test_create_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -2239,12 +2239,14 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "scheduled"],
                 "description": (
                     "Initial card status. Use 'blocked' for tasks that "
                     "require immediate human ops (R3 gate) to skip the "
-                    "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "brief running-to-blocked transition, or 'scheduled' "
+                    "to park outside the dispatcher until explicit "
+                    "release. Defaults to 'running', which preserves the "
+                    "usual dispatch path."
                 ),
             },
             "skills": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1739,7 +1739,7 @@ KANBAN_LIST_SCHEMA = {
                 "type": "string",
                 "enum": [
                     "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "blocked", "scheduled", "done", "archived",
                 ],
                 "description": "Optional task status filter.",
             },

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -645,7 +645,7 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `boards show` / `boards current` | Print the currently-active board's name, DB path, and task counts. |
 | `boards rename <slug> "<name>"` | Change a board's display name. Slug is immutable. |
 | `boards rm <slug>` | Archive (default) or hard-delete a board. `--delete` skips the archive step. Archived boards move to `boards/_archived/<slug>-<ts>/`. Refused for `default`. |
-| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). |
+| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--initial-status running\|blocked\|scheduled`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). `scheduled` parks the task outside the dispatcher until an explicit `unblock`. |
 | `list` / `ls` | List tasks on the active board. Filter with `--mine`, `--assignee`, `--status`, `--tenant`, `--archived`, `--json`. |
 | `show <id>` | Show a task with comments and events. `--json` for machine output. |
 | `assign <id> <profile>` | Assign or reassign. Use `none` to unassign. Refused while task is running. |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -645,7 +645,7 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `boards show` / `boards current` | Print the currently-active board's name, DB path, and task counts. |
 | `boards rename <slug> "<name>"` | Change a board's display name. Slug is immutable. |
 | `boards rm <slug>` | Archive (default) or hard-delete a board. `--delete` skips the archive step. Archived boards move to `boards/_archived/<slug>-<ts>/`. Refused for `default`. |
-| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--initial-status running\|blocked\|scheduled`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). `scheduled` parks the task outside the dispatcher until an explicit `unblock`. |
+| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--initial-status running\|blocked\|scheduled`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). Use `scheduled` to assign a card without making it dispatchable. It stays outside the queue until `unblock` releases it. |
 | `list` / `ls` | List tasks on the active board. Filter with `--mine`, `--assignee`, `--status`, `--tenant`, `--archived`, `--json`. |
 | `show <id>` | Show a task with comments and events. `--json` for machine output. |
 | `assign <id> <profile>` | Assign or reassign. Use `none` to unassign. Refused while task is running. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -726,6 +726,7 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]
                                 [--branch <name>]
                                 [--priority N] [--triage] [--idempotency-key KEY]
+                                [--initial-status running|blocked|scheduled]
                                 [--max-runtime 30m|2h|1d|<seconds>]
                                 [--max-retries N]
                                 [--goal] [--goal-max-turns N]
@@ -782,6 +783,10 @@ hermes kanban specify [<id> | --all] [--tenant T]      # flesh out a triage-colu
 hermes kanban gc [--event-retention-days N]            # workspaces + old events + old logs
         [--log-retention-days N]
 ```
+
+`--initial-status scheduled` creates the task outside the dispatcher queue.
+It remains parked until an explicit `hermes kanban unblock <id>` releases it
+to `ready` or `todo`, depending on whether its parents are complete.
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -305,7 +305,7 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_attach` | Attach a file to a task by passing its bytes inline (base64); stored under the task's attachments dir (25 MB cap). | file bytes + name |
 | `kanban_attach_url` | Attach a file to a task by URL. | `url` |
 | `kanban_attachments` | List a task's attachments. | — |
-| `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
+| `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. Set `initial_status="scheduled"` to assign a card without making it dispatchable. Release it later with `kanban_unblock`. | `title`, `assignee` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
 | `kanban_unblock` | (Orchestrators) restore a blocked task to its source phase (`review` or `ready`), or `todo` while a parent remains open. | `task_id` |
 
@@ -784,9 +784,7 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
         [--log-retention-days N]
 ```
 
-`--initial-status scheduled` creates the task outside the dispatcher queue.
-It remains parked until an explicit `hermes kanban unblock <id>` releases it
-to `ready` or `todo`, depending on whether its parents are complete.
+`--initial-status scheduled` creates and assigns a card without making it dispatchable. Creation and parking happen in the same database transaction, so the dispatcher cannot claim it between those steps. Run `hermes kanban unblock <id>` when the card is ready to start. Hermes checks its parent dependencies again and returns it to `ready` or `todo`.
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 


### PR DESCRIPTION
## What this changes

Hermes already uses `scheduled` for tasks that exist on the board but must not enter the dispatch queue. This PR lets callers choose that state during creation:

```bash
hermes kanban create "route before dispatch" \
  --assignee worker \
  --initial-status scheduled
```

Creation and parking now happen in the same database transaction. An assigned task cannot be claimed by a dispatcher between those two operations. `hermes kanban unblock <id>` remains the explicit release action and checks parent dependencies again before returning the task to `ready` or `todo`.

The option is available through the database API, `hermes kanban create`, `/kanban create`, and `kanban_create`. The `kanban_list` status filter now accepts `scheduled` as well.

## Provenance

This is the current-`main` adaptation of #67577 by @adrianabezerrabessa-source. Adriana Bessa remains the author of the original feature and documentation commits. The follow-up commit adds current test coverage, exposes the existing status in the list filter, and tightens the docs.

I opened a new PR because KC's account cannot push to either the original contributor branch or the upstream repository. This PR supersedes #67577 without replacing Adriana's work or credit.

## Scope

This is an additive creation option. It does not change ordinary task creation, readiness recomputation, claim rules, dependency handling, decomposition holds, manual-ready gates, review state, or dispatcher selection.

There is no database migration and no new status. Existing scheduled tasks keep their current behavior.

## Verification

- 48 Kanban test files: 374 passed, 2 skipped, 0 failed
- 10 focused scheduled-task contract tests passed
- regression sabotage confirmed that removing scheduled parking makes both the nested-transaction and live-dispatch tests fail
- Ruff passed
- `py_compile` passed
- staged and committed diff checks passed
- synthetic merge with current `origin/main` passed
- independent broad, dispatcher, and nested-transaction reviews passed with no blocking findings

The two skipped tests are Windows-only and run in the repository's Windows CI lane. I am not describing the repository-wide local suite as green; its unrelated environment and baseline failures are outside this Kanban change and representative failures reproduce on clean `main`.

## Risk and rollback

The main risk is exposing `scheduled` through one more creation path. The tests cover claim exclusion, dispatcher exclusion with a live ready control, parent-gated release, and visibility across nested transactions.

Reverting these three commits removes atomic scheduled creation. Existing scheduled tasks remain valid because the status predates this change.
