### PR TITLE
fix(runtime_provider): skip providers entries with non-string base_url instead of crashing

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -774,6 +774,19 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             ):
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                if base_url and not isinstance(base_url, str):
+                    # A malformed entry (e.g. a YAML list under base_url/api)
+                    # must not crash every auxiliary resolve with
+                    # ``'list' object has no attribute 'strip'`` (#96512) —
+                    # treat it as unmatched, mirroring the legacy
+                    # ``custom_providers`` scan's isinstance guard below.
+                    logger.warning(
+                        "providers.%s: base_url/api/url must be a string, got %s "
+                        "— entry ignored during custom provider resolution",
+                        ep_name,
+                        type(base_url).__name__,
+                    )
+                    continue
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1624,6 +1624,71 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["requested_provider"] == "custom:lmstudio"
 
 
+def test_providers_dict_entry_with_list_base_url_is_skipped_not_crash(monkeypatch):
+    """A ``providers:`` entry whose base_url/api/url is a YAML list must be
+    ignored during custom provider resolution instead of raising
+    ``'list' object has no attribute 'strip'``.
+
+    Regression for #96512: ``vision_analyze`` with an auxiliary vision model
+    on a custom OpenAI-compatible provider crashed with that AttributeError
+    deep inside ``_get_named_custom_provider`` whenever the matching entry
+    carried a non-string base URL, and the tool surfaced the raw
+    ``'list' object has no attribute 'strip'`` string. Mirrors the legacy
+    ``custom_providers`` scan, which already guards name/base_url types.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("MYGATEWAY_TEST_KEY", "test-key-value")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mygateway": {
+                    "name": "mygateway",
+                    "base_url": ["http://localhost:4000/v1"],
+                    "key_env": "MYGATEWAY_TEST_KEY",
+                    "default_model": "databricks-gemini-3-7-flash",
+                }
+            }
+        },
+    )
+
+    # Must not raise; the malformed entry is treated as unmatched.
+    assert rp._get_named_custom_provider("custom:mygateway") is None
+    assert rp._get_named_custom_provider("mygateway") is None
+
+
+def test_providers_dict_scan_continues_past_list_base_url_entry(monkeypatch):
+    """A malformed entry must not shadow later well-formed matches: the
+    providers scan keeps going and resolves the next candidate key."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("GOODGATEWAY_TEST_KEY", "test-key-value")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "broken": {
+                    "name": "broken",
+                    "api": ["http://localhost:9999/v1"],
+                },
+                "good": {
+                    "name": "good",
+                    "base_url": "http://localhost:4000/v1",
+                    "key_env": "GOODGATEWAY_TEST_KEY",
+                    "default_model": "databricks-gemini-3-7-flash",
+                },
+            }
+        },
+    )
+
+    resolved = rp._get_named_custom_provider("custom:good")
+
+    assert resolved is not None
+    assert resolved["base_url"] == "http://localhost:4000/v1"
+    assert resolved["api_key"] == "test-key-value"
+
+
 def test_resolve_runtime_provider_opencode_free_keyless_despite_exhausted_pool(monkeypatch):
     """OpenCode Free is keyless: an exhausted credential pool must not raise
     a missing-credential error. The provider resolves with the keyless


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in custom provider resolution: a `providers:` entry in config.yaml whose `base_url`/`api`/`url` key holds a non-string value (e.g. a YAML list) made `_get_named_custom_provider()` raise `AttributeError: 'list' object has no attribute 'strip'`. The error propagated all the way up to tools — `vision_analyze` with an auxiliary vision model on a custom OpenAI-compatible provider surfaced the raw string `Error analyzing image: 'list' object has no attribute 'strip'` (issue #96512).

The fix mirrors the type guard the legacy `custom_providers:` list-form scan already applies to `name`/`base_url`: a malformed entry is treated as unmatched — a warning naming the offending key and value type is logged, the scan continues past it (so later well-formed entries still resolve), and downstream callers fail soft with the actionable `No LLM provider configured for task=vision provider=... Run: hermes setup` error instead of an AttributeError.

Reproduced end-to-end before the fix with a list-valued `base_url` under `providers.mygateway` + `auxiliary.vision.provider: custom:mygateway`: `vision_analyze_tool()` returned exactly the reporter's error. After the fix the same setup returns the structured configuration error.

## Related Issue

Fixes #96512

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — in `_get_named_custom_provider()`'s `providers:` dict scan, guard `base_url` (from `api`/`url`/`base_url`) with `isinstance(..., str)` before `.strip()`; on mismatch log a warning and `continue` to the next entry, matching the legacy `custom_providers:` scan's existing guard semantics.
- `tests/hermes_cli/test_runtime_provider_resolution.py` — two regressions: (1) a list-valued `base_url` entry no longer raises and resolves to `None` for both `custom:<name>` and bare-name lookups; (2) the scan skips a malformed entry and still resolves a later well-formed one.

## How to Test

1. `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` — should pass (66 passed, including the two new regressions).
2. Manual reproduction: write a config with `providers: {mygateway: {name: mygateway, base_url: ["http://example.invalid/v1"], key_env: MYGW_KEY}}` and `auxiliary: {vision: {provider: custom:mygateway, model: some-vision-model}}`, then call `vision_analyze` on any image.
   - Observed result (before fix): `Error analyzing image: 'list' object has no attribute 'strip'`.
   - Observed result (after fix): warning `providers.mygateway: base_url/api/url must be a string, got list — entry ignored during custom provider resolution` in the log, and the tool returns `Error analyzing image: No LLM provider configured for task=vision provider=custom:mygateway. Run: hermes setup`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/hermes_cli/test_runtime_provider_resolution.py` + `tests/hermes_cli/test_config.py` — 176 passed, 4 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python type guard)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
