### PR TITLE
fix(discord): fail closed on malformed server_actions policy

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -547,11 +547,33 @@ class TestConfigAllowlist:
         assert result == ["list_guilds", "list_channels", "fetch_messages"]
 
 
-    def test_config_load_failure_is_permissive(self, monkeypatch):
-        """If config can't be loaded at all, fall back to None (all allowed)."""
+    def test_config_load_failure_is_deny_all(self, monkeypatch):
+        """A config-read failure must not fail open as unrestricted."""
         def bad_load():
             raise RuntimeError("disk gone")
         monkeypatch.setattr("hermes_cli.config.load_config", bad_load)
+        assert _load_allowed_actions_config() == []
+
+    def test_unexpected_type_is_deny_all(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": {"unexpected": "dict"}}},
+        )
+        assert _load_allowed_actions_config() == []
+
+    def test_mixed_valid_invalid_is_deny_all(self, monkeypatch):
+        """Unknown names invalidate the whole policy, not a widened subset."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": "list_guilds,bogus_action"}},
+        )
+        assert _load_allowed_actions_config() == []
+
+    def test_missing_key_is_unrestricted(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
         assert _load_allowed_actions_config() is None
 
 
@@ -645,6 +667,18 @@ class TestDynamicSchema:
         assert get_dynamic_schema_core() is None
         assert get_dynamic_schema_admin() is None
 
+    @patch("tools.discord_tool._discord_request")
+    def test_mixed_unknown_name_hides_tools(self, mock_req, monkeypatch):
+        """A typo next to a valid name must not keep the valid remainder."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": "list_guilds,bogus_action"}},
+        )
+        mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
+        assert get_dynamic_schema_core() is None
+        assert get_dynamic_schema_admin() is None
+
 
 # ---------------------------------------------------------------------------
 # Runtime allowlist enforcement (defense in depth — schema already filtered)
@@ -673,6 +707,18 @@ class TestRuntimeAllowlistEnforcement:
         mock_req.return_value = []
         result = json.loads(discord_admin_handler(action="list_guilds"))
         assert "guilds" in result
+
+    @patch("tools.discord_tool._discord_request")
+    def test_malformed_config_blocks_runtime(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": {"unexpected": "dict"}}},
+        )
+        result = json.loads(discord_admin_handler(action="list_guilds"))
+        assert "error" in result
+        assert "disabled by config" in result["error"]
+        mock_req.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -18,7 +18,9 @@ The schema exposed to the model is filtered by two gates:
 2. User config allowlist at ``discord.server_actions``. If the user
    sets a comma-separated list (or YAML list) of action names, only
    those appear in the schema. Empty/unset means all intent-available
-   actions are exposed.
+   actions are exposed. A malformed value, a config-read failure, or
+   unknown action names fail closed (no actions) rather than treating
+   the policy as unrestricted (#96485).
 
 Per-guild permissions (MANAGE_ROLES etc.) are NOT pre-checked — Discord
 returns a 403 at call time and :func:`_enrich_403` maps it to
@@ -707,14 +709,22 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
     hasn't restricted the set (default: all actions allowed).
 
     Accepts either a comma-separated string or a YAML list.
-    Unknown action names are dropped with a log warning.
+
+    ``None`` is only the *absent* policy (key missing or empty string).
+    A config-read failure, an unexpected type, or any unknown action
+    name fail closed as an empty allowlist so schema generation and
+    runtime enforcement both refuse rather than going unrestricted
+    (#96485).
     """
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
     except Exception as exc:
-        logger.debug("discord: could not load config (%s); allowing all actions.", exc)
-        return None
+        logger.warning(
+            "discord: could not load config (%s); denying all server_actions.",
+            exc,
+        )
+        return []
 
     raw = (cfg.get("discord") or {}).get("server_actions")
     if raw is None or raw == "":
@@ -726,18 +736,20 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
         names = [str(n).strip() for n in raw if str(n).strip()]
     else:
         logger.warning(
-            "discord.server_actions: unexpected type %s; ignoring.", type(raw).__name__,
+            "discord.server_actions: unexpected type %s; denying all actions.",
+            type(raw).__name__,
         )
-        return None
+        return []
 
     valid = [n for n in names if n in _ACTIONS]
     invalid = [n for n in names if n not in _ACTIONS]
     if invalid:
         logger.warning(
-            "discord.server_actions: unknown action(s) ignored: %s. "
-            "Known: %s",
+            "discord.server_actions: unknown action(s) %s; denying all "
+            "actions rather than silently widening the remainder. Known: %s",
             ", ".join(invalid), ", ".join(_ACTIONS.keys()),
         )
+        return []
     return valid
 
 


### PR DESCRIPTION
## What does this PR do?

`discord.server_actions` is supposed to restrict which Discord REST actions the model can see and execute. `_load_allowed_actions_config()` returned `None` (unrestricted) for three cases that are not "policy absent":

- `load_config()` raises
- the value is neither a string nor a list
- the list mixes valid names with unknown names (unknowns were dropped, the rest stayed allowed)

Schema generation and runtime enforcement both treat `None` as "allow everything", so a typo or a config-read blip opened the full action set.

`None` is now only the documented default (key missing or empty string). The other cases return an empty allowlist, so both schema and handler refuse. Unknown names invalidate the whole policy rather than silently widening the remainder.

## Related Issue

Fixes #96485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/discord_tool.py`: `_load_allowed_actions_config` fail-closed contract
- `tests/tools/test_discord_tool.py`: load failure, unexpected type, mixed names, missing key, runtime block

## How to Test

1. `python -m pytest tests/tools/test_discord_tool.py -q` — 50 passed
2. Config `server_actions: {unexpected: dict}` or `list_guilds,bogus_action` → empty allowlist, tools hidden, handler errors "disabled by config"
3. Empty/missing `server_actions` still unrestricted

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
