### PR TITLE
fix(desktop): deliver transform_llm_output result to the streamed message

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -348,7 +348,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
           }
         : undefined
 
-    completeAssistantMessage(sessionId, finalText, payload?.response_previewed, failure, occurredAt)
+    completeAssistantMessage(
+      sessionId,
+      finalText,
+      payload?.response_previewed,
+      payload?.response_transformed,
+      failure,
+      occurredAt
+    )
 
     // Structured billing wall forwarded by the gateway (out of credits /
     // payment required) — cache it + raise a billing-specific toast.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -18,6 +18,7 @@ export interface GatewayEventDeps {
     sessionId: string,
     text: string,
     responsePreviewed?: boolean,
+    responseTransformed?: boolean,
     failure?: { error: string; partial: boolean },
     occurredAt?: number
   ) => void

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -562,6 +562,7 @@ export function useMessageStream({
       sessionId: string,
       text: string,
       responsePreviewed?: boolean,
+      responseTransformed?: boolean,
       failure?: { error: string; partial: boolean; surface?: ErrorSurface | null },
       occurredAt = Date.now() / 1000
     ) => {
@@ -678,7 +679,20 @@ export function useMessageStream({
               (finalText === existingText || finalText.startsWith(existingText) || existingText.startsWith(finalText))
             )
 
-            if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {
+            // A transform_llm_output plugin hook rewrites the final text after
+            // streaming finishes (e.g. restoring pseudonyms to real values).
+            // The rewritten text can share NO prefix relationship with what was
+            // streamed, yet it is still this turn's authoritative reply: settle
+            // it onto the current turn's bubble in place instead of appending a
+            // duplicate (which session reconciliation would then suppress,
+            // leaving the pre-transform text on screen while the DB holds the
+            // transformed one). Gated on sawAssistantPayload so a stale/foreign
+            // completion cannot overwrite an unrelated previous bubble.
+            const transformedCurrentReply = Boolean(
+              responseTransformed && state.sawAssistantPayload && finalText
+            )
+
+            if (existing.pending || transformedCurrentReply || (!interimBoundaryPending && finalText && existingText === finalText)) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/transformed-final.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/transformed-final.test.tsx
@@ -1,0 +1,102 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { chatMessageText } from '@/lib/chat-messages'
+import { clearSessionTodos } from '@/store/todos'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+const start = () => act(() => stream.handleEvent({ payload: {}, session_id: SID, type: 'message.start' }))
+
+const delta = (text: string) =>
+  act(() => stream.handleEvent({ payload: { text }, session_id: SID, type: 'message.delta' }))
+
+const interim = (text: string) =>
+  act(() => stream.handleEvent({ payload: { text, already_streamed: true }, session_id: SID, type: 'message.interim' }))
+
+const completeTransformed = (text: string) =>
+  act(() =>
+    stream.handleEvent({ payload: { text, response_transformed: true }, session_id: SID, type: 'message.complete' })
+  )
+
+function getState(): ClientSessionState {
+  return stream.state()
+}
+
+function assistantTexts(): string[] {
+  const state = getState()
+  return state.messages
+    .filter(m => m.role === 'assistant' && !m.hidden)
+    .map(m => chatMessageText(m))
+    .filter(Boolean)
+}
+
+describe('useMessageStream response_transformed settlement', () => {
+  beforeEach(() => {
+    clearSessionTodos(SID)
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearSessionTodos(SID)
+    vi.restoreAllMocks()
+  })
+
+  it('replaces the streamed bubble with transformed final text that shares no prefix', async () => {
+    mountStream()
+    await start()
+
+    // A transform_llm_output plugin hook (e.g. pseudonym restore) rewrites the
+    // final text after streaming finishes. The rewritten text shares NO prefix
+    // relationship with what was streamed: the prefix-continuity heuristic must
+    // not reject it — it is this turn's authoritative reply.
+    await delta('TOKEN_1')
+    await interim('TOKEN_1')
+    await completeTransformed('example-service.internal')
+
+    const texts = assistantTexts()
+    expect(texts).toHaveLength(1)
+    expect(texts[0]).toBe('example-service.internal')
+    expect(texts).not.toContain('TOKEN_1')
+  })
+
+  it('clears the interim mark when the transformed final settles onto the bubble', async () => {
+    mountStream()
+    await start()
+
+    await delta('TOKEN_1')
+    await interim('TOKEN_1')
+    await completeTransformed('example-service.internal')
+
+    const assistants = getState().messages.filter(m => m.role === 'assistant' && !m.hidden)
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0].interim).toBeFalsy()
+    expect(assistants[0].pending).toBe(false)
+  })
+
+  it('does not overwrite an unrelated bubble after a message.start reset', async () => {
+    mountStream()
+    await start()
+    await interim('old reply')
+
+    // A new turn begins: message.start resets sawAssistantPayload. A stale or
+    // foreign transformed completion must NOT overwrite the previous bubble —
+    // the sawAssistantPayload gate keeps it from settling there.
+    await start()
+    await completeTransformed('totally new answer')
+
+    const texts = assistantTexts()
+    expect(texts).toContain('old reply')
+    expect(texts).toContain('totally new answer')
+    expect(texts).toHaveLength(2)
+  })
+})

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -163,6 +163,10 @@ export type GatewayEventPayload = {
   // message.complete — signals the final text was already previewed via
   // interim_assistant_callback, so the UI can settle instead of duplicating.
   response_previewed?: boolean
+  // message.complete — a transform_llm_output hook rewrote the final text
+  // after streaming finished. The text authoritatively replaces the current
+  // turn's streamed assistant text even without a prefix relationship.
+  response_transformed?: boolean
   // message.complete with status "error" — `text` is streamed partial output
   // (keep it visible), not the error string.
   partial?: boolean

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -21078,3 +21078,98 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_prompt_submit_message_complete_carries_response_transformed(monkeypatch):
+    """A transform_llm_output plugin hook rewrites the final text after
+    streaming finishes (agent/turn_finalizer.py sets response_transformed on
+    the turn result). Desktop sessions deliver through _run_prompt_submit, so
+    the message.complete payload must forward that flag — the renderer needs
+    it to authoritatively replace the streamed bubble with text that may share
+    no prefix relationship with what was streamed (e.g. pseudonym restore)."""
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            assert self._target is not None
+            self._target()
+
+    def _make_agent(final_result: dict):
+        class _Agent:
+            model = "gold-model"
+            provider = "gold-provider"
+            session_id = "session-key"
+            session_input_tokens = 10
+            session_output_tokens = 5
+            session_prompt_tokens = 10
+            session_completion_tokens = 5
+            session_total_tokens = 15
+            session_api_calls = 1
+            context_compressor = None
+
+            def clear_interrupt(self):
+                return None
+
+            def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+                if stream_callback is not None:
+                    stream_callback("TOKEN_1")
+                return final_result
+
+        return _Agent()
+
+    fixed_info = {"model": "gold-model", "provider": "gold-provider", "usage": {"total": 15}}
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: dict(fixed_info))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    fake_title = types.ModuleType("agent.title_generator")
+    setattr(fake_title, "maybe_auto_title", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "agent.title_generator", fake_title)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}})
+
+    def _run_turn(final_result: dict):
+        events: list[tuple] = []
+        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+        server._sessions["sid"] = _session(agent=_make_agent(final_result))
+        try:
+            server.handle_request(
+                {"id": "turn-1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
+            )
+            return events
+        finally:
+            server._sessions.pop("sid", None)
+
+    # Hook rewrote the final text: the flag must ride on message.complete so
+    # the renderer can settle the rewritten text onto the streamed bubble.
+    transformed_result = {
+        "final_response": "example-service.internal",
+        "response_transformed": True,
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "example-service.internal"},
+        ],
+    }
+    events = _run_turn(transformed_result)
+    completes = [(e, sid, p) for e, sid, p in events if e == "message.complete"]
+    assert completes, "message.complete was never emitted"
+    _, _, payload = completes[-1]
+    assert payload.get("response_transformed") is True
+    assert payload.get("text") == "example-service.internal"
+
+    # No hook ran: the flag must be absent (old behavior preserved).
+    plain_result = {
+        "final_response": "TOKEN_1",
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "TOKEN_1"},
+        ],
+    }
+    events = _run_turn(plain_result)
+    completes = [(e, sid, p) for e, sid, p in events if e == "message.complete"]
+    assert completes, "message.complete was never emitted"
+    _, _, payload = completes[-1]
+    assert "response_transformed" not in payload

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12487,6 +12487,13 @@ def _run_prompt_submit(
                 payload["warning"] = status_note
             if result.get("response_previewed"):
                 payload["response_previewed"] = True
+            # A transform_llm_output plugin hook may have rewritten the final
+            # text after streaming finished. Tell the renderer so it treats
+            # this payload as the authoritative replacement for the current
+            # turn's streamed assistant text even when there is no prefix
+            # relationship between the streamed and final text.
+            if isinstance(result, dict) and result.get("response_transformed"):
+                payload["response_transformed"] = True
             # Forward the structured billing-wall descriptor (provider,
             # billing_url, is_nous, message) so the TUI/desktop render a
             # billing-specific recovery surface instead of re-parsing text.


### PR DESCRIPTION
## What does this PR do?

A `transform_llm_output` plugin hook runs once per turn after the tool-calling
loop completes (`agent/turn_finalizer.py`) and rewrites the assistant's final
response text before delivery. On messaging-platform sessions the gateway
reconciles the rewritten text by editing the already-streamed message
(`gateway/run.py`, the `response_transformed` branch), but desktop sessions
bypass that path entirely: `tui_gateway/server.py` drives `run_conversation`
directly and emits `message.complete` over the WebSocket.

The transformed final text already reaches the desktop renderer inside
`message.complete.payload.text` — but the renderer reconciliation
(`use-message-stream/index.ts`) only settles the final text onto the streamed
bubble when there is a prefix relationship between the streamed text and the
final text. When the hook rewrites tokens mid-message (e.g. a pseudonym-restore
redaction plugin replacing `<TOKEN_1>` with `example-service.internal`), no
prefix relationship exists, so the streamed bubble keeps the pre-transform text
while the corrected text lands only in `state.db`.

This PR forwards `response_transformed` on the `message.complete` payload and
treats it as an authoritative in-place replacement of the current turn's
streamed bubble in the renderer. The replacement is gated on
`sawAssistantPayload` (reset on every `message.start`) so a stale or foreign
completion cannot overwrite an unrelated previous bubble.

Backward compatible: old clients ignore the new field; no new event type or
relay op is introduced.

## Related Issue

Fixes #96465

Follow-up to #21235, which added the hook. Checked the open
`transform_llm_output` issues — #67890 (shell-hook stdout), #57282 (Honcho
memory leak), #50937 (non-default profiles), #87319 (sequential pipeline),
#77981 (Kanban attachments) — all distinct from this desktop-delivery gap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — forward `response_transformed` from the turn result onto the `message.complete` payload
- `apps/desktop/src/lib/chat-messages/types.ts` — add `response_transformed?: boolean` to `GatewayEventPayload`
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts` — extend `completeAssistantMessage` signature with `responseTransformed`
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts` — pass `payload.response_transformed` through
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts` — settle a transformed final onto the current turn's bubble in place even without prefix continuity, gated on `sawAssistantPayload`
- `tests/test_tui_gateway_server.py` — payload flag present when the turn result is transformed, absent otherwise
- `apps/desktop/.../use-message-stream/transformed-final.test.tsx` — renderer settles a prefix-unrelated transformed final onto the streamed bubble; guard against overwriting unrelated bubbles after a `message.start` reset

## How to Test

1. Register a minimal plugin hook:
   ```python
   ctx.register_hook(
       "transform_llm_output",
       lambda **kw: kw["response_text"] + " [TRANSFORMED]",
   )
   ```
2. Start a desktop session and ask anything.
3. Before this change: the on-screen reply lacks `[TRANSFORMED]`; the transcript in `state.db` contains it.
4. After this change: the on-screen reply ends with `[TRANSFORMED]`.

Also verified with a mid-message rewrite (token → value substitution), the
pseudonym-restore use case that motivated the fix.

Automated:

- `pytest tests/test_tui_gateway_server.py tests/test_transform_llm_output_hook.py -q` — 614 passed, 2 pre-existing failures unrelated to this change (`test_load_enabled_toolsets_*`, failing on clean `main` as well)
- `vitest run --project ui src/app/session/hooks/use-message-stream/ src/lib/chat-messages/` — 133 passed
- `tsc --build tsconfig.json` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(scoped to the affected suites; two pre-existing failures on clean `main` documented above)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04, Hermes v0.20.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(behavior documented in code comments; no docs page describes this internal payload field)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(change is platform-agnostic TypeScript + Python event payload)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed on a live desktop session (plugin pseudonym restore):

```
agent.log:
  hermes-redact llm_request: REDACTED session=<sid> forward_map={('INTERNAL_SERVICE', '<real value>'): '<INTERNAL_SERVICE_1>'}
  hermes-redact transform_llm_output: session_id=<sid> text_len=22
  hermes-redact transform_llm_output: RESTORED session=<sid>
```

Hook restored the token to the real value; `state.db` stored the restored text;
the desktop bubble kept showing the streamed token. `gateway.log` shows no
activity for the affected turns (desktop sessions do not traverse the gateway
reconciliation branch). After this patch the renderer settles the restored text
onto the bubble in place.
