### PR TITLE
fix(webhook): restore cross-platform delivery for post-restart redelivery

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -375,6 +375,32 @@ class WebhookAdapter(BasePlatformAdapter):
             return SendResult(success=True)
 
         delivery = self._delivery_info.get(chat_id, {})
+        if not delivery:
+            # Restart-recovery fallback: the delivery ledger replays an
+            # interrupted final response on the next boot, calling send()
+            # with the SAME webhook source chat_id, but the in-memory
+            # _delivery_info is gone after a restart. Without this,
+            # deliver_type defaults to "log" and the recovered response is
+            # silently logged + marked delivered instead of reaching its
+            # cross-platform target (e.g. Telegram). Reconstruct the config
+            # from the route definition — dynamic subscriptions are reloaded
+            # at startup, so the route IS present on a fresh process.
+            route_name = None
+            parts = str(chat_id).split(":")
+            if len(parts) >= 2 and parts[0] == "webhook":
+                route_name = parts[1]
+            if route_name:
+                route_config = self._routes.get(route_name) or {}
+                delivery = {
+                    "deliver": route_config.get("deliver", "log"),
+                    "deliver_extra": route_config.get("deliver_extra", {}),
+                }
+                if delivery["deliver"] != "log":
+                    logger.info(
+                        "[webhook] Reconstructed delivery config for %s from "
+                        "route '%s' (post-restart redelivery)",
+                        chat_id, route_name,
+                    )
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
@@ -395,7 +421,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 pass
         if self.gateway_runner and _is_known_platform:
             return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+                deliver_type, content, delivery, metadata=metadata
             )
 
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
@@ -1420,7 +1446,8 @@ class WebhookAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(
-        self, platform_name: str, content: str, delivery: dict
+        self, platform_name: str, content: str, delivery: dict,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Route response to another platform (telegram, discord, etc.)."""
         if not self.gateway_runner:
@@ -1467,10 +1494,16 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
-        metadata = None
+        # Pass thread_id from deliver_extra so Telegram forum topics work.
+        # Fall back to the caller-provided metadata (the delivery-ledger
+        # redelivery path passes the obligation's thread_id) so a recovered
+        # final response keeps its topic routing even when deliver_extra
+        # carries no thread_id.
+        out_metadata = None
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        if not thread_id and metadata:
+            thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
         if thread_id:
-            metadata = {"thread_id": thread_id}
+            out_metadata = {"thread_id": thread_id}
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        return await adapter.send(chat_id, content, metadata=out_metadata)

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -338,3 +338,72 @@ class TestGitHubCommentDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+
+# ===================================================================
+# Test 5: Post-restart redelivery (delivery-ledger recovery)
+# ===================================================================
+
+class TestRedeliveryAfterRestart:
+
+    @pytest.mark.asyncio
+    async def test_send_reconstructs_delivery_config_after_restart(self):
+        """After a gateway restart the in-memory _delivery_info is gone,
+        but the delivery-ledger recovery replays the interrupted final
+        response by calling send() with the same webhook source chat_id.
+        send() must reconstruct the deliver config from the route
+        definition so the recovered response still reaches its
+        cross-platform target instead of silently falling into the log
+        branch (which would mark the obligation 'delivered' without ever
+        sending)."""
+        routes = {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Alert: {message}",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "12345"},
+            }
+        }
+        adapter = _make_adapter(routes)
+
+        mock_tg_adapter = AsyncMock()
+        mock_tg_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform.TELEGRAM: mock_tg_adapter}
+        mock_runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+        )
+        adapter.gateway_runner = mock_runner
+
+        # Simulate a post-restart redelivery: NO webhook POST happened in
+        # this process, so _delivery_info is empty for this chat.
+        chat_id = "webhook:alerts:alert-001"
+        assert chat_id not in adapter._delivery_info
+
+        result = await adapter.send(
+            chat_id,
+            "Recovered final response",
+            metadata={"thread_id": "777"},
+        )
+
+        assert result.success is True
+        # The deliver config came from the route definition, and the
+        # caller-provided metadata supplied the thread_id.
+        mock_tg_adapter.send.assert_awaited_once_with(
+            "12345", "Recovered final response", metadata={"thread_id": "777"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_without_route_after_restart_falls_back_to_log(self):
+        """A redelivered chat_id whose route no longer exists must not
+        crash or invent a target — it falls back to the log branch and
+        reports success (the response is preserved in the ledger)."""
+        adapter = _make_adapter({})
+        mock_runner = MagicMock()
+        mock_runner.adapters = {}
+        adapter.gateway_runner = mock_runner
+
+        chat_id = "webhook:vanished-route:delivery-001"
+        result = await adapter.send(chat_id, "Recovered response")
+
+        assert result.success is True


### PR DESCRIPTION
## Problem

When the delivery ledger replays an interrupted **agent-mode** webhook final response on the next boot, `WebhookAdapter.send()` is called with the webhook source chat_id (e.g. `webhook:negative-chat:<delivery_id>`), but the in-memory `_delivery_info` dict is gone after the restart. With no entry, `deliver_type` defaults to `"log"`, so the recovered response is **silently logged and marked `delivered` in the ledger without ever being sent** to its cross-platform target (Telegram, Discord, etc.).

Observed in production: a webhook route with `deliver: telegram` generated a final investigation report; the gateway was SIGKILL'd (OOM) before delivery confirmed; on next boot the redelivery hit the `log` branch and the user never received the message, while the ledger showed `state='delivered'`.

## Fix

In `WebhookAdapter.send()`:
- When `_delivery_info` has no entry for the chat_id, reconstruct the delivery config from the route definition (`self._routes`). Dynamic subscriptions are reloaded at startup, so the route IS present on a fresh process. If the route's `deliver` is a real target, the recovered response now goes through the normal cross-platform path instead of the `log` branch. Unknown/vanished routes still fall back to `log` safely.
- Thread the caller-provided `metadata` (the ledger redelivery path passes the obligation's `thread_id`) through `_deliver_cross_platform` so a recovered final response keeps its topic routing even when `deliver_extra` carries no `thread_id`.

## Tests

- `test_send_reconstructs_delivery_config_after_restart` — send() with an empty `_delivery_info` reconstructs the config from the route and delivers to the Telegram target with the metadata thread_id.
- `test_send_without_route_after_restart_falls_back_to_log` — a vanished route falls back to `log` (success, no invented target).
- Full `tests/gateway/ -k webhook` suite: 125 passed.