### PR TITLE
feat(discord): add /voice doctor readiness diagnostics

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5950,8 +5950,8 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_reload_skills(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reload-skills")
 
-        @tree.command(name="voice", description="Toggle voice reply mode")
-        @discord.app_commands.describe(mode="Voice mode: join, channel, leave, on, tts, off, or status")
+        @tree.command(name="voice", description="Toggle voice reply mode or run diagnostics")
+        @discord.app_commands.describe(mode="Voice mode: join, channel, leave, on, tts, off, status, or doctor")
         @discord.app_commands.choices(mode=[
             # `join` and `channel` both route to _handle_voice_channel_join in
             # gateway/run.py — expose both in the slash UI so autocomplete
@@ -5964,8 +5964,27 @@ class DiscordAdapter(BasePlatformAdapter):
             discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),
             discord.app_commands.Choice(name="off — text only", value="off"),
             discord.app_commands.Choice(name="status — show current mode", value="status"),
+            discord.app_commands.Choice(name="doctor — check voice readiness", value="doctor"),
         ])
         async def slash_voice(interaction: discord.Interaction, mode: str = ""):
+            if mode == "doctor":
+                # Auth gate — must run before defer() so an ephemeral rejection
+                # can be delivered on the still-unresponded interaction.
+                if not await self._check_slash_authorization(
+                    interaction, "/voice doctor",
+                ):
+                    return
+                await interaction.response.defer(ephemeral=True)
+                try:
+                    report = await self._voice_doctor_report(interaction)
+                    await interaction.followup.send(report, ephemeral=True)
+                except Exception:
+                    logger.warning("[Discord] /voice doctor failed", exc_info=True)
+                    await interaction.followup.send(
+                        "Voice doctor encountered an error — check gateway logs.",
+                        ephemeral=True,
+                    )
+                return
             await self._run_simple_slash(interaction, f"/voice {mode}".strip())
 
         @tree.command(name="update", description="Update Hermes Agent to the latest version")
@@ -8645,7 +8664,110 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._pending_text_batch_tasks.pop(key, None)
 
 
-# ---------------------------------------------------------------------------
+    # ── /voice doctor diagnostics ────────────────────────────────────────
+
+    async def _voice_doctor_report(
+        self, interaction: "discord.Interaction",
+    ) -> str:
+        """Check voice-readiness and return a markdown report.
+
+        Runs on-demand when ``/voice doctor`` is invoked.  Never probes at
+        startup.  Reports presence-only for secrets (``configured`` /
+        ``not configured`` — never the key value itself).
+        """
+        lines: list[str] = ["**📋 Voice doctor**"]
+
+        # Lazy-import the voice doctor helpers from their dedicated module so
+        # adapter.py never triggers a top-level ``import discord`` just by
+        # being loaded — these helpers live in a separate module that handles
+        # the missing optional-dependency case gracefully (see voice_doctor.py).
+        try:
+            from .voice_doctor import (
+                _check_davey,
+                _check_ffmpeg,
+                _check_opus,
+                _check_pynacl,
+                _check_stt_provider,
+            )
+        except ImportError:
+            from voice_doctor import (
+                _check_davey,
+                _check_ffmpeg,
+                _check_opus,
+                _check_pynacl,
+                _check_stt_provider,
+            )
+
+        # 1. PyNaCl
+        icon, detail = _check_pynacl()
+        lines.append(f"{icon} {detail}")
+
+        # 2. Opus
+        icon, detail = _check_opus()
+        lines.append(f"{icon} {detail}")
+
+        # 3. ffmpeg / ffprobe
+        icon, detail = _check_ffmpeg()
+        lines.append(f"{icon} {detail}")
+
+        # 4. STT provider
+        icon, detail = _check_stt_provider()
+        lines.append(f"{icon} {detail}")
+
+        # 5. Bot permissions (needs live client / guild)
+        icon, detail = await self._check_voice_permissions(interaction)
+        lines.append(f"{icon} {detail}")
+
+        # 6. davey (DAVE E2EE)
+        icon, detail = _check_davey()
+        lines.append(f"{icon} {detail}")
+
+        # Summary
+        fail_count = sum(1 for l in lines if l.startswith("❌"))
+        warn_count = sum(1 for l in lines if l.startswith("⚠️"))
+        if fail_count == 0 and warn_count == 0:
+            lines.append("All checks passed — voice ready")
+        elif fail_count == 0:
+            lines.append(f"OK — {warn_count} warning(s) found")
+        else:
+            lines.append(f"{fail_count} issue(s) found")
+
+        return "\n".join(lines)
+
+    async def _check_voice_permissions(
+        self, interaction: "discord.Interaction",
+    ) -> tuple[str, str]:
+        """Check bot guild permissions (Connect, Speak, Use Voice Activity).
+
+        Guild-level check; per-channel overrides may still apply.
+        """
+        guild = getattr(interaction, "guild", None)
+        if guild is None:
+            return ("⚠️", "Bot permissions — cannot check in DMs (run /voice doctor in a server)")
+
+        try:
+            perms = guild.me.guild_permissions
+        except AttributeError:
+            return ("⚠️", "Bot permissions — could not resolve guild member")
+
+        missing: list[str] = []
+        if not perms.connect:
+            missing.append("Connect")
+        if not perms.speak:
+            missing.append("Speak")
+        if not perms.use_voice_activation:
+            missing.append("Use Voice Activity")
+
+        if missing:
+            return (
+                "❌",
+                f"Bot permissions — missing: {', '.join(missing)}. "
+                "Fix: grant these in Server Settings → Roles. "
+                "Note: per-channel overrides may still apply.",
+            )
+        return ("✅", "Bot permissions — Connect, Speak, Use Voice Activity granted (guild-level)")
+
+
 # Discord UI Components (outside the adapter class)
 # ---------------------------------------------------------------------------
 

--- a/plugins/platforms/discord/voice_doctor.py
+++ b/plugins/platforms/discord/voice_doctor.py
@@ -1,0 +1,136 @@
+"""
+Voice-readiness diagnostic helpers for the Discord adapter.
+
+These module-level helpers power the ``/voice doctor`` slash command, checking
+whether the local environment is capable of Discord voice: PyNaCl, Opus codec,
+ffmpeg, STT provider configuration, and DAVE E2EE (``davey``).
+
+**Why this module exists**
+
+This module MUST remain importable even when ``discord.py`` is NOT installed.
+In CI, ``discord.py`` is an optional platform extra and is absent from the test
+environment, but the :mod:`test_voice_doctor` unit tests import these helpers
+to verify their logic.  By isolating them here without a hard module-level
+dependency on ``discord``, we keep the test suite green on CI and avoid false
+positives from a missing optional dependency.
+
+``_check_opus`` is the only helper that needs ``discord`` at runtime; it
+handles the missing dependency with a try/except and returns a clear
+"not installed" diagnostic.  All other helpers have no dependency on the
+``discord`` package.
+"""
+
+from __future__ import annotations
+
+
+def _check_pynacl() -> tuple[str, str]:
+    """Check whether PyNaCl is importable."""
+    try:
+        import nacl  # noqa: F401 — only testing importability
+    except ImportError:
+        return ("❌", "PyNaCl — missing. Fix: pip install pynacl")
+    return ("✅", "PyNaCl — installed")
+
+
+def _check_opus() -> tuple[str, str]:
+    """Check whether the Opus codec is loaded.
+
+    Gracefully handles the case where ``discord.py`` itself is not installed
+    (returning a ❌ not-installed diagnostic) so this module can be imported
+    in CI environments that do not ship the optional ``discord.py`` extra.
+    """
+    try:
+        import discord
+    except ImportError:
+        return (
+            "❌",
+            "Opus — discord.py not installed — install it to use Discord voice "
+            "(pip install discord.py)",
+        )
+    if discord.opus.is_loaded():
+        return ("✅", "Opus — loaded")
+    return (
+        "⚠️",
+        "Opus — not loaded; Hermes will attempt to load it automatically",
+    )
+
+
+def _check_ffmpeg() -> tuple[str, str]:
+    """Check whether an ffmpeg/ffprobe executable is discoverable."""
+    try:
+        from .ffmpeg_utils import resolve_ffmpeg_executable
+    except ImportError:
+        try:
+            from ffmpeg_utils import resolve_ffmpeg_executable
+        except ImportError:
+            return ("❌", "ffmpeg — resolver unavailable. Fix: install ffmpeg")
+
+    try:
+        resolved = resolve_ffmpeg_executable()
+        if not resolved or resolved == "ffmpeg":
+            # resolve_ffmpeg_executable defaults to "ffmpeg" as a last resort
+            # — confirm it actually exists on PATH
+            import shutil
+            if not shutil.which("ffmpeg"):
+                return (
+                    "❌",
+                    "ffmpeg — not found. Fix: install ffmpeg "
+                    "(brew install ffmpeg / apt install ffmpeg)",
+                )
+        return ("✅", f"ffmpeg — {resolved}")
+    except Exception:
+        return ("❌", "ffmpeg — resolution failed. Fix: install ffmpeg")
+
+
+def _check_stt_provider() -> tuple[str, str]:
+    """Check the configured STT provider (presence-only, no key values)."""
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config() or {}
+        stt = cfg.get("stt") or {}
+        provider = stt.get("provider")
+        enabled = stt.get("enabled", True)
+    except Exception:
+        provider = None
+        enabled = True
+
+    # Check if STT is explicitly disabled (is_truthy semantics)
+    from utils import is_truthy_value
+
+    if not is_truthy_value(enabled, default=True):
+        return (
+            "⚠️",
+            "STT disabled in config (stt.enabled: false). "
+            "Fix: set stt.enabled: true in config.yaml",
+        )
+
+    if provider and str(provider).strip():
+        raw = str(provider).strip()
+        known = {"local", "groq", "openai", "mistral", "elevenlabs", "deepinfra", "xai", "whisper", "faster-whisper"}
+        if raw.lower() in known:
+            return ("✅", f"STT provider — {raw}")
+        return ("✅", "STT provider — configured (custom)")
+    # Autodetect: try faster-whisper
+    try:
+        import faster_whisper  # noqa: F401
+    except Exception:
+        return (
+            "⚠️",
+            "No STT provider configured and faster-whisper not installed — "
+            "voice transcription unavailable. "
+            "Fix: set stt.provider in config.yaml or pip install faster-whisper",
+        )
+    return ("✅", "STT — local faster-whisper available (autodetect)")
+
+
+def _check_davey() -> tuple[str, str]:
+    """Check whether the ``davey`` (DAVE E2EE) package is available."""
+    try:
+        import davey  # noqa: F401 — only testing importability
+    except ImportError:
+        return (
+            "⚠️",
+            "davey not installed — DAVE-encrypted voice channels unsupported "
+            "(older nacl-only mode will be used)",
+        )
+    return ("✅", "davey — installed")

--- a/tests/plugins/platforms/test_voice_doctor.py
+++ b/tests/plugins/platforms/test_voice_doctor.py
@@ -1,0 +1,518 @@
+"""Unit tests for /voice doctor readiness diagnostics.
+
+Tests the module-level helper functions (``_check_pynacl``,
+``_check_opus``, ``_check_ffmpeg``, ``_check_stt_provider``,
+``_check_davey``) and the overall report invariants.
+
+These are pure-logic tests that do NOT require a live discord.py client
+or network access.  Package-level monkeypatching simulates missing deps.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import builtins
+import pytest
+import sys
+
+from plugins.platforms.discord.voice_doctor import (
+    _check_davey,
+    _check_ffmpeg,
+    _check_opus,
+    _check_pynacl,
+    _check_stt_provider,
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _check_pynacl
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_pynacl_installed():
+    """When nacl imports, the check returns ✅."""
+    icon, detail = _check_pynacl()
+    assert icon == "✅"
+    assert "installed" in detail
+
+
+def test_pynacl_missing(monkeypatch):
+    """When nacl raises ImportError, the check returns ❌ with a fix hint."""
+    monkeypatch.setattr("builtins.__import__", _fail_import("nacl"))
+
+    icon, detail = _check_pynacl()
+    assert icon == "❌"
+    assert "pip install pynacl" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _check_opus
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_opus_loaded(monkeypatch):
+    """When discord.opus.is_loaded() is True, the check returns ✅."""
+    stub = MagicMock()
+    stub.opus.is_loaded = lambda: True
+    monkeypatch.setitem(sys.modules, "discord", stub)
+
+    icon, detail = _check_opus()
+    assert icon == "✅"
+    assert "loaded" in detail
+
+
+def test_opus_not_loaded(monkeypatch):
+    """When discord.opus.is_loaded() is False, the check warns (⚠️)."""
+    stub = MagicMock()
+    stub.opus.is_loaded = lambda: False
+    monkeypatch.setitem(sys.modules, "discord", stub)
+
+    icon, detail = _check_opus()
+    assert icon == "⚠️"
+    assert "not loaded" in detail
+    assert "automatically" in detail
+
+
+def test_opus_discord_not_installed(monkeypatch):
+    """When discord.py is not importable, the check returns ❌ with install hint."""
+    # Remove discord from sys.modules if present
+    if "discord" in sys.modules:
+        monkeypatch.setitem(sys.modules, "discord", None)
+        monkeypatch.delitem(sys.modules, "discord")
+
+    # Make importing discord raise ImportError
+    original_import = builtins.__import__
+
+    def _fail_discord_import(name, *args, **kwargs):
+        if name == "discord" or name.startswith("discord."):
+            raise ImportError(f"No module named {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _fail_discord_import)
+
+    icon, detail = _check_opus()
+    assert icon == "❌"
+    assert "discord.py not installed" in detail
+    assert "pip install discord.py" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _check_ffmpeg
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_ffmpeg_found(monkeypatch):
+    """When resolve_ffmpeg_executable returns a real path, the check returns ✅."""
+
+    def _mock_resolve():
+        return "/usr/local/bin/ffmpeg"
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.ffmpeg_utils.resolve_ffmpeg_executable",
+        _mock_resolve,
+    )
+
+    icon, detail = _check_ffmpeg()
+    assert icon == "✅"
+    assert "ffmpeg" in detail
+
+
+def test_ffmpeg_not_on_path(monkeypatch):
+    """When ffmpeg resolves to bare 'ffmpeg' but is not on PATH, the check
+    returns ❌ with a fix hint."""
+
+    def _mock_resolve():
+        return "ffmpeg"
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.ffmpeg_utils.resolve_ffmpeg_executable",
+        _mock_resolve,
+    )
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    icon, detail = _check_ffmpeg()
+    assert icon == "❌"
+    assert "brew install ffmpeg" in detail or "apt install ffmpeg" in detail
+
+
+def test_ffmpeg_resolver_unavailable(monkeypatch):
+    """When the ffmpeg_utils module itself is not importable, the check fails."""
+    original_import = builtins.__import__
+
+    def _bad_import(name, *args, **kwargs):
+        if "ffmpeg_utils" in name:
+            raise ImportError(f"No module named {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _bad_import)
+
+    icon, detail = _check_ffmpeg()
+    assert icon == "❌"
+    assert "install ffmpeg" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _check_stt_provider
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_stt_provider_configured(monkeypatch, tmp_path):
+    """When the config has stt.provider set, the check returns ✅ with provider name."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"stt": {"provider": "openai"}})
+    )
+
+    icon, detail = _check_stt_provider()
+    assert icon == "✅"
+    assert "STT provider — openai" in detail
+
+
+def test_stt_autodetect_available(monkeypatch, tmp_path):
+    """When no STT provider is set and faster-whisper is importable, ✅."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(yaml.safe_dump({"stt": {}}))
+
+    import sys
+    from unittest.mock import MagicMock
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
+
+    icon, detail = _check_stt_provider()
+    assert icon == "✅"
+    assert "faster-whisper" in detail
+    assert "autodetect" in detail
+
+
+def test_stt_autodetect_unavailable(monkeypatch, tmp_path):
+    """When no STT provider is set and faster-whisper is not importable, ⚠️."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(yaml.safe_dump({"stt": {}}))
+
+    # Ensure faster_whisper is NOT importable
+    if "faster_whisper" in sys.modules:
+        monkeypatch.setitem(sys.modules, "faster_whisper", None)
+        monkeypatch.delitem(sys.modules, "faster_whisper")
+
+    # Use a __import__ that fails only for faster_whisper
+    original_import = builtins.__import__
+
+    def _importer(name, *args, **kwargs):
+        if name == "faster_whisper":
+            raise ImportError(f"No module named {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _importer)
+
+    icon, detail = _check_stt_provider()
+    assert icon == "⚠️"
+    assert "No STT provider configured" in detail
+    assert "faster-whisper not installed" in detail
+    assert "pip install faster-whisper" in detail
+
+
+def test_stt_disabled(monkeypatch, tmp_path):
+    """When stt.enabled is false, the check warns (⚠️) with a fix hint."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"stt": {"enabled": False}})
+    )
+
+    icon, detail = _check_stt_provider()
+    assert icon == "⚠️"
+    assert "STT disabled" in detail
+    assert "stt.enabled: false" in detail
+    assert "stt.enabled: true" in detail
+
+
+def test_stt_provider_no_key_leak(monkeypatch, tmp_path):
+    """The report must never contain API-key-like patterns.
+
+    When a user accidentally places an API key into the stt.provider field,
+    the report must NOT echo the raw value — it must return a safe label.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "stt": {
+                    "provider": "sk-12345abc",
+                }
+            }
+        )
+    )
+
+    icon, detail = _check_stt_provider()
+    # The raw key-like value must never appear in the detail
+    assert "sk-12345abc" not in detail
+    # Instead, the safe generic label must be used
+    assert "configured (custom)" in detail
+
+
+def test_stt_autodetect_oserror(monkeypatch, tmp_path):
+    """When faster-whisper C-extensions raise OSError, the check handles it gracefully."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import yaml
+
+    (home / "config.yaml").write_text(yaml.safe_dump({"stt": {}}))
+
+    # Make faster_whisper raise OSError (broken C-extension install)
+    original_import = builtins.__import__
+
+    def _importer(name, *args, **kwargs):
+        if name == "faster_whisper":
+            raise OSError("dlopen: cannot load shared library")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _importer)
+
+    icon, detail = _check_stt_provider()
+    assert icon == "⚠️"
+    assert "No STT provider configured" in detail
+    assert "faster-whisper not installed" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _check_davey
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_davey_installed():
+    """When davey is importable, the check returns ✅."""
+    # Try real import first; fallback to mock
+    try:
+        import davey  # noqa: F401
+    except ImportError:
+        pytest.skip("davey package is not installed")
+
+    icon, detail = _check_davey()
+    assert icon == "✅"
+    assert "installed" in detail
+
+
+def test_davey_missing(monkeypatch):
+    """When davey raises ImportError, the check warns (⚠️)."""
+    monkeypatch.setattr("builtins.__import__", _fail_import("davey"))
+
+    icon, detail = _check_davey()
+    assert icon == "⚠️"
+    assert "davey not installed" in detail
+    assert "nacl-only" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Report invariants
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_voice_doctor_report_contains_all_checks(monkeypatch):
+    """The full report emitted by _voice_doctor_report must contain every
+    expected check label, regardless of individual pass/fail status."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.config import PlatformConfig
+
+    # Build a minimal adapter instance
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="fake_token")
+    )
+    # Simulate no connected client so permission check is lenient
+    adapter._client = None
+
+    # Mock all the helper functions to return known values so the
+    # report is deterministic and we can check labels.
+    mock_checks = {
+        "_check_pynacl": ("✅", "PyNaCl — installed"),
+        "_check_opus": ("✅", "Opus — loaded"),
+        "_check_ffmpeg": ("✅", "ffmpeg — /usr/bin/ffmpeg"),
+        "_check_stt_provider": ("✅", "STT provider — configured"),
+        "_check_davey": ("⚠️", "davey not installed — DAVE-encrypted ..."),
+    }
+
+    for func_name, (icon, detail) in mock_checks.items():
+        monkeypatch.setattr(
+            f"plugins.platforms.discord.voice_doctor.{func_name}",
+            lambda _icon=icon, _detail=detail: (_icon, _detail),
+        )
+
+    # Mock the permission check
+    async def _mock_perms(_self, _interaction):
+        return ("✅", "Bot permissions — Connect, Speak, Use Voice Activity granted")
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.DiscordAdapter._check_voice_permissions",
+        _mock_perms,
+    )
+
+    # Create a minimal fake interaction that has a guild_id but no real guild
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.guild_id = 12345
+    interaction.channel_id = 67890
+    interaction.user.id = 111
+    interaction.user.name = "testuser"
+
+    report = await adapter._voice_doctor_report(interaction)
+
+    # All check labels present
+    assert "PyNaCl" in report
+    assert "Opus" in report
+    assert "ffmpeg" in report
+    assert "STT provider" in report
+    assert "Bot permissions" in report
+    assert "davey" in report
+
+    # Summary line — warns for davey ⚠️
+    assert "OK — 1 warning(s) found" in report
+
+    # No key-like values
+    assert "sk-" not in report
+
+
+@pytest.mark.asyncio
+async def test_voice_doctor_report_counts_failures(monkeypatch):
+    """When multiple checks fail, the summary reflects the correct count."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.config import PlatformConfig
+
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="fake_token")
+    )
+    adapter._client = None
+
+    # Two failures, one warning, rest pass
+    mock_checks = {
+        "_check_pynacl": ("❌", "PyNaCl — missing. Fix: pip install pynacl"),
+        "_check_opus": ("✅", "Opus — loaded"),
+        "_check_ffmpeg": ("❌", "ffmpeg — not found. Fix: install ffmpeg"),
+        "_check_stt_provider": ("⚠️", "No STT provider configured"),
+        "_check_davey": ("✅", "davey — installed"),
+    }
+
+    for func_name, (icon, detail) in mock_checks.items():
+        monkeypatch.setattr(
+            f"plugins.platforms.discord.voice_doctor.{func_name}",
+            lambda _icon=icon, _detail=detail: (_icon, _detail),
+        )
+
+    async def _mock_perms(_self, _interaction):
+        return ("✅", "Bot permissions — granted")
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.DiscordAdapter._check_voice_permissions",
+        _mock_perms,
+    )
+
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.guild_id = 12345
+
+    report = await adapter._voice_doctor_report(interaction)
+
+    # Should say "2 issue(s) found"
+    assert "2 issue(s) found" in report
+    assert "pip install pynacl" in report
+    assert "install ffmpeg" in report
+
+
+@pytest.mark.asyncio
+async def test_voice_doctor_report_only_warnings(monkeypatch):
+    """When no ❌ checks but one or more ⚠️, the summary says 'OK — N warning(s)'."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.config import PlatformConfig
+
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="fake_token")
+    )
+    adapter._client = None
+
+    # No failures, one warning
+    mock_checks = {
+        "_check_pynacl": ("✅", "PyNaCl — installed"),
+        "_check_opus": ("⚠️", "Opus — not loaded"),
+        "_check_ffmpeg": ("✅", "ffmpeg — /usr/bin/ffmpeg"),
+        "_check_stt_provider": ("✅", "STT provider — configured"),
+        "_check_davey": ("✅", "davey — installed"),
+    }
+
+    for func_name, (icon, detail) in mock_checks.items():
+        monkeypatch.setattr(
+            f"plugins.platforms.discord.voice_doctor.{func_name}",
+            lambda _icon=icon, _detail=detail: (_icon, _detail),
+        )
+
+    async def _mock_perms(_self, _interaction):
+        return ("✅", "Bot permissions — granted")
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.DiscordAdapter._check_voice_permissions",
+        _mock_perms,
+    )
+
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.guild_id = 12345
+
+    report = await adapter._voice_doctor_report(interaction)
+
+    # Should say "OK — 1 warning(s) found"
+    assert "OK — 1 warning(s) found" in report
+
+
+@pytest.mark.asyncio
+async def test_voice_doctor_permissions_dm(monkeypatch):
+    """When interaction.guild is None (DM), the permission check warns."""
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.config import PlatformConfig
+
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="fake_token")
+    )
+    adapter._client = None
+
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.guild_id = None
+
+    icon, detail = await adapter._check_voice_permissions(interaction)
+    assert icon == "⚠️"
+    assert "cannot check in DMs" in detail
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helper: fail imports for a specific module name
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _fail_import(mod_name: str):
+    """Return a __import__ replacement that raises ImportError for *mod_name*."""
+    original_import = builtins.__import__
+
+    def _importer(name, *args, **kwargs):
+        if name == mod_name or name.startswith(mod_name + "."):
+            raise ImportError(f"No module named {name}")
+        # Support both: direct import and "from ... import ..." via __import__
+        # __import__('nacl') returns the top-level module; any submodule
+        # reference also hits the same name check.
+        return original_import(name, *args, **kwargs)
+
+    return _importer

--- a/tests/plugins/platforms/test_voice_doctor.py
+++ b/tests/plugins/platforms/test_voice_doctor.py
@@ -27,8 +27,15 @@ from plugins.platforms.discord.voice_doctor import (
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def test_pynacl_installed():
-    """When nacl imports, the check returns ✅."""
+def test_pynacl_installed(monkeypatch):
+    """When nacl imports, the check returns ✅.
+
+    Stubbed via ``sys.modules`` so the test does not depend on PyNaCl being
+    installed in the ambient environment (CI does not ship it — it arrives
+    only as a discord.py transitive dependency).
+    """
+    monkeypatch.setitem(sys.modules, "nacl", MagicMock())
+
     icon, detail = _check_pynacl()
     assert icon == "✅"
     assert "installed" in detail


### PR DESCRIPTION
## Summary

Partially addresses #33683 (Phase 1 — explicit-mode diagnostics).

Adds a `doctor` mode to the existing `/voice` slash command. `/voice doctor` runs on-demand (no startup probing) and reports an ephemeral readiness check for the voice path, in dependency order:

1. **PyNaCl** — import check, with `pip install pynacl` hint on failure
2. **Opus** — `discord.opus.is_loaded()`, non-fatal warning if not loaded
3. **ffmpeg/ffprobe** — reuses the existing `ffmpeg_utils.resolve_ffmpeg_executable()`, install hint on failure
4. **STT provider** — reports `stt.enabled`, an explicit `stt.provider` by name (known providers only; custom values are reported as "configured (custom)" without echoing the raw string), or the autodetect path (`faster-whisper` importability) when no provider is set
5. **Bot permissions** — guild-level `Connect` / `Speak` / `Use Voice Activity` via `guild.me.guild_permissions`, with a per-channel-overrides caveat; in DMs, reports that a server context is required
6. **davey (DAVE E2EE)** — import check, non-fatal

The report ends with a summary line distinguishing clean / warnings-only / failing states. All checks are presence-only: no key values are ever read into the report, and config values are not reflected verbatim into messages.

## Behavior details

- The doctor path bypasses `_run_simple_slash` (which dispatches to the gateway command parser, which has no doctor concept) and handles the interaction inline: auth gate **before** `defer()` so an ephemeral rejection can be delivered on the still-unresponded interaction, then ephemeral defer → checks → ephemeral followup. An exception envelope guarantees a fallback ephemeral message instead of a hung "interaction failed" state.
- No configuration is changed, nothing is auto-fixed; the command is diagnostic only.

## Testing

- `tests/plugins/platforms/test_voice_doctor.py` — behavior-contract tests for every check helper (import-mock failure paths use a captured reference to the original `__import__`, so the mocks cannot self-recurse), the four STT branches, the no-leak invariant (a key-shaped `stt.provider` value never appears in the report), the DM/no-guild permission branch, and the summary-state logic.
- All tests pass locally (`pytest tests/plugins/platforms/test_voice_doctor.py`, 19 passed) and `ast.parse` is clean.

## Notes

**Open question:** should the permission check also probe per-channel overrides for the channel the invoking user is in (currently guild-level, with a caveat line), or is guild-level enough for a first diagnostic?

Partially addresses #33683. Phase 2 (opt-in auto-join) follows in a separate PR.
