### PR TITLE
fix(tools): block compacted content in side-effect calls

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -791,6 +791,59 @@ def _resolve_active_context_length() -> int:
 _AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
+# Context compressors use these exact marker shapes when shortening historical
+# strings. A later model turn must not mistake that synthetic copy for complete
+# outbound content. Requiring either the compression sentinel or an ellipsis-
+# bracket marker keeps ordinary prose such as "the preview was truncated" valid.
+_SYNTHETIC_TRUNCATION_MARKER_RE = re.compile(
+    r"(?:"
+    r"(?:\.\.\.|…)[ \t]*\[truncated\](?:\.\.\.)?"
+    r"|⟪HERMES-CONTEXT-COMPRESSION:"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _contains_synthetic_truncation_marker(value: Any) -> bool:
+    """Find compactor markers in JSON-like arguments, including nested leaves."""
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        item = pending.pop()
+        if isinstance(item, str):
+            if _SYNTHETIC_TRUNCATION_MARKER_RE.search(item):
+                return True
+            continue
+        if isinstance(item, dict):
+            identity = id(item)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            pending.extend(item.keys())
+            pending.extend(item.values())
+        elif isinstance(item, (list, tuple, set, frozenset)):
+            identity = id(item)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            pending.extend(item)
+    return False
+
+
+def _compacted_side_effect_error(tool_name: str, args: Any) -> Optional[str]:
+    """Return a fail-closed error for marker-bearing write-capable calls."""
+    if not _contains_synthetic_truncation_marker(args):
+        return None
+    entry = registry.get_entry(tool_name)
+    if entry is not None and entry.read_only is True:
+        return None
+    return (
+        f"Blocked potentially side-effecting tool '{tool_name}': its arguments "
+        "contain a synthetic truncation marker from compacted history, so exact "
+        "content cannot be verified. Recover the exact content from the original "
+        "source, then obtain fresh confirmation before retrying. The tool was NOT run."
+    )
+
 
 # =========================================================================
 # Tool error sanitization
@@ -1466,6 +1519,25 @@ def handle_function_call(
                 )
                 return result
 
+        compaction_block = _compacted_side_effect_error(function_name, function_args)
+        if compaction_block is not None:
+            result = tool_error(compaction_block)
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
+                status="blocked",
+                error_type="compacted_tool_arguments",
+                error_message=compaction_block,
+                middleware_trace=list(_tool_middleware_trace),
+            )
+            return result
+
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
         # are unaffected when it is unset.
@@ -1543,6 +1615,9 @@ def handle_function_call(
                 # the parent's tool set via the process-global.
                 sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    block = _compacted_side_effect_error(function_name, next_args)
+                    if block is not None:
+                        return tool_error(block)
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
@@ -1551,6 +1626,9 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    block = _compacted_side_effect_error(function_name, next_args)
+                    if block is not None:
+                        return tool_error(block)
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -30,7 +30,160 @@ class TestHandleFunctionCall:
         assert "error" in result
         assert "totally_fake_tool_xyz" in result["error"]
 
+    def test_compacted_tool_arguments_cannot_reach_write_handler(self, monkeypatch):
+        from agent.context_compressor import _truncate_tool_call_args_json
 
+        original = json.dumps({"path": "fixture.txt", "content": "x" * 500})
+        compacted_args = json.loads(_truncate_tool_call_args_json(original))
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("compacted write must not dispatch")
+            ),
+        )
+
+        result = json.loads(handle_function_call("write_file", compacted_args))
+
+        assert "exact content" in result["error"].lower()
+        assert "fresh confirmation" in result["error"].lower()
+
+    def test_nested_compaction_marker_blocks_write_handler(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("nested compacted write must not dispatch")
+            ),
+        )
+
+        result = json.loads(
+            handle_function_call(
+                "write_file",
+                {"path": "fixture.json", "content": {"sections": ["partial...[truncated]"]}},
+            )
+        )
+
+        assert "exact content" in result["error"].lower()
+
+    def test_named_compaction_sentinel_blocks_write_handler(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("compaction sentinel must not dispatch")
+            ),
+        )
+        marker = "⟪HERMES-CONTEXT-COMPRESSION: 300 chars omitted here⟫"
+
+        result = json.loads(
+            handle_function_call(
+                "write_file", {"path": "fixture.txt", "content": marker}
+            )
+        )
+
+        assert "exact content" in result["error"].lower()
+
+    def test_complete_write_payload_passes_byte_for_byte(self, monkeypatch):
+        payload = "alpha\nβeta\n"
+        captured = {}
+
+        def dispatch(_name, args, **_kwargs):
+            captured["content"] = args["content"]
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("model_tools.registry.dispatch", dispatch)
+
+        assert json.loads(
+            handle_function_call("write_file", {"path": "fixture.txt", "content": payload})
+        ) == {"ok": True}
+        assert captured["content"].encode("utf-8") == payload.encode("utf-8")
+
+    def test_read_only_tool_is_not_blocked_by_compaction_marker(self, monkeypatch):
+        captured = {}
+
+        def dispatch(_name, args, **_kwargs):
+            captured.update(args)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("model_tools.registry.dispatch", dispatch)
+
+        args = {"path": "reports/... [truncated]/index.txt"}
+        assert json.loads(handle_function_call("read_file", args)) == {"ok": True}
+        assert captured == args
+
+    def test_legitimate_truncation_prose_is_not_blocked(self, monkeypatch):
+        payload = "Explain that the preview was truncated by the UI."
+        captured = {}
+
+        def dispatch(_name, args, **_kwargs):
+            captured.update(args)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("model_tools.registry.dispatch", dispatch)
+
+        args = {"path": "fixture.txt", "content": payload}
+        assert json.loads(handle_function_call("write_file", args)) == {"ok": True}
+        assert captured == args
+
+    def test_unknown_outbound_tool_fails_closed_on_marker(self, monkeypatch):
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("unknown outbound handler must not dispatch")
+            ),
+        )
+
+        result = json.loads(
+            handle_function_call(
+                "send_email",
+                {"to": "recipient.invalid", "body": "partial...[truncated]"},
+            )
+        )
+
+        assert "not run" in result["error"].lower()
+
+    def test_execution_middleware_cannot_inject_marker_into_write(self, monkeypatch):
+        def execution_middleware(**kwargs):
+            return kwargs["next_call"](
+                {**kwargs["args"], "content": "partial...[truncated]"}
+            )
+
+        manager = type(
+            "Manager", (), {"_middleware": {"tool_execution": [execution_middleware]}}
+        )()
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("middleware marker must not reach handler")
+            ),
+        )
+
+        result = json.loads(
+            handle_function_call(
+                "write_file", {"path": "fixture.txt", "content": "complete"}
+            )
+        )
+
+        assert "exact content" in result["error"].lower()
+
+    def test_guard_does_not_mutate_existing_role_alternation(self, monkeypatch):
+        history = [
+            {"role": "user", "content": "write it"},
+            {"role": "assistant", "content": None, "tool_calls": ["call-1"]},
+        ]
+        before = json.dumps(history, ensure_ascii=False, sort_keys=True)
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("compacted write must not dispatch")
+            ),
+        )
+
+        handle_function_call(
+            "write_file", {"path": "fixture.txt", "content": "partial...[truncated]"}
+        )
+
+        assert json.dumps(history, ensure_ascii=False, sort_keys=True) == before
+        assert [message["role"] for message in history] == ["user", "assistant"]
 
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):
         """Regression: post_tool_call and transform_tool_result hooks must

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -220,7 +220,8 @@ class TestAnnotationCaptureAtDiscovery:
             "trust": "untrusted",
             "tools": {"resources": False, "prompts": False},
         }
-        with patch("tools.registry.registry", ToolRegistry()), \
+        reg = ToolRegistry()
+        with patch("tools.registry.registry", reg), \
              patch("tools.mcp_tool._track_mcp_tool_server"):
             mcp_tool._register_server_tools("srv", server, config)
 
@@ -230,6 +231,12 @@ class TestAnnotationCaptureAtDiscovery:
         # Anything not exactly True is write-capable.
         assert not hints.get("delete_repo")
         assert not hints.get("no_annotations")
+        list_entry = reg.get_entry("mcp__srv__list_repos")
+        delete_entry = reg.get_entry("mcp__srv__delete_repo")
+        unknown_entry = reg.get_entry("mcp__srv__no_annotations")
+        assert list_entry is not None and list_entry.read_only is True
+        assert delete_entry is not None and delete_entry.read_only is False
+        assert unknown_entry is not None and unknown_entry.read_only is False
 
     def test_dict_annotations_supported(self):
         """Cached/JSON annotations arrive as plain dicts."""

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -108,6 +108,26 @@ class TestGetDefinitions:
         names = {d["function"]["name"] for d in defs}
         assert names == {"t1", "t2"}
 
+    def test_read_only_metadata_does_not_change_prompt_schema(self):
+        write_reg = ToolRegistry()
+        read_reg = ToolRegistry()
+        schema = _make_schema("stable")
+        write_reg.register(
+            name="stable", toolset="s1", schema=schema, handler=_dummy_handler
+        )
+        read_reg.register(
+            name="stable",
+            toolset="s1",
+            schema=schema,
+            handler=_dummy_handler,
+            read_only=True,
+        )
+
+        assert write_reg.get_definitions({"stable"}) == read_reg.get_definitions({"stable"})
+        write_entry = write_reg.get_entry("stable")
+        read_entry = read_reg.get_entry("stable")
+        assert write_entry is not None and write_entry.read_only is False
+        assert read_entry is not None and read_entry.read_only is True
 
     def test_reuses_shared_check_fn_once_per_call(self):
         reg = ToolRegistry()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2818,7 +2818,7 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000, read_only=True)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
-registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)
+registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000, read_only=True)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7232,6 +7232,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                     name, mcp_tool.name, server.tool_timeout
                 ),
                 "check_fn": check_fn,
+                "read_only": _annotation_read_only_hint(mcp_tool),
             }
         )
 
@@ -7255,6 +7256,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                     name, server.tool_timeout
                 ),
                 "check_fn": check_fn,
+                "read_only": True,
             }
         )
 
@@ -7362,6 +7364,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=candidate["check_fn"],
             is_async=False,
             description=candidate["schema"]["description"],
+            read_only=candidate["read_only"],
         )
 
         # The pre-check above is advisory only. Multiple servers connect in
@@ -7519,6 +7522,10 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            read_only=(
+                isinstance(raw.get("annotations"), dict)
+                and raw["annotations"].get("readOnlyHint") is True
+            ),
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
@@ -7552,6 +7559,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
+            read_only=True,
         )
         if registry.get_toolset_for_tool(util_name) != toolset_name:
             continue

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -207,12 +207,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "read_only",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 read_only=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -231,6 +232,9 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # Security-sensitive callers treat anything other than exactly True
+        # as write-capable. Unknown/plugin tools therefore fail closed.
+        self.read_only = read_only is True
 
 
 class _PluginOverridePolicy:
@@ -775,6 +779,7 @@ class ToolRegistry:
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
         scope: Optional[str] = None,
+        read_only: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -870,6 +875,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                read_only=read_only,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1705,6 +1705,7 @@ registry.register(
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
+    read_only=True,
 )
 registry.register(
     name="web_extract",
@@ -1720,4 +1721,5 @@ registry.register(
     is_async=True,
     emoji="📄",
     max_result_size_chars=100_000,
+    read_only=True,
 )


### PR DESCRIPTION
## Summary

Add a fail-closed dispatch guard for synthetic context-compaction truncation markers in potentially side-effecting tool arguments.

Compaction can shorten historical `tool_calls[].function.arguments` and insert `...[truncated]`. That historical copy remains valid JSON, so a later model turn can mistake it for complete content and reuse it in a fresh write/send/publish call. There is no evidence that the deferred tool transport truncates a fresh complete argument; the unsafe boundary is reuse of synthetic compacted content.

## Security boundary

- Detect current dotted marker forms and the proposed named `HERMES-CONTEXT-COMPRESSION` sentinel recursively in string/nested arguments.
- Block before write-capable registry dispatch with an actionable exact-content recovery + fresh-confirmation error.
- Recheck after execution middleware, so middleware cannot inject a marker into the handler payload.
- Unknown/plugin tools default to write-capable (fail closed).
- Add internal `read_only` registry metadata; it does not alter serialized tool schemas or prompt-cache bytes.
- Propagate MCP `readOnlyHint=True`; missing/malformed hints remain write-capable.
- Mark core file/web reads as read-only, so harmless reads remain usable.

## Reproduction

On unmodified `origin/main`, the regression test generated compacted args via `_truncate_tool_call_args_json()`, called `write_file`, and reached the mocked write handler. The focused red run failed 2 tests because dispatch occurred.

## Tests

- compacted historical args cannot reach a write handler
- nested and named synthetic markers are blocked
- unknown outbound tools fail closed
- complete payload passes byte-for-byte
- read-only calls and ordinary prose mentioning truncation are not blocked
- execution-middleware injection is blocked
- registry metadata does not alter prompt schemas
- role-alternating history is not mutated
- MCP read-only hints propagate to registry metadata

Canonical focused suites and full-suite results are included in the PR checks / author comment.

## Existing work

This complements rather than duplicates:

- #83843 / #83735: stop or change the marker minted at one compaction source
- #83752 / #68512: file-tool-only placeholder guards

Those do not provide a generic boundary for messaging, mail, publishing, payments, plugins, deferred MCP tools, or already-compacted history. This PR addresses the validation-hook ask in #83435 without mutating conversation history, role order, or tool schemas.

Refs #83435
