### PR TITLE
fix(desktop): spare durable rows when a sibling backend still holds the lease (supersedes #65059)

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -9,16 +9,22 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+class ActiveSessionRegistryError(RuntimeError):
+    """The liveness registry could not prove a safe ownership decision."""
 
 
 def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessions") -> Optional[int]:
@@ -114,16 +120,30 @@ def active_session_limit_message(
     )
 
 
-def _state_dir() -> Path:
-    return Path(get_hermes_home()) / "runtime"
+def _registry_home(registry_home: str | Path | None = None) -> Path:
+    return Path(registry_home) if registry_home is not None else Path(get_hermes_home())
 
 
-def _state_path() -> Path:
-    return _state_dir() / "active_sessions.json"
+def _state_dir(registry_home: str | Path | None = None) -> Path:
+    return _registry_home(registry_home) / "runtime"
 
 
-def _lock_path() -> Path:
-    return _state_dir() / "active_sessions.lock"
+def _state_path(registry_home: str | Path | None = None) -> Path:
+    return _state_dir(registry_home) / "active_sessions.json"
+
+
+def _lock_path(registry_home: str | Path | None = None) -> Path:
+    return _state_dir(registry_home) / "active_sessions.lock"
+
+
+def _lease_paths(
+    lease: Optional["ActiveSessionLease"] = None,
+    registry_home: str | Path | None = None,
+) -> tuple[Path, Path]:
+    if lease is not None and lease.state_path is not None and lease.lock_path is not None:
+        return lease.state_path, lease.lock_path
+    home = _registry_home(registry_home)
+    return _state_path(home), _lock_path(home)
 
 
 class _FileLock:
@@ -179,27 +199,100 @@ class _FileLock:
             self._fh = None
 
 
-def _read_entries(path: Path) -> list[dict[str, Any]]:
+def _read_entries(path: Path, *, strict: bool = False) -> list[dict[str, Any]]:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
     except FileNotFoundError:
         return []
-    except Exception:
+    except Exception as exc:
+        if strict:
+            raise ActiveSessionRegistryError(
+                f"active session registry unreadable: {path}"
+            ) from exc
         logger.warning("Ignoring corrupt active session registry at %s", path)
         return []
     entries = data.get("entries") if isinstance(data, dict) else data
     if not isinstance(entries, list):
+        if strict:
+            raise ActiveSessionRegistryError(
+                f"active session registry has invalid shape: {path}"
+            )
         return []
-    return [entry for entry in entries if isinstance(entry, dict)]
+    valid = [entry for entry in entries if isinstance(entry, dict)]
+    if not strict:
+        return valid
+    if len(valid) != len(entries):
+        raise ActiveSessionRegistryError(
+            f"active session registry contains invalid entries: {path}"
+        )
+    seen_leases: set[str] = set()
+    for entry in valid:
+        lease_id = entry.get("lease_id")
+        session_id = entry.get("session_id")
+        pid = entry.get("pid")
+        if not isinstance(lease_id, str) or not lease_id.strip():
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid lease id: {path}"
+            )
+        if lease_id in seen_leases:
+            raise ActiveSessionRegistryError(
+                f"active session registry contains a duplicate lease id: {path}"
+            )
+        seen_leases.add(lease_id)
+        if not isinstance(session_id, str) or not session_id.strip():
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid session id: {path}"
+            )
+        if isinstance(pid, bool) or not isinstance(pid, (int, str)):
+            pid_int = 0
+        else:
+            try:
+                pid_int = int(pid)
+            except (TypeError, ValueError):
+                pid_int = 0
+        if pid_int <= 0:
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid pid: {path}"
+            )
+        surface = entry.get("surface")
+        if surface is not None and not isinstance(surface, str):
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid surface: {path}"
+            )
+        tracked = entry.get("track_liveness")
+        if tracked is not None and not isinstance(tracked, bool):
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid liveness marker: {path}"
+            )
+        metadata = entry.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise ActiveSessionRegistryError(
+                f"active session registry contains invalid metadata: {path}"
+            )
+        process_start = entry.get("process_start_time")
+        parsed_process_start = _optional_float(process_start)
+        if process_start not in (None, "") and (
+            parsed_process_start is None or not math.isfinite(parsed_process_start)
+        ):
+            raise ActiveSessionRegistryError(
+                f"active session registry contains an invalid process start time: {path}"
+            )
+    return valid
 
 
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump({"entries": entries}, fh, sort_keys=True)
-    os.replace(tmp, path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"entries": entries}, fh, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _process_start_time(pid: int) -> Optional[float]:
@@ -220,6 +313,31 @@ def _optional_float(value: Any) -> Optional[float]:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _pid_liveness(pid: Any, process_start_time: Any = None) -> Optional[bool]:
+    """Return True/False for live/dead, or None when liveness is unknowable."""
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid_int <= 0:
+        return None
+    try:
+        from gateway.status import _pid_exists
+
+        exists = bool(_pid_exists(pid_int))
+    except Exception:
+        return None
+    if not exists:
+        return False
+    expected_start = _optional_float(process_start_time)
+    if expected_start is None:
+        return True
+    current_start = _process_start_time(pid_int)
+    if current_start is None:
+        return None
+    return abs(current_start - expected_start) < 0.001
 
 
 def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
@@ -246,12 +364,24 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     return abs(current_start - expected_start) < 0.001
 
 
-def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        entry
-        for entry in entries
-        if _pid_alive(entry.get("pid"), entry.get("process_start_time"))
-    ]
+def _prune_dead(
+    entries: list[dict[str, Any]], *, strict: bool = False
+) -> list[dict[str, Any]]:
+    live: list[dict[str, Any]] = []
+    for entry in entries:
+        tracked = bool(entry.get("track_liveness"))
+        if strict or tracked:
+            state = _pid_liveness(entry.get("pid"), entry.get("process_start_time"))
+            if state is None:
+                raise ActiveSessionRegistryError(
+                    "active session owner liveness is unknown"
+                )
+            if state:
+                live.append(entry)
+            continue
+        if _pid_alive(entry.get("pid"), entry.get("process_start_time")):
+            live.append(entry)
+    return live
 
 
 @dataclass
@@ -269,6 +399,7 @@ class ActiveSessionLease:
     # phantom leases (#85431).
     state_path: Optional[Path] = None
     lock_path: Optional[Path] = None
+    track_liveness: bool = False
 
     def release(self) -> None:
         if self.released or not self.enabled:
@@ -276,30 +407,16 @@ class ActiveSessionLease:
         release_active_session(self)
 
 
-def try_acquire_active_session(
+def _lease_entry(
     *,
+    lease_id: str,
     session_id: str,
     surface: str,
-    config: Any,
     metadata: Optional[dict[str, Any]] = None,
-) -> tuple[Optional[ActiveSessionLease], Optional[str]]:
-    """Acquire an active-session slot.
-
-    Returns ``(lease, None)`` on success.  When the cap is disabled, the lease is
-    a no-op object so callers can unconditionally call ``release()``.
-    """
-    max_sessions = resolve_max_concurrent_sessions(config)
-    lease_id = uuid.uuid4().hex
-    if max_sessions is None:
-        return ActiveSessionLease(
-            lease_id=lease_id,
-            session_id=session_id,
-            surface=surface,
-            enabled=False,
-        ), None
-
+    track_liveness: bool = False,
+) -> dict[str, Any]:
     now = time.time()
-    entry = {
+    entry: dict[str, Any] = {
         "lease_id": lease_id,
         "session_id": str(session_id),
         "surface": str(surface),
@@ -308,20 +425,75 @@ def try_acquire_active_session(
         "started_at": now,
         "updated_at": now,
     }
+    if track_liveness:
+        entry["track_liveness"] = True
     if metadata:
         entry["metadata"] = {
             str(k): v for k, v in metadata.items() if isinstance(k, str)
         }
+    return entry
 
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
-        raw_entries = _read_entries(state_path)
-        entries = _prune_dead(raw_entries)
+
+def try_acquire_active_session(
+    *,
+    session_id: str,
+    surface: str,
+    config: Any,
+    metadata: Optional[dict[str, Any]] = None,
+    registry_home: str | Path | None = None,
+    track_liveness: bool = False,
+) -> tuple[Optional[ActiveSessionLease], Optional[str]]:
+    """Acquire an active-session slot.
+
+    Returns ``(lease, None)`` on success.  When the cap is disabled, the lease is
+    a no-op object so callers can unconditionally call ``release()`` unless
+    ``track_liveness`` is true.  Liveness tracking keeps a real lease without
+    imposing a concurrency cap; ``registry_home`` lets profile-scoped backends
+    share the owning profile's registry even when launched from another home.
+    """
+    max_sessions = resolve_max_concurrent_sessions(config)
+    lease_id = uuid.uuid4().hex
+    if max_sessions is None and not track_liveness:
+        return ActiveSessionLease(
+            lease_id=lease_id,
+            session_id=session_id,
+            surface=surface,
+            enabled=False,
+        ), None
+
+    entry = _lease_entry(
+        lease_id=lease_id,
+        session_id=str(session_id),
+        surface=str(surface),
+        metadata=metadata,
+        track_liveness=track_liveness,
+    )
+
+    state_path, lock_path = _lease_paths(registry_home=registry_home)
+    with _FileLock(lock_path):
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=track_liveness)
+        except ActiveSessionRegistryError:
+            if track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; allowing an "
+                "untracked session without overwriting it"
+            )
+            return ActiveSessionLease(
+                lease_id=lease_id,
+                session_id=session_id,
+                surface=surface,
+                enabled=False,
+                state_path=state_path,
+                lock_path=lock_path,
+            ), None
         pruned = len(raw_entries) - len(entries)
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
         active_count = len(entries)
-        if active_count >= max_sessions:
+        if max_sessions is not None and active_count >= max_sessions:
             _write_entries(state_path, entries)
             logger.info(
                 "Active session limit reached: active=%d max=%d surface=%s",
@@ -340,26 +512,37 @@ def try_acquire_active_session(
         session_id=str(session_id),
         surface=str(surface),
         state_path=state_path,
-        lock_path=_lock_path(),
+        lock_path=lock_path,
+        track_liveness=track_liveness,
     ), None
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:
     # Prefer the registry the lease was acquired against: the caller may be
     # running under a profile HERMES_HOME override (#85431).
-    state_path = lease.state_path or _state_path()
-    lock_path = lease.lock_path or _lock_path()
-    try:
-        with _FileLock(lock_path):
-            entries = _prune_dead(_read_entries(state_path))
-            kept = [
-                entry
-                for entry in entries
-                if str(entry.get("lease_id") or "") != lease.lease_id
-            ]
-            if len(kept) != len(entries):
-                _write_entries(state_path, kept)
-    finally:
+    state_path, lock_path = _lease_paths(lease)
+    with _FileLock(lock_path):
+        if lease.released:
+            return
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=lease.track_liveness)
+        except ActiveSessionRegistryError:
+            if lease.track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; preserving it while "
+                "releasing an untracked lease"
+            )
+            lease.released = True
+            return
+        kept = [
+            entry
+            for entry in entries
+            if str(entry.get("lease_id") or "") != lease.lease_id
+        ]
+        if len(kept) != len(entries):
+            _write_entries(state_path, kept)
         lease.released = True
 
 
@@ -379,10 +562,23 @@ def transfer_active_session(
         lease.session_id = new_session_id
         return True
 
-    state_path = lease.state_path or _state_path()
-    lock_path = lease.lock_path or _lock_path()
+    state_path, lock_path = _lease_paths(lease)
     with _FileLock(lock_path):
-        entries = _prune_dead(_read_entries(state_path))
+        # release() may have won after the optimistic precheck but before this
+        # thread acquired the file lock. Never resurrect a durably removed lease.
+        if lease.released:
+            return False
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=lease.track_liveness)
+        except ActiveSessionRegistryError:
+            if lease.track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; refusing to overwrite "
+                "it during lease transfer"
+            )
+            return False
         updated = False
         for entry in entries:
             if str(entry.get("lease_id") or "") != lease.lease_id:
@@ -395,6 +591,17 @@ def transfer_active_session(
                 }
             updated = True
             break
+        if not updated and lease.track_liveness:
+            entries.append(
+                _lease_entry(
+                    lease_id=lease.lease_id,
+                    session_id=new_session_id,
+                    surface=lease.surface,
+                    metadata=metadata,
+                    track_liveness=True,
+                )
+            )
+            updated = True
         if updated:
             _write_entries(state_path, entries)
             lease.session_id = new_session_id
@@ -418,7 +625,14 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     if not state_path.exists():
         return 0
     with _FileLock(_lock_path()):
-        entries = _prune_dead(_read_entries(state_path))
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries)
+        except ActiveSessionRegistryError:
+            logger.warning(
+                "Active-session registry is unavailable; skipping orphaned-lease sweep"
+            )
+            return 0
         kept = [
             entry
             for entry in entries
@@ -431,10 +645,78 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     return dropped
 
 
-def active_session_registry_snapshot() -> list[dict[str, Any]]:
+def active_session_registry_snapshot(
+    registry_home: str | Path | None = None,
+) -> list[dict[str, Any]]:
     """Return the pruned active-session registry for diagnostics/tests."""
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
-        entries = _prune_dead(_read_entries(state_path))
-        _write_entries(state_path, entries)
+    state_path, lock_path = _lease_paths(registry_home=registry_home)
+    with _FileLock(lock_path):
+        raw_entries = _read_entries(state_path, strict=True)
+        entries = _prune_dead(raw_entries)
+        if entries != raw_entries:
+            _write_entries(state_path, entries)
         return entries
+
+
+@contextmanager
+def active_session_liveness_guard(
+    session_id: str,
+    *,
+    registry_home: str | Path | None = None,
+) -> Iterator[bool]:
+    """Hold the registry lock while reporting whether ``session_id`` is leased.
+
+    Keeping the lock across the caller's lifecycle mutation prevents a new
+    backend from acquiring a lease and reopening the row between the liveness
+    check and the corresponding ``end_session`` write.
+    """
+    target = str(session_id or "")
+    state_path, lock_path = _lease_paths(registry_home=registry_home)
+    with _FileLock(lock_path):
+        entries = _prune_dead(_read_entries(state_path, strict=True), strict=True)
+        _write_entries(state_path, entries)
+        yield bool(target) and any(
+            str(entry.get("session_id") or "") == target for entry in entries
+        )
+
+
+@contextmanager
+def release_active_session_liveness_guard(
+    lease: ActiveSessionLease,
+    session_id: str,
+) -> Iterator[bool]:
+    """Remove ``lease`` and hold its registry lock through a lifecycle write.
+
+    This makes automatic cleanup one atomic ownership decision: the local
+    runtime disappears, sibling liveness is checked, and the caller may end the
+    durable row before any new backend can acquire/reopen it.
+    """
+    if not lease.enabled or lease.released:
+        with active_session_liveness_guard(
+            session_id, registry_home=_registry_home_for_lease(lease)
+        ) as active:
+            yield active
+        return
+
+    target = str(session_id or "")
+    state_path, lock_path = _lease_paths(lease)
+    with _FileLock(lock_path):
+        raw_entries = _read_entries(state_path, strict=True)
+        entries = _prune_dead(raw_entries, strict=True)
+        kept = [
+            entry
+            for entry in entries
+            if str(entry.get("lease_id") or "") != lease.lease_id
+        ]
+        if len(kept) != len(entries):
+            _write_entries(state_path, kept)
+        lease.released = True
+        yield bool(target) and any(
+            str(entry.get("session_id") or "") == target for entry in kept
+        )
+
+
+def _registry_home_for_lease(lease: ActiveSessionLease) -> Path | None:
+    if lease.state_path is None:
+        return None
+    return lease.state_path.parent.parent

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -2,9 +2,12 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import pytest
 
 from hermes_cli import active_sessions
 
@@ -240,3 +243,320 @@ def test_transfer_under_profile_home_override_targets_acquisition_registry(
     root_registry = root / "runtime" / "active_sessions.json"
     entries = active_sessions._read_entries(root_registry)
     assert [entry["session_id"] for entry in entries] == ["after"]
+
+
+def test_liveness_registry_corruption_fails_closed_without_overwrite(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    state_path.parent.mkdir(parents=True)
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        with active_sessions.active_session_liveness_guard("session-1"):
+            pass
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.active_session_registry_snapshot()
+
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.try_acquire_active_session(
+            session_id="desktop-1",
+            surface="desktop",
+            config={},
+            track_liveness=True,
+        )
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    # The pre-existing concurrency-cap path remains available/fail-open, but
+    # must not erase evidence that strict liveness ownership is unknown.
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-1",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert state_path.read_text(encoding="utf-8") == corrupt
+    lease.release()
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_strict_registry_rejects_structurally_invalid_entries(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    base = {
+        "lease_id": "lease-1",
+        "session_id": "session-1",
+        "surface": "desktop",
+        "pid": os.getpid(),
+        "track_liveness": True,
+    }
+    invalid_entries = (
+        {key: value for key, value in base.items() if key != "lease_id"},
+        {**base, "lease_id": ""},
+        {key: value for key, value in base.items() if key != "session_id"},
+        {**base, "session_id": "  "},
+        {**base, "pid": 0},
+        {**base, "pid": 1.5},
+        {**base, "surface": 1},
+        {**base, "track_liveness": "yes"},
+        {**base, "metadata": []},
+        {**base, "process_start_time": "not-a-number"},
+        {**base, "process_start_time": "nan"},
+    )
+
+    for entry in invalid_entries:
+        active_sessions._write_entries(state_path, [entry])
+        original = state_path.read_text(encoding="utf-8")
+        with pytest.raises(active_sessions.ActiveSessionRegistryError):
+            with active_sessions.active_session_liveness_guard("session-1"):
+                pass
+        assert state_path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    "second_session_id",
+    ("session-a", "session-b"),
+    ids=("exact-duplicate", "conflicting-duplicate"),
+)
+def test_strict_registry_rejects_duplicate_lease_ids(
+    tmp_path, monkeypatch, second_session_id
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    active_sessions._write_entries(
+        state_path,
+        [
+            {
+                "lease_id": "duplicate-lease",
+                "session_id": "session-a",
+                "surface": "desktop",
+                "pid": os.getpid(),
+                "track_liveness": True,
+            },
+            {
+                "lease_id": "duplicate-lease",
+                "session_id": second_session_id,
+                "surface": "desktop",
+                "pid": os.getpid(),
+                "track_liveness": True,
+            },
+        ],
+    )
+    original = state_path.read_text(encoding="utf-8")
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.active_session_registry_snapshot()
+
+    assert state_path.read_text(encoding="utf-8") == original
+
+
+def test_cap_transfer_does_not_overwrite_registry_corruption(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-old",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+    assert not active_sessions.transfer_active_session(
+        lease,
+        session_id="cli-new",
+    )
+    assert lease.session_id == "cli-old"
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    lease.release()
+    assert lease.released is True
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_liveness_guard_rejects_unknown_pid_state(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    active_sessions._write_entries(
+        state_path,
+        [
+            {
+                "lease_id": "unknown-owner",
+                "session_id": "session-1",
+                "surface": "desktop",
+                "pid": 12345,
+                "track_liveness": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "gateway.status._pid_exists",
+        lambda _pid: (_ for _ in ()).throw(OSError("pid lookup unavailable")),
+    )
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        with active_sessions.active_session_liveness_guard("session-1"):
+            pass
+
+    original = state_path.read_text(encoding="utf-8")
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-cap-session",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert state_path.read_text(encoding="utf-8") == original
+
+
+def test_liveness_release_failure_is_retryable(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-1",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    original_write = active_sessions._write_entries
+    monkeypatch.setattr(
+        active_sessions,
+        "_write_entries",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        lease.release()
+    assert lease.released is False
+
+    monkeypatch.setattr(active_sessions, "_write_entries", original_write)
+    lease.release()
+    assert lease.released is True
+    assert active_sessions.active_session_registry_snapshot() == []
+
+
+def test_liveness_transfer_upserts_missing_entry_without_consuming_a_new_slot(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+    (home / "runtime" / "active_sessions.json").unlink()
+
+    assert active_sessions.transfer_active_session(lease, session_id="session-new")
+    snapshot = active_sessions.active_session_registry_snapshot()
+    assert [(entry["lease_id"], entry["session_id"]) for entry in snapshot] == [
+        (lease.lease_id, "session-new")
+    ]
+
+    blocked, limit_message = active_sessions.try_acquire_active_session(
+        session_id="session-other",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        track_liveness=True,
+    )
+    assert blocked is None
+    assert limit_message is not None
+    lease.release()
+
+
+def test_liveness_transfer_write_failure_keeps_old_id_for_retry(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    original_write = active_sessions._write_entries
+    monkeypatch.setattr(
+        active_sessions,
+        "_write_entries",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        active_sessions.transfer_active_session(lease, session_id="session-new")
+    assert lease.session_id == "session-old"
+
+    monkeypatch.setattr(active_sessions, "_write_entries", original_write)
+    assert active_sessions.transfer_active_session(lease, session_id="session-new")
+    assert lease.session_id == "session-new"
+    lease.release()
+
+
+def test_release_wins_against_transfer_waiting_on_same_lease_lock(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    release_wrote = threading.Event()
+    allow_release = threading.Event()
+    transfer_at_lock = threading.Event()
+    original_write = active_sessions._write_entries
+    original_enter = active_sessions._FileLock.__enter__
+
+    def _blocking_write(path, entries):
+        original_write(path, entries)
+        if threading.current_thread().name == "lease-release":
+            release_wrote.set()
+            assert allow_release.wait(timeout=5)
+
+    def _instrumented_enter(lock):
+        if threading.current_thread().name == "lease-transfer":
+            transfer_at_lock.set()
+        return original_enter(lock)
+
+    monkeypatch.setattr(active_sessions, "_write_entries", _blocking_write)
+    monkeypatch.setattr(active_sessions._FileLock, "__enter__", _instrumented_enter)
+    transfer_result: list[bool] = []
+    release_thread = threading.Thread(target=lease.release, name="lease-release")
+    transfer_thread = threading.Thread(
+        target=lambda: transfer_result.append(
+            active_sessions.transfer_active_session(lease, session_id="session-new")
+        ),
+        name="lease-transfer",
+    )
+
+    release_thread.start()
+    assert release_wrote.wait(timeout=5)
+    transfer_thread.start()
+    assert transfer_at_lock.wait(timeout=5)
+    allow_release.set()
+    release_thread.join(timeout=5)
+    transfer_thread.join(timeout=5)
+
+    assert not release_thread.is_alive()
+    assert not transfer_thread.is_alive()
+    assert transfer_result == [False]
+    assert lease.released is True
+    assert active_sessions.active_session_registry_snapshot() == []
+

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.active_sessions import (
+    active_session_liveness_guard,
+    active_session_registry_snapshot,
+    try_acquire_active_session,
+)
+from tui_gateway import server
+
+
+_LEASE_HOLDER_SCRIPT = """
+import os
+import time
+from pathlib import Path
+
+from hermes_cli import active_sessions
+from hermes_cli.active_sessions import try_acquire_active_session
+
+boundary_file = os.environ.get("BOUNDARY_FILE")
+if boundary_file:
+    original_enter = active_sessions._FileLock.__enter__
+    def instrumented_enter(self):
+        Path(boundary_file).write_text("boundary", encoding="utf-8")
+        return original_enter(self)
+    active_sessions._FileLock.__enter__ = instrumented_enter
+
+go_file = os.environ.get("GO_FILE")
+if go_file:
+    Path(os.environ["WAITING_FILE"]).write_text("waiting", encoding="utf-8")
+    deadline = time.monotonic() + 120
+    while not Path(go_file).exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("timed out waiting for acquisition signal")
+        time.sleep(0.02)
+lease, message = try_acquire_active_session(
+    session_id=os.environ["SESSION_ID"],
+    surface="desktop",
+    config={},
+    track_liveness=True,
+)
+assert lease is not None and message is None, message
+Path(os.environ["READY_FILE"]).write_text("ready", encoding="utf-8")
+try:
+    deadline = time.monotonic() + 120
+    release_file = Path(os.environ["RELEASE_FILE"])
+    while not release_file.exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("timed out waiting for release signal")
+        time.sleep(0.02)
+finally:
+    lease.release()
+"""
+
+
+def _spawn_lease_holder(
+    *,
+    home: Path,
+    session_id: str,
+    ready_file: Path,
+    release_file: Path,
+    boundary_file: Path | None = None,
+    go_file: Path | None = None,
+    waiting_file: Path | None = None,
+) -> subprocess.Popen[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    for key in list(env):
+        if key.endswith("_API_KEY") or key.endswith("_TOKEN"):
+            env.pop(key)
+    env.update({
+        "HERMES_HOME": str(home),
+        "PYTHONPATH": os.pathsep.join(
+            part for part in (str(repo_root), env.get("PYTHONPATH", "")) if part
+        ),
+        "READY_FILE": str(ready_file),
+        "RELEASE_FILE": str(release_file),
+        "SESSION_ID": session_id,
+    })
+    if boundary_file is not None:
+        env["BOUNDARY_FILE"] = str(boundary_file)
+    if go_file is not None and waiting_file is not None:
+        env["GO_FILE"] = str(go_file)
+        env["WAITING_FILE"] = str(waiting_file)
+    return subprocess.Popen(
+        [sys.executable, "-c", _LEASE_HOLDER_SCRIPT],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _wait_for_child_file(
+    child: subprocess.Popen[str],
+    path: Path,
+    *,
+    label: str,
+    timeout: float = 60.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if child.poll() is not None:
+            stdout, stderr = child.communicate()
+            pytest.fail(
+                f"{label} process exited before signalling readiness\n"
+                f"stdout: {stdout}\nstderr: {stderr}"
+            )
+        if time.monotonic() >= deadline:
+            pytest.fail(f"timed out waiting for {label} process")
+        time.sleep(0.02)
+
+
+def _stop_child(child: subprocess.Popen[str], release_file: Path) -> None:
+    release_file.touch()
+    if child.poll() is None:
+        child.kill()
+    child.communicate()
+
+
+def test_unlimited_session_lease_remains_noop_without_liveness_tracking(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "untracked-home"
+
+    lease, message = try_acquire_active_session(
+        session_id="untracked-session",
+        surface="tui",
+        config={},
+        registry_home=home,
+    )
+
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert active_session_registry_snapshot(registry_home=home) == []
+
+
+def test_orphan_guard_fails_closed_when_registry_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import active_sessions
+
+    def _unavailable(*_args, **_kwargs):
+        raise OSError("registry unavailable")
+
+    monkeypatch.setattr(
+        active_sessions,
+        "active_session_liveness_guard",
+        _unavailable,
+    )
+
+    with server._other_runtime_lease_guard(
+        "preserved-session",
+        {"profile_home": None},
+    ) as sibling_active:
+        assert sibling_active is True
+
+
+def test_desktop_claim_fails_closed_when_registry_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: (_ for _ in ()).throw(OSError("config unavailable")),
+    )
+
+    desktop_lease, desktop_message = server._claim_active_session_slot(
+        "desktop-session",
+        live_session_id="desktop-runtime",
+        surface="desktop",
+    )
+    tui_lease, tui_message = server._claim_active_session_slot(
+        "tui-session",
+        live_session_id="tui-runtime",
+        surface="tui",
+    )
+
+    assert desktop_lease is None
+    assert desktop_message == server._SESSION_OWNERSHIP_UNAVAILABLE
+    assert (tui_lease, tui_message) == (None, None)
+
+
+def test_server_release_retries_liveness_lease_before_dropping_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Lease:
+        enabled = True
+        released = False
+        track_liveness = True
+        calls = 0
+
+        def release(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise OSError("replace failed once")
+            self.released = True
+
+    lease = _Lease()
+    session = {"active_session_lease": lease}
+    monkeypatch.setattr(server.time, "sleep", lambda *_args: None)
+
+    assert server._release_active_session_slot(session) is True
+    assert lease.calls == 2
+    assert "active_session_lease" not in session
+
+
+def test_automatic_cleanup_preserves_corrupt_registry_without_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_home = tmp_path / "profile-home"
+    state_path = profile_home / "runtime" / "active_sessions.json"
+    state_path.parent.mkdir(parents=True)
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+    ended: list[tuple[str, str]] = []
+
+    class _FakeDB:
+        def get_session(self, target: str) -> dict[str, str]:
+            return {"id": target, "source": "desktop"}
+
+        def end_session(self, target: str, reason: str) -> None:
+            ended.append((target, reason))
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB()
+
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *args, **kwargs: None
+    )
+    session = {
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(profile_home),
+        "session_key": "preserved-session",
+        "slash_worker": None,
+        "source": "desktop",
+    }
+
+    server._finalize_session(session, end_reason="idle_timeout")
+
+    assert ended == []
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_liveness_guard_serializes_cross_process_acquire(tmp_path: Path) -> None:
+    home = tmp_path / "guard-home"
+    waiting_file = tmp_path / "child-waiting"
+    boundary_file = tmp_path / "child-lock-boundary"
+    go_file = tmp_path / "child-go"
+    acquired_file = tmp_path / "child-acquired"
+    release_file = tmp_path / "child-release"
+    session_id = "guarded-session"
+    child: subprocess.Popen[str] | None = None
+
+    try:
+        child = _spawn_lease_holder(
+            home=home,
+            session_id=session_id,
+            ready_file=acquired_file,
+            release_file=release_file,
+            boundary_file=boundary_file,
+            go_file=go_file,
+            waiting_file=waiting_file,
+        )
+        _wait_for_child_file(child, waiting_file, label="lease contender bootstrap")
+
+        with active_session_liveness_guard(
+            session_id,
+            registry_home=home,
+        ) as active:
+            assert active is False
+            go_file.write_text("go", encoding="utf-8")
+            _wait_for_child_file(child, boundary_file, label="lease lock boundary")
+            time.sleep(0.25)
+            assert not acquired_file.exists()
+            assert child.poll() is None
+
+        assert child is not None
+        _wait_for_child_file(child, acquired_file, label="lease contender")
+        release_file.write_text("release", encoding="utf-8")
+        stdout, stderr = child.communicate(timeout=30)
+        assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
+        assert active_session_registry_snapshot(registry_home=home) == []
+    finally:
+        if child is not None:
+            _stop_child(child, release_file)
+
+
+def test_automatic_desktop_cleanup_preserves_sibling_and_ends_sole_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every automatic cleanup reason must preserve another Desktop backend."""
+    profile_home = tmp_path / "profile-home"
+    ready_file = tmp_path / "child-ready"
+    release_file = tmp_path / "child-release"
+    session_id = "shared-profile-session"
+    child = _spawn_lease_holder(
+        home=profile_home,
+        session_id=session_id,
+        ready_file=ready_file,
+        release_file=release_file,
+    )
+    ended: list[tuple[str, str]] = []
+
+    class _FakeDB:
+        def get_session(self, target: str) -> dict[str, str] | None:
+            return {"id": target, "source": "desktop"}
+
+        def end_session(self, target: str, reason: str) -> None:
+            ended.append((target, reason))
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB()
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *args, **kwargs: None
+    )
+
+    def _session(lease) -> dict:
+        return {
+            "active_session_lease": lease,
+            "agent": None,
+            "history": [],
+            "history_lock": threading.Lock(),
+            "profile_home": str(profile_home),
+            "session_key": session_id,
+            "slash_worker": None,
+            "source": "desktop",
+        }
+
+    try:
+        _wait_for_child_file(child, ready_file, label="lease holder")
+
+        reasons = (
+            "ws_orphan_reap",
+            "ws_disconnect",
+            "idle_timeout",
+            "lru_evict",
+            "tui_shutdown",
+        )
+        assert set(reasons) == server._AUTOMATIC_SESSION_END_REASONS
+
+        for index, reason in enumerate(reasons):
+            local_lease, message = server._claim_active_session_slot(
+                session_id,
+                live_session_id=f"local-runtime-{index}",
+                surface="desktop",
+                profile_home=profile_home,
+            )
+            assert local_lease is not None and message is None
+            assert (
+                len(active_session_registry_snapshot(registry_home=profile_home)) == 2
+            )
+
+            server._finalize_session(_session(local_lease), end_reason=reason)
+
+            assert ended == []
+            remaining = active_session_registry_snapshot(registry_home=profile_home)
+            assert len(remaining) == 1
+            assert remaining[0]["session_id"] == session_id
+
+        # Explicit user close retains force/end semantics even with a sibling.
+        explicit_lease, message = server._claim_active_session_slot(
+            session_id,
+            live_session_id="explicit-runtime",
+            surface="desktop",
+            profile_home=profile_home,
+        )
+        assert explicit_lease is not None and message is None
+        server._finalize_session(_session(explicit_lease), end_reason="tui_close")
+        assert ended == [(session_id, "tui_close")]
+        ended.clear()
+
+        release_file.write_text("release", encoding="utf-8")
+        stdout, stderr = child.communicate(timeout=30)
+        assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
+        assert active_session_registry_snapshot(registry_home=profile_home) == []
+
+        for index, reason in enumerate(reasons):
+            sole_lease, message = server._claim_active_session_slot(
+                session_id,
+                live_session_id=f"sole-runtime-{index}",
+                surface="desktop",
+                profile_home=profile_home,
+            )
+            assert sole_lease is not None and message is None
+
+            server._finalize_session(_session(sole_lease), end_reason=reason)
+            assert active_session_registry_snapshot(registry_home=profile_home) == []
+
+        assert ended == [(session_id, reason) for reason in reasons]
+    finally:
+        _stop_child(child, release_file)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -631,12 +631,27 @@ def _notify_session_boundary(
         pass
 
 
+_SESSION_OWNERSHIP_UNAVAILABLE = (
+    "Hermes could not safely reserve this session. Try again."
+)
+
+_AUTOMATIC_SESSION_END_REASONS = frozenset({
+    "ws_orphan_reap",
+    "ws_disconnect",
+    "idle_timeout",
+    "lru_evict",
+    "tui_shutdown",
+})
+
+
 def _claim_active_session_slot(
     session_key: str,
     *,
     live_session_id: str,
     surface: str = "tui",
+    profile_home: str | Path | None = None,
 ) -> tuple[Any, str | None]:
+    track_liveness = str(surface or "").strip().lower() == "desktop"
     try:
         from hermes_cli.active_sessions import try_acquire_active_session
 
@@ -645,10 +660,16 @@ def _claim_active_session_slot(
             surface=surface,
             config=_load_cfg(),
             metadata={"live_session_id": live_session_id},
+            registry_home=profile_home,
+            track_liveness=track_liveness,
         )
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
-        return None, None
+        return (
+            (None, _SESSION_OWNERSHIP_UNAVAILABLE)
+            if track_liveness
+            else (None, None)
+        )
 
 
 def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
@@ -671,6 +692,7 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
         str(session.get("session_key") or ""),
         live_session_id=sid,
         surface=_session_source(session),
+        profile_home=session.get("profile_home"),
     )
     if limit_message is not None:
         return limit_message
@@ -678,16 +700,89 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     return None
 
 
-def _release_active_session_slot(session: dict | None) -> None:
-    if not session:
-        return
-    lease = session.pop("active_session_lease", None)
+def _release_active_session_lease(lease) -> bool:
     if lease is None:
+        return True
+    attempts = 3 if getattr(lease, "track_liveness", False) else 1
+    for attempt in range(attempts):
+        try:
+            lease.release()
+            break
+        except Exception:
+            if attempt + 1 >= attempts:
+                logger.warning("Failed to release active session slot", exc_info=True)
+                return False
+            time.sleep(0.05 * (attempt + 1))
+    released = getattr(lease, "released", True)
+    enabled = getattr(lease, "enabled", True)
+    return bool(released or not enabled)
+
+
+def _release_active_session_slot(session: dict | None) -> bool:
+    if not session:
+        return True
+    lease = session.get("active_session_lease")
+    if _release_active_session_lease(lease):
+        if session.get("active_session_lease") is lease:
+            session.pop("active_session_lease", None)
+        return True
+    return False
+
+
+@contextlib.contextmanager
+def _other_runtime_lease_guard(session_id: str, session: dict):
+    """Release this runtime and lock sibling ownership through the DB write."""
+    lease = session.get("active_session_lease")
+    try:
+        from hermes_cli.active_sessions import (
+            active_session_liveness_guard,
+            release_active_session_liveness_guard,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to load active session ownership guard; preserving session %s: %s",
+            session_id,
+            exc,
+        )
+        yield True
+        return
+
+    last_error: Exception | None = None
+    stack = contextlib.ExitStack()
+    for attempt in range(3):
+        try:
+            if lease is not None and getattr(lease, "enabled", False):
+                guard = release_active_session_liveness_guard(lease, session_id)
+            else:
+                guard = active_session_liveness_guard(
+                    session_id, registry_home=session.get("profile_home")
+                )
+            active = stack.enter_context(guard)
+            break
+        except Exception as exc:
+            stack.close()
+            stack = contextlib.ExitStack()
+            last_error = exc
+            if attempt < 2:
+                time.sleep(0.05 * (attempt + 1))
+    else:
+        logger.warning(
+            "Failed to inspect active session leases; preserving session %s: %s",
+            session_id,
+            last_error,
+        )
+        yield True
         return
     try:
-        lease.release()
-    except Exception:
-        logger.debug("Failed to release active session slot", exc_info=True)
+        yield active
+    finally:
+        stack.close()
+        if (
+            lease is not None
+            and getattr(lease, "released", False)
+            and session.get("active_session_lease") is lease
+        ):
+            session.pop("active_session_lease", None)
 
 
 def _transfer_active_session_slot(
@@ -713,6 +808,9 @@ def _transfer_active_session_slot(
     except Exception:
         logger.debug("Failed to transfer active session slot", exc_info=True)
 
+    if getattr(lease, "track_liveness", False):
+        return False
+
     # Fallback: the in-place transfer could not move the lease (entry pruned /
     # pid-check transiently failed). Reserve the new slot BEFORE releasing the
     # old one, so a concurrent gateway at the session cap cannot grab the freed
@@ -722,6 +820,7 @@ def _transfer_active_session_slot(
         new_session_id,
         live_session_id=sid,
         surface=_session_source(session),
+        profile_home=session.get("profile_home"),
     )
     if new_lease is not None:
         old_lease = session.pop("active_session_lease", None)
@@ -796,7 +895,14 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     if history_ready is not None and not history_ready.is_set():
         session["resume_history_error"] = "session resume cancelled"
         history_ready.set()
-    _release_active_session_slot(session)
+    _desktop_automatic_cleanup = bool(
+        end_reason in _AUTOMATIC_SESSION_END_REASONS
+        and _session_source(session).strip().lower() == "desktop"
+    )
+    # Automatic Desktop cleanup removes its lease inside the lock-held lifecycle
+    # guard below. Explicit close and non-Desktop paths keep force/end semantics.
+    if not _desktop_automatic_cleanup:
+        _release_active_session_slot(session)
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
@@ -864,27 +970,42 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     # Use session_id (from agent.session_id) not session_key — after compression,
     # session_key may be stale (the ended parent) while session_id is the live
     # continuation. Fix for #20001.
-    _tui_owns_lifecycle = True
-    if session_id:
-        try:
-            # End the row in the *session's* profile state.db (app-global
-            # remote mode), not the launch profile's shared handle.
-            with _session_db(session) as db:
-                if db is not None:
-                    # Don't end gateway-originated sessions — the gateway owns
-                    # their lifecycle.  The TUI is a viewer, not the owner.
-                    # Ending a gateway session in state.db triggers a Groundhog
-                    # Day routing loop: the gateway's #54878 self-heal detects
-                    # the stale entry, recovers to the parent session, context
-                    # compression splits back to the reaped child, and the cycle
-                    # repeats on every inbound message.  (#60609)
-                    row = db.get_session(session_id)
-                    source = (row or {}).get("source", "")
-                    _tui_owns_lifecycle = not _is_gateway_owned_source(source)
-                    if _tui_owns_lifecycle:
-                        db.end_session(session_id, end_reason)
-        except Exception:
-            pass
+    if _desktop_automatic_cleanup and not session_id:
+        _release_active_session_slot(session)
+    _lifecycle_guard = (
+        _other_runtime_lease_guard(session_id, session)
+        if _desktop_automatic_cleanup and session_id
+        else contextlib.nullcontext(False)
+    )
+    with _lifecycle_guard as _other_runtime_owns_lifecycle:
+        _tui_owns_lifecycle = not _other_runtime_owns_lifecycle
+        if _other_runtime_owns_lifecycle:
+            logger.info(
+                "Preserving session %s during %s: another backend owns an active lease",
+                session_id,
+                end_reason,
+            )
+        if session_id:
+            try:
+                # End the row in the *session's* profile state.db (app-global
+                # remote mode), not the launch profile's shared handle.
+                with _session_db(session) as db:
+                    if db is not None:
+                        # Don't end gateway-originated sessions — the gateway owns
+                        # their lifecycle.  The TUI is a viewer, not the owner.
+                        # Ending a gateway session in state.db triggers a Groundhog
+                        # Day routing loop: the gateway's #54878 self-heal detects
+                        # the stale entry, recovers to the parent session, context
+                        # compression splits back to the reaped child, and the cycle
+                        # repeats on every inbound message.  (#60609)
+                        row = db.get_session(session_id)
+                        source = (row or {}).get("source", "")
+                        if _is_gateway_owned_source(source):
+                            _tui_owns_lifecycle = False
+                        elif _tui_owns_lifecycle:
+                            db.end_session(session_id, end_reason)
+            except Exception:
+                pass
 
     # A session's in-flight async delegations end WITH the session (#55578):
     # once nobody owns the return address, a still-running background subagent


### PR DESCRIPTION
## What does this PR do?

Supersedes #65059.

Desktop can temporarily serve one profile from two Python backends (primary with a per-session `profile_home`, and a profile sidecar whose process-level `HERMES_HOME` is that profile). Both can hold a runtime for the same durable session. Process-local orphan checks cannot see the sibling, so a WebSocket disconnect or idle reap would end the shared `state.db` row and interrupt durable-key delegations while the other backend was still producing messages.

This rebases the core of #65059 onto current main: Desktop writes a real liveness lease even when `max_concurrent_sessions` is disabled, and automatic finalization holds the registry lock across the durable DB decision. Explicit user-close is unchanged. Profile-DB routing already on main is not repeated.

This is complementary to #94971 (heartbeat gate on the startup orphan sweep). It does not stop a sole-owner `ws_orphan_reap` after an SSH drop — raise `dashboard.ws_orphan_reap_grace_s` for that.

## Related Issue

Supersedes #65059. Related to #94895 / #94971 (different bug: shared-DB startup sweep).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/active_sessions.py`: optional `track_liveness` leases, profile `registry_home`, fail-closed inspect, lock-held sibling guard. Keeps #85431 path pinning and the holder-named cap message.
- `tui_gateway/server.py`: Desktop first-turn claims take a liveness lease; automatic ends (`ws_orphan_reap`, `ws_disconnect`, `idle_timeout`, `lru_evict`, `tui_shutdown`) preserve the durable row when another live lease remains.
- Tests for corrupt/unknown registry, release-vs-transfer, and a spawned sibling process for every automatic end reason.

## How to Test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_active_sessions.py \
  tests/hermes_cli/test_cli_active_session_limit.py \
  tests/tui_gateway/test_cross_process_orphan_ownership.py \
  tests/tui_gateway/test_protocol.py \
  tests/tui_gateway/test_session_profile_db.py \
  tests/tui_gateway/test_gateway_owned_session_reap.py \
  tests/tui_gateway/test_finalize_session_persist.py \
  -q
```

104 + 25 related tests passed locally.

## Checklist

- [x] Conventional Commits
- [x] Tests for the sibling-ownership bug class
- [x] Targeted suite green; full suite deferred to CI

Credit: @metamindedu (primary).