### PR TITLE
Fix lifecycle walker bare-path over-blocking + link dependency-blocked cards to named siblings

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -815,7 +815,15 @@ def _references_at(
     if executable.strip("/"):
         if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
             resolved = _resolve_terminal_script_path(executable, cwd)
-            if resolved is not None:
+            # Only real files can be shell-script references: directories,
+            # missing entries, and other non-regular paths (path-shaped
+            # strings in heredocs/comments, directory assignments like
+            # `SRC=/tmp/tabjoy-e2e`) used to be yielded here and then
+            # hard-blocked by _read_referenced_script as unsafe. Skip them
+            # at the source; the cloud-placeholder branch upstream of
+            # _read_referenced_script still fails closed on any yielded
+            # path that turns out to be a FileProvider placeholder.
+            if resolved is not None and resolved.is_file():
                 yield resolved
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6254,6 +6254,49 @@ def edit_completed_task_result(
     return True
 
 
+_DEPENDENCY_SIBLING_RE = re.compile(r"\bt_[0-9a-f]{8}\b")
+
+
+def _resolve_dependency_sibling(
+    conn: sqlite3.Connection, task_id: str, reason: Optional[str]
+) -> Optional[str]:
+    """Return the first sibling task id named in ``reason`` that exists and
+    is not ``task_id`` itself, else ``None``.
+
+    Best-effort by design: a reason that names no sibling, or names one
+    that cannot be resolved to a card, yields ``None`` so the block still
+    succeeds — the caller records the unresolved state on the block event
+    for alerting instead of failing the worker exit path.
+    """
+    if not reason:
+        return None
+    for candidate in _DEPENDENCY_SIBLING_RE.findall(reason):
+        if candidate == task_id:
+            continue
+        if get_task(conn, candidate) is not None:
+            return candidate
+    return None
+
+
+def _insert_dependency_link(
+    conn: sqlite3.Connection, parent_id: str, child_id: str
+) -> None:
+    """Persist a ``parent_id -> child_id`` dependency link.
+
+    Runs inside the caller's open transaction (``link_tasks`` opens its
+    own, so it cannot be reused here). Raises ``ValueError`` on a cycle;
+    duplicate links are idempotent via ``INSERT OR IGNORE``.
+    """
+    if _would_cycle(conn, parent_id, child_id):
+        raise ValueError(
+            f"linking {parent_id} -> {child_id} would create a cycle"
+        )
+    conn.execute(
+        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+        (parent_id, child_id),
+    )
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6335,6 +6378,22 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            # Persist a parent link to the sibling named in the reason BEFORE the
+            # block outcome lands, so ``recompute_ready`` sees an unmet parent
+            # instead of a parentless todo card (which it would re-promote on the
+            # next tick — the bug this link exists to prevent). Resolution is
+            # best-effort: a reason that names no resolvable sibling must not
+            # fail the block, so any failure is recorded on the event payload
+            # for alerting instead of raised.
+            sibling_id = _resolve_dependency_sibling(conn, task_id, reason)
+            link_created = False
+            link_error = None
+            if sibling_id is not None:
+                try:
+                    _insert_dependency_link(conn, parent_id=sibling_id, child_id=task_id)
+                    link_created = True
+                except ValueError as exc:
+                    link_error = str(exc)
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6350,6 +6409,10 @@ def block_task(
                     "reason": reason,
                     "kind": kind,
                     "source_status": source_status,
+                    "sibling_id": sibling_id,
+                    "sibling_resolved": sibling_id is not None,
+                    "link_created": link_created,
+                    "link_error": link_error,
                 },
                 run_id=run_id,
             )

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1329,6 +1329,81 @@ class TestLifecycleGuardModule:
         assert "cloud-synced" in message
         assert "lifecycle command" not in message
 
+    def test_preflight_script_with_directory_assignment_not_blocked(self):
+        """Regression: a cron preflight .sh script whose body contains
+        ``SRC=/tmp/tabjoy-e2e`` (a directory assignment, not an executable
+        reference) and heredoc-echoed status strings used to be hard-blocked
+        because the bare-path walker yielded any token containing a slash
+        and ``_read_referenced_script`` returned unsafe=True for directories.
+        The walker is now restricted to real files, so the innocent preflight
+        is allowed through. The actual preflight script is the canonical
+        repro — kept here as a regression guard."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        preflight = "/home/hermes/.hermes/scripts/tabjoy-e2e-preflight.sh"
+        import os
+        if not os.path.isfile(preflight):
+            pytest.skip(f"{preflight} not present in this environment")
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"sh {preflight}", cwd="/home/hermes"
+        )
+        assert result is False
+
+    def test_shell_script_with_directory_assignment_and_lifecycle_still_blocked(
+        self, tmp_path
+    ):
+        """Regression: the real-file restriction must NOT silently
+        disable the walker for genuine threats. A .sh script that assigns a
+        path to a variable AND invokes a direct lifecycle command is still
+        caught by the direct regex scan on the script body. This proves
+        the fix narrows the walker without weakening the guard."""
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        script = tmp_path / "ops.sh"
+        script.write_text(
+            "#!/bin/bash\n"
+            "SRC=/tmp/tabjoy-e2e\n"
+            "hermes gateway restart\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_bare_path_walker_only_yields_real_files(self, tmp_path):
+        """Regression: the bare-path branch of ``_iter_referenced_shell_scripts``
+        (tokens without a leading shell executable) must only yield paths
+        that resolve to a real regular file. Directory tokens,
+        path-shaped strings in heredocs/comments, and bare ``./`` paths
+        pointing at non-existent entries are skipped — they cannot be
+        shell-script references by construction. A real file with any
+        name (including no extension) IS yielded so the upstream
+        cloud-placeholder branch can fail closed on it."""
+        from cron.lifecycle_guard import _iter_referenced_shell_scripts
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "real.sh").write_text("#!/bin/bash\necho hi\n")
+        (scripts_dir / "noext").write_text("#!/bin/bash\necho noext\n")
+        # A directory that the walker used to yield and crash on:
+        dir_token = tmp_path / "src-dir"
+        dir_token.mkdir()
+        command = (
+            "#!/usr/bin/env bash\n"
+            f"SRC={dir_token}\n"
+            "./real.sh\n"               # bare path, real script
+            "./noext\n"                # bare path, real file no extension
+            "./missing\n"               # bare path, missing
+            "cat <<EOF\n"
+            "missing/incomplete: $x\n"
+            "EOF\n"
+        )
+        yielded = list(
+            _iter_referenced_shell_scripts(command, cwd=str(scripts_dir))
+        )
+        names = sorted(p.name for p in yielded)
+        # Real files are yielded (any name); directory / missing / heredoc
+        # tokens are skipped.
+        assert names == ["noext", "real.sh"]
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -100,6 +100,71 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_dependency_block_names_sibling_creates_parent_link(kanban_home: Path) -> None:
+    """A dependency block naming sibling X links the blocked card to X."""
+    with kb.connect_closing() as conn:
+        sibling = kb.create_task(conn, title="sibling", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason=f"waiting on sibling {sibling}", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        link = conn.execute(
+            "SELECT parent_id, child_id FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (sibling, child),
+        ).fetchone()
+        assert link is not None, "expected parent link child -> sibling"
+        ev = [e for e in kb.list_events(conn, child)
+              if e.kind == "dependency_wait"][-1]
+        payload = ev.payload or {}
+        assert payload.get("sibling_id") == sibling
+        assert payload.get("sibling_resolved") is True
+        assert payload.get("link_created") is True
+
+
+def test_dependency_block_unknown_sibling_fails_safe(kanban_home: Path) -> None:
+    """An unresolvable sibling id still blocks, with alert metadata recorded."""
+    with kb.connect_closing() as conn:
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason="waiting on t_ffffffff (missing)", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        assert conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id = ?", (child,)
+        ).fetchone() is None
+        ev = [e for e in kb.list_events(conn, child)
+              if e.kind == "dependency_wait"][-1]
+        payload = ev.payload or {}
+        assert payload.get("sibling_resolved") is False
+        assert payload.get("link_created") is False
+
+
+def test_dependency_block_sibling_gates_recompute_ready(kanban_home: Path) -> None:
+    """A dependency-blocked card stays parked until the named sibling completes."""
+    with kb.connect_closing() as conn:
+        sibling = kb.create_task(conn, title="sibling", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason=f"needs {sibling} first", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        # Sibling still incomplete: recompute_ready must NOT re-promote.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+        # Sibling completes: the card may now promote.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (sibling,))
+        kb.claim_task(conn, sibling, claimer="worker")
+        kb.complete_task(conn, sibling, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two fleet-hardened fixes originally carried as local-only patches (t_51d1ed3b "Move fleet-local upstream infra out where feasible"):

**1. Lifecycle walker: bare-path branch yields only real files**

`cron/lifecycle_guard.py` `_references_at` bare-path branch used to yield any slash-containing token that resolved to a path, including directories (`SRC=/tmp/tabjoy-e2e`), heredoc-echoed status strings, and comment fragments. `_read_referenced_script` then returned `unsafe=True` for directories, hard-blocking innocent cron preflight scripts. Now only regular files are yielded; the cloud-placeholder branch upstream of `_read_referenced_script` still fails closed on anything that turns out to be a FileProvider placeholder.

Ported onto current main (upstream had rewritten `_iter_referenced_shell_scripts` into `_references_at` since the original patch was authored) — same one-guard change, same regression tests.

**2. Dependency-block outcomes create parent links to named siblings**

`hermes_cli/kanban_db.py`: when a task is blocked because a dependency is blocked/missing, the block record now links the task to the sibling cards it names, so consumers can traverse dependency-block parents instead of guessing which card blocked which.

## Tests

```
TMPDIR=~/tmp .venv/bin/python -m pytest \
  tests/hermes_cli/test_gateway_restart_loop.py \
  tests/hermes_cli/test_kanban_block_kinds.py -q
# 305 passed
```

Coverage: directory-assignment preflight allowed through; direct lifecycle command still caught; bare-path walker yields real files only (any name, no extension requirement); dependency-block parent links present on named siblings.