### PR TITLE
fix(logging): default missing session_tag on records that bypass the record factory

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1423,5 +1423,11 @@ class RedactingFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
+        # Records created manually by libraries, deserialised from another
+        # process, or retained across an in-place runtime update can bypass
+        # hermes_logging's record factory, leaving %(session_tag)s undefined
+        # and turning every log write into a logging error. The formatter is
+        # the final boundary before interpolation, so default it here.
+        record.__dict__.setdefault("session_tag", "")
         original = super().format(record)
         return redact_sensitive_text(original)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -338,6 +338,26 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_record_without_session_tag_still_formats(self):
+        # Records that bypass hermes_logging's record factory (library-created,
+        # deserialised, or retained across an in-place update) would crash the
+        # %(session_tag)s format with ValueError on every log write.
+        formatter = RedactingFormatter(
+            "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
+        )
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="factory-bypassing record",
+            args=(),
+            exc_info=None,
+        )
+        assert "session_tag" not in record.__dict__
+        result = formatter.format(record)
+        assert "factory-bypassing record" in result
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""


### PR DESCRIPTION
## Problem

`hermes_logging` installs a global LogRecord factory that injects `%(session_tag)s` into every record it creates, and the production format strings (`_LOG_FORMAT`, `_LOG_FORMAT_VERBOSE`) reference that field unconditionally. But records that never pass through the factory still reach handlers:

- records created manually by third-party libraries via `logging.LogRecord(...)`
- records deserialised from another process (pickled through a `QueueHandler`)
- records retained across an in-place runtime update

For any of those, `RedactingFormatter.format` raises on **every single emitted record**:

```
ValueError: Formatting field not found in record: 'session_tag'
```

Observed in the field immediately after an update restart: `gateway.error.log` grew past 390 MB and a dashboard error log past 300 MB of nothing but logging-error tracebacks, degrading every service in the fleet while the desktop client stalled in its reconnect loop.

## Fix

Default the attribute in the formatter itself — it is the final boundary before interpolation, so it can guarantee the format string is always satisfiable:

```python
record.__dict__.setdefault("session_tag", "")
```

`setdefault` keeps factory-tagged records untouched; only factory-bypassing records get the same empty-context default the factory would have produced.

## Testing

- New regression test `test_record_without_session_tag_still_formats` formats a bare `logging.LogRecord` (no factory, no `session_tag` in `__dict__`) using the production format string and asserts formatting succeeds.
- `pytest tests/agent/test_redact.py`: 98 passed.
- Verified on a live fleet: after applying and restarting gateway + dashboards + backends, zero new `session_tag` logging errors (previously thousands per minute).