### PR TITLE
fix(bedrock): pass session model to startup runtime resolution so non-Claude models route to Converse

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -44,6 +44,14 @@ class CLIAgentSetupMixin:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                # Pass the session's actual model so model-dependent routing
+                # (Bedrock's Claude→AnthropicBedrock vs non-Claude→Converse
+                # dual path) resolves for THIS session's model, not the
+                # config default. Without this, `hermes chat --model
+                # qwen.qwen3-vl-235b-a22b` on a Claude-default config gets
+                # api_mode=anthropic_messages and sends Anthropic-format
+                # tools (no `type` field) to a Converse-only model → 400.
+                target_model=self.model or None,
             )
         except Exception as exc:
             _primary_exc = exc


### PR DESCRIPTION
## Summary

`_ensure_runtime_credentials()` (hermes_cli/cli_agent_setup_mixin.py) re-resolves the provider runtime on CLI startup **without passing the session's model**. Bedrock routing in `resolve_runtime_provider()` is model-dependent (`is_anthropic_bedrock_model` → `anthropic_messages` via the AnthropicBedrock SDK; everything else → `bedrock_converse`), so `api_mode` was always resolved for the **config default** model instead of the model the session actually runs.

## Symptom

With a Claude default in `config.yaml`, any non-Claude Bedrock session — `hermes chat --model qwen.qwen3-vl-235b-a22b`, or an interactive `/model` switch to a Qwen/Nova/Llama alias — started with `api_mode=anthropic_messages`. The first request with tools attached went to `/model/<id>/invoke-with-response-stream` with an Anthropic-format payload, and Bedrock rejected it:

```
HTTP 400: {"error":{"code":"validation_error","message":"Failed to deserialize the JSON body into the target type: ?[0]: Invalid 'tools': missing field `type` ..."}}
```

The conversation loop then silently activated the fallback chain, so the user's explicitly selected non-Claude model was quietly replaced by a fallback model. For users choosing a non-Anthropic model on purpose, that silent substitution defeats the choice.

## Fix

Pass `target_model=self.model` so the dual-path Bedrock routing resolves for the session's actual model. One-line change plus comment. `resolve_runtime_provider()` already accepts `target_model` and every other model-dependent caller (model_switch, fallback resolution) already passes it — this startup path was the one that didn't.

## Reproduction

1. `config.yaml` with `model.default: us.anthropic.claude-<any>` and `model.provider: bedrock`
2. `hermes chat --model qwen.qwen3-vl-235b-a22b -q "run a shell command"` (any prompt that triggers a tool call)
3. Observe the 400 above in `~/.hermes/logs/agent.log` and a "Model fallback: … unavailable (provider failure)" notice.

## Verification (live Bedrock account, us-east-1)

- `hermes chat --model qwen.qwen3-vl-235b-a22b` with a terminal tool call → executes on Qwen via Converse, no fallback; session_model_usage records `qwen.qwen3-vl-235b-a22b`
- Interactive `/model qwen` switch followed by a tool call → same, works end-to-end
- `tests/hermes_cli/test_runtime_provider_resolution.py`: **64 passed**
- Broader `-k "runtime or model_switch or bedrock"` selection: 40 pre-existing failures are **identical with and without this patch** (stash-verified), none introduced.
