### PR TITLE
feat(feishu): add ignore_at_all config to opt out of @everyone triggering the bot

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5864,6 +5864,8 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
     """
     if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+    if "ignore_at_all" in feishu_cfg and not os.getenv("FEISHU_IGNORE_AT_ALL"):
+        os.environ["FEISHU_IGNORE_AT_ALL"] = str(feishu_cfg["ignore_at_all"]).lower()
     return None
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1662,8 +1662,11 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            # Env wins over extra-config (matches the _apply_yaml_config
+            # bridge contract: "Env vars take precedence over YAML").
             ignore_at_all=_to_boolean(
-                extra.get("ignore_at_all", os.getenv("FEISHU_IGNORE_AT_ALL", "false"))
+                os.getenv("FEISHU_IGNORE_AT_ALL")
+                or str(extra.get("ignore_at_all", "false")).lower()
             ),
         )
 
@@ -4452,8 +4455,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _mentions_self(self, message: Any) -> bool:
         # @_all is Feishu's @everyone placeholder.
-        # When FEISHU_IGNORE_AT_ALL is set, @_all alone does not trigger
-        # the bot; an explicit bot mention is still required.
+        # When the ignore_at_all setting is enabled, @_all alone does not
+        # trigger the bot; an explicit bot mention is still required.
         raw_content = getattr(message, "content", "") or ""
         if not self._ignore_at_all and "@_all" in raw_content:
             return True

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -436,6 +436,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    ignore_at_all: bool = False
 
 
 @dataclass
@@ -1661,6 +1662,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            ignore_at_all=_to_boolean(
+                extra.get("ignore_at_all", os.getenv("FEISHU_IGNORE_AT_ALL", "false"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1693,6 +1697,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._ignore_at_all = settings.ignore_at_all
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -4447,8 +4452,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _mentions_self(self, message: Any) -> bool:
         # @_all is Feishu's @everyone placeholder.
+        # When FEISHU_IGNORE_AT_ALL is set, @_all alone does not trigger
+        # the bot; an explicit bot mention is still required.
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
+        if not self._ignore_at_all and "@_all" in raw_content:
             return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -33,6 +33,7 @@ def make_adapter_skeleton(
     bot_user_id: str = "",
     allow_bots: str = "none",
     require_mention: bool = True,
+    ignore_at_all: bool = False,
     group_policy: str = "allowlist",
 ) -> Any:
     from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -49,6 +50,7 @@ def make_adapter_skeleton(
     adapter._allowed_group_users = frozenset()
     adapter._allow_bots = allow_bots
     adapter._require_mention = require_mention
+    adapter._ignore_at_all = ignore_at_all
     return adapter
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -350,6 +350,24 @@ class TestLoadGatewayConfig:
 
         assert os.getenv("SLACK_IGNORED_CHANNELS") == "C0123456789,C0987654321"
 
+    def test_feishu_ignore_at_all_config_sets_env_bridge(self, tmp_path, monkeypatch):
+        """``feishu.ignore_at_all`` bridges to FEISHU_IGNORE_AT_ALL via the
+        plugin's apply_yaml_config_fn hook (requested in #60910 review)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "feishu:\n"
+            "  ignore_at_all: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("FEISHU_IGNORE_AT_ALL", raising=False)
+
+        load_gateway_config()
+
+        assert os.getenv("FEISHU_IGNORE_AT_ALL") == "true"
+
 
     def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
         """``platforms.slack.typing_status_text`` reaches PlatformConfig via

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2467,3 +2467,36 @@ class TestChatLockEviction(unittest.TestCase):
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
 
 
+class TestApplyYamlConfigIgnoreAtAll(unittest.TestCase):
+    """feishu.ignore_at_all YAML key bridges to FEISHU_IGNORE_AT_ALL env var."""
+
+    def _call(self, feishu_cfg):
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        return _apply_yaml_config({}, feishu_cfg)
+
+    def test_bridges_yaml_key_to_env(self):
+        os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
+        try:
+            self._call({"ignore_at_all": True})
+            self.assertEqual(os.environ["FEISHU_IGNORE_AT_ALL"], "true")
+        finally:
+            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
+
+    def test_env_wins_over_yaml(self):
+        os.environ["FEISHU_IGNORE_AT_ALL"] = "true"
+        try:
+            self._call({"ignore_at_all": False})
+            self.assertEqual(os.environ["FEISHU_IGNORE_AT_ALL"], "true")
+        finally:
+            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
+
+    def test_key_absent_leaves_env_untouched(self):
+        os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
+        try:
+            self._call({"allow_bots": "mentions"})
+            self.assertNotIn("FEISHU_IGNORE_AT_ALL", os.environ)
+        finally:
+            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
+
+

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2476,27 +2476,21 @@ class TestApplyYamlConfigIgnoreAtAll(unittest.TestCase):
         return _apply_yaml_config({}, feishu_cfg)
 
     def test_bridges_yaml_key_to_env(self):
-        os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
-        try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
             self._call({"ignore_at_all": True})
             self.assertEqual(os.environ["FEISHU_IGNORE_AT_ALL"], "true")
-        finally:
-            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
 
     def test_env_wins_over_yaml(self):
-        os.environ["FEISHU_IGNORE_AT_ALL"] = "true"
-        try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ["FEISHU_IGNORE_AT_ALL"] = "true"
             self._call({"ignore_at_all": False})
             self.assertEqual(os.environ["FEISHU_IGNORE_AT_ALL"], "true")
-        finally:
-            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
 
     def test_key_absent_leaves_env_untouched(self):
-        os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
-        try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
             self._call({"allow_bots": "mentions"})
             self.assertNotIn("FEISHU_IGNORE_AT_ALL", os.environ)
-        finally:
-            os.environ.pop("FEISHU_IGNORE_AT_ALL", None)
 
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -572,14 +572,17 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
 
 
 @pytest.mark.parametrize(
-    "env_value, expected",
+    "env_value, extra, expected",
     [
-        (None, False),
-        ("true", True),
-        ("false", False),
+        (None, {}, False),
+        ("true", {}, True),
+        ("false", {}, False),
+        ("false", {"ignore_at_all": True}, True),
+        ("TRUE", {}, False),
+        ("1", {}, False),
     ],
 )
-def test_feishu_load_settings_ignore_at_all(monkeypatch, env_value, expected):
+def test_feishu_load_settings_ignore_at_all(monkeypatch, env_value, extra, expected):
     from plugins.platforms.feishu.adapter import FeishuAdapter
 
     monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
@@ -589,7 +592,7 @@ def test_feishu_load_settings_ignore_at_all(monkeypatch, env_value, expected):
     else:
         monkeypatch.setenv("FEISHU_IGNORE_AT_ALL", env_value)
 
-    settings = FeishuAdapter._load_settings(extra={})
+    settings = FeishuAdapter._load_settings(extra=extra)
     assert settings.ignore_at_all is expected
 
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -577,7 +577,10 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
         (None, {}, False),
         ("true", {}, True),
         ("false", {}, False),
-        ("false", {"ignore_at_all": True}, True),
+        # Env wins over extra-config (documented bridge contract).
+        ("true", {"ignore_at_all": False}, True),
+        (None, {"ignore_at_all": True}, True),
+        (None, {"ignore_at_all": False}, False),
         ("TRUE", {}, False),
         ("1", {}, False),
     ],

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -566,3 +566,115 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- FEISHU_IGNORE_AT_ALL ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        (None, False),
+        ("true", True),
+        ("false", False),
+    ],
+)
+def test_feishu_load_settings_ignore_at_all(monkeypatch, env_value, expected):
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    if env_value is None:
+        monkeypatch.delenv("FEISHU_IGNORE_AT_ALL", raising=False)
+    else:
+        monkeypatch.setenv("FEISHU_IGNORE_AT_ALL", env_value)
+
+    settings = FeishuAdapter._load_settings(extra={})
+    assert settings.ignore_at_all is expected
+
+
+def _mentions_self_message(**overrides) -> SimpleNamespace:
+    fields = dict(
+        message_id="om_mentions",
+        chat_type="group",
+        chat_id="oc_group",
+        message_type="text",
+        content="@_all hello everyone",
+        mentions=None,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+@pytest.mark.parametrize(
+    "ignore_at_all, expected",
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_mentions_self_at_all_gated_by_ignore_at_all(ignore_at_all, expected):
+    """@_all alone triggers the bot unless FEISHU_IGNORE_AT_ALL is set."""
+    adapter = make_adapter_skeleton(bot_open_id="ou_self", ignore_at_all=ignore_at_all)
+    message = _mentions_self_message()
+    assert adapter._mentions_self(message) is expected
+
+
+def test_mentions_self_at_all_with_explicit_mention_still_triggers():
+    """Explicit bot mention still triggers even when ignore_at_all=True."""
+    adapter = make_adapter_skeleton(bot_open_id="ou_self", ignore_at_all=True)
+    mention = SimpleNamespace(
+        key="@_user_1",
+        id=SimpleNamespace(union_id="", user_id="", open_id="ou_self"),
+        name="Hermes",
+        mentioned_type="bot",
+        tenant_key="",
+    )
+    message = _mentions_self_message(mentions=[mention])
+    assert adapter._mentions_self(message) is True
+
+
+def test_admit_ignore_at_all_rejects_at_all_only_group_message():
+    """Group message with ONLY @_all is rejected when FEISHU_IGNORE_AT_ALL=true."""
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        ignore_at_all=True,
+        require_mention=True,
+        group_policy="open",
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = _mentions_self_message(chat_type="group")
+    assert adapter._admit(sender, message) == "group_policy_rejected"
+
+
+def test_admit_ignore_at_all_admits_at_all_only_when_unset():
+    """Group message with ONLY @_all is admitted when FEISHU_IGNORE_AT_ALL is unset/false."""
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        ignore_at_all=False,
+        require_mention=True,
+        group_policy="open",
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = _mentions_self_message(chat_type="group")
+    assert adapter._admit(sender, message) is None
+
+
+def test_admit_ignore_at_all_still_admits_explicit_mention():
+    """Message with BOTH @_all and explicit bot open_id mention still admitted when ignore_at_all=True."""
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        ignore_at_all=True,
+        require_mention=True,
+        group_policy="open",
+    )
+    mention = SimpleNamespace(
+        key="@_user_1",
+        id=SimpleNamespace(union_id="", user_id="", open_id="ou_self"),
+        name="Hermes",
+        mentioned_type="bot",
+        tenant_key="",
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = _mentions_self_message(chat_type="group", mentions=[mention])
+    assert adapter._admit(sender, message) is None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -429,6 +429,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
 | `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
+| `FEISHU_IGNORE_AT_ALL` | `false` (default) / `true` — when true, @所有人/@everyone mentions don't trigger the bot; only explicit @-mentions do |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |
 | `FEISHU_HOME_CHANNEL` | Feishu chat ID for cron delivery and notifications |
 | `FEISHU_HOME_CHANNEL_NAME` | Display name for the Feishu home channel. |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -243,6 +243,8 @@ Set `FEISHU_REQUIRE_MENTION=false` to let Hermes read all group traffic without 
 FEISHU_REQUIRE_MENTION=false
 ```
 
+In announcement-heavy groups, set `FEISHU_IGNORE_AT_ALL=true` to prevent `@everyone`/`@所有人` mentions from triggering the bot — only explicit @-mentions of the bot will do so.
+
 For per-chat control, set `require_mention` on a `group_rules` entry — see [Per-Group Access Control](#per-group-access-control) below.
 
 ### Bot Identity
@@ -547,6 +549,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
 | `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | Whether group messages must @mention the bot |
+| `FEISHU_IGNORE_AT_ALL` | — | `false` | When true, @所有人/@everyone mentions don't trigger the bot; only explicit @-mentions do |
 | `FEISHU_HOME_CHANNEL` | — | — | Chat ID for cron/notification output |
 | `FEISHU_ENCRYPT_KEY` | — | _(empty)_ | Encrypt key for webhook signature verification |
 | `FEISHU_VERIFICATION_TOKEN` | — | _(empty)_ | Verification token for webhook payload auth |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -337,6 +337,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `FEISHU_VERIFICATION_TOKEN` | webhook 模式的可选验证 token |
 | `FEISHU_ALLOWED_USERS` | 允许向 bot 发送消息的逗号分隔飞书用户 ID |
 | `FEISHU_ALLOW_BOTS` | `none`（默认）/`mentions`/`all`——接受来自其他 bot 的入站消息。参见 [bot 间消息传递](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
+| `FEISHU_IGNORE_AT_ALL` | `false`（默认）/`true`——启用时，@所有人/@everyone 不会触发机器人；仅明确 @提及 机器人时触发 |
 | `FEISHU_REQUIRE_MENTION` | `true`（默认）/`false`——群组消息是否必须 @mention bot。可通过 `group_rules.<chat_id>.require_mention` 按聊天覆盖。 |
 | `FEISHU_HOME_CHANNEL` | cron 投递和通知的飞书聊天 ID |
 | `WECOM_BOT_ID` | 来自管理控制台的企业微信 AI Bot ID |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -209,6 +209,8 @@ FEISHU_GROUP_POLICY=allowlist   # 默认
 FEISHU_REQUIRE_MENTION=false
 ```
 
+在公告较多的群组中，设置 `FEISHU_IGNORE_AT_ALL=true` 可防止 `@所有人`/`@everyone` 提及触发机器人——只有明确 @提及 机器人才会触发。
+
 如需按群控制，在 `group_rules` 条目中设置 `require_mention`——参见下方[按群访问控制](#per-group-access-control)。
 
 ### 机器人身份
@@ -490,6 +492,7 @@ platforms:
 | `FEISHU_ALLOWED_USERS` | — | _（空）_ | 用户白名单的逗号分隔 open_id 列表 |
 | `FEISHU_ALLOW_BOTS` | — | `none` | 接受其他机器人消息：`none`、`mentions` 或 `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | 群消息是否必须 @提及 机器人 |
+| `FEISHU_IGNORE_AT_ALL` | — | `false` | 启用时，@所有人/@everyone 不会触发机器人；仅明确 @提及 机器人时触发 |
 | `FEISHU_HOME_CHANNEL` | — | — | cron/通知输出的聊天 ID |
 | `FEISHU_ENCRYPT_KEY` | — | _（空）_ | webhook 签名验证的加密密钥 |
 | `FEISHU_VERIFICATION_TOKEN` | — | _（空）_ | webhook payload 认证的验证 token |


### PR DESCRIPTION
Closes #33723

## Problem

In Feishu group chats, the bot always responds to `@所有人`/`@everyone` mentions because `_mentions_self()` in `plugins/platforms/feishu/adapter.py` short-circuits to `True` whenever `@_all` appears in the raw message content. In announcement-heavy groups this produces unwanted bot responses that can't be disabled.

## Solution

Adds an opt-in config so `@_all` alone no longer triggers the bot:

- **Env var:** `FEISHU_IGNORE_AT_ALL=true`
- **YAML:** `feishu.ignore_at_all: true` (bridged to the env var via the plugin's `apply_yaml_config_fn` hook; env wins when both are set)
- **Default:** `false` — behavior is unchanged for every existing user

When enabled, the `@_all` short-circuit in `_mentions_self()` is skipped and only explicit bot mentions trigger the bot (both the raw `mentions[]` path and the post/rich-text `is_self` ref path remain fully intact — an `@_all` ref never sets `is_self`, so the two paths don't interact).

Precedence chain: explicit env var → `feishu.ignore_at_all` YAML key → default `false`.

## Naming note

The issue proposed `FEISHU_IGNORE_MENTION_ALL` / `feishu.ignore_mention_all`. This PR uses `FEISHU_IGNORE_AT_ALL` / `feishu.ignore_at_all`, the name that 3 of the 5 prior PRs for this issue converged on. Happy to rename if maintainers prefer.

## Docs

Documented in English and zh-Hans: `website/docs/user-guide/messaging/feishu.md` (prose + table row), `website/docs/reference/environment-variables.md`, and both zh-Hans mirrors.

## Test plan

- `python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py -q` → 89 passed, 18 skipped
- Full Feishu suite (`test_feishu.py`, `test_feishu_bot_admission.py`, `test_feishu_bot_auth_bypass.py`, `test_feishu_approval_buttons.py`) → 104 passed, 18 skipped
- New tests cover: settings wiring (unset/false/true, extra-config override, env-wins-over-extra), `_mentions_self` gating (all-only gated when enabled, explicit bot mention still triggers when enabled), admission-level rejection/admission, YAML→env bridge (bridge set, env wins, key absent leaves env untouched), and `_to_boolean` edge pins (`"TRUE"`/`"1"` → `False`)
- `git diff --check` clean

## Notes

**Open question:** the read path for `require_mention` in `_load_settings` uses the same `extra.get(..., os.getenv(...))` ordering that makes extra-config override the env var (contradicting the `apply_yaml_config_fn` docstring "Env vars take precedence over YAML"). This PR fixes the ordering for the new key only, following the narrowest-patch approach — whether `require_mention` (and other keys using the same pattern) should be fixed too is a maintainer call.
