### PR TITLE
fix(mcp): clear partial SDK import state so guard never returns True with unbound symbols (#96528)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3012,3 +3012,39 @@ class TestRedirectHeaderStripper:
         asyncio.run(hook(response))
         assert next_request.headers["authorization"] == "Bearer x"
         assert next_request.headers["x-tenant"] == "t"
+
+
+def test_ensure_mcp_sdk_partial_import_clears_state(monkeypatch):
+    """#96528: a partial `from mcp import ClientSession, StdioServerParameters`
+    (an SDK version that moved StdioServerParameters out of the top-level
+    namespace binds ClientSession first, then fails) must NOT leave the
+    availability guard returning True with an unbound symbol — the partial
+    state is cleared so callers see the SDK as unavailable instead of hitting
+    NameError at the stdio call site."""
+    import builtins
+    from tools import mcp_tool as mt
+
+    class _PartialMCP:
+        ClientSession = object()  # binds fine
+        # StdioServerParameters intentionally absent from the top level
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp":
+            return _PartialMCP
+        return real_import(name, *args, **kwargs)
+
+    # Fresh guard state so the partial import path is actually exercised.
+    mt._MCP_AVAILABLE = True
+    mt._MCP_SDK_IMPORT_ATTEMPTED = False
+    mt.ClientSession = None
+    mt.StdioServerParameters = None
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    available = mt._ensure_mcp_sdk()
+
+    assert available is False, "partial import must not report the SDK available"
+    assert mt.ClientSession is None, "partial ClientSession bind must be cleared"
+    assert mt.StdioServerParameters is None
+    assert mt._MCP_AVAILABLE is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -422,6 +422,17 @@ def _ensure_mcp_sdk() -> bool:
                 logger.debug("MCP notification types not available -- dynamic tool discovery disabled")
         except ImportError:
             logger.debug("mcp package not installed -- MCP tool support disabled")
+            # A `from mcp import ClientSession, StdioServerParameters` can bind
+            # ClientSession BEFORE StdioServerParameters fails (SDK versions
+            # that moved it out of the top-level namespace). That partial bind
+            # made the availability guard below return True on later calls
+            # (`ClientSession is not None`) while StdioServerParameters stayed
+            # unbound → NameError at the stdio call site (#96528). Clear the
+            # partial state so the guard never reports available with unbound
+            # symbols.
+            _MCP_AVAILABLE = False
+            ClientSession = None
+            StdioServerParameters = None
 
         if _MCP_AVAILABLE:
             try:


### PR DESCRIPTION
MCP stdio servers (obsidian-vault, codegraph) no longer park with `NameError: name 'StdioServerParameters' is not defined` when the mcp SDK moved it out of the top-level namespace.

**Root cause:** `_ensure_mcp_sdk()` runs `from mcp import ClientSession, StdioServerParameters`. When the installed SDK exports `ClientSession` from the top level but not `StdioServerParameters` (moved to `mcp.client.stdio` in newer versions), the import binds `ClientSession` **before** failing — and Python's `from ... import a, b` leaves the already-bound `a` in place. The lazy availability guard then short-circuits on later calls (`if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None: return _MCP_AVAILABLE`), returning `True` while `StdioServerParameters` stays unbound → `NameError` at the stdio call site, server parked after 3 attempts.

**Fix:** the import-error path now clears the partial state (`_MCP_AVAILABLE = False`, `ClientSession = None`, `StdioServerParameters = None`), so the guard never reports the SDK available with unbound symbols — callers treat the SDK as unavailable instead of crashing.

**Regression:** `test_ensure_mcp_sdk_partial_import_clears_state` — patches `__import__` with a module exposing `ClientSession` but not `StdioServerParameters`, asserts the guard returns `False` and the partial binds are cleared. Verified against the installed mcp SDK too (top-level export present there, so the failure mode is version-dependent — hence the guard hardening).