### PR TITLE
fix(mcp): isolate concurrent stdio PID attribution

### DIFF
--- a/tests/tools/test_mcp_stdio_spawn_attribution.py
+++ b/tests/tools/test_mcp_stdio_spawn_attribution.py
@@ -1,0 +1,49 @@
+"""Regression tests for concurrent stdio MCP PID attribution."""
+
+import asyncio
+
+from tools import mcp_tool
+
+
+def test_parallel_stdio_spawn_capture_keeps_each_server_pid_owned(monkeypatch):
+    active_pids: set[int] = set()
+    captured: dict[int, set[int]] = {}
+
+    class FakeStdioClient:
+        def __init__(self, pid: int):
+            self.pid = pid
+
+        async def __aenter__(self):
+            active_pids.add(self.pid)
+            await asyncio.sleep(0.02)
+            return (object(), object())
+
+        async def __aexit__(self, *_exc):
+            active_pids.discard(self.pid)
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_snapshot_child_pids",
+        lambda: set(active_pids),
+    )
+    monkeypatch.setattr(mcp_tool, "_filter_mcp_children", lambda pids: pids)
+
+    async def capture(pid: int):
+        async with mcp_tool._tracked_stdio_spawn(FakeStdioClient(pid)) as (
+            _streams,
+            owned_pids,
+        ):
+            captured[pid] = owned_pids
+            await asyncio.sleep(0.04)
+
+    async def run_both():
+        await asyncio.gather(capture(101), capture(202))
+
+    asyncio.run(run_both())
+    assert captured == {101: {101}, 202: {202}}
+
+    # Hermes tears down and recreates its MCP event loop. The spawn guard must
+    # remain usable after the loop that first contended on it has closed.
+    captured.clear()
+    asyncio.run(run_both())
+    assert captured == {101: {101}, 202: {202}}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3277,8 +3277,6 @@ class MCPServerTask:
         # exist, which would otherwise stall the shared MCP event loop.
         await asyncio.to_thread(_kill_orphaned_mcp_children)
 
-        # Snapshot child PIDs before spawning so we can track the new one.
-        pids_before = _snapshot_child_pids()
         new_pids: set = set()
         # Redirect subprocess stderr into a shared log file so MCP servers
         # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
@@ -3287,20 +3285,12 @@ class MCPServerTask:
         _write_stderr_log_header(self.name)
         _errlog = _get_mcp_stderr_log()
         try:
-            async with stdio_client(server_params, errlog=_errlog) as (
-                read_stream,
-                write_stream,
-            ):
-                # Capture the newly spawned subprocess PID for force-kill cleanup.
-                # Filter out non-MCP children that race into the snapshot window:
-                # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
-                # directly by the gateway without start_new_session, so their pgid
-                # equals the TUI parent PID. If they leak into _stdio_pgids, the
-                # shutdown sweep's killpg() kills the TUI parent itself.
-                # See agent/lsp/client.py for the complementary start_new_session fix.
-                new_pids = _filter_mcp_children(
-                    _snapshot_child_pids() - pids_before
-                )
+            async with _tracked_stdio_spawn(
+                stdio_client(server_params, errlog=_errlog)
+            ) as ((read_stream, write_stream), owned_pids):
+                # Serialize only process creation and PID attribution. The
+                # resulting MCP sessions remain fully concurrent.
+                new_pids = set(owned_pids)
                 if new_pids:
                     # Capture pgid while the child is alive — once it exits we
                     # can no longer call ``os.getpgid`` on it, and the cleanup
@@ -5400,6 +5390,42 @@ _orphan_stdio_pid_servers: Dict[int, str] = {}
 # exited and been removed from the active map.  Empty on Windows
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
+
+# Only the stdio process-spawn window is serialized. A threading lock remains
+# valid when Hermes tears down and recreates the MCP asyncio event loop.
+_stdio_spawn_lock = threading.Lock()
+
+
+async def _acquire_stdio_spawn_lock() -> None:
+    """Acquire the loop-neutral spawn lock without blocking an event loop."""
+    while not _stdio_spawn_lock.acquire(blocking=False):
+        await asyncio.sleep(0.01)
+
+
+@asynccontextmanager
+async def _tracked_stdio_spawn(client_context):
+    """Enter one stdio client and attribute only its own child processes."""
+    await _acquire_stdio_spawn_lock()
+    try:
+        pids_before = _snapshot_child_pids()
+        streams = await client_context.__aenter__()
+        try:
+            owned_pids = _filter_mcp_children(
+                _snapshot_child_pids() - pids_before
+            )
+        except BaseException:
+            await client_context.__aexit__(*sys.exc_info())
+            raise
+    finally:
+        _stdio_spawn_lock.release()
+
+    try:
+        yield streams, owned_pids
+    except BaseException:
+        if not await client_context.__aexit__(*sys.exc_info()):
+            raise
+    else:
+        await client_context.__aexit__(None, None, None)
 
 
 def _snapshot_child_pids() -> set:


### PR DESCRIPTION
## Summary

- serialize only stdio MCP process creation and PID snapshot attribution
- keep MCP sessions concurrent after each child has been assigned to its owning server
- use a loop-neutral `threading.Lock` so attribution still works after Hermes recreates its MCP asyncio loop
- add a behavioral regression that starts two servers concurrently across two separate event loops and verifies exact PID ownership

## Problem

The existing `snapshot after - snapshot before` attribution can run concurrently for multiple stdio MCP startups. Each startup can therefore observe the other server's child and record the wrong PID/PGID. That can contaminate liveness and cleanup ownership, including targeting the wrong process group during teardown.

## Scope

This is the focused PID-attribution/spawn-lock portion split from #95290 at the maintainer's request. It does not include the already-landed child-liveness polarity fix, reconnect-on-fast-fail work being salvaged in #96452, or the separate stdio idle-probe redesign.

## Verification

- all MCP tests: 593 passed, 0 failed, 1 skipped
- focused stdio attribution/liveness tests: 11 passed
- Ruff passed
- `git diff --check` passed
