### PR TITLE
feat(desktop+gateway): eager workspace resolution for remote drafts (workspace.preview) + fix blank panel on new-session tabs

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -59,6 +59,7 @@ import {
   $sessions,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
+  seedRemoteWorkspaceFromPreview,
   setConnection,
   setCurrentBranch,
   setCurrentCwd,
@@ -555,6 +556,12 @@ export function useGatewayBoot({
       if (!shouldPublish()) {
         return
       }
+
+      // Covers boot and Settings-apply (this function's two callers). The
+      // footer connection picker (store/connections.ts selectConnection)
+      // needs the SAME seeding and calls the same shared helper directly —
+      // see its own call site for why this couldn't just live here alone.
+      await seedRemoteWorkspaceFromPreview(shouldPublish)
 
       const remoteDefault = await desktopDefaultCwd().catch(() => null)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -771,6 +771,20 @@ export function useSessionActions({
         if (dir === 'center' && runtimeInfo?.cwd) {
           setCurrentCwdTransient(runtimeInfo.cwd)
           setWorkspaceCwdOwner(stored)
+          // #76696's fix set $currentCwd + the owner marker so the Files pane
+          // (which keys off both, per right-sidebar/index.tsx's `hasWorkspace`
+          // check) would follow a center tile's workspace — but the pane's
+          // ownership match is against $selectedStoredSessionId too, which
+          // this path never touched. A center tile IS meant to be the focused
+          // surface (see the comment above), so it should carry the same
+          // selection a navigated session gets; without this line the pane
+          // silently blanks for every session-tab tile after the first
+          // (whose accidental null===null match on the fresh-draft path was
+          // masking this gap — traced live via hermes-ddebug's CDP session,
+          // 2026-08-27, on the workspace.preview series once it started
+          // giving tiles a real cwd to lose).
+          setSelectedStoredSessionId(stored)
+          selectedStoredSessionIdRef.current = stored
         }
 
         revealTreePane(`session-tile:${stored}`)
@@ -782,7 +796,7 @@ export function useSessionActions({
         notifyError(error, copy.createSessionFailed)
       }
     },
-    [copy, requestGateway, updateSessionState]
+    [copy, requestGateway, selectedStoredSessionIdRef, updateSessionState]
   )
 
   const openSettings = useCallback(() => {

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -21,7 +21,7 @@ import {
   refreshActiveProfile,
   requestFreshSession
 } from '@/store/profile'
-import { $connection } from '@/store/session'
+import { $connection, seedRemoteWorkspaceFromPreview } from '@/store/session'
 
 const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
 
@@ -321,6 +321,10 @@ export async function selectConnection(connectionId: string, options: SelectConn
     captureNewChatSource()
     requestFreshSession()
     await rememberConnection(connectionId)
+    // No-op most of the time (this connection was already active, so it was
+    // seeded already) — cheap safety net for the same reason as the main
+    // switch branch below; see that call site's comment.
+    void seedRemoteWorkspaceFromPreview()
 
     return
   }
@@ -436,6 +440,15 @@ export async function selectConnection(connectionId: string, options: SelectConn
       captureNewChatSource()
       requestFreshSession()
       await refreshActiveProfile()
+      // The footer connection picker is a real switch path Desktop's
+      // cwd-seeding machinery historically never covered (only boot and a
+      // Settings → Gateway apply called ensureDefaultWorkspaceCwd) — so
+      // switching to a remote gateway this way left the project tree empty
+      // with no seeding attempt at all. Read-only on the backend, so safe
+      // here; fire-and-forget (never blocks the switch on it) since a fresh
+      // draft's own workspaceCwdForNewSession read happens later, by which
+      // point this will very likely have already landed.
+      void seedRemoteWorkspaceFromPreview()
     }
   } catch (error) {
     if (revision === switchRevision) {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -8,6 +8,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { activeConnectionScopeSuffix, rescopeConnectionScopedStores } from '@/lib/connection-scoped'
 import { persistBoolean, persistString, readJson, storedBoolean, storedString, writeJson } from '@/lib/storage'
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
+import { activeGateway } from '@/store/gateway'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 import type { SessionOwnerRoute, SessionOwnerScope } from './session-request-router'
@@ -293,6 +294,38 @@ export async function ensureDefaultWorkspaceCwd(shouldPublish: () => boolean = (
   if (remembered) {
     const { cwd } = await sanitize(remembered)
     seedLiveCwd(cwd)
+  }
+}
+
+/** Resolve and PERSIST the remote workspace cwd via the backend's
+ *  `workspace.preview` RPC, when nothing is remembered for this connection
+ *  yet — read-only on the backend (no session/agent built there), so cheap
+ *  enough to call from every place a remote connection can become active.
+ *
+ *  Desktop's cwd-seeding machinery historically only ran at boot and on a
+ *  Settings → Gateway apply (`ensureDefaultWorkspaceCwd`, called from
+ *  `use-gateway-boot.ts`) — the footer connection picker's `selectConnection`
+ *  (`store/connections.ts`) never called it, so switching to a remote gateway
+ *  that way (Architecture B's actual path) left the project tree empty with
+ *  no seeding attempt at all, not even the stale-cache bug this function's
+ *  first version had. Call this from every connection-establishment path
+ *  instead of re-deriving the same logic per call site.
+ *
+ *  Persists via `setCurrentCwd` (not the transient variant) into the same
+ *  per-connection remembered cache `workspaceCwdForNewSession` reads on every
+ *  "New chat" click, so one successful resolution covers every later draft
+ *  on this connection, not just the view active when it ran. */
+export async function seedRemoteWorkspaceFromPreview(shouldPublish: () => boolean = () => true): Promise<void> {
+  if ($connection.get()?.mode !== 'remote' || $activeSessionId.get() || getRememberedWorkspaceCwd()) {
+    return
+  }
+
+  const preview = await activeGateway()
+    ?.request<{ cwd?: string }>('workspace.preview', {})
+    .catch(() => null)
+
+  if (shouldPublish() && preview?.cwd && !$activeSessionId.get() && !getRememberedWorkspaceCwd()) {
+    setCurrentCwd(preview.cwd)
   }
 }
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -160,6 +160,34 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("workspace.preview")
+def _(rid, params: dict) -> dict:
+    """Resolve the workspace a fresh draft WOULD use, without creating a
+    session or building an agent.
+
+    ``session.create`` already resolves this cwd synchronously (see above),
+    but Desktop only calls it once a draft is actually sent
+    (``createBackendSessionForSend``), so a fresh new-chat tile has nothing to
+    show a file tree against until then. This mirrors session.create's own
+    cwd/branch/project resolution — same helpers, same params (an explicit
+    ``cwd`` wins, otherwise the profile's configured ``terminal.cwd``) — but
+    skips agent construction, MCP/tool discovery, and session-row creation
+    entirely, so it's safe to call on every new-chat tile open, not just on
+    send.
+    """
+    cwd = _completion_cwd(params)
+    profile = (params.get("profile") or "").strip() or None
+    return _ok(
+        rid,
+        {
+            "cwd": cwd,
+            "branch": _git_branch_for_cwd(cwd),
+            "project": _project_info_for_cwd(cwd),
+            "profile_name": _response_profile_name(profile),
+        },
+    )
+
+
 @method("session.list")
 def _(rid, params: dict) -> dict:
     with _profile_db(params) as db:


### PR DESCRIPTION
## Problem

On a remote gateway (e.g. Windows Desktop → WSL/SSH backend), a fresh "new chat" draft shows an **empty project tree until the first message is sent**. `session.create` is the only thing that resolves a workspace cwd, and it only runs on send — so before that, the draft has nothing to render a tree against. The per-connection remembered-workspace cache that `workspaceCwdForNewSession` reads on every New Chat click stays empty until something explicitly persists it (conversation cwd-follow is transient by design).

A second, related bug: even once a workspace *is* known, every "New session" **tab** after the first opened with a blank workspace panel.

## Fix (three commits)

1. **`feat(gateway): add workspace.preview RPC`** — mirrors `session.create`'s own cwd/branch/project resolution (same helpers, same params) but builds no session row, no agent, no MCP/tool discovery. Side-effect-free, ~5 ms round-trip vs. session.create's multi-second build, so it's safe to call on every connect.

2. **`feat(desktop): resolve and persist a remote workspace via workspace.preview on every connect path`** — a shared `seedRemoteWorkspaceFromPreview()` (`store/session.ts`) called from both `use-gateway-boot`'s `seedDefaultCwd` (boot + Settings-apply) **and** `selectConnection`'s commit paths (the footer connection picker — a connection-establishment path the cwd-seeding machinery historically never covered at all). Guarded on the remote-scoped remembered cache read at call time; persists via `setCurrentCwd` into the exact cache every later New Chat reads. Falls through silently on an older backend without the method — no regression, just no improvement.

3. **`fix(desktop): openNewSessionTile's center-tile carve-out must also move $selectedStoredSessionId`** — #76696's carve-out set `$currentCwd` + the workspace-cwd owner marker for a center tile, but the right sidebar's `hasWorkspace` check also requires the owner to match `$selectedStoredSessionId`, which this path never set. The first tile after a switch masked the gap (null trivially matches null on the fresh-draft path); every subsequent "New session" tab hit it. Independent of the other two commits and valid on its own.

## How this was verified

Live on a Windows 11 Desktop + WSL remote gateway topology, driven over CDP with WebSocket-frame capture and `localStorage` instrumentation, across four patch iterations:

- `workspace.preview` observed firing on picker connect; the remembered key observed persisted; the project tree renders on a fresh draft **before any message is sent**.
- Three consecutive "New session" tabs each keep a populated workspace panel.
- Regression spot-check on the selection change: a main-composer send from a draft still creates its own session (`session.create` → `prompt.submit` captured), navigates correctly, no transcript leakage into tile sessions, no drift-abort.

Two instructive dead ends are recorded in the desktop commit message (a `$currentCwd`-based guard that is dead code due to module-load-time initialization, and the discovery that the footer picker never runs the historical seeding path at all) — they explain the shape of the final fix.

## Notes for reviewers

- The desktop half degrades gracefully against a backend without the RPC (`.catch(() => null)`), and the backend half is inert until a client calls it — but they only deliver the feature together, hence one PR.
- `tsc --noEmit` and `eslint` clean per iteration; the tree diff of this branch against the live-verified working branch is empty except for the backend commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXpEJmG9xK3AF3cvzmmpgU
