### PR TITLE
fix(mcp): keep stdio tools working after subprocess exits

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -7,8 +7,8 @@ failed fast — correctly — but nothing asked the server task to respawn the
 subprocess, so every subsequent call kept failing until the idle keepalive
 probe eventually noticed. Both fast-fail sites must signal a reconnect:
 
-- pre-call gate (children already dead when the call arrives): return a clean
-  "reconnecting" tool error and set ``_reconnect_event``;
+- pre-call gate (children already dead when the call arrives): rebuild the
+  transport and execute the original call on the replacement session;
 - mid-call watcher race (children die while the RPC is in flight): raise the
   fast-fail TimeoutError and set ``_reconnect_event``.
 """
@@ -16,7 +16,7 @@ probe eventually noticed. Both fast-fail sites must signal a reconnect:
 import asyncio
 import json
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -64,36 +64,82 @@ def _cleanup(mcp_tool_module, name: str) -> None:
         mcp_tool_module._server_breaker_opened_at.pop(name, None)
 
 
-def test_precall_dead_children_signal_reconnect(monkeypatch, tmp_path):
-    """Dead-at-call-time subprocess → clean reconnecting error + reconnect
-    signal, instead of a bare fast-fail that leaves the server dead."""
+def test_precall_dead_children_reconnect_before_call(monkeypatch, tmp_path):
+    """Dead-at-call-time subprocess → respawn and run on the fresh session."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    stale_called = {"n": 0}
+
+    async def _stale_call_tool(*a, **kw):
+        stale_called["n"] += 1
+        return MagicMock(is_error=False, content=[])
+
+    server = _install_stub_server(
+        mcp_tool, "srv-dead", _stale_call_tool, children_dead=lambda: True
+    )
+    fresh_session = MagicMock()
+
+    async def _fresh_call_tool(*a, **kw):
+        return MagicMock(is_error=False, content=[])
+
+    fresh_session.call_tool = _fresh_call_tool
+
+    def _reconnect(server_name, srv, *, op_description, timeout):
+        assert server_name == "srv-dead"
+        assert srv is server
+        assert op_description == "tools/call tool1 after stdio child exit"
+        assert timeout == 10.0
+        srv.session = fresh_session
+        srv._stdio_children_dead = lambda: False
+        return True
+
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv-dead", "tool1", 10.0)
+        with patch(
+            "tools.mcp_tool._signal_reconnect_and_wait",
+            side_effect=_reconnect,
+        ) as reconnect:
+            result = handler({})
+        parsed = json.loads(result)
+        assert parsed == {"result": ""}, parsed
+        reconnect.assert_called_once()
+        assert stale_called["n"] == 0, "stale RPC must never be attempted"
+        assert mcp_tool._server_error_counts.get("srv-dead", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv-dead")
+
+
+def test_precall_dead_children_reconnect_timeout_is_bounded(monkeypatch, tmp_path):
+    """A failed respawn returns an error without touching the stale session."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from tools import mcp_tool
     from tools.mcp_tool import _make_tool_handler
 
     called = {"n": 0}
 
-    async def _call_tool(*a, **kw):
+    async def _stale_call_tool(*a, **kw):
         called["n"] += 1
-        return MagicMock(is_error=False, content=[])
 
-    server = _install_stub_server(
-        mcp_tool, "srv-dead", _call_tool, children_dead=lambda: True
+    _install_stub_server(
+        mcp_tool, "srv-timeout", _stale_call_tool, children_dead=lambda: True
     )
     mcp_tool._ensure_mcp_loop()
     try:
-        handler = _make_tool_handler("srv-dead", "tool1", 10.0)
-        result = handler({})
-        parsed = json.loads(result)
+        handler = _make_tool_handler("srv-timeout", "tool1", 10.0)
+        with patch(
+            "tools.mcp_tool._signal_reconnect_and_wait", return_value=False
+        ) as reconnect:
+            parsed = json.loads(handler({}))
         assert "error" in parsed, parsed
-        assert "reconnect" in parsed["error"].lower(), parsed
-        assert server._reconnect_event.set_calls == 1
-        assert called["n"] == 0, "RPC must not be attempted on a dead transport"
-        # The error payload flows through the handler's JSON parse, which
-        # bumps the breaker exactly once (no double-bump at the gate).
-        assert mcp_tool._server_error_counts.get("srv-dead", 0) == 1
+        assert "did not recover" in parsed["error"], parsed
+        reconnect.assert_called_once()
+        assert called["n"] == 0
+        assert mcp_tool._server_error_counts.get("srv-timeout", 0) == 1
     finally:
-        _cleanup(mcp_tool, "srv-dead")
+        _cleanup(mcp_tool, "srv-timeout")
 
 
 def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6142,6 +6142,34 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        # A stdio child can exit while the SDK still leaves a stale session
+        # object installed. Recover before scheduling the user's RPC so the
+        # first call after an idle/external process exit lands on the respawned
+        # transport instead of becoming a throwaway "retry in a few seconds"
+        # failure (#96497). Requiring a distinct ready session prevents the
+        # reconnect request from immediately reusing the stale object.
+        _stdio_dead = getattr(server, "_stdio_children_dead", None)
+        if (
+            callable(_stdio_dead)
+            and isinstance(_stdio_dead_result := _stdio_dead(), bool)
+            and _stdio_dead_result
+        ):
+            reconnect_timeout = min(
+                _RECYCLED_RECONNECT_TIMEOUT,
+                max(0.1, float(tool_timeout or _RECYCLED_RECONNECT_TIMEOUT)),
+            )
+            if not _signal_reconnect_and_wait(
+                server_name,
+                server,
+                op_description=f"tools/call {tool_name} after stdio child exit",
+                timeout=reconnect_timeout,
+            ):
+                _bump_server_error(server_name)
+                return tool_error(
+                    f"MCP server '{server_name}' stdio subprocess exited and "
+                    f"did not recover within {reconnect_timeout:.0f}s"
+                )
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock, _track_inflight_rpc(
@@ -6153,35 +6181,6 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    # Fast-fail (#81995): a stdio subprocess that is already
-                    # dead must not own this call slot — fail immediately
-                    # instead of waiting out the full tool timeout on a
-                    # transport nobody will ever answer.
-                    _stdio_dead = getattr(server, "_stdio_children_dead", None)
-                    # callable() + real-bool result: MagicMock attributes return
-                    # truthy Mocks, which would spuriously trip the fast-fail.
-                    if (
-                        callable(_stdio_dead)
-                        and isinstance(_stdio_dead_result := _stdio_dead(), bool)
-                        and _stdio_dead_result
-                    ):
-                        # Dead children but stale server.session, so the
-                        # transport-down path above never fired — signal the
-                        # server task to respawn and return a clean
-                        # reconnecting error. No explicit _bump_server_error:
-                        # the error return flows through the handler's JSON
-                        # parse, which already bumps once.
-                        if _signal_reconnect(server):
-                            return tool_error(
-                                f"MCP server '{server_name}' stdio subprocess is "
-                                f"dead and reconnect was requested. Do NOT retry "
-                                f"immediately — give it a few seconds to respawn."
-                            )
-                        raise TimeoutError(
-                            f"MCP stdio subprocess for '{server_name}' has "
-                            f"exited; failing the call fast instead of "
-                            f"waiting {float(tool_timeout):.0f}s"
-                        )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (


### PR DESCRIPTION
## What does this PR do?

A stdio MCP server whose subprocess exits after successful discovery now reconnects before the next tool call and executes that original call on the replacement session. Previously the first call after the exit always failed, even though Hermes had enough state to respawn the server.

### Symptom

After an MCP server registers its tools, its child process can disappear during an idle period. The next tool call immediately reports that the stdio subprocess exited instead of attempting the requested operation.

### Impact

Affected users cannot use any tool from that MCP server until a later retry lands after the asynchronous reconnect. The reported blast radius is one Windows Azure DevOps MCP installation; the wider incidence is unknown.

### Bug Cause

**Trigger:** `tools/mcp_tool.py` / `_make_tool_handler` / the pre-call `_stdio_children_dead()` branch.

**Causal chain:**
1. A tracked stdio subprocess exits while the MCP SDK still leaves its old session object installed.
2. The pre-call liveness gate detects the dead child and requests a reconnect, but immediately returns an error without waiting for a replacement session.
3. The user's original tool call is discarded and must be retried manually after the respawn finishes.

**Why it is wrong:** The failure happens before the RPC starts, so the call is safe to defer until a distinct ready session exists. Returning immediately exposes a recoverable lifecycle transition as a user-visible tool failure.

**Working sibling / contrast:** Session-expiry recovery already uses `_signal_reconnect_and_wait()` to require a distinct ready session before retrying. The dead-stdio pre-call path did not reuse that recovery contract.

**Ruled out:** The attached report shows no Azure DevOps MCP fatal error and reproduces across interactive and Azure CLI authentication, with and without VPN. The exact external exit cause is not logged, but authentication and network mode do not explain why Hermes discards a call before attempting transparent recovery.

### Fix

- Detect an already-dead stdio child before scheduling the RPC.
- Reuse the bounded reconnect-and-wait helper, which clears readiness, signals the lifecycle task, and requires a distinct session object.
- Execute the original call on the replacement session, or return a bounded recovery error without touching the stale session.
- Preserve the existing mid-call fast-fail behavior because replaying a call that may already have reached the server is not safe.

## Related Issue

Closes #96497

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - reconnect dead stdio transports synchronously before tool dispatch.
- `tests/tools/test_mcp_stdio_fastfail_reconnect.py` - cover transparent replacement-session dispatch and bounded reconnect failure.

## How to Test

1. Start a stdio MCP server and allow its child process to exit after tool discovery.
2. Invoke a registered tool and verify Hermes respawns the transport and executes the original call on the new session.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_stdio_children_dead.py tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_circuit_breaker.py -q
```

Result: 31 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (focused automated tests)

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and regression tests are documented in code
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the recovery logic is transport-level and uses existing cross-platform helpers
- [x] Tool description/schema updates are N/A; the tool contract is unchanged

## Screenshots / Logs

N/A. The focused regression suite result is listed above.
