### PR TITLE
state.db journal-mode choices are no longer silently ignored; synchronous is pinnable everywhere (salvage #85609, #89393, #90892)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -22,8 +22,9 @@ database:
   # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
   # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
   # interpreter, a distro python3 and a Homebrew one. Set it if you need to
-  # know which one you are running rather than infer it. macOS is always held
-  # at FULL regardless: Darwin's fsync() does not guarantee write ordering.
+  # know which one you are running rather than infer it. On macOS this is a
+  # floor, not a pin: values below FULL are refused because Darwin's fsync()
+  # does not guarantee write ordering, while EXTRA is honored normally.
   # synchronous: FULL
 
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -17,6 +17,14 @@ database:
   # Optional WAL sizing pragmas (integers). Unset = SQLite defaults.
   # wal_autocheckpoint: 1000     # pages between automatic checkpoints
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
+  #
+  # Durability level for every state.db connection: OFF, NORMAL, FULL, EXTRA
+  # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
+  # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
+  # interpreter, a distro python3 and a Homebrew one. Set it if you need to
+  # know which one you are running rather than infer it. macOS is always held
+  # at FULL regardless: Darwin's fsync() does not guarantee write ordering.
+  # synchronous: FULL
 
 # =============================================================================
 # Runtime Limits

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1596,6 +1596,91 @@ def _log_configured_delete_overridden_once(db_label: str) -> None:
 # ---------------------------------------------------------------------------
 # Config-driven database pragmas
 # ---------------------------------------------------------------------------
+# PRAGMA synchronous accepts either an integer or a symbolic name, and operators
+# write the names. Mapped here rather than passed through so a typo becomes a
+# warning instead of a silently different durability level.
+_SYNCHRONOUS_LEVELS: Dict[str, int] = {
+    "OFF": 0,
+    "NORMAL": 1,
+    "FULL": 2,
+    "EXTRA": 3,
+}
+_SYNCHRONOUS_NAMES: Dict[int, str] = {v: k for k, v in _SYNCHRONOUS_LEVELS.items()}
+_SYNCHRONOUS_FULL = 2
+
+
+def resolve_synchronous_level(raw_value: Any) -> Optional[int]:
+    """Map a configured ``database.synchronous`` value to its PRAGMA integer.
+
+    Accepts the symbolic names SQLite documents (``OFF``/``NORMAL``/``FULL``/
+    ``EXTRA``, any case) and the equivalent integers ``0``-``3``. Returns None
+    for anything else so the caller can warn and leave the level untouched —
+    guessing at a malformed durability setting is worse than ignoring it.
+    """
+    if isinstance(raw_value, bool):
+        # bool is an int subclass, and YAML turns a bare `on`/`off` into one.
+        # "off" as a durability level is a real choice; True is meaningless.
+        return 0 if raw_value is False else None
+    if isinstance(raw_value, int):
+        return raw_value if raw_value in _SYNCHRONOUS_NAMES else None
+    text = str(raw_value).strip()
+    if not text:
+        return None
+    upper = text.upper()
+    if upper in _SYNCHRONOUS_LEVELS:
+        return _SYNCHRONOUS_LEVELS[upper]
+    try:
+        value = int(text)
+    except (TypeError, ValueError):
+        return None
+    return value if value in _SYNCHRONOUS_NAMES else None
+
+
+def _apply_synchronous_pragma(
+    conn: sqlite3.Connection,
+    raw_value: Any,
+    *,
+    db_label: str,
+) -> None:
+    """Set ``PRAGMA synchronous`` from config, never below FULL on macOS.
+
+    Split out of the integer loop in :func:`apply_database_pragmas` because
+    this PRAGMA is not interchangeable with the sizing ones around it. Those
+    trade memory or disk for speed; this one decides whether a commit is on
+    the platter, so an unrecognised value must not fall through to "SQLite
+    default" the way a bad ``cache_size`` harmlessly can.
+
+    The Darwin floor exists because :func:`_enforce_macos_synchronous_full`
+    runs during ``apply_wal_with_fallback()`` and this function runs after it,
+    so a configured ``NORMAL`` would otherwise silently undo the macOS btree
+    protection that fix put there deliberately. Raising the level on macOS is
+    allowed; lowering it is refused out loud.
+    """
+    level = resolve_synchronous_level(raw_value)
+    if level is None:
+        logger.warning(
+            "%s: ignoring unrecognized database.synchronous=%r "
+            "(expected OFF, NORMAL, FULL, EXTRA, or 0-3)",
+            db_label,
+            raw_value,
+        )
+        return
+    if sys.platform == "darwin" and level < _SYNCHRONOUS_FULL:
+        logger.warning(
+            "%s: refusing database.synchronous=%s on macOS; keeping FULL. "
+            "Darwin's fsync() does not guarantee write ordering, so a lower "
+            "level readmits the half-written btree pages FULL exists to "
+            "prevent.",
+            db_label,
+            _SYNCHRONOUS_NAMES[level],
+        )
+        return
+    try:
+        conn.execute(f"PRAGMA synchronous={level}")
+    except sqlite3.OperationalError:
+        pass
+
+
 def apply_database_pragmas(
     conn: sqlite3.Connection,
     *,
@@ -1618,6 +1703,11 @@ def apply_database_pragmas(
     * ``temp_store`` — 0=DEFAULT(file), 1=FILE, 2=MEMORY, 3=ALWAYS
     * ``wal_autocheckpoint`` — WAL auto-checkpoint threshold in pages
     * ``journal_size_limit`` — max journal/WAL size in bytes
+    * ``synchronous`` — durability level: ``OFF``/``NORMAL``/``FULL``/``EXTRA``
+      or ``0``-``3``. Unset leaves SQLite's own default, which is a
+      *compile-time* constant (``SQLITE_DEFAULT_WAL_SYNCHRONOUS``) and so
+      differs between the bundled, distro and Homebrew builds an operator
+      might be running. Setting it explicitly is the only way to know.
 
     Best-effort: config load or pragma failures are ignored so DB init
     never breaks on a malformed ``database:`` section.
@@ -1656,6 +1746,14 @@ def apply_database_pragmas(
             conn.execute(f"PRAGMA {pragma_name}={value}")
         except sqlite3.OperationalError:
             pass
+
+    # Last, so it wins over nothing and loses to nothing: the sizing pragmas
+    # above cannot change durability, and the macOS enforcement ran earlier
+    # during WAL activation (see _apply_synchronous_pragma for why that
+    # ordering needs an explicit floor rather than an explicit override).
+    raw_synchronous = cfg_get(cfg, "database", "synchronous", default=None)
+    if raw_synchronous is not None:
+        _apply_synchronous_pragma(conn, raw_synchronous, db_label=db_label)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -702,6 +702,10 @@ _wal_fallback_warned_lock = threading.Lock()
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
 
+# Dedup ERROR for the "configured delete overridden by on-disk WAL" warning.
+_delete_overridden_warned_paths: set[str] = set()
+_delete_overridden_warned_lock = threading.Lock()
+
 def _set_last_init_error(msg: Optional[str]) -> None:
     """Record (or clear) the most recent state.db init failure.
 
@@ -1145,6 +1149,10 @@ def apply_wal_with_fallback(
     # Skipping the set-pragma prevents WAL-init from unlinking files other connections hold open.
     current_mode = _on_disk_journal_mode(conn)
     if current_mode == "wal":
+        if configured == "delete":
+            # Never-live-downgrade keeps this WAL; tell the operator their
+            # configured delete did not apply (see _log_configured_delete_overridden_once).
+            _log_configured_delete_overridden_once(db_label)
         _apply_wal_size_limit(conn)
         _apply_macos_checkpoint_barrier(conn)
         _enforce_macos_synchronous_full(conn)
@@ -1312,9 +1320,15 @@ def _apply_delete_for_wal_reset_bug(
     current = _on_disk_journal_mode(conn)
 
     if current == "wal":
-        # Do not TRUNCATE / journal_mode=DELETE while other processes may
-        # still hold this WAL DB open — same safety rule as the NFS path.
         _log_wal_reset_bug_once(db_label, kept_wal=True)
+        if require_delete:
+            # The vulnerability warning above suggests upgrading SQLite, which
+            # does not help on a WAL-incompatible filesystem; surface that the
+            # configured delete is not in effect (see _log_configured_delete_overridden_once).
+            # Emitted last so the actionable message is the final one in the log.
+            _log_configured_delete_overridden_once(db_label)
+        # Do not TRUNCATE / journal_mode=DELETE while other processes may
+        # still hold this WAL DB open; same safety rule as the NFS path.
         _apply_wal_size_limit(conn)
         _apply_macos_checkpoint_barrier(conn)
         _enforce_macos_synchronous_full(conn)
@@ -1451,6 +1465,37 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         "fires once per process per database.",
         db_label,
         exc,
+    )
+
+
+def _log_configured_delete_overridden_once(db_label: str) -> None:
+    """Log a single ERROR per (process, db_label) when the operator configured
+    ``journal_mode=delete`` but the on-disk DB is already WAL, so the configured
+    mode is not in effect.
+
+    Counterpart to :func:`_log_wal_fallback_once` for the opposite direction:
+    there WAL was refused by the filesystem and we silently fell back to DELETE;
+    here the operator asked for DELETE but an inherited on-disk WAL header means
+    we keep WAL (the never-live-downgrade rule prevents a live downgrade, which
+    causes mixed-mode corruption). The signal matters because otherwise the
+    operator has no indication that ``database.journal_mode: delete`` had no
+    effect and the DB still requires a one-time offline ``PRAGMA
+    journal_mode=DELETE`` (with no open connections) to apply.
+
+    Fires once per process per database.
+    """
+    with _delete_overridden_warned_lock:
+        if db_label in _delete_overridden_warned_paths:
+            return
+        _delete_overridden_warned_paths.add(db_label)
+    logger.error(
+        "%s: database.journal_mode=delete is configured but the on-disk "
+        "database is already WAL; keeping WAL (a live downgrade under open "
+        "connections can corrupt the DB). To apply journal_mode=DELETE, stop "
+        "all connections to this DB and run a one-time offline "
+        "'PRAGMA journal_mode=DELETE' on the file. This message fires once "
+        "per process per database.",
+        db_label,
     )
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1038,6 +1038,31 @@ def sqlite_source_id() -> str:
     return str(row[0])
 
 
+def _database_has_content(conn: sqlite3.Connection) -> bool:
+    """Return whether the database file already holds pages.
+
+    Used to tell an EXISTING database apart from a brand-new one before
+    rewriting its journal mode. ``PRAGMA page_count`` is a header read, so
+    this costs nothing and takes no lock.
+
+    Fail-quiet: any error, or a database we cannot measure, answers False.
+    The only caller uses this to decide whether to emit a warning, and a
+    warning that fires when the answer is unknown would fire on every fresh
+    database -- precisely the case where there is provably no operator choice
+    being overwritten.
+    """
+    try:
+        row = conn.execute("PRAGMA page_count").fetchone()
+    except sqlite3.Error:
+        return False
+    if not row or row[0] is None:
+        return False
+    try:
+        return int(row[0]) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 def resolve_journal_mode() -> str:
     """Return the configured journal mode (``wal`` or ``delete``).
 
@@ -1181,6 +1206,21 @@ def apply_wal_with_fallback(
             )
         return actual
 
+    # Decide BEFORE the flip whether it would silently overwrite a mode
+    # somebody chose. Both inputs are only readable while the file is still
+    # in its original state: `current_mode` is the probe above, and
+    # page_count distinguishes an existing database from a fresh one.
+    #
+    # A 0-page database has no prior choice to overwrite, and every caller
+    # reaches this before creating any schema (SessionDB._connect_and_init
+    # applies WAL, then _init_schema), so brand-new databases land here empty
+    # and stay quiet.
+    _upgrading_existing_db = (
+        current_mode is not None
+        and current_mode != "wal"
+        and _database_has_content(conn)
+    )
+
     try:
         # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
         # resulting journal mode. Network filesystems that refuse WAL by
@@ -1194,6 +1234,8 @@ def apply_wal_with_fallback(
         row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
         mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
         if mode == "wal":
+            if _upgrading_existing_db:
+                _log_journal_mode_upgrade_once(db_label, current_mode)
             _apply_wal_size_limit(conn)
             _apply_macos_checkpoint_barrier(conn)
             _enforce_macos_synchronous_full(conn)
@@ -1243,6 +1285,11 @@ def apply_wal_with_fallback(
                     else ""
                 )
                 if mode == "wal":
+                    # Same flip, later door: a transient EIO cleared and the
+                    # switch went through. The header rewrite is identical, so
+                    # the signal must be too.
+                    if _upgrading_existing_db:
+                        _log_journal_mode_upgrade_once(db_label, current_mode)
                     _apply_wal_size_limit(conn)
                     _apply_macos_checkpoint_barrier(conn)
                     _enforce_macos_synchronous_full(conn)
@@ -1400,6 +1447,12 @@ def _wal_reset_repair_hint() -> str:
     )
 
 
+# Dedup state for _log_journal_mode_upgrade_once, mirroring the
+# _wal_fallback_warned_* pair below it.
+_journal_upgrade_warned_paths: set = set()
+_journal_upgrade_warned_lock = threading.Lock()
+
+
 def _log_wal_reset_bug_once(
     db_label: str,
     *,
@@ -1439,6 +1492,47 @@ def _log_wal_reset_bug_once(
         sqlite3.sqlite_version,
         action,
         repair_hint,
+    )
+
+
+def _log_journal_mode_upgrade_once(db_label: str, previous_mode: str) -> None:
+    """Log a single WARNING per (process, db_label) about a non-WAL -> WAL flip.
+
+    ``PRAGMA journal_mode`` is a property of the FILE, not of the connection:
+    switching an existing database to WAL rewrites its header and outlives the
+    process that did it. Operators do set it directly on the file -- that was
+    the documented mitigation for the SQLite 3.50.4 WAL-reset bug -- and
+    nothing here told them the next open would silently put it back.
+
+    WARNING, not ERROR, and deliberately so. The reverse move is logged at
+    ERROR by ``_log_wal_fallback_once`` because dropping to DELETE is a real
+    loss of concurrency; this direction is normally the desirable one (see
+    ``hermes_cli/managed_uv._default_live_venv``, which treats a database
+    stuck on DELETE as a bug worth repairing on update). The problem is not
+    the change, it is that the change was invisible: an operator who chose
+    DELETE deliberately had no way to learn their choice had been overwritten,
+    or which lever makes it stick. So this says what happened and names the
+    durable setting, without claiming a degradation that is not there.
+
+    Deduped per process per ``db_label`` like its siblings: kanban opens a
+    fresh connection per operation, so an undeduped line here would be a log
+    flood rather than a signal.
+    """
+    with _journal_upgrade_warned_lock:
+        if db_label in _journal_upgrade_warned_paths:
+            return
+        _journal_upgrade_warned_paths.add(db_label)
+    logger.warning(
+        "%s: on-disk journal_mode was %s and has been switched to WAL. This "
+        "rewrites the database header and persists after this process exits. "
+        "If %s was a deliberate choice (for example the mitigation for the "
+        "SQLite WAL-reset bug, or a WAL-unsafe filesystem), setting it with "
+        "PRAGMA on the file will not survive -- every open re-applies the "
+        "configured mode. Set `database.journal_mode: delete` in config.yaml "
+        "to make it stick. This message fires once per process per database.",
+        db_label,
+        previous_mode,
+        previous_mode,
     )
 
 

--- a/tests/test_journal_mode_config.py
+++ b/tests/test_journal_mode_config.py
@@ -29,6 +29,17 @@ def _disable_vulnerable_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_configured_delete_override_warned_paths():
+    """Reset the configured-delete-override warned-paths set so the
+    once-per-process-per-db_label dedup doesn't leak between tests."""
+    import hermes_state
+
+    hermes_state._delete_overridden_warned_paths.clear()
+    yield
+    hermes_state._delete_overridden_warned_paths.clear()
+
+
 def test_database_journal_mode_has_a_canonical_default():
     from hermes_cli.config import DEFAULT_CONFIG
 
@@ -112,7 +123,10 @@ def test_configured_delete_validates_vulnerable_sqlite_result(monkeypatch, tmp_p
         conn.close()
 
 
-def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_path):
+def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_path, caplog):
+    """Keeping WAL is correct, but the operator must be told their configured
+    delete had no effect (otherwise the DB silently stays WAL and the protection
+    they configured never applies)."""
     from hermes_state import apply_wal_with_fallback
 
     _configure_mode(monkeypatch, tmp_path, "delete")
@@ -124,8 +138,96 @@ def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_p
             "hermes_state.is_sqlite_wal_reset_vulnerable",
             lambda **kwargs: True,
         )
-        assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert any(
+            "database.journal_mode=delete is configured" in r.message
+            and "on-disk" in r.message
+            for r in caplog.records
+        ), "expected a warning that configured delete was overridden by on-disk WAL"
+    finally:
+        conn.close()
+
+
+def test_configured_delete_overridden_warns_on_non_vulnerable_runtime_too(monkeypatch, tmp_path, caplog):
+    """When the SQLite runtime is NOT WAL-reset-vulnerable (e.g. after a
+    3.51.3+ upgrade), the on-disk WAL + configured-delete case reaches the
+    read-only probe path instead of the vulnerability path. That path used to
+    return WAL with no signal at all; it must emit the same override warning."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    _disable_vulnerable_gate(monkeypatch)
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        warnings = [
+            r for r in caplog.records
+            if "database.journal_mode=delete is configured" in r.message
+        ]
+        assert len(warnings) == 1, (
+            "probe path must warn when configured delete is overridden by on-disk WAL, "
+            "and dedup to one per process per db_label"
+        )
+    finally:
+        conn.close()
+
+
+def test_configured_delete_overridden_warning_fires_once_per_db(monkeypatch, tmp_path, caplog):
+    """The override warning is deduped per process per db_label (same discipline
+    as the WAL-fallback warning), so repeated connections don't flood the log."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    monkeypatch.setattr(
+        "hermes_state.is_sqlite_wal_reset_vulnerable",
+        lambda **kwargs: True,
+    )
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+        warnings = [
+            r for r in caplog.records
+            if "database.journal_mode=delete is configured" in r.message
+        ]
+        assert len(warnings) == 1, "override warning must fire once per process per db_label"
+    finally:
+        conn.close()
+
+
+def test_configured_delete_with_require_wal_and_existing_wal_returns_wal(monkeypatch, tmp_path, caplog):
+    """Pin the require_wal=True + configured=delete + on-disk WAL edge case: the
+    existing-WAL probe branch returns "wal" unconditionally (require_wal only
+    governs the WAL-refusal fallback paths), so the override warning fires and no
+    WalUnsupportedError is raised."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    _disable_vulnerable_gate(monkeypatch)
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            result = apply_wal_with_fallback(
+                conn, db_label="existing-wal.db", require_wal=True
+            )
+        assert result == "wal"
+        assert any(
+            "database.journal_mode=delete is configured" in r.message
+            for r in caplog.records
+        )
     finally:
         conn.close()
 

--- a/tests/test_journal_mode_upgrade_warning.py
+++ b/tests/test_journal_mode_upgrade_warning.py
@@ -1,0 +1,358 @@
+"""An existing database's journal mode must not be rewritten silently (#89293).
+
+``PRAGMA journal_mode`` is a property of the FILE. Switching an existing
+database to WAL rewrites its header and outlives the process that did it.
+
+``apply_wal_with_fallback`` already treats on-disk WAL as authoritative and
+refuses to live-downgrade it. The mirror case had no protection at all: an
+on-disk DELETE database was flipped to WAL by the *default* configured value,
+with no log line -- so an operator who set DELETE on the file (the documented
+mitigation for the SQLite 3.50.4 WAL-reset bug) had no way to learn their
+choice had been overwritten, or that ``database.journal_mode`` is the lever
+that makes it stick.
+
+#89293 is the field report: after upgrading past the vulnerable SQLite,
+``is_sqlite_wal_reset_vulnerable()`` stopped short-circuiting to DELETE and
+4 of 5 databases silently returned to WAL.
+
+This is a LOG-ONLY change. Half of these tests exist to prove that: the return
+value, the resulting header, and the never-live-downgrade rule are all pinned
+unchanged, and the brand-new-database case must stay silent or the warning
+would fire on every fresh install.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import yaml
+
+
+def _write_config(monkeypatch: pytest.MonkeyPatch, tmp_path, config: object) -> None:
+    home = tmp_path / "hermes-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def _configure_mode(monkeypatch: pytest.MonkeyPatch, tmp_path, mode: object) -> None:
+    _write_config(monkeypatch, tmp_path, {"database": {"journal_mode": mode}})
+
+
+def _disable_vulnerable_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "hermes_state.is_sqlite_wal_reset_vulnerable",
+        lambda **kwargs: False,
+    )
+
+
+def _make_delete_db_with_content(path) -> None:
+    """Create a real, non-empty database left in journal_mode=DELETE."""
+    conn = sqlite3.connect(str(path))
+    try:
+        assert conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0].lower() == "delete"
+        conn.execute("CREATE TABLE t (x)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup():
+    """Order-independence: the warning is deduped per process per db_label."""
+    import hermes_state
+
+    hermes_state._journal_upgrade_warned_paths.clear()
+    yield
+    hermes_state._journal_upgrade_warned_paths.clear()
+
+
+class TestTheContentProbe:
+    """``_database_has_content`` is what keeps fresh installs quiet."""
+
+    def test_a_brand_new_database_has_no_content(self, tmp_path):
+        from hermes_state import _database_has_content
+
+        conn = sqlite3.connect(str(tmp_path / "new.db"))
+        try:
+            assert _database_has_content(conn) is False
+        finally:
+            conn.close()
+
+    def test_a_database_with_a_table_has_content(self, tmp_path):
+        from hermes_state import _database_has_content
+
+        path = tmp_path / "used.db"
+        _make_delete_db_with_content(path)
+        conn = sqlite3.connect(str(path))
+        try:
+            assert _database_has_content(conn) is True
+        finally:
+            conn.close()
+
+    def test_an_unreadable_probe_answers_no_content(self, tmp_path):
+        """Fail-quiet.
+
+        Answering True on an error would emit the warning for a database we
+        could not measure, which includes every fresh one.
+        """
+        from hermes_state import _database_has_content
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.close()
+            assert _database_has_content(conn) is False
+        finally:
+            pass
+
+
+class TestTheWarningFires:
+
+    def test_an_existing_delete_database_warns_when_flipped(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+        finally:
+            conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "state.db" in blob
+        assert "delete" in blob.lower()
+
+    def test_the_warning_names_the_setting_that_makes_it_stick(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """The whole point.
+
+        Telling an operator their mode changed, without telling them which
+        lever survives an open, leaves them doing the same PRAGMA again.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                apply_wal_with_fallback(conn, db_label="state.db")
+        finally:
+            conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "database.journal_mode" in blob, (
+            "the warning must name the config key, not just report the change"
+        )
+
+    def test_the_flip_still_happens(self, monkeypatch, tmp_path):
+        """Log-only: WAL is still applied, and it still persists.
+
+        Staying on DELETE is itself treated as a defect elsewhere in the tree
+        (managed_uv repairs it on update, citing ~2600x slower appends), so
+        this must warn about the change without preventing it.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            assert apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_it_fires_once_per_process_per_database(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """kanban opens a connection per operation; undeduped this is a flood."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for name in ("a", "b"):
+                path = tmp_path / f"{name}.db"
+                _make_delete_db_with_content(path)
+                conn = sqlite3.connect(str(path))
+                try:
+                    apply_wal_with_fallback(conn, db_label="same-label.db")
+                finally:
+                    conn.close()
+
+        hits = [r for r in caplog.records if "same-label.db" in r.getMessage()]
+        assert len(hits) == 1, f"expected one deduped warning, got {len(hits)}"
+
+    def test_a_second_database_gets_its_own_warning(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """#89293 saw four databases flip. Dedup is per label, not global."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for label in ("state.db", "kanban.db"):
+                path = tmp_path / f"{label}"
+                _make_delete_db_with_content(path)
+                conn = sqlite3.connect(str(path))
+                try:
+                    apply_wal_with_fallback(conn, db_label=label)
+                finally:
+                    conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "state.db" in blob and "kanban.db" in blob
+
+
+class TestTheWarningStaysQuiet:
+    """Every one of these would be a false positive shipped to every user."""
+
+    def test_a_brand_new_database_is_silent(self, monkeypatch, tmp_path, caplog):
+        """The load-bearing guard.
+
+        A fresh file reports journal_mode=delete (SQLite's default) and is
+        about to be switched to WAL, which looks identical to the reported
+        bug from `current_mode` alone. Only page_count tells them apart, and
+        every opener applies WAL before creating any schema -- so without
+        this guard the warning fires on every first run of every install.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        conn = sqlite3.connect(str(tmp_path / "fresh.db"))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="fresh.db") == "wal"
+        finally:
+            conn.close()
+
+        assert not [r for r in caplog.records if "fresh.db" in r.getMessage()]
+
+    def test_an_existing_wal_database_is_silent(self, monkeypatch, tmp_path, caplog):
+        """No flip happens: the probe returns early. Nothing to report."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "already-wal.db"
+        conn = sqlite3.connect(str(path))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("CREATE TABLE t (x)")
+            conn.commit()
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="already-wal.db") == "wal"
+        finally:
+            conn.close()
+
+        assert not [r for r in caplog.records if "already-wal.db" in r.getMessage()]
+
+    def test_configured_delete_is_silent(self, monkeypatch, tmp_path, caplog):
+        """The operator used the durable lever. There is nothing to tell them."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "delete")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "configured-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="configured-delete.db") == "delete"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+        finally:
+            conn.close()
+
+        assert not [
+            r for r in caplog.records if "configured-delete.db" in r.getMessage()
+        ]
+
+    def test_the_wal_reset_vulnerable_path_is_silent(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """That branch returns before any flip, so it must not warn.
+
+        It is also the branch that KEPT #89293's databases on DELETE before
+        the SQLite upgrade -- warning here would blame the guard that was
+        doing its job.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        monkeypatch.setattr(
+            "hermes_state.is_sqlite_wal_reset_vulnerable",
+            lambda **kwargs: True,
+        )
+        path = tmp_path / "vulnerable.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                apply_wal_with_fallback(conn, db_label="vulnerable.db")
+        finally:
+            conn.close()
+
+        assert not [
+            r
+            for r in caplog.records
+            if "database.journal_mode" in r.getMessage()
+        ]
+
+
+class TestTheExistingContractIsUnchanged:
+    """Behaviour preservation for the rules this change sits next to."""
+
+    def test_on_disk_wal_is_still_never_live_downgraded(self, monkeypatch, tmp_path):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "delete")
+        path = tmp_path / "existing-wal.db"
+        conn = sqlite3.connect(str(path))
+        try:
+            assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+            monkeypatch.setattr(
+                "hermes_state.is_sqlite_wal_reset_vulnerable",
+                lambda **kwargs: True,
+            )
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_default_config_still_yields_wal_on_a_fresh_database(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        conn = sqlite3.connect(str(tmp_path / "default.db"))
+        try:
+            assert apply_wal_with_fallback(conn, db_label="default.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()

--- a/tests/test_state_synchronous_pragma.py
+++ b/tests/test_state_synchronous_pragma.py
@@ -1,0 +1,228 @@
+"""``database.synchronous`` is configurable, validated, and floored on macOS.
+
+Before this, `apply_database_pragmas()` accepted five sizing pragmas and no
+durability one, and `_enforce_macos_synchronous_full()` returned early off
+Darwin. So on Linux and Windows nothing in the process ever executed
+`PRAGMA synchronous` against state.db, and the effective level was whichever
+`SQLITE_DEFAULT_WAL_SYNCHRONOUS` the interpreter's SQLite happened to be
+compiled with -- invisible from config, unpinnable, and different between
+builds. See #90837, where three weeks of corruption forensics were carried out
+under the stated assumption of `synchronous=FULL` on Ubuntu.
+"""
+
+import sqlite3
+import sys
+
+import pytest
+
+import hermes_state
+from hermes_state import (
+    apply_database_pragmas,
+    resolve_synchronous_level,
+)
+
+
+def _wal_conn(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "state.db"), isolation_level=None)
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _level(conn):
+    return conn.execute("PRAGMA synchronous").fetchone()[0]
+
+
+def _config(monkeypatch, database_section):
+    """Point apply_database_pragmas at an in-memory config.
+
+    It imports `hermes_cli.config` lazily inside the function body, so the
+    patch has to land on that module rather than on a name in this one.
+    """
+    import hermes_cli.config as config_mod
+
+    cfg = {"database": database_section}
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda *a, **k: cfg)
+    return cfg
+
+
+class TestResolveSynchronousLevel:
+    """The parser, in isolation -- a wrong answer here is a silent downgrade."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("OFF", 0),
+            ("NORMAL", 1),
+            ("FULL", 2),
+            ("EXTRA", 3),
+            ("full", 2),
+            ("Full", 2),
+            ("  FULL  ", 2),
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            ("2", 2),
+            (" 2 ", 2),
+        ],
+    )
+    def test_accepts_documented_spellings(self, raw, expected):
+        assert resolve_synchronous_level(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "PARANOID",
+            "",
+            "   ",
+            4,
+            -1,
+            "4",
+            None,
+            [],
+            {},
+            2.5,
+            "2.0",
+        ],
+    )
+    def test_rejects_everything_else(self, raw):
+        assert resolve_synchronous_level(raw) is None
+
+    def test_yaml_off_is_a_level_but_yaml_on_is_not(self):
+        """`synchronous: off` is bool False in YAML and means OFF.
+
+        `synchronous: on` is bool True and means nothing -- there is no
+        durability level it could map to, so it must be rejected rather than
+        coerced to 1 by int(True).
+        """
+        assert resolve_synchronous_level(False) == 0
+        assert resolve_synchronous_level(True) is None
+
+
+class TestAppliedFromConfig:
+    def test_configured_level_reaches_the_connection(self, tmp_path, monkeypatch):
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 1
+        finally:
+            conn.close()
+
+    def test_full_reaches_the_connection(self, tmp_path, monkeypatch):
+        """The #90837 case: an operator asking for FULL on Linux gets FULL.
+
+        Fails without the patch -- the pragma was never executed at all, so the
+        connection kept whatever the build's default was.
+        """
+        _config(monkeypatch, {"synchronous": "FULL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=0")
+            assert _level(conn) == 0
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+        finally:
+            conn.close()
+
+    def test_unset_leaves_the_level_alone(self, tmp_path, monkeypatch):
+        """No config key must mean no write -- this is the default path."""
+        _config(monkeypatch, {"wal_autocheckpoint": 1000})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=0")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 0
+            assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 1000
+        finally:
+            conn.close()
+
+    def test_garbage_warns_and_changes_nothing(self, tmp_path, monkeypatch, caplog):
+        """A typo must not fall through to a different durability level."""
+        _config(monkeypatch, {"synchronous": "PARANOID"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=2")
+            with caplog.at_level("WARNING"):
+                apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+            assert "PARANOID" in caplog.text
+        finally:
+            conn.close()
+
+    def test_the_other_pragmas_still_apply(self, tmp_path, monkeypatch):
+        """Guardrail for #77630's five keys -- they share the same function."""
+        _config(
+            monkeypatch,
+            {"synchronous": "FULL", "wal_autocheckpoint": 250, "mmap_size": 0},
+        )
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+            assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 250
+            assert conn.execute("PRAGMA mmap_size").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+
+class TestMacOSFloor:
+    """#64355 enforced FULL on Darwin. Config must not be able to undo it.
+
+    `_enforce_macos_synchronous_full()` runs inside `apply_wal_with_fallback()`,
+    which is earlier than `apply_database_pragmas()`, so without an explicit
+    floor the config value would simply win by running last.
+    """
+
+    def test_lowering_below_full_is_refused_on_darwin(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            hermes_state._enforce_macos_synchronous_full(conn)
+            assert _level(conn) == 2
+            with caplog.at_level("WARNING"):
+                apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2, "config lowered the macOS btree protection"
+            assert "macOS" in caplog.text
+        finally:
+            conn.close()
+
+    def test_raising_above_full_is_allowed_on_darwin(self, tmp_path, monkeypatch):
+        """The floor is a floor, not a pin -- EXTRA is strictly safer."""
+        _config(monkeypatch, {"synchronous": "EXTRA"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 3
+        finally:
+            conn.close()
+
+    def test_the_floor_does_not_apply_off_darwin(self, tmp_path, monkeypatch):
+        """Linux operators may deliberately choose NORMAL for write volume."""
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=2")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 1
+        finally:
+            conn.close()
+
+
+def test_example_config_documents_the_key():
+    """An unpinnable durability level is the bug; docs are half the fix."""
+    from pathlib import Path
+
+    text = Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
+    body = text.read_text(encoding="utf-8")
+    assert "synchronous: FULL" in body

--- a/tests/test_state_synchronous_pragma.py
+++ b/tests/test_state_synchronous_pragma.py
@@ -226,3 +226,22 @@ def test_example_config_documents_the_key():
     text = Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
     body = text.read_text(encoding="utf-8")
     assert "synchronous: FULL" in body
+
+
+def test_example_config_calls_the_darwin_rule_a_floor_not_a_pin():
+    """The macOS wording has to match _apply_synchronous_pragma's actual rule.
+
+    Saying macOS is "always held at FULL" reads as "your setting is ignored
+    here", which would talk an operator out of choosing EXTRA -- the one level
+    that IS honored on Darwin. Only sub-FULL values are refused. The wording
+    is the whole interface for a key nobody can otherwise observe, so pin the
+    distinction rather than just the key's presence.
+    """
+    from pathlib import Path
+
+    body = (
+        Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
+    ).read_text(encoding="utf-8")
+    assert "floor, not a pin" in body
+    assert "EXTRA is honored" in body
+    assert "always held" not in body

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -87,6 +87,39 @@ sandboxes
 where the limit cannot be changed, startup continues without changing the
 limit.
 
+## Database Settings
+
+The `database:` section controls how Hermes opens its SQLite state database
+(`state.db`), which stores sessions, messages, and gateway routing:
+
+```yaml
+database:
+  # Journal mode for state.db: wal (default) or delete.
+  # Use delete on filesystems where WAL is unsafe (network mounts, some
+  # virtiofs setups). Note: an existing on-disk WAL database is never
+  # live-downgraded — Hermes keeps WAL and logs an error telling you the
+  # configured delete did not apply. To convert an existing database, stop
+  # every process using it and run a one-time offline
+  # `PRAGMA journal_mode=DELETE` on the file.
+  journal_mode: wal
+
+  # Durability level for every state.db connection: OFF, NORMAL, FULL,
+  # EXTRA (or 0-3). Unset leaves SQLite's compile-time default, which
+  # differs between interpreter builds. On macOS this is a floor, not a
+  # pin: values below FULL are refused to protect against Darwin fsync
+  # reordering; EXTRA is honored.
+  # synchronous: FULL
+
+  # Optional WAL sizing pragmas (integers). Unset = SQLite defaults.
+  # wal_autocheckpoint: 1000     # pages between automatic checkpoints
+  # journal_size_limit: 67108864 # cap the WAL/journal size in bytes
+```
+
+Hermes also warns (once per process per database) when an existing
+database's on-disk journal mode is silently flipped to WAL on open — for
+example a database an operator had manually converted to `delete` — and
+names `database.journal_mode` as the setting that makes the choice stick.
+
 ## Environment Variable Substitution
 
 You can reference environment variables in `config.yaml` using `${VAR_NAME}` syntax:


### PR DESCRIPTION
## Summary

Operators now get told when their `state.db` journal-mode choice was silently ignored or overwritten, and can pin the `PRAGMA synchronous` durability level on every platform. Salvages three open contributor PRs from the #90950/#90837 corruption-forensics cluster onto current main.

Root cause of the silence: `apply_wal_with_fallback()` returns early for an on-disk WAL database without ever consulting a configured `journal_mode: delete` (never-live-downgrade is correct, but was invisible), the reverse WAL flip rewrote the file header with no signal, and on Linux/Windows nothing in the process ever executed `PRAGMA synchronous` — the level was whatever the interpreter's SQLite was compiled with.

## Changes

- `hermes_state.py`: ERROR (once per process per DB) when configured `delete` is overridden by on-disk WAL, at both the probe path and the WAL-reset-bug path — @paoloantinori's #85609 (closes #85608)
- `hermes_state.py`: WARNING (deduped) when an existing non-WAL database's header is flipped to WAL, naming `database.journal_mode` as the durable lever — @jackulau's #89393 (closes #89293)
- `hermes_state.py` + `cli-config.yaml.example`: `database.synchronous` config key (OFF/NORMAL/FULL/EXTRA or 0-3), validated, applied via `apply_database_pragmas()`; macOS refuses levels below FULL (floor, not pin) — @jackulau's #90892 (helps #90837)
- `website/docs/user-guide/configuration.md`: new Database Settings section covering `journal_mode`, `synchronous`, and the WAL sizing pragmas
- Tests: 69 targeted tests across `test_journal_mode_config.py`, `test_journal_mode_upgrade_warning.py` (new), `test_state_synchronous_pragma.py` (new)

## Validation

| Scenario (temp HERMES_HOME, real `hermes_state` functions) | origin/main | this branch |
|---|---|---|
| on-disk WAL + configured `delete` → override warning | silent | ERROR fires |
| existing DELETE db flipped to WAL → upgrade warning | silent | WARNING fires |
| `synchronous: FULL` on Linux, level forced to 1 → after `apply_database_pragmas()` | stays 1 | becomes 2 (FULL) |

**Live repro:** all three gaps reproduced silent on `origin/main` and confirmed firing/applying on this branch via the same isolated-env script (`/tmp/e2e_90950_cluster.py` pattern: real imports, temp HERMES_HOME, real SQLite files).

Contributor authorship preserved via cherry-pick; credit to @paoloantinori and @jackulau.

## Infographic

![state.db operator signals — 1-bit Mac System 7 style infographic](https://v3b.fal.media/files/b/0aa807b0/4Y160xNK1FGeLcIGELE7k_DMTks0gw.png)
