### PR TITLE
fix(cron): preserve recurring manual run intent against the stale-schedule guard (salvage of #94033)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2434,6 +2434,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             f"Create a new occurrence with 'hermes cron resume {name} "
             "--run-now' or '--at <ISO-8601>'."
         )
+    manual_run_at = _hermes_now().isoformat()
     return update_job(
         job["id"],
         {
@@ -2441,7 +2442,10 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "next_run_at": manual_run_at,
+            # Persist run-now intent alongside the arbitrary instant so cron
+            # expression/TZ repair guards do not mistake it for stale state.
+            "manual_run_at": manual_run_at,
         },
     )
 
@@ -2693,6 +2697,7 @@ def _mark_job_run_locked(
                         return False
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
+                job.pop("manual_run_at", None)
                 job["last_status"] = status or ("ok" if success else "error")
                 job["last_error"] = error if not success else None
                 # A healthy run means the configuration validates again — drop
@@ -3548,6 +3553,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             next_run_dt = _ensure_aware(raw_next_run_dt)
+            manual_run = job.get("manual_run_at") == next_run
             # Migration repair: a cron job persists next_run_at as an absolute
             # instant, but the cron expr describes local wall-clock intent. If the
             # configured/system timezone changed after persistence, the stored
@@ -3565,6 +3571,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # rare relative to the double-fire bug this prevents (#28934).
             if (
                 kind == "cron"
+                and not manual_run
                 and next_run_dt <= now
                 and _timezone_offset_mismatch(raw_next_run_dt, now)
                 and _stored_wall_clock_is_future(raw_next_run_dt, now)
@@ -3651,7 +3658,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # so re-anchor before either can fire. Recomputation uses the
                 # current expression, so this converges — it cannot defer
                 # forever.
-                if kind == "cron" and not _cron_next_run_matches_expr(
+                if not manual_run and kind == "cron" and not _cron_next_run_matches_expr(
                     schedule, next_run_dt
                 ):
                     new_next = compute_next_run(schedule, now.isoformat())
@@ -3676,7 +3683,11 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # (gateway was down and missed the window). Fast-forward to
                 # the next future occurrence instead of firing a stale run.
                 grace = _compute_grace_seconds(schedule)
-                if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+                if (
+                    not manual_run
+                    and kind in {"cron", "interval"}
+                    and (now - next_run_dt).total_seconds() > grace
+                ):
                     # Job is past its catch-up grace window — skip accumulated
                     # missed runs but still execute once now to avoid deferring
                     # indefinitely (e.g. a long-running job just finished).

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3553,6 +3553,11 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             next_run_dt = _ensure_aware(raw_next_run_dt)
+            # Intentionally string-exact (raw stored values, not normalized
+            # datetimes): trigger_job stamps the SAME isoformat string into
+            # both fields, and any rewrite of next_run_at (schedule edit,
+            # recovery re-anchor, fire-claim advance) must invalidate the
+            # marker. Do not "fix" this with _ensure_aware normalization.
             manual_run = job.get("manual_run_at") == next_run
             # Migration repair: a cron job persists next_run_at as an absolute
             # instant, but the cron expr describes local wall-clock intent. If the

--- a/tests/cron/test_due_stale_cron_edit.py
+++ b/tests/cron/test_due_stale_cron_edit.py
@@ -171,3 +171,25 @@ def test_helper_reports_match_for_non_cron_and_unvalidatable(temp_home):
         )
         is False
     )
+
+
+def test_stale_edit_without_manual_marker_still_reanchors(temp_home, monkeypatch):
+    """#93049 protection intact after the #94010 fix: a hand-edited stale
+    next_run_at WITHOUT the manual_run_at marker still re-anchors without
+    firing (carried from #94034's suite)."""
+    from cron.jobs import get_due_jobs, get_job
+
+    monkeypatch.setattr(
+        "cron.jobs._hermes_now", lambda: _SATURDAY_0700 + timedelta(minutes=5)
+    )
+    jid = _write_cron_job("0 7 * * 1-5", _SATURDAY_0700)
+
+    stored_before = get_job(jid)
+    assert "manual_run_at" not in stored_before
+
+    due = get_due_jobs()
+
+    assert [j["id"] for j in due if j["id"] == jid] == []
+    after = get_job(jid)
+    assert after["next_run_at"] != _SATURDAY_0700.isoformat()
+    assert "manual_run_at" not in after

--- a/tests/cron/test_due_stale_cron_edit.py
+++ b/tests/cron/test_due_stale_cron_edit.py
@@ -76,6 +76,65 @@ def test_matching_next_run_still_fires(temp_home, monkeypatch):
     assert jid in [j["id"] for j in due]
 
 
+def test_manual_trigger_bypasses_stale_schedule_guard(temp_home, monkeypatch):
+    """An explicit run-now instant need not occur in the cron expression."""
+    from cron.jobs import create_job, get_due_jobs, get_job, mark_job_run, trigger_job
+
+    now = _SATURDAY_0700 + timedelta(seconds=30)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="manual")
+
+    triggered = trigger_job(job["id"])
+    due = get_due_jobs()
+
+    assert triggered is not None
+    assert job["id"] in [candidate["id"] for candidate in due]
+    assert triggered["manual_run_at"] == triggered["next_run_at"]
+
+    mark_job_run(job["id"], success=True)
+
+    assert "manual_run_at" not in get_job(job["id"])
+
+
+def test_delayed_manual_trigger_is_not_counted_as_catch_up(temp_home, monkeypatch):
+    """Run-now intent remains explicit even when the next scan is hours later."""
+    from cron.jobs import (
+        create_job,
+        get_catch_up_occurrence_count,
+        get_due_jobs,
+        trigger_job,
+    )
+
+    trigger_time = _SATURDAY_0700 + timedelta(seconds=30)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: trigger_time)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="delayed")
+    trigger_job(job["id"])
+    monkeypatch.setattr(
+        "cron.jobs._hermes_now", lambda: trigger_time + timedelta(hours=5)
+    )
+
+    due = get_due_jobs()
+
+    assert job["id"] in [candidate["id"] for candidate in due]
+    assert get_catch_up_occurrence_count() == 0
+
+
+def test_manual_trigger_survives_timezone_change_before_tick(temp_home, monkeypatch):
+    """TZ migration repair must not replace an explicit run-now instant."""
+    from cron.jobs import create_job, get_due_jobs, trigger_job
+
+    trigger_time = datetime.fromisoformat("2026-08-22T21:00:00+10:00")
+    scan_time = datetime.fromisoformat("2026-08-22T13:00:00+02:00")
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: trigger_time)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="tz-manual")
+    trigger_job(job["id"])
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: scan_time)
+
+    due = get_due_jobs()
+
+    assert job["id"] in [candidate["id"] for candidate in due]
+
+
 def test_stale_next_run_skips_even_inside_catchup_window(temp_home, monkeypatch):
     """The catch-up 'run once now' policy must not resurrect a stale instant:
     hours after the stored time, the drifted job re-anchors without firing."""


### PR DESCRIPTION
## Summary

Manual triggers of recurring cron jobs fire again. `trigger_job()` writes `next_run_at = "now"` — an instant that is almost never an occurrence of the job's cron expression — so the #93049 stale-schedule guard re-anchored every manual trigger without firing, while all three "run now" surfaces (CLI `hermes cron run`, REST `POST /api/jobs/{id}/run`, direct `trigger_job()`) reported success. Fixes #94010.

Salvage of #94033 by @fangliquanflq (authorship preserved), plus the no-marker regression test carried from the duplicate #94034 by @liuhao1024 (authorship preserved), as promised in its close comment.

## Changes

- `cron/jobs.py`: `trigger_job` stamps `manual_run_at` beside `next_run_at` (same isoformat string). Only that exact instant bypasses the three guards that could eat it — the stale-schedule re-anchor, the TZ-migration repair, and the catch-up grace-window skip. The marker is popped unconditionally in `_mark_job_run_locked` (success AND failure), and any rewrite of `next_run_at` (edit, recovery, advance) invalidates it via the string-exact equality gate (now pinned by comment against future normalization).
- Tests: the three bypass shapes one-to-one (stale guard, delayed trigger not counted as catch-up, TZ change before tick), marker cleanup, guard-intact regression — plus #94034's explicit hand-edited-jobs.json no-marker case.

## Validation

| | Before | After |
|---|---|---|
| `hermes cron run <recurring-job>` | silent no-op (re-anchored, `last_run_at: null`) | fires on next tick |
| hand-edited stale `next_run_at`, no marker | re-anchors without firing (#93049) | unchanged — still re-anchors |
| tests | — | 8/8 test_due_stale_cron_edit.py; mutation check: 3 guard tests fail with cron/jobs.py reverted |

Closes #94033 (salvaged); #94034 closed as duplicate with credit.
