### PR TITLE
fix(cli): don't suppress the first focus-regain redraw in the process's first second

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5791,8 +5791,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         per ``min_interval`` seconds.
         """
         now = time.monotonic()
-        last = getattr(self, "_last_focus_regain_redraw", 0.0)
-        if now - last < min_interval:
+        last = getattr(self, "_last_focus_regain_redraw", None)
+        # ``time.monotonic()`` is relative to process start, so a ``0.0``
+        # initial timestamp reads as "redrawn at t=0" and suppresses the
+        # first focus-regain redraw whenever the process has been alive for
+        # less than ``min_interval`` seconds. ``None`` means "never redrawn".
+        if last is not None and now - last < min_interval:
             return
         self._last_focus_regain_redraw = now
         self._force_full_redraw()

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -426,3 +426,20 @@ class TestFocusRegainRedraw:
         bare_cli._schedule_focus_regain_redraw(min_interval=0.0)
 
         assert calls == ["redraw", "redraw"]
+
+    def test_first_focus_regain_fires_even_in_first_second_of_process(
+        self, bare_cli, monkeypatch
+    ):
+        """#87392 carry-over: with a 0.0 initial sentinel, a focus-in during
+        the process's first ``min_interval`` seconds was silently suppressed
+        (monotonic() - 0.0 < min_interval). None = "never redrawn"."""
+        calls = []
+        bare_cli._force_full_redraw = lambda: calls.append("redraw")
+        # Simulate a process alive for 0.2s: monotonic returns a small value.
+        import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod.time, "monotonic", lambda: 0.2)
+
+        bare_cli._schedule_focus_regain_redraw(min_interval=1.0)
+
+        assert calls == ["redraw"]


### PR DESCRIPTION
## Summary

A terminal focus-in (`CSI I`) arriving during the process's first second no longer gets silently swallowed by the focus-regain redraw rate-limiter. Carried from #87392 (@JoaoMarcos44), where this orthogonal cli.py fix was riding along with a ZIP-guard fix that had already landed via another chain.

Root cause: the rate-limiter seeded `_last_focus_regain_redraw` with `0.0`, and `time.monotonic()` is relative to process start — so a focus regain at t=0.2s computed `0.2 - 0.0 < 1.0` and skipped the redraw, exactly when a fresh session behind a tab switch needs its first repaint.

## Changes

- `cli.py`: sentinel is `None` ("never redrawn") instead of `0.0`; the limiter only applies when a previous redraw actually happened.
- 1 regression test pinning the process-early case.

## Validation

| | Before | After |
|---|---|---|
| focus-in at monotonic()=0.2, min_interval=1.0 | redraw suppressed | redraw fires |
| tests/cli/test_cli_force_redraw.py | 19 passed | 20 passed; new test fails on unmodified main (mutation-checked) |

Credit: @JoaoMarcos44 — authorship preserved.
