### PR TITLE
fix(agent): carve out model-not-supported 401s from auth failover

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -249,6 +249,20 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "unsupported model",
 ]
 
+# Some providers answer an *invalid model name* with HTTP 401 instead of 404 —
+# opencode-go / OpenCode Zen returns ``401`` with a body like
+# ``"Model gpt-5-codex is not supported"``.  The credential is perfectly
+# healthy; only the requested model id is wrong.  These phrases are matched
+# *in addition to* requiring the word "model" in the body so a genuine auth
+# rejection that merely happens to contain "not supported" (e.g. "your region
+# is not supported") keeps the normal auth path.
+_MODEL_NOT_SUPPORTED_401_PATTERNS = [
+    "is not supported",
+    "are not supported",
+    "not a supported model",
+    "unsupported model",
+]
+
 # Request-validation patterns — the request is malformed and will fail
 # identically on every retry. Some OpenAI-compatible gateways (notably
 # codex.nekos.me) return these as 5xx instead of the standard 4xx, which
@@ -738,6 +752,33 @@ def _classify_by_status(
     """Classify based on HTTP status code with message-aware refinement."""
 
     if status_code == 401:
+        # Carve-out: a 401 that is really "you asked for a model that does not
+        # exist".  opencode-go / OpenCode Zen returns HTTP 401 with a body like
+        # ``Model <name> is not supported`` when the *model id* in the request
+        # is invalid, not when the key is bad.  Classifying that as auth
+        # rotates the credential pool and benches the (healthy) key for
+        # ``EXHAUSTED_TTL_401_SECONDS`` (5 minutes, see agent/credential_pool.py),
+        # which can empty a small pool for no reason and delays the only fix
+        # that helps — trying a different model — behind a pointless
+        # auth-recovery detour.  Mirrors the 404 refinements below: require the
+        # body to mention a model AND carry an explicit "not supported" phrase
+        # so ordinary auth rejections are untouched.
+        if "model" in error_msg and any(
+            p in error_msg for p in _MODEL_NOT_SUPPORTED_401_PATTERNS
+        ):
+            logger.warning(
+                "HTTP 401 with a model-validity body classified as "
+                "model_not_found, NOT auth — the credential is healthy and is "
+                "NOT being rotated; the requested model id is invalid "
+                "(provider=%s model=%s). error=%.200s",
+                provider, model, error_msg,
+            )
+            return result_fn(
+                FailoverReason.model_not_found,
+                retryable=False,
+                should_rotate_credential=False,
+                should_fallback=True,
+            )
         # Not retryable on its own — credential pool rotation and
         # provider-specific refresh (Codex, Anthropic, Nous) run before
         # the retryability check in run_agent.py.  If those succeed, the

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -228,6 +228,69 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_fallback is True
 
+    def test_401_model_not_supported_is_model_not_found(self):
+        """opencode-go returns 401 for an invalid model id, not a bad key.
+
+        The credential must NOT be rotated — only the model was wrong.
+        """
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={"error": {"message": "Model gpt-5-codex is not supported"}},
+        )
+        result = classify_api_error(
+            e, provider="opencode-go", model="gpt-5-codex",
+        )
+        assert result.reason == FailoverReason.model_not_found
+        assert result.reason != FailoverReason.auth
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_401_invalid_api_key_still_auth(self):
+        """Regression guard: a genuinely auth-shaped 401 is unchanged."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={"error": {"message": "Invalid API key provided"}},
+        )
+        result = classify_api_error(e, provider="opencode-go")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_401_mentioning_model_without_not_supported_is_auth(self):
+        """False-positive guard: "model" alone must not trigger the carve-out."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={
+                "error": {
+                    "message": (
+                        "Invalid API key for model gpt-5-codex — "
+                        "contact support to enable model access"
+                    )
+                }
+            },
+        )
+        result = classify_api_error(
+            e, provider="opencode-go", model="gpt-5-codex",
+        )
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
+
+    def test_401_region_not_supported_is_auth(self):
+        """False-positive guard: "not supported" without a model mention."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={"error": {"message": "Your region is not supported"}},
+        )
+        result = classify_api_error(e, provider="opencode-go")
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
+
     def test_403_classified_as_auth(self):
         e = MockAPIError("Forbidden", status_code=403)
         result = classify_api_error(e, provider="anthropic")


### PR DESCRIPTION
## Problem

Some providers (opencode-go / OpenCode Zen) answer an invalid *model id* with HTTP 401 and a body like `"Model X is not supported"` rather than the more typical 404. `_classify_by_status()` (`agent/error_classifier.py`) treats every 401 as `FailoverReason.auth`, which rotates the credential pool and benches a perfectly healthy key for `EXHAUSTED_TTL_401_SECONDS` (5 minutes, see `agent/credential_pool.py`). That can empty a small credential pool for no reason, and delays the only fix that actually helps — falling back to a different model — behind a pointless auth-recovery detour.

## Fix

Adds a narrow carve-out at the top of the `if status_code == 401:` branch in `_classify_by_status()`, mirroring the existing message-aware 404 refinements already in the same function: when the error body mentions "model" **and** carries an explicit "not supported"-style phrase, classify as `FailoverReason.model_not_found` (`retryable=False`, `should_rotate_credential=False`, `should_fallback=True`) and log a warning making the 401-but-not-auth case visible. Requiring both signals avoids false-positiving on a genuine auth rejection that happens to mention "model" or "not supported" for unrelated reasons (e.g. "your region is not supported"). The generic 401→auth path is otherwise untouched — real auth failures behave exactly as before.

## Files changed

- `agent/error_classifier.py` — new `_MODEL_NOT_SUPPORTED_401_PATTERNS` constant + carve-out branch (+34 lines)
- `tests/agent/test_error_classifier.py` — 4 new tests in `TestClassifyApiError`: fires on a model-not-supported 401, regression guard that a real auth 401 is unchanged, and two false-positive guards (mentions "model" without "not supported"; "not supported" without a model mention) (+63 lines)

## Testing

```
.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q
159 passed
```

The existing `test_401_classified_as_auth` is unmodified and still passes — real auth 401s are unaffected.

Note: the fix is written from the documented/inferred shape of the opencode-go / OpenCode Zen error body; I did not capture a live production trace of this exact response.