### PR TITLE
test(cli): isolate update HEAD-movement tests from live runtimes

### DIFF
--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -18,6 +18,9 @@ import hermes_cli.main_web_build as main_web_build
 import hermes_cli.main_install_repair as main_install_repair
 from hermes_cli import update_cmd
 
+# These tests simulate git movement, so retain the shared fleet/process stubs.
+pytestmark = pytest.mark.usefixtures("isolated_update_runtime")
+
 
 def _make_head_moved_side_effect(pre_sha="abc123", post_sha="def456"):
     """Simulate git commands where HEAD advances from pre_sha to post_sha."""


### PR DESCRIPTION
The HEAD-movement tests simulate a successful update but did not use the shared runtime-isolation fixture. The simulated update could discard gateway mocks during module refresh and enter real runtime recovery paths.

Apply the existing `isolated_update_runtime` fixture to this test module. It keeps the stale-module purge, process discovery, desktop cleanup, and fleet-restart boundaries stubbed using their current namespaces. Upstream already covers the autostash and `--yes` paths, so their old changes and obsolete namespace-introspection tests are no longer needed in this PR.

Validation: the successful HEAD-movement case failed on unmodified upstream c3ce41645c; after the fixture change, all 38 tests across the HEAD-movement, autostash, and `--yes` files passed with `scripts/run_tests.sh` on Linux. No host-OS impersonation is used.
