### PR TITLE
fix(windows): let Task Scheduler supervise the gateway

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8454,9 +8454,9 @@ def _gateway_command_inner(args):
             elif is_windows():
                 from hermes_cli import gateway_windows
 
-                # On Windows, even without a registered Scheduled Task / Startup
-                # entry, gateway_windows.start() uses the safe detached
-                # pythonw.exe launcher.  Do not fall back to run_gateway() here:
+                # On Windows, gateway_windows.start() uses the installed
+                # Scheduled Task when available, otherwise its safe detached
+                # hidden-console launcher. Do not fall back to run_gateway() here:
                 # when invoked from a gateway-hosted agent/tool call, foreground
                 # run_gateway() is tied to the very gateway process we just
                 # stopped and can die before the replacement is stable.

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -9,12 +9,13 @@ dropper when Scheduled Task creation is denied (locked-down corporate boxes).
 Design notes
 ------------
 * ``schtasks /Create /SC ONLOGON /RL LIMITED`` means the task runs at the
-  CURRENT USER's next logon without any elevation prompt. Manual starts and
-  install ``--start-now`` use the direct hidden-console launcher instead
-  of ``schtasks /Run`` so start/restart behavior is consistent.
+  CURRENT USER's next logon without any elevation prompt. When that task is
+  installed, manual starts and install ``--start-now`` route through it so
+  Task Scheduler remains the gateway's restart owner.
 * We write a shared ``gateway.cmd`` wrapper plus a console-less ``gateway.vbs``
   launcher. Scheduled Task and Startup-folder persistence both route through
-  VBS/wscript; immediate manual starts route through direct ``subprocess`` spawn.
+  VBS/wscript; direct ``subprocess`` spawn is reserved for the fallback path
+  where no Scheduled Task is installed.
 * Status = merge of "is the schtasks entry registered?" + "is the startup
   login item present?" + "is there a gateway process running?" so the status
   command keeps working regardless of which install path was taken.
@@ -473,8 +474,10 @@ def _build_gateway_vbs_script(
     by every console-subsystem descendant (git, gh, node, …) so none of them
     allocate a visible flashing conhost (#54220/#56747; the previous
     console-less pythonw.exe gateway forced exactly that per-descendant
-    flash). No cmd.exe anywhere in the chain. Mirrors
-    ``_build_gateway_cmd_script`` (same env + argv via
+    flash). No cmd.exe anywhere in the chain. The launcher waits for Python
+    and returns its exit code so Task Scheduler's ``RestartOnFailure`` policy
+    supervises the actual gateway instead of an already-completed bootstrap.
+    Mirrors ``_build_gateway_cmd_script`` (same env + argv via
     ``_resolve_detached_python``).
     """
     python_exe_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
@@ -494,7 +497,7 @@ def _build_gateway_vbs_script(
     lines = [
         f"' {_TASK_DESCRIPTION}",
         "Option Explicit",
-        "Dim sh, env, existing_pp",
+        "Dim sh, env, existing_pp, exit_code",
         'Set sh = CreateObject("WScript.Shell")',
         'Set env = sh.Environment("PROCESS")',
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
@@ -510,10 +513,11 @@ def _build_gateway_vbs_script(
         f"  env.Item({_quote_vbs_string('PYTHONPATH')}) = {_quote_vbs_string(static_pythonpath)}",
         "End If",
         f"sh.CurrentDirectory = {_quote_vbs_string(working_dir)}",
-        # Window style 0 = hidden; bWaitOnReturn False = detached/async. The
-        # console python's one console is created hidden and inherited by all
-        # descendants, so nothing ever flashes.
-        f"sh.Run {_quote_vbs_string(command_line)}, 0, False",
+        # Window style 0 = hidden; bWaitOnReturn True keeps wscript (and thus
+        # the Scheduled Task) alive for the gateway's lifetime. Propagating
+        # Python's result makes RestartOnFailure observe real gateway crashes.
+        f"exit_code = sh.Run({_quote_vbs_string(command_line)}, 0, True)",
+        "WScript.Quit exit_code",
     ]
     return "\r\n".join(lines) + "\r\n"
 
@@ -675,7 +679,8 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
         # the final error if creation also fails.
     user = _resolve_task_user()
     # The Scheduled Task launches the console-less .vbs (issue #45599 fix A), not
-    # the .cmd. Immediate manual starts use _spawn_detached().
+    # the .cmd. The VBS remains attached to Python so task failure policy owns
+    # the complete gateway lifetime.
     launcher_path = script_path.with_suffix(".vbs")
     xml_path = _write_scheduled_task_xml(task_name, launcher_path, user)
     base = ["/Create", "/F", "/TN", task_name, "/XML", str(xml_path)]
@@ -1115,8 +1120,7 @@ def install(
             if running_pids:
                 print(f"✓ Gateway already running (PID: {', '.join(map(str, running_pids))})")
             else:
-                pid = _spawn_detached()
-                _report_gateway_start(f"direct spawn (PID {pid})")
+                _start_via_scheduled_task()
         else:
             print("ℹ Gateway not started now.")
             print("  Start manually with: hermes gateway start")
@@ -1190,6 +1194,37 @@ def _wait_for_gateway_ready(timeout_s: float = 6.0, interval_s: float = 0.4) -> 
             return pids
         time.sleep(interval_s)
     return []
+
+
+def _start_via_scheduled_task() -> list[int]:
+    """Start the installed task and verify its profile gateway appears.
+
+    The generated VBS remains alive while Python runs, so routing starts
+    through ``schtasks /Run`` makes Task Scheduler the real process owner and
+    lets its ``RestartOnFailure`` policy observe a later crash. If no gateway
+    is currently detectable, ending a stale task instance first is safe and
+    avoids ``MultipleInstancesPolicy=IgnoreNew`` silently discarding the run.
+    """
+    _assert_windows()
+    task_name = get_task_name()
+    _exec_schtasks(["/End", "/TN", task_name])
+    code, out, err = _exec_schtasks(["/Run", "/TN", task_name])
+    if code != 0:
+        detail = (err or out or f"exit code {code}").strip()
+        raise RuntimeError(f"Could not start Windows gateway task {task_name}: {detail}")
+
+    pids = _wait_for_gateway_ready(timeout_s=30.0)
+    if not pids:
+        raise RuntimeError(
+            f"Windows gateway task {task_name} started, but no gateway process "
+            "was detected after 30s. Check logs/gateway.log and "
+            "logs/gateway-stdio.log."
+        )
+    print(
+        f"✓ Gateway started via Scheduled Task {task_name} "
+        f"(PID: {', '.join(map(str, pids))})"
+    )
+    return pids
 
 
 def _report_gateway_start(via: str) -> None:
@@ -1486,7 +1521,7 @@ def status(deep: bool = False) -> None:
 
 
 def start() -> None:
-    """Start the gateway using the canonical detached Windows launch path."""
+    """Start the gateway through its installed Windows persistence owner."""
     _assert_windows()
     running_pids = _gateway_pids()
     if running_pids:
@@ -1511,9 +1546,13 @@ def start() -> None:
             print("  If a UAC prompt opened, approve it, then run: hermes gateway start")
             return
 
-    # Manual starts use the same console-less direct spawn path as restart()
-    # and install --start-now. Scheduled Task / Startup entries are only login
-    # persistence mechanisms.
+    if task_installed:
+        _start_via_scheduled_task()
+        return
+
+    # The Startup-folder fallback has no always-running supervisor. Preserve
+    # the hidden-console direct spawn for locked-down machines where the task
+    # could not be installed.
     pid = _spawn_detached()
     _report_gateway_start(f"direct spawn (PID {pid})")
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -2,6 +2,8 @@
 
 import logging
 import subprocess
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -314,9 +316,8 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
-def test_gateway_vbs_script_is_console_less(monkeypatch):
-    """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
-    (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""
+def test_gateway_vbs_script_is_console_less_and_supervised(monkeypatch):
+    """The VBS stays hidden but waits so Scheduler observes Python's exit."""
     monkeypatch.setattr(
         gateway_windows,
         "_resolve_detached_python",
@@ -333,11 +334,187 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert "pythonw.exe" in content
     assert "hermes_cli.main" in content
     assert "gateway run" in content
-    assert ", 0, False" in content  # hidden window, detached/async
+    assert ", 0, True)" in content  # hidden window, wait for gateway
+    assert "exit_code = sh.Run(" in content
+    assert "WScript.Quit exit_code" in content
+    assert ", 0, False" not in content
     for var in ("HERMES_HOME", "PYTHONIOENCODING", "HERMES_GATEWAY_DETACHED", "VIRTUAL_ENV", "PYTHONPATH"):
         assert var in content
     assert "--profile" in content and "work" in content
     assert content.endswith("\r\n")
+
+
+@pytest.mark.windows_only
+def test_gateway_vbs_waits_for_real_child_and_propagates_exit(monkeypatch, tmp_path):
+    project = tmp_path / "fake-project"
+    package = project / "hermes_cli"
+    hermes_home = tmp_path / "hermes-home"
+    marker = hermes_home / "child-started"
+    release = hermes_home / "release-child"
+    package.mkdir(parents=True)
+    hermes_home.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "main.py").write_text(
+        "import os\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        "home = Path(os.environ['HERMES_HOME'])\n"
+        "(home / 'child-started').write_text('ready')\n"
+        "deadline = time.monotonic() + 30\n"
+        "while not (home / 'release-child').exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.05)\n"
+        "raise SystemExit(23)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway_windows, "__file__", str(package / "gateway_windows.py")
+    )
+    launcher = tmp_path / "gateway.vbs"
+    launcher.write_text(
+        gateway_windows._build_gateway_vbs_script(
+            sys.executable, str(tmp_path), str(hermes_home), ""
+        ),
+        encoding="utf-8",
+        newline="",
+    )
+
+    process = subprocess.Popen(
+        ["wscript.exe", "//B", "//Nologo", str(launcher)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 15
+        while not marker.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert marker.read_text(encoding="utf-8") == "ready"
+        assert process.poll() is None
+        release.write_text("go", encoding="utf-8")
+        assert process.wait(timeout=10) == 23
+    finally:
+        release.touch(exist_ok=True)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest.mark.windows_only
+def test_install_start_now_uses_new_scheduled_task_as_restart_owner(
+    monkeypatch, tmp_path
+):
+    calls = []
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    monkeypatch.setattr(
+        gateway_windows,
+        "_prompt_install_choices",
+        lambda *args, **kwargs: (True, True),
+    )
+    monkeypatch.setattr(gateway_windows, "_is_running_as_admin", lambda: True)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda task_name, path: (True, "Installed Windows Scheduled Task"),
+    )
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        gateway_windows,
+        "_start_via_scheduled_task",
+        lambda: calls.append("scheduled-task") or [12345],
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda: pytest.fail("the newly installed task must own the gateway start"),
+    )
+    monkeypatch.setattr(gateway_windows, "_print_next_steps", lambda: None)
+
+    gateway_windows.install(start_now=True, start_on_login=True)
+
+    assert calls == ["scheduled-task"]
+
+
+@pytest.mark.windows_only
+def test_install_without_login_task_keeps_direct_start_fallback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        gateway_windows,
+        "_prompt_install_choices",
+        lambda *args, **kwargs: (True, False),
+    )
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda: calls.append("direct") or 12345,
+    )
+    monkeypatch.setattr(gateway_windows, "_report_gateway_start", lambda via: None)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_start_via_scheduled_task",
+        lambda: pytest.fail("no Scheduled Task was requested"),
+    )
+
+    gateway_windows.install(start_now=True, start_on_login=False)
+
+    assert calls == ["direct"]
+
+
+@pytest.mark.windows_only
+def test_start_uses_scheduled_task_as_restart_owner(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_start_via_scheduled_task",
+        lambda: calls.append("scheduled-task") or [12345],
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda: pytest.fail("an installed task must own the gateway start"),
+    )
+
+    gateway_windows.start()
+
+    assert calls == ["scheduled-task"]
+
+
+@pytest.mark.windows_only
+def test_start_via_scheduled_task_clears_stale_instance_and_verifies(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+
+    def fake_exec(args):
+        calls.append(tuple(args))
+        return (0, "SUCCESS", "")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_exec)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_wait_for_gateway_ready",
+        lambda timeout_s=6.0, interval_s=0.4: [23456],
+    )
+
+    assert gateway_windows._start_via_scheduled_task() == [23456]
+    assert calls == [
+        ("/End", "/TN", "Hermes_Gateway_alice"),
+        ("/Run", "/TN", "Hermes_Gateway_alice"),
+    ]
+
+
+@pytest.mark.windows_only
+def test_start_via_scheduled_task_fails_without_gateway(monkeypatch):
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", lambda args: (0, "SUCCESS", ""))
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda **kwargs: [])
+
+    with pytest.raises(RuntimeError, match="no gateway process was detected after 30s"):
+        gateway_windows._start_via_scheduled_task()
 
 
 
@@ -362,10 +539,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
-
-
-
 
 
 


### PR DESCRIPTION
## Summary
- keep the generated VBScript action attached to the gateway process and propagate Python's exit code
- route manual starts and install `--start-now` through an installed Scheduled Task
- preserve the direct hidden-console fallback when no Scheduled Task is installed

## Why
The task XML already configures `RestartOnFailure`, but the VBScript action used `bWaitOnReturn=False`. Task Scheduler therefore marked the action complete while the gateway kept running detached, so a later gateway exit was invisible and could not be restarted.

This keeps the existing least-privilege, interactive-user Scheduled Task boundary; it does not introduce a LocalSystem service. It complements #84409 by making the task a real lifetime supervisor when update recovery also routes through it. Addresses the supervision gap in #84694 and the follow-up discussion on #41662.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -q`: 15 passed
- repository Windows lane: 52 files, 158 passed, 0 failed, 1 skipped, no retry
- real Windows `wscript.exe` regression test proves the launcher stays alive with its child and returns the child's exit code
- `ruff check` and `git diff --check` pass