### PR TITLE
fix(cron): verify a persisted final assistant message before booking complete (salvage of #93829)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6821,9 +6821,40 @@ def run_job(
                             break
                     except (Exception, KeyboardInterrupt):
                         continue
+            # Fail-closed completion booking (#93820): the run may only be
+            # recorded as cron_complete when the session's LAST message row is
+            # a real assistant reply — a plain answer or the [SILENT] sentinel
+            # (both are assistant-text rows, so both classify as 'complete').
+            # A turn that died after a tool call, mid-API-wait, or without any
+            # assistant text leaves the last row as a tool result / pending
+            # call / user prompt and must not surface as a healthy run.
+            # session_lifecycle_statuses is the existing cost-bounded
+            # classifier for exactly this shape. Only a POSITIVELY recognized
+            # pathological status downgrades the booking: an unknown value
+            # (newer classifier shape, test doubles) keeps the historical
+            # reason, and so does a failed probe — classification is
+            # best-effort metadata and must not mislabel a healthy run.
+            _end_reason = "cron_complete"
+            try:
+                _statuses = _session_db.session_lifecycle_statuses(
+                    [_final_cron_session_id]
+                )
+                _lifecycle = _statuses.get(_final_cron_session_id)
+                if _lifecycle in ("interrupted", "error", "empty"):
+                    _end_reason = "cron_incomplete_no_output"
+                    logger.warning(
+                        "Job '%s': session ended without a final assistant "
+                        "message (lifecycle=%s) — booking run as %s",
+                        job_id, _lifecycle, _end_reason,
+                    )
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': session lifecycle classification failed: %s",
+                    job_id, e,
+                )
             try:
                 _session_db.end_session(
-                    _final_cron_session_id, "cron_complete"
+                    _final_cron_session_id, _end_reason
                 )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6821,7 +6821,7 @@ def run_job(
                             break
                     except (Exception, KeyboardInterrupt):
                         continue
-            # Fail-closed completion booking (#93820): the run may only be
+            # Verified completion booking (#93820): the run may only be
             # recorded as cron_complete when the session's LAST message row is
             # a real assistant reply — a plain answer or the [SILENT] sentinel
             # (both are assistant-text rows, so both classify as 'complete').
@@ -6830,9 +6830,12 @@ def run_job(
             # call / user prompt and must not surface as a healthy run.
             # session_lifecycle_statuses is the existing cost-bounded
             # classifier for exactly this shape. Only a POSITIVELY recognized
-            # pathological status downgrades the booking: an unknown value
-            # (newer classifier shape, test doubles) keeps the historical
-            # reason, and so does a failed probe — classification is
+            # pathological status (see the status vocabulary in
+            # hermes_state's session_lifecycle_statuses docstring — keep the
+            # tuple below in sync when it grows) downgrades the booking: an
+            # unknown value (newer classifier shape, test doubles) keeps the
+            # historical reason, and so does a failed probe — the booking
+            # itself is FAIL-OPEN on probe errors, because classification is
             # best-effort metadata and must not mislabel a healthy run.
             _end_reason = "cron_complete"
             try:

--- a/tests/cron/test_scheduler_completion_verification.py
+++ b/tests/cron/test_scheduler_completion_verification.py
@@ -1,0 +1,153 @@
+"""Fail-closed completion booking for cron runs (#93820).
+
+The scheduler booked every finished run as ``cron_complete`` based on the run
+lifecycle alone: a job whose agent turn died after a tool call, mid-API-wait,
+or without any assistant text still surfaced as a healthy run (one audited
+day held 10 such silently-failed sessions). The fix classifies the session's
+LAST message row through the existing ``session_lifecycle_statuses`` helper
+before ``end_session``: only a real assistant reply — a plain answer or the
+``[SILENT]`` sentinel, both assistant-text rows — books as ``cron_complete``;
+anything else books as ``cron_incomplete_no_output``. Classification is
+best-effort: a probe failure keeps the historical reason rather than
+mislabeling a healthy run.
+"""
+
+import os
+
+import pytest
+
+import cron.scheduler as cron_scheduler
+from gateway.session_context import reset_session_vars
+
+
+class _FakeCronAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run_conversation(self, prompt):
+        return {
+            "completed": True,
+            "failed": False,
+            "final_response": "done",
+            "turn_exit_reason": "",
+        }
+
+    def close(self):
+        pass
+
+
+class _RecordingSessionDB:
+    """SessionDB double with a configurable lifecycle classification."""
+
+    def __init__(self, *args, **kwargs):
+        self.ended: list[tuple[str, str]] = []
+        self.lifecycle = type(self).next_lifecycle
+
+    next_lifecycle = "complete"
+
+    def set_session_title(self, *args, **kwargs):
+        return True
+
+    def get_compression_tip(self, session_id):
+        return None
+
+    def session_lifecycle_statuses(self, session_ids):
+        if isinstance(type(self).next_lifecycle, Exception):
+            raise type(self).next_lifecycle
+        return {sid: type(self).next_lifecycle for sid in session_ids}
+
+    def end_session(self, session_id, reason):
+        self.ended.append((session_id, reason))
+
+    def close(self):
+        pass
+
+
+def _run_booked_job(monkeypatch, tmp_path):
+    import hermes_state
+    import run_agent
+
+    instances: list[_RecordingSessionDB] = []
+    real_init = _RecordingSessionDB.__init__
+
+    def _capture_init(self, *args, **kwargs):
+        real_init(self, *args, **kwargs)
+        instances.append(self)
+
+    monkeypatch.setattr(_RecordingSessionDB, "__init__", _capture_init)
+    monkeypatch.setattr(hermes_state, "SessionDB", _RecordingSessionDB)
+    monkeypatch.setattr(run_agent, "AIAgent", _FakeCronAgent)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_a, **_k: None
+    )
+    # The runtime key is read from the environment (never a literal here);
+    # AIAgent and SessionDB are fakes above, so the value is never used.
+    monkeypatch.setenv("HERMES_TEST_RUNTIME_KEY", "unused-placeholder")
+
+    def _fake_runtime(**_kwargs):
+        return {
+            "api_key": os.environ.get("HERMES_TEST_RUNTIME_KEY", ""),
+            "base_url": None,
+            "provider": "test-provider",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _fake_runtime
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        cron_scheduler, "_guard_job_credential_exfil", lambda _job: None
+    )
+    cron_scheduler.run_job(
+        {
+            "id": "verify-complete",
+            "name": "Verification",
+            "prompt": "Do the thing",
+            "schedule_display": "manual",
+        }
+    )
+    return instances
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_session_vars()
+    _RecordingSessionDB.next_lifecycle = "complete"
+    yield
+    reset_session_vars()
+
+
+def test_run_without_final_assistant_message_books_incomplete(monkeypatch, tmp_path):
+    """Last row a tool result / pending call (lifecycle 'interrupted') must
+    not surface as a healthy complete run."""
+    _RecordingSessionDB.next_lifecycle = "interrupted"
+
+    instances = _run_booked_job(monkeypatch, tmp_path)
+
+    assert instances, "SessionDB was never constructed"
+    reasons = [reason for _sid, reason in instances[0].ended]
+    assert reasons == ["cron_incomplete_no_output"]
+
+
+def test_run_with_final_assistant_reply_books_complete(monkeypatch, tmp_path):
+    """A real assistant reply (plain answer or [SILENT] — both assistant
+    text rows) keeps the healthy booking."""
+    instances = _run_booked_job(monkeypatch, tmp_path)
+
+    reasons = [reason for _sid, reason in instances[0].ended]
+    assert reasons == ["cron_complete"]
+
+
+def test_classification_probe_failure_keeps_historical_reason(monkeypatch, tmp_path):
+    """Best-effort metadata: a failing classifier must not mislabel a run."""
+    _RecordingSessionDB.next_lifecycle = RuntimeError("db busy")
+
+    instances = _run_booked_job(monkeypatch, tmp_path)
+
+    reasons = [reason for _sid, reason in instances[0].ended]
+    assert reasons == ["cron_complete"]


### PR DESCRIPTION
## Summary

Cron no longer books `end_reason=cron_complete` for runs that died without a final assistant message. The scheduler stamped every finished lifecycle as complete — a turn that died after a tool call, mid-API-wait, or with no assistant text still showed green in run history (the reporter's one-day audit found 10 such invisible failures). Fixes #93820.

Salvage of #93829 by @liuhao1024 (authorship preserved) + a comment-accuracy follow-up from review.

## Changes

- `cron/scheduler.py`: before `end_session`, the session tail is classified through the EXISTING cost-bounded `session_lifecycle_statuses` helper. Only a positively-recognized pathological status (`interrupted` / `error` / `empty`) downgrades the booking to `cron_incomplete_no_output` (with a warning log). Unknown statuses and probe failures keep `cron_complete` — the booking is fail-open, since classification is best-effort metadata and must not mislabel a healthy run. The `[SILENT]` sentinel classifies as complete.
- New test file: incomplete run books incomplete; complete run stays complete; probe failure stays complete.

## Validation

| | Before | After |
|---|---|---|
| run dies after tool call / mid-API-wait | `cron_complete`, green history | `cron_incomplete_no_output` + warning |
| healthy run / [SILENT] run | `cron_complete` | unchanged |
| classification probe raises | n/a | `cron_complete` (fail-open) |
| tests | — | 3/3 new; full tests/cron/ green (only pre-existing test_monitor_kind failures, reproduced on unmodified main); mutation check: guard fails with cron/scheduler.py reverted |

Closes #93829 (salvaged); #93946 closed in favor of this with credit — its stricter transport-level finish_reason classifier was invited as its own follow-up PR.
