### PR TITLE
test(state): skip /proc holder simulation where readlink returns \\?\\ paths

### DIFF
--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -202,6 +202,11 @@ class TestRuntimeFtsRebuild:
             fd_dir.mkdir(parents=True)
         # PID 222 holds the deleted WAL sidecar
         os.symlink(db_path_wal + " (deleted)", str(proc_root / "222" / "fd" / "3"))
+        # Windows resolves symlink targets into \\?\ extended-path strings,
+        # which never canonicalize to the watched paths — the /proc simulation
+        # can only prove itself on POSIX.
+        if os.readlink(str(proc_root / "222" / "fd" / "3")).startswith("\\\\?\\"):
+            pytest.skip("readlink returns \\\\?\\ paths on Windows")
         # PID 111 (self) holds the db — should be excluded
         os.symlink(str(db_path), str(proc_root / "111" / "fd" / "3"))
         # PID 333 holds an unrelated file


### PR DESCRIPTION
Windows `os.readlink` resolves symlink targets to `\\?\` extended-length paths, which never canonicalize to the watched DB paths, so `test_foreign_holder_detection_proc_readlink_deleted_wal`'s holder match can never fire and the assertion fails vacuously. The /proc-fd-symlink simulation is POSIX-only behaviour; skip it when `readlink` returns extended-length paths instead of false-failing. Linux CI still exercises the real path unchanged.

Found while reviewing #92419 on a Windows dev box — the file currently has two Windows-only failures there, which suggests CI never runs it on Windows. Happy to fold this into #92419 if that's preferred.