### PR TITLE
Kanban: refuse delete/archive while a worker run is active

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -742,6 +742,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         default=None,
         help="Permanently delete already-archived task ids from the board",
     )
+    p_archive.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Archive even when a worker run is still active: the run is "
+            "closed with outcome='reclaimed'. Use only for stuck workers "
+            "that will not respond to a kanban_block; without --force the "
+            "command refuses so a running worker can always finish or "
+            "comment on its own card."
+        ),
+    )
 
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
@@ -2579,23 +2590,48 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     if not ids and not purge_ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    force = bool(getattr(args, "force", False))
     failed: list[str] = []
+    refused: list[tuple[str, int]] = []
     with kb.connect_closing() as conn:
         if purge_ids:
             for tid in purge_ids:
-                if not kb.delete_archived_task(conn, tid):
-                    failed.append(tid)
-                    print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
-                else:
-                    print(f"Deleted {tid}")
-            return 0 if not failed else 1
+                try:
+                    if not kb.delete_archived_task(conn, tid):
+                        failed.append(tid)
+                        print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
+                    else:
+                        print(f"Deleted {tid}")
+                except kb.TaskHasActiveRunError as exc:
+                    refused.append((exc.task_id, exc.run_id))
+                    print(str(exc), file=sys.stderr)
+            if refused:
+                print(
+                    "delete refused: one or more tasks still have a worker "
+                    "run in flight; kanban_block the card first to land "
+                    "the run cleanly before removing the row.",
+                    file=sys.stderr,
+                )
+            return 0 if not failed and not refused else 1
         for tid in ids:
-            if not kb.archive_task(conn, tid):
-                failed.append(tid)
-                print(f"cannot archive {tid}", file=sys.stderr)
-            else:
-                print(f"Archived {tid}")
-    return 0 if not failed else 1
+            try:
+                if not kb.archive_task(conn, tid, force=force):
+                    failed.append(tid)
+                    print(f"cannot archive {tid}", file=sys.stderr)
+                else:
+                    print(f"Archived {tid}")
+            except kb.TaskHasActiveRunError as exc:
+                refused.append((exc.task_id, exc.run_id))
+                print(str(exc), file=sys.stderr)
+        if refused and not force:
+            print(
+                "archive refused: one or more tasks still have a worker "
+                "run in flight. Re-run with --force to reclaim the run "
+                "and archive anyway, or kanban_block the card so the "
+                "worker can land its own result first.",
+                file=sys.stderr,
+            )
+    return 0 if not failed and not refused else 1
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7609,9 +7609,14 @@ def archive_task(
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Permanently remove an already-archived task and its related rows.
 
-    Safety guard: only archived tasks can be deleted. Active / blocked / done
-    tasks must be explicitly archived first so accidental data loss requires a
-    second deliberate action.
+    Safety guards:
+      1. Only archived tasks can be deleted. Active / blocked / done
+         tasks must be explicitly archived first so accidental data loss
+         requires a second deliberate action.
+      2. Refuses with :class:`TaskHasActiveRunError` if a worker run is
+         still in flight. Same stranded-worker guard as :func:`delete_task`
+         — cleanup flows (``archive --rm``, post-verification purge) must
+         SKIP such cards and retry later, never delete mid-run.
     """
     with write_txn(conn):
         row = conn.execute(
@@ -7620,6 +7625,9 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         ).fetchone()
         if not row or row["status"] != "archived":
             return False
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None:
+            raise TaskHasActiveRunError(task_id, active_run)
         conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
             (task_id, task_id),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5360,6 +5360,43 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class TaskHasActiveRunError(RuntimeError):
+    """Raised when delete/archive is attempted while a worker run is still active.
+
+    Carries ``task_id`` and ``run_id`` so callers can surface the live run
+    identifier and an actionable next step (complete/block the run first, or
+    pass ``force=True`` to archive and reclaim the run). Workers always need a
+    way to complete or comment on their own card; deleting or archiving the
+    card mid-run orphans the worker session.
+    """
+
+    def __init__(self, task_id: str, run_id: int):
+        self.task_id = task_id
+        self.run_id = run_id
+        super().__init__(
+            f"task {task_id} has an active worker run (id={run_id}); "
+            f"complete or block the run first "
+            f"(or pass force=True to archive and reclaim the run)"
+        )
+
+
+def _has_active_run(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
+    """Return the active run id for ``task_id`` or ``None``.
+
+    "Active" = ``task_runs.status='running'`` AND ``ended_at IS NULL``. This
+    matches what the dispatcher treats as in-flight; stale claim rows whose
+    ``ended_at`` is set are excluded so the refusal does not fire on
+    long-completed work.
+    """
+    row = conn.execute(
+        "SELECT id FROM task_runs "
+        "WHERE task_id = ? AND status = 'running' AND ended_at IS NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return int(row["id"]) if row else None
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7521,7 +7558,20 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    force: bool = False,
+) -> bool:
+    """Archive a task.
+
+    Refuses with :class:`TaskHasActiveRunError` when a worker run is still
+    in flight, unless ``force=True``. Force reclaims the active run (closes
+    it with ``outcome='reclaimed'``) so cleanup can still race past a stuck
+    worker; without ``force`` we want a worker to always finish or block
+    on its own card before the card is removed.
+    """
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -7531,13 +7581,19 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         if cur.rowcount != 1:
             return False
-        # If archive happened while a run was still in flight (e.g. user
-        # archived a running task from the dashboard), close that run with
-        # outcome='reclaimed' so attempt history isn't orphaned.
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None and not force:
+            # Roll back the archive we just did — refuse, don't silently
+            # orphan a worker. Force-mode keeps the archive and reclaims
+            # the run below.
+            raise TaskHasActiveRunError(task_id, active_run)
+        # If archive happened while a run was still in flight (force path,
+        # or the user archived a long-running task from the dashboard), close
+        # that run with outcome='reclaimed' so attempt history isn't orphaned.
         run_id = _end_run(
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
-            summary="task archived with run still active",
+            summary="task archived with run still active" if force else None,
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
@@ -7583,10 +7639,18 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     we explicitly delete from child tables first, then the task row.
     This keeps the operation atomic (single ``write_txn``).
 
+    Refuses with :class:`TaskHasActiveRunError` if a worker run is still
+    in flight. Delete has no force-mode escape hatch — there is no
+    graceful close path; the operator must ``kanban_block`` (kind=capability)
+    the card first so the run lands cleanly before the row goes away.
+
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
     with write_txn(conn):
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None:
+            raise TaskHasActiveRunError(task_id, active_run)
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -852,6 +852,10 @@ class UpdateTaskBody(BaseModel):
     # override doesn't silently reset the depth the operator chose.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Forwarded to archive_task(force=...). Only consulted when
+    # status='archived'. Lets the dashboard surface an "archive anyway"
+    # affordance when the refusal fires on a stuck worker.
+    force: bool = False
 
 
 def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
@@ -935,7 +939,28 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     # Direct status write for drag-drop (todo -> ready etc).
                     ok = reopened if reopened is not None else _set_status_direct(conn, task_id, "ready")
             elif s == "archived":
-                ok = kanban_db.archive_task(conn, task_id)
+                # PATCH path: honor UpdateTaskBody.force so the dashboard
+                # "force archive" button can reclaim a stuck worker; without
+                # force we surface the active-run refusal to the caller.
+                try:
+                    ok = kanban_db.archive_task(
+                        conn, task_id, force=bool(payload.force),
+                    )
+                except kanban_db.TaskHasActiveRunError as exc:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "task_has_active_run",
+                            "task_id": exc.task_id,
+                            "run_id": exc.run_id,
+                            "message": (
+                                f"task {exc.task_id} has an active worker "
+                                f"run (id={exc.run_id}); retry with "
+                                f"force=true to reclaim the run and "
+                                f"archive anyway."
+                            ),
+                        },
+                    )
             elif s == "running":
                 raise HTTPException(
                     status_code=400,
@@ -1065,7 +1090,23 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.delete_task(conn, task_id)
+        try:
+            ok = kanban_db.delete_task(conn, task_id)
+        except kanban_db.TaskHasActiveRunError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "task_has_active_run",
+                    "task_id": exc.task_id,
+                    "run_id": exc.run_id,
+                    "message": (
+                        f"task {exc.task_id} has an active worker run "
+                        f"(id={exc.run_id}); block the card first so the "
+                        f"worker can land its own result, then retry the "
+                        f"delete."
+                    ),
+                },
+            )
         if not ok:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         return {"deleted": True, "task_id": task_id}
@@ -1312,6 +1353,8 @@ class BulkTaskBody(BaseModel):
     # Bulk thinking-depth override — same semantics as UpdateTaskBody.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Forwarded to archive_task(force=...). Only used when archive=True.
+    force: bool = False
 
 
 @router.post("/tasks/bulk")
@@ -1337,8 +1380,18 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     results.append(entry)
                     continue
                 if payload.archive:
-                    if not kanban_db.archive_task(conn, tid):
-                        entry.update(ok=False, error="archive refused")
+                    try:
+                        if not kanban_db.archive_task(
+                            conn, tid, force=bool(payload.force),
+                        ):
+                            entry.update(ok=False, error="archive refused")
+                    except kanban_db.TaskHasActiveRunError as exc:
+                        entry.update(
+                            ok=False,
+                            error="task_has_active_run",
+                            run_id=exc.run_id,
+                            message=str(exc),
+                        )
                 if payload.status is not None and not payload.archive:
                     s = payload.status
                     if s == "done":

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -179,3 +179,54 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# archive / --rm CLI active-run refusal
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_cli_archive_refuses_while_run_active(kanban_home, capsys):
+    """`hermes kanban archive` exits non-zero and prints the run id when
+    a worker run is still active. Regression for RV2 cleanup deleting
+    running cards mid-run."""
+    parser = kc.build_parser(_top_subparsers())
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:worker")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        args = parser.parse_args(["archive", tid])
+        rc = kc._cmd_archive(args)
+        captured = capsys.readouterr()
+        assert rc == 1, "archive must exit non-zero when refusing"
+        assert f"run (id={run_id})" in captured.err
+        assert "complete or block" in captured.err
+        # Card untouched.
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_kanban_cli_archive_force_reclaims_run(kanban_home, capsys):
+    """`hermes kanban archive --force` reclaims the run and archives anyway."""
+    parser = kc.build_parser(_top_subparsers())
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stuck", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:stuck")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        args = parser.parse_args(["archive", tid, "--force"])
+        rc = kc._cmd_archive(args)
+        capsys.readouterr()
+        assert rc == 0
+        assert kb.get_task(conn, tid).status == "archived"
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id = ?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "reclaimed"
+
+
+def _top_subparsers():
+    """Return a parent subparsers action for ``build_parser``."""
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    return sub

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1647,3 +1647,81 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Active-run guard on archive / delete
+# ---------------------------------------------------------------------------
+
+
+def test_archive_task_refuses_while_run_active(kanban_home):
+    """archive_task must refuse when a worker run is still in flight, and
+    the error must name the run id so the caller knows what to land first.
+    Regression for RV2 cleanup that archived running cards mid-run.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        claimed = kb.claim_task(conn, tid, claimer="test:worker")
+        assert claimed is not None
+        assert kb.get_task(conn, tid).status == "running"
+        run_id = kb.get_task(conn, tid).current_run_id
+        assert run_id, "claim_task must record a current run"
+
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.archive_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # The card is untouched — still running, not archived.
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_archive_task_force_reclaims_active_run(kanban_home):
+    """force=True keeps the archive path live and reclaims the active run
+    so cleanup can still race past a stuck worker."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stuck", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:stuck")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        assert kb.archive_task(conn, tid, force=True) is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "archived"
+        # Run row closed with outcome='reclaimed' so attempt history isn't orphaned.
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id = ?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "reclaimed"
+        assert run["outcome"] == "reclaimed"
+
+
+def test_delete_task_refuses_while_run_active(kanban_home):
+    """delete_task must refuse when a worker run is still in flight. No
+    force escape hatch — delete the row only when no worker can still
+    reference it."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:worker")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.delete_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # Row still present.
+        assert kb.get_task(conn, tid) is not None
+
+
+def test_archive_and_delete_proceed_after_run_ends(kanban_home):
+    """Once the active run is closed, archive/delete must succeed again.
+    Guards against an over-broad check that would lock the card forever."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="will-finish", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:w")
+        # Simulate the worker landing its result.
+        assert kb.complete_task(conn, tid, result="ok")
+        assert kb.get_task(conn, tid).status == "done"
+
+        assert kb.archive_task(conn, tid) is True
+        assert kb.get_task(conn, tid).status == "archived"
+        assert kb.delete_archived_task(conn, tid) is True
+        assert kb.get_task(conn, tid) is None

--- a/tests/hermes_cli/test_kanban_delete_active_run.py
+++ b/tests/hermes_cli/test_kanban_delete_active_run.py
@@ -1,0 +1,142 @@
+"""Stranded-worker guard on the ARCHIVED-task purge path.
+
+Sibling commit fa3efdcc7 guarded ``archive_task`` / ``delete_task`` (and the
+``--rm`` CLI loop's try/except around ``delete_archived_task``), but
+``delete_archived_task`` itself never raised the refusal — the ``--rm`` purge
+path (the exact RV2 post-verification cleanup that deleted running children
+mid-run) was unguarded. These tests close that gap:
+
+* ``delete_archived_task`` refuses while a run is active,
+* stale terminal-status runs never block a delete,
+* the CLI ``archive --rm`` loop skips the in-flight card and keeps going.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _seed_archived_with_active_run(kanban_home):
+    """Create + claim a card, then force it to archived while its run is
+    still active — the RV2 incident shape (post-verification cleanup trying
+    to purge children whose worker runs are still in flight)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="archived but running", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = int(
+            conn.execute(
+                "SELECT current_run_id FROM tasks WHERE id = ?", (tid,)
+            ).fetchone()["current_run_id"]
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'archived' WHERE id = ?", (tid,)
+        )
+        conn.commit()
+    return tid, run_id
+
+
+def test_delete_archived_task_refused_while_run_active(kanban_home):
+    tid, run_id = _seed_archived_with_active_run(kanban_home)
+
+    with kb.connect() as conn:
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.delete_archived_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # Card + run untouched.
+        assert kb.get_task(conn, tid) is not None
+        assert (
+            conn.execute(
+                "SELECT status FROM task_runs WHERE id = ?", (run_id,)
+            ).fetchone()["status"]
+            == "running"
+        )
+
+
+def test_delete_archived_task_succeeds_after_run_ends(kanban_home):
+    tid, run_id = _seed_archived_with_active_run(kanban_home)
+    with kb.connect() as conn:
+        kb._end_run(conn, tid, outcome="completed", status="done")
+    with kb.connect() as conn:
+        assert kb.delete_archived_task(conn, tid) is True
+        assert kb.get_task(conn, tid) is None
+
+
+def test_delete_archived_task_clears_task_links(kanban_home):
+    """Deleting an archived card with no active run still cleans links."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker")
+        kb.complete_task(conn, child, result="ok")
+        assert kb.archive_task(conn, child)
+        assert kb.delete_archived_task(conn, child) is True
+        leftover = conn.execute(
+            "SELECT COUNT(*) FROM task_links "
+            "WHERE parent_id = ? OR child_id = ?",
+            (child, child),
+        ).fetchone()[0]
+        assert leftover == 0
+
+
+def test_terminal_run_statuses_do_not_block_delete(kanban_home):
+    """Stale runs in ANY terminal status must not block a delete — only
+    'running' counts as active. Guards against an over-broad check."""
+    for terminal in ("done", "blocked", "crashed", "timed_out", "failed", "released"):
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"stale {terminal}", assignee="worker")
+            cur = conn.execute(
+                "INSERT INTO task_runs (task_id, status, started_at, ended_at) "
+                "VALUES (?, ?, ?, ?)",
+                (tid, terminal, int(time.time()), int(time.time())),
+            )
+            run_id = int(cur.lastrowid)
+            conn.execute(
+                "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+                (run_id, tid),
+            )
+            conn.commit()
+
+        with kb.connect() as conn:
+            assert kb.delete_task(conn, tid) is True, f"terminal={terminal}"
+            assert kb.get_task(conn, tid) is None
+
+
+def test_cli_archive_purge_loop_skips_active_run(capsys, monkeypatch, kanban_home):
+    """The CLI ``hermes kanban archive --rm <ids>`` loop must skip a card
+    whose run is still active and continue the batch — not abort."""
+    from hermes_cli.kanban import _cmd_archive
+
+    active_tid, _ = _seed_archived_with_active_run(kanban_home)
+    with kb.connect() as conn:
+        clean_tid = kb.create_task(conn, title="clean", assignee="worker")
+        kb.complete_task(conn, clean_tid, result="ok")
+        assert kb.archive_task(conn, clean_tid)
+
+    args = argparse.Namespace(task_ids=[], purge_ids=[active_tid, clean_tid])
+    rc = _cmd_archive(args)
+
+    captured = capsys.readouterr()
+    # Refusal is tracked (exit 1 signals retry needed) but the batch
+    # continues: the clean card still got deleted.
+    assert rc == 1
+    assert active_tid in captured.err
+    assert "active worker run" in captured.err or "active run" in captured.err
+    assert f"Deleted {clean_tid}" in captured.out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, clean_tid) is None
+        assert kb.get_task(conn, active_tid) is not None


### PR DESCRIPTION
## What

Closes the stranded-worker deletion hole that the TabJoy fleet hit (RV2 cleanup deleted archived children whose worker runs were still in flight, leaving dangling `task_links` and a stuck `unknown id` task).

Two commits, each with regression tests:

- `archive_task(conn, task_id, *, force=False)` refuses with `TaskHasActiveRunError(task_id, run_id)` when a `task_runs.status='running' AND ended_at IS NULL` row exists. `force=True` reclaims the run (`outcome='reclaimed'`) and archives anyway, for stuck-worker cleanup.
- `delete_task` / `delete_archived_task` raise the same error unconditionally; no force hatch. This is the actual `archive --rm` purge path RV2 cleanup used.
- `_cmd_archive` surfaces the refusal, prints `refused: one or more tasks still have a worker run in flight` to stderr, exits 1; `--force` exposed on the archive path only.
- Dashboard `update_task` (PATCH) / `bulk_update` translate `TaskHasActiveRunError` to HTTP 409 `{error: "task_has_active_run", task_id, run_id, message}`.

## Tests

```
TMPDIR=~/tmp .venv/bin/python -m pytest \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/hermes_cli/test_kanban_delete_active_run.py -q
# 46 passed, 1 skipped
```

Coverage: archive_refuses, delete_refuses, force_reclaims, proceed_after_run_ends, purge-path refusal/success, terminal-run-statuses-do-not-block-delete, CLI skip-and-continue on purge loop.

Independent verification (fleet-side, before this PR): 44 kanban tests green locally, isolated repro on a scratch board confirmed no dangling links, live board showed zero dangling links after the guard landed on the runtime checkout.