### PR TITLE
fix(context): scale subdirectory hint cap with the model context window

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2948,6 +2948,7 @@ def init_agent(
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
         working_dir=os.getenv("TERMINAL_CWD") or None,
+        context_length=getattr(agent.context_compressor, "context_length", 0),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -34,7 +34,9 @@ _HINT_FILENAMES = [
     ".cursorrules",
 ]
 
-# Maximum chars per hint file to prevent context bloat
+# Minimum chars per hint file. Scales up with the model's context window via
+# ``_hint_max_chars`` so a large-window model does not silently drop the
+# operational half of a long AGENTS.md.
 _MAX_HINT_CHARS = 8_000
 
 # Tool argument keys that typically contain file paths
@@ -82,8 +84,13 @@ class SubdirectoryHintTracker:
             tool_result += hints  # append to the tool result string
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(
+        self,
+        working_dir: Optional[str] = None,
+        context_length: Optional[int] = None,
+    ):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
+        self.context_length = context_length
         self._loaded_dirs: Set[Path] = set()
         # Content digests already injected — prevents re-sending the same file
         # reachable through symlinks, hardlinks, or duplicated copies.
@@ -91,6 +98,28 @@ class SubdirectoryHintTracker:
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
         self._seed_working_dir_digest()
+
+    def _hint_max_chars(self) -> int:
+        """Resolve the per-hint char cap for this session.
+
+        Delegates to the resolver the startup context path already uses
+        (``prompt_builder._get_context_file_max_chars``) so a hint and a
+        startup-loaded context file obey one rule: an explicit
+        ``context_file_max_chars`` wins, otherwise the cap scales with the
+        model's window. Falls back to the historical 8K floor when the window
+        is unknown or the resolver is unavailable.
+        """
+        if not isinstance(self.context_length, int) or self.context_length <= 0:
+            return _MAX_HINT_CHARS
+        try:
+            from agent.prompt_builder import _get_context_file_max_chars
+
+            return max(
+                _MAX_HINT_CHARS, _get_context_file_max_chars(self.context_length)
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve dynamic hint cap: %s", exc)
+            return _MAX_HINT_CHARS
 
     def _seed_working_dir_digest(self) -> None:
         """Record the CWD context file's digest so it is never re-injected.
@@ -303,9 +332,10 @@ class SubdirectoryHintTracker:
                 self._loaded_digests.add(digest)
                 # Same security scan as startup context loading
                 content = _scan_context_content(content, filename)
-                if len(content) > _MAX_HINT_CHARS:
+                max_hint_chars = self._hint_max_chars()
+                if len(content) > max_hint_chars:
                     content = (
-                        content[:_MAX_HINT_CHARS]
+                        content[:max_hint_chars]
                         + f"\n\n[...truncated {filename}: {len(content):,} chars total]"
                     )
                 # Best-effort relative path for display

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -108,6 +108,40 @@ class TestSubdirectoryHintTracker:
         # Should be capped
         assert len(result) < 20_000
 
+    def test_cap_scales_with_context_length(self, tmp_path):
+        """A large-window model keeps hint content an 8K cap would drop."""
+        sub = tmp_path / "bigdir"
+        sub.mkdir()
+        # Head stays under the 8K floor; the marker only appears past it.
+        body = "HEAD-SECTION\n" + ("x" * 60_000) + "\nTAIL-SECTION"
+        (sub / "AGENTS.md").write_text(body)
+
+        tracker = SubdirectoryHintTracker(
+            working_dir=str(tmp_path), context_length=1_000_000
+        )
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(sub / "file.py")}
+        )
+        assert result is not None
+        # At a 1M window the scaled cap admits the whole file, so the
+        # operational tail survives instead of being silently dropped.
+        assert "TAIL-SECTION" in result
+        assert "truncated" not in result.lower()
+
+    def test_small_window_still_truncates_at_floor(self, tmp_path):
+        """Without a context length the historical 8K floor still applies."""
+        sub = tmp_path / "bigdir"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("y" * 60_000)
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(sub / "file.py")}
+        )
+        assert result is not None
+        assert "truncated" in result.lower()
+        assert len(result) < 20_000
+
     def test_empty_args(self, project):
         """Empty args should not crash."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## Problem

Subdirectory hints are capped at a hardcoded `_MAX_HINT_CHARS = 8_000`
(`agent/subdirectory_hints.py:38`), while the startup context path scales its cap
to the model's window through `_get_context_file_max_chars` /
`_dynamic_context_file_max_chars` (20K floor, 48K at a 200K window, 240K at 1M).

The two paths load the same files. Only one of them scales.

A project `AGENTS.md` discovered mid-session is therefore cut to its first 8,000
chars, head-only with no tail, so the model receives the file's preamble and none
of its operational rules. The startup path loads the identical file whole.

## Measurement

Against this repository's own 95,153-char `AGENTS.md`:

| Cap | Injected | Sections kept |
|---|---|---|
| 8K (before) | 8,106 chars | **2 of 25** |
| Scaled, 1M window (after) | 95,213 chars | **25 of 25** |

Sections silently dropped at 8K include Development Environment, Project
Structure, Adding New Tools, Adding Configuration, Plugins, Skills, Toolsets,
Delegation, Cron, Kanban, Important Policies, Known Pitfalls, and Testing.

The failure is silent: the truncation marker sits at the end of the injected
text, so nothing signals that the build and test rules were the part removed.

## Fix

Resolve the hint cap through the resolver the startup path already uses, so both
obey one rule, including an explicit `context_file_max_chars` override. The 8K
value becomes a floor rather than a ceiling: when the window is unknown the
behavior is byte-identical to before.

The session's context length is already available at the construction site as
`agent.context_compressor.context_length`, so this threads an existing value
rather than adding configuration.

## Tests

- `test_cap_scales_with_context_length` — a 1M-window tracker keeps a tail an 8K
  cap drops.
- `test_small_window_still_truncates_at_floor` — with no context length the 8K
  floor still truncates.

Both assert the invariant (does the content survive), not a snapshot of the cap
value.

**Teeth check:** reverting only the enforcement line to the hardcoded constant
fails `test_cap_scales_with_context_length` and passes the floor test, so the
gate fails on known-bad rather than passing vacuously.

## Verification

- `scripts/run_tests.sh tests/agent/test_subdirectory_hints.py tests/agent/test_subdirectory_hints_tilde.py` — 30 passed, 0 failed
- `python3 -m ruff check agent/subdirectory_hints.py agent/agent_init.py tests/agent/test_subdirectory_hints.py` — All checks passed
- `python scripts/check-windows-footguns.py --all` — no footguns, 1,018 files
- Sibling sweep: `_MAX_HINT_CHARS` has no other reader (`rg` shows 4 hits, all in the changed function and its floor fallback). `SubdirectoryHintTracker(` has one non-test caller, `agent/agent_init.py:2949`, which this PR updates.

## Known / out of scope

- The new parameter defaults to `None`, so every existing caller keeps the 8K
  behavior. This is deliberate: it makes the change additive for embedders
  constructing the tracker directly.
- Prompt caching is unaffected. Hints are appended to tool results, not to the
  system prompt.
