### PR TITLE
fix(gitlock): tolerate non-UTF-8 tasklist output on Windows (UnicodeDecodeError)

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -62,6 +62,7 @@ def _git_proc_running() -> bool:
             out = subprocess.run(
                 ["tasklist", "/FI", "IMAGENAME eq git.exe", "/FO", "CSV"],
                 capture_output=True, text=True, timeout=10,
+                encoding="utf-8", errors="replace",
             ).stdout.lower()
             return "git.exe" in out
         out = subprocess.run(
@@ -185,6 +186,7 @@ def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
             ["git", "merge-base", "--is-ancestor", rev, "HEAD"],
             cwd=str(repo_root),
             capture_output=True, text=True, timeout=10,
+            encoding="utf-8", errors="replace",
         )
         return result.returncode == 0
     except Exception:


### PR DESCRIPTION
## Problem

On Chinese (and other non-UTF-8) Windows locales, `hermes --version` and the update check crash a background reader thread:

```
Exception in thread Thread-9 (_readerthread):
...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcf in position 3: invalid continuation byte
```

**Root cause:** `clear_stale_git_locks()` -> `_git_proc_running()` runs `tasklist /FI "IMAGENAME eq git.exe"` with `text=True` but no `encoding`/`errors`. Hermes runs with `PYTHONUTF8=1` (UTF-8 mode), so `text=True` defaults to strict UTF-8 decoding - but on Chinese Windows, `tasklist` emits GBK/ANSI output (e.g. the 0xcf byte in the localized header), which crashes the stdlib reader thread. The crash is non-fatal (the caller swallows the exception) but prints a traceback on every `hermes --version` invocation, obscuring real errors.

## Fix

Add `encoding="utf-8", errors="replace"` to the `tasklist` subprocess call, and defensively to the `git merge-base` probe in the same file. The process-name match (`"git.exe" in out`) is ASCII-only, so replacement characters in localized header text don't affect correctness.

## Verification

- Before: `hermes --version` prints the UnicodeDecodeError traceback (Chinese Windows + PYTHONUTF8=1)
- After: clean output; update check runs normally