### PR TITLE
feat(desktop): show per-model pricing and discounts in the composer model menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -31,7 +31,25 @@ beforeEach(() => {
   $visibleModels.set(null)
   setModelVisibilityOpen(false)
   getGlobalModelOptions.mockResolvedValue({
-    providers: [{ models: ['gemini-3.1-pro', 'gemini-2.5-flash'], name: 'Google', slug: 'google' }]
+    providers: [
+      {
+        models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
+        name: 'Google',
+        slug: 'google',
+        pricing: {
+          'gemini-3.1-pro': { cache: null, free: false, input: '$1.25', output: '$10.00' },
+          'gemini-2.5-flash': {
+            cache: null,
+            discount_percent: 75,
+            free: false,
+            input: '$0.075',
+            output: '$0.30',
+            was_input: '$0.30',
+            was_output: '$1.20'
+          }
+        }
+      }
+    ]
   })
 })
 
@@ -104,5 +122,39 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit Models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+})
+
+// Pricing rides the SAME catalog payload the standalone model picker reads, so
+// the composer dropdown must show what the gateway already sends: per-model
+// in/out $/Mtok, sale badges, and struck-through "was" prices. A row with no
+// pricing entry renders nothing (older backends, providers without live
+// pricing) — never a placeholder.
+describe('per-model pricing in the catalog rows', () => {
+  it('shows input/output price next to each model', async () => {
+    renderMenu()
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+    expect(screen.getByText('$1.25 / $10.00')).toBeTruthy()
+    expect(screen.getByText('$0.075 / $0.30')).toBeTruthy()
+  })
+
+  it('surfaces the gateway discount: badge + struck-through was price', async () => {
+    renderMenu()
+
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+    expect(screen.getByText('-75%')).toBeTruthy()
+    expect(screen.getByText(/was \$0\.30 \/ \$1\.20/)).toBeTruthy()
+  })
+
+  it('renders no price tag when the provider sends no pricing', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: ['gemini-3.1-pro'], name: 'Google', slug: 'google' }]
+    })
+
+    renderMenu()
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+    expect(screen.queryByText(/\$\d/)).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
+import { ModelPrice } from '@/components/model-price'
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import {
@@ -409,6 +410,12 @@ export function ModelCatalogMenu({
                     const name = modelDisplayParts(family.id).name
                     const caps = group.provider.capabilities?.[family.id]
 
+                    // Price the variant the row actually represents: when the
+                    // active session runs the -fast sibling, show THAT price;
+                    // otherwise the base model's. Rows are collapsed families,
+                    // so the base price stands in for an inactive fast variant.
+                    const price = group.provider.pricing?.[activeId ?? family.id]
+
                     // Effective settings for this row: the live choice when it's
                     // the active model, otherwise its remembered preset. Row
                     // label AND submenu read from these so they never disagree.
@@ -457,8 +464,9 @@ export function ModelCatalogMenu({
                             <HighlightMatches query={search} text={name} />
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
                           </span>
+                          <ModelPrice isCurrent={false} price={price} />
                           {isCurrent ? (
-                            <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
+                            <Codicon className="shrink-0 text-foreground" name="check" size="0.75rem" />
                           ) : null}
                         </DropdownMenuSubTrigger>
                         <ModelEditSubmenu

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -6,12 +6,13 @@ import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
-import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
+import type { ModelOptionProvider } from '@/types/hermes'
 
 import type { HermesGateway } from '../hermes'
 import { cn } from '../lib/utils'
 import { startManualOnboarding } from '../store/onboarding'
 
+import { ModelPrice } from './model-price'
 import { InlineNotice } from './notifications'
 import { Button } from './ui/button'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './ui/command'
@@ -251,77 +252,8 @@ function ModelResults({
   )
 }
 
-// Compact In/Out $/Mtok price tag, mirroring the CLI picker's price columns.
-// Renders nothing when pricing is unavailable for the model.
-function ModelPrice({ price, isCurrent }: { price?: ModelPricing; isCurrent: boolean }) {
-  const { t } = useI18n()
-  const copy = t.modelPicker
-
-  if (!price || (!price.input && !price.output)) {
-    return null
-  }
-
-  if (price.free) {
-    return (
-      <span className="shrink-0 inline-flex items-center gap-1.5">
-        {typeof price.discount_percent === 'number' ? (
-          <span
-            className={cn(
-              'rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold',
-              isCurrent ? 'bg-primary-foreground/20' : 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
-            )}
-          >
-            -{price.discount_percent}%
-          </span>
-        ) : null}
-        <span
-          className={cn(
-            'shrink-0 rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold uppercase tracking-wide',
-            isCurrent ? 'bg-primary-foreground/20' : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-          )}
-        >
-          {copy.free}
-        </span>
-      </span>
-    )
-  }
-
-  const onSale = typeof price.discount_percent === 'number' && Boolean(price.was_input || price.was_output)
-
-  return (
-    <span
-      className={cn(
-        'shrink-0 inline-flex items-center gap-1.5 text-[0.66rem] tabular-nums',
-        isCurrent ? 'text-primary-foreground/80' : 'text-muted-foreground'
-      )}
-      title={copy.priceTitle}
-    >
-      {onSale ? (
-        <span
-          className={cn(
-            'rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold',
-            isCurrent ? 'bg-primary-foreground/20' : 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
-          )}
-        >
-          -{price.discount_percent}%
-        </span>
-      ) : null}
-      <span>
-        {price.input || '?'} / {price.output || '?'}
-      </span>
-      {onSale ? (
-        <span
-          className={cn(
-            'line-through decoration-from-font opacity-70',
-            isCurrent ? 'text-primary-foreground/60' : 'text-muted-foreground/80'
-          )}
-        >
-          {copy.wasPrice} {price.was_input || '?'} / {price.was_output || '?'}
-        </span>
-      ) : null}
-    </span>
-  )
-}
+// Compact In/Out $/Mtok price tag extracted to ./model-price so every
+// model-picking surface renders pricing identically.
 
 function LoadingResults() {
   return (

--- a/apps/desktop/src/components/model-price.tsx
+++ b/apps/desktop/src/components/model-price.tsx
@@ -1,0 +1,79 @@
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import type { ModelPricing } from '@/types/hermes'
+
+// Compact In/Out $/Mtok price tag, mirroring the CLI picker's price columns.
+// Shows sale badges and struck-through pre-discount ("was") prices when the
+// gateway reports a discount. Renders nothing when pricing is unavailable.
+//
+// Shared by every model-picking surface (composer catalog menu, standalone
+// model picker, onboarding) so pricing can never drift between them.
+export function ModelPrice({ price, isCurrent }: { price?: ModelPricing; isCurrent: boolean }) {
+  const { t } = useI18n()
+  const copy = t.modelPicker
+
+  if (!price || (!price.input && !price.output)) {
+    return null
+  }
+
+  if (price.free) {
+    return (
+      <span className="shrink-0 inline-flex items-center gap-1.5">
+        {typeof price.discount_percent === 'number' ? (
+          <span
+            className={cn(
+              'rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold',
+              isCurrent ? 'bg-primary-foreground/20' : 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+            )}
+          >
+            -{price.discount_percent}%
+          </span>
+        ) : null}
+        <span
+          className={cn(
+            'shrink-0 rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold uppercase tracking-wide',
+            isCurrent ? 'bg-primary-foreground/20' : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+          )}
+        >
+          {copy.free}
+        </span>
+      </span>
+    )
+  }
+
+  const onSale = typeof price.discount_percent === 'number' && Boolean(price.was_input || price.was_output)
+
+  return (
+    <span
+      className={cn(
+        'shrink-0 inline-flex items-center gap-1.5 text-[0.66rem] tabular-nums',
+        isCurrent ? 'text-primary-foreground/80' : 'text-muted-foreground'
+      )}
+      title={copy.priceTitle}
+    >
+      {onSale ? (
+        <span
+          className={cn(
+            'rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold',
+            isCurrent ? 'bg-primary-foreground/20' : 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+          )}
+        >
+          -{price.discount_percent}%
+        </span>
+      ) : null}
+      <span>
+        {price.input || '?'} / {price.output || '?'}
+      </span>
+      {onSale ? (
+        <span
+          className={cn(
+            'line-through decoration-from-font opacity-70',
+            isCurrent ? 'text-primary-foreground/60' : 'text-muted-foreground/80'
+          )}
+        >
+          {copy.wasPrice} {price.was_input || '?'} / {price.was_output || '?'}
+        </span>
+      ) : null}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
The gateway's `model.options` payload already carries per-model pricing (input/output $/Mtok, `free` flag, and sale fields: `discount_percent` + `was_input`/`was_output`), and the standalone model picker dialog renders it — but the **composer's model dropdown silently dropped it**, so the cost of a model was invisible at the exact moment you pick one.

This adds the price tag to every row of the composer model menu, including sale badges:

- **`-75% $0.075 / $0.30  was $0.30 / $1.20`** — discounted models show the amber sale badge and struck-through list price
- **`$1.25 / $10.00`** — regular models show input / output per-Mtok (hover for the explanation tooltip)
- **`Free`** — free-tier models get the green badge
- Rows with no pricing data (older backends, providers without live pricing) render nothing

## Changes
- Extracted `ModelPrice` from `components/model-picker.tsx` into shared `components/model-price.tsx` so every model-picking surface renders pricing identically (verbatim move, no picker behavior change).
- `ModelCatalogMenu` now looks up `provider.pricing[model]` per row and renders it between the name and the check mark. When the active session runs a `-fast` variant, the row shows **that** variant's price; otherwise the base model's.
- The catalog menu is shared by the composer pill and session tiles, so both get pricing at once.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx eslint` on touched files — clean
- [x] New catalog-menu tests: price text renders, discount badge + was-price render, nothing renders when pricing is absent
- [x] Full `npm run test:ui` — 617 files / 6081 tests pass