### PR TITLE
fix(telegram): gate inline approval callbacks

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1602,6 +1602,27 @@ def load_gateway_config() -> GatewayConfig:
             _merge_platform_map(gateway_platforms)
             _merge_platform_map(yaml_cfg.get("platforms"))
 
+            # Approval policy is global/profile-scoped, while platform
+            # adapters receive only PlatformConfig. Bridge the Telegram gate
+            # into that adapter's extra data so multiplexed profiles keep
+            # their own policy instead of consulting process-global state.
+            _security_cfg = yaml_cfg.get("security")
+            _approval_cfg = (
+                _security_cfg.get("approval")
+                if isinstance(_security_cfg, dict)
+                else None
+            )
+            if (
+                isinstance(_approval_cfg, dict)
+                and "telegram_callbacks_enabled" in _approval_cfg
+            ):
+                _telegram_data, _telegram_extra = _ensure_platform_extra_dict(
+                    platforms_data, Platform.TELEGRAM.value
+                )
+                _telegram_extra["approval_callbacks_enabled"] = _approval_cfg[
+                    "telegram_callbacks_enabled"
+                ]
+
             # Also merge platform configs placed directly under ``gateway.*``
             # (e.g. ``gateway.api_server``) so subsections are discovered the
             # same way ``gateway.streaming`` is handled elsewhere.  Iterate

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2590,6 +2590,10 @@ DEFAULT_CONFIG = {
         "approval": {
             "transport": "builtin",
             "transport_fallback": "deny",
+            # Keep Telegram's inline command-approval callbacks available for
+            # existing installs. Operators can close only this decision path
+            # while retaining Telegram notifications and status messages.
+            "telegram_callbacks_enabled": True,
         },
         # Writes to agent-instruction files (AGENTS.md/CLAUDE.md/SOUL.md/
         # .cursorrules, project-local .hermes config) always require human

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -836,6 +836,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._choice_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        self._approval_callbacks_enabled = self._coerce_bool_extra(
+            "approval_callbacks_enabled", True
+        )
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -7231,6 +7234,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     approval_id = int(parts[2])
                 except (ValueError, IndexError):
                     await query.answer(text="Invalid approval data.")
+                    return
+
+                if not self._approval_callbacks_enabled:
+                    await query.answer(text="⛔ Telegram approvals are disabled.")
                     return
 
                 # Only authorized users may click approval buttons.

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -187,35 +187,47 @@ class TestTelegramApprovalCallback:
         update = MagicMock(callback_query=query)
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
-            with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            with (
+                patch.object(
+                    adapter, "_is_callback_user_authorized"
+                ) as mock_authorize,
+                patch("tools.approval.resolve_gateway_approval") as mock_resolve,
+            ):
                 await adapter._handle_callback_query(update, MagicMock())
 
         query.answer.assert_awaited_once_with(
             text="⛔ Telegram approvals are disabled."
         )
+        mock_authorize.assert_not_called()
         mock_resolve.assert_not_called()
         assert adapter._approval_state[5] == "agent:main:telegram:group:12345:99"
         query.edit_message_text.assert_not_called()
 
     def test_gateway_config_bridges_profile_scoped_callback_gate(
-        self, tmp_path, monkeypatch
+        self, tmp_path
     ):
         from gateway.config import load_gateway_config
+        from gateway.run import _profile_runtime_scope
 
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "security:\n"
-            "  approval:\n"
-            "    telegram_callbacks_enabled: false\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        callback_values = []
+        for profile_name, enabled in (("locked", False), ("open", True)):
+            profile_home = tmp_path / profile_name
+            profile_home.mkdir()
+            (profile_home / "config.yaml").write_text(
+                "security:\n"
+                "  approval:\n"
+                f"    telegram_callbacks_enabled: {str(enabled).lower()}\n",
+                encoding="utf-8",
+            )
 
-        config = load_gateway_config()
+            with _profile_runtime_scope(profile_home):
+                config = load_gateway_config()
+                telegram = config.platforms[Platform.TELEGRAM]
+                callback_values.append(
+                    telegram.extra["approval_callbacks_enabled"]
+                )
 
-        telegram = config.platforms[Platform.TELEGRAM]
-        assert telegram.extra["approval_callbacks_enabled"] is False
+        assert callback_values == [False, True]
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -175,6 +175,48 @@ class TestTelegramExecApproval:
 class TestTelegramApprovalCallback:
     """Test the approval callback handling in _handle_callback_query."""
 
+    @pytest.mark.asyncio
+    async def test_disabled_callback_rejects_without_recording_decision(self):
+        adapter = _make_adapter({"approval_callbacks_enabled": False})
+        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+
+        query = AsyncMock()
+        query.data = "ea:once:5"
+        query.message = MagicMock(chat_id=12345)
+        query.from_user = MagicMock(id="12345", first_name="Norbert")
+        update = MagicMock(callback_query=query)
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+                await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_awaited_once_with(
+            text="⛔ Telegram approvals are disabled."
+        )
+        mock_resolve.assert_not_called()
+        assert adapter._approval_state[5] == "agent:main:telegram:group:12345:99"
+        query.edit_message_text.assert_not_called()
+
+    def test_gateway_config_bridges_profile_scoped_callback_gate(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.config import load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  approval:\n"
+            "    telegram_callbacks_enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.extra["approval_callbacks_enabled"] is False
+
 
     @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):


### PR DESCRIPTION
## Summary

- add the backward-compatible `security.approval.telegram_callbacks_enabled` operator setting
- bridge the profile-scoped setting into each Telegram adapter, including multiplexed profiles
- reject disabled inline command-approval callbacks before authorization without consuming pending approval state

## Testing

- `scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py -q` (12 passed)

## Related Issue

Closes #96567
