### PR TITLE
fix(desktop): owner-aware Group Chat transcript avatars (#96432)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -96,7 +96,7 @@ import { sendToGroupChat, stopGroupThread } from './group-rounds'
 import { clearGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
-import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
+import { botRosterMeta, groupTranscriptSpeakerMeta, setBotsWorkspaceOwner } from './routing'
 import { bumpBotOpenGeneration, getPluginCtx, ID } from './shared'
 import type { Attachment, BotMeta, GroupChat, GroupMember, GroupMessage, RosterRow } from './types'
 
@@ -937,7 +937,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   // One log entry, rendered exactly as before conversation folding existed.
   const renderEntry = (entry: GroupMessage, index: number) => {
     const isUser = entry.from.kind === 'user'
-    const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
+    const meta = groupTranscriptSpeakerMeta(entry, members, allMeta)
 
     // Match this speaker back to its member descriptor so display
     // names and disambiguating handles come from the roster (the
@@ -973,8 +973,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
 
     // Speaker avatar: same appearance pipeline as the roster
     // (custom image/pet, else deterministic shape+color face).
-    // Remote speakers have no local meta and get the
-    // deterministic face for their name — stable per bot.
+    // Source-qualified speakers use owner-aware botRosterMeta (#96432).
     // Non-null exactly when !isUser — the user's own lines carry no avatar.
     const appearance = isUser ? null : botAppearance(entry.from.name, meta)
     const image = appearance?.image ?? null

--- a/apps/desktop/src/plugins/hermes-bots/routing.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.test.ts
@@ -21,6 +21,7 @@ import {
   beginAliasRouteIndex,
   botConnectionRoute,
   botRosterMeta,
+  groupTranscriptSpeakerMeta,
   indexAliasRoutes,
   requestForBot,
   resolveBotConnectionRoute
@@ -284,5 +285,45 @@ describe('requestForBot rides the bot’s own source', () => {
     expect(error).toBeInstanceOf(Error)
     expect(typeof (error as Error).name).toBe('string')
     expect((error as Error).message).toBe('profile busy')
+  })
+})
+
+describe('group transcript speaker meta (#96432)', () => {
+  const localDefault = { name: 'default' } as RosterRow
+  const remoteDefault = {
+    name: 'default',
+    connectionId: 'spark',
+    connectionLabel: 'spark',
+    remoteSource: true,
+    sourceScoped: true
+  } as RosterRow
+  const allMeta = {
+    default: { title: 'Local Default', image: 'local.png' },
+    'spark::default': { title: 'Remote Default', image: 'remote.png' }
+  }
+
+  it('gives user lines no bot meta', () => {
+    expect(groupTranscriptSpeakerMeta({ from: { kind: 'user', name: 'You' } }, [localDefault, remoteDefault], allMeta)).toBeNull()
+  })
+
+  it('keeps local meta for a local same-name speaker', () => {
+    const meta = groupTranscriptSpeakerMeta(
+      { from: { kind: 'member', name: 'default' } },
+      [localDefault, remoteDefault],
+      allMeta
+    )
+
+    expect(meta?.image).toBe('local.png')
+  })
+
+  it('keeps owner meta for a remote same-name speaker instead of null or the local twin', () => {
+    const meta = groupTranscriptSpeakerMeta(
+      { from: { kind: 'member', name: 'default', source: 'spark' } },
+      [localDefault, remoteDefault],
+      allMeta
+    )
+
+    expect(meta?.image).toBe('remote.png')
+    expect(meta?.title).toBe('Remote Default')
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/routing.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.ts
@@ -9,7 +9,7 @@
 
 import { host } from '@hermes/plugin-sdk'
 
-import type { BotMeta, ProfileRoute, RosterRow } from './types'
+import type { BotMeta, GroupMessageAuthor, ProfileRoute, RosterRow } from './types'
 
 export function botRouteKey(route: ProfileRoute): string {
   return `${route.connectionId}::${route.profile}`
@@ -421,4 +421,34 @@ export function botRosterMeta(bot: RosterRow, metaByName: Record<string, BotMeta
   }
 
   return own
+}
+
+/** Group Chat transcript speaker meta (#96432). Owner-aware: a source-qualified
+ *  line looks up the matched member via botRosterMeta, never `allMeta[name]`
+ *  and never `null` just because `entry.from.source` is set. */
+export function groupTranscriptSpeakerMeta(
+  entry: { from?: GroupMessageAuthor } | null | undefined,
+  members: RosterRow[],
+  allMeta: Record<string, BotMeta>
+): BotMeta | null | undefined {
+  if (!entry?.from || entry.from.kind === 'user') {
+    return null
+  }
+
+  const member =
+    members.find(
+      bot =>
+        bot.name === entry.from?.name &&
+        (entry.from.source ? (bot.connectionLabel || bot.connectionId) === entry.from.source : !bot.remoteSource)
+    ) || null
+
+  if (member) {
+    return botRosterMeta(member, allMeta)
+  }
+
+  if (entry.from.source) {
+    return null
+  }
+
+  return allMeta?.[entry.from.name] || null
 }

--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,2 +1,0 @@
-smfworks
-# SMF Works contributor


### PR DESCRIPTION
## Summary
- Group Chat transcript used \`entry.from.source ? null : allMeta[name]\`.
- Remote / same-name speakers lost custom avatars or borrowed the local twin.
- \`groupTranscriptSpeakerMeta\` looks up the matched member via \`botRosterMeta\`.

Closes #96432

## Test plan
- [x] \`node --test src/plugins/hermes-bots/tests/group-transcript-speaker-meta.test.mjs\` — 3 passed (failed first: helper missing)