### PR TITLE
fix(model): don't crash the Model tab on numeric custom provider names

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -88,9 +88,11 @@ def load_picker_context() -> ConfigContext:
     cfg = load_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, dict):
-        current_model = model_cfg.get("default", model_cfg.get("name", "")) or ""
-        current_provider = model_cfg.get("provider", "") or ""
-        current_base_url = model_cfg.get("base_url", "") or ""
+        # PyYAML parses unquoted scalars as int (`provider: 2070`). Keep these
+        # as strings so picker/options paths never call `.strip()` on an int.
+        current_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "")
+        current_provider = str(model_cfg.get("provider", "") or "")
+        current_base_url = str(model_cfg.get("base_url", "") or "")
     else:
         # config.model can be a bare string in older configs.
         current_model = str(model_cfg) if model_cfg else ""

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2645,8 +2645,14 @@ def list_authenticated_providers(
 
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
-    _current_provider_norm = str(current_provider or "").strip().lower()
-    _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
+    # PyYAML parses unquoted numeric names (`provider: 2070`) as int. Later
+    # `.strip()` on that raw value 500s GET /api/model/options and the Desktop
+    # Model tab cannot assign custom endpoints.
+    current_provider = str(current_provider or "").strip()
+    current_base_url = str(current_base_url or "").strip()
+    current_model = str(current_model or "").strip()
+    _current_provider_norm = current_provider.lower()
+    _current_base_url_norm = current_base_url.rstrip("/").lower()
 
     def _can_probe_custom_provider(*, row_is_current: bool) -> bool:
         return bool(probe_custom_providers or (probe_current_custom_provider and row_is_current))

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -40,6 +40,30 @@ def _cfg(model=None, providers=None, custom_providers=None) -> dict:
     }
 
 
+def test_load_picker_context_coerces_numeric_yaml_provider():
+    """PyYAML parses unquoted `provider: 2070` as int; picker context must be str.
+
+    Desktop GET /api/model/options crashed with AttributeError: 'int' object
+    has no attribute 'strip' when a custom endpoint was named after a GPU.
+    """
+    cfg = _cfg(
+        model={
+            "provider": 2070,
+            "default": "Qwen3.5-9B-Q4_K_M.gguf",
+            "base_url": "http://192.168.1.10:8082/v1",
+        }
+    )
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch(
+        "hermes_cli.config.get_compatible_custom_providers", return_value=[]
+    ):
+        ctx = load_picker_context()
+    assert ctx.current_provider == "2070"
+    assert isinstance(ctx.current_provider, str)
+    assert ctx.current_model == "Qwen3.5-9B-Q4_K_M.gguf"
+    assert ctx.current_base_url == "http://192.168.1.10:8082/v1"
+
+
+
 
 
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -115,6 +115,26 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     )
 
 
+def test_list_authenticated_providers_numeric_current_provider_does_not_crash(
+    monkeypatch,
+):
+    """Unquoted YAML `provider: 2070` must not 500 GET /api/model/options."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
+
+    providers = list_authenticated_providers(
+        current_provider=2070,
+        current_base_url="http://192.168.1.10:8082/v1",
+        current_model="Qwen3.5-9B-Q4_K_M.gguf",
+        user_providers={},
+        custom_providers=[],
+        max_models=0,
+        probe_custom_providers=False,
+    )
+
+    assert isinstance(providers, list)
+
 
 def test_providers_singular_model_does_not_suppress_ollama_native_discovery(monkeypatch):
     """A saved selection in ``providers:`` is not an explicit catalog."""


### PR DESCRIPTION
## Summary
- PyYAML parses unquoted `provider: 2070` as an integer. `GET /api/model/options` then called `.strip()` on that value and 500ed, so Desktop could not assign custom endpoints to a profile.
- Coerce provider/model/base_url to strings at picker-context load and at the start of `list_authenticated_providers`.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_switch_custom_providers.py -q`
- [ ] Desktop: set `model.provider: 2070` (unquoted) on a profile, open Settings → Model — picker should load, not 500
- [ ] Assign distinct custom endpoints (`:8080` / `:8081` / `:8082`) per profile and confirm they stick after switching profiles