### PR TITLE
fix(desktop): route Ctrl+R to the terminal shell unless focus is in a webview guest

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6689,9 +6689,19 @@ function installPreviewShortcut(window) {
     // see #77845), so a menu accelerator would leave Windows and Linux with no
     // way to reload a page at all. ⇧⌘R is left alone — that is `forceReload`,
     // the unconditional whole-window escape hatch.
+    //
+    // Only claim the chord when the user is INSIDE a webview guest page: that
+    // webContents is out-of-process, so main is the only party that can
+    // reload it. Everywhere else the key is passed through to the renderer,
+    // which owns the rest of the routing — the terminal pane needs Ctrl+R to
+    // reach the shell (readline reverse-i-search), and the preview-nav
+    // registry answers when a preview tab's own chrome has focus. Without
+    // this carve-out the renderer never saw the key at all, and Ctrl+R typed
+    // in the terminal hard-reloaded the whole client.
     if (key === 'r' && accel && !input.shift) {
-      event.preventDefault()
-      sendPreviewNavCommand('reload')
+      if (commandFocusedGuest('reload')) {
+        event.preventDefault()
+      }
     }
   })
 }

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
+import { isFocusWithin } from '@/lib/keybinds/combo'
+import { isMacPlatform } from '@/lib/platform'
 import { openSession } from '@/app/open-session'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
 import { pathFromHermesDeepLink, resolveHermesOpenPath } from '@/lib/hermes-open-target'
@@ -312,7 +314,10 @@ export function useDesktopIntegrations({
   // Native browser gestures (⌘R, a mouse's back/forward buttons, a trackpad
   // swipe) that landed on the app's own chrome rather than inside a page — main
   // answers those against the focused guest and never asks. Only ⌘R has an
-  // app-level meaning to fall back to; an unfocused swipe is a no-op.
+  // app-level meaning to fall back to; an unfocused swipe is a no-op. This IPC
+  // path still serves the macOS View > Reload item; the keyboard chord itself
+  // is routed by the capture-phase handler below (main's before-input-event
+  // only claims ⌘R for webview guests now).
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onPreviewNav?.(command => {
       if (!commandFocusedPreview(command) && command === 'reload') {
@@ -321,6 +326,39 @@ export function useDesktopIntegrations({
     })
 
     return () => unsubscribe?.()
+  }, [])
+
+  // Ctrl/Cmd+R reaching the renderer (main's before-input-event hook now only
+  // claims it when focus is inside a webview guest page — the only case main
+  // can act on directly). Route by focus:
+  //   1. the terminal pane owns the chord — readline reverse-i-search needs
+  //      the key to reach the shell, so pass it through untouched,
+  //   2. a preview tab's own chrome (address bar / toolbar) reloads that tab,
+  //   3. anywhere else keeps the old app-level meaning: reload the client.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const accel = (isMacPlatform() ? event.metaKey : event.ctrlKey) && !event.altKey
+
+      if (event.key.toLowerCase() !== 'r' || !accel || event.shiftKey) {
+        return
+      }
+
+      if (isFocusWithin('[data-terminal]')) {
+        return // the terminal gets the key — bash reverse-i-search
+      }
+
+      event.preventDefault()
+
+      if (commandFocusedPreview('reload')) {
+        return // reloaded the focused preview tab
+      }
+
+      window.location.reload()
+    }
+
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [])
 
   // File > Open Folder… — same open-folder-as-project upsert as the ⌘O keybind.


### PR DESCRIPTION
## Summary

Fixes #96482 — pressing **Ctrl+R** inside the embedded terminal hard-reloads the entire desktop client instead of reaching the shell (breaking readline reverse-search and similar).

The main-process `before-input-event` hook claimed the `Ctrl/Cmd+R` chord unconditionally to drive preview reloads. This change limits main to the one case only it can act on — focus inside a **webview guest page** (out-of-process; the renderer cannot reload it) — and passes the key through everywhere else. The renderer then routes by focus: the terminal pane owns the chord for the shell, and the preview-nav registry answers when a preview tab's own chrome has focus.

## Changes

- `apps/desktop/electron/main.ts` — `installPreviewShortcut` now only `preventDefault`s Ctrl+R when `commandFocusedGuest('reload')` is true.
- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` — renderer-side capture-phase routing for Ctrl/Cmd+R by focus target (terminal → pass-through; preview chrome → reload command; else no-op), plus the macOS View > Reload IPC path retained.

## Testing

- `npm run typecheck` (renderer + electron + e2e tsconfigs) — clean
- Desktop packaged build (`hermes desktop --build-only`) — succeeds
- **Runtime verified** (Linux, desktop app restarted onto the rebuilt bundle): Ctrl+R in the embedded terminal now reaches the shell — readline reverse-search works, no client reload. Preview-pane reload via Ctrl+R with preview chrome focused also confirmed working.

## Notes

The upstream commit `4d1cdf83c9` ("claim Cmd/Ctrl+R in before-input-event so it works off macOS") introduced the unconditional claim this PR narrows; the cherry-pick of this change onto current `main` applies cleanly.
