### PR TITLE
fix(skills): resolve project roots from session cwd

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from agent.runtime_cwd import resolve_agent_cwd
 from hermes_constants import get_config_path, get_skills_dir, is_termux
 
 logger = logging.getLogger(__name__)
@@ -675,18 +676,17 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     Returns None when cwd is not inside a git checkout. ``.git`` may be a dir
     (normal clone) or a file (worktree/submodule) — both count.
 
-    When *start* is not given, the surface's working directory wins over the
-    process cwd: ``TERMINAL_CWD`` is the same per-surface workdir the terminal
-    tool and cron jobs use (a cron job sets it from its per-job ``workdir``
-    without chdir'ing the scheduler process). This is what lets
+    When *start* is not given, the session's working directory wins over the
+    process cwd. ``resolve_agent_cwd()`` first consults the session-scoped cwd,
+    then ``TERMINAL_CWD`` (used by CLI and cron), and finally the process cwd.
+    This is what lets
     non-interactive surfaces inherit a prior interactive trust decision by
     project identity — and a surface with no workdir in a trusted repo simply
     resolves no project and loads nothing (#48975).
     """
     try:
         if start is None:
-            env_cwd = os.environ.get("TERMINAL_CWD")
-            start = Path(env_cwd) if env_cwd else Path.cwd()
+            start = resolve_agent_cwd()
         cur = Path(start).resolve()
     except OSError:
         return None

--- a/tests/agent/test_project_skills.py
+++ b/tests/agent/test_project_skills.py
@@ -149,6 +149,25 @@ class TestNonInteractiveInheritance:
         assert su.find_project_root() == project_env["repo"].resolve()
         assert su.get_project_skills_dirs() != []
 
+    def test_session_cwd_beats_backend_launch_cwd(
+        self, project_env, monkeypatch, tmp_path
+    ):
+        """Desktop project skills follow the active session, not launch cwd."""
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        launcher = tmp_path / "desktop-launcher"
+        launcher.mkdir()
+        monkeypatch.chdir(launcher)
+        monkeypatch.setenv("TERMINAL_CWD", str(launcher))
+        _trust(project_env["config"], project_env["repo"])
+
+        tokens = set_session_vars(cwd=str(project_env["repo"]))
+        try:
+            assert su.find_project_root() == project_env["repo"].resolve()
+            assert su.get_project_skills_dirs() != []
+        finally:
+            clear_session_vars(tokens)
+
     def test_no_workdir_no_trust_inheritance(self, project_env, monkeypatch, tmp_path):
         # A surface running outside any repo (API server from home-like dir)
         # resolves no project even when OTHER repos are trusted.


### PR DESCRIPTION
## Summary

- make project-root discovery honor the session-scoped working directory
- preserve the existing `TERMINAL_CWD` and process-cwd fallbacks for CLI and cron
- cover the session-over-launch-directory behavior with a regression test

## Consolidation scope

This PR is now the resolver-only prerequisite for #90234. It intentionally no longer changes skill-command caching, catalog/completion RPCs, command dispatch, slash routing, or Desktop completion caches. Those surfaces remain owned by #90234 so the two PRs can be reviewed and merged without competing implementations.

Refs #96402
Refs #90231

## Testing

- `PYTHONUTF8=1 python -m pytest -p no:cacheprovider tests/agent/test_project_skills.py tests/agent/test_runtime_cwd.py -q` — 29 passed
- `python -m ruff check agent/skill_utils.py tests/agent/test_project_skills.py`
- `git diff --check`