### PR TITLE
fix(delegate): run batch children inside delegated_child_context

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1046,6 +1046,42 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
 
 class TestChildCredentialLeasing(unittest.TestCase):
+    def test_run_single_child_sets_delegated_context_flag(self):
+        """Batch submit copies context after construction's with-block exits.
+
+        The worker must re-enter delegated_child_context so session-key,
+        sudo, and kanban guards see a child rather than a parent turn (#96483).
+        """
+        from agent.delegation_context import is_delegated_child_context
+        from tools.delegate_tool import _run_single_child
+
+        seen = []
+        child = MagicMock()
+        child.session_id = "child-sid"
+        child._credential_pool = None
+        child._delegate_saved_tool_names = []
+
+        def run_conversation(**_kwargs):
+            seen.append(is_delegated_child_context())
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = run_conversation
+        result = _run_single_child(
+            task_index=0,
+            goal="Investigate",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(seen, [True])
+        self.assertFalse(is_delegated_child_context())
+
     def test_run_single_child_acquires_and_releases_lease(self):
         from tools.delegate_tool import _run_single_child
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2466,6 +2466,25 @@ def _run_single_child(
     Run a pre-built child agent. Called from within a thread.
     Returns a structured result dict.
     """
+    # Batch submit copies contextvars *after* construction's
+    # delegated_child_context() has exited, so the copy is False.
+    # Re-enter here so every path (batch, single, timeout inner worker)
+    # sees is_delegated_child_context() == True (#96483).
+    from agent.delegation_context import delegated_child_context, is_delegated_child_context
+
+    if not is_delegated_child_context():
+        with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            return _run_single_child(
+                task_index,
+                goal,
+                child,
+                parent_agent,
+                owner_session_id=owner_session_id,
+                owner_transport=owner_transport,
+                owner_session_record=owner_session_record,
+                **_kwargs,
+            )
+
     child_start = time.monotonic()
 
     # Get the progress callback from the child agent


### PR DESCRIPTION
## What does this PR do?

The batch delegation worker `_run_single_child` never re-entered `delegated_child_context()`. Construction does wrap child *creation*, but that `with` exits before `contextvars.copy_context()` at submit time, so the copied context has the flag False. The single/timeout inner worker (`_run_with_thread_capture`) already re-enters; the batch path did not.

Batch children therefore ran as normal parent/gateway turns: session-key collision, non-headless sudo, and kanban guards that key off `is_delegated_child_context()` all misfired.

`_run_single_child` now re-enters the child context if it is not already inside one, so batch, single, and the inner timeout worker all see the flag.

Related but not a duplicate of #82009 (approval-key binding inside the context manager itself).

## Related Issue

Fixes #96483

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: re-enter `delegated_child_context` at the start of `_run_single_child`
- `tests/tools/test_delegate.py`: assert `run_conversation` sees the flag True and it resets after return

## How to Test

1. `python -m pytest tests/tools/test_delegate.py::TestChildCredentialLeasing tests/tools/test_delegate_kanban_isolation.py tests/tools/test_zombie_process_cleanup.py -q` — 25 passed
2. A batch `delegate_task` child's `is_delegated_child_context()` is True for the whole worker, matching the single-task path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
