### PR TITLE
fix(auxiliary): stop concurrent calls from aborting in-flight streams

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7720,9 +7720,10 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
         # receive a non-functional client on the next cache hit.
         return
     with _client_cache_lock:
-        old_entry = _client_cache.get(cache_key)
-        if old_entry is not None and old_entry[0] is not client:
-            _close_cached_client(old_entry[0])
+        # Cache lookups hand the raw client to callers without a usage lease,
+        # so a displaced entry may still own an in-flight request.  Replacing
+        # the cache reference is safe; closing the old transport here is not.
+        # Its remaining callers retain it until their requests complete.
         _client_cache[cache_key] = (client, default_model, bound_loop)
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7702,13 +7702,10 @@ def _client_cache_key(
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
     # The model MUST participate in the key. Two concurrent auxiliary calls to
     # the SAME provider/base_url/key but DIFFERENT models (e.g. a MoA reference
-    # fan-out running opus + gpt-5.5 in parallel threads) would otherwise share
-    # one cache entry. On a cache MISS both build a client for the same key; the
-    # second's _store_cached_client sees the first as the "old" entry and CLOSES
-    # it — while the first call is still mid-request on it — yielding a spurious
-    # APIConnectionError that fails the sibling advisor (root cause of the run2
-    # double-advisor "Connection error" collapse). Keying on model gives each
-    # model its own client, so concurrent fan-out calls never cross-close.
+    # fan-out running opus + gpt-5.5 in parallel threads) need distinct cache
+    # entries. Otherwise one call can reuse the client/default-model pairing
+    # created for its sibling. Keying on model keeps each call bound to the
+    # client configuration selected for that model.
     model_key = model or runtime.get("model", "")
     api_key_key = _runtime_cache_discriminator("api_key", api_key or "")
     return (provider, async_mode, base_url or "", api_key_key, api_mode or "", runtime_key, is_vision, task_key, pool_hint, model_key)

--- a/tests/agent/test_auxiliary_cache_replacement.py
+++ b/tests/agent/test_auxiliary_cache_replacement.py
@@ -1,0 +1,52 @@
+"""Regression coverage for auxiliary cache replacement ownership."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+import agent.auxiliary_client as aux
+
+
+class _BlockingClient:
+    def __init__(self) -> None:
+        self.closed = Event()
+        self.started = Event()
+        self.release = Event()
+
+    def request(self) -> str:
+        self.started.set()
+        assert self.release.wait(timeout=2)
+        if self.closed.is_set():
+            raise ConnectionError("client closed during request")
+        return "complete"
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+def test_same_key_replacement_does_not_close_inflight_client():
+    key = ("replacement-test", False)
+    inflight = _BlockingClient()
+    replacement = _BlockingClient()
+
+    with aux._client_cache_lock:
+        saved = aux._client_cache.pop(key, None)
+        aux._client_cache[key] = (inflight, "old-model", None)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(inflight.request)
+            assert inflight.started.wait(timeout=2)
+
+            aux._store_cached_client(key, replacement, "new-model")
+            inflight.release.set()
+
+            assert future.result(timeout=2) == "complete"
+
+        with aux._client_cache_lock:
+            assert aux._client_cache[key] == (replacement, "new-model", None)
+        assert not inflight.closed.is_set()
+    finally:
+        with aux._client_cache_lock:
+            aux._client_cache.pop(key, None)
+            if saved is not None:
+                aux._client_cache[key] = saved


### PR DESCRIPTION
## What does this PR do?

Prevents a same-key auxiliary cache replacement from closing a client that another caller is still using. Without this change, concurrent auxiliary work can abort an otherwise successful in-flight stream with a spurious connection error.

### Symptom

An auxiliary stream can fail with `Connection error` when another caller replaces the same cache entry while the stream is still active.

### Impact

Concurrent compression and other auxiliary calls sharing a cache key can lose completed provider responses and retry until their operation times out.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:7717` / `_store_cached_client()` replaces an existing same-key client.

**Causal chain:**
1. A caller obtains a raw cached client and starts a request.
2. A concurrent credential refresh stores a new client for the same cache key.
3. Cache replacement closes the displaced transport even though the first caller still owns an active request, so that request fails locally.

**Why it is wrong:** Cache lookup does not provide usage leases or reference tracking, so cache membership cannot prove that a displaced client is idle.

**Working sibling / contrast:** Normal FIFO cache eviction already drops the cache reference without closing the client because an in-flight caller may still retain it.

**Ruled out:** The regression test uses no network and deterministically reproduces the failure when `close()` is invoked during the blocked request, ruling out an upstream transport failure.

### Fix

Replace the cache entry without closing the displaced client. Existing callers retain the old object until their requests finish, while subsequent lookups receive the refreshed client.

## Related Issue

Fixes #96491

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - stop same-key replacement from closing a potentially in-flight client.
- `tests/agent/test_auxiliary_cache_replacement.py` - add deterministic concurrent regression coverage for replacement ownership.

## How to Test

1. Start a request on the cached client and block it after acquisition.
2. Replace that same cache key with a fresh client.
3. Release the request and verify it completes while subsequent lookups use the replacement.
4. Automated (197 tests passed locally):

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_cache_replacement.py tests/agent/test_auxiliary_client.py tests/run_agent/test_async_httpx_del_neuter.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings - N/A; behavior is covered by an inline ownership comment and regression test
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the fix uses platform-independent locking and object lifetime semantics
- [x] Tool descriptions/schemas - N/A; no tool schema changed

## Screenshots / Logs

Before the fix, the regression test failed with `ConnectionError: client closed during request`. After the fix, the focused suite passes 197 tests.
