### PR TITLE
fix(auth): restore Anthropic Pro and Max OAuth login

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1188,12 +1188,8 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
         }).encode()
         content_type = "application/x-www-form-urlencoded"
 
-    token_endpoints = [
-        "https://platform.claude.com/v1/oauth/token",
-        "https://console.anthropic.com/v1/oauth/token",
-    ]
     last_error = None
-    for endpoint in token_endpoints:
+    for endpoint in _OAUTH_TOKEN_URLS:
         req = urllib.request.Request(
             endpoint,
             data=data,
@@ -1531,13 +1527,12 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-# Anthropic migrated the OAuth token endpoint to platform.claude.com;
-# console.anthropic.com now 404s. Callers should iterate _OAUTH_TOKEN_URLS
-# (new host first, console fallback). _OAUTH_TOKEN_URL is kept as the primary
-# for backward compatibility with existing imports and now points at the live host.
+# Keep these URLs aligned with Claude Code's manual OAuth flow. Authorization
+# codes are single-use, so a rejected exchange must not be replayed to retired
+# hosts. _OAUTH_TOKEN_URL is retained for existing imports.
+_OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 _OAUTH_TOKEN_URLS = [
     "https://platform.claude.com/v1/oauth/token",
-    "https://console.anthropic.com/v1/oauth/token",
 ]
 _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 # User-Agent sent on the OAuth *token endpoint* (login exchange + refresh).
@@ -1550,7 +1545,7 @@ _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 # (build_anthropic_kwargs) still uses the ``claude-code/`` UA + ``x-app: cli`` —
 # that fingerprint is required there and is NOT throttled on the messages API.
 _OAUTH_TOKEN_USER_AGENT = "axios/1.7.9"
-_OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+_OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 def _get_hermes_oauth_file() -> Path:
     return get_hermes_home() / ".anthropic_oauth.json"
@@ -1590,7 +1585,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     }
     from urllib.parse import urlencode
 
-    auth_url = f"https://claude.ai/oauth/authorize?{urlencode(params)}"
+    auth_url = f"{_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
 
     print()
     print("Authorize Hermes with your Claude Pro/Max subscription.")
@@ -1648,9 +1643,8 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        # Anthropic migrated the OAuth token endpoint to platform.claude.com;
-        # console.anthropic.com now 404s. Try the new host first, then fall
-        # back to console for older deployments (mirrors the refresh path).
+        # Use only Claude Code's live token endpoint. Authorization codes are
+        # single-use and must not be replayed to retired fallback hosts.
         # UA is _OAUTH_TOKEN_USER_AGENT (a non-claude-code UA) — see the
         # constant's definition for why the token endpoint must not send
         # claude-code/ (429 UA-prefix block).

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -16,8 +16,12 @@ History:
 from __future__ import annotations
 
 import json
+from io import BytesIO
 from typing import Any, Dict
+from urllib.error import HTTPError
 from urllib.parse import parse_qs, urlparse
+
+import pytest
 
 
 def _patch_oauth_flow(
@@ -25,6 +29,7 @@ def _patch_oauth_flow(
     *,
     callback_code: str,
     token_response: Dict[str, Any] | None = None,
+    token_error_status: int | None = None,
     capture_token_request: Dict[str, Any] | None = None,
     capture_auth_url: Dict[str, str] | None = None,
 ) -> None:
@@ -77,8 +82,18 @@ def _patch_oauth_flow(
     def fake_urlopen(req, *_a, **_kw):
         if capture_token_request is not None:
             capture_token_request["url"] = req.full_url
+            capture_token_request["method"] = req.get_method()
             capture_token_request["data"] = json.loads(req.data.decode())
             capture_token_request["headers"] = dict(req.headers)
+            capture_token_request.setdefault("requests", []).append(req.full_url)
+        if token_error_status is not None:
+            raise HTTPError(
+                req.full_url,
+                token_error_status,
+                "Bad Request" if token_error_status == 400 else "Method Not Allowed",
+                hdrs=None,
+                fp=BytesIO(b'{"type":"error"}'),
+            )
         return _FakeResponse(json.dumps(token_response).encode())
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
@@ -185,6 +200,79 @@ def test_login_token_exchange_uses_platform_claude_host(monkeypatch, tmp_path):
         "login token exchange must target platform.claude.com first, not the "
         "dead console.anthropic.com host (regression of #45250 / #49821)"
     )
+
+
+def test_login_exchange_matches_current_claude_code_manual_flow(monkeypatch, tmp_path):
+    """The authorization and exchange redirects must use Claude Code's live URI."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_token: Dict[str, Any] = {}
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_token_request=captured_token,
+        capture_auth_url=captured_url,
+    )
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url["url"]).query)
+        return f"auth-code#{qs['state'][0]}"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    assert run_hermes_oauth_login_pure() is not None
+
+    auth_url = urlparse(captured_url["url"])
+    auth_query = parse_qs(auth_url.query)
+    assert (auth_url.scheme, auth_url.netloc, auth_url.path) == (
+        "https",
+        "claude.com",
+        "/cai/oauth/authorize",
+    )
+    assert auth_query["redirect_uri"] == [
+        "https://platform.claude.com/oauth/code/callback"
+    ]
+    assert captured_token["url"] == "https://platform.claude.com/v1/oauth/token"
+    assert captured_token["method"] == "POST"
+    assert captured_token["headers"]["Content-type"] == "application/json"
+    assert captured_token["data"]["redirect_uri"] == auth_query["redirect_uri"][0]
+    assert captured_token["data"]["state"] == auth_query["state"][0]
+    assert captured_token["data"]["code_verifier"]
+
+
+@pytest.mark.parametrize("status", [400, 405])
+def test_login_exchange_does_not_retry_rejected_request(
+    monkeypatch, tmp_path, capsys, status
+):
+    """A rejected authorization-code request must not be replayed to stale hosts."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_token: Dict[str, Any] = {}
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        token_error_status=status,
+        capture_token_request=captured_token,
+        capture_auth_url=captured_url,
+    )
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url["url"]).query)
+        return f"auth-code#{qs['state'][0]}"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    assert run_hermes_oauth_login_pure() is None
+    assert captured_token["requests"] == [
+        "https://platform.claude.com/v1/oauth/token"
+    ]
+    assert f"HTTP Error {status}" in capsys.readouterr().out
 
 
 


### PR DESCRIPTION
## What does this PR do?

Restores `hermes auth add anthropic --type oauth` for Claude Pro and Max users by matching Claude Code's current manual PKCE endpoints. Without this change, authorization can succeed in the browser but the token exchange fails with HTTP 400 or 405, leaving Anthropic unavailable to Hermes.

### Symptom

The browser authorization completes and returns a pasted `<code>#<state>` value, but Hermes cannot exchange it for credentials. Users see `Token exchange failed: HTTP Error 400: Bad Request` or `HTTP Error 405: Method Not Allowed`.

### Impact

Users relying on a Claude Pro or Max subscription cannot add Anthropic OAuth credentials through the Hermes CLI. API-key authentication is not affected.

### Bug Cause

**Trigger:** `agent/anthropic_adapter.py:run_hermes_oauth_login_pure` builds the manual authorization URL and exchanges its returned code.

**Causal chain:**
1. Hermes requests an authorization code with the retired `claude.ai/oauth/authorize` and `console.anthropic.com/oauth/code/callback` URI pair.
2. The current Anthropic flow uses `claude.com/cai/oauth/authorize` with `platform.claude.com/oauth/code/callback`, so Hermes sends a stale redirect URI during the token exchange.
3. The exchange is rejected, then Hermes replays the single-use code to a retired fallback token host, obscuring the primary failure with another 400 or 405 response.

**Why it is wrong:** OAuth authorization codes are bound to the redirect URI used by the current client flow and are single-use. The authorization and exchange paths must use the same live URI, and a rejected code must not be replayed to stale hosts.

**Working sibling / contrast:** Claude Code 2.1.239 uses the live `claude.com` authorization URL, the `platform.claude.com` callback, and a single `platform.claude.com/v1/oauth/token` POST.

**Ruled out:** The PKCE verifier and state lifecycle is not lost inside Hermes. Both are generated and retained in the same `run_hermes_oauth_login_pure` invocation, and the regression test verifies that the echoed state and private verifier reach the exchange unchanged.

### Fix

- Align the authorization URL and redirect URI with Claude Code's current manual OAuth flow.
- Keep one live token endpoint for login and refresh instead of replaying credentials to the retired console host.
- Cover the successful POST contract and the HTTP 400 and 405 failure paths, including the no-replay invariant.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` - align authorization, callback, and token endpoint selection with the current Anthropic flow.
- `tests/agent/test_anthropic_oauth_pkce.py` - verify the complete successful exchange contract and 400/405 no-replay behavior.

## How to Test

1. Run the focused Anthropic OAuth and adapter tests.
2. Run the CLI auth command regression tests.

```bash
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_oauth_pkce.py tests/agent/test_anthropic_oauth_ua_prefix.py tests/hermes_cli/test_anthropic_oauth_flow.py -q
scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py -q
```

Local result on Windows 11: 131 passed, 1 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates: N/A - no user-facing workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the change uses existing stdlib URL and HTTP behavior on all supported platforms
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - automated tests cover the request contract without exposing live OAuth credentials.
