### PR TITLE
fix(cli): resolve model_aliases direct aliases on explicit -m/--model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5177,6 +5177,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # clobber an explicit override with the session's stored model.
         self._explicit_model_override = bool(model)
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        # Resolve a config.yaml `model_aliases:` direct alias on the explicit
+        # -m/--model value, mirroring the oneshot path (hermes_cli/oneshot.py)
+        # and interactive /model (model_switch.switch_model).  Without this,
+        # `hermes chat -q -m <alias>` sends the raw alias string to the
+        # default provider (e.g. "local8b" → zai → HTTP 400 → silent fallback
+        # chain), because cmd_chat → cli.main() never runs alias resolution.
+        # Only applies to an explicit -m: the config-default model was already
+        # resolved when it was written by `hermes config set` / the picker.
+        _alias_provider_override: Optional[str] = None
+        _alias_base_url_override: Optional[str] = None
+        if model:
+            try:
+                from hermes_cli import model_switch as _ms
+
+                _ms._ensure_direct_aliases()
+                _da = _ms.DIRECT_ALIASES.get(model.strip().lower())
+            except Exception:
+                _da = None
+            if _da is not None:
+                self.model = _da.model
+                self._model_is_default = False
+                if _da.provider and _da.provider != "custom":
+                    # Named provider alias: route provider explicitly —
+                    # unless the user passed --provider themselves
+                    # (explicit CLI args win over alias resolution).
+                    if not provider:
+                        _alias_provider_override = _da.provider
+                elif _da.base_url:
+                    # Bare custom endpoint alias: pin the endpoint via
+                    # _explicit_base_url — _ensure_runtime_credentials routes
+                    # `custom` + explicit_base_url through
+                    # _resolve_named_custom_runtime ("direct-alias" source),
+                    # which builds the runtime from the alias's base_url.
+                    # Only when the user didn't pass --provider/--base-url
+                    # themselves (explicit args win over alias resolution).
+                    if not provider and not base_url:
+                        _alias_base_url_override = _da.base_url
+                # A bare `custom` provider with no base_url is unresolvable;
+                # leave routing untouched and let the resolver surface it.
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
@@ -5248,6 +5287,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._model_is_default = False
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
+
+        # Direct-alias overrides resolved from an explicit -m/--model in
+        # __init__.  Applied after the ambient assignments so an alias pins
+        # its provider/endpoint over the config default, while explicit
+        # --provider / --base-url CLI args already won inside the resolution
+        # block (those skip the alias overrides entirely).
+        if _alias_provider_override:
+            self.requested_provider = _alias_provider_override
+            self.provider = _alias_provider_override
+        if _alias_base_url_override:
+            self._explicit_base_url = _alias_base_url_override
+            # Bare custom endpoint: route resolution through the direct-alias
+            # path (_resolve_named_custom_runtime "direct-alias" source) so
+            # the alias's base_url is used verbatim.
+            self.requested_provider = "custom"
+            self.provider = "custom"
         self.api_mode = "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []

--- a/tests/cli/test_cli_explicit_model_alias.py
+++ b/tests/cli/test_cli_explicit_model_alias.py
@@ -1,0 +1,138 @@
+"""Regression tests: ``hermes chat -q -m <alias>`` must resolve direct
+aliases from config.yaml ``model_aliases:``.
+
+Bug: ``cmd_chat`` → ``cli.main()`` never ran alias resolution, so the raw
+alias string (e.g. ``local8b``) was sent to the default provider as the
+model id — HTTP 400, then a *silent* fallback to the first configured
+fallback provider. The answer looked fine but came from a different model.
+
+The oneshot path (``hermes_cli/oneshot.py``, DIRECT_ALIASES check) and
+interactive ``/model`` (``model_switch.switch_model``) already resolved
+aliases; this file pins the same behaviour for ``HermesCLI.__init__`` with
+an explicit ``-m`` value.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.model_switch import DirectAlias
+
+
+def _make_cli(**kwargs):
+    """Create a HermesCLI instance with minimal mocking (mirrors
+    tests/cli/test_cli_init.py::_make_cli, without env overrides)."""
+    import importlib
+
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    try:
+        with patch.dict(sys.modules, prompt_toolkit_stubs), \
+             patch.dict("os.environ", clean_env, clear=False):
+            import cli as _cli_mod
+            _cli_mod = importlib.reload(_cli_mod)
+            with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+                 patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+                return _cli_mod.HermesCLI(**kwargs)
+    finally:
+        import cli as _cli_restore
+        importlib.reload(_cli_restore)
+
+
+_LOCAL_ALIASES = {
+    "local8b": DirectAlias(
+        model="qwen3-8b", provider="custom", base_url="http://localhost:8080/v1"
+    ),
+    "fav": DirectAlias(model="claude-sonnet-4.6", provider="anthropic", base_url=""),
+}
+
+
+def _patched_aliases():
+    """Patch DIRECT_ALIASES for the duration of a HermesCLI construction."""
+    import hermes_cli.model_switch as ms
+    return patch.object(ms, "DIRECT_ALIASES", _LOCAL_ALIASES)
+
+
+class TestExplicitModelAliasResolution:
+    """``-m <direct-alias>`` routes to the alias's model + provider/endpoint."""
+
+    def test_custom_alias_resolves_model_and_pins_base_url(self):
+        with _patched_aliases():
+            cli = _make_cli(model="local8b")
+        # The alias's model id is sent, not the raw alias string.
+        assert cli.model == "qwen3-8b"
+        # Bare-custom alias: provider routes to custom and the alias's
+        # base_url is pinned via _explicit_base_url so
+        # _ensure_runtime_credentials resolves the direct-alias runtime.
+        assert cli.requested_provider == "custom"
+        assert cli._explicit_base_url == "http://localhost:8080/v1"
+        # An explicit -m is not "the default model".
+        assert cli._model_is_default is False
+
+    def test_named_provider_alias_routes_provider(self):
+        with _patched_aliases():
+            cli = _make_cli(model="fav")
+        assert cli.model == "claude-sonnet-4.6"
+        assert cli.requested_provider == "anthropic"
+        # No base_url pin — the provider's own resolution applies.
+        assert not cli._explicit_base_url
+
+    def test_explicit_provider_arg_wins_over_alias(self):
+        with _patched_aliases():
+            cli = _make_cli(model="local8b", provider="anthropic")
+        # Model still resolves through the alias, but the explicit
+        # --provider arg wins for routing: no custom/base_url override.
+        assert cli.model == "qwen3-8b"
+        assert cli.requested_provider == "anthropic"
+        assert not cli._explicit_base_url
+
+    def test_explicit_base_url_arg_wins_over_alias(self):
+        with _patched_aliases():
+            cli = _make_cli(model="local8b", base_url="https://my-gateway.example/v1")
+        assert cli.model == "qwen3-8b"
+        assert cli._explicit_base_url == "https://my-gateway.example/v1"
+        # No provider rerouting to custom — the explicit endpoint stands.
+        assert cli.requested_provider != "custom"
+
+    def test_non_alias_model_untouched(self):
+        with _patched_aliases():
+            cli = _make_cli(model="glm-5.2")
+        assert cli.model == "glm-5.2"
+        # No alias resolution for a plain model id: routing keeps the
+        # config default and no endpoint pin appears.
+        assert cli.requested_provider == "auto"
+        assert not cli._explicit_base_url
+
+    def test_no_model_arg_untouched(self):
+        # No -m: config default flows through unchanged (aliases must not
+        # apply — the config default was resolved when it was written).
+        with _patched_aliases():
+            cli = _make_cli()
+        assert cli.model == "anthropic/claude-opus-4.6"
+        assert cli.requested_provider == "auto"
+        assert not cli._explicit_base_url


### PR DESCRIPTION
## Problem

`hermes chat -q -m <alias>` (and any `hermes … -m <alias>` invocation routed through `cmd_chat` → `cli.main()`) never resolved user-defined `model_aliases:` entries. The raw alias string was sent to the configured default provider as the model id:

```
⚠ Auxiliary title generation failed: HTTP 400: modelCode: does not exist
⚠️ Model fallback: local8b via zai unavailable (provider failure); using stepfun/step-3.7-flash:free via nous.
```

Worse than the 400 itself: the fallback chain kicks in **silently**, so the user gets a normal-looking answer from a completely different (fallback) model while believing they are talking to their alias target — e.g. a local llama.cpp server.

## Root cause

Alias resolution for `model_aliases:` direct aliases exists in two places, but not on the `chat` path:

- oneshot (`hermes -z`): `hermes_cli/oneshot.py` checks `DIRECT_ALIASES` before provider auto-detection
- interactive `/model`: `hermes_cli/model_switch.py::switch_model` → `resolve_alias`

`cmd_chat` hands the `-m` value straight to `HermesCLI(model=…)`, and `__init__` stored it verbatim as `self.model` — no alias lookup anywhere.

## Fix

Resolve direct aliases inside `HermesCLI.__init__`, mirroring the oneshot semantics:

- applies **only** to an explicit `-m`/`--model` value (a config default was already resolved when it was written by `hermes config set` / the picker)
- the alias's model id replaces the raw string, and `_model_is_default` is cleared
- bare `custom` alias with a `base_url`: the endpoint is pinned via `_explicit_base_url` and `requested_provider` routes to `custom`, which `_ensure_runtime_credentials` → `_resolve_named_custom_runtime` already handles as the "direct-alias" runtime source
- named-provider alias (`provider` ≠ custom): routes `requested_provider` to it
- an explicit `--provider` or `--base-url` CLI arg **wins** over the alias (guards in the resolution block)
- non-alias model ids and no-`-m` runs are completely untouched

## Testing

New regression suite `tests/cli/test_cli_explicit_model_alias.py` (6 tests):

- custom alias resolves model + pins base_url + routes custom
- named provider alias routes its provider
- explicit `--provider` wins over alias routing
- explicit `--base-url` wins over alias endpoint
- plain model id untouched
- no `-m` untouched

```
=== Summary: 1 files, 6 tests passed, 0 failed ===
```

Also ran the surrounding suites (model switch, aliases, resume, oneshot, custom providers — 15 files / 332 tests) green, and verified end-to-end against a live local llama.cpp server: `hermes chat -q … -m local8b` now routes to `provider=custom base_url=http://localhost:8080/v1 model=qwen3-8b` with zero fallbacks (confirmed via agent.log and the llama-server timing log).