### PR TITLE
fix(mcp): keep stdio servers available after partial lazy import

### DIFF
--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -134,6 +134,26 @@ class TestLazyMcpSdk:
         assert mcp_tool.ClientSession is not None
         assert mcp_tool.stdio_client is not None
 
+    def test_ensure_mcp_sdk_completes_partially_bound_state(self):
+        """One pre-bound SDK symbol must not skip the complete lazy import."""
+        import importlib.util
+        import subprocess
+
+        if importlib.util.find_spec("mcp") is None:
+            pytest.skip("mcp SDK not installed")
+        code = (
+            "import tools.mcp_tool as m; "
+            "m.ClientSession = object(); "
+            "assert m._ensure_mcp_sdk() is True; "
+            "assert 'StdioServerParameters' in vars(m); "
+            "assert 'stdio_client' in vars(m)"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr
+
     def test_ensure_respects_patched_unavailable(self):
         from tools import mcp_tool
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -316,9 +316,9 @@ def _ensure_mcp_sdk() -> bool:
 
     Idempotent and thread-safe. Sets the module-level ``_MCP_*`` flags and
     SDK symbol globals exactly as the old import-time block did. Honors a
-    test-patched ``_MCP_AVAILABLE=False`` (returns False without importing)
-    and test-installed mock symbols (``ClientSession`` already set → no
-    re-import, so mocks are never clobbered).
+    test-patched ``_MCP_AVAILABLE=False`` (returns False without importing).
+    Only the completed-import flag may short-circuit: one pre-bound symbol
+    does not prove that the rest of the SDK surface was materialized.
     """
     global _MCP_SDK_IMPORT_ATTEMPTED, _MCP_AVAILABLE, _MCP_HTTP_AVAILABLE
     global _MCP_SAMPLING_TYPES, _MCP_NOTIFICATION_TYPES, _MCP_ELICITATION_TYPES
@@ -334,10 +334,10 @@ def _ensure_mcp_sdk() -> bool:
 
     if not _MCP_AVAILABLE:
         return False
-    if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None:
+    if _MCP_SDK_IMPORT_ATTEMPTED:
         return _MCP_AVAILABLE
     with _MCP_SDK_IMPORT_LOCK:
-        if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None:
+        if _MCP_SDK_IMPORT_ATTEMPTED:
             return _MCP_AVAILABLE
         try:
             from mcp import ClientSession, StdioServerParameters
@@ -421,6 +421,7 @@ def _ensure_mcp_sdk() -> bool:
             except ImportError:
                 logger.debug("MCP notification types not available -- dynamic tool discovery disabled")
         except ImportError:
+            _MCP_AVAILABLE = False
             logger.debug("mcp package not installed -- MCP tool support disabled")
 
         if _MCP_AVAILABLE:


### PR DESCRIPTION
## What does this PR do?

Stdio MCP servers can fail during startup with `NameError: name 'StdioServerParameters' is not defined` when the lazy SDK state has only `ClientSession` pre-bound. This change makes the completed-import flag the only successful short-circuit, so a true availability result guarantees the required stdio symbols are bound.

### Symptom

A configured stdio MCP server retries its initial connection three times, then parks after `_run_stdio()` reads an unbound `StdioServerParameters` global.

### Impact

Affected stdio MCP servers do not connect and their tools remain unavailable until the underlying partial lazy-import state is corrected.

### Bug Cause

**Trigger:** `tools/mcp_tool.py:337` / `_ensure_mcp_sdk()` / `ClientSession is not None` before the lazy import completed

**Causal chain:**
1. The process reaches `_ensure_mcp_sdk()` with `ClientSession` pre-bound but the remaining lazy SDK symbols absent.
2. The guard treats that single symbol as proof that the complete import ran and returns true.
3. `_run_stdio()` trusts the result and reads `StdioServerParameters`, which raises `NameError` before the transport can start.

**Why it is wrong:** One populated global is not a completion invariant for a lazy import that binds several required symbols.

**Working sibling / contrast:** A fresh process with no pre-bound symbol executes the complete import and binds both `StdioServerParameters` and `stdio_client` before returning true.

**Ruled out:** The installed MCP SDK exports the stdio parameter type correctly; the regression test reproduces the failure by changing only Hermes' partial module state.

### Fix

Short-circuit only after `_MCP_SDK_IMPORT_ATTEMPTED` records a completed attempt. If the required SDK import itself fails, mark MCP unavailable instead of returning a stale metadata-probe result. A fresh-process regression test covers the partially bound state while preserving the zero-server lazy startup contract.

## Related Issue

Closes #96528

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - complete the SDK import unless a prior attempt finished, and fail availability closed on required import errors.
- `tests/tools/test_startup_latency_regressions.py` - reproduce a pre-bound `ClientSession` in a fresh process and assert all required stdio symbols are materialized.

## How to Test

1. Run the lazy-import and stdio MCP regression files.
2. Confirm all 21 focused tests pass.

```bash
scripts/run_tests.sh tests/tools/test_mcp_stdio_encoding_handler.py tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_startup_latency_regressions.py -q
```

The broader `tests/tools/test_mcp_tool.py` file also produced 98 passing tests and one unrelated Windows environment-key casing failure that reproduces unchanged on `hermes/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the internal contract docstring was updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by the fresh-process regression test.
