### PR TITLE
feat(desktop): add chat backdrop opacity slider

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -13,7 +13,15 @@ import { Check, Download, Loader2, Palette, Trash2 } from '@/lib/icons'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
-import { $backdrop, setBackdrop } from '@/store/backdrop'
+import {
+  $backdrop,
+  $backdropOpacity,
+  BACKDROP_OPACITY_MAX,
+  BACKDROP_OPACITY_MIN,
+  BACKDROP_OPACITY_STEP,
+  setBackdrop,
+  setBackdropOpacity
+} from '@/store/backdrop'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $introSplash, setIntroSplash } from '@/store/intro-splash'
@@ -357,6 +365,7 @@ export function AppearanceSettings() {
   const reactionsEnabled = useStore($reactionsEnabled)
   const vibeHeartsEnabled = useStore($vibeHeartsEnabled)
   const backdrop = useStore($backdrop)
+  const backdropOpacity = useStore($backdropOpacity)
   const introSplash = useStore($introSplash)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
@@ -705,6 +714,32 @@ export function AppearanceSettings() {
                 ]}
                 value={backdrop ? 'on' : 'off'}
               />
+            }
+            below={
+              backdrop ? (
+                <div className="mt-3 flex items-center gap-3">
+                  <span className="w-12 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                    {a.backdropOpacityTitle}
+                  </span>
+                  <input
+                    aria-label={a.backdropOpacityTitle}
+                    className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
+                    max={BACKDROP_OPACITY_MAX}
+                    min={BACKDROP_OPACITY_MIN}
+                    onChange={event => {
+                      triggerHaptic('selection')
+                      setBackdropOpacity(Number(event.target.value))
+                    }}
+                    step={BACKDROP_OPACITY_STEP}
+                    style={{ accentColor: 'var(--dt-primary)' }}
+                    type="range"
+                    value={backdropOpacity}
+                  />
+                  <span className="w-9 text-right text-[length:var(--conversation-caption-font-size)] tabular-nums text-(--ui-text-tertiary)">
+                    {backdropOpacity}%
+                  </span>
+                </div>
+              ) : undefined
             }
             description={a.backdropDesc}
             id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.backdrop)}

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -1,18 +1,23 @@
 import { useStore } from '@nanostores/react'
 
-import { $backdrop } from '@/store/backdrop'
+import { $backdrop, $backdropOpacity } from '@/store/backdrop'
 
 const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\/+/, '')}`
 
 export function Backdrop() {
   const on = useStore($backdrop)
+  const opacity = useStore($backdropOpacity)
 
-  if (!on) {
+  if (!on || opacity <= 0) {
     return null
   }
 
   return (
-    <div aria-hidden className="pointer-events-none absolute inset-0 z-2 opacity-[0.025] mix-blend-difference">
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-2 mix-blend-difference"
+      style={{ opacity: opacity / 100 }}
+    >
       <img
         alt=""
         className="h-[160dvh] w-auto min-w-dvw object-cover object-left-top [filter:invert(var(--backdrop-invert-mul,1))]"

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -465,6 +465,7 @@ export const ar = defineLocale({
       },
       backdropTitle: 'خلفية النافذة',
       backdropDesc: 'اختيار مقدار مزج خلفية سطح المكتب مع سطح Hermes.',
+      backdropOpacityTitle: 'الشفافية',
       introSplashTitle: 'شاشة المقدمة',
       introSplashDesc: 'الشعار النصي والعبارة التمهيدية في محادثة فارغة.',
       reactionsTitle: 'تفاعلات الرسائل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -584,6 +584,7 @@ export const en: Translations = {
       },
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
+      backdropOpacityTitle: 'Visibility',
       introSplashTitle: 'Intro Splash',
       introSplashDesc: 'The wordmark and prompt shown on an empty chat.',
       reactionsTitle: 'Message Reactions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -406,6 +406,7 @@ export const ja = defineLocale({
       },
       backdropTitle: 'チャット背景',
       backdropDesc: '会話の背後に表示される淡い彫像の画像。',
+      backdropOpacityTitle: '不透明度',
       introSplashTitle: 'イントロ表示',
       introSplashDesc: '空のチャットに表示されるワードマークとプロンプト。',
       reactionsTitle: 'メッセージリアクション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -474,6 +474,7 @@ export interface Translations {
       }
       backdropTitle: string
       backdropDesc: string
+      backdropOpacityTitle: string
       introSplashTitle: string
       introSplashDesc: string
       reactionsTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -396,6 +396,7 @@ export const zhHant = defineLocale({
       },
       backdropTitle: '聊天背景',
       backdropDesc: '對話後方那張淡淡的雕像圖片。',
+      backdropOpacityTitle: '不透明度',
       introSplashTitle: '開場標識',
       introSplashDesc: '空白對話中顯示的字標和提示語。',
       reactionsTitle: '訊息回應',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -570,6 +570,7 @@ export const zh: Translations = {
       },
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
+      backdropOpacityTitle: '不透明度',
       introSplashTitle: '开场标识',
       introSplashDesc: '空白对话中显示的字标和提示语。',
       reactionsTitle: '消息回应',

--- a/apps/desktop/src/store/backdrop.test.ts
+++ b/apps/desktop/src/store/backdrop.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $backdropOpacity,
+  BACKDROP_OPACITY_DEFAULT,
+  BACKDROP_OPACITY_MAX,
+  BACKDROP_OPACITY_MIN,
+  clampBackdropOpacity,
+  setBackdropOpacity
+} from '@/store/backdrop'
+
+const OPACITY_KEY = 'hermes.desktop.backdrop-opacity.v1'
+
+describe('backdrop opacity', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(OPACITY_KEY)
+    // Reset to the pre-lever default without going through the setter's
+    // persist path first.
+    $backdropOpacity.set(BACKDROP_OPACITY_DEFAULT)
+  })
+
+  it('defaults to the pre-lever visual strength so existing installs see no change', () => {
+    expect($backdropOpacity.get()).toBe(BACKDROP_OPACITY_DEFAULT)
+  })
+
+  it('sets and persists a new value', () => {
+    setBackdropOpacity(40)
+    expect($backdropOpacity.get()).toBe(40)
+    expect(window.localStorage.getItem(OPACITY_KEY)).toBe('40')
+  })
+
+  it('clamps above the max', () => {
+    setBackdropOpacity(500)
+    expect($backdropOpacity.get()).toBe(BACKDROP_OPACITY_MAX)
+  })
+
+  it('clamps below the min', () => {
+    setBackdropOpacity(-20)
+    expect($backdropOpacity.get()).toBe(BACKDROP_OPACITY_MIN)
+  })
+
+  it('falls back to the default for a non-finite value', () => {
+    expect(clampBackdropOpacity(Number.NaN)).toBe(BACKDROP_OPACITY_DEFAULT)
+    expect(clampBackdropOpacity(Number.POSITIVE_INFINITY)).toBe(BACKDROP_OPACITY_DEFAULT)
+  })
+
+  it('falls back to the default when the stored value is malformed', () => {
+    window.localStorage.setItem(OPACITY_KEY, 'not-a-number')
+    // Re-run the module's read path the way a fresh load would: the store
+    // itself only reads storage once at import time, so we exercise the
+    // same clamp/parse helper a reload would use.
+    expect(clampBackdropOpacity(Number('not-a-number'))).toBe(BACKDROP_OPACITY_DEFAULT)
+  })
+})

--- a/apps/desktop/src/store/backdrop.ts
+++ b/apps/desktop/src/store/backdrop.ts
@@ -1,8 +1,9 @@
 import { atom } from 'nanostores'
 
-import { persistBoolean, storedBoolean } from '@/lib/storage'
+import { persistBoolean, readKey, storedBoolean, writeKey } from '@/lib/storage'
 
 const KEY = 'hermes.desktop.backdrop.v1'
+const OPACITY_KEY = 'hermes.desktop.backdrop-opacity.v1'
 
 /** Whether the faint statue image renders behind the chat transcript. */
 export const $backdrop = atom(storedBoolean(KEY, false))
@@ -11,4 +12,41 @@ $backdrop.subscribe(on => persistBoolean(KEY, on))
 
 export function setBackdrop(on: boolean) {
   $backdrop.set(on)
+}
+
+// The image ships tuned for a barely-there watermark (2.5%), so that stays the
+// default for anyone who never touches the new lever — only an explicit visit
+// to Settings changes what's on screen.
+export const BACKDROP_OPACITY_DEFAULT = 2.5
+export const BACKDROP_OPACITY_MIN = 0
+export const BACKDROP_OPACITY_MAX = 100
+export const BACKDROP_OPACITY_STEP = 0.5
+
+export function clampBackdropOpacity(value: number): number {
+  if (!Number.isFinite(value)) {
+    return BACKDROP_OPACITY_DEFAULT
+  }
+
+  return Math.min(BACKDROP_OPACITY_MAX, Math.max(BACKDROP_OPACITY_MIN, value))
+}
+
+const storedOpacity = (): number => {
+  const raw = readKey(OPACITY_KEY)
+
+  if (raw === null) {
+    return BACKDROP_OPACITY_DEFAULT
+  }
+
+  const parsed = Number(raw)
+
+  return Number.isFinite(parsed) ? clampBackdropOpacity(parsed) : BACKDROP_OPACITY_DEFAULT
+}
+
+/** How visible the statue image is, 0–100 (percent), independent of the on/off toggle. */
+export const $backdropOpacity = atom(storedOpacity())
+
+$backdropOpacity.subscribe(value => writeKey(OPACITY_KEY, String(value)))
+
+export function setBackdropOpacity(value: number) {
+  $backdropOpacity.set(clampBackdropOpacity(value))
 }


### PR DESCRIPTION
## What does this PR do?

Adds an Appearance -> Chat Backdrop **Visibility** slider (0-100%) that controls how visible the decorative statue image is behind the chat transcript, independent of the existing on/off toggle.

## Related Issue

No linked issue. Related prior art:

- #64598 added the on/off toggle for the backdrop (merged).
- #54413 proposed this same idea earlier and was self-closed by its own author citing "not necessary with the new toggle" -- but that toggle is binary on/off, not a continuous visibility control, so I don't believe it's actually a duplicate/superseded case. Reopening the idea here with tests and a rationale for review.
- #54276 (open) proposes a different, coarser Off/Subtle/Full accessibility control bundled with unrelated theme changes. This PR is scoped narrowly to a continuous slider only, matching the existing Translucency slider's UX pattern already in Appearance settings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/store/backdrop.ts` -- new `$backdropOpacity` atom (0-100, persisted independently of the on/off toggle), `setBackdropOpacity`, and a `clampBackdropOpacity` helper. Defaults to `2.5` (the prior hardcoded opacity), so existing installs see no visual change until the lever is touched.
- `apps/desktop/src/store/backdrop.test.ts` -- new Vitest coverage: default value, persistence, clamping above/below range, non-finite input handling.
- `apps/desktop/src/components/Backdrop.tsx` -- applies opacity via inline `style` instead of the previous fixed Tailwind opacity class; short-circuits to `null` when opacity is 0.
- `apps/desktop/src/app/settings/appearance-settings.tsx` -- adds a "Visibility" slider under the Chat Backdrop row, shown only while the toggle is on, styled to match the existing Translucency slider.
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar,types}.ts` -- adds the `backdropOpacityTitle` label across all five bundled locales.

## How to Test

1. `npm --workspace apps/desktop run test:ui -- src/store/backdrop.test.ts`
2. `npm --workspace apps/desktop run typecheck` (or `npx tsc --noEmit -p tsconfig.json` from `apps/desktop`)
3. `npx eslint src/store/backdrop.ts src/store/backdrop.test.ts src/components/Backdrop.tsx src/app/settings/appearance-settings.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/ar.ts src/i18n/types.ts` from `apps/desktop`
4. Launch the desktop app -> Settings -> Appearance -> turn on Chat Backdrop -> drag the new Visibility slider and confirm the statue image's opacity updates live and persists across a restart.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see Related Issue above for the closest prior art and why this is scoped differently)
- [x] My PR contains only changes related to this feature
- [x] I've run the desktop test/typecheck/lint commands above and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A -- no README/docs/config-key changes needed for this renderer-only preference
- [x] N/A -- no architecture/workflow changes to CONTRIBUTING.md/AGENTS.md
- [x] N/A -- pure renderer preference, no platform-specific behavior
- [x] N/A -- no tool schema changes

## Screenshots / Logs

Vitest output:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```
