### PR TITLE
fix(slack): grace transient Socket Mode disconnects

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1291,6 +1291,12 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # slack_sdk briefly reports disconnected while it rotates Socket Mode
+        # endpoints. Let the SDK own that transient reconnect; rebuilding the
+        # handler on the first false sample races its retry loop and can create
+        # a reconnect storm. Only a sustained disconnect belongs to Hermes.
+        self._socket_disconnect_grace_s = 45.0
+        self._socket_disconnected_since_monotonic: Optional[float] = None
         # Monotonic timestamp of the most recent Socket Mode handler (re)start,
         # used to grant a grace window for the first ping/pong after connect.
         self._socket_handler_started_monotonic: Optional[float] = None
@@ -1449,6 +1455,7 @@ class SlackAdapter(BasePlatformAdapter):
         task = asyncio.create_task(self._handler.start_async())
         self._socket_mode_task = task
         self._socket_handler_started_monotonic = time.monotonic()
+        self._socket_disconnected_since_monotonic = None
         task.add_done_callback(self._on_socket_mode_task_done)
 
     async def _stop_socket_mode_handler(self) -> None:
@@ -1583,8 +1590,19 @@ class SlackAdapter(BasePlatformAdapter):
 
                 connected = await self._socket_transport_connected()
                 if connected is False:
-                    await self._restart_socket_mode("transport disconnected")
-                elif self._socket_ping_pong_stale():
+                    now = time.monotonic()
+                    if self._socket_disconnected_since_monotonic is None:
+                        self._socket_disconnected_since_monotonic = now
+                        continue
+                    if (
+                        now - self._socket_disconnected_since_monotonic
+                        >= self._socket_disconnect_grace_s
+                    ):
+                        await self._restart_socket_mode("transport disconnected")
+                    continue
+                if connected is True:
+                    self._socket_disconnected_since_monotonic = None
+                if self._socket_ping_pong_stale():
                     # is_connected() can lie when the aiohttp session is closed
                     # but the client keeps retrying; ping/pong staleness catches
                     # that wedged-zombie case that the bool check above misses.

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -276,7 +276,7 @@ class TestSocketModeRestart:
 
     @pytest.mark.asyncio
     async def test_watchdog_restarts_when_transport_disconnected(self, adapter):
-        """A transport that reports itself down still triggers a reconnect."""
+        """A transport that stays down beyond grace still triggers a reconnect."""
         live_task = MagicMock()
         live_task.done.return_value = False
         adapter._socket_mode_task = live_task
@@ -291,7 +291,38 @@ class TestSocketModeRestart:
         adapter._restart_socket_mode = _fake_restart
         adapter._socket_transport_connected = AsyncMock(return_value=False)
         adapter._socket_watchdog_interval_s = 0.01
+        adapter._socket_disconnect_grace_s = 0.0
 
         await adapter._socket_watchdog_loop()
 
         assert reasons == ["transport disconnected"]
+
+    @pytest.mark.asyncio
+    async def test_watchdog_leaves_short_disconnect_to_slack_sdk(self, adapter):
+        """One false sample followed by recovery must not rebuild the handler."""
+        live_task = MagicMock()
+        live_task.done.return_value = False
+        adapter._socket_mode_task = live_task
+        adapter._handler = MagicMock()
+        adapter._socket_watchdog_interval_s = 0.001
+        adapter._socket_disconnect_grace_s = 1.0
+        samples = iter((False, True))
+        reasons: list[str] = []
+
+        async def _probe():
+            value = next(samples)
+            if value:
+                adapter._running = False
+            return value
+
+        async def _fake_restart(reason: str) -> None:
+            reasons.append(reason)
+            adapter._running = False
+
+        adapter._socket_transport_connected = _probe
+        adapter._restart_socket_mode = _fake_restart
+
+        await adapter._socket_watchdog_loop()
+
+        assert reasons == []
+        assert adapter._socket_disconnected_since_monotonic is None


### PR DESCRIPTION
## Summary

- give Slack SDK up to 45 seconds to recover a transient Socket Mode disconnect before Hermes rebuilds the handler
- reset the disconnect timer after transport recovery or handler restart
- preserve immediate recovery for stopped tasks and stale ping/pong state
- add a behavioral test proving a short false-to-true transport transition does not create a second handler

## Problem

The watchdog rebuilt the Socket Mode handler on the first `is_connected == false` sample. Slack SDK briefly reports disconnected while rotating endpoints, so Hermes could race the SDK's own reconnect loop. In production this produced repeated `Socket Mode unhealthy (transport disconnected)` rebuilds and thousands of `Session is closed` retries.

## Verification

- [x] `PYTHONPATH=/Users/yanada/work/hermes-slack-disconnect-grace /Users/yanada/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_slack_socket_reconnect_heal.py` — 4 passed
- [x] Ruff on the modified adapter and test
- [x] `git diff --check`
- [x] Production profile restarted with the patch: new Socket Mode generation stayed connected, with 0 unhealthy samples and 0 `Session is closed` retries through a real Slack inbound → response → outbound E2E

## Broader local test note

Running all `tests/gateway/test_slack*.py` from the latest worktree with an older shared venv produced four unrelated dependency-version failures in proxy/standalone-send tests. The reconnect test file and lint pass on the latest source tree; CI should use the repository's current dependency lock.
