### PR TITLE
fix(gateway): preserve runtime lock during stale cleanup

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -768,27 +768,45 @@ def _running_pid_cache_signature(
     return tuple(parts)
 
 
-def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
-    """Delete a stale gateway PID file (and its sibling lock metadata).
+def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> bool:
+    """Delete stale PID metadata only while owning the runtime lock.
 
-    Called from ``get_running_pid()`` after the runtime lock has already been
-    confirmed inactive, so the on-disk metadata is known to belong to a dead
-    process.  Unlike ``remove_pid_file()`` (which defensively refuses to delete
-    a PID file whose ``pid`` field differs from ``os.getpid()`` to protect
-    ``--replace`` handoffs), this path force-unlinks both files so the next
-    startup sees a clean slate.
+    A prior lock probe is not authority to unlink later: a new gateway can
+    acquire the lock and publish its PID between those two operations.  Claim
+    the same lock inode again and keep it held through PID cleanup so a new
+    owner either wins first (and cleanup does nothing) or waits for cleanup to
+    finish.  The lock path itself is a stable rendezvous file and is never
+    removed here; the next owner overwrites its metadata after acquiring it.
+
+    Returns ``True`` only when cleanup held the lock.  ``False`` means a live
+    or concurrently starting gateway may own it, so callers must not remove
+    either identity file based on their earlier observation.
     """
     if not cleanup_stale:
-        return
-    _clear_running_pid_cache()
+        return False
+    lock_path = _get_gateway_lock_path(pid_path)
     try:
-        pid_path.unlink(missing_ok=True)
-    except Exception:
-        pass
+        handle = open(lock_path, "a+", encoding="utf-8")
+    except OSError:
+        return False
+    lock_acquired = False
     try:
-        _get_gateway_lock_path(pid_path).unlink(missing_ok=True)
-    except Exception:
-        pass
+        lock_acquired = _try_acquire_file_lock(handle)
+        if not lock_acquired:
+            return False
+        _clear_running_pid_cache()
+        try:
+            pid_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return True
+    finally:
+        if lock_acquired:
+            _release_file_lock(handle)
+        try:
+            handle.close()
+        except OSError:
+            pass
 
 
 def _write_gateway_lock_record(handle) -> None:
@@ -2358,8 +2376,15 @@ def get_running_pid(
             runtime_pid = get_runtime_status_running_pid()
             if runtime_pid is not None:
                 return runtime_pid
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
-        return None
+        if not cleanup_stale:
+            return None
+        if _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=True):
+            return None
+        # Another gateway may have acquired the lock after the first probe.
+        # Re-read it once and, if active now, validate the new owner's records
+        # below.  Ambiguous/inaccessible state stays non-destructive.
+        if not is_gateway_runtime_lock_active(resolved_lock_path):
+            return None
 
     primary_record = _read_pid_record(resolved_pid_path)
     fallback_record = _read_gateway_lock_record(resolved_lock_path)
@@ -2380,7 +2405,9 @@ def get_running_pid(
         if _record_matches_live_gateway_pid(record, pid):
             return pid
 
-    _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+    # An owned lock is authoritative even while its owner is between writing
+    # the lock record and the O_EXCL PID record.  Never unlink either path from
+    # a read-side metadata failure while the lock is active.
     if pid_path is None:
         runtime_pid = get_runtime_status_running_pid()
         if runtime_pid is not None:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -134,6 +134,114 @@ class TestGatewayPidState:
         finally:
             status.release_gateway_runtime_lock()
 
+    def test_stale_pid_cleanup_keeps_lock_rendezvous(self, tmp_path, monkeypatch):
+        """Stale PID cleanup must not unlink the path future owners lock."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        stale_record = {
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }
+        pid_path.write_text(json.dumps(stale_record), encoding="utf-8")
+        lock_path.write_text(json.dumps(stale_record), encoding="utf-8")
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: False)
+
+        assert status.get_running_pid(pid_path) is None
+        assert not pid_path.exists()
+        assert lock_path.exists()
+        assert status.is_gateway_runtime_lock_active(lock_path) is False
+
+    def test_stale_probe_cannot_unlink_a_new_gateway_identity(
+        self, tmp_path, monkeypatch
+    ):
+        """Cleanup must re-claim the lock after an inactive observation.
+
+        This deterministically reproduces the startup race: the reader first
+        observes an inactive lock, then a gateway acquires that same path and
+        publishes its PID before the reader reaches stale cleanup.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("stale", encoding="utf-8")
+        real_lock_probe = status.is_gateway_runtime_lock_active
+        probes = 0
+        process = None
+
+        def stale_then_current(path=None):
+            import subprocess
+
+            nonlocal probes, process
+            probes += 1
+            if probes == 1:
+                script = """
+import os, sys
+os.environ['HERMES_HOME'] = sys.argv[1]
+from gateway import status
+sys.argv = ['python', '-m', 'hermes_cli.main', 'gateway', 'run']
+assert status.acquire_gateway_runtime_lock()
+status.write_pid_file()
+print(os.getpid(), flush=True)
+sys.stdin.readline()
+status.remove_pid_file()
+status.release_gateway_runtime_lock()
+"""
+                process = subprocess.Popen(
+                    [sys.executable, "-c", script, str(tmp_path)],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    text=True,
+                )
+                assert int(process.stdout.readline()) == process.pid
+                return False
+            return real_lock_probe(path)
+
+        monkeypatch.setattr(
+            status,
+            "is_gateway_runtime_lock_active",
+            stale_then_current,
+        )
+        # The child command is intentionally a tiny Python fixture rather than
+        # a real gateway command; persisted metadata remains authoritative for
+        # this lock-cleanup contract.
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda _pid: None)
+
+        try:
+            assert status.get_running_pid(pid_path) == process.pid
+            assert pid_path.exists()
+            assert lock_path.exists()
+            assert json.loads(pid_path.read_text(encoding="utf-8"))["pid"] == process.pid
+            assert json.loads(lock_path.read_text(encoding="utf-8"))["pid"] == process.pid
+        finally:
+            if process is not None and process.poll() is None:
+                process.stdin.write("stop\n")
+                process.stdin.flush()
+                process.wait(timeout=5)
+
+    def test_active_lock_with_incomplete_metadata_is_never_unlinked(
+        self, tmp_path, monkeypatch
+    ):
+        """A reader may land between lock acquisition and PID publication."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            handle = status._gateway_lock_handle
+            handle.seek(0)
+            handle.truncate()
+            handle.flush()
+
+            assert status.get_running_pid(pid_path) is None
+            assert lock_path.exists()
+            assert status.is_gateway_runtime_lock_active(lock_path) is True
+        finally:
+            status.release_gateway_runtime_lock()
+
     def test_gateway_identity_files_use_process_home_not_context_override(
         self, tmp_path, monkeypatch
     ):
@@ -1436,4 +1544,3 @@ def test_strict_gateway_identity_rejects_reused_pid(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="identity changed"):
         status.get_running_pid_identity_strict(pid_path)
-


### PR DESCRIPTION
## What does this PR do?

Prevents a read-side gateway status probe from unlinking the identity files of a gateway that started after an earlier inactive-lock observation.

The runtime lock path becomes a stable rendezvous file. Stale PID cleanup now reacquires the same OS lock and holds it through PID removal. If a new gateway won the lock first, cleanup leaves both files untouched and the caller re-probes the new owner. An active lock with temporarily incomplete startup metadata is also kept non-destructive.

This addresses the remaining TOCTOU gap that runtime-status fallback does not cover: fallback can recover liveness after the paths are deleted, but it cannot preserve the singleton lock pathname or prevent a second inode from being locked.

## Related Issue

Fixes #96582

Related: #17492, #26643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/status.py: make stale PID cleanup acquire the runtime lock before mutation and never unlink the lock rendezvous path.
- gateway/status.py: re-probe after a lost cleanup race and keep active-lock/incomplete-metadata reads non-destructive.
- tests/gateway/test_status.py: add deterministic subprocess coverage for the inactive-probe/startup race.
- tests/gateway/test_status.py: cover stale PID cleanup retaining the lock path and active lock ownership with incomplete metadata.

## How to Test

1. On unmodified main, run the deterministic interleaving: the child remains alive while get_running_pid() returns None and both identity paths disappear.
2. Apply this PR and run the same interleaving: get_running_pid() returns the child PID and both paths remain visible.
3. Run:

       HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/gateway/test_status.py tests/hermes_cli/test_gateway.py tests/gateway/test_runner_startup_failures.py -q
       HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q
       python -m ruff check gateway/status.py tests/gateway/test_status.py

Observed on macOS 26.5.2 / Python 3.11.14:

- 219 focused tests passed, 0 failed, 6 platform-specific skipped.
- Ruff passed.
- Unmodified main A/B result: child alive, observed PID null, PID path absent, lock path absent.
- Patched A/B result: child alive, observed PID matches child, PID path present, lock path present.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs, including #17492 and #26643.
- [x] This PR contains only the focused gateway cleanup fix and its tests.
- [ ] I've run the entire repository test suite; focused affected suites are green as documented above.
- [x] I've added behavior tests for the bug.
- [x] I've tested on macOS 26.5.2.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the changed internal contract is documented in the function docstring and comments.
- [x] cli-config.yaml.example: N/A; no configuration changes.
- [x] CONTRIBUTING.md / AGENTS.md: N/A; no architecture or workflow changes.
- [x] Cross-platform impact considered: the fix reuses the existing POSIX/Windows lock helpers and introduces no platform-specific process APIs.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Not applicable. The regression is deterministic and covered by the subprocess test.