### PR TITLE
fix(desktop): arm the backend READY scanner at spawn instead of after the claim (#96315)

### DIFF
--- a/apps/desktop/electron/backend-claim.test.ts
+++ b/apps/desktop/electron/backend-claim.test.ts
@@ -130,3 +130,45 @@ test('attach tolerates a child with missing stdio streams', () => {
   tail.attach({ stderr: null, stdout: null })
   assert.equal(tail.text(), '')
 })
+
+test('observe() receives raw chunks from both streams and unsubscribes cleanly', () => {
+  const child = { stderr: new EventEmitter(), stdout: new EventEmitter() }
+  const tail = createBackendOutputTail(64)
+  const seen: string[] = []
+
+  tail.attach(child)
+  const stop = tail.observe(chunk => seen.push(chunk))
+
+  child.stdout.emit('data', Buffer.from('out\n'))
+  child.stderr.emit('data', Buffer.from('err\n'))
+  stop()
+  child.stdout.emit('data', Buffer.from('after\n'))
+
+  assert.deepEqual(seen, ['out\n', 'err\n'])
+})
+
+test('observe() sees chunks the ring buffer has already evicted', () => {
+  const tail = createBackendOutputTail(8)
+  const seen: string[] = []
+
+  tail.observe(chunk => seen.push(chunk))
+  tail.append('HERMES_BACKEND_READY port=50468\n')
+
+  assert.equal(seen.length, 1)
+  assert.match(seen[0], /port=50468/)
+  assert.doesNotMatch(tail.text(), /HERMES_BACKEND_READY/)
+})
+
+test('a throwing observer cannot break buffering or the other observers', () => {
+  const tail = createBackendOutputTail(64)
+  const seen: string[] = []
+
+  tail.observe(() => {
+    throw new Error('observer fault')
+  })
+  tail.observe(chunk => seen.push(chunk))
+
+  assert.doesNotThrow(() => tail.append('still buffered\n'))
+  assert.deepEqual(seen, ['still buffered\n'])
+  assert.match(tail.text(), /still buffered/)
+})

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -153,6 +153,18 @@ export interface BackendOutputTail {
     stderr?: { on: (event: 'data', listener: (chunk: unknown) => void) => unknown } | null
   }): void
   append(chunk: unknown): void
+  /**
+   * Register an observer for every chunk this tail receives, on both streams.
+   * Returns an unsubscribe function.
+   *
+   * The tail is the only listener attached at spawn time, and a Node stream in
+   * flowing mode delivers each chunk exactly once to the listeners that exist
+   * when it is emitted — a listener attached later never sees it. Anything that
+   * has to read the child's output (the port-announcement scanner) therefore
+   * reads it through here instead of racing to attach a second `data` listener
+   * of its own after the claim (#96315).
+   */
+  observe(listener: (chunk: string) => void): () => void
   /** The buffered tail (most recent `limit` characters), or ''. */
   text(): string
   /** Human-readable suffix for error messages, or '' when nothing buffered. */
@@ -169,12 +181,25 @@ export const DEFAULT_OUTPUT_TAIL_LIMIT = 8192
  */
 export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMIT): BackendOutputTail {
   let buffer = ''
+  const observers = new Set<(chunk: string) => void>()
 
   const append = (chunk: unknown) => {
-    buffer += String(chunk)
+    const text = String(chunk)
+    buffer += text
 
     if (buffer.length > limit) {
       buffer = buffer.slice(buffer.length - limit)
+    }
+
+    // Observers see the raw chunk, not the ring buffer, so a burst of output
+    // larger than `limit` can never evict a line before it has been scanned.
+    // An observer must not be able to break output buffering for the others.
+    for (const observer of observers) {
+      try {
+        observer(text)
+      } catch {
+        /* observer faults are never the child's problem */
+      }
     }
   }
 
@@ -183,6 +208,13 @@ export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMI
     attach(child) {
       child.stdout?.on('data', append)
       child.stderr?.on('data', append)
+    },
+    observe(listener) {
+      observers.add(listener)
+
+      return () => {
+        observers.delete(listener)
+      }
     },
     text() {
       return buffer

--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -19,7 +19,9 @@ import path from 'node:path'
 
 import { test } from 'vitest'
 
+import { createBackendOutputTail } from './backend-claim'
 import {
+  armPortAnnouncement,
   DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS,
   MIN_PORT_ANNOUNCE_TIMEOUT_MS,
   readDashboardReadyFile,
@@ -30,17 +32,32 @@ import {
 } from './backend-ready'
 
 type FakeChildProcess = EventEmitter & {
+  stderr: EventEmitter
   stdout: EventEmitter
 }
 
-// A minimal stand-in for a spawned child process: an EventEmitter with a
-// stdout EventEmitter, matching the surface waitForDashboardPort consumes
-// (child.stdout.on('data'), child.on('exit'|'error') + the .off() teardown).
+// A minimal stand-in for a spawned child process: an EventEmitter with stdout
+// and stderr EventEmitters, matching the surface the waiters and the output
+// tail consume (child.std*.on('data'), child.on('exit'|'error') + .off()).
 function makeFakeChild(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
   child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
 
   return child
+}
+
+/**
+ * Reproduce the spawn path's real ordering: attach the output tail and arm the
+ * announcement in one tick, then let the caller emit output BEFORE the waiter
+ * is created — which is what happens while `claimBackendChild` is awaited.
+ */
+function spawnWithArmedTail() {
+  const child = makeFakeChild()
+  const tail = createBackendOutputTail()
+  tail.attach(child)
+
+  return { announcement: armPortAnnouncement(tail), child, tail }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +154,121 @@ test('a late announcement after timeout does not throw (listeners torn down)', a
   assert.doesNotThrow(() => {
     child.stdout.emit('data', 'HERMES_DASHBOARD_READY port=9999\n')
   })
+})
+
+// ---------------------------------------------------------------------------
+// armPortAnnouncement (#96315): the sentinel is scanned from the spawn-time
+// output tail, so it survives the awaits between spawn and the READY wait.
+// ---------------------------------------------------------------------------
+
+test('resolves a sentinel that was emitted BEFORE the waiter was created', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+
+  // The claim is in flight here; the only listener on the stream is the tail.
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=50468\n')
+  child.stdout.emit('data', '  Hermes backend listening on 127.0.0.1:50468\n')
+
+  // Waiter created several awaits later — pre-fix this could never settle and
+  // burned the full deadline against a healthy, listening backend.
+  const port = await waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 50 })
+  assert.equal(port, 50468)
+})
+
+test('a late-created waiter WITHOUT the armed announcement misses the sentinel', async () => {
+  const child = makeFakeChild()
+  const tail = createBackendOutputTail()
+  tail.attach(child)
+
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=50468\n')
+
+  // Documents the bug this fix removes: the tail consumed the chunk, and a
+  // `data` listener attached afterwards can never see it again.
+  await assert.rejects(waitForDashboardPortAnnouncement(child, { timeoutMs: 20 }), /Timed out/)
+  assert.match(tail.text(), /HERMES_BACKEND_READY port=50468/)
+})
+
+test('resolves a sentinel that lands on stderr (import-time stdout redirect)', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+  const wait = waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 1000 })
+
+  child.stderr.emit('data', 'INFO: started\nHERMES_BACKEND_READY port=43210\n')
+
+  assert.equal(await wait, 43210)
+})
+
+test('parses a tail-fed sentinel split across chunks and across streams', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+  const wait = waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 1000 })
+
+  child.stderr.emit('data', 'HERMES_BACKEND_READY po')
+  child.stderr.emit('data', 'rt=8080\n')
+
+  assert.equal(await wait, 8080)
+})
+
+test('a burst larger than the tail ring cannot evict an unscanned sentinel', async () => {
+  const child = makeFakeChild()
+  const tail = createBackendOutputTail(64)
+  tail.attach(child)
+  const announcement = armPortAnnouncement(tail)
+
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=61234\n')
+  child.stdout.emit('data', `${'x'.repeat(4096)}\n`)
+
+  // The ring buffer has long since dropped the line; the scanner saw the chunk.
+  assert.doesNotMatch(tail.text(), /HERMES_BACKEND_READY/)
+  assert.equal(await waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 50 }), 61234)
+})
+
+test('the armed announcement settles the ready-file wait when no file appears', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+  const readyFile = path.join(os.tmpdir(), `hermes-ready-absent-${process.pid}-${Date.now()}.json`)
+
+  const wait = waitForDashboardPortAnnouncement(child, { announcement, readyFile, timeoutMs: 1000 })
+
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=7777\n')
+
+  assert.equal(await wait, 7777)
+})
+
+test('exit before any announcement still rejects with the output tail', async () => {
+  const { announcement, child, tail } = spawnWithArmedTail()
+
+  child.stderr.emit('data', 'ModuleNotFoundError: hermes_cli\n')
+
+  const wait = waitForDashboardPortAnnouncement(child, {
+    announcement,
+    describeOutputTail: () => tail.describe(),
+    timeoutMs: 1000
+  })
+
+  child.emit('exit', 1, null)
+
+  await assert.rejects(wait, /exited before port announcement \(1\)[\s\S]*ModuleNotFoundError: hermes_cli/)
+})
+
+test('a settled waiter detaches from the tail (a later sentinel is inert)', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+  const wait = waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 1000 })
+
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=5555\n')
+  assert.equal(await wait, 5555)
+
+  assert.doesNotThrow(() => {
+    child.stdout.emit('data', 'HERMES_BACKEND_READY port=9999\n')
+  })
+  assert.equal(announcement.port(), 5555)
+})
+
+test('a timed-out armed waiter tears down and does not double-settle', async () => {
+  const { announcement, child } = spawnWithArmedTail()
+
+  await assert.rejects(waitForDashboardPortAnnouncement(child, { announcement, timeoutMs: 20 }), /Timed out/)
+
+  assert.doesNotThrow(() => {
+    child.stdout.emit('data', 'HERMES_BACKEND_READY port=9999\n')
+  })
+  assert.equal(announcement.port(), null)
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs'
 
+import type { BackendOutputTail } from './backend-claim'
+
 // `hermes serve` announces HERMES_BACKEND_READY; the legacy `hermes dashboard`
 // backend announces HERMES_DASHBOARD_READY. Accept either so the desktop spawn
 // works against both the headless backend and old/dashboard runtimes.
@@ -35,6 +37,111 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
 }
 
 /**
+ * Line-buffered scanner for the port-announcement sentinel.
+ *
+ * One implementation, fed either by the spawn-time output tail (the armed
+ * path) or by a raw `data` listener (the legacy path), so both parse the
+ * sentinel identically — including a line split across chunk boundaries.
+ * Latches the first match: later output can never re-settle it.
+ */
+function createReadyLineScanner(onPort: (port: number) => void) {
+  let buf = ''
+  let port: number | null = null
+
+  return {
+    feed(chunk: unknown) {
+      if (port !== null) {
+        return
+      }
+
+      buf += String(chunk)
+
+      let nl
+
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl)
+        buf = buf.slice(nl + 1)
+        const m = line.match(_READY_RE)
+
+        if (m) {
+          port = parseInt(m[1], 10)
+          onPort(port)
+
+          return
+        }
+      }
+    },
+    port() {
+      return port
+    }
+  }
+}
+
+/**
+ * The port announcement, armed on the spawn-time output tail.
+ *
+ * `port()` is the already-observed port (null until the sentinel arrives);
+ * `whenAnnounced(cb)` fires the callback once, immediately if the sentinel was
+ * already seen. Never rejects and owns no timers — deadline, exit and error
+ * handling stay with the waiters below.
+ */
+export interface PortAnnouncement {
+  port(): number | null
+  whenAnnounced(listener: (port: number) => void): void
+  dispose(): void
+}
+
+/**
+ * Arm the port-announcement scanner on a child's output tail (#96315).
+ *
+ * MUST be called synchronously after `tail.attach(child)` — before the first
+ * `await` in the spawn path. This is the whole fix: the readiness sentinel is
+ * matched by a listener that exists from the instant of spawn, instead of by
+ * one attached several awaits later (after `claimBackendChild`, whose Windows
+ * start-marker probe alone budgets 30s of PowerShell). A stream in flowing
+ * mode hands each chunk only to the listeners present when it is emitted, so
+ * an announcement that arrived during those awaits was delivered to the tail
+ * and to nothing else — the waiter then sat on a promise that could no longer
+ * be resolved and burned the full 90s deadline against a healthy, listening
+ * backend, which is exactly the reported failure.
+ *
+ * Reading through the tail also means both streams are covered for free: the
+ * tail attaches to stdout AND stderr, so a runtime whose sentinel lands on
+ * stderr (a `sys.stdout` redirect installed at import time by
+ * `tui_gateway/server.py`, see #96282/#96324) is handled by the same code
+ * path rather than by a second channel.
+ */
+export function armPortAnnouncement(tail: BackendOutputTail): PortAnnouncement {
+  let listener: ((port: number) => void) | null = null
+
+  const scanner = createReadyLineScanner(port => {
+    unsubscribe()
+    listener?.(port)
+  })
+
+  const unsubscribe = tail.observe(chunk => scanner.feed(chunk))
+
+  return {
+    port: scanner.port,
+    whenAnnounced(next) {
+      const seen = scanner.port()
+
+      if (seen !== null) {
+        next(seen)
+
+        return
+      }
+
+      listener = next
+    },
+    dispose() {
+      listener = null
+      unsubscribe()
+    }
+  }
+}
+
+/**
  * Watch a child process's stdout for the `HERMES_(BACKEND|DASHBOARD)_READY
  * port=<N>` line that web_server.py prints after uvicorn binds its socket.
  *
@@ -50,11 +157,24 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  * A single `cleanup()` tears down every listener (data/exit/error/timeout)
  * on every terminal path — resolve, reject, or timeout — so repeated
  * backend spawns don't leak listener slots on the child.
+ *
+ * Pass `announcement` (from `armPortAnnouncement`, armed at spawn time) to
+ * read the sentinel out of the output tail instead of attaching a `data`
+ * listener here — see `armPortAnnouncement` for why that ordering matters.
+ * Without it the legacy stdout-only listener is used, which is correct only
+ * when this waiter is created in the same tick as the spawn.
  */
-function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
+function waitForDashboardPort(
+  child,
+  timeoutMs = resolvePortAnnounceTimeoutMs(),
+  describeOutputTail = () => '',
+  announcement: PortAnnouncement | null = null
+) {
   return new Promise((resolve, reject) => {
-    let buf = ''
     let done = false
+
+    // Legacy path only: the armed path reads through the tail instead.
+    const scanner = announcement ? null : createReadyLineScanner(port => settle(port))
 
     function cleanup() {
       if (done) {
@@ -63,27 +183,24 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
 
       done = true
       clearTimeout(timer)
-      child.stdout.off('data', onData)
+
+      if (announcement) {
+        announcement.dispose()
+      } else {
+        child.stdout.off('data', onData)
+      }
+
       child.off('exit', onExit)
       child.off('error', onError)
     }
 
+    function settle(port: number) {
+      cleanup()
+      resolve(port)
+    }
+
     function onData(chunk) {
-      buf += chunk.toString()
-      let nl
-
-      while ((nl = buf.indexOf('\n')) !== -1) {
-        const line = buf.slice(0, nl)
-        buf = buf.slice(nl + 1)
-        const m = line.match(_READY_RE)
-
-        if (m) {
-          cleanup()
-          resolve(parseInt(m[1], 10))
-
-          return
-        }
-      }
+      scanner?.feed(chunk)
     }
 
     function onExit(code, signal) {
@@ -101,9 +218,16 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
       reject(new Error(`Timed out waiting for Hermes backend port announcement (${timeoutMs}ms)`))
     }, timeoutMs)
 
-    child.stdout.on('data', onData)
     child.on('exit', onExit)
     child.on('error', onError)
+
+    if (announcement) {
+      // Resolves synchronously when the sentinel already flew past during the
+      // spawn path's awaits — the case that used to hang for the full 90s.
+      announcement.whenAnnounced(settle)
+    } else {
+      child.stdout.on('data', onData)
+    }
   })
 }
 
@@ -126,7 +250,8 @@ function waitForDashboardReadyFile(
   readyFile,
   child,
   timeoutMs = resolvePortAnnounceTimeoutMs(),
-  describeOutputTail = () => ''
+  describeOutputTail = () => '',
+  announcement: PortAnnouncement | null = null
 ) {
   return new Promise((resolve, reject) => {
     let done = false
@@ -144,16 +269,21 @@ function waitForDashboardReadyFile(
         clearInterval(interval)
       }
 
+      announcement?.dispose()
       child.off('exit', onExit)
       child.off('error', onError)
+    }
+
+    function settle(port: number) {
+      cleanup()
+      resolve(port)
     }
 
     function check() {
       const port = readDashboardReadyFile(readyFile)
 
       if (port) {
-        cleanup()
-        resolve(port)
+        settle(port)
       }
     }
 
@@ -180,6 +310,10 @@ function waitForDashboardReadyFile(
       interval.unref()
     }
 
+    // The ready file is opportunistic — a runtime that never writes it must
+    // still be able to announce on its streams, so the armed announcement
+    // settles this wait too instead of losing to the deadline.
+    announcement?.whenAnnounced(settle)
     check()
   })
 }
@@ -187,6 +321,13 @@ function waitForDashboardReadyFile(
 function waitForDashboardPortAnnouncement(
   child,
   options: {
+    /**
+     * Port announcement armed on the spawn-time output tail
+     * (`armPortAnnouncement`). Supply it whenever this waiter is created
+     * after an `await` — without it a sentinel emitted in the meantime is
+     * unrecoverable (#96315).
+     */
+    announcement?: PortAnnouncement | null
     /** Returns a formatted stdout/stderr tail suffix for exit errors (#93608). */
     describeOutputTail?: () => string
     readyFile?: fs.PathOrFileDescriptor | null
@@ -195,12 +336,13 @@ function waitForDashboardPortAnnouncement(
 ) {
   const timeoutMs = options.timeoutMs ?? resolvePortAnnounceTimeoutMs()
   const describeOutputTail = options.describeOutputTail ?? (() => '')
+  const announcement = options.announcement ?? null
 
   if (options.readyFile) {
-    return waitForDashboardReadyFile(options.readyFile, child, timeoutMs, describeOutputTail)
+    return waitForDashboardReadyFile(options.readyFile, child, timeoutMs, describeOutputTail, announcement)
   }
 
-  return waitForDashboardPort(child, timeoutMs, describeOutputTail)
+  return waitForDashboardPort(child, timeoutMs, describeOutputTail, announcement)
 }
 
 export {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -62,7 +62,7 @@ import {
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
-import { waitForDashboardPortAnnouncement } from './backend-ready'
+import { armPortAnnouncement, waitForDashboardPortAnnouncement } from './backend-ready'
 import { isPidAliveWindows, waitForBackendRelease } from './backend-release-gate'
 import {
   isHostKeyChangedBootFailure,
@@ -12070,6 +12070,11 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // the claim, and would miss anything printed before it.
   const outputTail = createBackendOutputTail()
   outputTail.attach(child)
+  // Arm the READY scanner in the SAME tick as attach(), before the first await
+  // below: the claim can take tens of seconds (Windows start-marker probe), and
+  // a sentinel emitted while it runs reaches only the listeners that already
+  // exist (#96315).
+  const announcement = armPortAnnouncement(outputTail)
   await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce, outputTail)
 
   child.stdout.on('data', rememberLog)
@@ -12104,7 +12109,11 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   // Discover the ephemeral port the child bound to
   const port = await Promise.race([
-    waitForDashboardPortAnnouncement(child, { describeOutputTail: () => outputTail.describe(), readyFile }),
+    waitForDashboardPortAnnouncement(child, {
+      announcement,
+      describeOutputTail: () => outputTail.describe(),
+      readyFile
+    }),
     startFailed
   ])
 
@@ -12457,6 +12466,10 @@ async function startHermes() {
     // later, after the claim, and would miss anything printed before it.
     const primaryOutputTail = createBackendOutputTail()
     primaryOutputTail.attach(hermesProcess)
+    // Same-tick arming as the pool path above: the READY sentinel must be
+    // matched by a listener that exists from the instant of spawn, not by one
+    // attached after the claim + boot-progress awaits (#96315).
+    const primaryAnnouncement = armPortAnnouncement(primaryOutputTail)
     await claimBackendChild(
       hermesProcess,
       `${backend.command} ${backend.args.join(' ')}`,
@@ -12545,6 +12558,7 @@ async function startHermes() {
     // Discover the ephemeral port the child bound to
     const port = await Promise.race([
       waitForDashboardPortAnnouncement(hermesProcess, {
+        announcement: primaryAnnouncement,
         describeOutputTail: () => primaryOutputTail.describe(),
         readyFile
       }),


### PR DESCRIPTION
## What Problem This Solves

The desktop's port-announcement wait could never settle even though the backend was healthy, listening, and had printed its sentinel — the boot then failed at the 90s deadline and the renderer looped `refreshProfiles failed` forever (#96315).

The cause is listener ordering in the spawn path, not the sentinel itself:

1. `spawn()` → `outputTail.attach(child)` puts the child's stdout **and** stderr into flowing mode. From this instant the tail is the only listener.
2. `await claimBackendChild(...)` — on Windows the start-marker probe alone budgets **30s** of PowerShell (`backend-claim.ts`, `timeout: 30_000`). Then `await advanceBootProgress('backend.port', …)`.
3. Only *after* those awaits did `waitForDashboardPortAnnouncement` attach **its own** `data` listener.

A Node stream in flowing mode delivers each chunk exactly once, to the listeners that exist when it is emitted. A `HERMES_BACKEND_READY port=N` line printed during step 2 therefore reached the tail and nothing else — and it is **not replayable**. The waiter sat on a promise that could no longer be settled and burned the full deadline, which is precisely the reported log shape: the READY/listening lines are present in `desktop.log`, and the wait times out anyway.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 spawn hermes serve] --> B[🔥 outputTail.attach — stdout + stderr flowing]
    B --> C{⚔️ Before: scanner armed later}
    C -->|await claimBackendChild — up to 30s| D[💀 READY chunk delivered to tail ONLY]
    D --> E[☠️ waiter attaches too late — chunk unreplayable]
    E --> F[🕯️ 90s deadline wins against a live backend]
    B --> G{🗡️ After: scanner armed same tick}
    G --> H[🔥 armPortAnnouncement observes every raw chunk]
    H --> I[⚡ sentinel latched whenever it arrives]
    I --> J[🏆 waiter settles instantly — stdout or stderr]
```

## What Changed

**`backend-claim.ts`** — `BackendOutputTail` gains `observe(listener)`: every raw chunk from both streams is forwarded to registered observers, and returns an unsubscribe function. Observers receive the chunk **before** the ring buffer trims it, so a burst larger than the 8 KiB tail cannot evict a line that was never scanned. A throwing observer cannot break buffering for the others.

**`backend-ready.ts`**
- `createReadyLineScanner()` — one line-buffered sentinel parser, latching the first match, now shared by both paths so a chunk-split line behaves identically in each.
- `armPortAnnouncement(tail)` — builds the scanner on the tail's feed and exposes `port()` / `whenAnnounced(cb)` / `dispose()`. It owns no timers and never rejects; the deadline, exit and error semantics stay exactly where they were.
- `waitForDashboardPort` / `waitForDashboardReadyFile` / `waitForDashboardPortAnnouncement` accept the armed announcement and settle from it — synchronously when the sentinel already flew past. Without one, the legacy stdout listener is used unchanged.

**`main.ts`** — both local-backend spawn sites (`primary` and the profile pool) call `armPortAnnouncement(tail)` in the **same tick** as `tail.attach(child)`, before their first `await`, and pass it into the wait.

Because the tail attaches to stdout **and** stderr, reading through it also covers the sentinel-on-stderr family (the import-time `sys.stdout = sys.stderr` in `tui_gateway/server.py`, #96282 / #96324) with the same code path instead of a second channel. That redirect's own fix (`_write_machine_sentinel_line`, merged in #96311) is already on `main`; this PR is the consumer-side half — it is the reason the race survives even with the sentinel correctly on fd 1.

## Why This Shape, and How It Differs From #96347

#96347 targets the same issue with four parallel channels (spawn-time tail scan, live stdout **and** stderr `data` listeners, a `HERMES_DESKTOP_READY_FILE` armed for every spawn with 50 ms `fs` polling, plus last-chance scans of the partial-line buffer and `stream.read()` at exit). This PR removes the race at its source instead:

- **One channel, not four.** The tail is already the sole listener attached at spawn; the sentinel is read from it. Nothing else needs a fallback because no byte is ever lost in the first place.
- **Immune to ring-buffer eviction.** A tail-*text* scan reads a truncated 8 KiB ring; a chatty backend can evict the sentinel before it is scanned. Observing raw chunks cannot. Covered by a regression test with a 64-byte tail.
- **No new I/O surface.** No ready file per boot in `userData`, no 50 ms polling interval, no unlink path, and no dependency on the Python `_write_dashboard_ready_file()` channel for correctness.
- **Deliberately no exit-time resolve.** A backend that exited is gone; handing its port to `waitForHermes()` converts a clear "exited before ready" error (which already carries the output tail from #93608) into a confusing connection failure downstream. Exit stays a rejection here.

Out of scope, intentionally: scoping the import-time `sys.stdout` redirect in `tui_gateway/server.py` (issue #96324's part 1), and the fact that `backend.readyFile` is still never set by any runtime resolver — that channel is left exactly as it was.

## Evidence

**Sabotage run** — announcement wiring disabled (`const announcement = null`), tests untouched:

```
× resolves a sentinel that was emitted BEFORE the waiter was created
× resolves a sentinel that lands on stderr (import-time stdout redirect)
× parses a tail-fed sentinel split across chunks and across streams
× a burst larger than the tail ring cannot evict an unscanned sentinel
× the armed announcement settles the ready-file wait when no file appears
× a timed-out armed waiter tears down and does not double-settle
Tests  6 failed | 23 passed (29)
```

**With the fix**: `backend-ready.test.ts` + `backend-claim.test.ts` → **46/46 pass**.

**Full electron vitest project**: 34 failures both with and without the change — the failing-file set is byte-identical to the fix-stashed baseline (git/ssh/`electron`-module/python-path environment failures on this Windows box, since `apps/desktop/node_modules` is not installed here). The one file that differed, `git-review-ops.test.ts`, passes on its own twice with the fix applied and is load-flaky (real `git`, 8.5s under full-suite load).

**Typecheck** (`tsc -p tsconfig.electron.json --noEmit`): 38 errors before, 38 after, identical apart from shifted line numbers — all pre-existing `Cannot find module 'electron'` noise from the uninstalled desktop deps. **Zero** in the touched files.

## Test Plan

- [x] 12 new tests (8 in `backend-ready.test.ts`, 4 in `backend-claim.test.ts`)
- [x] Sabotage run proves 6 of them fail pre-fix
- [x] Control test asserts the *old* shape still loses the sentinel, documenting the bug
- [x] `backend-ready` + `backend-claim` suites: 46/46
- [x] Full electron project: failure set identical to the fix-stashed baseline
- [x] Electron typecheck: no new diagnostics

Closes #96315
