### PR TITLE
fix(telegram): scope allowed topics by chat

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -72,11 +72,24 @@ def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
                     e["name"] = friendly
                     matched = True
             if not matched:
+                entry_type = "group" if chat_id.endswith("@g.us") else "dm"
+                thread_id = None
+                if plat_name == "telegram":
+                    base_chat_id, separator, candidate_thread_id = chat_id.rpartition(":")
+                    if (
+                        separator
+                        and base_chat_id.startswith("-")
+                        and candidate_thread_id.isdecimal()
+                    ):
+                        entry_type = "forum"
+                        thread_id = candidate_thread_id
+                    elif chat_id.startswith("-"):
+                        entry_type = "group"
                 entries.append({
                     "id": chat_id,
                     "name": friendly,
-                    "type": "group" if str(chat_id).endswith("@g.us") else "dm",
-                    "thread_id": None,
+                    "type": entry_type,
+                    "thread_id": thread_id,
                 })
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8793,6 +8793,25 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
         return bool(chat_id) and f"{chat_id}:{topic_id}" in allowed_topics
 
+    def _telegram_require_explicit_mention_topics(self) -> set[str]:
+        """Return exact ``<chat_id>:<thread_id>`` routes that require a tag."""
+        raw = self.config.extra.get("require_explicit_mention_topics", [])
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _telegram_requires_explicit_mention(self, message: Message) -> bool:
+        """True when replies and wake words must not substitute for ``@bot``."""
+        routes = self._telegram_require_explicit_mention_topics()
+        if not routes:
+            return False
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        if not chat_id:
+            return False
+        thread_id = self._effective_message_thread_id(message)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        return f"{chat_id}:{topic_id}" in routes
+
     def _telegram_ignored_threads(self) -> set[int]:
         raw = self.config.extra.get("ignored_threads")
         if raw is None:
@@ -9245,20 +9264,22 @@ class TelegramAdapter(BasePlatformAdapter):
         if not allowed or chat_id_str not in allowed:
             return False
 
+        strict_mention = self._telegram_requires_explicit_mention(message)
+
         # Only observe messages skipped by the require_mention gate.  If the
         # message would be processed normally, let the dispatcher handle it;
         # if require_mention is disabled, every group message is a request.
-        if chat_id_str in self._telegram_free_response_chats():
+        if not strict_mention and chat_id_str in self._telegram_free_response_chats():
             return False
-        if self._telegram_is_free_response_topic(message):
+        if not strict_mention and self._telegram_is_free_response_topic(message):
             return False
-        if not self._telegram_require_mention():
+        if not strict_mention and not self._telegram_require_mention():
             return False
-        if self._is_reply_to_bot(message):
+        if not strict_mention and self._is_reply_to_bot(message):
             return False
         if self._message_mentions_bot(message):
             return False
-        if self._message_matches_mention_patterns(message):
+        if not strict_mention and self._message_matches_mention_patterns(message):
             return False
         return True
 
@@ -9630,6 +9651,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
+        if self._telegram_requires_explicit_mention(message):
+            return self._message_mentions_bot(message)
         if chat_id_str in self._telegram_free_response_chats():
             return True
         if self._telegram_is_free_response_topic(message):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8763,12 +8763,14 @@ class TelegramAdapter(BasePlatformAdapter):
         return group_allowed
 
     def _telegram_allowed_topics(self) -> set[str]:
-        """Return the whitelist of Telegram forum topic IDs this bot handles.
+        """Return the whitelist of Telegram forum routes this bot handles.
 
-        When non-empty, group/supergroup messages from other topics are
-        silently ignored. DMs are never filtered by topic. Telegram may omit
-        ``message_thread_id`` for the forum General topic, so ``None`` is
-        treated as topic ``1`` for matching purposes.
+        Legacy ``<thread_id>`` entries allow that numeric topic in every
+        otherwise-allowed chat.  Scoped ``<chat_id>:<thread_id>`` entries allow
+        only the exact forum route, which prevents same-numbered topics in two
+        chats from sharing a gate. DMs are never filtered by topic. Telegram
+        may omit ``message_thread_id`` for the forum General topic, so ``None``
+        is treated as topic ``1`` for matching purposes.
         """
         raw = self.config.extra.get("allowed_topics")
         if raw is None:
@@ -8776,6 +8778,20 @@ class TelegramAdapter(BasePlatformAdapter):
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _telegram_topic_is_allowed(self, message: Message) -> bool:
+        """Return whether ``message`` passes the configured forum-topic gate."""
+        allowed_topics = self._telegram_allowed_topics()
+        if not allowed_topics:
+            return True
+
+        thread_id = self._effective_message_thread_id(message)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        if topic_id in allowed_topics:
+            return True
+
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        return bool(chat_id) and f"{chat_id}:{topic_id}" in allowed_topics
 
     def _telegram_ignored_threads(self) -> set[int]:
         raw = self.config.extra.get("ignored_threads")
@@ -9204,12 +9220,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._is_group_chat(message):
             return False
 
-        thread_id = getattr(message, "message_thread_id", None)
-        allowed_topics = self._telegram_allowed_topics()
-        if allowed_topics:
-            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
-            if topic_id not in allowed_topics:
-                return False
+        if not self._telegram_topic_is_allowed(message):
+            return False
+
+        thread_id = self._effective_message_thread_id(message)
 
         if thread_id is not None:
             try:
@@ -9577,12 +9591,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._is_group_chat(message):
             return True
 
+        if not self._telegram_topic_is_allowed(message):
+            return False
+
         thread_id = self._effective_message_thread_id(message)
-        allowed_topics = self._telegram_allowed_topics()
-        if allowed_topics:
-            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
-            if topic_id not in allowed_topics:
-                return False
 
         # Check ignored_threads first — applies to both groups and DM topics
         if thread_id is not None:

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -382,6 +382,26 @@ class TestChannelAliases:
             assert injected and injected[0]["type"] == "group"
 
 
+    def test_alias_injects_undiscovered_telegram_forum_topic(self, tmp_path):
+        """A pre-named Telegram topic retains its forum delivery metadata."""
+        target = "-1001234567890:3823"
+        cache_file = _write_directory(tmp_path, {"telegram": []})
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             self._setup_aliases(
+                 tmp_path,
+                 {"telegram": {target: "EXL Deepfates Program"}},
+             ):
+            assert resolve_channel_name("telegram", "EXL Deepfates Program") == target
+            entries = load_directory()["platforms"]["telegram"]
+            injected = [entry for entry in entries if entry["id"] == target]
+            assert injected == [{
+                "id": target,
+                "name": "EXL Deepfates Program",
+                "type": "forum",
+                "thread_id": "3823",
+            }]
+
+
     def test_alias_persists_through_rebuild(self, tmp_path, monkeypatch):
         """build_channel_directory must bake aliases into the written file so
         they survive the periodic regeneration, not just live reads."""
@@ -397,4 +417,3 @@ class TestChannelAliases:
         names = [e["name"] for e in on_disk["platforms"]["whatsapp"]
                  if e["id"] == "120363@g.us"]
         assert names == ["general"]
-

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -16,6 +16,7 @@ def _make_adapter(
     exclusive_bot_mentions=None,
     ignored_threads=None,
     allowed_topics=None,
+    require_explicit_mention_topics=None,
     allow_from=None,
     group_allow_from=None,
     allowed_chats=None,
@@ -46,6 +47,8 @@ def _make_adapter(
         # environment; production adapters without this explicit key still fall
         # back to the env var.
         extra["allowed_topics"] = []
+    if require_explicit_mention_topics is not None:
+        extra["require_explicit_mention_topics"] = require_explicit_mention_topics
     if allow_from is not None:
         extra["allow_from"] = allow_from
     if group_allow_from is not None:
@@ -468,6 +471,36 @@ def test_observed_group_context_honors_chat_scoped_topic_gate():
     assert adapter._should_observe_unmentioned_group_message(
         _group_message("context", chat_id=-200, thread_id=8)
     ) is False
+
+
+def test_explicit_mention_topic_does_not_treat_reply_as_a_tag():
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100"],
+        group_allowed_chats=["-100"],
+        require_explicit_mention_topics=["-100:8"],
+        observe_unmentioned_group_messages=True,
+    )
+
+    reply = _group_message("continuing", chat_id=-100, thread_id=8, reply_to_bot=True)
+    assert adapter._should_process_message(reply) is False
+    assert adapter._should_observe_unmentioned_group_message(reply) is True
+
+    tagged_reply = _group_message(
+        "@hermes_bot continuing",
+        chat_id=-100,
+        thread_id=8,
+        reply_to_bot=True,
+    )
+    assert adapter._should_process_message(tagged_reply) is True
+    assert adapter._should_observe_unmentioned_group_message(tagged_reply) is False
+
+    # The setting is route-scoped: ordinary Telegram reply semantics remain
+    # unchanged in another topic served by the same profile.
+    other_topic_reply = _group_message(
+        "continuing", chat_id=-100, thread_id=9, reply_to_bot=True
+    )
+    assert adapter._should_process_message(other_topic_reply) is True
 
 
 def _forum_message(*, chat_id, thread_id, is_topic_message, is_forum, chat_type="supergroup"):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -438,6 +438,38 @@ def test_allowed_topics_drop_other_forum_topics_before_other_gates():
     ) is False
 
 
+def test_allowed_topics_can_be_scoped_to_one_chat_topic_pair():
+    adapter = _make_adapter(
+        require_mention=False,
+        allowed_chats=["-100", "-200"],
+        allowed_topics=["-100:8"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message("hello", chat_id=-100, thread_id=8)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("hello", chat_id=-200, thread_id=8)
+    ) is False
+
+
+def test_observed_group_context_honors_chat_scoped_topic_gate():
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100", "-200"],
+        group_allowed_chats=["-100", "-200"],
+        allowed_topics=["-100:8"],
+        observe_unmentioned_group_messages=True,
+    )
+
+    assert adapter._should_observe_unmentioned_group_message(
+        _group_message("context", chat_id=-100, thread_id=8)
+    ) is True
+    assert adapter._should_observe_unmentioned_group_message(
+        _group_message("context", chat_id=-200, thread_id=8)
+    ) is False
+
+
 def _forum_message(*, chat_id, thread_id, is_topic_message, is_forum, chat_type="supergroup"):
     """Build a message with independently-controlled topic/forum flags.
 
@@ -540,7 +572,8 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "  group_allowed_chats:\n"
         "    - \"-100\"\n"
         "  allowed_topics:\n"
-        "    - 8\n",
+        "    - 8\n"
+        '    - "-100:9"\n',
         encoding="utf-8",
     )
 
@@ -582,7 +615,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert tg_cfg.extra.get("mention_patterns") == [r"^\s*chompy\b"]
     assert tg_cfg.extra.get("allowed_chats") == ["-100"]
     assert tg_cfg.extra.get("group_allowed_chats") == ["-100"]
-    assert tg_cfg.extra.get("allowed_topics") == [8]
+    assert tg_cfg.extra.get("allowed_topics") == [8, "-100:9"]
     # free_response_chats is bridged to the env var only (not PlatformConfig.extra).
     # TELEGRAM_FREE_RESPONSE_CHATS is not a key that appears in developer .env
     # files, so asserting it via os.environ stays deterministic.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -541,6 +541,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
   - matches for one of your configured regex wake words in `telegram.mention_patterns`
 - In groups with multiple Hermes bots, `telegram.exclusive_bot_mentions` keeps routing deterministic. When a message explicitly mentions one or more Telegram bot usernames, only the mentioned bot profiles process it; other Hermes bots ignore it before reply and wake-word fallbacks run. This is enabled by default.
 - Renaming the bot's `@username` in BotFather is picked up automatically — Hermes follows the new handle for mention routing without a gateway restart. Collectible (Fragment) usernames that don't end in `bot` are supported too.
+- Use `telegram.allowed_topics` to limit a multi-forum profile to explicit routes. A bare topic ID such as `8` is the legacy form and applies in every otherwise-allowed chat; prefer a chat-scoped entry such as `"-1001234567890:8"` when the profile serves more than one forum.
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -542,6 +542,14 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - In groups with multiple Hermes bots, `telegram.exclusive_bot_mentions` keeps routing deterministic. When a message explicitly mentions one or more Telegram bot usernames, only the mentioned bot profiles process it; other Hermes bots ignore it before reply and wake-word fallbacks run. This is enabled by default.
 - Renaming the bot's `@username` in BotFather is picked up automatically — Hermes follows the new handle for mention routing without a gateway restart. Collectible (Fragment) usernames that don't end in `bot` are supported too.
 - Use `telegram.allowed_topics` to limit a multi-forum profile to explicit routes. A bare topic ID such as `8` is the legacy form and applies in every otherwise-allowed chat; prefer a chat-scoped entry such as `"-1001234567890:8"` when the profile serves more than one forum.
+- To require a literal `@botusername` tag on every turn in selected topics, add exact routes under `telegram.extra.require_explicit_mention_topics`. In those topics, replying to a bot message or matching a wake-word pattern does not dispatch the agent unless the message also tags the bot:
+
+  ```yaml
+  telegram:
+    extra:
+      require_explicit_mention_topics:
+        - "-1001234567890:8"
+  ```
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
 


### PR DESCRIPTION
## Summary
- accept chat-scoped entries (`<chat_id>:<thread_id>`) in `telegram.allowed_topics`
- preserve legacy bare topic IDs for backward compatibility
- apply the same exact-route gate to dispatched and observed group messages
- document the multi-forum configuration form

## Reproduction
Two Telegram forums can assign the same numeric `message_thread_id`. The current global topic-ID gate admits both once their chats are allowlisted, so a profile cannot safely expose topic 8 in one forum while rejecting topic 8 in another.

## Verification
- `pytest -q tests/gateway/test_telegram_group_gating.py` (25 passed)
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_group_gating.py`
- `git diff --check`
