### PR TITLE
fix(desktop): attach err.statusCode in fetchJson/fetchPublicJson so a gateway 401 reports as reauth, not as unreachable

### DIFF
--- a/apps/desktop/electron/fetch-json-status-code.test.ts
+++ b/apps/desktop/electron/fetch-json-status-code.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression coverage for #fetchJson / #fetchPublicJson error shape.
+ *
+ * isGatewayAuthRejection() classifies an auth failure SOLELY from
+ * err.statusCode, and gatewayTicketFailure()'s own comment already states
+ * "the fetch layer attaches err.statusCode". These two fetchers only embedded
+ * the status in the message string, so a gateway 401/403 reached the classifier
+ * with statusCode undefined, was treated as a transport failure, and surfaced
+ * to the user as "Could not reach the remote Hermes gateway while refreshing
+ * its WebSocket ticket" — while the gateway was healthy and the real fault was
+ * an expired session.
+ *
+ * These fetchers close over main-process singletons (http/https, the session
+ * token header), so their shape is asserted on source — the same approach as
+ * gateway-file-download-transport.test.ts — while the consequence for the
+ * classifier is covered behaviorally below.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+import { gatewayTicketFailure, isGatewayAuthRejection } from './connection-config'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const source = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+function extract(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker)
+  assert.notEqual(start, -1, `${startMarker} should exist`)
+  const end = source.indexOf(endMarker, start + startMarker.length)
+  assert.notEqual(end, -1, `boundary after ${startMarker} should exist`)
+
+  return source.slice(start, end)
+}
+
+test('fetchJson attaches the HTTP status as err.statusCode, not only in the message', () => {
+  const fn = extract('function fetchJson(url, token, options', '\nfunction fetchPublicJson')
+
+  assert.match(fn, /err\.statusCode = res\.statusCode \|\| 500/)
+})
+
+test('fetchPublicJson attaches the HTTP status as err.statusCode', () => {
+  const fn = extract('function fetchPublicJson(url, options', '\nfunction ')
+
+  assert.match(fn, /err\.statusCode = res\.statusCode \|\| 500/)
+})
+
+test('a 401 carrying statusCode routes to reauth, not to a transport failure', () => {
+  // The shape the patched fetchers reject with.
+  const err = new Error('401: {"error":"session_expired"}') as any
+  err.statusCode = 401
+
+  assert.equal(isGatewayAuthRejection(err), true)
+
+  const wrapped = gatewayTicketFailure(err, 'Session expired — sign in again.', 'Could not reach the gateway.') as any
+
+  assert.equal(wrapped.needsOauthLogin, true)
+  assert.equal(wrapped.message, 'Session expired — sign in again.')
+  assert.equal(wrapped.statusCode, 401)
+})
+
+test('the pre-fix shape (status only in the message) is what misreported a 401', () => {
+  // Documents the regression this guards: no statusCode property means the
+  // classifier cannot see the 401 and the user is told the gateway is down.
+  const legacy = new Error('401: {"error":"session_expired"}') as any
+
+  assert.equal(isGatewayAuthRejection(legacy), false)
+
+  const wrapped = gatewayTicketFailure(
+    legacy,
+    'Session expired — sign in again.',
+    'Could not reach the gateway.'
+  ) as any
+
+  assert.equal(wrapped.needsOauthLogin, undefined)
+  assert.equal(wrapped.message, 'Could not reach the gateway.')
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5049,7 +5049,13 @@ function fetchJson(url, token, options: any = {}) {
               const text = Buffer.concat(chunks).toString('utf8')
 
               if ((res.statusCode || 500) >= 400) {
-                reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+                // Attach the status as a property, not only in the message.
+                // isGatewayAuthRejection() classifies solely from
+                // err.statusCode, so a bare message prefix leaves a 401/403
+                // looking like a transport failure.
+                const err = new Error(`${res.statusCode}: ${text || res.statusMessage}`) as any
+                err.statusCode = res.statusCode || 500
+                reject(err)
 
                 return
               }
@@ -5215,7 +5221,13 @@ function fetchPublicJson(url, options: any = {}) {
               const text = Buffer.concat(chunks).toString('utf8')
 
               if ((res.statusCode || 500) >= 400) {
-                reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+                // Attach the status as a property, not only in the message.
+                // isGatewayAuthRejection() classifies solely from
+                // err.statusCode, so a bare message prefix leaves a 401/403
+                // looking like a transport failure.
+                const err = new Error(`${res.statusCode}: ${text || res.statusMessage}`) as any
+                err.statusCode = res.statusCode || 500
+                reject(err)
 
                 return
               }


### PR DESCRIPTION
## Problem

A gateway `401`/`403` is reported to the user as a network failure. On the desktop that surfaces as:

> Desktop boot failed — Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.

…while the gateway is healthy and answering `200` on `/api/health`. The actual fault is an expired session, and the correct action is "sign in again", not "check your network".

## Root cause

`isGatewayAuthRejection()` (`apps/desktop/electron/connection-config.ts`) classifies an auth rejection **solely** from `err.statusCode`:

```ts
const statusCode = Number(error && typeof error === 'object' ? (error as any).statusCode : NaN)

return statusCode === 401 || statusCode === 403
```

`gatewayTicketFailure()` right below it already documents the expectation — *"the fetch layer attaches `err.statusCode`"*.

But `fetchJson` and `fetchPublicJson` in `main.ts` only put the status in the **message string**:

```ts
reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
```

So `err.statusCode` is `undefined`, `isGatewayAuthRejection` returns `false`, and the 401 is wrapped as the transport-failure message instead of the reauth one. `withTransientRetries` is affected the same way: it treats the auth rejection as retryable and re-hammers a dead session before failing.

Two other paths in the same file already do it correctly — `fetchJsonViaOauthSession` (`err.statusCode = statusCode`) and `finalizeGatewayDownload` (`error.statusCode = statusCode`, asserted by `gateway-file-download-transport.test.ts`). These two fetchers were just missed.

## Fix

Attach the status as a property at both sites, matching the existing pattern:

```ts
const err = new Error(`${res.statusCode}: ${text || res.statusMessage}`) as any
err.statusCode = res.statusCode || 500
reject(err)
```

## Tests

New `apps/desktop/electron/fetch-json-status-code.test.ts`:

- source assertions on both fetchers (same approach as `gateway-file-download-transport.test.ts`, since these close over main-process singletons)
- behavioral: a 401 carrying `statusCode` routes through `gatewayTicketFailure` to `needsOauthLogin: true` with the auth message
- behavioral: the pre-fix message-only shape does **not** classify — documents the regression being guarded

Verified the source assertions fail on unpatched `main.ts` (2 failed) and pass with the change.

```
vitest run --project electron
  Test Files  131 passed | 2 skipped (133)
       Tests  1861 passed | 6 skipped (1867)
```

`prettier --check` and `eslint` clean on both files.

## How this was found

A self-hosted gateway using the bundled `dashboard_auth/basic` provider without a configured `dashboard.basic_auth.secret` mints tokens with a random per-process HMAC key, so every gateway restart invalidates all issued access **and** refresh tokens. The desktop then reported "could not reach the gateway" every morning. The misleading message cost most of a debugging session — the gateway had been healthy the whole time.

The signing-key behaviour is documented and configurable, so that side is operator error. This PR is only about the desktop reporting an auth failure honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
