### PR TITLE
fix(ollama): probe localhost without honoring system proxies

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1001,6 +1001,19 @@ def _localhost_to_ipv4(url: str) -> str:
     )
 
 
+def _local_probe_httpx_client(timeout: float, headers: Optional[dict] = None):
+    """httpx client for localhost Ollama/LM Studio probes.
+
+    ``trust_env=False`` so Windows WinINET / macOS system proxies cannot
+    hijack ``127.0.0.1`` and return 502, which previously skipped
+    ``num_ctx`` auto-detection (#96476). Explicit ``HTTP(S)_PROXY`` env
+    vars are also ignored here: these probes are loopback-only.
+    """
+    import httpx
+
+    return httpx.Client(timeout=timeout, headers=headers, trust_env=False)
+
+
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 
@@ -1066,7 +1079,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
 
     result: Optional[str] = None
     try:
-        with httpx.Client(timeout=2.0, headers=headers) as client:
+        with _local_probe_httpx_client(timeout=2.0, headers=headers) as client:
             # LM Studio exposes /api/v1/models — check first (most specific)
             try:
                 r = client.get(f"{lmstudio_url}/api/v1/models")
@@ -1992,7 +2005,7 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with _local_probe_httpx_client(timeout=3.0, headers=headers) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -2050,7 +2063,7 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with _local_probe_httpx_client(timeout=3.0, headers=headers) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -2130,7 +2143,7 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=5.0, headers=headers) as client:
+        with _local_probe_httpx_client(timeout=5.0, headers=headers) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": model})
             if resp.status_code != 200:
                 return None
@@ -2315,7 +2328,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
         server_type = None
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with _local_probe_httpx_client(timeout=3.0, headers=headers) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
                 resp = client.post(f"{server_url}/api/show", json={"name": model})

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -584,6 +584,28 @@ class TestDetectLocalServerTypeAuth:
         assert mock_client.call_args.kwargs["headers"] == {
             "Authorization": "Bearer lm-token"
         }
+        assert mock_client.call_args.kwargs.get("trust_env") is False
+
+    def test_local_probes_disable_trust_env(self):
+        """Windows WinINET proxies must not hijack localhost num_ctx probes (#96476)."""
+        from agent import model_metadata
+        from agent.model_metadata import detect_local_server_type
+
+        model_metadata._endpoint_probe_path_cache.clear()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"models": []}
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = resp
+
+        with patch("httpx.Client", return_value=client_mock) as mock_client:
+            detect_local_server_type("http://127.0.0.1:11434")
+
+        assert mock_client.call_args.kwargs.get("trust_env") is False
 
     def test_native_api_base_url_is_not_doubled(self):
         from agent.model_metadata import detect_local_server_type


### PR DESCRIPTION
## What does this PR do?

`detect_local_server_type` and Ollama `num_ctx` / vision / show probes used `httpx.Client()` with default `trust_env=True`. On Windows that honors WinINET system proxies, so probes to `http://127.0.0.1:11434` return 502. Hermes then skips auto `num_ctx`, Ollama serves the server-default window, and a normal tool-heavy turn dies with `exceed_context_size_error`.

Local probes now go through `_local_probe_httpx_client(..., trust_env=False)`. These requests are loopback-only; explicit `HTTP(S)_PROXY` is also ignored there.

## Related Issue

Fixes #96476

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: `_local_probe_httpx_client`; all local Ollama/LM Studio `httpx.Client` sites use it
- `tests/agent/test_model_metadata_local_ctx.py`: assert `trust_env is False` on the probe client

## How to Test

1. `python -m pytest tests/agent/test_model_metadata_local_ctx.py tests/test_ollama_num_ctx.py tests/agent/test_probe_cache_followups.py -q` — 58 passed
2. Not live-tested against WinINET (no Windows host here). The unit test pins `trust_env=False` on `httpx.Client`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
