### PR TITLE
fix(cron): route multiplex delivery through profile adapters

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7119,6 +7119,22 @@ def _run_one_job_body(
             fire_claim_lost.set()
         return True
 
+    def _deliver_under_profile_secret_scope(content: str) -> Optional[str]:
+        """Resolve delivery config and standalone credentials per profile."""
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+
+        delivery_scope_token = set_secret_scope(
+            build_profile_secret_scope(_get_hermes_home())
+        )
+        try:
+            return _deliver_result(job, content, adapters=adapters, loop=loop)
+        finally:
+            reset_secret_scope(delivery_scope_token)
+
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
@@ -7374,11 +7390,8 @@ def _run_one_job_body(
                         if not owns_delivery:
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
-                        delivery_error = _deliver_result(
-                            job,
-                            deliver_content,
-                            adapters=adapters,
-                            loop=loop,
+                        delivery_error = _deliver_under_profile_secret_scope(
+                            deliver_content
                         )
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
@@ -7532,8 +7545,7 @@ def _run_one_job_body(
             else:
                 try:
                     delivery_attempted = True
-                    delivery_error = _deliver_result(
-                        job,
+                    delivery_error = _deliver_under_profile_secret_scope(
                         # Composed exactly like the normal failure delivery above.
                         # mark_job_run below records THIS run in failure_streak
                         # whichever layer failed, so a job that fails before the
@@ -7541,9 +7553,7 @@ def _run_one_job_body(
                         # about: its alerts only ever leave through here, and the
                         # nudge only ever left through there (#88655).
                         _summarize_cron_failure_for_delivery(job, _err_text)
-                        + _failure_streak_nudge(job),
-                        adapters=adapters,
-                        loop=loop,
+                        + _failure_streak_nudge(job)
                     )
                 except Exception as delivery_exc:
                     delivery_error = str(delivery_exc)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -30,6 +31,42 @@ from typing import Any
 # here so a still-alive-but-exhausted gateway never sleeps longer than this
 # between recovery attempts.
 _EMFILE_BACKOFF_MAX_SECONDS = 15 * 60  # 15 minutes
+
+
+class _SecondaryCronAdapterView(Mapping):
+    """Live secondary adapters plus the primary-owned Relay transport only."""
+
+    def __init__(self, secondary_adapters, primary_adapters):
+        from gateway.config import Platform
+
+        self._secondary_adapters = (
+            secondary_adapters if secondary_adapters is not None else {}
+        )
+        self._primary_adapters = (
+            primary_adapters if primary_adapters is not None else {}
+        )
+        self._relay_platform = Platform.RELAY
+
+    def __getitem__(self, platform):
+        if platform == self._relay_platform:
+            return self._primary_adapters[platform]
+        return self._secondary_adapters[platform]
+
+    def __iter__(self):
+        if self._relay_platform in self._primary_adapters:
+            yield self._relay_platform
+        yield from (
+            platform
+            for platform in self._secondary_adapters
+            if platform != self._relay_platform
+        )
+
+    def __len__(self):
+        return (
+            len(self._secondary_adapters)
+            - int(self._relay_platform in self._secondary_adapters)
+            + int(self._relay_platform in self._primary_adapters)
+        )
 
 
 def _backoff_wait_seconds(interval: float, consecutive_failures: int) -> float:
@@ -532,6 +569,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -556,6 +594,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -627,6 +666,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -682,13 +722,22 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        tick_adapters = (
+                            adapters
+                            if profile_name in (None, "default")
+                            else _SecondaryCronAdapterView(
+                                (profile_adapters or {}).get(profile_name),
+                                adapters,
+                            )
+                        )
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31799,6 +31799,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                cron_start_kwargs["profile_adapters"] = getattr(
+                    runner, "_profile_adapters", {}
+                )
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,340 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_delivers_secondary_origin_via_its_live_adapter(
+    tmp_path, monkeypatch
+):
+    """A Rob-origin Telegram job resolves Rob's live adapter, not default's."""
+    import asyncio
+    from concurrent.futures import Future
+
+    import cron.scheduler as scheduler
+    import gateway.delivery as delivery
+    from cron.scheduler_provider import InProcessCronScheduler
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from hermes_constants import get_hermes_home
+
+    class Adapter:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, chat_id, content, metadata=None):
+            self.sent.append((chat_id, content, metadata))
+            return {"success": True}
+
+    class RunningLoop:
+        def is_running(self):
+            return True
+
+    def run_immediately(coro, loop, **kwargs):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:
+            future.set_exception(exc)
+        return future
+
+    luma_home = tmp_path / "luma"
+    rob_home = tmp_path / "rob"
+    for home in (luma_home, rob_home):
+        (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(luma_home))
+
+    luma_adapter = Adapter()
+    rob_adapter = Adapter()
+    luma_adapters = {Platform.TELEGRAM: luma_adapter}
+    rob_adapters = {Platform.TELEGRAM: rob_adapter}
+    gateway_config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    )
+    resolved = []
+    real_resolve = delivery.resolve_delivery_transport
+
+    def tracking_resolve(platform, config, adapters):
+        transport = real_resolve(platform, config, adapters)
+        resolved.append((get_hermes_home(), adapters, transport.adapter if transport else None))
+        return transport
+
+    stop = threading.Event()
+    tick_adapters = []
+
+    def tick_secondary_delivery(*args, **kwargs):
+        current_home = get_hermes_home()
+        tick_adapters.append((current_home, kwargs["adapters"]))
+        if current_home == rob_home:
+            assert scheduler._deliver_result(
+                {
+                    "id": "rob-telegram-origin",
+                    "name": "Rob reminder",
+                    "deliver": "origin",
+                    "origin": {"platform": "telegram", "chat_id": "424242"},
+                },
+                "Rob's scheduled result",
+                adapters=kwargs["adapters"],
+                loop=RunningLoop(),
+            ) is None
+            stop.set()
+        return 0
+
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"wrap_response": False}})
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: gateway_config)
+    monkeypatch.setattr(delivery, "resolve_delivery_transport", tracking_resolve)
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", run_immediately)
+    monkeypatch.setattr("cron.scheduler.tick", tick_secondary_delivery)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **kwargs: None)
+
+    InProcessCronScheduler().start(
+        stop,
+        interval=0,
+        adapters=luma_adapters,
+        profile_adapters={"rob": rob_adapters},
+        profile_homes=[("default", luma_home), ("rob", rob_home)],
+    )
+
+    assert tick_adapters[0] == (luma_home, luma_adapters)
+    assert tick_adapters[1][0] == rob_home
+    assert tick_adapters[1][1].get(Platform.TELEGRAM) is rob_adapter
+    assert any(
+        home == rob_home and adapter is rob_adapter
+        for home, adapters, adapter in resolved
+    )
+    assert [message[0] for message in rob_adapter.sent] == ["424242"]
+    assert luma_adapter.sent == []
+
+
+def test_multiplex_ticker_never_borrows_default_adapters_for_missing_secondary(
+    tmp_path, monkeypatch
+):
+    """A secondary without live adapters falls back to its own standalone path."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from gateway.config import Platform
+    from hermes_constants import get_hermes_home
+
+    luma_home = tmp_path / "luma"
+    rob_home = tmp_path / "rob"
+    for home in (luma_home, rob_home):
+        (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(luma_home))
+
+    luma_adapters = {Platform.TELEGRAM: object()}
+    calls = []
+    stop = threading.Event()
+
+    def capture_adapters(*args, **kwargs):
+        calls.append((get_hermes_home(), kwargs["adapters"]))
+        if get_hermes_home() == rob_home:
+            stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", capture_adapters)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **kwargs: None)
+
+    InProcessCronScheduler().start(
+        stop,
+        interval=0,
+        adapters=luma_adapters,
+        profile_adapters={},
+        profile_homes=[("default", luma_home), ("rob", rob_home)],
+    )
+
+    assert calls[0] == (luma_home, luma_adapters)
+    assert calls[1][0] == rob_home
+    assert calls[1][1].get(Platform.TELEGRAM) is None
+
+
+def test_multiplex_secondary_tick_uses_only_own_adapters_and_shared_relay(
+    tmp_path, monkeypatch
+):
+    """Secondary delivery keeps live profile adapters and the primary Relay only."""
+    import gateway.delivery as delivery
+    from cron.scheduler_provider import InProcessCronScheduler
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from hermes_constants import get_hermes_home
+
+    class Relay:
+        def fronts_platform(self, platform):
+            return platform is Platform.DISCORD
+
+    luma_home = tmp_path / "luma"
+    rob_home = tmp_path / "rob"
+    for home in (luma_home, rob_home):
+        (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(luma_home))
+
+    luma_telegram = object()
+    luma_discord = object()
+    shared_relay = Relay()
+    rob_telegram = object()
+    luma_adapters = {
+        Platform.TELEGRAM: luma_telegram,
+        Platform.DISCORD: luma_discord,
+        Platform.RELAY: shared_relay,
+    }
+    rob_adapters = {Platform.TELEGRAM: rob_telegram}
+    calls = []
+    stop = threading.Event()
+
+    def capture_adapters(*args, **kwargs):
+        calls.append((get_hermes_home(), kwargs["adapters"]))
+        if get_hermes_home() == rob_home:
+            stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", capture_adapters)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **kwargs: None)
+
+    InProcessCronScheduler().start(
+        stop,
+        interval=0,
+        adapters=luma_adapters,
+        profile_adapters={"rob": rob_adapters},
+        profile_homes=[("default", luma_home), ("rob", rob_home)],
+    )
+
+    assert calls[0] == (luma_home, luma_adapters)
+    secondary_adapters = calls[1][1]
+    assert secondary_adapters.get(Platform.TELEGRAM) is rob_telegram
+    assert secondary_adapters.get(Platform.DISCORD) is None
+    assert secondary_adapters.get(Platform.RELAY) is shared_relay
+    assert set(secondary_adapters) == {Platform.TELEGRAM, Platform.RELAY}
+
+    replacement = object()
+    rob_adapters[Platform.TELEGRAM] = replacement
+    assert secondary_adapters.get(Platform.TELEGRAM) is replacement
+
+    relay_config = GatewayConfig(
+        platforms={Platform.RELAY: PlatformConfig(enabled=True)}
+    )
+    transport = delivery.resolve_delivery_transport(
+        Platform.DISCORD, relay_config, secondary_adapters
+    )
+    assert transport is not None
+    assert transport.adapter is shared_relay
+    assert transport.is_relay
+
+
+def test_multiplex_ticker_keeps_primary_adapters_for_default_and_path_entries(
+    tmp_path, monkeypatch
+):
+    """Default and legacy path-only multiplex entries retain primary adapters."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from gateway.config import Platform
+    from hermes_constants import get_hermes_home
+
+    default_home = tmp_path / "default"
+    path_only_home = tmp_path / "path-only"
+    for home in (default_home, path_only_home):
+        (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    primary_adapters = {Platform.TELEGRAM: object()}
+    calls = []
+    stop = threading.Event()
+
+    def capture_adapters(*args, **kwargs):
+        calls.append((get_hermes_home(), kwargs["adapters"]))
+        if len(calls) == 2:
+            stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", capture_adapters)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **kwargs: None)
+
+    InProcessCronScheduler().start(
+        stop,
+        interval=0,
+        adapters=primary_adapters,
+        profile_homes=[("default", default_home), path_only_home],
+    )
+
+    assert calls == [
+        (default_home, primary_adapters),
+        (path_only_home, primary_adapters),
+    ]
+
+
+def test_multiplex_secondary_standalone_delivery_keeps_owner_secret_scope(
+    tmp_path, monkeypatch
+):
+    """Both normal and failure delivery use Rob's token, never Luma's."""
+    import cron.scheduler as scheduler
+    from agent import secret_scope
+    from cron.scheduler_provider import _SecondaryCronAdapterView
+    from gateway.config import Platform
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    luma_home = tmp_path / "luma"
+    rob_home = tmp_path / "rob"
+    for home in (luma_home, rob_home):
+        (home / "cron").mkdir(parents=True)
+    (rob_home / ".env").write_text("TELEGRAM_BOT_TOKEN=rob-token\n")
+    monkeypatch.setenv("HERMES_HOME", str(luma_home))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "luma-token")
+
+    selected_tokens = []
+
+    async def capture_standalone_send(platform, pconfig, *args, **kwargs):
+        assert platform is Platform.TELEGRAM
+        selected_tokens.append(pconfig.token)
+        return {"success": True}
+
+    run_results = iter(
+        [
+            (True, "normal output", "normal delivery", None),
+            RuntimeError("simulated run failure"),
+        ]
+    )
+
+    def fake_run_job(*args, **kwargs):
+        result = next(run_results)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def job(job_id):
+        return {
+            "id": job_id,
+            "name": job_id,
+            "execution_id": f"{job_id}-execution",
+            "deliver": "telegram:424242",
+        }
+
+    def mark_running(execution_id):
+        if execution_id == "early-failure-execution":
+            raise RuntimeError("execution ledger unavailable")
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *args, **kwargs: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", mark_running)
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *args, **kwargs: "output")
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *args, **kwargs: True)
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"wrap_response": False}})
+    monkeypatch.setattr(
+        "tools.send_message_tool._send_to_platform", capture_standalone_send
+    )
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    home_token = set_hermes_home_override(str(rob_home))
+    secondary_adapters = _SecondaryCronAdapterView(
+        None, {Platform.TELEGRAM: object()}
+    )
+    try:
+        assert scheduler._run_one_job_body(
+            job("normal"), adapters=secondary_adapters
+        )
+        assert not scheduler._run_one_job_body(
+            job("failure"), adapters=secondary_adapters
+        )
+        # This fails before the normal run scope is installed. The outer
+        # failure path must still resolve delivery under Rob's secret scope,
+        # rather than raising UnboundLocalError for its delivery helper.
+        assert not scheduler._run_one_job_body(
+            job("early-failure"), adapters=secondary_adapters
+        )
+    finally:
+        reset_hermes_home_override(home_token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+    assert selected_tokens == ["rob-token", "rob-token", "rob-token"]


### PR DESCRIPTION
## What does this PR do?

Fixes multiplex cron delivery selecting the primary profile's native messaging adapter for secondary-profile jobs.

Observed symptom: a secondary-profile cron result arrived through the primary profile's Telegram adapter, and the delivery log was attributed to `agent:avery`, even though the job-owning profile had its own live Telegram adapter.

The fix keeps the existing multiplex profile-home/store scoping, but gives each secondary tick a live adapter view containing:

- that profile's own native adapters;
- the primary-owned shared `relay` adapter only; and
- no primary native adapter fallback when the secondary adapter is missing.

Normal and failure-result delivery also rebuild the secret scope from the active profile home and reliably reset it afterward, so standalone fallback resolves credentials from the job-owning profile rather than process-global/default-profile state.

## Related Issue

Fixes #83182

Related implementations were reviewed before opening this draft, including #73363, #83197, #91795, #93043, and #95899. This draft preserves a narrower four-file diff while explicitly retaining the shared Relay transport alongside profile-owned native adapters; it does not modify another contributor's branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` passes the live secondary-profile adapter registry only to the built-in multiplex scheduler.
- `cron/scheduler_provider.py` selects each profile's live adapters, fails closed for missing secondary native adapters, and preserves the primary-owned Relay adapter via a live mapping view.
- `cron/scheduler.py` scopes both normal and failure delivery to the active profile's secret scope and resets it in `finally`.
- `tests/cron/test_scheduler_provider.py` adds end-to-end routing, missing-adapter, shared-Relay, default/path compatibility, and standalone secret-scope regressions.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler_provider.py`
   - **35 passed, 0 failed**.
2. `scripts/run_tests.sh tests/gateway/test_multiplex_lifecycle.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_multiplex_phase0.py tests/hermes_cli/test_desktop_cron_ticker_profiles.py`
   - **48 passed, 0 failed**.
3. `scripts/run_tests.sh tests/cron/`
   - **995 passed, 1 failed, 10 skipped**.
   - The sole failure was `test_repeated_heartbeat_errors_cancel_after_bounded_grace`, a timing-sensitive heartbeat test outside this diff. Direct diagnostic runs reproduced nondeterminism with unmodified `origin/main` production files (4 failures / 2 passes across 6 runs) and on this branch (5 failures / 1 pass across 6 runs).
4. `.venv/bin/ruff check cron/scheduler.py cron/scheduler_provider.py gateway/run.py tests/cron/test_scheduler_provider.py`
   - **All checks passed**.
5. `git diff --check origin/main...HEAD`
   - **Passed**.
6. Regression sabotage: running `test_multiplex_ticker_delivers_secondary_origin_via_its_live_adapter` with the three production files temporarily restored from `origin/main` fails with `TypeError: InProcessCronScheduler.start() got an unexpected keyword argument 'profile_adapters'`; the restored branch test file passes as part of the 35-test canonical run.

## Checklist

### Code

- [x] I've read the Contributing Guide / repository `AGENTS.md`.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and documented the related alternatives above.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the entire repository test suite with zero failures. (Proportionate canonical checks are recorded above; one unrelated timing-sensitive cron test is nondeterministic on both base and branch.)
- [x] I've added regression tests.
- [x] I've tested on macOS using the repository's hermetic canonical runner.

### Documentation & Housekeeping

- [x] Documentation changes: N/A — no user-facing config or command changes.
- [x] `cli-config.yaml.example`: N/A — no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow changes.
- [x] Cross-platform impact considered: production change is Python mapping/context management with no platform-specific APIs.
- [x] Tool descriptions/schemas: N/A.

## Risk / Rollback

- Security impact: narrows native adapter and credential selection to the job-owning profile; shared Relay remains intentionally primary-owned.
- Migration/config impact: none.
- Rollback: revert the single commit.
- No gateway restart, deployment, merge, user-config edit, or live message send was performed for this draft.
