### PR TITLE
fix(dashboard-auth): support durable restricted OIDC sessions

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -184,6 +184,8 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         client_id: str,
         scopes: str = _DEFAULT_SCOPES,
         client_secret: str = "",
+        authorization_params: Dict[str, str] | None = None,
+        allowed_emails: list[str] | None = None,
     ) -> None:
         if not issuer:
             raise ValueError("issuer is required")
@@ -202,6 +204,29 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # provisioned-but-blank secret can't flip us into a broken confidential
         # mode that sends an empty client_secret. Non-empty ⇒ confidential.
         self._client_secret = (client_secret or "").strip()
+        reserved_params = {
+            "response_type", "client_id", "redirect_uri", "scope", "state",
+            "code_challenge", "code_challenge_method",
+        }
+        self._authorization_params: Dict[str, str] = {}
+        for key, value in (authorization_params or {}).items():
+            normalized_key = str(key).strip()
+            normalized_value = str(value).strip()
+            if not normalized_key or not normalized_value:
+                raise ValueError(
+                    "authorization_params keys and values must be non-empty"
+                )
+            if normalized_key in reserved_params:
+                raise ValueError(
+                    "authorization_params cannot override reserved parameter "
+                    f"{normalized_key!r}"
+                )
+            self._authorization_params[normalized_key] = normalized_value
+        self._allowed_emails = {
+            str(email).strip().casefold()
+            for email in (allowed_emails or [])
+            if str(email).strip()
+        }
 
         # Discovery + JWKS are lazily resolved on first use so plugin
         # registration never makes a network call (the IDP may be down at
@@ -232,6 +257,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        params.update(self._authorization_params)
         redirect_url = (
             f"{disco['authorization_endpoint']}?{urllib.parse.urlencode(params)}"
         )
@@ -680,6 +706,11 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             raise ProviderError("ID token missing 'sub' (user_id) claim")
 
         email = str(claims.get("email", "") or "")
+        if self._allowed_emails:
+            if claims.get("email_verified") is not True:
+                raise ProviderError("OIDC identity email is not verified")
+            if email.casefold() not in self._allowed_emails:
+                raise ProviderError("OIDC identity email is not allowed")
         # Standard OIDC display claims, in preference order.
         display_name = str(
             claims.get("name")
@@ -822,6 +853,24 @@ def register(ctx) -> None:
     client_secret = _resolve_setting(
         "HERMES_DASHBOARD_OIDC_CLIENT_SECRET", oidc_cfg.get("client_secret")
     )
+    raw_authorization_params = oidc_cfg.get("authorization_params", {})
+    raw_allowed_emails = oidc_cfg.get("allowed_emails", [])
+    if not isinstance(raw_authorization_params, dict):
+        LAST_SKIP_REASON = (
+            "dashboard.oauth.self_hosted.authorization_params must be a mapping"
+        )
+        logger.warning("dashboard-auth-self-hosted: %s", LAST_SKIP_REASON)
+        return
+    if not isinstance(raw_allowed_emails, list):
+        LAST_SKIP_REASON = (
+            "dashboard.oauth.self_hosted.allowed_emails must be a list"
+        )
+        logger.warning("dashboard-auth-self-hosted: %s", LAST_SKIP_REASON)
+        return
+    authorization_params = {
+        str(key): str(value) for key, value in raw_authorization_params.items()
+    }
+    allowed_emails = [str(value) for value in raw_allowed_emails]
 
     if not issuer or not client_id:
         LAST_SKIP_REASON = (
@@ -842,6 +891,8 @@ def register(ctx) -> None:
             client_id=client_id,
             scopes=scopes,
             client_secret=client_secret,
+            authorization_params=authorization_params,
+            allowed_emails=allowed_emails,
         )
     except (ValueError, ProviderError) as exc:
         LAST_SKIP_REASON = (
@@ -853,10 +904,12 @@ def register(ctx) -> None:
     ctx.register_dashboard_auth_provider(provider)
     logger.info(
         "dashboard-auth-self-hosted: registered provider "
-        "(issuer=%s, client_id=%s, scopes=%r, confidential=%s)",
+        "(issuer=%s, client_id=%s, scopes=%r, confidential=%s, "
+        "email_allowlist=%s)",
         issuer,
         client_id,
         scopes,
         # Log only whether a secret is present, never the secret itself.
         bool(client_secret),
+        bool(allowed_emails),
     )

--- a/plugins/dashboard_auth/self_hosted/plugin.yaml
+++ b/plugins/dashboard_auth/self_hosted/plugin.yaml
@@ -1,6 +1,6 @@
 name: self-hosted
 version: 1.0.0
-description: "Dashboard auth provider — generic self-hosted OpenID Connect (authorization-code + PKCE, public client). Works against any conformant OIDC identity provider (Authentik, Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …) via OIDC discovery. Auto-activates when an issuer + client_id are configured, either under dashboard.oauth.self_hosted.{issuer,client_id} in config.yaml (canonical surface) or via the HERMES_DASHBOARD_OIDC_ISSUER + HERMES_DASHBOARD_OIDC_CLIENT_ID env vars (operator override / secret injection). Scopes default to 'openid profile email'. Verifies the OIDC ID token (RS256/ES256) against the discovered jwks_uri."
+description: "Dashboard auth provider — generic self-hosted OpenID Connect (authorization-code + PKCE). Works against any conformant OIDC identity provider (Authentik, Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …) via OIDC discovery. Auto-activates when an issuer + client_id are configured under dashboard.oauth.self_hosted in config.yaml or via operator environment overrides. Supports confidential clients, provider-specific authorization parameters, and an optional verified-email allowlist. Scopes default to 'openid profile email'. Verifies the OIDC ID token (RS256/ES256) against the discovered jwks_uri."
 author: NousResearch
 kind: backend
 requires_env:

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -133,6 +133,8 @@ def _make_provider(
     scopes: str | None = None,
     client_secret: str | None = None,
     auth_methods: Any = "__unset__",
+    authorization_params: Dict[str, str] | None = None,
+    allowed_emails: list[str] | None = None,
 ):
     """Construct a provider with discovery + JWKS stubbed (no network).
 
@@ -146,6 +148,10 @@ def _make_provider(
         kwargs["scopes"] = scopes
     if client_secret is not None:
         kwargs["client_secret"] = client_secret
+    if authorization_params is not None:
+        kwargs["authorization_params"] = authorization_params
+    if allowed_emails is not None:
+        kwargs["allowed_emails"] = allowed_emails
     p = oidc_plugin.SelfHostedOIDCProvider(**kwargs)
     # Pre-seed discovery so nothing hits the network.
     disco = dict(_DISCOVERY_DOC)
@@ -311,6 +317,29 @@ class TestStartLogin:
         assert "state" in params
         assert "code_challenge" in params
 
+    def test_additional_authorization_params_support_offline_sessions(
+        self, rsa_keypair
+    ):
+        provider = _make_provider(
+            rsa_keypair,
+            authorization_params={"access_type": "offline", "prompt": "consent"},
+        )
+        result = provider.start_login(
+            redirect_uri="https://hermes.example/auth/callback"
+        )
+        params = dict(
+            urllib.parse.parse_qsl(urllib.parse.urlparse(result.redirect_url).query)
+        )
+        assert params["access_type"] == "offline"
+        assert params["prompt"] == "consent"
+
+    def test_additional_authorization_params_cannot_override_pkce(self, rsa_keypair):
+        with pytest.raises(ValueError, match="reserved parameter"):
+            _make_provider(
+                rsa_keypair,
+                authorization_params={"redirect_uri": "https://evil.example/callback"},
+            )
+
 
     def test_state_in_cookie_matches_url(self, provider):
         result = provider.start_login(
@@ -361,6 +390,47 @@ class TestCompleteLogin:
         # The verified ID token is stored in the access_token slot.
         assert session.access_token == id_token
         assert session.refresh_token == "rt_initial"
+
+    def test_email_allowlist_accepts_verified_address_case_insensitively(
+        self, rsa_keypair
+    ):
+        provider = _make_provider(rsa_keypair, allowed_emails=["ALICE@example.com"])
+        id_token = _mint_id_token(rsa_keypair, extra_claims={"email_verified": True})
+        mock_resp = _mock_post(200, {"id_token": id_token, "refresh_token": "rt"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            session = provider.complete_login(
+                code="abc",
+                state="s",
+                code_verifier="vfy",
+                redirect_uri="https://hermes.example/auth/callback",
+            )
+        assert session.email == "alice@example.com"
+
+    @pytest.mark.parametrize(
+        ("email", "verified", "message"),
+        [
+            ("mallory@example.com", True, "not allowed"),
+            ("alice@example.com", False, "not verified"),
+            ("alice@example.com", None, "not verified"),
+        ],
+    )
+    def test_email_allowlist_fails_closed(self, rsa_keypair, email, verified, message):
+        provider = _make_provider(rsa_keypair, allowed_emails=["alice@example.com"])
+        extra = {} if verified is None else {"email_verified": verified}
+        id_token = _mint_id_token(rsa_keypair, email=email, extra_claims=extra)
+        mock_resp = _mock_post(200, {"id_token": id_token, "refresh_token": "rt"})
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(ProviderError, match=message):
+                provider.complete_login(
+                    code="abc",
+                    state="s",
+                    code_verifier="vfy",
+                    redirect_uri="https://hermes.example/auth/callback",
+                )
 
     def test_tolerates_missing_refresh_token(self, provider, rsa_keypair):
         id_token = _mint_id_token(rsa_keypair)
@@ -652,6 +722,53 @@ class TestPluginRegister:
         assert registered._scopes == "openid profile email"
         assert oidc_plugin.LAST_SKIP_REASON == ""
 
+    def test_registers_behavioral_policy_from_config(self, patch_config):
+        patch_config(
+            {
+                "self_hosted": {
+                    "issuer": _ISSUER,
+                    "client_id": _CLIENT_ID,
+                    "authorization_params": {
+                        "access_type": "offline",
+                        "prompt": "consent",
+                    },
+                    "allowed_emails": ["alice@example.com"],
+                }
+            }
+        )
+        ctx = MagicMock()
+        oidc_plugin.register(ctx)
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._authorization_params == {
+            "access_type": "offline",
+            "prompt": "consent",
+        }
+        assert registered._allowed_emails == {"alice@example.com"}
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("authorization_params", "access_type=offline", "must be a mapping"),
+            ("allowed_emails", "alice@example.com", "must be a list"),
+        ],
+    )
+    def test_invalid_behavioral_policy_fails_closed(
+        self, patch_config, field, value, message
+    ):
+        patch_config(
+            {
+                "self_hosted": {
+                    "issuer": _ISSUER,
+                    "client_id": _CLIENT_ID,
+                    field: value,
+                }
+            }
+        )
+        ctx = MagicMock()
+        oidc_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert message in oidc_plugin.LAST_SKIP_REASON
+
 
     def test_env_overrides_config(self, patch_config, monkeypatch):
         patch_config(
@@ -726,4 +843,3 @@ class TestPluginRegister:
         oidc_plugin.register(ctx)
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._client_secret == "cfg-secret"
-

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -822,6 +822,15 @@ dashboard:
       issuer: https://auth.example.com/application/o/hermes/   # required
       client_id: hermes-dashboard                              # required
       scopes: "openid profile email"                           # optional (this is the default)
+      # Optional provider-specific authorize parameters. Required keys such as
+      # redirect_uri, state, and PKCE parameters cannot be overridden.
+      authorization_params:
+        access_type: offline
+        prompt: consent
+      # Optional fail-closed identity policy. Every listed address must appear
+      # in a verified email claim in the ID token.
+      allowed_emails:
+        - operator@example.com
 ```
 
 **Environment variables** — operator overrides (env wins over `config.yaml` when set non-empty; an empty value is treated as unset):
@@ -833,6 +842,13 @@ dashboard:
 | `HERMES_DASHBOARD_OIDC_SCOPES` | `dashboard.oauth.self_hosted.scopes` | Defaults to `openid profile email` |
 
 In your IDP, register a **public** application/client with the authorization-code + PKCE (S256) grant and add the dashboard's callback as an allowed redirect URI. The callback is `<dashboard public URL>/auth/callback` (see [Public URL override](#public-url-override) for how the dashboard derives its public URL behind a proxy).
+
+`authorization_params` is useful for providers whose durable-session switch is
+not expressed as a standard scope. For example, Google requires
+`access_type: offline` to issue a refresh token and may require
+`prompt: consent` when consent was previously granted. `allowed_emails` limits
+dashboard access after cryptographic ID-token verification; an unverified or
+unlisted address is rejected server-side.
 
 #### What it verifies
 


### PR DESCRIPTION
Summary:
- allow provider-specific authorization parameters without permitting overrides of Hermes-owned OAuth and PKCE fields
- add an optional verified-email allowlist enforced after ID-token verification
- fail closed on malformed policy configuration
- document Google offline-session parameters

Why:
The generic OIDC provider advertises Google compatibility, but Google requires access_type=offline and sometimes prompt=consent to issue a refresh token. Operators also need a server-side identity restriction when an external IdP application cannot restrict its audience to one account.

Verification:
- ruff check passed
- focused dashboard-auth suite: 41 passed