### PR TITLE
fix(mcp): use process liveness for stdio idle probes

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -110,6 +110,7 @@ class TestKeepaliveProbe:
 
     async def test_keepalive_uses_ping_for_prompt_only_server(self):
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.invalid/mcp"}
         task.initialize_result = _caps(prompts=SimpleNamespace())
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),
@@ -126,6 +127,7 @@ class TestKeepaliveProbe:
     async def test_keepalive_uses_ping_legacy_fallback(self):
         """No captured capabilities → still pings (no spurious list_tools)."""
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.invalid/mcp"}
         assert task.initialize_result is None
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),

--- a/tests/tools/test_mcp_failure_classification.py
+++ b/tests/tools/test_mcp_failure_classification.py
@@ -85,7 +85,10 @@ def test_keepalive_failure_logs_root_cause(monkeypatch, tmp_path, caplog):
             raise _group(BrokenPipeError())
 
     task = _Task("pipey")
-    task._config = {"keepalive_interval": 0.01}
+    task._config = {
+        "url": "https://example.invalid/mcp",
+        "keepalive_interval": 0.01,
+    }
     task.session = object()
 
     monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)

--- a/tests/tools/test_mcp_stdio_idle_probe.py
+++ b/tests/tools/test_mcp_stdio_idle_probe.py
@@ -1,0 +1,67 @@
+"""Regression tests for stdio MCP idle liveness probing."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from tools import mcp_tool
+from tools.mcp_tool import MCPServerTask
+
+
+async def _run_one_idle_cycle(task: MCPServerTask, monkeypatch):
+    real_wait = asyncio.wait
+    cycles = {"count": 0}
+
+    async def fake_wait(tasks, timeout=None, return_when=None):
+        cycles["count"] += 1
+        if cycles["count"] == 1:
+            return set(), set(tasks)
+        task._shutdown_event.set()
+        return await real_wait(
+            tasks,
+            timeout=0.5,
+            return_when=return_when or asyncio.FIRST_COMPLETED,
+        )
+
+    monkeypatch.setattr(mcp_tool.asyncio, "wait", fake_wait)
+    return await task._wait_for_lifecycle_event()
+
+
+def test_alive_stdio_uses_process_liveness_without_protocol_ping(monkeypatch):
+    task = MCPServerTask("stdio-alive")
+    task._config = {"command": "fake", "keepalive_interval": 0.01}
+    task.session = SimpleNamespace(send_ping=AsyncMock(), list_tools=AsyncMock())
+    probes = []
+    monkeypatch.setattr(
+        MCPServerTask,
+        "_stdio_children_dead",
+        lambda self: probes.append(self) or False,
+    )
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)
+
+    assert asyncio.run(_run_one_idle_cycle(task, monkeypatch)) == "shutdown"
+    assert probes == [task]
+    task.session.send_ping.assert_not_awaited()
+    task.session.list_tools.assert_not_awaited()
+
+
+def test_dead_stdio_idle_probe_retires_session_and_reconnects(monkeypatch):
+    task = MCPServerTask("stdio-dead")
+    task._config = {"command": "fake", "keepalive_interval": 0.01}
+    session = SimpleNamespace(send_ping=AsyncMock(), list_tools=AsyncMock())
+    task.session = session
+    task._ready.set()
+    probes = []
+    monkeypatch.setattr(
+        MCPServerTask,
+        "_stdio_children_dead",
+        lambda self: probes.append(self) or True,
+    )
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)
+
+    assert asyncio.run(_run_one_idle_cycle(task, monkeypatch)) == "reconnect"
+    assert probes == [task]
+    assert task.session is None
+    assert not task._ready.is_set()
+    session.send_ping.assert_not_awaited()
+    session.list_tools.assert_not_awaited()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3036,11 +3036,11 @@ class MCPServerTask:
 
         Shutdown takes precedence if both events are set simultaneously.
 
-        Periodically sends a lightweight keepalive (``ping``, with a
-        ``list_tools`` fallback for servers that don't implement the optional
-        ping utility — see :meth:`_keepalive_probe`) to prevent TCP/session
-        state from going stale during idle periods (#17003). If the keepalive
-        fails, triggers a reconnect.
+        HTTP/SSE sessions periodically send a lightweight keepalive (``ping``,
+        with a ``list_tools`` fallback for servers that do not implement the
+        optional ping utility). Stdio sessions use owned-process liveness
+        instead because local transports have no remote session TTL and some
+        otherwise-valid servers close on the optional ping method.
 
         The cadence is ``keepalive_interval`` from server config (default
         :data:`_DEFAULT_KEEPALIVE_INTERVAL`, floored at
@@ -3087,11 +3087,25 @@ class MCPServerTask:
                     self._mark_stdio_recycled(recycle_reason)
                     return "recycle"
 
-                # Timeout — no lifecycle event fired.  Probe the connection
-                # to detect stale/expired sessions — but NEVER while an RPC
-                # is in flight (#48069): the stdio session is a single
-                # JSON-RPC stream and a concurrent ping/list_tools can wedge
-                # the in-flight request. A busy server is provably alive.
+                # Local stdio servers have no remote session TTL and several
+                # valid SDK servers close their transport when sent the optional
+                # MCP ping utility. Process liveness is the safe idle probe;
+                # protocol health is proved by real tool calls. HTTP/SSE keeps
+                # the protocol ping/list_tools keepalive below.
+                if not self._is_http():
+                    if self._stdio_children_dead():
+                        self.mark_suspect("stdio subprocess exited while idle")
+                        self.session = None
+                        self._ready.clear()
+                        self._reconnect_event.set()
+                        break
+                    continue
+
+                # Timeout — no lifecycle event fired. Probe the remote
+                # connection to detect stale/expired sessions — but NEVER while
+                # an RPC is in flight (#48069): concurrent JSON-RPC liveness
+                # probes can wedge an in-flight request. A busy server is
+                # already provably alive.
                 if self.session:
                     if self._rpc_lock.locked() or any(
                         not t.done() for t in self._inflight_tasks


### PR DESCRIPTION
## Summary

- keep MCP protocol `ping`/`list_tools` idle probes for HTTP and SSE transports
- use owned subprocess liveness for local stdio transports instead of sending the optional MCP `ping`
- retire and reconnect a stdio session when all tracked child processes have exited while idle
- add deterministic regressions proving live stdio receives no protocol probe, dead stdio reconnects, and HTTP keepalive behavior remains covered

## Problem

Local stdio transports have no remote session TTL, and valid MCP SDK servers can close their transport when sent the optional `ping` method. Sending protocol keepalives to every idle stdio server can therefore churn otherwise healthy local sessions.

## Trade-off

Process liveness cannot identify a wedged-but-alive protocol while the server is idle. Real tool calls remain bounded and prove protocol health when traffic resumes. HTTP and SSE retain protocol keepalives because remote session expiry cannot be inferred from a local process.

## Scope

This is the focused stdio idle-probe portion split from #95290 at the maintainer's request. It does not include the already-landed child-liveness polarity fix, reconnect-on-fast-fail work being salvaged in #96452, or PID attribution/spawn locking.

## Verification

- all MCP tests: 594 passed, 0 failed, 1 skipped
- focused lifecycle/capability/failure tests: 41 passed
- Ruff passed
- `git diff --check` passed
