### PR TITLE
fix(group-chat): stop repeated prefix cache misses across turns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1075,6 +1075,13 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # subsequent turn).
     if agent._session_db:
         try:
+            # ``UPDATE`` does not create a missing row. Group-run agents can be
+            # short-lived, so persist their row here instead of relying on the
+            # later turn prologue to create it after this write has no-op'd.
+            if not getattr(agent, "_session_db_created", False):
+                ensure_session = getattr(agent, "_ensure_db_session", None)
+                if callable(ensure_session):
+                    ensure_session()
             agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
         except Exception as exc:
             logger.warning(

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.conversation_loop import _restore_or_build_system_prompt
+from hermes_state import SessionDB
+from run_agent import AIAgent
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -142,6 +144,43 @@ class TestLegitimateFreshBuild:
         _restore_or_build_system_prompt(agent, None, [])
         agent._build_system_prompt.assert_called_once()
         assert agent._cached_system_prompt == "BUILT_PROMPT"
+
+    def test_first_group_turn_persists_prompt_for_next_agent(self, tmp_path):
+        """A fresh group-run row is durable before the next agent restores it."""
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+
+            def group_agent():
+                agent = AIAgent.__new__(AIAgent)
+                agent._cached_system_prompt = None
+                agent._persist_disabled = False
+                agent._session_db_created = False
+                agent._session_init_model_config = None
+                agent._parent_session_id = None
+                agent._session_db = db
+                agent._use_prompt_caching = False
+                agent.session_id = "gc_run_test"
+                agent.model = "test-model"
+                agent.provider = "openrouter"
+                agent.platform = "desktop"
+                agent._build_system_prompt = MagicMock(return_value="GROUP_PROMPT")
+                return agent
+
+            first = group_agent()
+            _restore_or_build_system_prompt(
+                first, None, [{"role": "user", "content": "start group turn"}]
+            )
+
+            stored = db.get_session(first.session_id)
+            assert stored is not None
+            assert stored["system_prompt"] == "GROUP_PROMPT"
+
+            resumed = group_agent()
+            _restore_or_build_system_prompt(
+                resumed, None, [{"role": "user", "content": "continue group turn"}]
+            )
+
+            assert resumed._cached_system_prompt == "GROUP_PROMPT"
+            resumed._build_system_prompt.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Group-chat turns no longer lose the freshly built session system prompt when its durable session row has not been created yet. The restore/build path now creates the row before updating the prompt, so a later agent instance can reuse identical prompt bytes and hit the prefix cache instead of rebuilding every turn.

### Symptom

Continuing group-chat runs log that the stored system prompt is null and rebuild it from scratch, so the next turn cannot reuse the cached prefix.

### Impact

Affected group-chat sessions repeatedly pay the uncached input-token cost for the system prompt. The exact affected-session count is unknown.

### Bug Cause

**Trigger:** `agent/conversation_loop.py` / `_restore_or_build_system_prompt()` when a fresh short-lived group-run agent builds its prompt before a durable session row exists.

**Causal chain:**
1. A fresh group-run agent builds its system prompt and calls `SessionDB.update_system_prompt()`.
2. The SQLite `UPDATE` matches no row, succeeds without an exception, and persists nothing.
3. A later agent instance finds no stored prompt, rebuilds it, and misses the prefix cache again.

**Why it is wrong:** The helper promises to persist a freshly built prompt, but its write depended on a separate later prologue creating the session row.

**Working sibling / contrast:** Normal long-lived turns eventually reach the later session-row creation step, while short-lived group-run lifecycles cannot safely depend on that separate step.

**Ruled out:** Prompt deduplication is not the cause; the real `SessionDB` roundtrip resolves a stored prompt correctly once the session row exists.

### Fix

Ensure the agent's durable session row exists immediately before updating the freshly built prompt. The regression test uses a real `SessionDB`, proves the first turn stores a non-null prompt, and proves a fresh second agent restores the exact prompt without rebuilding it.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` - create the session row before persisting a freshly built system prompt.
- `tests/agent/test_system_prompt_restore.py` - cover first-turn persistence and next-agent prompt reuse with a real SQLite session store.

## How to Test

1. Run the focused system-prompt, turn-context, and prompt-deduplication suites.
2. Confirm all 43 tests pass, including the red-before-fix group-run regression.

```bash
scripts/run_tests.sh tests/agent/test_system_prompt_restore.py tests/agent/test_turn_context.py tests/test_session_system_prompt_dedup.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the fix uses existing platform-independent session persistence
- [x] Tool description/schema updates are N/A because no tool behavior changed

## Screenshots / Logs

N/A - covered by the automated SQLite roundtrip regression test.

