### PR TITLE
fix(skills): stop syncing bookkeeping dirs (.hub, .archive, backups) to sandboxes

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".curator_backups",
         ".venv",
         "venv",
         "node_modules",

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -147,6 +147,46 @@ class TestIterSkillsFiles:
         # Symlink should be excluded
         assert not any("evil" in f["container_path"] for f in files)
 
+    def test_skips_excluded_bookkeeping_dirs(self, tmp_path):
+        """Bookkeeping and dependency dirs must not be uploaded to a sandbox.
+
+        The sync path used a bare rglob("*"), so the .hub download cache,
+        .archive, curator backups and any node_modules/.git under a skills
+        tree were packed up on every sync even though the sandbox never
+        reads them. Sync now honours EXCLUDED_SKILL_DIRS like discovery.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        (skills_dir / "cat" / "myskill").mkdir(parents=True)
+        (skills_dir / "cat" / "myskill" / "SKILL.md").write_text("# skill")
+        # Progressive-disclosure support files must still be synced.
+        (skills_dir / "cat" / "myskill" / "references").mkdir()
+        (skills_dir / "cat" / "myskill" / "references" / "api.md").write_text("ref")
+
+        for excluded in (".hub", ".archive", ".curator_backups", "node_modules"):
+            junk = skills_dir / excluded / "vendored"
+            junk.mkdir(parents=True)
+            (junk / "SKILL.md").write_text("# stale copy")
+        # Also nested inside an otherwise-valid skill package.
+        cache = skills_dir / "cat" / "myskill" / "__pycache__"
+        cache.mkdir()
+        (cache / "helper.cpython-311.pyc").write_text("bytecode")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            files = iter_skills_files()
+
+        paths = {f["container_path"] for f in files}
+        assert "/root/.hermes/skills/cat/myskill/SKILL.md" in paths
+        assert "/root/.hermes/skills/cat/myskill/references/api.md" in paths
+        for excluded in (
+            ".hub",
+            ".archive",
+            ".curator_backups",
+            "node_modules",
+            "__pycache__",
+        ):
+            assert not any(excluded in path for path in paths), excluded
+
     def test_empty_when_no_skills_dir(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from hermes_cli.config import cfg_get
 
+from agent.skill_utils import EXCLUDED_SKILL_DIRS
+
 try:  # pragma: no cover - exercised via the fail-closed test below
     from agent.file_safety import get_read_block_error
 except ImportError:  # noqa: F401 - sentinel consumed in register_credential_file
@@ -344,15 +346,32 @@ def _safe_skills_path(skills_dir: Path) -> str:
     return str(safe_dir)
 
 
+def _is_excluded_skills_dir(rel: Path) -> bool:
+    """True if *rel* sits under a directory excluded from skill scanning.
+
+    Reuses ``agent.skill_utils.EXCLUDED_SKILL_DIRS`` so the sync path agrees
+    with discovery. These are local bookkeeping and dependency directories
+    (``.hub`` download cache, ``.archive``, ``.curator_backups``,
+    ``node_modules``, ``__pycache__``, ``.git``, ...) that the remote agent
+    never reads.
+
+    This deliberately does not use ``is_excluded_skill_path()``, which also
+    prunes ``references/``, ``templates/``, ``assets/`` and ``scripts/``.
+    Those hold progressive-disclosure support files and bundled scripts the
+    sandbox does execute, so they must keep syncing.
+    """
+    return any(part in EXCLUDED_SKILL_DIRS for part in rel.parts[:-1])
+
+
 def iter_skills_files(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:
     """Yield individual (host_path, container_path) entries for skills files.
 
     Includes both the local skills dir and any external dirs configured via
-    skills.external_dirs.  Skips symlinks entirely.  Preferred for backends
-    that upload files individually (Daytona, Modal) rather than mounting a
-    directory.
+    skills.external_dirs.  Skips symlinks and anything under
+    EXCLUDED_SKILL_DIRS entirely.  Preferred for backends that upload files
+    individually (Daytona, Modal) rather than mounting a directory.
     """
     result: List[Dict[str, str]] = []
 
@@ -364,6 +383,8 @@ def iter_skills_files(
             if item.is_symlink() or not item.is_file():
                 continue
             rel = item.relative_to(skills_dir)
+            if _is_excluded_skills_dir(rel):
+                continue
             result.append({
                 "host_path": str(item),
                 "container_path": f"{container_root}/{rel}",
@@ -380,6 +401,8 @@ def iter_skills_files(
                 if item.is_symlink() or not item.is_file():
                     continue
                 rel = item.relative_to(ext_dir)
+                if _is_excluded_skills_dir(rel):
+                    continue
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",
@@ -392,6 +415,8 @@ def iter_skills_files(
                 if item.is_symlink() or not item.is_file():
                     continue
                 rel = item.relative_to(proj_dir)
+                if _is_excluded_skills_dir(rel):
+                    continue
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",


### PR DESCRIPTION
## Problem

`iter_skills_files()` walks the skills tree with a bare `rglob("*")` and returns
every regular file it finds. It has no notion of the exclusion set the rest of
the codebase uses, so local bookkeeping and dependency directories are packed up
and shipped to the sandbox on every sync:

- `.hub/` — the skill hub download cache
- `.archive/` — skills the curator has retired
- curator/restore backup snapshots
- `__pycache__/`, `node_modules/`, `.git/` under any skill package

None of it is ever read inside the sandbox. Skill content is resolved host-side
(`skill_view()`, `build_skills_system_prompt()`), so these files are write-only
uploads.

`agent/skill_utils.py` already defines `EXCLUDED_SKILL_DIRS` as the canonical
exclusion set, and discovery (`prompt_builder.py`, `skills_tool.py`) and backup
(`hermes_cli/backup.py`) all honour it. The sync path is the one place that
doesn't.

Measured on two installs here:

| install | files before | size before | files after | size after |
|---|---|---|---|---|
| main skills dir | 900 | 67.3 MB | 771 | 8.4 MB |
| a profile skills dir | 368 | 12.3 MB | 343 | 3.4 MB |

For a profile that also syncs the main dir as an external skills dir, that is
79.6 MB per sync instead of 11.8 MB — an 85% reduction, and `.hub` alone was
41.6 MB of it.

This is load-bearing on the SSH backend, where `_ssh_bulk_upload` has a hard
120s timeout (`tools/environments/ssh.py:327`). On a link that sustains a few
MB/s, the oversized payload does not merely slow the turn down, it exceeds the
timeout, and the failure surfaces to the user as the agent hanging for two
minutes on every tool call rather than as an error.

#6035 reported the same underlying waste on Daytona ("The synced files are never
read inside the sandbox ... The files are write-only") and was closed once
Daytona moved to a bulk-upload path. That fixed the transport; the file list was
left as-is, so the cost returns on any backend where the transport has a
deadline.

Note this also now reaches project-local skills: `get_project_skills_dirs()`
roots are git checkouts, so `.git/` (and often `node_modules/`) under a
project's `.hermes/skills` or `.agents/skills` is currently uploaded in full.

## Change

- `iter_skills_files()` skips paths under `EXCLUDED_SKILL_DIRS`, applied to all
  three roots it walks (local, external, project-local).
- Add `.curator_backups` to `EXCLUDED_SKILL_DIRS`. Curator backups live inside
  the skills tree and are the second-largest offender above, but the set does
  not currently list them.

The filter deliberately does **not** reuse `is_excluded_skill_path()`. That
helper additionally prunes `references/`, `templates/`, `assets/` and
`scripts/`, which are progressive-disclosure support files and bundled scripts
the sandbox genuinely does read and execute. Excluding those would break skills
that shell out to their own scripts. The existing test asserting
`scripts/run.sh` is synced pins that behaviour, and the new test asserts
`references/api.md` still syncs.

## Tests

New `test_skips_excluded_bookkeeping_dirs` covers both directions: bookkeeping
dirs (including one nested inside a valid skill package) are excluded, while
`SKILL.md` and `references/` are still returned. Verified it fails without the
production change and passes with it.

`tests/tools/test_credential_files.py` — 44 passed.

## Related

- #6035 — same root cause on Daytona, fixed at the transport layer only.
- #82178 / #82240 — backup snapshots inside the skills tree breaking
  `skill_view`, fixed by adding `.restore-backups` to the same frozenset. That
  PR and the one-line addition here touch the same set and will need a trivial
  conflict resolution depending on merge order; the two changes are
  complementary (that one fixes discovery, this one fixes sync).
- #26451 — proposes skipping hidden dirs during discovery generally. This PR
  stays with the explicit set rather than a blanket dot-prefix rule, since a
  blanket rule would silently drop a legitimate dot-directory inside a skill
  package.
