### PR TITLE
fix(gateway): size systemd TimeoutStopSec from the full stop budget incl. the cron drain floor (salvage of #94775)

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -51,6 +51,12 @@ DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT = float(
 # SIGKILLed mid-write and stays wedged at ``last_status=running`` forever.
 CRON_DRAIN_CLEANUP_RESERVE_S = 10.0
 
+# systemd TimeoutStopSec headroom after the stop-path drain budget, and the
+# floor used when that budget is still the default immediate (0s) chat drain.
+# Keep these in lockstep with generate_systemd_unit() / #94759.
+SYSTEMD_STOP_HEADROOM_S = 30.0
+SYSTEMD_TIMEOUT_STOP_SEC_FLOOR = 60.0
+
 
 def is_gateway_supervisor_process(
     environ: Mapping[str, str] | None = None,
@@ -140,10 +146,12 @@ def resolve_cron_drain_budget(
 
     The configured floor is clamped to what this process can actually honour.
     The shutdown watchdog hard-exits at ``watchdog_delay`` and the service
-    manager's ``TimeoutStopSec`` is sized from the same drain timeout, so
-    waiting past that leash (minus ``cleanup_reserve_s`` for the teardown that
-    follows the drain) would swap a cleanly-interrupted job for a SIGKILL that
-    leaves it wedged mid-run — strictly worse than the bug being fixed.
+    manager's ``TimeoutStopSec`` is sized from the full stop budget (drain
+    vs cron floor + cleanup reserve, plus headroom — see
+    ``resolve_systemd_timeout_stop_sec``), so waiting past that leash
+    (minus ``cleanup_reserve_s`` for the teardown that follows the drain)
+    would swap a cleanly-interrupted job for a SIGKILL that leaves it
+    wedged mid-run — strictly worse than the bug being fixed.
 
     Never returns less than ``drain_timeout``: the cron floor only ever
     extends the wait, so an operator who deliberately configured a long
@@ -166,6 +174,42 @@ def resolve_cron_drain_budget(
         - _seconds(cleanup_reserve_s, CRON_DRAIN_CLEANUP_RESERVE_S)
     )
     return max(drain, min(floor, ceiling))
+
+
+def resolve_systemd_timeout_stop_sec(
+    drain_timeout: float,
+    cron_drain_timeout: float = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+    *,
+    cleanup_reserve_s: float = CRON_DRAIN_CLEANUP_RESERVE_S,
+    headroom_s: float = SYSTEMD_STOP_HEADROOM_S,
+    floor_s: float = SYSTEMD_TIMEOUT_STOP_SEC_FLOOR,
+) -> int:
+    """Seconds systemd ``TimeoutStopSec`` must cover the full stop budget.
+
+    ``restart_drain_timeout`` is only the chat-turn interrupt budget (default
+    0). The stop path may wait longer for in-flight cron work —
+    ``cron_drain_timeout`` plus ``cleanup_reserve_s`` — before it even starts
+    interrupting. Sizing the unit from drain alone lets systemd SIGKILL an
+    in-budget drain (#94759).
+
+    A zero ``cron_drain_timeout`` is a deliberate opt-out and does not extend
+    the budget. Non-numeric inputs degrade to 0 rather than raising.
+    """
+
+    def _seconds(value: object) -> float:
+        try:
+            return max(float(value), 0.0)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0.0
+
+    drain = _seconds(drain_timeout)
+    cron = _seconds(cron_drain_timeout)
+    reserve = _seconds(cleanup_reserve_s)
+    headroom = _seconds(headroom_s)
+    floor = _seconds(floor_s)
+    cron_budget = (cron + reserve) if cron > 0.0 else 0.0
+    stop_budget = max(drain, cron_budget)
+    return int(max(floor, stop_budget + headroom))
 
 
 def resolve_restart_exit_wait_budget(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12818,16 +12818,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # a phantom kill in the journal.  Best-effort, never raises.
         try:
             from gateway.shutdown_forensics import check_systemd_timing_alignment
-            _alignment = check_systemd_timing_alignment(self._restart_drain_timeout)
+            _alignment = check_systemd_timing_alignment(
+                self._restart_drain_timeout,
+                getattr(self, "_cron_drain_timeout", DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT),
+            )
             if _alignment is not None and _alignment.get("mismatch"):
                 logger.warning(
                     "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
-                    "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway install --force` "
-                    "to regenerate the unit, or shorten agent.restart_drain_timeout.",
+                    "drain_timeout=%.0fs cron_drain_timeout=%.0fs (expected >=%.0fs). "
+                    "systemd may SIGKILL the gateway mid-drain. Run "
+                    "`hermes gateway install --force` to regenerate the unit, or "
+                    "shorten agent.restart_drain_timeout / agent.cron_drain_timeout.",
                     _alignment.get("unit", "(unknown)"),
                     _alignment["timeout_stop_sec"],
                     _alignment["drain_timeout"],
+                    _alignment.get(
+                        "cron_drain_timeout", DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+                    ),
                     _alignment["expected_min"],
                 )
         except Exception as _e:

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -26,6 +26,11 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from gateway.restart import (
+    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+    resolve_systemd_timeout_stop_sec,
+)
+
 
 _SIGNAL_NAME_BY_NUM: Dict[int, str] = {}
 for _name in ("SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2"):
@@ -319,15 +324,19 @@ def context_as_json(ctx: Dict[str, Any]) -> str:
         return "{}"
 
 
-def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, Any]]:
-    """At startup, sanity-check that systemd's TimeoutStopSec >= drain_timeout.
+def check_systemd_timing_alignment(
+    drain_timeout: float,
+    cron_drain_timeout: float = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+) -> Optional[Dict[str, Any]]:
+    """At startup, sanity-check that systemd's TimeoutStopSec covers stop.
 
     When the gateway is run under a stale systemd unit file (e.g. the user
     upgraded hermes-agent but never re-ran ``hermes setup`` to regenerate
-    the unit), ``TimeoutStopSec`` can be smaller than the configured
-    ``restart_drain_timeout``.  Result: SIGTERM arrives, the drain starts,
-    and systemd SIGKILLs the cgroup mid-drain — looks like a phantom kill
-    in the journal because the journal only logs ``code=killed status=9``.
+    the unit), ``TimeoutStopSec`` can be smaller than the full stop budget
+    (``restart_drain_timeout`` vs ``cron_drain_timeout`` + cleanup reserve,
+    plus headroom).  Result: SIGTERM arrives, the drain starts, and systemd
+    SIGKILLs the cgroup mid-drain — looks like a phantom kill in the journal
+    because the journal only logs ``code=killed status=9``.
 
     Returns ``None`` when the alignment is fine OR we can't determine it
     (not running under systemd, ``systemctl`` unavailable, etc.).  Returns
@@ -392,15 +401,14 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
         return None
 
     timeout_stop_sec = timeout_us / 1_000_000.0
-    # systemd needs headroom for: post-interrupt kill, adapter disconnect,
-    # SessionDB close, file unlinks, etc.  30s matches the unit-template
-    # constant in hermes_cli/gateway.py.
-    headroom = 30.0
-    expected = drain_timeout + headroom
+    expected = float(
+        resolve_systemd_timeout_stop_sec(drain_timeout, cron_drain_timeout)
+    )
     return {
         "unit": unit_name,
         "timeout_stop_sec": timeout_stop_sec,
         "drain_timeout": drain_timeout,
+        "cron_drain_timeout": cron_drain_timeout,
         "expected_min": expected,
         "mismatch": timeout_stop_sec < expected,
     }

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -39,9 +39,11 @@ from gateway.restart import (
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     is_gateway_supervisor_process,
+    parse_cron_drain_timeout,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
     resolve_restart_exit_wait_budget,
+    resolve_systemd_timeout_stop_sec,
 )
 from hermes_cli.config import (
     get_env_value,
@@ -3684,12 +3686,15 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         "/sbin",
         "/bin",
     ]
-    # Preserve 30s for post-drain cleanup before systemd escalates, with a
-    # 60s minimum for installs that use the default immediate drain. Positive
-    # drain values extend the deadline directly instead of inheriting a second
-    # 60s floor, so a configured 45s drain yields 75s rather than 90s.
-    _drain_timeout = int(_get_restart_drain_timeout() or 0)
-    restart_timeout = max(60, _drain_timeout + 30)
+    # TimeoutStopSec must cover the full stop budget, not just
+    # restart_drain_timeout. Cron work can legally wait cron_drain_timeout
+    # plus cleanup reserve before interrupt/teardown, and systemd SIGKILLs
+    # if the unit's deadline is shorter (#94759). 30s of post-drain headroom
+    # is preserved on top, with a 60s floor.
+    restart_timeout = resolve_systemd_timeout_stop_sec(
+        _get_restart_drain_timeout(),
+        _get_cron_drain_timeout(),
+    )
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -4108,6 +4113,18 @@ def _get_restart_drain_timeout() -> float:
             )
         )
     return parse_restart_drain_timeout(raw)
+
+
+def _get_cron_drain_timeout() -> float:
+    """Return the configured cron-only drain floor in seconds (#82161)."""
+    env_raw = os.getenv("HERMES_CRON_DRAIN_TIMEOUT")
+    if env_raw is not None and str(env_raw).strip() != "":
+        return parse_cron_drain_timeout(env_raw)
+    cfg = read_raw_config()
+    agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+    if isinstance(agent_cfg, dict) and "cron_drain_timeout" in agent_cfg:
+        return parse_cron_drain_timeout(agent_cfg.get("cron_drain_timeout"))
+    return parse_cron_drain_timeout(None)
 
 
 def _get_restart_after_turn_timeout() -> float:

--- a/tests/gateway/test_cron_drain_floor.py
+++ b/tests/gateway/test_cron_drain_floor.py
@@ -25,6 +25,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     parse_cron_drain_timeout,
     resolve_cron_drain_budget,
+    resolve_systemd_timeout_stop_sec,
 )
 from tests.gateway.restart_test_helpers import make_restart_runner
 
@@ -156,3 +157,40 @@ class TestResolveCronDrainBudget:
         assert resolve_cron_drain_budget(
             None, "30", watchdog_delay=60.0, elapsed=None
         ) == 30.0
+
+
+class TestResolveSystemdTimeoutStopSec:
+    """#94759: TimeoutStopSec must cover cron drain, not just chat drain."""
+
+    def test_default_cron_floor_beats_the_old_drain_only_formula(self):
+        # Old unit: max(60, 0+30) = 60. Stop path may wait 30+10=40s, then
+        # still needs the 30s teardown headroom — 70s, not 60s.
+        timeout = resolve_systemd_timeout_stop_sec(
+            0.0, DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        )
+        assert timeout == int(
+            max(
+                60,
+                DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT + CRON_DRAIN_CLEANUP_RESERVE_S + 30,
+            )
+        )
+        assert timeout > 60
+
+    def test_configured_drain_still_extends_the_deadline_directly(self):
+        assert resolve_systemd_timeout_stop_sec(60.0, 30.0) == 90
+        assert resolve_systemd_timeout_stop_sec(180.0, 30.0) == 210
+
+    def test_larger_cron_floor_raises_timeout_stop_sec(self):
+        # 60s cron + 10s reserve + 30s headroom = 100s
+        assert resolve_systemd_timeout_stop_sec(0.0, 60.0) == 100
+
+    def test_zero_cron_floor_is_an_opt_out_not_a_hidden_default(self):
+        assert resolve_systemd_timeout_stop_sec(0.0, 0.0) == 60
+
+    def test_cron_floor_never_shortens_a_long_drain(self):
+        assert resolve_systemd_timeout_stop_sec(180.0, 30.0) == resolve_systemd_timeout_stop_sec(
+            180.0, 0.0
+        )
+
+    def test_garbage_inputs_degrade_to_the_floor(self):
+        assert resolve_systemd_timeout_stop_sec("soon", None) == 60

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2532,3 +2532,58 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
+
+
+class TestTimeoutStopSecCoversCronFloor:
+    """#94759: TimeoutStopSec must cover the FULL stop budget.
+
+    resolve_cron_drain_budget() can hold the shutdown drain for
+    agent.cron_drain_timeout plus CRON_DRAIN_CLEANUP_RESERVE_S on top of
+    (as a max of) the restart drain, so the unit leash is sized from
+    max(restart_drain, cron_floor) + 30 — not the restart drain alone."""
+
+    def _unit_with_config(self, tmp_path, monkeypatch, config_yaml, env=None):
+        hermes = tmp_path / "home" / ".hermes"
+        hermes.mkdir(parents=True)
+        (hermes / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes))
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths", lambda home, existing: []
+        )
+        for key, value in (env or {}).items():
+            monkeypatch.setenv(key, value)
+        return gateway_cli.generate_systemd_unit(system=False)
+
+    def test_cron_floor_dominates_when_larger(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 0\n  cron_drain_timeout: 120\n",
+        )
+        # cron floor 120 + reserve 10 + cleanup 30 = 160 > the old formula's 60.
+        assert "TimeoutStopSec=160" in unit
+
+    def test_restart_drain_still_dominates_when_larger(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 60\n",
+        )
+        # An explicit restart drain above the default cron floor (30+10=40)
+        # keeps the old formula's result — no regression for
+        # restart-drain-dominated installs. (Default installs differ from
+        # main: restart_drain_timeout defaults to 0, so the cron floor 40+30
+        # raises the leash from 60 to 70 — see the PR description.)
+        assert "TimeoutStopSec=90" in unit
+
+    def test_env_override_extends_the_leash(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 0\n",
+            env={"HERMES_CRON_DRAIN_TIMEOUT": "200"},
+        )
+        assert "TimeoutStopSec=240" in unit

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -14,9 +14,11 @@ grp = pytest.importorskip("grp")
 import hermes_cli.gateway as gateway_cli
 from gateway import status
 from gateway.restart import (
+    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    resolve_systemd_timeout_stop_sec,
 )
 
 
@@ -184,12 +186,91 @@ class TestRequireServiceInstalled:
         gateway_cli._require_service_installed("start")
 
 
+class TestGetCronDrainTimeout:
+    def test_missing_config_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        assert (
+            gateway_cli._get_cron_drain_timeout() == DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        )
+
+    def test_zero_in_config_is_opt_out(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"cron_drain_timeout": 0}},
+        )
+        assert gateway_cli._get_cron_drain_timeout() == 0.0
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_DRAIN_TIMEOUT", "45")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"cron_drain_timeout": 90}},
+        )
+        assert gateway_cli._get_cron_drain_timeout() == 45.0
+
+
 class TestGeneratedSystemdUnits:
     def _expected_timeout_stop_sec(self) -> str:
-        timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30))
+        timeout = resolve_systemd_timeout_stop_sec(
+            DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+            DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+        )
         return f"TimeoutStopSec={timeout}"
 
+    def test_timeout_stop_sec_covers_default_cron_drain_floor(self, monkeypatch):
+        """#94759: default restart_drain_timeout=0 still leaves a 30s cron
+        floor plus cleanup reserve. The old max(60, drain+30)=60 unit
+        SIGKILLed that in-budget drain."""
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_cron_drain_timeout",
+            lambda: DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+        )
 
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        expected = resolve_systemd_timeout_stop_sec(
+            0.0, DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        )
+        assert f"TimeoutStopSec={expected}" in unit
+        assert expected > 60
+        assert self._expected_timeout_stop_sec() in unit
+
+    def test_timeout_stop_sec_follows_a_raised_cron_drain_timeout(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_cron_drain_timeout", lambda: 60.0)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        assert f"TimeoutStopSec={resolve_systemd_timeout_stop_sec(0.0, 60.0)}" in unit
+
+    def test_timeout_stop_sec_keeps_the_floor_when_cron_drain_is_opted_out(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_cron_drain_timeout", lambda: 0.0)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        assert "TimeoutStopSec=60" in unit
+
+    def test_unit_stop_budget_beats_drain_only_formula_with_real_loaders(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        drain = gateway_cli._get_restart_drain_timeout()
+        cron = gateway_cli._get_cron_drain_timeout()
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        expected = resolve_systemd_timeout_stop_sec(drain, cron)
+        assert f"TimeoutStopSec={expected}" in unit
+        old_drain_only = int(max(60, int(drain or 0) + 30))
+        if cron > 0 and drain <= 0:
+            assert expected > old_drain_only
 
     def test_user_unit_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Regression for the multi-profile gateway restart-loop flap (#48700):


### PR DESCRIPTION
## Summary

systemd units now size `TimeoutStopSec` from the FULL stop budget — the max of the restart drain and the cron drain floor (`agent.cron_drain_timeout` + 10s cleanup reserve) — instead of the restart drain alone. Previously, with in-flight cron work, systemd SIGKILLed an in-budget drain and left the unit `failed (timeout)`. Fixes #94759.

Salvage of #94775 by @HexLab98 (2 commits, authorship preserved), plus the end-to-end rendered-unit tests carried from the duplicate #94770 by @liuhao1024 (authorship preserved), as promised in its close comment.

## Changes

- `gateway/restart.py`: `resolve_systemd_timeout_stop_sec()` — single source of truth: `max(60, max(drain, cron_floor + reserve) + 30)`; `cron_drain_timeout: 0` is a deliberate opt-out (no phantom reserve); garbage inputs coerce safely.
- `hermes_cli/gateway.py`: the unit generator consumes the helper (defaults go 60s → 70s).
- `gateway/shutdown_forensics.py` + `gateway/run.py`: the startup stale-unit detector (`check_systemd_timing_alignment`) uses the SAME formula, so a leftover under-sized unit is flagged instead of looking like a phantom kill — the sibling site the narrower duplicate missed.
- Tests: helper unit tests (dominance both ways, opt-out, garbage), `_get_cron_drain_timeout` precedence (env > config > default, zero honored), rendered-unit assertions, plus #94770's black-box e2e class (`TimeoutStopSec=160/90/240` against a real temp config.yaml incl. env override).

## Validation

| | Before | After |
|---|---|---|
| default unit, cron work in flight | `TimeoutStopSec=60`, SIGKILL mid-drain | `TimeoutStopSec=70` covers cron floor + reserve |
| `cron_drain_timeout: 0` | n/a | old 60s floor kept (opt-out) |
| stale-unit startup check | drain-only formula, never flags cron under-sizing | same shared formula |
| tests | — | 122 passed (test_gateway_service.py + test_cron_drain_floor.py); mutation check: helper tests fail with prod files reverted |

Closes #94775 (salvaged); #94770 closed as duplicate with credit.
