### PR TITLE
fix(config): keep Always Approve from reverting after later saves

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4918,13 +4918,21 @@ def save_config_value(key_path: str, value: any) -> bool:
     config_path = get_hermes_home() / 'config.yaml'
     
     try:
-        # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Save back atomically while preserving comments, ordering, quotes, and
-        # readable Unicode in user-edited config.yaml.
-        from utils import atomic_roundtrip_yaml_update
-        atomic_roundtrip_yaml_update(config_path, key_path, value)
+        from hermes_cli import config as config_module
+
+        with config_module._CONFIG_LOCK:
+            # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save back atomically while preserving comments, ordering, quotes, and
+            # readable Unicode in user-edited config.yaml.
+            from utils import atomic_roundtrip_yaml_update
+            atomic_roundtrip_yaml_update(config_path, key_path, value)
+
+            # The atomic replace invalidates stat-keyed caches naturally, but
+            # discard the raw cache eagerly for coarse-mtime filesystems.
+            config_module._RAW_CONFIG_CACHE.pop(str(config_path), None)
+            config_module._LOAD_CONFIG_CACHE.pop(str(config_path), None)
         
         # Enforce owner-only permissions on config files (contain API keys)
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -304,6 +304,20 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+
+
+class _LoadedConfig(dict):
+    """Mutable config snapshot carrying the state it was loaded from.
+
+    ``save_config`` uses the baseline for a three-way merge so a caller that
+    saves an older snapshot does not overwrite keys changed on disk since its
+    ``load_config`` call. It remains a dict subclass to preserve the public
+    return contract and normal deepcopy behavior.
+    """
+
+    def __init__(self, value: Dict[str, Any]):
+        super().__init__(value)
+        self._baseline = copy.deepcopy(value)
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -2668,6 +2682,43 @@ def _merge_partial_save(raw: dict, override: dict) -> dict:
     return result
 
 
+_CONFIG_MISSING = object()
+
+
+def _merge_loaded_config_snapshot(base: Any, requested: Any, current: Any) -> Any:
+    """Merge a loaded snapshot without clobbering newer on-disk values.
+
+    Caller changes relative to *base* win. Paths the caller left untouched
+    take their value from *current*, including additions and deletions made by
+    another config writer after the caller loaded its snapshot.
+    """
+    if requested is _CONFIG_MISSING:
+        if base is _CONFIG_MISSING:
+            return copy.deepcopy(current)
+        return _CONFIG_MISSING
+
+    if base is not _CONFIG_MISSING and requested == base:
+        return copy.deepcopy(current)
+
+    if (
+        isinstance(base, dict)
+        and isinstance(requested, dict)
+        and isinstance(current, dict)
+    ):
+        merged: Dict[str, Any] = {}
+        for key in base.keys() | requested.keys() | current.keys():
+            value = _merge_loaded_config_snapshot(
+                base.get(key, _CONFIG_MISSING),
+                requested.get(key, _CONFIG_MISSING),
+                current.get(key, _CONFIG_MISSING),
+            )
+            if value is not _CONFIG_MISSING:
+                merged[key] = value
+        return merged
+
+    return copy.deepcopy(requested)
+
+
 def _deep_merge(base: dict, override: dict) -> dict:
     """Recursively merge *override* into *base*, preserving nested defaults.
 
@@ -3585,7 +3636,7 @@ def load_config() -> Dict[str, Any]:
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return _LoadedConfig(_load_config_impl(want_deepcopy=True))
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -4041,6 +4092,17 @@ def save_config(
         if is_managed():
             managed_error("save configuration")
             return
+
+        tracked_config = config if isinstance(config, _LoadedConfig) else None
+        loaded_baseline = getattr(tracked_config, "_baseline", None)
+        requested_snapshot = copy.deepcopy(dict(config))
+        if isinstance(loaded_baseline, dict):
+            current = _load_config_impl(want_deepcopy=True)
+            config = _merge_loaded_config_snapshot(
+                loaded_baseline,
+                requested_snapshot,
+                current,
+            )
         # Managed scope: strip any leaf the managed layer pins, so a bulk write
         # (wizard / programmatic save) never persists a user value that would
         # silently lose to managed on the next load. Single-key `config set`
@@ -4130,6 +4192,11 @@ def save_config(
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        if tracked_config is not None:
+            # Track what this caller requested, not the merged disk state. This
+            # keeps a reused stale object from treating a preserved concurrent
+            # value as its own edit on the next save.
+            tracked_config._baseline = copy.deepcopy(requested_snapshot)
 
 
 def _parse_env_value(raw_value: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -318,6 +318,12 @@ class _LoadedConfig(dict):
     def __init__(self, value: Dict[str, Any]):
         super().__init__(value)
         self._baseline = copy.deepcopy(value)
+
+    def copy(self) -> "_LoadedConfig":
+        """Return a shallow snapshot without losing stale-write tracking."""
+        cloned = _LoadedConfig(dict(self))
+        cloned._baseline = copy.deepcopy(self._baseline)
+        return cloned
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -387,6 +393,11 @@ _EXTRA_ENV_KEYS = frozenset({
     "COPILOT_ACP_BASE_URL",
 })
 import yaml
+
+yaml.SafeDumper.add_representer(
+    _LoadedConfig,
+    yaml.representer.SafeRepresenter.represent_dict,
+)
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -47,6 +47,49 @@ class TestSaveConfigValueAtomic:
         result = yaml.safe_load(config_env.read_text())
         assert result["auxiliary"]["compression"]["model"] == "google/gemini-3-flash-preview"
 
+    def test_uses_shared_config_lock(self, config_env, monkeypatch):
+        """Single-key writes serialize with full save_config writes."""
+        from hermes_cli import config as config_module
+
+        class RecordingLock:
+            active = False
+
+            def __enter__(self):
+                self.active = True
+
+            def __exit__(self, *_args):
+                self.active = False
+
+        lock = RecordingLock()
+        monkeypatch.setattr(config_module, "_CONFIG_LOCK", lock)
+
+        def assert_locked(*_args):
+            assert lock.active is True
+
+        monkeypatch.setattr("utils.atomic_roundtrip_yaml_update", assert_locked)
+
+        from cli import save_config_value
+
+        assert save_config_value("display.skin", "mono") is True
+
+    def test_stale_loaded_snapshot_preserves_newer_single_key_write(
+        self, config_env
+    ):
+        """A later full save must not revert a value written after its load."""
+        from cli import save_config_value
+        from hermes_cli.config import load_config, save_config
+
+        stale = load_config()
+        assert stale["approvals"]["destructive_slash_confirm"] is True
+
+        assert save_config_value("approvals.destructive_slash_confirm", False) is True
+        stale["agent"]["max_turns"] = 42
+        save_config(stale)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["approvals"]["destructive_slash_confirm"] is False
+        assert saved["agent"]["max_turns"] == 42
+
 
 
     def test_model_write_runs_shared_cron_drift_warning(self, config_env, monkeypatch):

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -90,6 +90,34 @@ class TestSaveConfigValueAtomic:
         assert saved["approvals"]["destructive_slash_confirm"] is False
         assert saved["agent"]["max_turns"] == 42
 
+    def test_copied_stale_snapshot_preserves_newer_single_key_write(
+        self, config_env
+    ):
+        """A normal dict-style copy must retain the loaded baseline."""
+        from cli import save_config_value
+        from hermes_cli.config import load_config, save_config
+
+        stale = load_config().copy()
+        assert stale["approvals"]["destructive_slash_confirm"] is True
+
+        assert save_config_value("approvals.destructive_slash_confirm", False) is True
+        stale["agent"]["max_turns"] = 42
+        save_config(stale)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["approvals"]["destructive_slash_confirm"] is False
+        assert saved["agent"]["max_turns"] == 42
+
+    def test_loaded_config_remains_safe_yaml_serializable(self, config_env):
+        """The tracked mapping preserves the former plain-dict YAML contract."""
+        from hermes_cli.config import load_config
+
+        dumped = yaml.safe_dump(load_config())
+
+        assert yaml.safe_load(dumped)["model"]["default"] == "test-model"
+        assert "_baseline" not in dumped
+        assert "!!python" not in dumped
+
 
 
     def test_model_write_runs_shared_cron_drift_warning(self, config_env, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Keeps runtime preferences such as "Always Approve" from being silently reverted when another component later saves an older in-memory config snapshot. Config persistence now serializes single-key and full-document writes, and full saves merge caller changes against the latest disk state.

## Related Issue

Closes #96571

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` - serialize `save_config_value` with the shared config lock and invalidate config caches after its atomic write.
- `hermes_cli/config.py` - retain the baseline for mutable loaded configs and three-way merge stale full saves with current disk state.
- `tests/cli/test_cli_save_config_value.py` - cover shared locking and the reported stale `approvals.destructive_slash_confirm` overwrite.

## How to Test

1. Load config while `approvals.destructive_slash_confirm` is still `true`.
2. Persist `false` through `save_config_value`, mutate an unrelated field on the old loaded snapshot, and save that snapshot through `save_config`.
3. Verify both the newer `false` preference and the unrelated caller change remain on disk.

```bash
scripts/run_tests.sh tests/cli/test_cli_save_config_value.py tests/hermes_cli/test_config.py -q
```

Result: 122 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by deterministic unit tests.
