### PR TITLE
fix(models): empty live fetch no longer shadows the curated catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4155,9 +4155,22 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                                 merged_lower.add(_model_dedup_key(m))
                         return merged
                     return live
-            # Use profile's fallback_models if defined
+            # Live fetch unavailable: static catalog first (it carries the
+            # newest curated entries), profile fallback_models appended after.
+            # Returning ONLY the profile tuple would shadow the richer static
+            # catalog, so the picker regresses whenever the live probe fails
+            # or comes back empty (seen with zai on Z.AI's Anthropic wire,
+            # which has no /models route and answers 200 with an error body
+            # that parses as an empty catalog).
+            static_fallback = list(_PROVIDER_MODELS.get(normalized, []))
             if _p.fallback_models:
-                return list(_p.fallback_models)
+                seen = {_model_dedup_key(m) for m in static_fallback}
+                for m in _p.fallback_models:
+                    if _model_dedup_key(m) not in seen:
+                        static_fallback.append(m)
+                        seen.add(_model_dedup_key(m))
+            if static_fallback:
+                return static_fallback
     except Exception:
         pass
 

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -119,8 +119,52 @@ def _glm_5_2_reasoning_effort(
     return clamped if clamped in efforts else floor
 
 
+def _catalog_url_for_base(base_url: str | None) -> str | None:
+    """Rewrite an inference base URL onto Z.AI's OpenAI-wire models catalog.
+
+    Z.AI splits wires: inference may run on the Anthropic Messages wire
+    (``/api/anthropic``) or the coding plan (``/api/coding/paas/v4``), but the
+    account-wide model catalog is only served on the ``/api/paas/v4/models``
+    route of the same host. The Anthropic wire answers ``/models`` with
+    HTTP 200 + an error body that parses as an EMPTY catalog, which downstream
+    code treats as "live fetch came back empty" rather than "no endpoint" —
+    so glm-5.3 vanished from the picker for coding-plan users.
+
+    Known Z.AI hosts get rewritten; foreign hosts (relays/proxies) return
+    None so the caller keeps its default ``base_url + /models`` behavior.
+    Returns the catalog BASE (no ``/models`` suffix — the base class appends
+    it).
+    """
+    from urllib.parse import urlsplit
+
+    raw = (base_url or "").strip()
+    if not raw:
+        return None
+    parts = urlsplit(raw if "//" in raw else f"https://{raw}")
+    host = (parts.hostname or "").lower()
+    if host not in ("api.z.ai", "open.bigmodel.cn", "api.bigmodel.cn"):
+        return None
+    return f"{parts.scheme or 'https'}://{parts.netloc}/api/paas/v4"
+
+
 class ZaiProfile(ProviderProfile):
     """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Probe the paas/v4 catalog even when inference runs on another wire."""
+        catalog = _catalog_url_for_base(base_url)
+        if catalog is None:
+            # Foreign host (relay/proxy) or empty — keep the caller's base.
+            return super().fetch_models(
+                api_key=api_key, base_url=base_url, timeout=timeout
+            )
+        return super().fetch_models(api_key=api_key, base_url=catalog, timeout=timeout)
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -153,6 +197,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -59,6 +59,36 @@ class TestGenericProviderLiveCuratedMerge:
         assert result.count("glm-5") == 1
 
 
+    def test_live_unavailable_falls_back_to_static_catalog_plus_profile_models(self):
+        """Live fetch fails/empty → static catalog must NOT be shadowed.
+
+        Regression: the no-live path used to return ONLY the profile's
+        ``fallback_models`` tuple. For zai that tuple lagged the static
+        catalog (no glm-5.3), so picker users on Z.AI's Anthropic wire —
+        whose /models probe returns 200 + an error body that parses as an
+        EMPTY catalog — silently lost every curated-only model. Static
+        entries must lead, profile-only entries append.
+        """
+        profile = self._make_profile(models=[])  # live probe "succeeds" empty
+        profile.fallback_models = ("glm-5.2", "glm-5", "glm-4-9b")
+
+        with (
+            patch("providers.get_provider_profile", return_value=profile),
+            patch(
+                "hermes_cli.auth.resolve_api_key_provider_credentials",
+                return_value={"api_key": "k", "base_url": ""},
+            ),
+            patch.dict(
+                "hermes_cli.models._PROVIDER_MODELS",
+                {"zai": ["glm-5.3", "glm-5.2", "glm-5.1"]},
+            ),
+        ):
+            result = provider_model_ids("zai")
+
+        assert result[:3] == ["glm-5.3", "glm-5.2", "glm-5.1"]
+        assert "glm-5" in result and "glm-4-9b" in result  # profile-only appended
+        assert result.count("glm-5.2") == 1  # dedup across sources
+
     def test_no_models_dropped_either_direction(self):
         """Every live AND curated model survives the merge for both modes."""
         live = ["a", "b"]


### PR DESCRIPTION
## Problem

glm-5.3 disappeared from the model selector for Z.AI coding-plan users despite being in the static catalog since #86433-content landed (01d8562fce).

## Root cause

Two stacked defects:

1. **Z.AI's Anthropic wire has no `/models` route.** `api.z.ai/api/anthropic/models` answers HTTP 200 with `{"code":500,"msg":"404 NOT_FOUND"}` — the body parses as an **empty catalog**, not a failure. `provider_model_ids()` then falls to the no-live branch.
2. **The no-live branch returned only the profile's `fallback_models`.** For zai that tuple never got glm-5.3 (the 7th site missed by 01d8562fce), and it **shadows** the richer `_PROVIDER_MODELS["zai"]` static catalog which does have it. Result: picker shows `glm-5.2 / glm-5 / glm-4-9b` only, and the empty-parse result gets pinned to `provider_models_cache.json` for the cache TTL.

Verified live: `resolve_api_key_provider_credentials('zai')` with `GLM_BASE_URL=https://api.z.ai/api/anthropic` → `fetch_models` → `[]`; the same key against `api.z.ai/api/paas/v4/models` returns the full 10-model catalog including `glm-5.3` and `glm-5.3-flash`.

## Fix

- **`hermes_cli/models.py`** — the no-live fallback now returns static-catalog-first with profile `fallback_models` appended (deduped via `_model_dedup_key`), instead of the tuple alone. Applies to every api-key provider, not just zai.
- **`plugins/model-providers/zai/__init__.py`** — `fetch_models` override rewrites known Z.AI hosts (`api.z.ai`, `open.bigmodel.cn`, `api.bigmodel.cn`, any wire) onto the `/api/paas/v4` catalog, which serves the account-wide list across wires. Foreign relay hosts pass through untouched.
- **zai `fallback_models`** — adds `glm-5.3`.
- **Regression test** pinning the no-live fallback contract in `tests/hermes_cli/test_provider_live_curated_merge.py`.

## Testing

- `tests/hermes_cli/test_provider_live_curated_merge.py` — 43 passed (incl. new regression test)
- `tests/plugins/model_providers/` — 237 passed
- `tests/hermes_cli/test_api_key_providers.py` — 105 passed
- Live E2E: picker list for zai now returns curated-first (glm-5.3 leads) with live-only models (`glm-5.3-flash`, `glm-4.5-air`, `glm-4.6`) appended; disk cache rewritten with the corrected list.