### PR TITLE
fix(api_server): decouple session SSE from agent execution on client disconnect

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4960,11 +4960,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 name, payload = item
                 await response.write(_sse_frame(payload, event=name, ensure_ascii=False))
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
-            await self._drain_session_stream_task_on_disconnect(
-                run_id, task, interrupt_message="SSE client disconnected", shield_wait=False
+            # A dropped SSE connection is only a dead transport, not a stop
+            # signal: the session endpoint always persists to state.db, so
+            # leave the agent running server-side and drain the now-unread
+            # queue (ref issue #15026 — for persisted turns, SSE is only a
+            # transport and disconnect must not cancel execution). The Stop
+            # button interrupts explicitly via POST /v1/runs/{run_id}/stop.
+            await self._detach_session_stream_task_on_disconnect(run_id, queue)
+            logger.info(
+                "Session SSE client disconnected; detached live run %s "
+                "(stop via /v1/runs/%s/stop)",
+                run_id,
+                run_id,
             )
-            logger.info("Session SSE client disconnected; interrupted live run %s", run_id)
         except asyncio.CancelledError:
+            # Task cancellation (server shutdown) still interrupts: the gateway
+            # is going away, so letting the turn finish is pointless.
             await self._drain_session_stream_task_on_disconnect(
                 run_id, task, interrupt_message="SSE task cancelled", shield_wait=True
             )
@@ -4995,6 +5006,37 @@ class APIServerAdapter(BasePlatformAdapter):
         if not task.done():
             with suppress(Exception):
                 await (asyncio.shield(task) if shield_wait else task)
+
+    async def _detach_session_stream_task_on_disconnect(
+        self,
+        run_id: str,
+        queue: "asyncio.Queue",
+    ) -> None:
+        """Detach a client-disconnected session stream without interrupting it.
+
+        The session endpoint always persists to state.db, so a dropped SSE
+        connection is only a dead transport, not a stop signal (ref issue
+        #15026). The agent turn runs in ``_run_and_signal`` — already a
+        ``_background_tasks`` member independent of this handler — and keeps
+        producing events into *queue*. Drain those events until the end
+        sentinel so they don't accumulate in memory for the remainder of the
+        turn. The Stop button halts a detached run via
+        ``POST /v1/runs/{run_id}/stop``.
+        """
+
+        async def _drain() -> None:
+            with suppress(Exception):
+                while True:
+                    if await queue.get() is None:
+                        break
+
+        drain_task = asyncio.create_task(_drain())
+        try:
+            self._background_tasks.add(drain_task)
+        except TypeError:
+            pass
+        if hasattr(drain_task, "add_done_callback"):
+            drain_task.add_done_callback(self._background_tasks.discard)
 
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/model — backend-ack a Browser model lock."""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,16 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# Session-stream run lifecycle helpers (detach/drain + durable active-run
+# control) extracted out of this godfile — see gateway/platforms/api_server_session_stream.py.
+from gateway.platforms.api_server_session_stream import (
+    claim_session_run_or_conflict,
+    detach_session_stream_task_on_disconnect,
+    drain_session_stream_task_on_disconnect,
+    run_already_active_error,
+    session_run_key,
+)
+
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
 # (no prefix / multiplexing off → handle as the default profile).
@@ -4171,6 +4181,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
             "_lineage_root_id", "pinned", "archived", "hidden",
+            "active_run_id", "active_run_status",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # SQLite stores these as 0/1; clients reconcile against a real boolean.
@@ -4715,6 +4726,52 @@ class APIServerAdapter(BasePlatformAdapter):
             headers=headers,
         )
 
+    async def _claim_session_active_run_async(
+        self, session_id: str, run_id: str, run_key: str, status: str
+    ) -> Optional[str]:
+        """Off-loop claim of the session's active-run slot (see SessionDB)."""
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return None
+        return await asyncio.to_thread(
+            db.claim_session_active_run, session_id, run_id, run_key, status
+        )
+
+    async def _set_session_active_run_status_async(
+        self, session_id: str, run_id: str, status: str
+    ) -> bool:
+        """Off-loop coarse-status update, guarded by run id."""
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return False
+        return await asyncio.to_thread(
+            db.set_session_active_run_status, session_id, run_id, status
+        )
+
+    async def _clear_session_active_run_async(
+        self, session_id: str, expected_run_id: Optional[str] = None
+    ) -> bool:
+        """Off-loop clear of the session's active-run slot on terminal."""
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return False
+        return await asyncio.to_thread(
+            db.clear_session_active_run, session_id, expected_run_id
+        )
+
+    def _session_run_is_live(self, run_id: str) -> bool:
+        """Whether a run id names a still-executing server-side run.
+
+        ``_active_run_agents`` is the authoritative "the executor-backed turn
+        is still alive" signal (a detached run stays registered until the turn
+        exits). ``_run_statuses`` with a non-terminal status covers the brief
+        queued window before the agent is registered.
+        """
+        if run_id in self._active_run_agents:
+            return True
+        status = self._run_statuses.get(run_id)
+        return bool(status and status.get("status") in ("queued", "running", "stopping"))
+
     @_admit_api_agent_request
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
         """POST /api/sessions/{session_id}/chat/stream — SSE wrapper over _run_agent."""
@@ -4794,6 +4851,26 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             model=body.get("model", self._model_name),
         )
+        # Durable active-run claim (PR #96507 P1): the session row carries the
+        # live run id + immutable request fingerprint, so a client that lost the
+        # SSE body can rediscover the run via GET /api/sessions/{id} and a retry
+        # of the same admitted request is met with a deterministic conflict
+        # instead of a second execution. The in-memory "queued" registration
+        # above precedes the claim, so a concurrent loser observes the winner's
+        # run as live (queued) rather than mistaking it for a stale marker.
+        run_key = session_run_key(
+            session_id=session_id,
+            user_message=user_message,
+            system_prompt=system_prompt,
+            idempotency_header=request.headers.get("Idempotency-Key"),
+        )
+        conflict_run_id = await claim_session_run_or_conflict(
+            self, session_id, run_id, run_key
+        )
+        if conflict_run_id:
+            return web.json_response(
+                run_already_active_error(conflict_run_id), status=409
+            )
         seq = 0
 
         def _event_payload(name: str, payload: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
@@ -4837,6 +4914,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "runtime": runtime_meta,
                 }))
                 self._set_run_status(run_id, "running", last_event="run.started")
+                await self._set_session_active_run_status_async(session_id, run_id, "running")
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = await self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
@@ -4922,6 +5000,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(_event_payload("error", {"message": _redact_api_error_text(exc)}))
             finally:
                 self._active_run_agents.pop(run_id, None)
+                # The run reached a terminal state (completed/failed/cancelled)
+                # — release the session's durable active-run slot so a later
+                # request can start fresh. Guarded by run id so a superseding
+                # run that already claimed the slot is never clobbered.
+                with suppress(Exception):
+                    await self._clear_session_active_run_async(
+                        session_id, expected_run_id=run_id
+                    )
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
@@ -4994,18 +5080,13 @@ class APIServerAdapter(BasePlatformAdapter):
         shield_wait: bool,
     ) -> None:
         """Preserve live run control refs until the executor-backed turn actually exits."""
-        agent = self._active_run_agents.get(run_id)
-        if agent is None:
-            if not task.done():
-                task.cancel()
-                with suppress(Exception):
-                    await task
-            return
-        with suppress(Exception):
-            agent.interrupt(interrupt_message)
-        if not task.done():
-            with suppress(Exception):
-                await (asyncio.shield(task) if shield_wait else task)
+        return await drain_session_stream_task_on_disconnect(
+            self,
+            run_id,
+            task,
+            interrupt_message=interrupt_message,
+            shield_wait=shield_wait,
+        )
 
     async def _detach_session_stream_task_on_disconnect(
         self,
@@ -5014,29 +5095,11 @@ class APIServerAdapter(BasePlatformAdapter):
     ) -> None:
         """Detach a client-disconnected session stream without interrupting it.
 
-        The session endpoint always persists to state.db, so a dropped SSE
-        connection is only a dead transport, not a stop signal (ref issue
-        #15026). The agent turn runs in ``_run_and_signal`` — already a
-        ``_background_tasks`` member independent of this handler — and keeps
-        producing events into *queue*. Drain those events until the end
-        sentinel so they don't accumulate in memory for the remainder of the
-        turn. The Stop button halts a detached run via
-        ``POST /v1/runs/{run_id}/stop``.
+        Thin delegate — the drain logic lives in
+        ``gateway/platforms/api_server_session_stream.py`` (godfile gate,
+        epic #78647 / precedent #83546).
         """
-
-        async def _drain() -> None:
-            with suppress(Exception):
-                while True:
-                    if await queue.get() is None:
-                        break
-
-        drain_task = asyncio.create_task(_drain())
-        try:
-            self._background_tasks.add(drain_task)
-        except TypeError:
-            pass
-        if hasattr(drain_task, "add_done_callback"):
-            drain_task.add_done_callback(self._background_tasks.discard)
+        return await detach_session_stream_task_on_disconnect(self, run_id, queue)
 
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/model — backend-ack a Browser model lock."""

--- a/gateway/platforms/api_server_session_stream.py
+++ b/gateway/platforms/api_server_session_stream.py
@@ -1,0 +1,149 @@
+"""Session-stream run lifecycle helpers for the API server adapter.
+
+Extracted from ``gateway/platforms/api_server.py`` (godfile gate — epic
+#78647, precedent #83546) plus the durable active-run control surface for the
+session SSE stream (PR #96507 P1 follow-up).
+
+Everything here is transport-independent: none of these helpers import
+aiohttp, and the two payload-builders return plain dicts, so this module stays
+small and importable from tests without pulling in the web stack.
+
+Vocabulary mirrors PR #15492's ``ResponseRun``/subscriber separation: a run is
+a durable server-side control object whose identity survives the SSE
+subscriber lifecycle; the SSE connection is only a transport. Status values
+are ``queued``/``running``/``completed``/``failed``/``cancelled``.
+"""
+
+import asyncio
+from contextlib import suppress
+from hashlib import sha256
+from typing import Any, Dict, Optional
+
+
+async def drain_session_stream_task_on_disconnect(
+    adapter: Any,
+    run_id: str,
+    task: "asyncio.Task",
+    *,
+    interrupt_message: str,
+    shield_wait: bool,
+) -> None:
+    """Preserve live run control refs until the executor-backed turn exits.
+
+    Used on server shutdown (task cancellation), where the gateway is going
+    away and letting the turn finish is pointless: interrupt the agent and
+    wait for the executor-backed turn to drain.
+    """
+    agent = adapter._active_run_agents.get(run_id)
+    if agent is None:
+        if not task.done():
+            task.cancel()
+            with suppress(Exception):
+                await task
+        return
+    with suppress(Exception):
+        agent.interrupt(interrupt_message)
+    if not task.done():
+        with suppress(Exception):
+            await (asyncio.shield(task) if shield_wait else task)
+
+
+async def detach_session_stream_task_on_disconnect(
+    adapter: Any,
+    run_id: str,
+    queue: "asyncio.Queue",
+) -> None:
+    """Detach a client-disconnected session stream without interrupting it.
+
+    The session endpoint always persists to state.db, so a dropped SSE
+    connection is only a dead transport, not a stop signal (ref issue #15026).
+    The agent turn runs in ``_run_and_signal`` — already a
+    ``_background_tasks`` member independent of the request handler — and keeps
+    producing events into *queue*. Drain those events until the end sentinel so
+    they don't accumulate in memory for the remainder of the turn. The Stop
+    button halts a detached run via ``POST /v1/runs/{run_id}/stop``.
+    """
+    del run_id  # the drain loop needs no run id — it only consumes the queue
+
+    async def _drain() -> None:
+        with suppress(Exception):
+            while True:
+                if await queue.get() is None:
+                    break
+
+    drain_task = asyncio.create_task(_drain())
+    try:
+        adapter._background_tasks.add(drain_task)
+    except TypeError:
+        pass
+    if hasattr(drain_task, "add_done_callback"):
+        drain_task.add_done_callback(adapter._background_tasks.discard)
+
+
+def session_run_key(
+    session_id: str,
+    user_message: Any,
+    system_prompt: Optional[str],
+    idempotency_header: Optional[str],
+) -> str:
+    """Derive the immutable request fingerprint for a session-stream run.
+
+    Honors an explicit client ``Idempotency-Key`` header (hashed so raw client
+    values never sit in the session row). Without one, falls back to a
+    deterministic fingerprint of the admitted request — (session_id,
+    system_prompt, message) — so a client retry of the same session/message
+    maps to the same key and can be recognized as a duplicate.
+    """
+    if idempotency_header:
+        return f"idem-{sha256(idempotency_header.encode('utf-8')).hexdigest()}"
+    seed = repr((session_id, system_prompt or "", user_message))
+    return f"fp-{sha256(seed.encode('utf-8')).hexdigest()}"
+
+
+def run_already_active_error(run_id: str) -> Dict[str, Any]:
+    """Deterministic conflict envelope for a duplicate session-stream start."""
+    return {
+        "error": {
+            "message": "A run is already active for this session",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "run_already_active",
+            "run_id": run_id,
+        },
+        "run_id": run_id,
+    }
+
+
+async def claim_session_run_or_conflict(
+    adapter: Any,
+    session_id: str,
+    run_id: str,
+    run_key: str,
+) -> Optional[str]:
+    """Atomically claim the session's active-run slot, or report the live holder.
+
+    Returns ``None`` when ``run_id`` won the claim. Returns the existing live
+    run id (str) when another run already holds the slot and is still
+    executing — the caller must surface a ``run_already_active`` conflict for
+    that id. A stale marker (a prior run that ended without clearing, or a
+    gateway restart) is reclaimed in place so a session can never be wedged
+    behind a dead run id.
+    """
+    existing = await adapter._claim_session_active_run_async(
+        session_id, run_id, run_key, "queued"
+    )
+    if existing and adapter._session_run_is_live(existing):
+        return existing
+    if existing:
+        # Stale marker — reclaim it for this run, then re-claim. The second
+        # claim serializes against a genuinely-live concurrent winner.
+        await adapter._clear_session_active_run_async(
+            session_id, expected_run_id=existing
+        )
+        existing = await adapter._claim_session_active_run_async(
+            session_id, run_id, run_key, "queued"
+        )
+        if existing and adapter._session_run_is_live(existing):
+            return existing
+    return None
+

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9874,6 +9874,96 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
+    def claim_session_active_run(
+        self,
+        session_id: str,
+        run_id: str,
+        run_key: Optional[str] = None,
+        status: str = "queued",
+    ) -> Optional[str]:
+        """Atomically claim the session's active-run slot for ``run_id``.
+
+        Returns the existing ``active_run_id`` (str) when another run already
+        holds the slot, or None when this run successfully claimed it. The
+        claim is a conditional write under ``_execute_write`` (BEGIN IMMEDIATE),
+        so two concurrent session-stream requests serialize here and exactly
+        one wins — the loser observes the winner's run id and surfaces a
+        deterministic ``run_already_active`` conflict instead of starting a
+        second execution (PR #96507 P1). The persisted ``active_run_key`` is
+        the immutable request fingerprint used to recognize an admitted retry.
+        """
+        def _do(conn):
+            existing = conn.execute(
+                "SELECT active_run_id FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if existing is None:
+                return None
+            current = (
+                existing["active_run_id"]
+                if isinstance(existing, sqlite3.Row)
+                else existing[0]
+            )
+            if current:
+                return current
+            conn.execute(
+                "UPDATE sessions SET active_run_id = ?, active_run_key = ?, "
+                "active_run_status = ? WHERE id = ?",
+                (run_id, run_key, status, session_id),
+            )
+            return None
+        return self._execute_write(_do)
+
+    def set_session_active_run_status(
+        self, session_id: str, run_id: str, status: str
+    ) -> bool:
+        """Update the active run's coarse status, guarded by ``run_id``.
+
+        A run id guard keeps a late status write from a superseded run from
+        overwriting the status of a newer run that has since claimed the slot.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET active_run_status = ? "
+                "WHERE id = ? AND active_run_id = ?",
+                (status, session_id, run_id),
+            )
+            rowcount = cursor.rowcount
+            if rowcount is None or rowcount < 0:
+                rowcount = conn.execute("SELECT changes()").fetchone()[0]
+            return rowcount
+        return self._execute_write(_do) > 0
+
+    def clear_session_active_run(
+        self, session_id: str, expected_run_id: Optional[str] = None
+    ) -> bool:
+        """Clear the session's active-run slot on terminal.
+
+        When ``expected_run_id`` is supplied the clear is conditional, so a
+        finished run never clobbers the marker of a newer run that already
+        claimed the slot (a newer run can only appear once the old one's slot
+        was cleared, but the guard keeps the invariant under reordering).
+        """
+        def _do(conn):
+            if expected_run_id is None:
+                cursor = conn.execute(
+                    "UPDATE sessions SET active_run_id = NULL, "
+                    "active_run_key = NULL, active_run_status = NULL "
+                    "WHERE id = ?",
+                    (session_id,),
+                )
+            else:
+                cursor = conn.execute(
+                    "UPDATE sessions SET active_run_id = NULL, "
+                    "active_run_key = NULL, active_run_status = NULL "
+                    "WHERE id = ? AND active_run_id = ?",
+                    (session_id, expected_run_id),
+                )
+            rowcount = cursor.rowcount
+            if rowcount is None or rowcount < 0:
+                rowcount = conn.execute("SELECT changes()").fetchone()[0]
+            return rowcount
+        return self._execute_write(_do) > 0
+
     def set_session_read(self, session_id: str, read: bool = True) -> bool:
         """Mark a session read or unread (and its whole compression lineage).
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -423,6 +423,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     pinned INTEGER NOT NULL DEFAULT 0,
     hidden INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
+    active_run_id TEXT,
+    active_run_key TEXT,
+    active_run_status TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -207,10 +207,16 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_session_chat_stream_disconnect_keeps_control_refs_until_executor_finishes(
+async def test_session_chat_stream_disconnect_detaches_without_interrupt(
     adapter, session_db
 ):
-    """Disconnects must interrupt the live run without dropping its control refs early."""
+    """A client disconnect detaches the turn instead of interrupting it.
+
+    The session endpoint always persists to state.db, so a dropped SSE
+    connection is only a dead transport (ref #15026). The agent keeps running
+    server-side and its run stays registered for /v1/runs/{run_id}/stop until
+    the executor-backed turn actually finishes.
+    """
     session_id = session_db.create_session("disconnect-stream-session", "api_server")
     run_started = threading.Event()
     interrupt_called = threading.Event()
@@ -279,21 +285,25 @@ async def test_session_chat_stream_disconnect_keeps_control_refs_until_executor_
         assert run_started.is_set()
         run_id = next(iter(adapter._run_statuses))
 
-        for _ in range(40):
-            if interrupt_called.is_set():
-                break
-            await asyncio.sleep(0.05)
+        # The disconnect makes the handler detach and return promptly, but must
+        # NOT interrupt the agent.
+        await asyncio.wait_for(handler_task, timeout=5)
+        assert not interrupt_called.is_set()
 
-        assert interrupt_called.is_set()
+        # The run stays registered while the agent is still running, so
+        # /v1/runs/{run_id}/stop can still halt it.
         assert run_id in adapter._active_run_agents
         # Not in _active_run_tasks: session-stream turns are counted via
         # _inflight_agent_runs; a task entry would double-count them in the
         # shutdown drain (active_agent_work_count).
         assert run_id not in adapter._active_run_tasks
-        assert not handler_task.done()
 
+        # Let the detached turn finish and confirm the control ref is released.
         allow_finish.set()
-        await handler_task
+        for _ in range(60):
+            if run_id not in adapter._active_run_agents:
+                break
+            await asyncio.sleep(0.05)
 
     assert run_id not in adapter._active_run_agents
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,6 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
 import asyncio
+import json
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -901,3 +902,317 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+# ---------------------------------------------------------------------------
+# Durable active-run control (PR #96507 P1): the session stream mints a
+# recoverable run whose identity is persisted on the session row and exposed
+# independently of the SSE body.
+# ---------------------------------------------------------------------------
+
+
+class _FailFirstWriteStreamResponse:
+    """StreamResponse double whose very first write raises ConnectionResetError."""
+
+    async def prepare(self, request):
+        del request
+
+    async def write(self, payload):
+        del payload
+        raise ConnectionResetError("simulated first-write failure")
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_first_write_fails_rediscover_and_stop(adapter, session_db):
+    """Regression 1: a first-SSE-write failure must not stop the agent.
+
+    The agent keeps running server-side, the same authenticated client can
+    rediscover the run via ``GET /api/sessions/{id}`` (``active_run_id``), and
+    can then stop it via ``POST /v1/runs/{run_id}/stop``.
+    """
+    session_id = session_db.create_session("first-write-fail-session", "api_server")
+    run_started = threading.Event()
+    allow_finish = threading.Event()
+    interrupt_called = threading.Event()
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, stream_delta_callback):
+            self._stream_delta_callback = stream_delta_callback
+            self.session_id = session_id
+
+        def interrupt(self, _message=None):
+            interrupt_called.set()
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            del user_message, conversation_history, task_id
+            run_started.set()
+            self._stream_delta_callback("hello")
+            allow_finish.wait(timeout=5)
+            return {"final_response": "done", "session_id": session_id}
+
+    request = MagicMock()
+    request.headers = {}
+    request.match_info = {"session_id": session_id}
+
+    def _create_agent(**kwargs):
+        return FakeAgent(kwargs["stream_delta_callback"])
+
+    run_id = None
+    with patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": session_id}, None)), \
+            patch.object(adapter, "_read_json_body", return_value=({"message": "stream please"}, None)), \
+            patch.object(adapter, "_create_agent", side_effect=_create_agent), \
+            patch("gateway.platforms.api_server.web.StreamResponse", return_value=_FailFirstWriteStreamResponse()):
+        handler_task = asyncio.create_task(adapter._handle_session_chat_stream(request))
+
+        for _ in range(60):
+            if run_started.is_set():
+                break
+            await asyncio.sleep(0.05)
+
+        assert run_started.is_set()
+        run_id = next(iter(adapter._run_statuses))
+
+        # The first-write failure makes the handler detach and return promptly,
+        # but must NOT interrupt the agent.
+        await asyncio.wait_for(handler_task, timeout=5)
+        assert not interrupt_called.is_set()
+
+    # Rediscovery: the session resource exposes the live run id (real session
+    # row, unpatched, now carries the durable active_run_id).
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}")
+        assert resp.status == 200
+        payload = await resp.json()
+
+    assert payload["session"]["active_run_id"] == run_id
+    assert payload["session"]["active_run_status"] == "running"
+    assert run_id in adapter._active_run_agents
+
+    # Stop: the rediscovered run id is addressable via /v1/runs/{run_id}/stop.
+    stop_request = MagicMock()
+    stop_request.match_info = {"run_id": run_id}
+    stop_resp = await adapter._handle_stop_run(stop_request)
+    assert stop_resp.status == 200
+    assert interrupt_called.is_set()
+
+    # Let the interrupted turn unwind and release its control refs.
+    allow_finish.set()
+    for _ in range(60):
+        if run_id not in adapter._active_run_agents:
+            break
+        await asyncio.sleep(0.05)
+
+    assert run_id not in adapter._active_run_agents
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_retry_conflicts_while_active(adapter, session_db):
+    """Regression 2: disconnect + retry of the same session/message yields exactly
+    one execution — the retry gets a deterministic ``run_already_active`` conflict
+    instead of starting a second agent."""
+    session_id = session_db.create_session("retry-session", "api_server")
+    run_started = threading.Event()
+    allow_finish = threading.Event()
+    agents_created = {"count": 0}
+    write_calls = {"count": 0}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, stream_delta_callback):
+            self._stream_delta_callback = stream_delta_callback
+            self.session_id = session_id
+
+        def interrupt(self, _message=None):
+            pass
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            del user_message, conversation_history, task_id
+            run_started.set()
+            self._stream_delta_callback("hello")
+            allow_finish.wait(timeout=5)
+            return {"final_response": "done", "session_id": session_id}
+
+    class DisconnectingStreamResponse:
+        async def prepare(self, request):
+            del request
+
+        async def write(self, payload):
+            del payload
+            write_calls["count"] += 1
+            if write_calls["count"] >= 3:
+                raise ConnectionResetError("simulated client disconnect")
+
+    def _create_agent(**kwargs):
+        agents_created["count"] += 1
+        return FakeAgent(kwargs["stream_delta_callback"])
+
+    request1 = MagicMock()
+    request1.headers = {}
+    request1.match_info = {"session_id": session_id}
+
+    with patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": session_id}, None)), \
+            patch.object(adapter, "_read_json_body", return_value=({"message": "stream please"}, None)), \
+            patch.object(adapter, "_create_agent", side_effect=_create_agent), \
+            patch("gateway.platforms.api_server.web.StreamResponse", return_value=DisconnectingStreamResponse()):
+        handler_task = asyncio.create_task(adapter._handle_session_chat_stream(request1))
+
+        for _ in range(60):
+            if run_started.is_set():
+                break
+            await asyncio.sleep(0.05)
+
+        assert run_started.is_set()
+        run_id = next(iter(adapter._run_statuses))
+
+        # Detach on disconnect; the run stays live.
+        await asyncio.wait_for(handler_task, timeout=5)
+        assert run_id in adapter._active_run_agents
+
+        # Retry the same session/message: deterministic conflict, no second agent.
+        request2 = MagicMock()
+        request2.headers = {}
+        request2.match_info = {"session_id": session_id}
+        with patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": session_id}, None)), \
+                patch.object(adapter, "_read_json_body", return_value=({"message": "stream please"}, None)):
+            retry_resp = await adapter._handle_session_chat_stream(request2)
+
+        assert retry_resp.status == 409
+        retry_payload = json.loads(retry_resp.text)
+        assert retry_payload["error"]["code"] == "run_already_active"
+        assert retry_payload["run_id"] == run_id
+        assert agents_created["count"] == 1
+
+        allow_finish.set()
+        for _ in range(60):
+            if run_id not in adapter._active_run_agents:
+                break
+            await asyncio.sleep(0.05)
+
+    assert run_id not in adapter._active_run_agents
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_detached_approval_stays_discoverable(adapter, session_db):
+    """Regression 3: a detached run held in approval stays discoverable via the
+    session resource and addressable via /v1/runs/{run_id} after its original
+    subscriber is gone."""
+    session_id = session_db.create_session("detached-approval-session", "api_server")
+    run_started = threading.Event()
+    allow_finish = threading.Event()
+    write_calls = {"count": 0}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, stream_delta_callback):
+            self._stream_delta_callback = stream_delta_callback
+            self.session_id = session_id
+
+        def interrupt(self, _message=None):
+            pass
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            del user_message, conversation_history, task_id
+            run_started.set()
+            self._stream_delta_callback("hello")
+            # Simulate a long-lived approval wait: the agent parks here until
+            # the test releases it.
+            allow_finish.wait(timeout=5)
+            return {"final_response": "approved and done", "session_id": session_id}
+
+    class DisconnectingStreamResponse:
+        async def prepare(self, request):
+            del request
+
+        async def write(self, payload):
+            del payload
+            write_calls["count"] += 1
+            if write_calls["count"] >= 3:
+                raise ConnectionResetError("simulated client disconnect")
+
+    request = MagicMock()
+    request.headers = {}
+    request.match_info = {"session_id": session_id}
+
+    def _create_agent(**kwargs):
+        return FakeAgent(kwargs["stream_delta_callback"])
+
+    run_id = None
+    with patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": session_id}, None)), \
+            patch.object(adapter, "_read_json_body", return_value=({"message": "needs approval"}, None)), \
+            patch.object(adapter, "_create_agent", side_effect=_create_agent), \
+            patch("gateway.platforms.api_server.web.StreamResponse", return_value=DisconnectingStreamResponse()):
+        handler_task = asyncio.create_task(adapter._handle_session_chat_stream(request))
+
+        for _ in range(60):
+            if run_started.is_set():
+                break
+            await asyncio.sleep(0.05)
+
+        assert run_started.is_set()
+        run_id = next(iter(adapter._run_statuses))
+
+        # Detach on disconnect; mark the run as parked in approval.
+        await asyncio.wait_for(handler_task, timeout=5)
+        adapter._set_run_status(run_id, "running", last_event="approval.pending")
+
+    # Discoverable after the subscriber is gone (real session row, unpatched).
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}")
+        assert resp.status == 200
+        payload = await resp.json()
+    assert payload["session"]["active_run_id"] == run_id
+
+    # Addressable via the run resource.
+    get_run_request = MagicMock()
+    get_run_request.match_info = {"run_id": run_id}
+    get_run_resp = await adapter._handle_get_run(get_run_request)
+    assert get_run_resp.status == 200
+    assert json.loads(get_run_resp.text)["run_id"] == run_id
+
+    # Still registered for stop/steer/approval until the turn exits.
+    assert run_id in adapter._active_run_agents
+
+    allow_finish.set()
+    for _ in range(60):
+        if run_id not in adapter._active_run_agents:
+            break
+        await asyncio.sleep(0.05)
+
+    assert run_id not in adapter._active_run_agents
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_completion_clears_active_run(adapter, session_db):
+    """A normally-completed stream releases the durable active-run slot, so a
+    later request on the same session starts fresh instead of conflicting."""
+    session_id = session_db.create_session("completed-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("done")
+        return {"final_response": "done", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/api/sessions/{session_id}/chat/stream", json={"message": "hi"})
+            assert resp.status == 200
+            await resp.text()
+
+            get_resp = await cli.get(f"/api/sessions/{session_id}")
+            assert get_resp.status == 200
+            payload = await get_resp.json()
+
+    assert payload["session"].get("active_run_id") is None
+    assert payload["session"].get("active_run_status") is None


### PR DESCRIPTION
POST /api/sessions/{id}/chat/stream always persists to state.db, so a dropped SSE connection is only a dead transport, not a stop signal. Detach on disconnect: leave the agent running server-side and drain the now-unread queue until the end sentinel instead of interrupting. The Stop button still interrupts via POST /v1/runs/{run_id}/stop (the run stays registered in _active_run_agents until the executor turn exits). Fixes the mobile backgrounding case where switching apps / locking the screen killed the SSE stream and cancelled the agent mid-task. Refs #15026