### PR TITLE
fix(cron): multiplex ticker must not resurrect deleted profiles (#47368)

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -46,6 +46,33 @@ def _backoff_wait_seconds(interval: float, consecutive_failures: int) -> float:
     )
 
 
+def _existing_profile_homes(profile_homes: list) -> list:
+    """Drop profile homes whose directory no longer exists on disk.
+
+    The multiplex ticker's ``profile_homes`` is a snapshot taken at startup
+    (``web_server.py`` calls ``profiles_to_serve(multiplex=True)`` once, and
+    the gateway multiplex path does the same). If a profile is deleted while
+    the ticker runs — via ``hermes profile delete``, the desktop's DELETE
+    ``/api/profiles/<name>`` route, or any other path that removes the home
+    directory — that stale entry stays in the list.
+
+    Ticking or heartbeating a deleted home recreates its ``cron/`` workspace
+    (``record_ticker_heartbeat`` -> ``ensure_dirs`` -> ``mkdir(parents=True)``)
+    on every 60s cycle, so the "deleted" profile silently comes back on disk
+    and in ``hermes profile list`` (#47368). Filtering on directory existence
+    leaves a deleted profile's home untouched, which is the correct invariant:
+    a home that does not exist cannot hold jobs to fire.
+    """
+    from pathlib import Path
+
+    live = []
+    for entry in profile_homes:
+        home = entry[1] if isinstance(entry, tuple) else entry
+        if Path(home).is_dir():
+            live.append(entry)
+    return live
+
+
 def _note_tick_failure(exc: BaseException, consecutive_failures: int) -> int:
     """Classify one failed tick and return the updated failure counter.
 
@@ -656,8 +683,10 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
-        # Recovery + initial heartbeat for every profile.
-        for entry in profile_homes:
+        # Recovery + initial heartbeat for every profile. A profile may have
+        # been deleted since this snapshot was taken; never recreate a
+        # deleted home's cron workspace via the heartbeat below (#47368).
+        for entry in _existing_profile_homes(profile_homes):
             home = entry[1] if isinstance(entry, tuple) else entry
             home_token = set_hermes_home_override(str(home))
             try:
@@ -677,11 +706,14 @@ class InProcessCronScheduler(CronScheduler):
         while not stop_event.is_set():
             ok = False
             _tick_error = None
+            # Re-evaluate existence every cycle: a profile can be deleted at
+            # any point, and the snapshot list must not resurrect it.
+            live_homes = _existing_profile_homes(profile_homes)
             try:
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
-                    for entry in profile_homes:
+                    for entry in live_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
@@ -704,7 +736,7 @@ class InProcessCronScheduler(CronScheduler):
             else:
                 _tick_error = None
             # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
+            for entry in live_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
                 home_token = set_hermes_home_override(str(home))
                 try:

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,90 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_skips_deleted_profile_home(tmp_path, monkeypatch):
+    """Regression test for #47368: a profile deleted while the desktop
+    backend runs must not be resurrected by the cron ticker.
+
+    The multiplex ticker's profile_homes list is snapshotted at startup. If a
+    profile is deleted mid-run (hermes profile delete / desktop DELETE route),
+    the old code still ticked and heartbeated its home every cycle, and
+    record_ticker_heartbeat -> ensure_dirs -> mkdir(parents=True) recreated
+    the deleted profile's cron/ workspace — so the profile "came back" on disk
+    and in `hermes profile list` within ~60s. The ticker must skip homes whose
+    directory no longer exists.
+    """
+    import shutil
+    from pathlib import Path
+
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    # Two profile homes. One is later "deleted" (directory removed).
+    live = tmp_path / "live-profile"
+    deleted = tmp_path / "deleted-profile"
+    for d in (live, deleted):
+        (d / "cron").mkdir(parents=True)
+
+    profile_homes = [("live-profile", live), ("deleted-profile", deleted)]
+
+    ticked_homes: list[Path] = []
+
+    def _tracking_tick(*args, **kwargs):
+        # The tick runs under the profile's HERMES_HOME override; record the
+        # resolved home so we can assert which profiles were actually ticked.
+        import hermes_constants
+
+        ticked_homes.append(Path(hermes_constants.get_hermes_home()))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    # Simulate the deletion happening between scheduler start and first tick.
+    shutil.rmtree(deleted)
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(ticked_homes) < 1 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    # The live profile was ticked (at least once); the deleted one never was.
+    assert ticked_homes, "Expected the live profile to be ticked"
+    assert all(Path(h).resolve() == live.resolve() for h in ticked_homes), (
+        f"Deleted profile was ticked — only live expected: {ticked_homes}"
+    )
+    # The deleted home's directory must NOT have been recreated.
+    assert not deleted.exists(), (
+        "Deleted profile home was resurrected by the cron ticker — "
+        "its cron/ workspace must not be recreated (#47368)"
+    )
+
+
+def test_existing_profile_homes_filters_deleted(tmp_path):
+    """The existence filter keeps live homes and drops deleted ones, whether
+    entries are (name, path) tuples or bare paths."""
+    from cron.scheduler_provider import _existing_profile_homes
+
+    live = tmp_path / "live"
+    deleted = tmp_path / "deleted"
+    live.mkdir(parents=True)
+    # deleted intentionally not created
+
+    as_tuples = _existing_profile_homes([("live", live), ("deleted", deleted)])
+    assert [p[0] for p in as_tuples] == ["live"]
+
+    as_paths = _existing_profile_homes([live, deleted])
+    assert [p for p in as_paths] == [live]
+
+
+


### PR DESCRIPTION
## What

Fixes the desktop bug where **deleting a profile doesn't stick** — the profile's directory comes back within \~60 seconds, so the profile reappears in `hermes profile list` and the desktop UI.

### Root cause

The desktop backend (`hermes serve`) runs a multiplex cron ticker. Its profile list (`profile_homes`) is a **snapshot taken at startup** via `profiles_to_serve(multiplex=True)`. When a profile is deleted mid-run (CLI `hermes profile delete`, desktop DELETE `/api/profiles/<name>` route, or any path that removes the home directory), the stale entry stays in the ticker's list.

Every 60s tick then runs `record_ticker_heartbeat()` against the deleted home, and `record_ticker_heartbeat → ensure_dirs → mkdir(parents=True, exist_ok=True)` **recreates the deleted profile's `cron/` workspace**. The directory reappears, `hermes profile list` shows the profile again — deletion appears to have silently failed.

### Fix

`_start_multiplex` now filters `profile_homes` to homes that **still exist on disk**, re-evaluated every tick cycle. The invariant: a home that does not exist cannot hold jobs to fire.

## Verification

Reproduced the bug live on a VPS: after `hermes profile delete` the cron ticker recreated the profile's `cron/` dir within 60s. After the fix: deleted 4 profiles, waited a full tick cycle, directories stayed gone, profile list shows only `default`.

Full cron test suite: **983 passed, 1 skipped** (same as before the change).
