### PR TITLE
fix(desktop): keep background session titles active

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -7,6 +7,7 @@ import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
+import { $backgroundRunningSessionIds } from '@/store/composer-status'
 import type * as ComposerStatusStore from '@/store/composer-status'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
@@ -156,6 +157,12 @@ const handoffAvatar = (container: HTMLElement) =>
 
 const noop = vi.fn()
 
+// The production export is computed/read-only; this file replaces it with an
+// atom above so individual row tests can drive the exact resolved state.
+const writableBackgroundRunningSessionIds = $backgroundRunningSessionIds as unknown as {
+  set: (ids: string[]) => void
+}
+
 const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
   render(
     <SidebarSessionRow
@@ -178,7 +185,10 @@ const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
 // the wiring rather than the predicate — the arc has gone missing before.
 describe('SidebarSessionRow running arc', () => {
   afterEach(() => {
-    clearAllSessionStates()
+    act(() => {
+      writableBackgroundRunningSessionIds.set([])
+      clearAllSessionStates()
+    })
   })
 
   const arc = (container: HTMLElement) => container.querySelector('.arc-row')
@@ -195,6 +205,18 @@ describe('SidebarSessionRow running arc', () => {
     const { container } = renderRow(makeSession({ title: 'Running' }))
 
     expect(arc(container)).toBeTruthy()
+  })
+
+  it('keeps the active title treatment when background work outlives the turn', () => {
+    act(() => {
+      writableBackgroundRunningSessionIds.set(['s1'])
+    })
+
+    const { container } = renderRow(makeSession({ title: 'Background work' }))
+    const row = container.querySelector<HTMLElement>('.row-hover')
+
+    expect(row?.dataset.working).toBe('true')
+    expect(arc(container)).toBeNull()
   })
 
   // The row owns its status subscription so a turn starting repaints that row

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -28,7 +28,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
-import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $sessionDotStateById, hasActiveWork, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
 import { $openStoredSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
@@ -256,7 +256,7 @@ function SidebarSessionRowImpl({
   // contradict each other. A selector, not a plain useStore: the map is rebuilt
   // whenever any session's status changes, but a row only repaints on its own.
   const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
-  const liveTurn = hasLiveTurn(dotState)
+  const activeWork = hasActiveWork(dotState)
 
   // Card header line: the workspace this belongs to — the project when it
   // resolves (same function the session color reads, so name and tint agree;
@@ -362,7 +362,7 @@ function SidebarSessionRowImpl({
           // token rather than row opacity — dimming the whole row would take
           // the title and the status dot down with it.
           openUnfocused && 'bg-(--ui-row-open-background)',
-          liveTurn && 'text-foreground',
+          activeWork && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
           // it (translucency let the rows below bleed through). data-glass-opaque
           // keeps that true when window glass thins the field.
@@ -370,7 +370,7 @@ function SidebarSessionRowImpl({
           className
         )}
         data-glass-opaque={dragging ? '' : undefined}
-        data-working={liveTurn ? 'true' : undefined}
+        data-working={activeWork ? 'true' : undefined}
         // The row runs BOTH drags off one press, and each declines outside its
         // own region — so no timing/arbitration rule is needed and neither can
         // steal the other's gesture. Over the sidebar only the reorder has a

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -79,6 +79,11 @@ export const showsRunningArc = (state: SessionDotState): boolean => state === 's
  *  answer has not ended. */
 export const hasLiveTurn = (state: SessionDotState): boolean => showsRunningArc(state) || state === 'needs-input'
 
+/** Whether the session still owns any active work. Background processes and
+ * parked delegated children outlive the parent turn, but the session must not
+ * visually collapse to the same muted title as a fully idle conversation. */
+export const hasActiveWork = (state: SessionDotState): boolean => hasLiveTurn(state) || state === 'background'
+
 /** The buckets the sidebar's status filter and ordering work in. `stalled` and
  *  `background` fold into the state a user would name them. */
 export type SessionStatusBucket = 'draft' | 'idle' | 'needs-input' | 'unread' | 'working'


### PR DESCRIPTION
## Summary

- keep a session title visually active while background work still belongs to that session
- preserve the existing distinction between direct turns (animated running arc) and background processes/delegated children (no arc)
- add a focused renderer regression for the exact grey-title transition

## Problem

On current `main`, `SessionDotState: 'background'` is authoritative active work: either a `terminal(background=true)` process or parked delegated children continue after the parent turn has ended.

The session row, however, derives its brighter title treatment from `hasLiveTurn()`. That helper intentionally excludes `background`, so the row drops `data-working` and its title greys to the same treatment as a fully idle conversation even though the hollow background-status dot still says work is running.

This matches the user-visible gap discussed in #64851: the active indicator exists, but the row itself looks finished at a glance.

## Fix

Add a narrow `hasActiveWork()` presentation classifier:

- direct `working` / `stalled` turns and `needs-input` remain active as before
- `background` also keeps the row's bright title / `data-working` treatment
- the running arc remains governed by `showsRunningArc()`, so background work does **not** gain the direct-turn animation
- authoritative state production, priority resolution, dots, unread state, and terminal transitions are unchanged

This is complementary to #87915. That PR changes delegation production/hydration so parked children claim `working`; this PR fixes the renderer contract for the `background` state itself, including terminal background processes and current-main delegation behavior.

## TDD / regression proof

Authoritative baseline: `82e18567205ebd0a119b7e322e5470b9363de91b` (`origin/main` at final rebase).

With only the new test transplanted onto that exact base:

```text
expected data-working="true"
received undefined
1 failed, 12 skipped
```

On this candidate:

```text
src/app/chat/sidebar/session-row.test.tsx
src/store/session-dot-state.test.ts

2 files passed
33 tests passed
```

The regression also asserts that `.arc-row` remains absent for background work.

## Verification

```text
npm run test:ui                                 617 files / 6,079 tests passed
npm run typecheck                               passed
eslint --max-warnings=0 (3 changed TS/TSX files) passed
git diff --cached --check                      passed
npm run build                                  passed
```

No live runtime uses this branch; the installed Hermes Agent remains on clean upstream `main`.

## Related

- #64851 — working/background sessions can look indistinguishable from idle
- #87915 — complementary delegation lifecycle + reconnect hydration work
- #86604 — prior stale-resume/busy-state correctness fix already on main
