### PR TITLE
feat(gateway): platform-wide "default" channel override key

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3813,6 +3813,10 @@ def _get_channel_override(
 
     Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
     ``parent_id`` (forum threads / child channels inherit the parent entry).
+    Finally falls back to a platform-wide ``"default"`` key when present, so an
+    operator can set one override for every channel on a platform (e.g. route
+    all Matrix DMs to a cheaper model) without enumerating each chat_id. A
+    specific chat_id/thread_id/parent_id entry always wins over ``"default"``.
     """
     platforms = getattr(config, "platforms", None)
     if not platforms:
@@ -3827,7 +3831,9 @@ def _get_channel_override(
         ov = overrides.get(key)
         if ov is not None:
             return ov
-    return None
+    # Platform-wide default (lowest priority): applies to any channel with no
+    # specific entry. Keyed literally by "default" in channel_overrides.
+    return overrides.get("default")
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -68,6 +68,61 @@ class TestGetChannelOverride:
         assert result is not None
         assert result.model == "topic-model"
 
+    def test_platform_wide_default_applies_when_no_specific_entry(self):
+        """A ``"default"`` key applies to any channel with no specific entry."""
+        config = GatewayConfig(
+            platforms={
+                Platform.MATRIX: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "default": ChannelOverride(
+                            model="stealth/ox-alpha", provider="openrouter"
+                        ),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(config, Platform.MATRIX, "!unlisted:server")
+        assert result is not None
+        assert result.model == "stealth/ox-alpha"
+        assert result.provider == "openrouter"
+
+    def test_specific_entry_wins_over_platform_wide_default(self):
+        """A chat_id/thread_id/parent_id entry always beats ``"default"``."""
+        config = GatewayConfig(
+            platforms={
+                Platform.MATRIX: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "default": ChannelOverride(model="cheap-default"),
+                        "!vip:server": ChannelOverride(model="premium-model"),
+                    },
+                ),
+            },
+        )
+        # Specific chat_id hits its own entry, not "default".
+        specific = _get_channel_override(config, Platform.MATRIX, "!vip:server")
+        assert specific is not None
+        assert specific.model == "premium-model"
+        # An unlisted chat_id falls through to "default".
+        fallback = _get_channel_override(config, Platform.MATRIX, "!other:server")
+        assert fallback is not None
+        assert fallback.model == "cheap-default"
+
+    def test_no_default_key_still_returns_none(self):
+        """Without a ``"default"`` key, an unlisted channel returns None."""
+        config = GatewayConfig(
+            platforms={
+                Platform.MATRIX: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "!vip:server": ChannelOverride(model="premium-model"),
+                    },
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.MATRIX, "!other:server") is None
+
 
 class TestResolveModelForChannel:
     def test_uses_channel_override_when_present(self):


### PR DESCRIPTION
## What

`_get_channel_override` resolves `channel_overrides` by `chat_id`, then
`thread_id`, then `parent_id`. This adds a final fallback to a literal
`"default"` key, so an operator can route **every** channel on a platform
through one override without enumerating each chat_id.

Example — send all Matrix DMs to a cheaper model:

```yaml
platforms:
  matrix:
    channel_overrides:
      default:
        model: some/cheaper-model
        provider: openrouter
```

## Behaviour

- A specific `chat_id` / `thread_id` / `parent_id` entry **always wins** over `"default"` (default is lowest priority).
- When no `"default"` key is present, behaviour is unchanged — unlisted channels return `None`.
- Fully backward compatible: existing configs without a `"default"` key are unaffected.

## Tests

Adds 3 cases to `TestGetChannelOverride` in `tests/gateway/test_channel_overrides.py`:

- `test_platform_wide_default_applies_when_no_specific_entry` — default applies to an unlisted channel
- `test_specific_entry_wins_over_platform_wide_default` — a specific entry beats default; unlisted falls through
- `test_no_default_key_still_returns_none` — absence of a default key preserves the `None` return

All 6 cases in the class pass.
