### PR TITLE
fix(mcp): re-import SDK when symbols are only partially bound

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1375,6 +1375,40 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_partial_sdk_symbols_trigger_reimport_not_nameerror(self):
+        """Regression test for #96528.
+
+        When only ``ClientSession`` is bound but ``StdioServerParameters``
+        is still ``None`` (e.g. a test or external code sets one symbol but
+        not the other), ``_ensure_mcp_sdk()`` must NOT short-circuit on the
+        partial state — it must re-import and bind all symbols. Otherwise
+        ``_run_stdio`` leaks a bare ``NameError: name 'StdioServerParameters'
+        is not defined``.
+        """
+        import tools.mcp_tool as m
+        pytest.importorskip("mcp", reason="mcp SDK not installed")
+
+        async def _test():
+            # Simulate partial symbol state: ClientSession bound,
+            # StdioServerParameters missing.
+            orig_cs = m.ClientSession
+            orig_ssp = m.StdioServerParameters
+            orig_attempted = m._MCP_SDK_IMPORT_ATTEMPTED
+            try:
+                m.ClientSession = MagicMock()
+                m.StdioServerParameters = None
+                m._MCP_SDK_IMPORT_ATTEMPTED = False
+                # Force a re-import so all symbols get bound.
+                assert m._ensure_mcp_sdk() is True
+                # After _ensure_mcp_sdk, StdioServerParameters must be bound.
+                assert m.StdioServerParameters is not None
+            finally:
+                m.ClientSession = orig_cs
+                m.StdioServerParameters = orig_ssp
+                m._MCP_SDK_IMPORT_ATTEMPTED = orig_attempted
+
+        asyncio.run(_test())
+
 # ---------------------------------------------------------------------------
 # Reconnection logic
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -282,6 +282,7 @@ if not _MCP_AVAILABLE:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
 ClientSession: Any = None
+StdioServerParameters: Any = None
 _MCP_SDK_IMPORT_ATTEMPTED = False
 _MCP_SDK_IMPORT_LOCK = threading.Lock()
 
@@ -334,10 +335,10 @@ def _ensure_mcp_sdk() -> bool:
 
     if not _MCP_AVAILABLE:
         return False
-    if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None:
+    if _MCP_SDK_IMPORT_ATTEMPTED or (ClientSession is not None and StdioServerParameters is not None):
         return _MCP_AVAILABLE
     with _MCP_SDK_IMPORT_LOCK:
-        if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None:
+        if _MCP_SDK_IMPORT_ATTEMPTED or (ClientSession is not None and StdioServerParameters is not None):
             return _MCP_AVAILABLE
         try:
             from mcp import ClientSession, StdioServerParameters


### PR DESCRIPTION
## Summary

Fixes #96528.

`_ensure_mcp_sdk()` short-circuits on `ClientSession is not None`, but
`ClientSession` is the only SDK symbol with a module-level `None` sentinel.
If `ClientSession` gets bound without `StdioServerParameters` (partial
import state, external symbol injection, or a test mock), the guard returns
`True` without binding the remaining symbols, and `_run_stdio` leaks a bare
`NameError: name 'StdioServerParameters' is not defined`.

## Root cause

The lazy-import refactor (startup latency optimization) moved SDK imports
from module-level into `_ensure_mcp_sdk()`. The early-return guard checks:

```python
if _MCP_SDK_IMPORT_ATTEMPTED or ClientSession is not None:
    return _MCP_AVAILABLE
```

This assumes that if `ClientSession` is non-None, all other symbols were
bound in the same import. But `ClientSession` is the only symbol with a
module-level `None` sentinel (line 284), so it's the only one that can be
set independently. Any code path that sets `ClientSession` without
`StdioServerParameters` (a test mock, an external patch, or a partial
import) causes the guard to return `True` while `StdioServerParameters`
remains undefined.

## Fix

1. Add a module-level `None` sentinel for `StdioServerParameters` (matching
   `ClientSession`'s pattern).
2. Require BOTH symbols to be non-None in the early-return guard so partial
   state triggers a full re-import.

## Reproduction

```python
import tools.mcp_tool as m
m.ClientSession = <some mock or class>
m.StdioServerParameters = None  # not bound
m._ensure_mcp_sdk()  # returns True (bug!)
# Now _run_stdio raises NameError: StdioServerParameters not defined
```

## Testing

- Added regression test `test_partial_sdk_symbols_trigger_reimport_not_nameerror`
  in `tests/tools/test_mcp_tool.py`.
- All 99 MCP tool tests pass.
- All 22 related MCP tests (issue_948, stdio_encoding, startup_latency) pass.
