### PR TITLE
fix(tools): isolate execute_code reads from model read dedup

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1205,6 +1205,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    suppress_read_dedup: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1226,6 +1227,9 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        suppress_read_dedup: Internal execute_code path flag.  Programmatic
+                       sandbox reads should return actual content on repeated
+                       calls instead of the model-facing dedup status stub.
 
     Returns:
         Function result as a JSON string.
@@ -1503,6 +1507,14 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    if function_name == "read_file" and suppress_read_dedup:
+                        return registry.dispatch(
+                            function_name, next_args,
+                            task_id=task_id,
+                            session_id=session_id,
+                            user_task=user_task,
+                            suppress_dedup=True,
+                        )
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -51,7 +51,7 @@ from tools.code_execution_tool import (
 from tools.registry import registry
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None, **kwargs):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
@@ -277,6 +277,36 @@ print(result.get("output", ""))
         self.assertEqual(result["status"], "success")
         self.assertIn("mock output for: echo hello", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
+
+    def test_read_file_calls_suppress_parent_dedup(self):
+        """Sandbox read_file calls must not receive the model-facing dedup stub."""
+        calls = []
+
+        def mock_dispatch(function_name, function_args, **kwargs):
+            calls.append((function_name, kwargs))
+            if function_name == "read_file":
+                return json.dumps({"content": "line 1\n", "total_lines": 1})
+            return json.dumps({"error": f"unexpected tool: {function_name}"})
+
+        code = """
+from hermes_tools import read_file
+first = read_file("notes.txt")
+second = read_file("notes.txt")
+print(first["content"].strip())
+print(second["content"].strip())
+"""
+        with patch("model_tools.handle_function_call", side_effect=mock_dispatch):
+            result = json.loads(execute_code(
+                code=code,
+                task_id="test-task",
+                enabled_tools=["read_file"],
+            ))
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["tool_calls_made"], 2)
+        read_kwargs = [kwargs for name, kwargs in calls if name == "read_file"]
+        self.assertEqual(len(read_kwargs), 2)
+        self.assertTrue(all(kwargs.get("suppress_read_dedup") is True for kwargs in read_kwargs))
 
 
     def test_concurrent_tool_calls_match_responses(self):

--- a/tests/tools/test_execute_code_read_dedup.py
+++ b/tests/tools/test_execute_code_read_dedup.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""End-to-end regression tests for the execute_code read-dedup boundary.
+
+Issue #44843 / PR #44847.  ``read_file``'s dedup exists to save MODEL context:
+on a repeated same-range read of an unchanged file it returns a
+``status: "unchanged"`` stub instead of the content, because the earlier
+content is still visible in the conversation.  A script running inside
+``execute_code`` has no conversation, so the stub points at something it can
+never see — and the documented sandbox contract
+(``read_file(path) -> {"content": ..., "total_lines": N}``) is silently
+violated.  A script that does ``read_file(p)["content"]`` raises ``KeyError``;
+one that does ``.get("content", "")`` and writes the result back truncates the
+file.
+
+Everything here drives the REAL chain — ``model_tools.handle_function_call`` →
+``execute_code`` → sandbox RPC → ``handle_function_call`` again → registry →
+``tools.file_tools`` — against real files on disk.  The dispatcher and the file
+layer are deliberately not mocked: the boundary this fix introduces lives
+*between* them, so unit tests on either side cannot see a break in the middle.
+
+The RPC transport is whichever one the host provides: an AF_UNIX socket on
+POSIX, loopback TCP on native Windows (``_use_tcp_rpc``).  Both run the same
+``_rpc_server_loop`` and the same dispatch site, so these tests exercise the
+Windows TCP RPC route when they run on a Windows host.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+import uuid
+
+import pytest
+
+os.environ["TERMINAL_ENV"] = "local"
+
+from model_tools import handle_function_call  # noqa: E402
+from tools.file_tools import _read_tracker, _read_tracker_lock  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _force_local_terminal(monkeypatch):
+    """Keep the terminal backend local for every test in this module."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+
+# The sandbox stub always sends this limit (``_TOOL_STUBS["read_file"]``), and
+# the dedup key is ``(resolved_path, offset, limit)``.  Model-facing reads in
+# these tests use the same value on purpose: a different limit lands on a
+# different key and the surfaces would never meet.
+SANDBOX_READ_LIMIT = 2000
+
+
+def _model_read(path, task_id, limit=SANDBOX_READ_LIMIT, offset=1):
+    """One model-facing ``read_file`` call, through the normal dispatcher."""
+    return json.loads(handle_function_call(
+        "read_file",
+        {"path": path, "offset": offset, "limit": limit},
+        task_id=task_id,
+    ))
+
+
+def _run_sandbox(code, task_id):
+    """One ``execute_code`` call, dispatched the way the model dispatches it."""
+    return json.loads(handle_function_call(
+        "execute_code",
+        {"code": code},
+        task_id=task_id,
+        enabled_tools=["read_file"],
+    ))
+
+
+def _sandbox_reads(result):
+    """Parse the JSON line the sandbox scripts below print as their last line."""
+    output = (result.get("output") or "").strip()
+    assert output, f"sandbox produced no output: {result}"
+    return json.loads(output.splitlines()[-1])
+
+
+_READ_TWICE = """
+import json
+from hermes_tools import read_file
+
+seen = []
+for _ in range(2):
+    r = read_file({path!r})
+    seen.append({{"keys": sorted(r), "content": r.get("content")}})
+print(json.dumps(seen))
+"""
+
+
+_POLL_A_CHANGING_FILE = """
+import json
+from hermes_tools import read_file
+
+seen = []
+for i in range(5):
+    with open({path!r}, "a", encoding="utf-8") as fh:
+        fh.write("tick %d\\n" % i)
+    r = read_file({path!r})
+    seen.append({{"keys": sorted(r), "content": r.get("content")}})
+print(json.dumps(seen))
+"""
+
+
+class _SandboxReadCase(unittest.TestCase):
+    """Shared fixture: a real file, a fresh task id, a clean read tracker."""
+
+    def setUp(self):
+        self._dir = tempfile.mkdtemp(prefix="hermes_read_dedup_")
+        self.path = os.path.join(self._dir, "ledger.md")
+        with open(self.path, "w", encoding="utf-8") as fh:
+            fh.write("alpha\nbravo\ncharlie\n")
+        self.task_id = f"read-dedup-{uuid.uuid4().hex[:8]}"
+        self.addCleanup(self._forget_task)
+
+    def _forget_task(self):
+        with _read_tracker_lock:
+            _read_tracker.pop(self.task_id, None)
+
+    def assert_carries_content(self, response, where):
+        self.assertIn(
+            "content", response["keys"],
+            f"{where} returned no content: {response['keys']}",
+        )
+        self.assertIn("alpha", response["content"] or "", where)
+
+
+class TestSandboxReadsAlwaysReturnContent(_SandboxReadCase):
+    """The bug in #44843, both orders, through the real sandbox."""
+
+    def test_repeated_sandbox_reads_after_a_model_read_both_return_content(self):
+        """The regression test asked for in the 2026-07-14 review of #44847.
+
+        Seed normal dedup for the task with a model-facing read, then call
+        ``hermes_tools.read_file()`` twice through ``execute_code`` and assert
+        both responses contain ``content``.
+        """
+        seed = _model_read(self.path, self.task_id)
+        self.assertIn("content", seed, "the seeding model read should return content")
+
+        result = _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+        self.assertEqual(result.get("status"), "success", result)
+        self.assertEqual(result.get("tool_calls_made"), 2)
+
+        reads = _sandbox_reads(result)
+        self.assertEqual(len(reads), 2)
+        self.assert_carries_content(reads[0], "first sandbox read")
+        self.assert_carries_content(reads[1], "second sandbox read")
+
+    def test_two_sandbox_reads_in_one_script_both_return_content(self):
+        """The reported incident needs no model read at all.
+
+        Two ``read_file`` calls on the same path inside one script: before the
+        fix the second returns a stub with no ``content``, which is what a
+        read-modify-write helper writes back over the file.
+        """
+        result = _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+        self.assertEqual(result.get("status"), "success", result)
+
+        reads = _sandbox_reads(result)
+        self.assertEqual(len(reads), 2)
+        self.assert_carries_content(reads[0], "first sandbox read")
+        self.assert_carries_content(reads[1], "second sandbox read")
+
+    def test_sandbox_polling_a_changing_file_keeps_returning_content(self):
+        """A script that re-reads a file it is appending to must keep seeing it.
+
+        Every read here reaches disk (the file changes between reads, so dedup
+        never applies) — what denied content before the fix was the
+        consecutive-read guard, which counts the repeated *key* and blocks on
+        the fourth hit while asserting "The content has NOT changed."
+        """
+        result = _run_sandbox(_POLL_A_CHANGING_FILE.format(path=self.path), self.task_id)
+        self.assertEqual(result.get("status"), "success", result)
+        self.assertEqual(result.get("tool_calls_made"), 5)
+
+        reads = _sandbox_reads(result)
+        self.assertEqual(len(reads), 5)
+        for i, read in enumerate(reads):
+            self.assert_carries_content(read, f"poll read {i + 1}")
+        self.assertIn("tick 4", reads[-1]["content"])
+
+
+class TestSandboxReadsLeaveTheModelSurfaceAlone(_SandboxReadCase):
+    """The reverse direction: a program's reads must not degrade the model's."""
+
+    def test_sandbox_reads_do_not_block_a_later_model_read(self):
+        """Program reads must not spend the model's repeat-read budget.
+
+        Before the fix the sandbox's two reads land on the model's own dedup
+        key, so the model's next read of a file it read once is refused
+        outright — told it has already read the region four times, citing
+        results that were never in the conversation.
+        """
+        _model_read(self.path, self.task_id)
+        _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+
+        after = _model_read(self.path, self.task_id)
+
+        self.assertNotIn(
+            "already_read", after,
+            f"a program's reads escalated the model's read guard: {after}",
+        )
+        self.assertIsNone(after.get("error"), after)
+
+    def test_model_dedup_still_applies_to_the_model_after_a_sandbox_read(self):
+        """The other half: model-facing dedup is preserved, not disabled.
+
+        The model really did read this region, so the stub it gets back is
+        correct — the program's intervening reads neither suppress it nor
+        escalate it.
+        """
+        _model_read(self.path, self.task_id)
+        _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+
+        after = _model_read(self.path, self.task_id)
+
+        self.assertTrue(after.get("dedup"), after)
+        self.assertEqual(after.get("status"), "unchanged", after)
+        self.assertFalse(after.get("content_returned"), after)
+
+    def test_a_model_read_after_program_reads_still_returns_content(self):
+        """Program first, model second — the order the two tests above miss.
+
+        Nothing has ever read this file on the model surface, so the model's
+        FIRST read of it must carry ``content``.  Before the fix the sandbox's
+        reads land on the model's own dedup key, so the model is handed a
+        ``status: "unchanged"`` stub for content it never received — the same
+        empty-``content`` shape that truncated the file in #44843, one surface
+        over.
+
+        This is the half of the fix that lives in the ``dedup[dedup_key]``
+        write guard in ``read_file_tool``.  Both other program/model tests
+        begin with a *model* read, which seeds that key legitimately, so they
+        stay green if the guard is dropped in a rebase.  This one does not.
+        """
+        result = _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+        self.assertEqual(result.get("status"), "success", result)
+
+        first_model_read = _model_read(self.path, self.task_id)
+
+        self.assertIn(
+            "content", first_model_read,
+            "the model's first read of this file returned no content: "
+            f"{first_model_read}",
+        )
+        self.assertIn("alpha", first_model_read.get("content") or "")
+        self.assertIsNone(first_model_read.get("error"), first_model_read)
+
+@pytest.mark.windows_only
+class TestSandboxReadsOnWindowsTcpRpc(_SandboxReadCase):
+    """Same contract over the native-Windows loopback-TCP RPC transport.
+
+    #44843 was re-confirmed from Windows 11 on 2026-08-15, and that reporter
+    asked for the TCP route to be covered as well as the POSIX one.  The socket
+    family is the only difference — both transports run the same
+    ``_rpc_server_loop`` and the same dispatch site — so this is the same
+    assertion pinned to the host that selects ``_use_tcp_rpc``.  Skipped
+    everywhere else; do not gate it on a patched ``sys.platform``.
+    """
+
+    def test_repeated_sandbox_reads_after_a_model_read_both_return_content(self):
+        _model_read(self.path, self.task_id)
+
+        result = _run_sandbox(_READ_TWICE.format(path=self.path), self.task_id)
+        self.assertEqual(result.get("status"), "success", result)
+
+        reads = _sandbox_reads(result)
+        self.assertEqual(len(reads), 2)
+        self.assert_carries_content(reads[0], "first sandbox read")
+        self.assert_carries_content(reads[1], "second sandbox read")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -421,6 +421,29 @@ class TestFileDedup(unittest.TestCase):
         self.assertNotIn("content", r2)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_suppress_dedup_returns_content_on_repeated_reads(self, mock_ops):
+        """Programmatic callers can opt out of model-facing read dedup stubs."""
+        mock_ops.return_value = _make_fake_ops(
+            content="line one\nline two\n", file_size=20,
+        )
+
+        r1 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+        r2 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+
+        self.assertEqual(r1.get("content"), "line one\nline two\n")
+        self.assertEqual(r2.get("content"), "line one\nline two\n")
+        self.assertNotIn("dedup", r1)
+        self.assertNotIn("dedup", r2)
+
+    @patch("tools.file_tools._get_file_ops")
     def test_write_rejects_internal_read_status_text(self, mock_ops):
         """write_file must not persist internal read_file status text."""
         fake = MagicMock()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -745,8 +745,12 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     with thread_scoped_silence():
+                        dispatch_kwargs = {"task_id": task_id}
+                        if tool_name == "read_file":
+                            dispatch_kwargs["suppress_read_dedup"] = True
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name, tool_args,
+                            **dispatch_kwargs,
                         )
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
@@ -1022,8 +1026,12 @@ def _rpc_poll_loop(
                     # Dispatch through the standard tool handler
                     try:
                         with thread_scoped_silence():
+                            dispatch_kwargs = {"task_id": task_id}
+                            if tool_name == "read_file":
+                                dispatch_kwargs["suppress_read_dedup"] = True
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name, tool_args,
+                                **dispatch_kwargs,
                             )
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -343,7 +343,9 @@ _TOOL_STUBS = {
     "read_file": (
         "read_file",
         "path: str, offset: int = 1, limit: int = 2000",
-        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
+        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines". '
+        'Always returns the content, however many times you read the same range: the '
+        'model-facing read deduplication does not apply to these calls."""',
         '{"path": path, "offset": offset, "limit": limit}',
     ),
     "write_file": (
@@ -2082,7 +2084,10 @@ _TOOL_DOC_LINES = [
      "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
     ("read_file",
      "  read_file(path: str, offset: int = 1, limit: int = 2000) -> dict\n"
-     "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
+     "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}\n"
+     "    Repeated reads of the same range always return the content: the read\n"
+     "    deduplication that stubs your own repeated read_file calls does not\n"
+     "    apply to reads made from inside execute_code."),
     ("write_file",
      "  write_file(path: str, content: str) -> dict\n"
      "    Always overwrites the entire file."),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1633,7 +1633,13 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 2000,
+    task_id: str = "default",
+    suppress_dedup: bool = False,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1819,7 +1825,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
+        if cached_mtime is not None and not suppress_dedup:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
@@ -1947,12 +1953,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             # earlier and we fell through.)
             task_data["dedup_hits"].pop(dedup_key, None)
             task_data["read_history"].add((path, offset, limit))
-            if task_data["last_key"] == read_key:
+            if suppress_dedup:
+                count = 1
+            elif task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1
+                count = task_data["consecutive"]
             else:
                 task_data["last_key"] = read_key
                 task_data["consecutive"] = 1
-            count = task_data["consecutive"]
+                count = task_data["consecutive"]
 
             # Store mtime at read time for two purposes:
             # 1. Dedup: skip identical re-reads of unchanged files.
@@ -1960,7 +1969,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             #    the agent last read it (external edit, concurrent agent, etc.).
             try:
                 _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
+                if not suppress_dedup:
+                    task_data["dedup"][dedup_key] = _mtime_now
                 task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
             except OSError:
                 pass  # Can't stat — skip tracking for this entry
@@ -2766,7 +2776,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        suppress_dedup=bool(kw.get("suppress_dedup", False)),
+    )
 
 
 def _handle_write_file(args, **kw):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -718,7 +718,7 @@ file_read_max_chars: 200000
 file_read_max_chars: 30000
 ```
 
-The agent also deduplicates file reads automatically — if the same file region is read twice and the file hasn't changed, a lightweight stub is returned instead of re-sending the content. This resets on context compression so the agent can re-read files after their content is summarized away.
+The agent also deduplicates file reads automatically — if the same file region is read twice and the file hasn't changed, a lightweight stub is returned instead of re-sending the content. This resets on context compression so the agent can re-read files after their content is summarized away. It applies to the agent's own `read_file` calls only — `hermes_tools.read_file()` inside `execute_code` always returns the content, because a sandbox script has no conversation to refer back to.
 
 ## Tool Output Truncation Limits
 


### PR DESCRIPTION
## Summary

- Repeated `hermes_tools.read_file()` calls inside `execute_code` return file content instead of the model-facing unchanged-file stub.
- Programmatic reads use an internal suppression flag, so they neither seed nor consume the ordinary model-facing `read_file` dedup budget. Ordinary model-facing dedup remains unchanged.

## Attribution

**The underlying fix is by Pluviobyte.** This replacement preserves and extends Pluviobyte's implementation and authorship from [PR #44847](https://github.com/NousResearch/hermes-agent/pull/44847), which remains open but inactive. The first commit preserves that fix; the second adds end-to-end regression coverage requested in its review.

This addresses [issue #44843](https://github.com/NousResearch/hermes-agent/issues/44843).

## Boundary coverage

The end-to-end tests exercise the real dispatcher, sandbox RPC, registry, and file layer across three boundary sequences:

1. model read → two program reads: both program reads return content;
2. model read → program reads → model read: ordinary model dedup still returns its unchanged stub;
3. program reads → first model read: the model still receives content because program reads did not spend its budget.

Focused result: **91 passed, 1 skipped** on macOS. The skipped case is the Windows-only TCP-RPC case; it was **unexecuted on macOS, not passed**.
