### PR TITLE
feat(gateway): import sanity canary — detect source swapped under a live process

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,6 +9,13 @@ to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) w
 - Platform-specific toolsets (different capabilities per platform)
 """
 
+# Source-swap canary (#96464): importing this module at package load captures
+# the birth receipt (HEAD commit + on-disk identity of already-loaded repo
+# modules) before run.py's body — and every lazy import it will ever do —
+# runs. Purely passive: no behavior, no threads, just the earliest possible
+# observation of the source generation this process starts against.
+from . import import_sanity as _import_sanity  # noqa: F401
+
 from .config import GatewayConfig, PlatformConfig, HomeChannel, load_gateway_config
 from .session import (
     SessionContext,

--- a/gateway/import_sanity.py
+++ b/gateway/import_sanity.py
@@ -1,0 +1,387 @@
+"""Detect source code swapped under a running gateway process.
+
+The gateway is long-lived; Python caches imported modules in ``sys.modules``.
+If the checkout changes while the process runs — an update flow, a concurrent
+git operation, a stray test suite — the process keeps executing the OLD
+modules while lazy imports of changed files fail with ``ImportError``. The
+process looks healthy (platforms stay connected, polling works) yet lazy
+imports fail unpredictably, and fixing the on-disk source does not help: only
+a restart does, and nothing in the logs points there.
+
+The check is a two-time proof (#96464):
+
+1. At import time — for a gateway process that is effectively process birth,
+   because ``gateway/__init__`` imports this module before ``run.py``'s body
+   runs — capture a *birth receipt*: the HEAD commit (read straight from the
+   ``.git`` files, no subprocess) and the on-disk identity of every repo
+   module already loaded at that moment.
+2. :func:`startup_import_smoke`, run at the end of gateway startup: eagerly
+   import the late-loaded critical modules, then compare the world against
+   the birth receipt. A checkout that moved during the startup window — a
+   cached OLD module in ``sys.modules`` while the file on disk is already NEW
+   — cannot masquerade as healthy: the receipt still describes the OLD
+   generation, so the mismatch fails the comparison. Only when it passes does
+   the smoke seed the runtime snapshot: the on-disk identity of every loaded
+   module living inside this repository (a ``sys.modules`` sweep, not a
+   hand-picked list).
+3. :func:`verify_runtime_snapshots` — called periodically. Re-stats the
+   snapshotted files; any mtime/size drift from the snapshot means the
+   checkout moved under the live process and is reported exactly once per
+   file with a restart instruction, while the return value stays False for as
+   long as the drift persists.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+# Modules the gateway only imports lazily (per-message agent turns, cron job
+# execution) — eagerly imported by the smoke so a swap that already happened
+# during the launch window surfaces immediately, and so they are guaranteed
+# to be part of the runtime snapshot. Tests pass their own tuple explicitly.
+_MONITORED_MODULES = ("run_agent", "tools.terminal_tool")
+
+# Runtime snapshot populated only by a startup smoke whose receipt comparison
+# passed: {module_name: (path, st_mtime_ns, st_size)}.
+_snapshots: dict[str, tuple[str, int, int]] = {}
+_reported: set[str] = set()
+
+# Birth receipt: (HEAD commit or None, {module_name: (path, mtime_ns, size)}).
+# Captured once, at this module's import — the earliest observation it can
+# make. Overridable in tests to stage specific startup-window scenarios.
+_BIRTH: tuple[str | None, dict[str, tuple[str, int, int]]] | None = None
+
+
+def _repo_root() -> str:
+    """Repository root (parent of the ``gateway`` package), resolved."""
+    return os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+def _read_git_dir(root: str) -> str | None:
+    """Resolve the .git dir for a plain checkout or a linked worktree."""
+    dot = os.path.join(root, ".git")
+    if os.path.isdir(dot):
+        return dot
+    if os.path.isfile(dot):
+        # Linked worktree pointer: "gitdir: /path/to/main/.git/worktrees/<n>"
+        try:
+            with open(dot, encoding="utf-8") as fh:
+                first = fh.readline().strip()
+        except OSError:
+            return None
+        if first.startswith("gitdir:"):
+            return first[len("gitdir:"):].strip() or None
+    return None
+
+
+def _resolve_git_ref(git_dir: str, ref: str) -> str | None:
+    """Resolve a ref name to a commit id via loose refs and packed-refs."""
+    common = git_dir
+    commondir = os.path.join(git_dir, "commondir")
+    if os.path.isfile(commondir):
+        try:
+            with open(commondir, encoding="utf-8") as fh:
+                rel = fh.read().strip()
+        except OSError:
+            rel = ""
+        if rel:
+            common = rel if os.path.isabs(rel) else os.path.normpath(
+                os.path.join(git_dir, rel)
+            )
+    # Per-worktree refs live under git_dir; shared refs under the common dir.
+    for base in (git_dir, common):
+        path = os.path.join(base, *ref.split("/"))
+        try:
+            with open(path, encoding="utf-8") as fh:
+                value = fh.read().strip()
+        except OSError:
+            continue
+        if value.startswith("ref:"):  # nested symref — don't guess
+            return None
+        return value or None
+    packed = os.path.join(common, "packed-refs")
+    try:
+        with open(packed, encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) == 2 and parts[1] == ref:
+                    return parts[0]
+    except OSError:
+        pass
+    return None
+
+
+def _read_head_commit(root: str) -> str | None:
+    """Best-effort HEAD commit id through plain file reads (no subprocess).
+
+    Covers the layouts a gateway process actually meets: a plain checkout,
+    a linked worktree, detached HEAD, and refs packed into packed-refs.
+    Returns None on anything unexpected — a missing receipt disables the
+    startup comparison rather than guessing (same conservatism as the probe:
+    no proof, no verdict).
+    """
+    git_dir = _read_git_dir(root)
+    if not git_dir:
+        return None
+    try:
+        with open(os.path.join(git_dir, "HEAD"), encoding="utf-8") as fh:
+            head = fh.read().strip()
+    except OSError:
+        return None
+    if head.startswith("ref:"):
+        return _resolve_git_ref(git_dir, head[4:].strip())
+    return head or None  # detached HEAD carries the raw commit id
+
+
+def _iter_loaded_repo_modules(root: str):
+    """Yield (name, path) for every loaded module whose file lives under root.
+
+    Sweeping sys.modules instead of a hand-picked list means any repo file
+    touched by a later checkout swap (tools.environments.*, registry, cron,
+    plugins...) is covered without maintaining an inventory that would rot.
+    """
+    for name, module in list(sys.modules.items()):
+        path = getattr(module, "__file__", None)
+        if not path:
+            continue
+        try:
+            resolved = os.path.realpath(path)
+        except OSError:
+            continue
+        if resolved == root or resolved.startswith(root + os.sep):
+            yield name, path
+
+
+def _capture_birth_receipt(root: str) -> tuple[str | None, dict[str, tuple[str, int, int]]]:
+    """Snapshot the source generation as of NOW (= this module's import).
+
+    The HEAD commit catches checkout-level switches (update flows, rebases,
+    resets); the per-module stats of whatever repo modules are already loaded
+    close the only pre-receipt blind spot (the gateway package init itself).
+    Modules imported AFTER this moment are covered by the other half of the
+    proof: the startup smoke compares against this receipt before seeding.
+    """
+    modules: dict[str, tuple[str, int, int]] = {}
+    for name, path in _iter_loaded_repo_modules(root):
+        try:
+            st = os.stat(path)
+        except OSError:
+            continue
+        modules[name] = (path, st.st_mtime_ns, st.st_size)
+    return _read_head_commit(root), modules
+
+
+_BIRTH = _capture_birth_receipt(_repo_root())
+
+
+def _snapshot_module(name: str) -> tuple[int, int] | None:
+    """Return (st_mtime_ns, st_size) for an imported module, or None.
+
+    Never raises — a module vanishing between the sys.modules lookup and the
+    stat is a skip, not a canary failure (TOCTOU window is nanoseconds).
+    """
+    module = sys.modules.get(name)
+    path = getattr(module, "__file__", None)
+    if not path:
+        return None
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _snapshot_loaded_repo_modules(root: str) -> None:
+    """Record the on-disk identity of every loaded repo module as baseline."""
+    for name, path in _iter_loaded_repo_modules(root):
+        snap = _snapshot_module(name)
+        if snap is not None:
+            _snapshots[name] = (path, snap[0], snap[1])
+            _reported.discard(name)
+
+
+def _verify_birth_receipt() -> bool:
+    """Compare the import-time receipt against the world as it is NOW.
+
+    This is the second observation of the two-time proof. ``import_module``
+    returns the cached object for anything already in ``sys.modules`` and
+    never re-reads disk, so without an earlier receipt a swap that happened
+    during the startup window would be adopted as the healthy baseline. The
+    receipt was minted before the late imports ran, so cached-OLD-module +
+    NEW-file-on-disk necessarily mismatches it here.
+
+    The HEAD leg follows the same law as the per-module leg: a birth commit
+    that cannot be re-read at smoke time (ref lock, repack, mid-transition)
+    is INCONCLUSIVE — unhealthy, no seeding, WARNING instead of a
+    confirmed-swap ERROR — and a later smoke can recover once the ref is
+    readable again. A missing second observation is not proof of equality:
+    modules first imported after the receipt have no birth stat, so the HEAD
+    leg is their only first observation and must not vanish silently.
+    """
+    receipt = _BIRTH
+    if receipt is None:  # receipt capture failed — disable, don't guess
+        return True
+    commit, modules = receipt
+    healthy = True
+    if commit:
+        now_commit = _read_head_commit(_repo_root())
+        if now_commit is None:
+            healthy = False
+            logger.warning(
+                "Import sanity check INCONCLUSIVE: the birth receipt captured "
+                "HEAD %s but the current HEAD cannot be read — cannot verify "
+                "the checkout generation, runtime snapshot not seeded; a "
+                "later smoke can recover once the ref is readable again",
+                commit[:12],
+            )
+        elif commit != now_commit:
+            healthy = False
+            logger.error(
+                "Import sanity check FAILED: the checkout changed during the "
+                "startup window (HEAD %s -> %s) — this process may be running a "
+                "mix of pre- and post-change code; restart the gateway to load a "
+                "consistent tree",
+                commit[:12],
+                now_commit[:12],
+            )
+    for name, (path, mtime_ns, size) in modules.items():
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            healthy = False
+            logger.error(
+                "Import sanity check FAILED: source for %s vanished during "
+                "the startup window (%s) — the checkout moved under this "
+                "process while it was launching; restart the gateway before "
+                "trusting it",
+                name,
+                path,
+            )
+            continue
+        except OSError as exc:
+            # Transient stat failure: can't confirm the world matches the
+            # receipt, so don't seed a baseline from an unverified state.
+            logger.warning(
+                "Cannot stat %s (%s) while comparing the startup receipt — "
+                "treating as unhealthy, runtime snapshot not seeded",
+                path,
+                exc,
+            )
+            healthy = False
+            continue
+        if (st.st_mtime_ns, st.st_size) != (mtime_ns, size):
+            healthy = False
+            logger.error(
+                "Import sanity check FAILED: %s changed on disk during the "
+                "startup window (%s) — modules imported before the change "
+                "hold OLD code in sys.modules while later imports read NEW "
+                "files; restart the gateway",
+                name,
+                path,
+            )
+    return healthy
+
+
+def startup_import_smoke(
+    modules: tuple[str, ...] = _MONITORED_MODULES,
+    snapshot_root: str | None = None,
+) -> bool:
+    """Eagerly import the lazy critical modules, then seed the runtime snapshot.
+
+    The order is the proof: receipt was captured at import time, the eager
+    imports happen now, and only if the world still matches the receipt does
+    the snapshot become the ongoing baseline. Returns True when every
+    monitored module imported cleanly AND the receipt comparison passed;
+    False means the gateway is already in a broken state and an ERROR has
+    been logged. Never raises — the canary must not block startup.
+    """
+    healthy = True
+    for name in modules:
+        try:
+            importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001 - report, don't crash startup
+            healthy = False
+            logger.error(
+                "Import sanity check FAILED for %s: %s: %s — the environment is "
+                "broken or the source tree changed under this process since it "
+                "started; lazy imports (cron jobs, agent turns) will keep failing "
+                "until the gateway is restarted",
+                name,
+                type(exc).__name__,
+                exc,
+            )
+    healthy = _verify_birth_receipt() and healthy
+    # Seed the ongoing baseline ONLY from a verified state: seeding after a
+    # detected swap would adopt the NEW generation as "healthy" and mute the
+    # runtime canary for the exact mixed state it exists to catch.
+    if healthy:
+        _snapshot_loaded_repo_modules(snapshot_root or _repo_root())
+        logger.info(
+            "Import sanity check OK (%d repo modules snapshotted; eager-imported: %s)",
+            len(_snapshots),
+            ", ".join(sorted(modules)) or "none",
+        )
+    return healthy
+
+
+def verify_runtime_snapshots() -> bool:
+    """Re-stat snapshotted modules; report on-disk drift exactly once per file.
+
+    Returns True only while every snapshotted file still matches disk — the
+    ERROR is logged once, but the return value stays False for as long as the
+    drift persists, so callers reading the bool cannot mistake "already
+    reported" for "recovered". A mismatch means the checkout was switched
+    under the live process — the process runs mixed/stale code until it is
+    restarted (#96464).
+    """
+    healthy = True
+    for name, (path, mtime_ns, size) in list(_snapshots.items()):
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            # File vanished (checkout switched / branch deleted): same class
+            # of incident — the on-disk world no longer matches the process.
+            if name not in _reported:
+                _reported.add(name)
+                logger.error(
+                    "Source file for %s disappeared (%s) after this process "
+                    "started — the checkout was switched under a running "
+                    "gateway; restart required to pick up consistent code",
+                    name,
+                    path,
+                )
+            healthy = False
+            continue
+        except OSError as exc:
+            # Transient filesystem trouble (permissions, NFS stale handle) is
+            # indistinguishable from a moved checkout at this layer — warn at
+            # a level that won't be mistaken for a confirmed swap, and keep
+            # returning False so the condition can't be silently ignored.
+            logger.warning(
+                "Cannot stat source file for %s (%s): %s — transient filesystem "
+                "error or the checkout moved; will re-check next tick",
+                name,
+                path,
+                exc,
+            )
+            healthy = False
+            continue
+        if (st.st_mtime_ns, st.st_size) != (mtime_ns, size):
+            if name not in _reported:
+                _reported.add(name)
+                logger.error(
+                    "Source file for %s changed on disk after this process started "
+                    "(%s) — the checkout was switched under a running gateway; this "
+                    "process keeps the OLD code in memory while later imports read "
+                    "the NEW files, so it runs mixed/stale code with undefined "
+                    "behavior until the gateway is restarted",
+                    name,
+                    path,
+                )
+            healthy = False
+    return healthy

--- a/tests/gateway/test_import_sanity.py
+++ b/tests/gateway/test_import_sanity.py
@@ -1,0 +1,355 @@
+"""Tests for gateway.import_sanity — the source-swap canary (#96464).
+
+The canary exists to catch a checkout switched under a running gateway
+(update flow racing the launch, a concurrent git operation, a stray test
+suite): old modules stay cached in sys.modules while lazy imports of the new
+files fail. These tests drive the canary against throwaway modules instead
+of the real run_agent/tools chains.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import types
+
+import pytest
+
+from gateway import import_sanity
+
+
+@pytest.fixture(autouse=True)
+def _reset_canary_state(monkeypatch):
+    # Isolate every test from the real repo's birth receipt (captured when
+    # this test process imported the module); tests that exercise the
+    # two-time proof install a controlled receipt explicitly.
+    monkeypatch.setattr(import_sanity, "_BIRTH", None)
+    import_sanity._snapshots.clear()
+    import_sanity._reported.clear()
+    yield
+    import_sanity._snapshots.clear()
+    import_sanity._reported.clear()
+
+
+def _install_fake_module(monkeypatch, tmp_path, name: str, content: str = "x = 1\n"):
+    """Register a module in sys.modules backed by a real file on disk."""
+    path = tmp_path / f"{name}.py"
+    path.write_text(content)
+    mod = types.ModuleType(name)
+    mod.__file__ = str(path)
+    monkeypatch.setitem(sys.modules, name, mod)
+    return path
+
+
+def _stage_receipt(monkeypatch, name: str, path, commit: str | None = None):
+    """Install a birth receipt describing the CURRENT state of ``path``.
+
+    ``commit=None`` keeps the HEAD comparison out of the picture — these
+    tests exercise the file-identity half of the proof; the commit half has
+    its own test with a controlled ``_read_head_commit``.
+    """
+    st = os.stat(path)
+    monkeypatch.setattr(
+        import_sanity,
+        "_BIRTH",
+        (commit, {name: (str(path), st.st_mtime_ns, st.st_size)}),
+    )
+
+
+# --- The vertical regression the review asked for: a swap that already
+# --- happened before the smoke runs must NOT become the healthy baseline.
+
+
+def test_startup_smoke_detects_file_swapped_before_smoke(monkeypatch, tmp_path, caplog):
+    # Module imported from generation A, its backing file swapped to B on
+    # disk BEFORE the smoke runs. import_module() returns the cached object
+    # and never re-reads disk, so only the birth receipt can catch it —
+    # without the receipt comparison the smoke would stat the NEW file and
+    # adopt the mixed state as its baseline.
+    path = _install_fake_module(
+        monkeypatch, tmp_path, "fake_swapped_mod", "x = 1  # generation A\n"
+    )
+    _stage_receipt(monkeypatch, "fake_swapped_mod", path)
+    path.write_text(
+        "x = 2222222222  # generation B — swapped under the launching process\n"
+    )
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=("fake_swapped_mod",), snapshot_root=str(tmp_path)
+        )
+    assert healthy is False
+    assert any("changed on disk during the startup window" in r.message for r in caplog.records)
+    # The failure must point the operator at a restart, not at the individual
+    # lazy-import sites where the symptom will appear.
+    assert any("restart the gateway" in r.message for r in caplog.records)
+    # And the NEW generation must not be adopted as the runtime baseline:
+    assert "fake_swapped_mod" not in import_sanity._snapshots
+
+
+def test_startup_smoke_detects_commit_change_during_startup(monkeypatch, tmp_path, caplog):
+    _install_fake_module(monkeypatch, tmp_path, "fake_commit_mod")
+    monkeypatch.setattr(import_sanity, "_BIRTH", ("aaaaaaaaaaaa", {}))
+    monkeypatch.setattr(import_sanity, "_read_head_commit", lambda root: "bbbbbbbbbbbb")
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=(), snapshot_root=str(tmp_path)
+        )
+    assert healthy is False
+    assert any("checkout changed during the startup window" in r.message for r in caplog.records)
+    assert "fake_commit_mod" not in import_sanity._snapshots
+
+
+def test_startup_smoke_unreadable_second_head_is_inconclusive_then_recovers(
+    monkeypatch, tmp_path, caplog
+):
+    # Review #5045506662: the birth receipt captured a valid commit A, but
+    # the SECOND HEAD read at smoke time fails (ref lock, repack, a checkout
+    # mid-transition). A missing second observation is not proof of equality
+    # — modules first imported after the receipt have no birth stat, so the
+    # HEAD leg is their only first observation. The smoke must be unhealthy
+    # and must not seed, without claiming a confirmed swap; a later smoke
+    # recovers once the ref is readable again.
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_head_unreadable_mod")
+    _stage_receipt(monkeypatch, "fake_head_unreadable_mod", path, commit="aaaaaaaaaaaa")
+    monkeypatch.setattr(import_sanity, "_read_head_commit", lambda root: None)
+    with caplog.at_level(logging.WARNING, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=(), snapshot_root=str(tmp_path)
+        )
+    assert healthy is False
+    assert any(
+        "cannot verify the checkout generation" in r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+    # An unreadable ref is inconclusive, not a confirmed swap.
+    assert not any(r.levelno == logging.ERROR for r in caplog.records)
+    assert import_sanity._snapshots == {}
+
+    # Ref readable again and matching the receipt → a later smoke verifies
+    # and seeds normally.
+    caplog.clear()
+    monkeypatch.setattr(import_sanity, "_read_head_commit", lambda root: "aaaaaaaaaaaa")
+    healthy = import_sanity.startup_import_smoke(
+        modules=(), snapshot_root=str(tmp_path)
+    )
+    assert healthy is True
+    assert "fake_head_unreadable_mod" in import_sanity._snapshots
+
+
+def test_startup_smoke_detects_birth_file_vanished(monkeypatch, tmp_path, caplog):
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_gone_at_birth_mod")
+    _stage_receipt(monkeypatch, "fake_gone_at_birth_mod", path)
+    path.unlink()
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=(), snapshot_root=str(tmp_path)
+        )
+    assert healthy is False
+    assert any("vanished during the startup window" in r.message for r in caplog.records)
+
+
+def test_startup_smoke_birth_transient_stat_error_does_not_seed(monkeypatch, tmp_path, caplog):
+    # A stat failure during the receipt comparison can't confirm the world,
+    # so the smoke must not seed a baseline from an unverified state — but it
+    # also must not claim a confirmed swap for a merely invisible file.
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_birth_stat_mod")
+    _stage_receipt(monkeypatch, "fake_birth_stat_mod", path)
+
+    real_stat = os.stat
+
+    def _raising_stat(p, **kwargs):
+        if str(p).endswith("fake_birth_stat_mod.py"):
+            raise PermissionError("EACCES (simulated)")
+        return real_stat(p, **kwargs)
+
+    monkeypatch.setattr(import_sanity.os, "stat", _raising_stat)
+    with caplog.at_level(logging.WARNING, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=(), snapshot_root=str(tmp_path)
+        )
+    assert healthy is False
+    assert any("Cannot stat" in r.message for r in caplog.records)
+    assert not any(r.levelno == logging.ERROR and "restarted" in r.message for r in caplog.records)
+    assert import_sanity._snapshots == {}
+
+
+def test_startup_smoke_matching_receipt_seeds_snapshots(monkeypatch, tmp_path):
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_verified_mod")
+    _stage_receipt(monkeypatch, "fake_verified_mod", path)
+    healthy = import_sanity.startup_import_smoke(
+        modules=("fake_verified_mod",), snapshot_root=str(tmp_path)
+    )
+    assert healthy is True
+    # Passing the proof is what licenses the ongoing baseline:
+    assert "fake_verified_mod" in import_sanity._snapshots
+    assert import_sanity.verify_runtime_snapshots() is True
+
+
+def test_startup_smoke_imports_monitored_modules_and_snapshots_repo_tree(monkeypatch, tmp_path):
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(exist_ok=True)
+    _install_fake_module(monkeypatch, tmp_path, "fake_inside_mod")
+    _install_fake_module(monkeypatch, outside, "fake_outside_mod")
+
+    healthy = import_sanity.startup_import_smoke(
+        modules=("json",),  # import succeeds but lives outside the snapshot root
+        snapshot_root=str(tmp_path),
+    )
+    assert healthy is True
+    # Snapshot sweeps ALL loaded modules under the root — not just the
+    # monitored list — so any repo file later touched by a swap is covered.
+    assert "fake_inside_mod" in import_sanity._snapshots
+    assert "fake_outside_mod" not in import_sanity._snapshots
+    assert "json" not in import_sanity._snapshots  # outside the root
+    path, mtime_ns, size = import_sanity._snapshots["fake_inside_mod"]
+    assert path.startswith(str(tmp_path))
+    assert mtime_ns > 0
+    assert size > 0
+
+
+def test_startup_smoke_reports_import_failure(caplog):
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.startup_import_smoke(
+            modules=("definitely_not_a_module_xyz",), snapshot_root="/nonexistent-root"
+        )
+    assert healthy is False
+    assert any("definitely_not_a_module_xyz" in r.message for r in caplog.records)
+    # The failure message must point the operator at a restart, not at the
+    # individual lazy-import sites where the symptom will appear.
+    assert any("restarted" in r.message for r in caplog.records)
+
+
+def test_startup_smoke_never_raises_on_bad_modules():
+    # A canary must not crash the startup sequence it guards.
+    import_sanity.startup_import_smoke(
+        modules=("definitely_not_a_module_xyz",), snapshot_root="/nonexistent-root"
+    )
+
+
+# --- Runtime verification (periodic re-stat of the seeded baseline). ---
+
+
+def test_verify_clean_while_unchanged(monkeypatch, tmp_path):
+    _install_fake_module(monkeypatch, tmp_path, "fake_stable_mod")
+    import_sanity.startup_import_smoke(modules=(), snapshot_root=str(tmp_path))
+    assert import_sanity.verify_runtime_snapshots() is True
+
+
+def test_verify_detects_modified_file(monkeypatch, tmp_path, caplog):
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_drifted_mod")
+    import_sanity.startup_import_smoke(modules=(), snapshot_root=str(tmp_path))
+    path.write_text("x = 222  # changed under the running process\n")
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.verify_runtime_snapshots()
+    assert healthy is False
+    assert any("changed on disk" in r.message for r in caplog.records)
+    assert any("restarted" in r.message for r in caplog.records)
+
+
+def test_verify_reports_drift_once_but_stays_unhealthy(monkeypatch, tmp_path, caplog):
+    # The ERROR is logged once, yet the return value must stay False for as
+    # long as the drift persists — "already reported" must never read as
+    # "recovered" to a caller consuming the bool.
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_once_mod")
+    import_sanity.startup_import_smoke(modules=(), snapshot_root=str(tmp_path))
+    path.write_text("x = 222\n")
+    results = []
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        for _ in range(3):
+            results.append(import_sanity.verify_runtime_snapshots())
+    assert results == [False, False, False]
+    drift_reports = [r for r in caplog.records if "changed on disk" in r.message]
+    assert len(drift_reports) == 1
+
+
+def test_verify_detects_deleted_file(monkeypatch, tmp_path, caplog):
+    path = _install_fake_module(monkeypatch, tmp_path, "fake_gone_mod")
+    import_sanity.startup_import_smoke(modules=(), snapshot_root=str(tmp_path))
+    path.unlink()
+    with caplog.at_level(logging.ERROR, logger="gateway.import_sanity"):
+        healthy = import_sanity.verify_runtime_snapshots()
+    assert healthy is False
+    assert any("disappeared" in r.message for r in caplog.records)
+
+
+def test_verify_transient_stat_error_warns_without_swap_claim(monkeypatch, tmp_path, caplog):
+    # stat failing with a non-ENOENT error (permissions, stale NFS handle)
+    # must not be diagnosed as a confirmed checkout swap.
+    _install_fake_module(monkeypatch, tmp_path, "fake_stat_mod")
+    import_sanity.startup_import_smoke(modules=(), snapshot_root=str(tmp_path))
+
+    real_stat = os.stat
+
+    def _raising_stat(path, **kwargs):
+        if str(path).endswith("fake_stat_mod.py"):
+            raise PermissionError("EACCES (simulated)")
+        return real_stat(path, **kwargs)
+
+    monkeypatch.setattr(import_sanity.os, "stat", _raising_stat)
+    with caplog.at_level(logging.WARNING, logger="gateway.import_sanity"):
+        healthy = import_sanity.verify_runtime_snapshots()
+    assert healthy is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Cannot stat" in r.message for r in warnings)
+    # No false "restart required" ERROR for a merely invisible file.
+    assert not any("restarted" in r.message for r in caplog.records if r.levelno == logging.ERROR)
+
+
+def test_verify_noop_without_snapshots():
+    # Housekeeping may tick before the startup smoke ran (or after a smoke
+    # that recorded nothing); verify must stay quiet and healthy.
+    assert import_sanity.verify_runtime_snapshots() is True
+
+
+# --- The birth receipt's HEAD-commit reader (plain .git file reads). ---
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_read_head_commit_plain_loose_ref(tmp_path):
+    _write(tmp_path / ".git" / "HEAD", "ref: refs/heads/main\n")
+    _write(tmp_path / ".git" / "refs" / "heads" / "main", "0123456789abcdef\n")
+    assert import_sanity._read_head_commit(str(tmp_path)) == "0123456789abcdef"
+
+
+def test_read_head_commit_detached(tmp_path):
+    _write(tmp_path / ".git" / "HEAD", "fedcba9876543210\n")
+    assert import_sanity._read_head_commit(str(tmp_path)) == "fedcba9876543210"
+
+
+def test_read_head_commit_packed_refs(tmp_path):
+    _write(tmp_path / ".git" / "HEAD", "ref: refs/heads/main\n")
+    _write(
+        tmp_path / ".git" / "packed-refs",
+        "# pack-refs with: peeled fully-peeled sorted \n"
+        "1111111111111111 refs/heads/other\n"
+        "0123456789abcdef refs/heads/main\n"
+        "9999999999999999 refs/heads/main^{}\n",
+    )
+    assert import_sanity._read_head_commit(str(tmp_path)) == "0123456789abcdef"
+
+
+def test_read_head_commit_linked_worktree(tmp_path):
+    # A linked worktree's .git is a FILE pointing into the main repo's
+    # worktrees dir; its commondir file points back at the shared refs.
+    main_git = tmp_path / "main" / ".git"
+    wt_git = main_git / "worktrees" / "wt"
+    _write(tmp_path / "worktree" / ".git", f"gitdir: {wt_git}\n")
+    _write(wt_git / "HEAD", "ref: refs/heads/feat/canary\n")
+    _write(wt_git / "commondir", "../..\n")  # back to the main repo's .git
+    _write(main_git / "refs" / "heads" / "feat" / "canary", "aaaaaaaaaaaaaaaa\n")
+    assert import_sanity._read_head_commit(str(tmp_path / "worktree")) == "aaaaaaaaaaaaaaaa"
+
+
+def test_read_head_commit_unresolvable_returns_none(tmp_path):
+    _write(tmp_path / ".git" / "HEAD", "ref: refs/heads/nope\n")
+    assert import_sanity._read_head_commit(str(tmp_path)) is None
+
+
+def test_read_head_commit_missing_git_dir(tmp_path):
+    assert import_sanity._read_head_commit(str(tmp_path)) is None


### PR DESCRIPTION
Implements the detection core for #96464. Runtime wiring intentionally lands through the gateway decomposition owners rather than this PR — see "Landing order".

## What

A two-time proof in `gateway/import_sanity.py`:

1. **Birth receipt** — captured when `gateway/__init__` imports this module, i.e. before `run.py`'s body (and every lazy import it will ever do) executes. The receipt describes the source generation the process actually starts against: the HEAD commit, read straight from the `.git` files (plain checkout, linked worktree via `gitdir:` + `commondir`, detached HEAD, packed-refs — no subprocess), plus the on-disk identity of the repo modules already loaded at that moment (closes the only pre-receipt blind spot: the gateway package init itself).
2. **`startup_import_smoke()`** — the startup gate. Eagerly imports the late-loaded critical modules (`run_agent`, `tools.terminal_tool`) so a swap surfaces *here*, with a restart instruction, instead of on the first inbound message. Then it compares the world against the birth receipt: a swap that already happened during the startup window — cached OLD module in `sys.modules` while the file on disk is NEW — cannot masquerade as healthy, because `import_module()` returns the cached object and never re-reads disk while the receipt still describes the OLD generation. **Only when the comparison passes** does it seed the runtime snapshot: the on-disk identity `(path, st_mtime_ns, st_size)` of every loaded module living inside the repository — a `sys.modules` sweep rather than a hand-picked list, so any repo file later touched by a swap (`tools.environments.*`, registry, cron, plugins) is covered without maintaining an inventory that would rot.
3. **`verify_runtime_snapshots()`** — the periodic re-stat. Drift (mtime/size change or file gone) is reported **exactly once per file** with a restart instruction, while the return value stays `False` for as long as the drift persists — so a caller consuming the bool cannot mistake "already reported" for "recovered". Transient stat failures (permissions, stale NFS handle) log a WARNING without claiming a confirmed swap.

The canary never blocks startup and its own failures stay silent — it is a canary, not a dependency.

## Why

Real incident (timeline in the issue and in [this #96435 comment](https://github.com/NousResearch/hermes-agent/pull/96435#issuecomment-5441337482)): a test suite ran the update flow against a live gateway — SIGTERM, `git reset --hard`, relaunch — and the relaunched process imported the old modules seconds before the checkout switched underneath it. It then ran for **~22 hours** of mixed/stale code: lazy imports (cron fires, agent turns) failing on the same `ImportError` while:

- the process stayed up (supervision saw nothing wrong),
- the on-disk source was fully consistent (a fresh interpreter imported the same modules fine),
- the only log clue repeated per cron-fire / per message, pointing at the victim module rather than at the process/code mismatch.

Post-hoc forensics on the incident's tracebacks show the smoking gun directly: frames whose **line numbers resolve against the old commit** while the **displayed source text is read from the new checkout** — the same process frame, two code worlds.

## Design notes

- **Two observations, not one.** The first draft minted the baseline at smoke time, which a review harness showed is *after* the race window: `import_module()` on an already-cached module returns the cached object, and the sweep stats the file **as it exists on disk now** — so a pre-smoke swap would be adopted as the healthy baseline. The birth receipt is the missing first observation; seeding is now conditional on the receipt still matching.
- **Sweep vs list**: the snapshot covers all repo-resident loaded modules. A two-name watchlist would only catch a swap that happens to touch those files; the incident's direct victim (`tools/environments/base.py`) wasn't in any obvious list.
- **Return-value semantics**: ERROR is logged once per file, but `verify_runtime_snapshots()` stays `False` while drift persists — logging once and returning healthy afterwards would let a status consumer believe the condition cleared.
- **Transient stat errors** are not diagnosed as a confirmed swap (WARNING + unhealthy, no "restart required"), during both the receipt comparison and the periodic verify.
- **The same law governs the HEAD leg of the receipt comparison** (review #5045506662): a birth commit that cannot be re-read at smoke time (ref lock, repack, mid-transition) is INCONCLUSIVE — WARNING + unhealthy + no seeding — not a silent pass and not a confirmed-swap ERROR. A later smoke recovers and seeds normally once the ref is readable again. A missing second observation is not proof of equality: modules first imported after the receipt have no birth stat, so the HEAD leg is their only first observation.

## Known limitation

The receipt's HEAD-commit leg catches checkout-level switches (update flows, rebases, resets — everything in the incident class). A file-level write that leaves HEAD untouched (hand edit, `git checkout -- <file>`, `stash pop`) during the startup window is only caught when the affected module predates the receipt; for modules first imported after the receipt but swapped before the smoke, a pyc-header comparison would be the precise instrument — noted as a possible follow-up, not smuggled into this PR. Concretely: at capture time the receipt holds the gateway package init and this module; `gateway/config.py`, `gateway/session.py`, `gateway/delivery.py` and everything `run.py` imports later are first-loaded after it, so they are the population that residual applies to.

## Landing order

- `gateway/run.py` carries no new hooks in this PR. The startup-gate call and the periodic verify land through the decomposition owners — #54962/#78647, with #77735 extracting `_start_gateway_housekeeping` into `gateway/housekeeping.py`. Once that topology lands, both call sites are one-line compositions from this module. If maintainers want the wiring sooner than #77735, happy to rederive the extraction on current main with the existing contributor lineage preserved.
- The `gateway/__init__.py` import is **not** a hook — it is passive birth-receipt capture (no behavior, no threads); it must sit at package load for the receipt to predate `run.py`'s lazy imports.
- #96435 (producer-side: hermetic update tests) and #96235 (recovery after an aborted update/restart path) stay complementary — this canary is defense in depth, neither a substitute nor a second restart controller. #96462 also touches `gateway/run.py`; purposes are independent, whichever lands second just needs a fresh semantic read.

## Explicitly out of scope (follow-ups)

- Machine-readable health event / `gateway status` exposure — the logging canary is the first layer; happy to follow up on whatever surface maintainers prefer.
- Wiring the same canary into other long-lived entry points (`tui_gateway`, `acp_adapter`) — the module is entry-point agnostic.

## Tests

`tests/gateway/test_import_sanity.py` — 21 tests, including the vertical regression from review #5042873887 (module imported from generation A, backing file swapped to B **before** the smoke, real smoke path must return `False` with a restart diagnosis and must **not** adopt the new generation as baseline), the review #5045506662 witness (birth receipt carries a valid commit, the second `_read_head_commit()` fails → smoke returns `False` with a "cannot verify the checkout generation" WARNING and no seeding; restore a readable matching commit → a later smoke verifies and seeds normally), commit-change-during-startup, birth-file vanished, transient stat error during the receipt comparison (no seeding from an unverified state), matching-receipt seeds + verify healthy, plus the original suite: repo-tree snapshot coverage, import-failure reporting, drift/deleted-file detection, report-exactly-once **and** stays-unhealthy-while-drift-persists, transient stat error → WARNING without swap claim, and the `.git` reader across plain loose refs, detached HEAD, packed-refs, linked worktrees, unresolvable/missing layouts.

```
PYTHONPATH=. python -m pytest tests/gateway/test_import_sanity.py -q          → 21 passed
PYTHONPATH=. python -m pytest tests/gateway/test_10710_auto_reset_evicts_cached_agent.py \
                                 tests/gateway/test_13121_shutdown_inflight_transcript_flush.py -q → 5 passed
ruff check gateway/import_sanity.py gateway/__init__.py gateway/run.py tests/gateway/test_import_sanity.py → clean
```
