### PR TITLE
test(logging): cover Windows cross-process log integrity

### DIFF
--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,10 +1,13 @@
 """Tests for hermes_logging — centralized logging setup."""
 import io
 import logging
+import multiprocessing
 import os
+import queue
 import stat
 import sys
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -18,6 +21,44 @@ import hermes_logging
 # (the #44873 fix) but keeps stdlib RotatingFileHandler on POSIX, so importing
 # the name from the module under test keeps the two in lockstep.
 from hermes_logging import RotatingFileHandler
+
+
+_MULTIPROCESS_LOG_RECORDS_PER_ROLE = 32
+_MULTIPROCESS_LOG_PAYLOAD = "多进程日志—Ω—" * 80
+_MULTIPROCESS_LOG_ROLES = (
+    ("supervisor", "tui_gateway.host_supervisor"),
+    ("compute-host", "tui_gateway.compute_host"),
+)
+
+
+def _multiprocess_log_message(role: str, index: int) -> str:
+    return (
+        f"MPLOG::{role}::{index:03d} "
+        f"{_MULTIPROCESS_LOG_PAYLOAD} "
+        f"END::{role}::{index:03d}"
+    )
+
+
+def _write_multiprocess_log_records(
+    hermes_home: str,
+    role: str,
+    logger_name: str,
+    ready_queue,
+    start_event,
+) -> None:
+    """Child entry point for the native-spawn logging integrity test."""
+    try:
+        hermes_logging.setup_logging(hermes_home=Path(hermes_home))
+        ready_queue.put(role)
+        if not start_event.wait(30.0):
+            raise TimeoutError(f"start signal not received for {role}")
+
+        child_logger = logging.getLogger(logger_name)
+        for index in range(_MULTIPROCESS_LOG_RECORDS_PER_ROLE):
+            child_logger.info(_multiprocess_log_message(role, index))
+        hermes_logging.flush_log_queue()
+    finally:
+        hermes_logging._reset_queued_handlers()
 
 
 @pytest.fixture(autouse=True)
@@ -314,6 +355,7 @@ class TestAddRotatingHandler:
             formatter=formatter,
         )
 
+
         rotating_handlers = [
             h for h in hermes_logging.rotating_file_handlers()
             if isinstance(h, RotatingFileHandler)
@@ -448,6 +490,105 @@ class TestWindowsConcurrentLogLockTimeout:
         finally:
             logger.removeHandler(handler)
             handler.close()
+
+    @pytest.mark.windows_only
+    def test_concurrent_processes_preserve_all_records_on_windows(
+        self, hermes_home
+    ):
+        """The formal logging path keeps every record from two OS processes."""
+        ctx = multiprocessing.get_context("spawn")
+        ready_queue = ctx.Queue()
+        start_event = ctx.Event()
+        processes = [
+            ctx.Process(
+                target=_write_multiprocess_log_records,
+                args=(str(hermes_home), role, logger_name, ready_queue, start_event),
+                name=f"hermes-log-{role}",
+            )
+            for role, logger_name in _MULTIPROCESS_LOG_ROLES
+        ]
+
+        ready_roles = []
+        alive_after_deadline = []
+        exit_codes = {}
+        started_processes = []
+        try:
+            for process in processes:
+                process.start()
+                started_processes.append(process)
+
+            ready_deadline = time.monotonic() + 30.0
+            for _ in processes:
+                remaining = max(0.01, ready_deadline - time.monotonic())
+                try:
+                    ready_roles.append(ready_queue.get(timeout=remaining))
+                except queue.Empty:
+                    pytest.fail(
+                        "logging children did not become ready: "
+                        f"ready={sorted(ready_roles)}"
+                    )
+
+            assert set(ready_roles) == {
+                role for role, _ in _MULTIPROCESS_LOG_ROLES
+            }
+            start_event.set()
+
+            completion_deadline = time.monotonic() + 30.0
+            for process in processes:
+                process.join(max(0.0, completion_deadline - time.monotonic()))
+
+            alive_after_deadline = [
+                process.name for process in processes if process.is_alive()
+            ]
+            exit_codes = {
+                process.name: process.exitcode for process in processes
+            }
+        finally:
+            start_event.set()
+            try:
+                for process in started_processes:
+                    if process.is_alive():
+                        process.terminate()
+                for process in started_processes:
+                    process.join(5.0)
+            finally:
+                ready_queue.close()
+                ready_queue.join_thread()
+
+        assert not alive_after_deadline, (
+            "logging children exceeded completion deadline: "
+            f"{alive_after_deadline}"
+        )
+        assert exit_codes == {
+            "hermes-log-supervisor": 0,
+            "hermes-log-compute-host": 0,
+        }
+
+        log_path = hermes_home / "logs" / "agent.log"
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        record_lines = [line for line in content.splitlines() if "MPLOG::" in line]
+        expected = {
+            f"MPLOG::{role}::{index:03d}": _multiprocess_log_message(role, index)
+            for role, _ in _MULTIPROCESS_LOG_ROLES
+            for index in range(_MULTIPROCESS_LOG_RECORDS_PER_ROLE)
+        }
+        problems = {
+            marker: {
+                "marker_count": content.count(marker),
+                "complete_count": content.count(message),
+            }
+            for marker, message in expected.items()
+            if content.count(marker) != 1 or content.count(message) != 1
+        }
+
+        expected_count = len(expected)
+        observed_count = len(record_lines)
+        if observed_count != expected_count:
+            pytest.fail(
+                f"expected {expected_count} records, observed {observed_count}"
+            )
+        assert not problems, f"incomplete, missing, or duplicate records: {problems}"
 
 
 
@@ -676,5 +817,4 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
-
 


### PR DESCRIPTION
## What does this PR do?

Adds a native-Windows behavior test for Hermes's existing centralized logging path. Two independent `spawn` processes use the real `hermes_logging.setup_logging()` stack to write long Unicode records to the same temporary `agent.log`, and the parent verifies that all 64 expected records are present exactly once and complete.

This is an evidence-first follow-up to #96430. It does not wire or remove the unused raw `append_log_record()` helper and does not choose ownership for the separate stalled/RSS telemetry contract. Instead, it puts the already-authoritative logging path under native Windows cross-process coverage without adding a second writer that could bypass formatting, redaction, rotation, or level handling.

## Related Issue

Refs #96430

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a module-scope Windows `spawn` worker in `tests/test_hermes_logging.py`.
- Coordinate supervisor- and compute-host-named loggers with a shared start gate.
- Verify 64 long Unicode records for loss, duplication, truncation, and line damage without relying on order.
- Bound child startup/completion and cleanup; keep failure diagnostics limited to record markers and counts.
- Leave all production files unchanged.

## How to Test

1. Run the focused native-Windows behavior:
   `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_hermes_logging.py -k test_concurrent_processes_preserve_all_records_on_windows`
2. Run all Windows-marked tests in the containing file:
   `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_hermes_logging.py -m "windows_only and not integration"`
3. Run static checks:
   `.venv/Scripts/python.exe -m ruff check tests/test_hermes_logging.py`
   and `git diff HEAD^ HEAD --check`

Observed on native Windows with Python 3.11.15 and file-level retries disabled:

- focused behavior: 1 passed, 0 failed;
- Windows-marked file subset: 3 passed, 0 failed;
- Ruff and diff check: exit 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: native Windows, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`README`, `docs/`, docstrings) — N/A; test-only change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a test-only change.