### PR TITLE
feat(telegram): prioritize selected skill menu commands

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1200,8 +1200,8 @@ platform_toolsets:
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
-#         # all built-in commands plus common skill commands stay visible
-#         # while remaining under Telegram's payload-size limit. Clamped 1..100.
+#         # high-priority commands stay visible while remaining under Telegram's
+#         # payload-size limit. Values are clamped to 1..100.
 #         max_commands: 60
 #         # prepend = user priority first, then Hermes defaults
 #         # append  = Hermes defaults first, then user priority
@@ -1209,6 +1209,12 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#         # Pin selected local skill commands ahead of the alphabetical skill
+#         # fallback. Pinned skills reserve slots when the cap is already full;
+#         # retained core/plugin commands remain ahead of them.
+#         # Hyphens and underscores are equivalent for Telegram command names.
+#         skill_priority:
+#           - my-important-skill
 #   slack:
 #     extra:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -703,9 +703,9 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     return result
 
 
-# Telegram allows up to 100 BotCommands. Hermes ships ~50 built-in commands;
-# a 60-slot default keeps every built-in plus common skill commands visible in
-# the `/` menu while staying comfortably under Telegram's ~4KB payload limit.
+# Telegram allows up to 100 BotCommands. A 60-slot default keeps the most useful
+# built-ins and any explicitly pinned skills visible in the `/` menu while
+# staying comfortably under Telegram's ~4KB payload limit.
 # Users can tune this via platforms.telegram.extra.command_menu.max_commands.
 _DEFAULT_TELEGRAM_MENU_MAX_COMMANDS = 60
 _TELEGRAM_BOT_API_MAX_COMMANDS = 100
@@ -791,10 +791,25 @@ def _telegram_command_menu_config() -> dict[str, Any]:
     else:
         priority = []
 
+    raw_skill_priority = menu_cfg.get("skill_priority")
+    if isinstance(raw_skill_priority, list):
+        skill_priority = list(
+            _dedupe_sanitized_names(
+                tuple(
+                    item
+                    for item in raw_skill_priority
+                    if isinstance(item, str) and item.strip()
+                )
+            )
+        )
+    else:
+        skill_priority = []
+
     return {
         "max_commands": max_commands,
         "priority_mode": priority_mode,
         "priority": priority,
+        "skill_priority": skill_priority,
     }
 
 
@@ -929,10 +944,11 @@ _clamp_telegram_names = _clamp_command_names
 
 def _collect_gateway_skill_entries(
     platform: str,
-    max_slots: int,
+    max_slots: int | None,
     reserved_names: set[str],
     desc_limit: int = 100,
     sanitize_name: "Callable[[str], str] | None" = None,
+    skill_priority: tuple[str, ...] = (),
 ) -> tuple[list[tuple[str, str, str]], int]:
     """Collect plugin + skill entries for a gateway platform.
 
@@ -948,13 +964,17 @@ def _collect_gateway_skill_entries(
         platform: Platform identifier for per-platform skill filtering
             (``"telegram"``, ``"discord"``, etc.).
         max_slots: Maximum number of entries to return (remaining slots after
-            built-in/core commands).
+            built-in/core commands), or ``None`` to return every eligible
+            entry so the caller can apply a combined cap.
         reserved_names: Names already taken by built-in commands.  Mutated
             in-place as new names are added.
         desc_limit: Max description length (40 for Telegram, 100 for Discord).
         sanitize_name: Optional name transform applied before clamping, e.g.
             :func:`_sanitize_telegram_name` for Telegram.  May return an
             empty string to signal "skip this entry".
+        skill_priority: Sanitized skill command names to place ahead of the
+            ordinary alphabetical skill order. Plugins and reserved core
+            commands always retain precedence.
 
     Returns:
         ``(entries, hidden_count)`` where *entries* is a list of
@@ -1039,9 +1059,27 @@ def _collect_gateway_skill_entries(
     except Exception:
         pass
 
+    if skill_priority:
+        priority_index = {
+            name: index
+            for index, name in enumerate(skill_priority)
+        }
+        skill_triples.sort(
+            key=lambda entry: (
+                0,
+                priority_index[entry[0]],
+            )
+            if entry[0] in priority_index
+            else (1, 0)
+        )
+
     # Clamp names; cmd_key is passed through as extra payload so it survives
     # any clamp-induced renames.
     skill_triples = _clamp_command_names(skill_triples, reserved_names)
+
+    if max_slots is None:
+        all_entries.extend(skill_triples)
+        return all_entries, 0
 
     # Skills fill remaining slots — only tier that gets trimmed
     remaining = max(0, max_slots - len(all_entries))
@@ -1059,12 +1097,14 @@ def _collect_gateway_skill_entries(
 def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str]], int]:
     """Return Telegram menu commands capped to the Bot API limit.
 
-    Priority order (higher priority = never bumped by overflow):
-      1. Core CommandDef commands (always included)
-      2. Plugin slash commands (take precedence over skills)
-      3. Built-in skill commands (fill remaining slots, alphabetical)
+    Priority order within the retained menu:
+      1. Core CommandDef and plugin commands
+      2. Configured priority skill commands
+      3. Other built-in skill commands (alphabetical)
 
-    Skills are the only tier that gets trimmed when the cap is hit.
+    Configured priority skills reserve menu slots. When core/plugin commands
+    alone reach the cap, the lowest-priority tail of that tier stays manually
+    dispatchable but is omitted from the visible menu so pinned skills fit.
     User-installed hub skills are excluded — accessible via /skills.
     Skills disabled for the ``"telegram"`` platform (via ``hermes skills
     config``) are excluded from the menu entirely.
@@ -1075,20 +1115,37 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     """
     core_commands = _prioritize_telegram_menu_commands(list(telegram_bot_commands()))
     reserved_names = {n for n, _ in core_commands}
-    all_commands = list(core_commands)
-    hidden_core_count = max(0, len(all_commands) - max_commands)
-
-    remaining_slots = max(0, max_commands - len(all_commands))
-    entries, hidden_count = _collect_gateway_skill_entries(
+    skill_priority = tuple(_telegram_command_menu_config()["skill_priority"])
+    entries, _ = _collect_gateway_skill_entries(
         platform="telegram",
-        max_slots=remaining_slots,
+        max_slots=None,
         reserved_names=reserved_names,
         desc_limit=40,
         sanitize_name=_sanitize_telegram_name,
+        skill_priority=skill_priority,
     )
-    # Drop the cmd_key — Telegram only needs (name, desc) pairs.
-    all_commands.extend((n, d) for n, d, _k in entries)
-    return all_commands[:max_commands], hidden_count + hidden_core_count
+    priority_names = set(skill_priority)
+    plugin_entries = [entry for entry in entries if not entry[2]]
+    priority_skill_entries = [
+        entry
+        for entry in entries
+        if entry[2]
+        and _sanitize_telegram_name(entry[2].lstrip("/")) in priority_names
+    ]
+    fallback_skill_entries = [
+        entry
+        for entry in entries
+        if entry[2]
+        and _sanitize_telegram_name(entry[2].lstrip("/")) not in priority_names
+    ]
+
+    reserved_entry_count = len(plugin_entries) + len(priority_skill_entries)
+    core_limit = max(0, max_commands - reserved_entry_count)
+    retained_core = core_commands[:core_limit]
+    ordered_entries = plugin_entries + priority_skill_entries + fallback_skill_entries
+    all_commands = retained_core + [(n, d) for n, d, _key in ordered_entries]
+    hidden_count = max(0, len(core_commands) + len(entries) - max_commands)
+    return all_commands[:max_commands], hidden_count
 
 
 def discord_skill_commands(

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -19,6 +19,7 @@ from hermes_cli.commands import (
     _clamp_command_names,
     _clamp_telegram_names,
     _sanitize_telegram_name,
+    _telegram_command_menu_config,
     discord_skill_commands,
     gateway_help_lines,
     resolve_command,
@@ -635,7 +636,245 @@ class TestDiscordSkillCmdKeyDispatch:
 
 
 class TestTelegramMenuCommands:
-    """Integration: telegram_menu_commands enforces the 32-char limit."""
+    """Integration coverage for capped Telegram command-menu construction."""
+
+    @staticmethod
+    def _fake_skills(skills_dir, names):
+        return {
+            f"/{name}": {
+                "name": name,
+                "description": f"{name} skill",
+                "skill_md_path": str(skills_dir / name / "SKILL.md"),
+                "skill_dir": str(skills_dir / name),
+            }
+            for name in names
+        }
+
+    def test_skill_priority_config_is_normalized_and_deduplicated(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority:\n"
+            "          - Please-Fix\n"
+            "          - please_fix\n"
+            "          - ' now-what '\n"
+            "          - '+++'\n"
+            "          - null\n"
+        )
+
+        assert _telegram_command_menu_config()["skill_priority"] == [
+            "please_fix",
+            "now_what",
+        ]
+
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority: now_what\n"
+        )
+        assert _telegram_command_menu_config()["skill_priority"] == []
+
+    def test_hyphenated_skill_matches_underscored_priority_under_cap(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority: [now_what]\n"
+        )
+        fake_cmds = self._fake_skills(skills_dir, ["alpha", "now-what"])
+
+        with (
+            patch("hermes_cli.commands.telegram_bot_commands", return_value=[("core", "Core")]),
+            patch("hermes_cli.plugins.get_plugin_commands", return_value={}),
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_project_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+        ):
+            menu, hidden = telegram_menu_commands(max_commands=2)
+
+        assert [name for name, _desc in menu] == ["core", "now_what"]
+        assert hidden == 1
+
+    def test_priority_skills_reserve_slots_when_core_commands_fill_cap(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority: [pinned-one, pinned-two]\n"
+        )
+        fake_cmds = self._fake_skills(skills_dir, ["pinned-one", "pinned-two"])
+        core_commands = [(f"core_{index}", f"Core {index}") for index in range(5)]
+
+        with (
+            patch(
+                "hermes_cli.commands.telegram_bot_commands",
+                return_value=core_commands,
+            ),
+            patch("hermes_cli.plugins.get_plugin_commands", return_value={}),
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_project_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+        ):
+            menu, hidden = telegram_menu_commands(max_commands=4)
+
+        assert [name for name, _desc in menu] == [
+            "core_0",
+            "core_1",
+            "pinned_one",
+            "pinned_two",
+        ]
+        assert hidden == 3
+
+    def test_missing_disabled_and_colliding_priority_skills_are_safe(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority:\n"
+            "          - missing-skill\n"
+            "          - disabled-skill\n"
+            "          - core\n"
+            "          - plugin-only\n"
+            "          - available-skill\n"
+        )
+        fake_cmds = self._fake_skills(
+            skills_dir,
+            ["available-skill", "core", "disabled-skill", "plugin-only"],
+        )
+
+        with (
+            patch(
+                "hermes_cli.commands.telegram_bot_commands",
+                return_value=[("core", "Core"), ("plugin_only", "Plugin")],
+            ),
+            patch("hermes_cli.plugins.get_plugin_commands", return_value={}),
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_project_skills_dirs", return_value=[]),
+            patch(
+                "agent.skill_utils.get_disabled_skill_names",
+                return_value={"disabled-skill"},
+            ),
+        ):
+            menu, hidden = telegram_menu_commands(max_commands=10)
+
+        assert [name for name, _desc in menu] == [
+            "core",
+            "plugin_only",
+            "available_skill",
+        ]
+        assert hidden == 0
+
+    def test_priority_skills_precede_alphabetical_skill_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority: [zulu]\n"
+        )
+        fake_cmds = self._fake_skills(
+            skills_dir, ["gamma", "alpha", "zulu", "beta"]
+        )
+
+        with (
+            patch("hermes_cli.commands.telegram_bot_commands", return_value=[("core", "Core")]),
+            patch("hermes_cli.plugins.get_plugin_commands", return_value={}),
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_project_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+        ):
+            menu, hidden = telegram_menu_commands(max_commands=5)
+
+        assert [name for name, _desc in menu] == [
+            "core",
+            "zulu",
+            "alpha",
+            "beta",
+            "gamma",
+        ]
+        assert hidden == 0
+
+    def test_hidden_count_tracks_reordered_skills_under_cap(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import patch
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        skill_priority: [echo, delta]\n"
+        )
+        fake_cmds = self._fake_skills(
+            skills_dir, ["alpha", "bravo", "charlie", "delta", "echo"]
+        )
+
+        with (
+            patch(
+                "hermes_cli.commands.telegram_bot_commands",
+                return_value=[("core", "Core"), ("plugin", "Plugin")],
+            ),
+            patch("hermes_cli.plugins.get_plugin_commands", return_value={}),
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_project_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+        ):
+            menu, hidden = telegram_menu_commands(max_commands=4)
+
+        assert [name for name, _desc in menu] == ["core", "plugin", "echo", "delta"]
+        assert hidden == 3
 
 
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -81,9 +81,9 @@ Notes:
 
 ### Command menu priority and cap (Optional)
 
-Hermes registers its command menu automatically when the Telegram gateway starts. The menu is built from the central slash-command registry plus eligible plugin/skill commands, then capped so Telegram accepts the payload reliably. The default cap is 60 commands — enough to keep all built-in commands plus common skill commands visible.
+Hermes registers its command menu automatically when the Telegram gateway starts. The menu is built from the central slash-command registry plus eligible plugin/skill commands, then capped so Telegram accepts the payload reliably. The default cap is 60 commands, with high-priority commands retained first.
 
-If you have local or plugin commands that should stay visible in Telegram's `/` picker, prioritize them in `~/.hermes/config.yaml`:
+If you have local plugin or skill commands that should stay visible in Telegram's `/` picker, prioritize them in `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:
@@ -94,6 +94,9 @@ platforms:
         priority_mode: prepend  # prepend | append | replace
         priority:
           - my_plugin_command
+        skill_priority:
+          - now-what
+          - remember_this
 ```
 
 `priority_mode` controls how your list combines with Hermes' built-in priority list:
@@ -101,6 +104,8 @@ platforms:
 - `prepend`: put your commands first, then Hermes defaults
 - `append`: keep Hermes defaults first, then your commands
 - `replace`: use only your list for priority ordering
+
+`skill_priority` is separate from `priority`: it pins eligible local skill commands ahead of the ordinary alphabetical skill entries. Pinned skills reserve slots when core/plugin commands already fill the cap; retained core/plugin commands remain ahead of them, while omitted commands stay available when typed or through `/commands`. Names are normalized to Telegram's format, so hyphens and underscores are equivalent. Missing skills, skills disabled for Telegram, and skills whose command names collide with core/plugin commands are ignored safely. This setting changes menu visibility only; typing the command uses the existing skill dispatch path.
 
 Telegram allows up to 100 BotCommands, but large command payloads can fail. Hermes defaults to 60 for reliability and clamps configured values to `1..100`; use `/commands` for the full command list.
 


### PR DESCRIPTION
## Summary
- add `platforms.telegram.extra.command_menu.skill_priority` with Telegram-safe normalization and stable fallback ordering
- reserve visible menu slots for eligible pinned skills while retaining core/plugin precedence and leaving dispatch unchanged
- document the option and its cap behavior in the example config and Telegram guide

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_commands.py` — 59 passed
- `git diff --check` — passed
- live read-only probe against the active default profile — 60 menu entries, all four configured skills present, exact hyphenated skill keys resolved, invocation payloads loaded

## Operational note
The config is read when Telegram registers its command menu. A gateway restart is required after this code is installed, but this PR does not restart or mutate the live gateway or Telegram Bot API menu.
