### PR TITLE
fix(update): capture pre_pull_sha before fork-sync to stop false 'Code did not move' no-op

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7833,6 +7833,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # commit_count == 0 branch, which returns immediately after: an update
         # that pulled hundreds of upstream commits printed "Already up to
         # date!" and verified nothing).
+        # pre_pull_sha is captured later for the main pull path, but when the
+        # fork sync (below) already advances HEAD, the subsequent
+        # ``merge --ff-only origin/<branch>`` is a no-op — HEAD already equals
+        # origin/<branch>. Capturing pre_pull_sha AFTER the sync would make the
+        # "Code did not move" guard (line ~8207) false-positive, because
+        # post_pull_sha would equal the already-advanced pre_pull_sha. When the
+        # sync moves HEAD, stash the PRE-sync SHA here so the guard sees the
+        # real movement and the syntax-error rollback target is the last
+        # known-good checkout, not the post-sync tip.
+        pre_pull_sha = None
+
         if commit_count == 0 and is_fork and branch == "main":
             pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
             _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
@@ -7847,6 +7858,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # HEAD moving is itself proof of an update. Keep the update
                 # path active even if the informational count cannot be read.
                 commit_count = max(1, synced_count)
+                # The sync already advanced HEAD; the main pull's
+                # ``merge --ff-only origin/<branch>`` will be a no-op. Use the
+                # pre-sync SHA as the pull baseline so the "Code did not move"
+                # guard and the syntax-error rollback both reference the state
+                # before ANY code moved this run.
+                pre_pull_sha = pre_sync_sha
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -8027,7 +8044,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # orphan merge-conflict markers in hermes_cli/config.py bricked
         # every user who ran ``hermes update`` for the 7 minutes between
         # the bad commit and the fix landing).
-        pre_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+        #
+        # When the fork-sync path above already advanced HEAD, pre_pull_sha
+        # was set to the PRE-sync SHA so the "Code did not move" guard and
+        # the syntax-error rollback reference the real baseline. Don't
+        # clobber it here — the merge below is a no-op against the already
+        # advanced checkout, so re-capturing now would make the guard
+        # false-positive (post_pull_sha would equal the new pre_pull_sha).
+        if pre_pull_sha is None:
+            pre_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
         try:
             # Merge the ref we already fetched above (→ Fetching updates...)
             # instead of `git pull`, which performs a SECOND network fetch of

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -147,3 +147,83 @@ def test_update_fails_loudly_when_head_pinned(monkeypatch, tmp_path, capsys):
     assert "Code did not move" in out
     assert "✓ Code updated!" not in out
     assert "checkout main" in out
+
+
+def _make_fork_sync_advances_head_side_effect(pre_sha="abc123", post_sha="def456"):
+    """Simulate a fork where origin/main == HEAD but upstream/main is ahead.
+
+    The fork sync path runs ``git pull --ff-only upstream main`` which
+    advances HEAD from pre_sha to post_sha. After that, the main pull's
+    ``merge --ff-only origin/main`` is a no-op (HEAD already == origin/main).
+
+    The "Code did not move" guard must NOT false-positive here — the sync
+    already moved HEAD, which is itself proof of an update.
+    """
+    calls = {"n": 0}
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+
+        # rev-list HEAD..origin/main --count → 0 (fork matches origin)
+        if "rev-list" in joined:
+            return SimpleNamespace(returncode=0, stdout="0\n", stderr="")
+
+        # rev-parse HEAD: first call (pre-sync) returns pre_sha, subsequent
+        # calls (post-sync) return post_sha.
+        if joined.endswith("rev-parse HEAD"):
+            if calls["n"] == 0:
+                calls["n"] += 1
+                return SimpleNamespace(returncode=0, stdout=f"{pre_sha}\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout=f"{post_sha}\n", stderr="")
+
+        # Everything else (merge, checkout, fetch, etc.) succeeds quietly.
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return side_effect
+
+
+def test_update_succeeds_when_fork_sync_advances_head(monkeypatch, tmp_path, capsys):
+    """When the fork sync advances HEAD, the update must succeed.
+
+    Regression for the false-positive "Code did not move" guard: when a
+    fork trails upstream, the sync path pulls from upstream and advances
+    HEAD. The subsequent ``merge --ff-only origin/main`` is a no-op because
+    HEAD already equals origin/main. The guard must compare against the
+    PRE-sync SHA, not the post-sync SHA, or every fork-trailing update
+    reports a spurious no-op.
+    """
+    from hermes_cli import update_cmd
+
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+
+    # Patch as a fork with an upstream remote that will sync.
+    monkeypatch.setattr(
+        hermes_main, "_get_origin_url",
+        lambda *a, **k: "git@github.com:learhy/hermes-agent.git",
+    )
+    monkeypatch.setattr(update_cmd, "_is_fork", lambda *a, **k: True)
+    monkeypatch.setattr(
+        hermes_main, "_has_upstream_remote", lambda *a, **k: True
+    )
+    # The sync advances HEAD from pre_sha to post_sha.
+    sync_calls = {"n": 0}
+
+    def _sync_side_effect(git_cmd, cwd):
+        sync_calls["n"] += 1
+
+    monkeypatch.setattr(
+        hermes_main, "_sync_with_upstream_if_needed", _sync_side_effect
+    )
+
+    _patch_update_deps(
+        monkeypatch, tmp_path, _make_fork_sync_advances_head_side_effect()
+    )
+
+    hermes_main.cmd_update(args)
+
+    out = capsys.readouterr().out
+    assert "Code did not move" not in out
+    assert sync_calls["n"] >= 1


### PR DESCRIPTION
## Summary

When updating from a fork that trails upstream, `hermes update` prints:

```
✗ Code did not move — update was a no-op.
  HEAD is pinned to <sha> (detached checkout); origin/main advanced but the working tree stayed put.
  Reattach to the branch and retry: git -C ... checkout main && hermes update
```

…even though the update **succeeded**. The code is current, the user just sees a scary error and exit 1.

## Root cause

The fork-sync path (`_sync_with_upstream_if_needed`) runs `git pull --ff-only upstream main`, which **advances HEAD** to upstream/main, then pushes back to origin. After that, the main pull path runs `merge --ff-only origin/main` — a **no-op** because HEAD already equals origin/main.

The post-pull HEAD-movement guard ("Code did not move", issue #79678) compares `post_pull_sha` to `pre_pull_sha`. But `pre_pull_sha` was captured **after** the fork sync already moved HEAD:

```python
# fork-sync block (line ~7836) — advances HEAD
if commit_count == 0 and is_fork and branch == "main":
    pre_sync_sha = _capture_head_sha(...)
    _sync_with_upstream_if_needed(...)
    post_sync_sha = _capture_head_sha(...)
    if pre_sync_sha != post_sync_sha:
        commit_count = max(1, synced_count)

# ...

# main pull block (line ~8030) — captures pre_pull_sha AFTER sync moved HEAD
pre_pull_sha = _capture_head_sha(...)   # ← already-advanced SHA
merge --ff-only origin/main             # ← no-op, HEAD unchanged
post_pull_sha = _capture_head_sha(...)  # ← same as pre_pull_sha
# guard: post == pre → false positive ✗
```

## Fix

1. Initialize `pre_pull_sha = None` **before** the fork-sync block.
2. When the sync moves HEAD, set `pre_pull_sha = pre_sync_sha` (the SHA **before** any movement this run).
3. At the main pull's capture point, only set `pre_pull_sha` if it's still `None` — don't clobber the pre-sync value.

This makes the guard compare `post_pull_sha` against the real baseline (pre-sync SHA), so it correctly sees the movement. It also keeps the syntax-error rollback target as the last known-good checkout (pre-sync), not the post-sync tip.

## Reproduction

Any fork that trails upstream will hit this on every `hermes update` where upstream has new commits. The user's box (fork `learhy/hermes-agent`) reproduced twice in a row:

```
✗ Code did not move — update was a no-op.
  HEAD is pinned to 42ac29eacc (detached checkout); origin/main advanced but the working tree stayed put.
```

Despite HEAD being at `42ac29eacc` (== origin/main == upstream/main) — the update was successful.

## Testing

- Added `test_update_succeeds_when_fork_sync_advances_head` to `tests/hermes_cli/test_update_head_moved_gate.py` — simulates a fork where origin/main == HEAD but upstream/main is ahead; the sync advances HEAD; the subsequent merge is a no-op; the guard must NOT false-positive.
- Existing `test_update_fails_loudly_when_head_pinned` still passes (the guard still catches genuinely-pinned detached HEADs).
- Verified the logic with a standalone simulation: `pre_pull_sha = pre_sync_sha` makes `post_pull_sha != pre_pull_sha` → guard passes.