### PR TITLE
fix(desktop): scope group chat avatars to bot owner

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -13229,6 +13229,33 @@ function migrateGroupComposerDraft(oldKey, newKey) {
   groupComposerDrafts.delete(oldKey)
 }
 
+function resolveGroupEntrySpeaker(entry, members, metaByName) {
+  const isUser = entry.from.kind === 'user'
+
+  if (isUser) {
+    return { isUser, member: null, meta: null }
+  }
+
+  // A profile name is only unique within its owning connection. Resolve the
+  // roster row first, then use the same owner-scoped metadata lookup as every
+  // other bot surface so a remote `default` never borrows the local avatar.
+  const member = members.find(bot =>
+    bot.name === entry.from.name &&
+    (entry.from.source
+      ? (bot.connectionLabel || bot.connectionId) === entry.from.source
+      : !bot.remoteSource)
+  ) || null
+  const fallback = entry.from.source
+    ? { name: entry.from.name, remoteSource: true }
+    : { name: entry.from.name }
+
+  return {
+    isUser,
+    member,
+    meta: botRosterMeta(member || fallback, metaByName)
+  }
+}
+
 function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
@@ -13684,20 +13711,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
 
   // One log entry, rendered exactly as before conversation folding existed.
   const renderEntry = (entry, index) => {
-                  const isUser = entry.from.kind === 'user'
-                  const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
-                  // Match this speaker back to its member descriptor so display
-                  // names and disambiguating handles come from the roster (the
-                  // primary "default" profile renders as Hermes, remote dupes
-                  // carry their @name-device handle) instead of raw profile ids.
-                  const member = isUser
-                    ? null
-                    : members.find(b =>
-                        b.name === entry.from.name &&
-                        (entry.from.source
-                          ? (b.connectionLabel || b.connectionId) === entry.from.source
-                          : !b.remoteSource)
-                      ) || null
+                  const { isUser, member, meta } = resolveGroupEntrySpeaker(entry, members, allMeta)
                   const display = isUser ? 'You' : displayName(member || { name: entry.from.name }, meta)
                   const entryKey = `${entry.at}:${index}`
                   const revealed = !isUser && revealedSpeaker === entryKey
@@ -13710,8 +13724,6 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                       : display
                   // Speaker avatar: same appearance pipeline as the roster
                   // (custom image/pet, else deterministic shape+color face).
-                  // Remote speakers have no local meta and get the
-                  // deterministic face for their name — stable per bot.
                   const { shape, color, image } = isUser
                     ? { shape: null, color: null, image: null }
                     : botAppearance(entry.from.name, meta)

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__botConnectionRoute = botConnectionRoute;\nglobalThis.__resolveBotConnectionRoute = resolveBotConnectionRoute;\nglobalThis.__preferReachableSameNameRows = preferReachableSameNameRows;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__botConnectionRoute = botConnectionRoute;\nglobalThis.__resolveBotConnectionRoute = resolveBotConnectionRoute;\nglobalThis.__preferReachableSameNameRows = preferReachableSameNameRows;\nglobalThis.__resolveGroupEntrySpeaker = resolveGroupEntrySpeaker;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -298,6 +298,46 @@ test('botRosterMeta: an unrelated failure while resolving meta for a live route 
   })
 
   assert.throws(() => metaFor(owned, explodingMetaByName), /unrelated invariant failure/)
+})
+
+test('group transcript resolves same-name speaker metadata through its owning connection', () => {
+  const { __resolveGroupEntrySpeaker: resolve } = runtime()
+  const local = { name: 'default' }
+  const remote = {
+    name: 'default',
+    connectionId: 'homelab',
+    connectionLabel: 'Homelab',
+    remoteSource: true,
+    sourceScoped: true
+  }
+  const metadata = {
+    default: { image: 'local-avatar' },
+    'homelab::default': { image: 'remote-avatar' }
+  }
+
+  const remoteSpeaker = resolve(
+    { from: { kind: 'bot', name: 'default', source: 'Homelab' } },
+    [local, remote],
+    metadata
+  )
+  assert.equal(remoteSpeaker.member.connectionId, 'homelab')
+  assert.equal(remoteSpeaker.meta.image, 'remote-avatar')
+
+  const missingRemote = resolve(
+    { from: { kind: 'bot', name: 'default', source: 'Deleted device' } },
+    [local],
+    metadata
+  )
+  assert.equal(missingRemote.member, null)
+  assert.equal(missingRemote.meta, null)
+
+  const localSpeaker = resolve({ from: { kind: 'bot', name: 'default' } }, [local, remote], metadata)
+  assert.equal(localSpeaker.member, local)
+  assert.equal(localSpeaker.meta.image, 'local-avatar')
+
+  const userSpeaker = resolve({ from: { kind: 'user', name: 'user' } }, [local, remote], metadata)
+  assert.equal(userSpeaker.member, null)
+  assert.equal(userSpeaker.meta, null)
 })
 
 test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {


### PR DESCRIPTION
## Summary

- resolve each group transcript speaker to its connection-owned roster member before reading metadata
- prevent same-named remote bots from losing or borrowing the local bot avatar
- keep missing/deleted remote owners from falling back to bare-name local metadata

## Tests

- `node --test src/plugins/hermes-bots/tests/multi-source-roster.test.mjs`: 34 passed

Fixes #96432