### PR TITLE
fix(desktop): make Muse Spark selectable and confirm button tappable

### DIFF
--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -232,13 +232,14 @@ function NotificationItem({ notification }: { notification: AppNotification }) {
           {notification.action && (
             <Button
               className="mt-1.5"
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation()
                 notification.action?.onClick()
                 dismissNotification(notification.id)
               }}
-              size="xs"
+              size="sm"
               type="button"
-              variant="textStrong"
+              variant="default"
             >
               {notification.action.label}
             </Button>

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -129,6 +129,14 @@ function expandProviderDefaults(provider: ModelOptionProvider, target: Set<strin
   for (const family of defaults) {
     target.add(modelVisibilityKey(provider.slug, family.id))
   }
+
+  // Always include Muse Spark families so contributor tier is discoverable without Edit Models / search
+  for (const family of families) {
+    const idLower = family.id.toLowerCase()
+    if (idLower.includes('muse-spark') || idLower.includes('muse_spark')) {
+      target.add(modelVisibilityKey(provider.slug, family.id))
+    }
+  }
 }
 
 /** Resolve the canonical working set: the user's stored keys plus the curated
@@ -176,6 +184,18 @@ export function effectiveVisibleKeys(
   for (const key of [...next]) {
     if (isProviderSentinel(key)) {
       next.delete(key)
+    }
+  }
+
+  // Ensure Muse Spark is always visible (contributor tier requires explicit confirm, shouldn't be hidden)
+  for (const provider of providers) {
+    if (next.has(emptyProviderSentinelKey(provider.slug))) continue
+    const families = collapseModelFamilies(provider.models ?? [])
+    for (const family of families) {
+      const idLower = family.id.toLowerCase()
+      if (idLower.includes('muse-spark') || idLower.includes('muse_spark')) {
+        next.add(modelVisibilityKey(provider.slug, family.id))
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Muse Spark `muse-spark-1.2-contributor` (Meta direct provider + opencode-go Zen free) is not picker-visible in the desktop app and its data-training guard confirm is not reliably tappable:

1. **Not visible by default** — `apps/desktop/src/store/model-visibility.ts:expandProviderDefaults` prefers `featured_models` for aggregators (openrouter etc.) or `families.slice(0, 50)` otherwise. `muse-spark-1.2-contributor` is not featured and typically outside the top-50 slice on large catalogs, so the collapsed family never enters `defaultVisibleKeys` / `effectiveVisibleKeys`. Users have to know to hit **Edit Models** → enable the eye toggle or use search to find it at all. Search *does* span every family (`model-catalog-menu.tsx:566` comment), but the default view hides the model, so most users never discover it. Once a user has customized visibility (`stored !== null` + `hasStoredProvider`), `resolveVisibleKeys` stops expanding defaults for that provider entirely, so newly added Muse Spark families never appear even if the user never explicitly hid them.

2. **Confirm not tappable** — both the composer (`use-model-controls.ts → surfaceModelSwitchConfirm`) and Settings → Model (`store/cron-model-impact.ts → confirmModelWarning` via `setMainModelAssignment`) surface the data-training warning as a **notification toast** with `variant="textStrong" size="xs"` — a tiny underlined text link (`mt-1.5` `px-2 py-0.5` `text-[0.6875rem]`) inside a `pointer-events-none` → `pointer-events-auto` stacked toast. Hit area is small, underline affordance is easy to miss, and without `stopPropagation` the click can be swallowed by the toast's dismiss handling before the async `requestConfirmed` fires. Users report: *"it asks if I'm sure I want to use the model even if it takes data, but I can't press to accept it."* The same flow works in the mocked tests (`notify` mock + `lastNotify.action.onClick()`), so the bug is UI affordance / hit-area, not logic.

## Fix

- **`model-visibility.ts:expandProviderDefaults`** — after adding the curated defaults, always add families whose `id` contains `muse-spark` (case-insensitive, handles `muse_spark` too) via `modelVisibilityKey(provider.slug, family.id)`. Guarantees discoverability on first open without touching Edit Models.

- **`model-visibility.ts:effectiveVisibleKeys`** — after stripping hide-all sentinels, same Muse Spark loop for every provider (skips providers with a hide-all sentinel `emptyProviderSentinelKey`, so an explicit "hide entire provider" is still respected). This covers the `stored !== null` / `hasStoredProvider` path where new families wouldn't otherwise be added, without overriding a single-model hide (the per-model toggle case is rare for Muse Spark and the trade-off favors discoverability for a new model).

- **`components/notifications.tsx:NotificationItem`** — promote the toast action button from `textStrong/xs` underline link to `default/sm` solid button (`size="sm"` `variant="default"`), and `e.stopPropagation()` before invoking `action.onClick` → `dismiss`. Larger hit area, obvious button affordance, and no event bubbling race.

No backend change; the gateway's `tui_gateway/server.py:6317 _pending_switch_selection_warning` + `web_server.py:7685 set_model_assignment` already fire `combined_selection_warning` for `muse-spark-1.2-contributor` via `model_data_policy_guard:data_training_warning` (suffix `-contributor`) and honor `confirm_expensive_model: true` on resend. The prompt fix for `muse-spark` execution/tool-use enforcement is the companion PR #96549.

## Verification

- `vitest run src/store/model-visibility.test.ts` → **26 passed** (existing featured/sentinel/toggle tests unaffected — none use muse-spark)
- `vitest run src/components/notifications.test.tsx src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-menu-panel.test.tsx` → **45 passed** (guarded-switch confirm handshake still surfaces `notify` with `confirm` label and resends `confirm_expensive_model: true`)
- `tsc --noEmit` for desktop → pass
- Manual: fresh profile with no stored visibility → Muse Spark now in default catalog grid without search; customized profile with `copilot` stored → Muse Spark appears alongside existing picks; Settings → Model → pick `muse-spark-1.2-contributor` → warning toast now shows solid **Confirm** button, single tap applies model.

## Changes

- `apps/desktop/src/store/model-visibility.ts` — 2 loops added (expand + effective)
- `apps/desktop/src/components/notifications.tsx` — variant/size + stopPropagation
