### PR TITLE
feat(discord): opt-in voice auto-join with safety gates

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2409,6 +2409,18 @@ DEFAULT_CONFIG = {
                 "On it.",
             ],
         },
+        # Opt-in Discord voice auto-join (issue #33683).  OFF by default for
+        # safety — auto-joining a voice channel means transcribing everyone who
+        # speaks.  Both CHANNEL allowlist (channel_ids) and USER allowlist
+        # (user_ids) MUST be non-empty for the feature to activate; there is
+        # deliberately no "allow all" fallthrough.
+        "voice_auto_join": {
+            "enabled": False,
+            "channel_ids": [],      # VC IDs the bot may auto-join (required, non-empty, to activate)
+            "user_ids": [],         # user IDs whose VC entry triggers auto-join (required, non-empty)
+            "join_mode": "user_prompt",  # "user_prompt" | "automatic"
+            "require_text_opt_in": True,
+        },
     },
 
     # WhatsApp platform settings (gateway mode)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1113,6 +1113,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_mixers: Dict[int, Any] = {}  # guild_id -> VoiceMixer
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
+        # Voice auto-join debounce timestamps: key -> time.monotonic()
+        self._auto_join_debounce: Dict[str, float] = {}
+        self._auto_join_cfg: Dict[str, Any] = self._load_voice_auto_join_config()
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -1426,14 +1429,8 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
+                # Ignore the bot itself (loop-prevention blocker — must run
+                # before any policy code).
                 if member == adapter_self._client.user:
                     return
 
@@ -1445,6 +1442,99 @@ class DiscordAdapter(BasePlatformAdapter):
                     and before.channel != after.channel
                 )
 
+                # ------------------------------------------------------------------
+                # Auto-join: evaluate policy on user join events (runs even when
+                # the bot is not yet connected to any voice channel).
+                # ------------------------------------------------------------------
+                if joined:
+                    try:
+                        guild = member.guild
+                        channel = after.channel
+                        policy_cfg = adapter_self._auto_join_cfg
+
+                        # Cheap early-out: only read config for joined events
+                        if not policy_cfg.get("enabled", False):
+                            pass  # fall through to existing logging
+                        else:
+                            from plugins.platforms.discord.voice_policy import (
+                                AutoJoinPolicy,
+                                VoicePolicyEvaluator,
+                            )
+
+                            guild_id = guild.id
+                            channel_id = str(channel.id)
+                            member_id = str(member.id)
+
+                            debounce_key = f"aj:{guild_id}:{member_id}:{channel_id}"
+                            if adapter_self._auto_join_debounced(debounce_key, seconds=60.0):
+                                pass  # already processed / rate-limited
+                            else:
+                                policy = AutoJoinPolicy(
+                                    enabled=policy_cfg.get("enabled", False),
+                                    channel_ids=frozenset(policy_cfg.get("channel_ids", [])),
+                                    user_ids=frozenset(policy_cfg.get("user_ids", [])),
+                                    join_mode=policy_cfg.get("join_mode", "user_prompt"),
+                                    require_text_opt_in=policy_cfg.get("require_text_opt_in", True),
+                                )
+
+                                # Resolve text channel for permissions check
+                                text_ch_id = adapter_self._select_auto_join_text_channel(
+                                    guild, channel,
+                                )
+                                text_ch = None
+                                if text_ch_id is not None:
+                                    text_ch = adapter_self._client.get_channel(text_ch_id)
+
+                                member_has_access = True
+                                if policy.require_text_opt_in:
+                                    member_has_access = adapter_self._member_has_text_access(
+                                        guild, member, text_ch,
+                                    )
+
+                                should_join, reason = VoicePolicyEvaluator.should_join(
+                                    policy,
+                                    channel_id=channel_id,
+                                    member_id=member_id,
+                                    member_has_text_access=member_has_access,
+                                )
+
+                                if should_join:
+                                    join_mode = policy.join_mode
+
+                                    if join_mode == "user_prompt":
+                                        prompt_key = f"prompt:{guild_id}:{member_id}:{channel_id}"
+                                        prompted = adapter_self._auto_join_debounced(
+                                            prompt_key, seconds=60.0,
+                                        )
+                                        if not prompted:
+                                            await adapter_self._prompt_auto_join_approval(
+                                                guild, text_ch, member, channel,
+                                            )
+                                    else:
+                                        # "automatic" — join directly
+                                        await adapter_self._do_auto_join(
+                                            channel, text_ch_id, guild_id,
+                                        )
+                                else:
+                                    logger.debug(
+                                        "Auto-join skipped for %s in %s: %s",
+                                        member_id, channel_id, reason,
+                                    )
+                    except Exception:
+                        logger.warning(
+                            "Auto-join handler failed", exc_info=True,
+                        )
+
+                # ------------------------------------------------------------------
+                # Existing tracking: only track channels where the bot is connected.
+                # ------------------------------------------------------------------
+                bot_guild_ids = set(adapter_self._voice_clients.keys())
+                if not bot_guild_ids:
+                    return
+                guild_id = member.guild.id
+                if guild_id not in bot_guild_ids:
+                    return
+
                 if joined or left or switched:
                     logger.info(
                         "Voice state: %s (%d) %s (guild %d)",
@@ -1455,6 +1545,69 @@ class DiscordAdapter(BasePlatformAdapter):
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
+
+                # ------------------------------------------------------------------
+                # Leave-when-no-authorized-users: if the last tracked user left and
+                # no non-bot member in the channel is allowlisted, auto-leave.
+                # ------------------------------------------------------------------
+                if left:
+                    try:
+                        # Derive guild locally: on a bare left event the outer
+                        # ``guild`` variable (set inside the ``if joined:``
+                        # block above) is unbound.
+                        guild = member.guild
+                        policy_cfg = adapter_self._auto_join_cfg
+                        if policy_cfg.get("enabled", False):
+                            # Count remaining non-bot members in the channel
+                            # that pass the adapter's user allowlist.
+                            left_channel = before.channel
+                            if left_channel is None:
+                                # Cannot determine which channel was left; skip.
+                                logger.debug(
+                                    "Skipping auto-leave: left_channel is None (guild %d)",
+                                    guild_id,
+                                )
+                                pass
+                            else:
+                                authorized_remaining = 0
+                                if left_channel.members:
+                                    for m in left_channel.members:
+                                        if m != adapter_self._client.user:
+                                            m_id = str(m.id)
+                                            allowed = adapter_self._is_allowed_user(
+                                                m_id, guild=guild, is_dm=False,
+                                            )
+                                            if allowed:
+                                                authorized_remaining += 1
+                                                break  # one is enough
+
+                                leave_key = f"leave:{guild_id}:{left_channel.id}"
+                                if authorized_remaining == 0:
+                                    # Guard: only leave if the bot is actually connected
+                                    # to the channel that was left (not a different channel
+                                    # in the same guild).
+                                    vc = adapter_self._voice_clients.get(guild_id)
+                                    if (
+                                        vc is None
+                                        or getattr(vc, "channel", None) is None
+                                        or vc.channel.id != left_channel.id
+                                    ):
+                                        logger.debug(
+                                            "Skipping auto-leave: bot not connected to "
+                                            "left channel %s (guild %d)",
+                                            left_channel.id, guild_id,
+                                        )
+                                    elif not adapter_self._auto_join_debounced(leave_key):
+                                        logger.info(
+                                            "No authorized users remain in voice; "
+                                            "auto-leaving guild %d",
+                                            guild_id,
+                                        )
+                                        await adapter_self.leave_voice_channel(guild_id)
+                    except Exception:
+                        logger.warning(
+                            "Auto-leave handler failed", exc_info=True,
+                        )
 
             # Register slash commands
             if self._slash_commands:
@@ -4367,6 +4520,246 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _voice_timeout_limit(self) -> int:
         return int(getattr(self, "_voice_timeout_seconds", self.VOICE_TIMEOUT))
+
+    # ------------------------------------------------------------------
+    # Voice auto-join config
+    # ------------------------------------------------------------------
+
+    def _load_voice_auto_join_config(self) -> Dict[str, Any]:
+        """Read voice auto-join settings from config.yaml.
+
+        All settings live under ``discord.voice_auto_join``.  The feature is
+        OFF by default; users opt in by setting ``enabled: true`` AND
+        populating both allowlists (see :mod:`voice_policy`).
+
+        Returns a dict with safe defaults so callers never KeyError.
+        """
+        defaults: Dict[str, Any] = {
+            "enabled": False,
+            "channel_ids": [],
+            "user_ids": [],
+            "join_mode": "user_prompt",
+            "require_text_opt_in": True,
+        }
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            raw = ((cfg.get("discord") or {}).get("voice_auto_join") or {})
+            if isinstance(raw, dict):
+                for k, v in raw.items():
+                    if k in defaults and v is not None:
+                        defaults[k] = v
+        except Exception as e:
+            logger.debug("Could not load discord.voice_auto_join config: %s", e)
+
+        # Coerce scalar strings to one-element lists before normalization
+        if isinstance(defaults.get("channel_ids"), str):
+            defaults["channel_ids"] = [defaults["channel_ids"]]
+        if isinstance(defaults.get("user_ids"), str):
+            defaults["user_ids"] = [defaults["user_ids"]]
+
+        # Normalize allowlists to lists of strings
+        if isinstance(defaults.get("channel_ids"), (list, tuple)):
+            defaults["channel_ids"] = [str(c) for c in defaults["channel_ids"] if c]
+        else:
+            defaults["channel_ids"] = []
+        if isinstance(defaults.get("user_ids"), (list, tuple)):
+            defaults["user_ids"] = [str(u) for u in defaults["user_ids"] if u]
+        else:
+            defaults["user_ids"] = []
+
+        # Validate join_mode
+        mode = defaults.get("join_mode", "user_prompt")
+        if mode not in ("user_prompt", "automatic"):
+            defaults["join_mode"] = "user_prompt"
+
+        return defaults
+
+    # ------------------------------------------------------------------
+    # Auto-join helpers
+    # ------------------------------------------------------------------
+
+    def _auto_join_debounced(self, key: str, seconds: float = 30.0) -> bool:
+        """Returns True when key is inside its debounce window (the
+        triggering event should be ignored); returns False otherwise
+        and records now as the new timestamp.
+        """
+        now = time.monotonic()
+        last = self._auto_join_debounce.get(key)
+        if last is not None and (now - last) < seconds:
+            return True  # still within the window
+        self._auto_join_debounce[key] = now
+
+        # Bounded eviction: when the dict grows past 256 entries, purge
+        # entries older than 300s.  300s far exceeds the largest used
+        # window (60s) so no active entry is evicted.
+        if len(self._auto_join_debounce) > 256:
+            stale = [k for k, ts in self._auto_join_debounce.items()
+                     if (now - ts) >= 300]
+            for k in stale:
+                del self._auto_join_debounce[k]
+
+        return False
+
+    @staticmethod
+    def _member_has_text_access(
+        guild,
+        member,
+        text_channel,
+    ) -> bool:
+        """Check if ``member`` has ``read_messages`` in ``text_channel``.
+
+        Returns False when ``text_channel`` or ``guild`` is unavailable.
+        """
+        if guild is None or text_channel is None or member is None:
+            return False
+        try:
+            permissions = text_channel.permissions_for(member)
+            return bool(permissions.read_messages)
+        except Exception:
+            return False
+
+    def _select_auto_join_text_channel(
+        self,
+        guild,
+        voice_channel,
+    ) -> Optional[int]:
+        """Select the best text channel for voice transcription binding.
+
+        Priority:
+        1. ``guild.system_channel`` if the bot can send messages there.
+        2. First guild text channel where the bot has ``send_messages``.
+        3. None (log warning, skip announcement).
+        """
+        if guild is None:
+            return None
+
+        # Tier 1: guild.system_channel
+        try:
+            sys_ch = guild.system_channel
+            if sys_ch is not None:
+                perms = sys_ch.permissions_for(guild.me)
+                if perms.send_messages:
+                    return sys_ch.id
+        except Exception:
+            pass
+
+        # Tier 2: first text channel with send_messages
+        try:
+            for ch in guild.text_channels:
+                perms = ch.permissions_for(guild.me)
+                if perms.send_messages:
+                    return ch.id
+        except Exception:
+            pass
+
+        # Tier 3: nothing suitable
+        logger.warning(
+            "Could not find a text channel for voice auto-join binding "
+            "(guild %s); proceeding without text binding.",
+            guild.id,
+        )
+        return None
+
+    async def _prompt_auto_join_approval(self, guild, text_ch, member, voice_channel):
+        """Post an approval prompt with ✅/❌ reactions and wait for response.
+
+        The caller rate-limits via ``_auto_join_debounced`` (once per 60
+        seconds per (guild, member, channel)), so this method does not
+        re-check.  On ✅ the bot joins; on ❌/timeout it logs and aborts.
+
+        Safety: failure to prompt = failure to join (fail-closed).  When
+        ``text_ch`` is None or the prompt cannot be sent, the method logs
+        a warning and returns without joining — the bot never auto-joins
+        silently when it cannot first obtain user approval.
+        """
+        if text_ch is None:
+            logger.warning(
+                "No suitable text channel for approval prompt; "
+                "aborting auto-join (guild %s)",
+                guild.id,
+            )
+            return
+
+        guild_id = guild.id
+        channel_id = voice_channel.id
+        member_id = member.id
+
+        try:
+            msg = await text_ch.send(
+                f"{member.mention} 🤖 Hermes wants to join "
+                f"<#{channel_id}> for voice transcription. "
+                "React ✅ to approve or ❌ to deny."
+            )
+        except Exception:
+            logger.warning(
+                "Could not send auto-join prompt; aborting auto-join "
+                "(guild %s)",
+                guild_id,
+            )
+            return
+
+        def check(reaction, reactor):
+            return (
+                reactor == member
+                and reaction.message.id == msg.id
+                and str(reaction.emoji) in ("✅", "❌")
+            )
+
+        try:
+            reaction, reactor = await self._client.wait_for(
+                "reaction_add", timeout=60.0, check=check,
+            )
+            if str(reaction.emoji) == "✅":
+                # User approved
+                try:
+                    await msg.clear_reactions()
+                except Exception:
+                    pass
+                await self._do_auto_join(voice_channel, text_ch.id, guild_id)
+            else:
+                logger.info(
+                    "Auto-join denied by user %s (guild %s)",
+                    member_id, guild_id,
+                )
+                try:
+                    await msg.clear_reactions()
+                except Exception:
+                    pass
+        except asyncio.TimeoutError:
+            logger.info(
+                "Auto-join prompt timed out (guild %s, member %s)",
+                guild_id, member_id,
+            )
+            try:
+                await msg.clear_reactions()
+            except Exception:
+                pass
+
+    async def _do_auto_join(self, voice_channel, text_ch_id, guild_id):
+        """Execute the auto-join: call ``join_voice_channel`` then announce."""
+        logger.info(
+            "Auto-joining voice channel %s (guild %d)",
+            voice_channel.id, guild_id,
+        )
+        succeeded = await self.join_voice_channel(
+            voice_channel,
+            text_channel_id=text_ch_id,
+        )
+        if succeeded and text_ch_id is not None:
+            try:
+                ch = self._client.get_channel(text_ch_id)
+                if ch is not None:
+                    await ch.send(
+                        "🤖 Hermes auto-joined <#{}> — transcribing for "
+                        "allowlisted users. Use `/voice leave` to disconnect."
+                        .format(voice_channel.id)
+                    )
+            except Exception:
+                logger.debug(
+                    "Failed to send auto-join announcement (guild %d)",
+                    guild_id,
+                )
 
     def _playback_timeout_limit(self) -> int:
         return int(getattr(self, "_playback_timeout_seconds", self.PLAYBACK_TIMEOUT))

--- a/plugins/platforms/discord/voice_policy.py
+++ b/plugins/platforms/discord/voice_policy.py
@@ -1,0 +1,99 @@
+"""
+Opt-in Discord voice auto-join policy — pure logic, zero discord.py imports.
+
+SAFETY RATIONALE
+----------------
+Voice auto-join is OFF by default for good reason: once the bot joins a voice
+channel it starts transcribing everyone who speaks.  Automatic transcription
+of users who did not opt in is a privacy risk.  Therefore the policy requires
+**both** allowlists to be non-empty before it will activate:
+
+  * ``channel_ids`` — which voice channels the bot may auto-join.
+  * ``user_ids`` — which Discord users may trigger an auto-join.
+
+Without both lists populated, activation_error() returns a descriptive string
+and should_join() returns False.  There is deliberately NO "allow all channels"
+or "allow all users" fallthrough — that would transcribe everyone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import FrozenSet, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class AutoJoinPolicy:
+    """Immutable auto-join policy for a Discord guild.
+
+    Both ``channel_ids`` and ``user_ids`` must be non-empty for the
+    policy to activate (safety gate — see module docstring).
+    """
+
+    enabled: bool = False
+    channel_ids: FrozenSet[str] = field(default_factory=frozenset)
+    user_ids: FrozenSet[str] = field(default_factory=frozenset)
+    join_mode: str = "user_prompt"  # "user_prompt" | "automatic"
+    require_text_opt_in: bool = True
+
+
+class VoicePolicyEvaluator:
+    """Stateless evaluator for :class:`AutoJoinPolicy`.
+
+    All methods are pure functions — no I/O, no imports from ``discord``.
+    """
+
+    @staticmethod
+    def activation_error(policy: AutoJoinPolicy) -> Optional[str]:
+        """Return an error string if ``policy`` cannot activate, else None.
+
+        Checks (in order):
+        1. ``enabled`` is False.
+        2. ``channel_ids`` is empty (no voice channels allowlisted).
+        3. ``user_ids`` is empty (no users allowlisted — privacy gate).
+        """
+        if not policy.enabled:
+            return "voice_auto_join is disabled"
+        if not policy.channel_ids:
+            return "voice_auto_join.channel_ids must list at least one voice channel ID"
+        if not policy.user_ids:
+            return "voice_auto_join.user_ids must list at least one user ID"
+        return None
+
+    @staticmethod
+    def should_join(
+        policy: AutoJoinPolicy,
+        *,
+        channel_id: str,
+        member_id: str,
+        member_has_text_access: bool = True,
+    ) -> Tuple[bool, str]:
+        """Decide whether the bot should auto-join for this member+channel.
+
+        Returns ``(True, "")`` when every check passes, or
+        ``(False, "reason string")`` on the first failure.
+
+        Checks (in order):
+        1. Policy is activation-valid (see :meth:`activation_error`).
+        2. ``channel_id`` is in ``policy.channel_ids``.
+        3. ``member_id`` is in ``policy.user_ids``.
+        4. If ``policy.require_text_opt_in`` then ``member_has_text_access``
+           must be True.
+        """
+        err = VoicePolicyEvaluator.activation_error(policy)
+        if err is not None:
+            return False, err
+
+        # Channel allowlist
+        if channel_id not in policy.channel_ids:
+            return False, "voice channel is not in voice_auto_join.channel_ids"
+
+        # User allowlist
+        if member_id not in policy.user_ids:
+            return False, "user is not in voice_auto_join.user_ids"
+
+        # Text-opt-in gate
+        if policy.require_text_opt_in and not member_has_text_access:
+            return False, "user lacks text-channel access (require_text_opt_in)"
+
+        return True, ""

--- a/tests/plugins/platforms/test_voice_policy.py
+++ b/tests/plugins/platforms/test_voice_policy.py
@@ -1,0 +1,382 @@
+"""
+Tests for plugins/platforms/discord/voice_policy.py — pure logic, no mocking.
+
+Every test exercises the dataclass and evaluator with plain Python values;
+there are no discord.py imports anywhere in this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path so we can import voice_policy.
+_src = Path(__file__).resolve().parents[3]  # tests/ -> repo root
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+import pytest
+
+from plugins.platforms.discord.voice_policy import AutoJoinPolicy, VoicePolicyEvaluator
+
+
+# ---------------------------------------------------------------------------
+# AutoJoinPolicy structural tests
+# ---------------------------------------------------------------------------
+
+class TestAutoJoinPolicy:
+    """AutoJoinPolicy dataclass — construction, defaults, immutability."""
+
+    def test_defaults_are_disabled(self):
+        """Default-constructed policy has every safety-gate off."""
+        p = AutoJoinPolicy()
+        assert p.enabled is False
+        assert p.channel_ids == frozenset()
+        assert p.user_ids == frozenset()
+        assert p.join_mode == "user_prompt"
+        assert p.require_text_opt_in is True
+
+    def test_explicit_construction(self):
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"123", "456"}),
+            user_ids=frozenset({"789"}),
+            join_mode="automatic",
+            require_text_opt_in=False,
+        )
+        assert p.enabled is True
+        assert p.channel_ids == frozenset({"123", "456"})
+        assert p.user_ids == frozenset({"789"})
+        assert p.join_mode == "automatic"
+        assert p.require_text_opt_in is False
+
+    def test_immutable_frozensets(self):
+        """channel_ids and user_ids are frozenset (immutable)."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"1"}),
+            user_ids=frozenset({"2"}),
+        )
+        with pytest.raises(AttributeError):
+            p.channel_ids = frozenset()  # frozen dataclass
+
+    def test_immutable_dataclass(self):
+        p = AutoJoinPolicy(enabled=True)
+        with pytest.raises(AttributeError):
+            p.enabled = False
+
+
+# ---------------------------------------------------------------------------
+# activation_error tests
+# ---------------------------------------------------------------------------
+
+class TestActivationError:
+    """VoicePolicyEvaluator.activation_error — all failure modes."""
+
+    def test_disabled_returns_error(self):
+        p = AutoJoinPolicy(
+            enabled=False,
+            channel_ids=frozenset({"123"}),
+            user_ids=frozenset({"456"}),
+        )
+        err = VoicePolicyEvaluator.activation_error(p)
+        assert err is not None
+        assert "disabled" in err.lower()
+
+    def test_empty_channel_ids_returns_error(self):
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset(),
+            user_ids=frozenset({"456"}),
+        )
+        err = VoicePolicyEvaluator.activation_error(p)
+        assert err is not None
+        assert "channel_ids" in err.lower()
+
+    def test_empty_user_ids_returns_error(self):
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"123"}),
+            user_ids=frozenset(),
+        )
+        err = VoicePolicyEvaluator.activation_error(p)
+        assert err is not None
+        assert "user_ids" in err.lower()
+
+    def test_both_empty_returns_first_error(self):
+        """Both channel_ids and user_ids empty — first error wins."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset(),
+            user_ids=frozenset(),
+        )
+        err = VoicePolicyEvaluator.activation_error(p)
+        # Should report channel_ids first (checked before user_ids)
+        assert err is not None
+        assert "channel_ids" in err.lower()
+
+    def test_all_prerequisites_met_returns_none(self):
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"123"}),
+            user_ids=frozenset({"456"}),
+        )
+        assert VoicePolicyEvaluator.activation_error(p) is None
+
+
+# ---------------------------------------------------------------------------
+# should_join tests
+# ---------------------------------------------------------------------------
+
+class TestShouldJoin:
+    """VoicePolicyEvaluator.should_join — allow/deny decisions."""
+
+    FULL_POLICY = AutoJoinPolicy(
+        enabled=True,
+        channel_ids=frozenset({"111", "222"}),
+        user_ids=frozenset({"aaa", "bbb"}),
+        join_mode="user_prompt",
+        require_text_opt_in=True,
+    )
+
+    # --- Activation gate ---
+
+    def test_disabled_policy_denies(self):
+        p = AutoJoinPolicy(enabled=False)
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is False
+        assert "disabled" in reason
+
+    def test_empty_channel_ids_denies(self):
+        p = AutoJoinPolicy(enabled=True, channel_ids=frozenset(), user_ids=frozenset({"aaa"}))
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is False
+        assert "channel_ids" in reason
+
+    def test_empty_user_ids_denies(self):
+        p = AutoJoinPolicy(enabled=True, channel_ids=frozenset({"111"}), user_ids=frozenset())
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is False
+        assert "user_ids" in reason
+
+    # --- Channel allowlist ---
+
+    def test_channel_not_in_allowlist_denies(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY, channel_id="999", member_id="aaa",
+        )
+        assert ok is False
+        assert "channel_ids" in reason
+
+    def test_channel_in_allowlist_allows(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY, channel_id="111", member_id="aaa",
+        )
+        assert ok is True
+        assert reason == ""
+
+    def test_second_channel_in_allowlist_allows(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY, channel_id="222", member_id="bbb",
+        )
+        assert ok is True
+        assert reason == ""
+
+    # --- User allowlist ---
+
+    def test_user_not_in_allowlist_denies(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY, channel_id="111", member_id="zzz",
+        )
+        assert ok is False
+        assert "user_ids" in reason
+
+    def test_user_in_allowlist_allows(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY, channel_id="111", member_id="bbb",
+        )
+        assert ok is True
+        assert reason == ""
+
+    # --- require_text_opt_in ---
+
+    def test_require_text_opt_in_no_access_denies(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY,
+            channel_id="111",
+            member_id="aaa",
+            member_has_text_access=False,
+        )
+        assert ok is False
+        assert "require_text_opt_in" in reason
+
+    def test_require_text_opt_in_with_access_allows(self):
+        ok, reason = VoicePolicyEvaluator.should_join(
+            self.FULL_POLICY,
+            channel_id="111",
+            member_id="aaa",
+            member_has_text_access=True,
+        )
+        assert ok is True
+        assert reason == ""
+
+    def test_require_text_opt_in_false_skips_gate(self):
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"111"}),
+            user_ids=frozenset({"aaa"}),
+            require_text_opt_in=False,
+        )
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p,
+            channel_id="111",
+            member_id="aaa",
+            member_has_text_access=False,  # would deny if gate were on
+        )
+        assert ok is True
+        assert reason == ""
+
+    # --- Empty-vs-set allowlists ---
+
+    def test_both_allowlists_populated_allows_correct_combinations(self):
+        """Cross-product: every valid (channel, user) pair is allowed."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"100", "200"}),
+            user_ids=frozenset({"u1", "u2"}),
+        )
+        for ch in ("100", "200"):
+            for uid in ("u1", "u2"):
+                ok, _ = VoicePolicyEvaluator.should_join(
+                    p, channel_id=ch, member_id=uid,
+                )
+                assert ok is True, f"expected allow for ch={ch} uid={uid}"
+
+    def test_both_allowlists_populated_denies_wrong_combinations(self):
+        """Cross-product: every invalid channel or user is denied."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"100", "200"}),
+            user_ids=frozenset({"u1", "u2"}),
+        )
+        # Wrong channel
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="999", member_id="u1",
+        )
+        assert ok is False
+        # Wrong user
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="100", member_id="u9",
+        )
+        assert ok is False
+        # Both wrong
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="999", member_id="u9",
+        )
+        assert ok is False
+
+    def test_disabled_policy_with_full_allowlists_still_denies(self):
+        """enabled=False overrides everything else."""
+        p = AutoJoinPolicy(
+            enabled=False,
+            channel_ids=frozenset({"111"}),
+            user_ids=frozenset({"aaa"}),
+        )
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is False
+        assert "disabled" in reason
+
+
+# ---------------------------------------------------------------------------
+# join_mode normalization (tested through the dataclass, not evaluator)
+# ---------------------------------------------------------------------------
+
+class TestJoinMode:
+    """join_mode is stored as-is by AutoJoinPolicy; normalization happens
+    in the adapter's _load_voice_auto_join_config, not in voice_policy."""
+
+    def test_valid_modes_accepted(self):
+        for mode in ("user_prompt", "automatic"):
+            p = AutoJoinPolicy(enabled=True, join_mode=mode)
+            assert p.join_mode == mode
+
+    def test_invalid_mode_stored_as_given(self):
+        """voice_policy does NOT validate join_mode; the adapter does."""
+        p = AutoJoinPolicy(enabled=True, join_mode="invalid")
+        assert p.join_mode == "invalid"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    """Boundary and edge-case checks."""
+
+    def test_channel_id_as_int_string(self):
+        """channel_ids are strings — '111' matches '111'."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"111"}),
+            user_ids=frozenset({"aaa"}),
+        )
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is True
+
+    def test_string_vs_int_distinct(self):
+        """String '111' is NOT frozenset({111}) — must compare as strings."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"111"}),
+            user_ids=frozenset({"aaa"}),
+        )
+        # member_id as int (won't match 'aaa' string)
+        ok, reason = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is True  # 'aaa' string matches
+
+    def test_member_has_text_access_default_true(self):
+        """Default value for member_has_text_access is True (compatible)."""
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=frozenset({"111"}),
+            user_ids=frozenset({"aaa"}),
+            require_text_opt_in=False,
+        )
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="111", member_id="aaa",
+        )
+        assert ok is True
+
+    def test_large_allowlists(self):
+        """Large frozensets work correctly."""
+        channels = frozenset(str(i) for i in range(100))
+        users = frozenset(f"u{i}" for i in range(100))
+        p = AutoJoinPolicy(
+            enabled=True,
+            channel_ids=channels,
+            user_ids=users,
+        )
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="50", member_id="u50",
+        )
+        assert ok is True
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="200", member_id="u50",
+        )
+        assert ok is False
+        ok, _ = VoicePolicyEvaluator.should_join(
+            p, channel_id="50", member_id="u200",
+        )
+        assert ok is False


### PR DESCRIPTION
## Summary

Partially addresses #33683 (Phase 2 — opt-in auto-join policy).

Adds a disabled-by-default Discord voice auto-join mode, gated on every side:

```yaml
discord:
  voice_auto_join:
    enabled: false                  # master switch — must be explicitly true
    channel_ids: []                 # REQUIRED non-empty: VC IDs the bot may auto-join
    user_ids: []                    # REQUIRED non-empty: users whose VC entry triggers auto-join
    join_mode: "user_prompt"        # "user_prompt" (approval reaction required) | "automatic"
    require_text_opt_in: true       # triggering user must be able to read the bound text channel
```

## Safety gates

- **Both allowlists required.** Activation refuses to run unless `channel_ids` *and* `user_ids` are non-empty. This is deliberate: without it, a user who enables auto-join without an explicit allowlist would hit the existing allow-all fallthrough and transcribe every speaker in the channel.
- **Fail-closed approval prompt.** In `user_prompt` mode (default), the bot posts an approval message with ✅/❌ reactions and only joins on ✅ (60 s window, scoped to the triggering member and that message). If no suitable text channel exists or the prompt cannot be sent, the join is **aborted**, never silently executed — failure to prompt is failure to join.
- **Loop prevention.** The bot-self guard in `on_voice_state_update` runs first and unconditionally returns (covers bot-initiated joins *and* admin-initiated bot moves, since the fired event's member is the bot itself). Auto-join/leave evaluation is debounced per (guild, member, channel).
- **Announced joins.** Every successful auto-join posts an announcement in the bound text channel ("🤖 Hermes auto-joined \<#…\> — transcribing for allowlisted users. Use `/voice leave` to disconnect.").
- **Leave conditions.** Existing idle timeout is untouched; auto-join adds leave-when-no-authorized-users, evaluated only when the last left channel is the one the bot is actually connected to (a user leaving an unrelated VC in the same guild does not disconnect the bot).
- **Wrong-channel protection.** The channel allowlist is checked by ID pre-join; `join_voice_channel`'s existing move-to behavior is unchanged.

## Design

- `plugins/platforms/discord/voice_policy.py` (new) — pure-logic, zero discord.py imports: frozen `AutoJoinPolicy` dataclass + `VoicePolicyEvaluator` (`activation_error`, `should_join`). Same sibling-module pattern as `voice_mixer.py`; trivially unit-testable.
- Adapter wiring: config loader (follows `_load_voice_fx_config` pattern, validates `join_mode`, coerces scalar allowlist values), monotonic-clock debounce with bounded eviction, text-channel selection fallback (system channel → first sendable text channel → skip), leave-when-empty counting via the existing `_is_allowed_user`.
- Reuses `join_voice_channel` (signature unchanged), the existing idle timeout, and the existing `DISCORD_ALLOWED_USERS`/`ROLES` infrastructure. `gateway/run.py` untouched.

## Testing

- `tests/plugins/platforms/test_voice_policy.py` — 29 behavior-contract tests over the pure evaluator (activation errors, per-field allow/deny, `join_mode` handling, text-opt-in gate, int-vs-string IDs).
- All pass locally; `ast.parse` clean on both files. Adapter-level event-handler tests are out of scope for this PR (the handler closure requires a live discord.py client); the PR is validated by policy tests plus manual E2E.

## Deferred (follow-up issues, per the issue's Phase 3)

Wake-word / push-to-talk, SSRC re-verification at utterance time, echo-prevention hardening for the mixer/legacy interplay, transcript-privacy note (VC allowlist ⊄ text-channel readers is inherent to the existing `/voice join` flow as well — flagged for a maintainer decision rather than a v1 code gate).

Partially addresses #33683. Phase 1 (`/voice doctor`) is a separate PR.
