### PR TITLE
fix(desktop): only redirect stdout for the TUI gateway subprocess

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -17,6 +17,12 @@ import threading
 import time
 import traceback
 
+# This process speaks JSON-RPC over stdin/stdout (see main() below). Tell
+# tui_gateway.server it owns stdout as the protocol channel so the module
+# keeps its stdout->stderr redirect; every non-gateway importer (web server,
+# dashboard, desktop-embedded gateway) skips it and keeps sys.stdout intact.
+os.environ.setdefault("HERMES_TUI_GATEWAY_PROCESS", "1")
+
 from tui_gateway._stdin_recovery import handle_spurious_eof
 
 from tui_gateway import server

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -396,9 +396,15 @@ _current_rpc_method: contextvars.ContextVar[str] = contextvars.ContextVar(
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
-# of corrupting the JSON protocol.
+# of corrupting the JSON protocol. Only the TUI gateway SUBPROCESS
+# (tui_gateway.entry — which sets HERMES_TUI_GATEWAY_PROCESS) owns stdout as a
+# protocol channel. Every other importer (web server / dashboard / delegate
+# tool / desktop-embedded gateway) must keep sys.stdout intact: the desktop
+# announces its backend port on the real stdout pipe, and a module-level
+# stdout redirect here silently breaks that announcement (issue #96548).
 _real_stdout = sys.stdout
-sys.stdout = sys.stderr
+if os.environ.get("HERMES_TUI_GATEWAY_PROCESS") == "1":
+    sys.stdout = sys.stderr
 
 
 class _DropTransport:


### PR DESCRIPTION
## Summary

On Windows the Desktop app fails to start: Electron spawns the serve backend and listens for `HERMES_BACKEND_READY` on the child's **stdout** pipe, but the sentinel never arrives there and the app times out after 90s:

```
[boot] Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
[profiles] refreshProfiles failed ... Timed out waiting for Hermes backend port announcement (90000ms)
```

### Root cause

`tui_gateway/server.py` runs this at **module import time** (line ~401):

```python
_real_stdout = sys.stdout
sys.stdout = sys.stderr   # JSON-RPC stdout safety for the TUI gateway
```

The redirect is intentional for the TUI gateway **subprocess** (which speaks JSON-RPC over stdin/stdout), but it is an *unconditional module-level side effect*: every process that imports `tui_gateway.server` loses its stdout. The serve/dashboard backend the Desktop spawns imports it inside `_serve()` (`hermes_cli/web_server.py:19780`), so its `HERMES_BACKEND_READY` sentinel is printed to stderr while Electron listens on the stdout pipe only → 90s timeout.

Regression window: introduced by `6d4e851d80` ("fix(serve): bounded flush-on-SIGTERM…"), which added the `from tui_gateway.server import install_exit_flush_signal_handlers` import to the serve path in v0.20.5. Before that the desktop backend either used a fixed port (dashboard mode) or never imported `tui_gateway.server`.

### This change

Gate the stdout→stderr redirect on `HERMES_TUI_GATEWAY_PROCESS`:

- `tui_gateway/entry.py` — the actual gateway subprocess — sets `HERMES_TUI_GATEWAY_PROCESS=1` before importing `server`, so the JSON-RPC protocol protection is fully preserved.
- `tui_gateway/server.py` — only redirects `sys.stdout` when that flag is set. All other importers (web server, dashboard, desktop-embedded gateway, delegate tool) keep `sys.stdout` intact, so the READY sentinel reaches Electron again.

No change to the desktop announcement code itself — the sentinel uses the plain `print()` it always did.

## Test Plan

- Non-gateway import: `sys.stdout` unchanged after `import tui_gateway.server`.
- Gateway subprocess (`HERMES_TUI_GATEWAY_PROCESS=1`): `sys.stdout` still redirected to `sys.stderr` (protocol intact).
- `python -m hermes_cli.main serve --host 127.0.0.1 --port 0 > out.log 2> err.log` → `HERMES_BACKEND_READY port=...` appears in `out.log`; `err.log` clean.
- Desktop boot completes past the port-announcement wait on Windows 11.

Fixes #96548