### PR TITLE
fix(desktop): show owning-profile badge on cron job rows

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -2,6 +2,7 @@ import { createCronTriggerController, type CronTriggerController } from '@hermes
 import { useStore } from '@nanostores/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { ProfileTag } from '@/app/chat/profile-tag'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
@@ -366,6 +367,9 @@ function CronJobSidebarRow({
                 />
               </SidebarRowLead>
               <SidebarRowLabel className="group-hover/cron:text-foreground">{label}</SidebarRowLabel>
+              {/* Owning-profile chip — same tag the session rows wear, so a
+                  cross-profile list reads as many owners at a glance. */}
+              {job.profile ? <ProfileTag profile={job.profile} /> : null}
               <DisclosureCaret
                 className={cn(
                   'shrink-0 text-(--ui-text-tertiary) transition',

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { ProfileTag } from '@/app/chat/profile-tag'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -770,6 +771,11 @@ function CronJobListRow({
       dotClassName={STATE_DOT[state] ?? 'bg-muted-foreground'}
       menuItems={menuItems}
       menuLabel={menuLabel}
+      meta={
+        // Owning-profile chip — same tag the sidebar session rows wear, so a
+        // cross-profile list reads as many owners at a glance.
+        job.profile ? <ProfileTag profile={job.profile} /> : undefined
+      }
       onSelect={onSelect}
       rowKey={job.id}
       title={jobTitle(job)}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -854,6 +854,9 @@ export interface CronJob {
   name?: null | string
   next_run_at?: null | string
   no_agent?: boolean
+  // Owning profile, stamped by the backend on every job (web_server
+  // _annotate_cron_job). Present on single-profile fetches too ('default').
+  profile?: null | string
   prompt?: null | string
   provider?: null | string
   schedule?: CronJobSchedule


### PR DESCRIPTION
## What does this PR do?

The backend already stamps every cron job with its owning profile
(`web_server.py` → `_annotate_cron_job` adds `profile`, `profile_name`,
`hermes_home`, `is_default_profile` to each job in the
`/api/cron/jobs` response, for both the aggregated `profile=all` fetch
and single-profile fetches). The desktop UI dropped the field: the
`CronJob` type never declared it, and neither the sidebar cron section
nor the full cron page rendered it.

In an aggregated (all-profiles) cron list, every job looked identical —
no way to tell which profile owns and fires it. This adds a small
owning-profile chip to each cron row, reusing the existing `ProfileTag`
component that session rows already wear, so the badge is visually
identical to the profile chips in the session list.

No backend or API changes — pure display.

## Related Issue

No issue filed. Follow-on display gap from the profile-identity work
(see #94450, which this does not depend on — it only consumes data the
backend already ships).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/types/hermes.ts` — added `profile?: null | string`
  to the `CronJob` interface (field already present in API payloads).
- `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx` —
  `CronJobSidebarRow` renders `<ProfileTag profile={job.profile} />`
  after the job label when the field is present.
- `apps/desktop/src/app/cron/index.tsx` — `CronJobListRow` passes the
  same chip through `PanelListRow`'s `meta` slot.

## How to Test

1. `cd apps/desktop && npm run build && npx tsc --build tsconfig.json`
   — typecheck clean.
2. `npx vitest run src/app/cron src/app/chat/profile-tag.test.tsx
   src/app/chat/sidebar/cron-jobs-section.test.tsx` — all pass
   (35/35 on this branch).
3. Manual: run with 2+ profiles that each have ≥1 cron job, open the
   sidebar in the aggregated (all-profiles) view — each row now shows
   its owner's chip. Same for the full cron page (Cmd/Ctrl-shift-C or
   the cron icon). Single-profile view is unaffected visually (chip
   shows the one owner, consistent with session rows).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites: `tsc --build`, `eslint`, and `vitest run src/app/cron src/app/chat/profile-tag.test.tsx src/app/chat/sidebar/cron-jobs-section.test.tsx` — all pass (35/35). Python `tests/` untouched by this PR (display-only frontend change).
- [ ] I've added tests for my changes — not added; the chip reuses the already-tested `ProfileTag` component and the touched rows are covered by the existing `cron-jobs-section`/`cron` suites.
