### PR TITLE
fix(packaging): include wheel in PEP 517 build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,7 +371,11 @@ all = [
 ]
 
 [build-system]
-requires = ["setuptools==83.0.0"]
+# setuptools.build_meta + our setup.py bdist_wheel guard import wheel during
+# PEP 517 isolated builds (uv sync / uv pip install -e .). Without wheel in
+# requires, the isolation sandbox only gets setuptools and Windows installer
+# fails with ModuleNotFoundError: wheel.cli (#96488).
+requires = ["setuptools==83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
@@ -409,7 +413,7 @@ exclude-newer = "14 days"
 # risk — their newest releases are years old — and unbricks resolvers that
 # cannot see upload dates.
 #
-# setuptools, pillow, mcp: exact-pinned bricks (#78227, #75992, #76020). uv
+# setuptools, wheel, pillow, mcp: build/core pin bricks (#78227, #75992, #76020, #96488). uv
 # applies exclude-newer to build-system.requires and core deps too; when a
 # resolver cannot see an upload date (old uv, mirror index, stale HTTP cache)
 # it filters the pinned version and the package cannot even BUILD
@@ -419,7 +423,7 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, wheel = false, pillow = false, mcp = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -288,6 +288,28 @@ def test_build_system_requires_exempt_from_exclude_newer():
 
 
 
+
+def test_build_system_requires_wheel_for_isolated_builds():
+    """Regression for #96488 — PEP 517 isolation must include wheel.
+
+    ``setuptools.build_meta`` and our ``setup.py`` bdist_wheel guard import
+    ``wheel`` during editable builds. uv's build-isolation sandbox is seeded
+    only from ``[build-system].requires``; without ``wheel`` there, Windows
+    ``uv sync`` / ``uv pip install -e .`` fails with
+    ``ModuleNotFoundError: No module named 'wheel.cli'`` even when the real
+    venv already has wheel installed.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    names = {
+        _distribution_name(req)
+        for req in data.get("build-system", {}).get("requires", [])
+    }
+    assert "wheel" in names, (
+        "wheel must be listed in [build-system].requires so PEP 517 isolated "
+        "builds can import wheel.cli / bdist_wheel — see #96488"
+    )
+
+
 def _lazy_deps_by_feature():
     """Parse LAZY_DEPS into {feature_name: [spec, ...]} via AST.
 


### PR DESCRIPTION
## Summary
Windows PowerShell installer editable installs fail in uv's PEP 517 build-isolation sandbox with `ModuleNotFoundError: No module named 'wheel.cli'` (and a follow-on `pkg_resources` miss) even when the real venv already has `wheel` installed.

## Root cause
`[build-system].requires` listed only `setuptools==83.0.0`. uv seeds the isolation environment from that list alone. `setuptools.build_meta` and our `setup.py` bdist_wheel guard import `wheel` during the build, so the sandbox cannot import `wheel.cli`.

## Fix
- Add `wheel` to `[build-system].requires`
- Add `wheel = false` to `[tool.uv].exclude-newer-package` so the existing build-system exclude-newer brick guard (`test_build_system_requires_exempt_from_exclude_newer`) remains green
- Regression test: `test_build_system_requires_wheel_for_isolated_builds`

## Why it matters
Blocks fresh Windows installs via `install.ps1` / `uv sync --extra all --locked` before the agent can launch. Workaround `UV_NO_BUILD_ISOLATION=true` works but should not be required.

## Test plan
```bash
python -m pytest tests/test_packaging_metadata.py -q
# 8 passed @ 715c96ba83
```

## Risk / blast radius
Build-metadata only. Does not change runtime deps. Unpinned `wheel` is the packaging toolchain; exclude-newer exemption matches the setuptools pattern for build requires.

## Closest work
none found (open PRs mentioning "wheel" are desktop scroll / unrelated)

Fixes #96488
