### PR TITLE
fix(acp): keep real-home hint coherent with selected HOME

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -122,6 +122,9 @@ def _build_subprocess_env() -> dict[str, str]:
     # See #29157.
     env = hermes_subprocess_env(inherit_credentials=True)
     env["HOME"] = _resolve_home_dir()
+    # A selected child HOME must not be overridden by the parent's stale
+    # real-home hint when applying the shared profile/real-home policy.
+    env["HERMES_REAL_HOME"] = env["HOME"]
     apply_subprocess_home_env(env)
     return env
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -421,3 +421,24 @@ def test_run_prompt_receives_picker_model():
             model="gpt-5.6-terra", messages=[{"role": "user", "content": "hi"}]
         )
     assert seen["model"] == "gpt-5.6-terra"
+
+
+@pytest.mark.parametrize('home_mode', ['real', 'profile'])
+def test_subprocess_home_override_does_not_inherit_stale_real_home(tmp_path, monkeypatch, home_mode):
+    from agent.copilot_acp_client import _build_subprocess_env
+
+    selected = tmp_path / 'selected-home'
+    selected.mkdir()
+    stale = tmp_path / 'parent-home'
+    stale.mkdir()
+    profile = tmp_path / 'profiles' / 'coder'
+    (profile / 'home').mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(selected))
+    monkeypatch.setenv('HERMES_REAL_HOME', str(stale))
+    monkeypatch.setenv('HERMES_HOME', str(profile))
+    monkeypatch.setenv('TERMINAL_HOME_MODE', home_mode)
+
+    env = _build_subprocess_env()
+
+    assert env['HERMES_REAL_HOME'] == str(selected)
+    assert env['HOME'] == str(profile / 'home' if home_mode == 'profile' else selected)


### PR DESCRIPTION
ACP subprocesses could pair a newly selected `HOME` with a stale inherited `HERMES_REAL_HOME`, sending child processes back to the parent's home. Set both values together before applying the shared subprocess home policy, preserving profile-home behavior.

Refreshed onto upstream `500e133beeb8` on 2026-09-14. The merge retains upstream model-discovery tests alongside the HOME regression. `scripts/run_tests.sh -j 2 tests/agent/test_copilot_acp_client.py tests/test_hermes_constants.py` passed 86 tests; 5 Windows-only cases were skipped on Linux. Removing the HOME-hint assignment reproduces both regression failures through the canonical runner. Upstream CI still requires maintainer approval.
