### PR TITLE
fix(desktop): bound the shared resume flight and adopt its straggler

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { isTimeoutError } from '@/lib/with-timeout'
+
 import {
   clearSingleFlightSessionResumeState,
   registerRecoveredRuntime,
+  SESSION_RESUME_SETTLEMENT_TIMEOUT_MS,
   singleFlightSessionResume,
   takeRecoveredRuntime
 } from './single-flight-resume'
 import { resumeStoredRuntimeSession, SessionRecoveryAborted, withSessionNotFoundResume } from './utils'
 
 afterEach(() => {
+  vi.useRealTimers()
   clearSingleFlightSessionResumeState()
   vi.restoreAllMocks()
 })
@@ -63,6 +67,140 @@ describe('singleFlightSessionResume', () => {
     await expect(singleFlightSessionResume('stored-a', run)).rejects.toThrow('boom')
     await expect(singleFlightSessionResume('stored-a', run)).resolves.toEqual({ session_id: 'rt-second' })
     expect(run).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('bounded settlement and straggler adoption', () => {
+  it('a never-settling resume rejects at the deadline instead of wedging the slot forever', async () => {
+    vi.useFakeTimers()
+
+    const flight = singleFlightSessionResume('stored-wedged', () => new Promise<never>(() => {}))
+    const settled = flight.catch(error => error)
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+
+    expect(isTimeoutError(await settled)).toBe(true)
+  })
+
+  it('a later caller for the same stored id gets a FRESH attempt, not the dead flight', async () => {
+    vi.useFakeTimers()
+
+    const first = singleFlightSessionResume('stored-wedged', () => new Promise<never>(() => {}))
+    const firstSettled = first.catch(() => 'timed-out')
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+    expect(await firstSettled).toBe('timed-out')
+
+    const run = vi.fn(async () => ({ session_id: 'rt-second' }))
+
+    await expect(singleFlightSessionResume('stored-wedged', run)).resolves.toEqual({ session_id: 'rt-second' })
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('a joiner of an already-wedged flight inherits the same deadline', async () => {
+    vi.useFakeTimers()
+
+    const first = singleFlightSessionResume('stored-wedged', () => new Promise<never>(() => {}))
+    // The joiner passes no run() of its own — it must not hang past the ceiling.
+    const joiner = singleFlightSessionResume('stored-wedged', async () => ({ session_id: 'never-used' }))
+
+    expect(joiner).toBe(first)
+
+    const settled = joiner.catch(error => error)
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+
+    expect(isTimeoutError(await settled)).toBe(true)
+  })
+
+  it('a slow-but-legitimate resume (profile probe + RPC) still settles inside the ceiling', async () => {
+    vi.useFakeTimers()
+
+    // The worst healthy shape the ceiling is derived from: an active-profile
+    // probe, one cross-profile probe, then the resume RPC — each on its own
+    // 30s budget. A tighter ceiling would abort this and re-mint a runtime.
+    const flight = singleFlightSessionResume(
+      'stored-slow',
+      () => new Promise<{ session_id: string }>(resolve => setTimeout(() => resolve({ session_id: 'rt-slow' }), 89_000))
+    )
+
+    await vi.advanceTimersByTimeAsync(89_000)
+
+    await expect(flight).resolves.toEqual({ session_id: 'rt-slow' })
+  })
+
+  it('a runtime minted by a timed-out resume is adopted, not stranded on the gateway', async () => {
+    vi.useFakeTimers()
+
+    let land: (value: { session_id: string }) => void = () => {}
+    const flight = singleFlightSessionResume(
+      'stored-late',
+      () =>
+        new Promise<{ session_id: string }>(resolve => {
+          land = resolve
+        })
+    )
+    const settled = flight.catch(() => 'timed-out')
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+    expect(await settled).toBe('timed-out')
+
+    // The RPC was never cancelled: it lands a real, registered runtime.
+    land({ session_id: 'rt-late' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The next resume-shaped action reuses it instead of minting a second one.
+    expect(takeRecoveredRuntime('stored-late')).toBe('rt-late')
+  })
+
+  it('a straggler is NOT cached when a newer flight already owns the stored id', async () => {
+    vi.useFakeTimers()
+
+    let land: (value: { session_id: string }) => void = () => {}
+    const first = singleFlightSessionResume(
+      'stored-late',
+      () =>
+        new Promise<{ session_id: string }>(resolve => {
+          land = resolve
+        })
+    )
+    const settled = first.catch(() => 'timed-out')
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+    expect(await settled).toBe('timed-out')
+
+    // A new flight claims the slot before the straggler lands.
+    const second = singleFlightSessionResume('stored-late', () => new Promise<never>(() => {}))
+
+    void second.catch(() => undefined)
+    land({ session_id: 'rt-late' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Its caller adopts the second flight's result; caching the older runtime
+    // here would aim the next action at the wrong one.
+    expect(takeRecoveredRuntime('stored-late')).toBeUndefined()
+  })
+
+  it('a straggler that fails minted nothing and caches nothing', async () => {
+    vi.useFakeTimers()
+
+    let fail: (error: unknown) => void = () => {}
+    const flight = singleFlightSessionResume(
+      'stored-late',
+      () =>
+        new Promise<{ session_id: string }>((_resolve, reject) => {
+          fail = reject
+        })
+    )
+    const settled = flight.catch(() => 'timed-out')
+
+    await vi.advanceTimersByTimeAsync(SESSION_RESUME_SETTLEMENT_TIMEOUT_MS)
+    expect(await settled).toBe('timed-out')
+
+    fail(new Error('resume failed'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(takeRecoveredRuntime('stored-late')).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -13,9 +13,52 @@
  * `session_id`); joiners receive whatever the winning call returns.
  */
 
+import { withTimeout } from '@/lib/with-timeout'
+
 const _inFlightResumeByStoredSessionId = new Map<string, Promise<unknown>>()
 
-export function singleFlightSessionResume<T>(storedSessionId: string, run: () => Promise<T>): Promise<T> {
+/**
+ * Ceiling on how long ONE flight may hold the shared slot.
+ *
+ * Sharing the promise is what makes an unsettled resume so expensive: the
+ * entry is only released by `.finally()`, so while it hangs every later
+ * caller for that stored id joins the same dead promise and the conversation
+ * is unrecoverable for the life of the window. The deadline exists to break
+ * that wedge, NOT to make a slow resume feel responsive — the RPC's own 30s
+ * budget already covers responsiveness.
+ *
+ * Derived from the longest LEGITIMATE settlement rather than picked round, so
+ * a slow-but-healthy resume is never aborted. `run()` bodies resolve the
+ * owning profile before they send anything, and `resolveStoredSession()`
+ * probes backends sequentially on a cache miss:
+ *
+ *   30s  active-profile `getSession` probe    (Electron DEFAULT_FETCH_TIMEOUT_MS)
+ * + 30s  one cross-profile `getSession` probe (same budget, per profile)
+ * + 30s  the `session.resume` RPC             (HermesGateway DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS)
+ * = 90s
+ *
+ * An install with more profiles can still exceed this, and that is deliberate:
+ * past this point the flight has held the slot longer than any single healthy
+ * recovery ever needs, and breaking it is better than stranding the window.
+ */
+export const SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 90_000
+
+/** Best-effort `session_id` off a `session.resume`-shaped response. */
+function resumedRuntimeId(result: unknown): string {
+  if (typeof result !== 'object' || result === null) {
+    return ''
+  }
+
+  const sessionId = (result as { session_id?: unknown }).session_id
+
+  return typeof sessionId === 'string' ? sessionId : ''
+}
+
+export function singleFlightSessionResume<T>(
+  storedSessionId: string,
+  run: () => Promise<T>,
+  timeoutMs = SESSION_RESUME_SETTLEMENT_TIMEOUT_MS
+): Promise<T> {
   const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)
 
   if (existing) {
@@ -25,13 +68,41 @@ export function singleFlightSessionResume<T>(storedSessionId: string, run: () =>
   // Promise.resolve().then(run) tolerates run() being synchronous, returning a
   // bare value, or throwing synchronously (test doubles and legacy callers do
   // all three) — a raw run().finally() would crash on a non-promise return.
-  const flight = Promise.resolve()
-    .then(run)
-    .finally(() => {
-      if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
-        _inFlightResumeByStoredSessionId.delete(storedSessionId)
-      }
-    })
+  const work = Promise.resolve().then(run)
+
+  // withTimeout does NOT cancel the work it bounds, and here the straggler is
+  // not inert: `session.resume` can still land a REAL runtime, registered on
+  // the gateway, that no client is holding. Dropping it on the floor is the
+  // exact orphan-per-resume shape this module exists to prevent (#91276), so
+  // hand a late arrival to the same recovered-runtime cache the drift-abort
+  // path uses and let the next resume-shaped action adopt it.
+  const adoptStraggler = () => {
+    void work.then(
+      result => {
+        // A newer flight already owns this stored id — its caller will adopt
+        // whatever it returns, so caching an older runtime here would just
+        // aim the next action at the wrong one.
+        if (_inFlightResumeByStoredSessionId.has(storedSessionId)) {
+          return
+        }
+
+        registerRecoveredRuntime(storedSessionId, resumedRuntimeId(result))
+      },
+      // A straggler that failed minted nothing — there is nothing to adopt.
+      () => undefined
+    )
+  }
+
+  const flight = withTimeout(
+    work,
+    timeoutMs,
+    `Timed out resuming session ${storedSessionId}`,
+    adoptStraggler
+  ).finally(() => {
+    if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
+      _inFlightResumeByStoredSessionId.delete(storedSessionId)
+    }
+  })
 
   _inFlightResumeByStoredSessionId.set(storedSessionId, flight)
 


### PR DESCRIPTION
## Summary

Closes #96522.

`singleFlightSessionResume()` shares ONE promise per stored session id across every Desktop surface that can recover a dead runtime, and the slot is released only by that promise's `.finally()`. An unsettled `run()` therefore makes the conversation unrecoverable for the life of the window, and the rejection-driven retry ladder never arms because nothing ever rejects.

This PR bounds the flight **and** decides what the straggler means — because a deadline on its own trades a hang for a stranded runtime.

## Root cause

The RPC is already bounded: `HermesGateway` sets `requestTimeoutMs = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS` (30s). The `run()` bodies are not just that RPC — they resolve the owning profile first, and `resolveStoredSession()` probes backends **sequentially** on a cache miss, one 30s `getSession()` per configured profile. Settlement time scales with profile count; a probe wedged the way #93454 describes never settles at all.

Because the map is module-level, a wedge created by any ONE entry point wedges all five:

| Call site | Surface |
| --- | --- |
| `resolve-target-session.ts:101` | route resolver |
| `utils.ts:122` (`resumeStoredRuntimeSession`) | shared recovery |
| `submit.ts:592` | prompt submit |
| `use-session-actions/index.ts:1393` | cold resume |
| `use-session-tile-delegate.ts:198` | tile resume |

## The half a deadline does not fix

`withTimeout()` says it outright:

```ts
/** Rejection raised by withTimeout. The bounded work is NOT cancelled — the
 * caller decides what a straggler that settles later means. */
```

For `session.resume` the straggler is **not inert**. `_claim_or_reuse_live()` registers the record before returning, so a late resume has already minted a real runtime on the gateway. Dropping it strands that runtime for the reaper AND makes the next recovery mint another — the per-resume orphan shape this module was built to stop (#91276). The module already solved the identical problem for drift-aborts via `registerRecoveredRuntime()` / `takeRecoveredRuntime()`; nothing wired the timeout path into it.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["🩸 Five Recovery Surfaces"] -->|"one shared slot per stored id"| B["🔥 Single Flight"]
    B --> C["⛓️ Profile Ladder<br/>30s per configured backend"]
    C --> D["📡 session.resume RPC<br/>30s budget"]
    B --> E{"⏳ Settlement Ceiling<br/>90s = 30 + 30 + 30"}
    E -->|"settles in budget"| F["⚔️ Runtime Adopted<br/>slot released"]
    E -->|"exceeded"| G["💀 Flight Rejected<br/>slot released · retry ladder arms"]
    G --> H["🕯️ Straggler Still Lands<br/>work was never cancelled"]
    H -->|"no newer flight owns the id"| I["🔮 Recovered-Runtime Cache<br/>next action adopts it"]
    H -->|"newer flight owns the id"| J["🚫 Discarded<br/>its caller adopts its own result"]
    I --> F
```

## Implementation

- `SESSION_RESUME_SETTLEMENT_TIMEOUT_MS = 90_000`, derived rather than picked round: active-profile probe (30s, Electron `DEFAULT_FETCH_TIMEOUT_MS`) + one cross-profile probe (30s) + the resume RPC (30s). A slow-but-healthy multi-profile recovery is never aborted; past that point the flight has held the slot longer than any single healthy recovery needs.
- The flight is wrapped in the repo's existing `withTimeout()`. Its `.finally()` still frees the slot, so the next caller gets a FRESH attempt and the existing rejection-driven ladder arms.
- `onTimeout` attaches a late-settle handler: a straggler that yields a `session_id` is handed to `registerRecoveredRuntime()`. Guarded two ways — a straggler that **rejects** minted nothing, and one that lands while a **newer flight already owns the stored id** is discarded, because that flight's caller will adopt its own result.
- `singleFlightSessionResume()` takes an optional `timeoutMs` so tests can pin the boundary; every production caller uses the derived default.

Two files, `+167 / −6`. No new dependency, no new module, no behavior change on the success path.

## Test plan

`apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts` — **13 passed** (6 existing + 7 new).

| New test | Pins |
| --- | --- |
| `a never-settling resume rejects at the deadline instead of wedging the slot forever` | the ceiling fires |
| `a later caller for the same stored id gets a FRESH attempt, not the dead flight` | the slot is released |
| `a joiner of an already-wedged flight inherits the same deadline` | joiners are bounded too |
| `a slow-but-legitimate resume (profile probe + RPC) still settles inside the ceiling` | 89s healthy resume is **not** aborted |
| `a runtime minted by a timed-out resume is adopted, not stranded on the gateway` | the straggler reaches the cache |
| `a straggler is NOT cached when a newer flight already owns the stored id` | no stale adoption |
| `a straggler that fails minted nothing and caches nothing` | failure path is inert |

**Falsification:** with the production file reverted to `origin/main` and the tests kept, **6 of the 7 fail** — by timing out at 5000 ms, which is the wedge itself. The seventh (`a slow-but-legitimate resume…`) passes on old code because old code has no ceiling at all; it exists so a future tightening of the constant cannot silently start aborting legitimate recoveries.

<details>
<summary>Local run notes</summary>

The desktop `vite.config.ts` in this checkout imports `@rolldown/plugin-babel`, which is declared in `apps/desktop/package.json` but absent from the installed tree, and `npm install` refuses on this machine (`EBADENGINE`: repo requires `npm <11.10.0 || >=11.17.0`, local is 11.4.1). The suite was therefore run through a throwaway vitest config providing only the `@` alias — the module under test needs nothing else. That config was deleted and is not part of this diff. Hosted CI remains the authority.

</details>

## Non-duplicate analysis

- **#95926 / #95910** (@fangliquanflq) own the user-visible "Waking up… forever" report and add a 35s settlement deadline in this same file. Correct direction, and credited. Two things separate this PR: (a) the abandoned runtime a deadline creates is not addressed there, and it is the specific orphan this module exists to prevent; (b) 35s sits **below** the derived legitimate worst case — one cross-profile probe plus the RPC is already 60s — so it can abort a healthy multi-profile recovery and re-mint. If #95926 lands first this becomes a small follow-up that raises the constant and adds the adoption; if this lands first, #95926's symptom is covered and its cold-`resumeSession` regression test still applies.
- **#91276** is the resume-storm this module was built for. The orphan here is that same failure mode re-entering through the timeout path.
- **#93454** is the unbounded main-process IPC round-trip class that can put a probe into a non-settling state; this PR bounds the consequence, not that cause.
- **#95709** touches gateway-side session/transport ownership (`tui_gateway`). Disjoint file set, disjoint concern — the gateway behaves correctly here; it is the client that abandons a runtime it asked for.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Derived, not guessed, constant with the derivation written into the code
- [x] New tests fail on the prior behavior (falsification recorded above)
- [x] No new dependency, module, or public surface beyond one exported constant and one optional parameter
- [x] Success path unchanged
