### PR TITLE
fix(vision): restore custom auxiliary vision results

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -62,6 +62,8 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
 
+from agent.message_content import flatten_message_text
+
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # openai SDK pulls a large type tree (~240 ms cold, including responses/*,
 # graders/*). We expose `OpenAI` here as a thin proxy that imports the SDK on
@@ -10193,8 +10195,8 @@ def extract_content_or_reasoning(response) -> str:
     Qwen-QwQ, etc.) returns ``content=None`` with reasoning in structured fields.
 
     Resolution order:
-      1. ``message.content`` — strip inline think/reasoning blocks, check for
-         remaining non-whitespace text.
+      1. ``message.content`` — flatten string or typed content-part shapes,
+         strip inline think/reasoning blocks, and check for remaining text.
       2. ``message.reasoning`` / ``message.reasoning_content`` — direct
          structured reasoning fields (DeepSeek, Moonshot, NovitaAI, etc.).
       3. ``message.reasoning_details`` — OpenRouter unified array format.
@@ -10204,7 +10206,7 @@ def extract_content_or_reasoning(response) -> str:
     import re
 
     msg = response.choices[0].message
-    content = (msg.content or "").strip()
+    content = flatten_message_text(msg.content).strip()
 
     if content:
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -159,6 +159,17 @@ class TestExtractContentOrReasoning:
         response = _make_response(None)
         assert extract_content_or_reasoning(response) == ""
 
+    def test_list_content_returns_joined_text_parts(self):
+        response = _make_response([
+            {"type": "text", "text": "  First observation  "},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+            {"type": "output_text", "text": "Second observation"},
+        ])
+
+        assert extract_content_or_reasoning(response) == (
+            "First observation  \nSecond observation"
+        )
+
 
     def test_think_blocks_stripped_with_remaining_content(self):
         response = _make_response("<think>internal reasoning</think>The answer is 42.")


### PR DESCRIPTION
## What does this PR do?

Custom OpenAI-compatible auxiliary vision providers can return assistant text as typed content-part lists. Hermes treated every auxiliary response as a string, so `vision_analyze` failed after a successful provider response with `'list' object has no attribute 'strip'` instead of returning the image analysis. This change normalizes auxiliary response content through the same shared text flattener used by the main agent path.

### Symptom

With a text-only main model and a custom auxiliary vision model, `vision_analyze` returns `Error analyzing image: 'list' object has no attribute 'strip'` when the provider response uses list content.

### Impact

Affected custom-provider users cannot receive auxiliary image analysis even though the provider accepted the multimodal request and returned a valid response.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:extract_content_or_reasoning` receives `message.content` as a list of typed text parts.

**Causal chain:**
1. `vision_analyze` sends the image through the configured auxiliary provider.
2. The provider returns a valid OpenAI-compatible response whose assistant content is a list rather than a string.
3. The auxiliary extractor calls `.strip()` directly on that list and the tool returns an error instead of the analysis.

**Why it is wrong:** OpenAI-compatible providers can expose assistant text through typed content-part arrays, so the extraction boundary must normalize supported content shapes before string processing.

**Working sibling / contrast:** The main agent response path already calls `agent.message_content.flatten_message_text`, which supports strings, typed mappings, and SDK object parts while ignoring non-text media blocks.

**Ruled out:** Image input parsing and provider request construction are not the failure source. The reported endpoint returns 200 for the same multimodal payload, and the exception occurs while extracting the completed response.

### Fix

Reuse `flatten_message_text` in the centralized auxiliary response extractor before whitespace and reasoning-tag handling. Existing string, `None`, think-block, and structured-reasoning fallbacks retain their behavior, while list content returns only its visible text parts.

## Related Issue

Closes #96512

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - normalize auxiliary assistant content before text and reasoning extraction.
- `tests/tools/test_llm_content_none_guard.py` - reproduce and cover typed list content with non-text media parts.

## How to Test

1. Run the regression test that supplies list content and confirms visible text parts are returned instead of raising `AttributeError`.
2. Run the related auxiliary, vision, and message-content suites:

```bash
scripts/run_tests.sh tests/tools/test_llm_content_none_guard.py tests/agent/test_message_content.py tests/tools/test_vision_tools.py tests/agent/test_auxiliary_client.py -q
```

Result: 241 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - host-independent parsing only
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the existing schema and documented result remain unchanged
