### PR TITLE
fix(group-chat): allow cancelling messages queued behind busy agents

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -438,8 +438,9 @@ function focusedRosterOwner(owner) {
 
 /** Optional secondary navigation inside the Bots pane (group-chat rooms). */
 
-/** Group-chat rooms: { [group]: { log: [{from:{kind,name},text,at}], watermarks:{[member]:idx}, epoch, running } }.
- *  Log + watermarks persist via plugin storage; epoch/running are runtime-only. */
+/** Group-chat rooms: { [group]: { log, pending, watermarks, epoch, running } }.
+ *  Log + pending messages + watermarks persist via plugin storage;
+ *  epoch/running/runSequence are runtime-only. */
 const $groupChats = atom({})
 /** Group whose room view is open in the Bots pane (secondary navigation
  *  inside the pane; a normal row click returns to the roster). */
@@ -1049,6 +1050,7 @@ function durableGroupChatRooms(all = $groupChats.get()) {
     }
     durable[name] = {
       log: room.log,
+      pending: Array.isArray(room.pending) ? room.pending : [],
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
       stranded: room.stranded || {},
@@ -7002,6 +7004,7 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
 
       durable[name] = {
         log: room.log,
+        pending: Array.isArray(room.pending) ? room.pending : [],
         watermarks: room.watermarks,
         sessions: room.sessions || {},
         sessionOwners: room.sessionOwners || {},
@@ -7101,6 +7104,7 @@ async function disbandGroupChat(group, members) {
       if (name !== group && Array.isArray(room.log)) {
         durable[name] = {
           log: room.log,
+          pending: Array.isArray(room.pending) ? room.pending : [],
           watermarks: room.watermarks,
           sessions: room.sessions || {},
           sessionOwners: room.sessionOwners || {},
@@ -8494,6 +8498,11 @@ async function runGroupChatRounds(group, members, thread) {
         return r
       })
 
+      // Busy sends stay outside the live log until the current drive settles,
+      // then advance FIFO. This avoids prompt.submit's busy redirect/interrupt
+      // policy and gives the UI a real, cancellable queue item meanwhile.
+      void drainQueuedGroupMessage(group, members)
+
       // #89545: the loop's harvest pass only ran at the top of each round of
       // an ACTIVE loop — a member whose turn timed out after the final round
       // stayed stranded until the user's NEXT send. Poll for the late reply
@@ -8545,11 +8554,111 @@ async function harvestStrandedUntilSettled(group, members, thread) {
   recordGroupActivity(group, { kind: 'failed', member: null, thread })
 }
 
-/** User send into a group room. `thread` continues that thread (its reply
- *  box); omitted/null mints a NEW thread — the main composer's Slack shape.
- *  Appends, bumps the room epoch (supersedes any running loop at its next
- *  member boundary), and starts the turn drive for the target thread.
- *  Returns the thread id the message landed in. */
+function runQueuedGroupMessage(group, members, queued) {
+  const roster = Array.isArray(members) && members.length ? members : ($groupChats.get()[group] || {}).members || []
+
+  if (!queued || !roster.length) {
+    return false
+  }
+
+  $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
+  const sent = appendGroupChatEntry(group, { kind: 'user', name: 'You' }, queued.text, queued.thread, queued.images)
+
+  updateGroupChat(group, room => {
+    room.pending = (room.pending || []).filter(item => item.id !== queued.id)
+    room.members = durableGroupChatMembers(roster)
+    room.epoch = (room.epoch || 0) + 1
+    room.runSequence = (room.runSequence || 0) + 1
+    room.running = true
+    room.holds = applyGroupHoldDirective(
+      room.holds,
+      parseGroupChatMentions(queued.text, roster),
+      queued.text,
+      { at: sent?.at, byMessageId: sent?.id, thread: queued.thread },
+      roster.map(member => groupMemberKey(member))
+    )
+    return room
+  })
+
+  recordGroupActivity(group, { kind: 'queued', member: 'You', thread: queued.thread })
+  void runGroupChatRounds(group, roster, queued.thread).catch(() => {
+    updateGroupChat(group, room => {
+      room.running = false
+      room.turn = null
+      return room
+    })
+    void drainQueuedGroupMessage(group, roster)
+  })
+  return true
+}
+
+/** Start the oldest queued send once no drive owns the room. Exactly one
+ * caller can win because the atom mutation and `running = true` are
+ * synchronous on the renderer thread. */
+function drainQueuedGroupMessage(group, members = null) {
+  const room = $groupChats.get()[group] || {}
+  const next = Array.isArray(room.pending) ? room.pending[0] : null
+
+  if (room.running || !next) {
+    return false
+  }
+
+  return runQueuedGroupMessage(group, members, next)
+}
+
+function cancelQueuedGroupMessage(group, messageId) {
+  const room = $groupChats.get()[group]
+
+  if (!room || !(room.pending || []).some(item => item.id === messageId)) {
+    return false
+  }
+
+  updateGroupChat(group, current => {
+    current.pending = current.pending.filter(item => item.id !== messageId)
+    return current
+  })
+  return true
+}
+
+function keepWaitingForQueuedGroupMessage(group, messageId) {
+  const room = $groupChats.get()[group]
+
+  if (!room || !(room.pending || []).some(item => item.id === messageId)) {
+    return false
+  }
+
+  updateGroupChat(group, current => {
+    current.pending = current.pending.map(item =>
+      item.id === messageId ? { ...item, decisionAt: Date.now() } : item
+    )
+    return current
+  })
+  return true
+}
+
+/** Stop the live member, then promote one selected queued send. Preserve
+ * pre-existing user holds: stopGroupThread's temporary all-member holds exist
+ * only long enough for the stale poll loop to observe cancellation. */
+async function interruptForQueuedGroupMessage(group, messageId, members = null) {
+  const room = $groupChats.get()[group] || {}
+  const queued = (room.pending || []).find(item => item.id === messageId)
+
+  if (!queued) {
+    return false
+  }
+
+  const priorHolds = { ...(room.holds || {}) }
+  const roster = Array.isArray(members) && members.length ? members : room.members || []
+  await stopGroupThread(group, queued.thread, roster)
+  updateGroupChat(group, current => {
+    current.holds = priorHolds
+    return current
+  })
+  return runQueuedGroupMessage(group, roster, queued)
+}
+
+/** User send into a group room. A busy room stores the send in a durable FIFO
+ * instead of submitting into the member's already-live gateway session. */
 function sendToGroupChat(group, members, text, thread, images) {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
@@ -8559,56 +8668,25 @@ function sendToGroupChat(group, members, text, thread, images) {
   }
 
   const target = thread || mintGroupThreadId()
+  const room = $groupChats.get()[group] || {}
+  const queued = {
+    id: groupChatEntryId(),
+    at: Date.now(),
+    text: trimmed,
+    thread: target,
+    ...(attached.length ? { images: attached } : {}),
+    queuedBehindRun: Math.max(1, Number(room.runSequence || 1))
+  }
 
-  $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
-  // Refresh the durable room roster on every send. This backfills rooms made
-  // by older Desktop builds and keeps the gateway mirror complete even when
-  // members overlap across multiple groups.
-  updateGroupChat(group, room => {
-    room.members = durableGroupChatMembers(members)
-    return room
-  })
-  const sent = appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed, target, attached)
-
-  const wasRunning = ($groupChats.get()[group] || {}).running === true
-
-  updateGroupChat(group, room => {
-    room.epoch = (room.epoch || 0) + 1
-    room.running = true
-    // #93129: user text is the ONLY input that changes member holds. An
-    // explicit "stop @member" sets a sticky hold; "@member resume" (or
-    // @all resume, or any direct non-stop mention of the held member)
-    // releases it. Bot replies never flow through this function.
-    room.holds = applyGroupHoldDirective(
-      room.holds,
-      parseGroupChatMentions(trimmed, members),
-      trimmed,
-      { at: sent?.at, byMessageId: sent?.id, thread: target },
-      members.map(member => groupMemberKey(member))
-    )
-    return room
-  })
-
-  recordGroupActivity(group, { kind: 'queued', member: 'You', thread: target })
-
-  if (!wasRunning) {
-    void runGroupChatRounds(group, members, target).catch(() => {
-      updateGroupChat(group, r => {
-        r.running = false
-        return r
-      })
+  if (room.running) {
+    updateGroupChat(group, current => {
+      current.members = durableGroupChatMembers(members)
+      current.pending = [...(current.pending || []), queued]
+      return current
     })
+    recordGroupActivity(group, { kind: 'queued', member: 'You', thread: target })
   } else {
-    // A loop is live; it bails at its next boundary. Chain the fresh loop
-    // after a short settle so exactly one drive owns the room.
-    setTimeout(() => {
-      void runGroupChatRounds(group, members, target).catch(() => {
-        updateGroupChat(group, r => {
-          r.running = false
-          return r
-        })
-      })
-    }, 250)
+    runQueuedGroupMessage(group, members, queued)
   }
 
   return target
@@ -13233,6 +13311,8 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
+  const pendingQueue = Array.isArray(room.pending) ? room.pending : []
+  const [queueNow, setQueueNow] = useState(() => Date.now())
   const composerKey = groupComposerDraftKey(group, room)
   const composerKeyRef = useRef(composerKey)
   const [composerDraft, setComposerDraft] = useState(() => groupComposerDraftSnapshot(composerKey))
@@ -13297,6 +13377,15 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   // already near the bottom, so reading history is never yanked away.
   const bottomSentinelRef = useRef(null)
   const stickToBottomRef = useRef(true)
+
+  useEffect(() => {
+    if (!pendingQueue.length) {
+      return undefined
+    }
+
+    const timer = setInterval(() => setQueueNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [pendingQueue.length])
 
   useEffect(() => {
     const sentinel = bottomSentinelRef.current
@@ -13479,6 +13568,20 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const stopRoomRun = async () => {
     await stopGroupThread(group, latestActivity?.thread || null, memberDescriptors())
     host.notify({ kind: 'success', message: `Stopped ${group} — remaining turns are held until you resume` })
+  }
+
+  const cancelQueued = queued => {
+    if (!cancelQueuedGroupMessage(group, queued.id)) {
+      host.notifyError?.(new Error('queued message not found'), 'That queued message is no longer waiting')
+    }
+  }
+
+  const interruptQueued = async queued => {
+    const promoted = await interruptForQueuedGroupMessage(group, queued.id, memberDescriptors())
+
+    if (!promoted) {
+      host.notifyError?.(new Error('queued message not found'), 'That queued message is no longer waiting')
+    }
   }
 
   const activityPanel = jsxs('div', {
@@ -13987,6 +14090,53 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
             ...roomClarifies.map(entry =>
               jsx(GroupClarifyCard, { entry, members }, `clarify:${entry.memberKey}:${entry.requestId}`)
             ),
+            ...pendingQueue.map(queued => {
+              const waitedMs = Math.max(0, queueNow - Number(queued.at || queueNow))
+              const decisionAge = Math.max(0, queueNow - Number(queued.decisionAt || queued.at || queueNow))
+              const overdue = decisionAge >= 60_000
+
+              return jsxs('div', {
+                className:
+                  'grid gap-1 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-secondary,#181818) px-2 py-1.5 text-[0.7rem]',
+                children: [
+                  jsxs('div', {
+                    className: 'flex items-center gap-1.5',
+                    children: [
+                      jsx(Codicon, { name: 'clock', className: 'shrink-0 text-(--ui-accent)' }),
+                      jsx('span', {
+                        className: 'min-w-0 flex-1 truncate text-(--ui-text-secondary)',
+                        children: `Queued — room agent busy (run #${queued.queuedBehindRun || 1}) · ${Math.floor(waitedMs / 1000)}s`
+                      }),
+                      jsx('button', {
+                        type: 'button',
+                        className: 'shrink-0 text-(--ui-accent) hover:underline',
+                        onClick: () => cancelQueued(queued),
+                        children: 'Cancel'
+                      })
+                    ]
+                  }),
+                  overdue
+                    ? jsxs('div', {
+                        className: 'flex items-center justify-end gap-2 text-[0.65rem]',
+                        children: [
+                          jsx('button', {
+                            type: 'button',
+                            className: 'text-(--ui-accent) hover:underline',
+                            onClick: () => void interruptQueued(queued),
+                            children: 'Interrupt & send'
+                          }),
+                          jsx('button', {
+                            type: 'button',
+                            className: 'text-(--ui-text-tertiary) hover:text-foreground',
+                            onClick: () => keepWaitingForQueuedGroupMessage(group, queued.id),
+                            children: 'Keep waiting'
+                          })
+                        ]
+                      })
+                    : null
+                ]
+              }, `queued:${queued.id}`)
+            }),
             room.running
               ? jsx('div', {
                   className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
@@ -15743,6 +15893,7 @@ export default {
                   // Pre-thread entries get synthetic thread ids on hydrate so
                   // every UI/engine path can assume entry.thread exists.
                   log: assignLegacyThreads(room.log),
+                  pending: Array.isArray(room.pending) ? room.pending : [],
                   watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
                   sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
                   sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
@@ -15798,6 +15949,11 @@ export default {
           // empty overwrite and then rendering an empty conversation.
           await pullGroupChatServerState().catch(() => false)
           scheduleGroupChatServerSync($groupChats.get())
+          for (const [roomName, room] of Object.entries($groupChats.get())) {
+            if (!room.running && Array.isArray(room.pending) && room.pending.length) {
+              void drainQueuedGroupMessage(roomName, room.members)
+            }
+          }
         })
         .catch(() => undefined)
     } catch {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7772,7 +7772,10 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
     // delivered (the #93127 commit check decides its fate, not this loop).
     const roomDuringPoll = $groupChats.get()[group] || {}
 
-    if ((roomDuringPoll.epoch || 0) !== dispatchEpoch && (roomDuringPoll.holds || {})[memberKey]) {
+    if (
+      (roomDuringPoll.epoch || 0) !== dispatchEpoch &&
+      ((roomDuringPoll.holds || {})[memberKey] || dispatchEpoch <= (roomDuringPoll.cancelledThroughEpoch ?? -1))
+    ) {
       return null
     }
 
@@ -8133,7 +8136,13 @@ async function stopGroupThread(
   const stamp = { at: Date.now(), byMessageId: null, thread: thread || null }
 
   updateGroupChat(group, r => {
+    const stoppedEpoch = r.epoch || 0
     r.epoch = (r.epoch || 0) + 1
+    // The interrupt RPC only acknowledges cancellation; it does not wait for
+    // the old renderer poll to observe it. Keep a generation fence so that
+    // poll cannot consume a promoted turn after interrupt-and-send restores
+    // the user's sticky holds.
+    r.cancelledThroughEpoch = Math.max(r.cancelledThroughEpoch ?? -1, stoppedEpoch)
     r.running = false
     r.turn = null
 
@@ -8636,7 +8645,11 @@ function drainQueuedGroupMessage(group, members = null) {
 function cancelQueuedGroupMessage(group, messageId) {
   const room = $groupChats.get()[group]
 
-  if (!room || !(room.pending || []).some(item => item.id === messageId)) {
+  if (
+    !room ||
+    room.interruptingQueue?.id === messageId ||
+    !(room.pending || []).some(item => item.id === messageId)
+  ) {
     return false
   }
 
@@ -8650,7 +8663,11 @@ function cancelQueuedGroupMessage(group, messageId) {
 function keepWaitingForQueuedGroupMessage(group, messageId) {
   const room = $groupChats.get()[group]
 
-  if (!room || !(room.pending || []).some(item => item.id === messageId)) {
+  if (
+    !room ||
+    room.interruptingQueue?.id === messageId ||
+    !(room.pending || []).some(item => item.id === messageId)
+  ) {
     return false
   }
 
@@ -8685,7 +8702,8 @@ async function interruptForQueuedGroupMessage(group, messageId, members = null) 
     if (current.interruptingQueue || !(current.pending || []).some(item => item.id === messageId)) {
       return current
     }
-    current.pending = current.pending.filter(item => item.id !== messageId)
+    // Keep the claimed item in the durable FIFO while the interrupt RPC is in
+    // flight. A window close or crash must not lose the user's message.
     current.interruptingQueue = queued
     return current
   })
@@ -8704,7 +8722,6 @@ async function interruptForQueuedGroupMessage(group, messageId, members = null) 
     if (current.interruptingQueue?.id === messageId) {
       updateGroupChat(group, latest => {
         latest.interruptingQueue = null
-        latest.pending = [queued, ...(latest.pending || []).filter(item => item.id !== messageId)]
         latest.holds = priorHolds
         return latest
       })
@@ -13377,10 +13394,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
-  const pendingQueue = [
-    ...(room.interruptingQueue ? [room.interruptingQueue] : []),
-    ...(Array.isArray(room.pending) ? room.pending : [])
-  ]
+  const pendingQueue = Array.isArray(room.pending) ? room.pending : []
   const [queueNow, setQueueNow] = useState(() => Date.now())
   const composerKey = groupComposerDraftKey(group, room)
   const composerKeyRef = useRef(composerKey)
@@ -13655,7 +13669,11 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
     const promoted = await interruptForQueuedGroupMessage(group, queued.id, memberDescriptors())
 
     if (!promoted) {
-      host.notifyError?.(new Error('queued message not found'), 'That queued message is no longer waiting')
+      const stillWaiting = ($groupChats.get()[group]?.pending || []).some(item => item.id === queued.id)
+      host.notifyError?.(
+        new Error(stillWaiting ? 'group interrupt failed' : 'queued message not found'),
+        stillWaiting ? 'Could not interrupt the current turn; the message is still queued' : 'That queued message is no longer waiting'
+      )
     }
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8121,7 +8121,12 @@ function unaddressedGroupMentions(group, members, thread) {
  *
  *  `members` is the live roster when the caller has one (the workspace);
  *  falls back to the room's durable roster so a two-arg call still works. */
-async function stopGroupThread(group, thread, members = null) {
+async function stopGroupThread(
+  group,
+  thread,
+  members = null,
+  { preservePending = false, preserveQueueClaim = false } = {}
+) {
   const room = $groupChats.get()[group] || {}
   const roster = Array.isArray(members) && members.length ? members : room.members || []
   const turnName = room.turn || null
@@ -8131,6 +8136,16 @@ async function stopGroupThread(group, thread, members = null) {
     r.epoch = (r.epoch || 0) + 1
     r.running = false
     r.turn = null
+
+    // Explicit Stop is terminal for sends waiting behind this run. The
+    // interrupt-and-send transition opts out while its selected item owns the
+    // room and the remainder of the FIFO must survive.
+    if (!preservePending) {
+      r.pending = []
+    }
+    if (!preserveQueueClaim) {
+      r.interruptingQueue = null
+    }
 
     // Same hold shape applyGroupHoldDirective mints for "@all stop" — the
     // held-skip path (watermark consume + 'held' activity note) and every
@@ -8165,8 +8180,11 @@ async function stopGroupThread(group, thread, members = null) {
     } catch {
       /* best-effort — the epoch/hold legs above already stopped the room;
          the abandoned poll loop exits on its staleness check */
+      return false
     }
   }
+
+  return true
 }
 
 /** Drive one bounded round-robin turn for ONE THREAD. Serial — one member at
@@ -8554,10 +8572,16 @@ async function harvestStrandedUntilSettled(group, members, thread) {
   recordGroupActivity(group, { kind: 'failed', member: null, thread })
 }
 
-function runQueuedGroupMessage(group, members, queued) {
+function runQueuedGroupMessage(group, members, queued, { claimed = false } = {}) {
   const roster = Array.isArray(members) && members.length ? members : ($groupChats.get()[group] || {}).members || []
+  const roomBefore = $groupChats.get()[group] || {}
 
-  if (!queued || !roster.length) {
+  if (
+    !queued ||
+    !roster.length ||
+    roomBefore.running ||
+    (roomBefore.interruptingQueue && (!claimed || roomBefore.interruptingQueue.id !== queued.id))
+  ) {
     return false
   }
 
@@ -8566,6 +8590,9 @@ function runQueuedGroupMessage(group, members, queued) {
 
   updateGroupChat(group, room => {
     room.pending = (room.pending || []).filter(item => item.id !== queued.id)
+    if (claimed) {
+      room.interruptingQueue = null
+    }
     room.members = durableGroupChatMembers(roster)
     room.epoch = (room.epoch || 0) + 1
     room.runSequence = (room.runSequence || 0) + 1
@@ -8599,7 +8626,7 @@ function drainQueuedGroupMessage(group, members = null) {
   const room = $groupChats.get()[group] || {}
   const next = Array.isArray(room.pending) ? room.pending[0] : null
 
-  if (room.running || !next) {
+  if (room.running || room.interruptingQueue || !next) {
     return false
   }
 
@@ -8636,25 +8663,64 @@ function keepWaitingForQueuedGroupMessage(group, messageId) {
   return true
 }
 
-/** Stop the live member, then promote one selected queued send. Preserve
- * pre-existing user holds: stopGroupThread's temporary all-member holds exist
- * only long enough for the stale poll loop to observe cancellation. */
+/** Claim one queued send before crossing the async interrupt boundary. The
+ * claim remains the room owner until promotion, so composer sends stay queued
+ * and repeat actions cannot start a second drive. */
 async function interruptForQueuedGroupMessage(group, messageId, members = null) {
   const room = $groupChats.get()[group] || {}
   const queued = (room.pending || []).find(item => item.id === messageId)
 
-  if (!queued) {
+  if (!queued || room.interruptingQueue) {
     return false
   }
 
   const priorHolds = { ...(room.holds || {}) }
   const roster = Array.isArray(members) && members.length ? members : room.members || []
-  await stopGroupThread(group, queued.thread, roster)
+
+  if (!room.running) {
+    return runQueuedGroupMessage(group, roster, queued)
+  }
+
+  updateGroupChat(group, current => {
+    if (current.interruptingQueue || !(current.pending || []).some(item => item.id === messageId)) {
+      return current
+    }
+    current.pending = current.pending.filter(item => item.id !== messageId)
+    current.interruptingQueue = queued
+    return current
+  })
+
+  if (($groupChats.get()[group] || {}).interruptingQueue?.id !== messageId) {
+    return false
+  }
+
+  const interrupted = await stopGroupThread(group, queued.thread, roster, {
+    preservePending: true,
+    preserveQueueClaim: true
+  })
+  const current = $groupChats.get()[group] || {}
+
+  if (!interrupted) {
+    if (current.interruptingQueue?.id === messageId) {
+      updateGroupChat(group, latest => {
+        latest.interruptingQueue = null
+        latest.pending = [queued, ...(latest.pending || []).filter(item => item.id !== messageId)]
+        latest.holds = priorHolds
+        return latest
+      })
+    }
+    return false
+  }
+
+  if (current.interruptingQueue?.id !== messageId || current.running) {
+    return false
+  }
+
   updateGroupChat(group, current => {
     current.holds = priorHolds
     return current
   })
-  return runQueuedGroupMessage(group, roster, queued)
+  return runQueuedGroupMessage(group, roster, queued, { claimed: true })
 }
 
 /** User send into a group room. A busy room stores the send in a durable FIFO
@@ -8678,7 +8744,7 @@ function sendToGroupChat(group, members, text, thread, images) {
     queuedBehindRun: Math.max(1, Number(room.runSequence || 1))
   }
 
-  if (room.running) {
+  if (room.running || room.interruptingQueue) {
     updateGroupChat(group, current => {
       current.members = durableGroupChatMembers(members)
       current.pending = [...(current.pending || []), queued]
@@ -13311,7 +13377,10 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
-  const pendingQueue = Array.isArray(room.pending) ? room.pending : []
+  const pendingQueue = [
+    ...(room.interruptingQueue ? [room.interruptingQueue] : []),
+    ...(Array.isArray(room.pending) ? room.pending : [])
+  ]
   const [queueNow, setQueueNow] = useState(() => Date.now())
   const composerKey = groupComposerDraftKey(group, room)
   const composerKeyRef = useRef(composerKey)
@@ -13566,8 +13635,14 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   // epoch bump + holds the loop marched on to the next member. Thread scope:
   // the run being stopped is the one the latest activity belongs to.
   const stopRoomRun = async () => {
+    const queuedCount = (room.pending || []).length + (room.interruptingQueue ? 1 : 0)
     await stopGroupThread(group, latestActivity?.thread || null, memberDescriptors())
-    host.notify({ kind: 'success', message: `Stopped ${group} — remaining turns are held until you resume` })
+    host.notify({
+      kind: 'success',
+      message: queuedCount
+        ? `Stopped ${group} — cancelled ${queuedCount} queued ${queuedCount === 1 ? 'message' : 'messages'}`
+        : `Stopped ${group} — remaining turns are held until you resume`
+    })
   }
 
   const cancelQueued = queued => {
@@ -14090,53 +14165,67 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
             ...roomClarifies.map(entry =>
               jsx(GroupClarifyCard, { entry, members }, `clarify:${entry.memberKey}:${entry.requestId}`)
             ),
-            ...pendingQueue.map(queued => {
-              const waitedMs = Math.max(0, queueNow - Number(queued.at || queueNow))
-              const decisionAge = Math.max(0, queueNow - Number(queued.decisionAt || queued.at || queueNow))
-              const overdue = decisionAge >= 60_000
+            pendingQueue.length
+              ? jsx('div', {
+                  className: 'grid gap-1 border-t border-(--ui-stroke-tertiary) px-2 py-1.5 text-[0.7rem]',
+                  children: pendingQueue.map(queued => {
+                    const waitedMs = Math.max(0, queueNow - Number(queued.at || queueNow))
+                    const decisionAge = Math.max(0, queueNow - Number(queued.decisionAt || queued.at || queueNow))
+                    const overdue = decisionAge >= 60_000
+                    const interrupting = room.interruptingQueue?.id === queued.id
 
-              return jsxs('div', {
-                className:
-                  'grid gap-1 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-secondary,#181818) px-2 py-1.5 text-[0.7rem]',
-                children: [
-                  jsxs('div', {
-                    className: 'flex items-center gap-1.5',
-                    children: [
-                      jsx(Codicon, { name: 'clock', className: 'shrink-0 text-(--ui-accent)' }),
-                      jsx('span', {
-                        className: 'min-w-0 flex-1 truncate text-(--ui-text-secondary)',
-                        children: `Queued — room agent busy (run #${queued.queuedBehindRun || 1}) · ${Math.floor(waitedMs / 1000)}s`
-                      }),
-                      jsx('button', {
-                        type: 'button',
-                        className: 'shrink-0 text-(--ui-accent) hover:underline',
-                        onClick: () => cancelQueued(queued),
-                        children: 'Cancel'
-                      })
-                    ]
-                  }),
-                  overdue
-                    ? jsxs('div', {
-                        className: 'flex items-center justify-end gap-2 text-[0.65rem]',
-                        children: [
-                          jsx('button', {
-                            type: 'button',
-                            className: 'text-(--ui-accent) hover:underline',
-                            onClick: () => void interruptQueued(queued),
-                            children: 'Interrupt & send'
-                          }),
-                          jsx('button', {
-                            type: 'button',
-                            className: 'text-(--ui-text-tertiary) hover:text-foreground',
-                            onClick: () => keepWaitingForQueuedGroupMessage(group, queued.id),
-                            children: 'Keep waiting'
-                          })
-                        ]
-                      })
-                    : null
-                ]
-              }, `queued:${queued.id}`)
-            }),
+                    return jsxs('div', {
+                      className: 'grid gap-1',
+                      children: [
+                        jsxs('div', {
+                          className: 'flex items-center gap-1.5',
+                          children: [
+                            jsx(Codicon, { name: 'clock', className: 'shrink-0 text-(--ui-accent)' }),
+                            jsx('span', {
+                              className: 'min-w-0 flex-1 truncate text-(--ui-text-secondary)',
+                              children: interrupting
+                                ? 'Interrupting current turn…'
+                                : room.running
+                                  ? `Queued — room agent busy (run #${queued.queuedBehindRun || 1}) · ${Math.floor(waitedMs / 1000)}s`
+                                  : `Queued — room stopped · ${Math.floor(waitedMs / 1000)}s`
+                            }),
+                            jsx(Button, {
+                              type: 'button',
+                              variant: 'text',
+                              size: 'inline',
+                              disabled: interrupting,
+                              'aria-label': 'Cancel queued group message',
+                              onClick: () => cancelQueued(queued),
+                              children: 'Cancel'
+                            })
+                          ]
+                        }),
+                        !interrupting && (overdue || !room.running)
+                          ? jsxs('div', {
+                              className: 'flex items-center justify-end gap-2 text-[0.65rem]',
+                              children: [
+                                jsx(Button, {
+                                  type: 'button',
+                                  variant: 'textStrong',
+                                  size: 'inline',
+                                  onClick: () => void interruptQueued(queued),
+                                  children: room.running ? 'Interrupt & send' : 'Send now'
+                                }),
+                                jsx(Button, {
+                                  type: 'button',
+                                  variant: 'text',
+                                  size: 'inline',
+                                  onClick: () => keepWaitingForQueuedGroupMessage(group, queued.id),
+                                  children: 'Keep waiting'
+                                })
+                              ]
+                            })
+                          : null
+                      ]
+                    }, `queued:${queued.id}`)
+                  })
+                })
+              : null,
             room.running
               ? jsx('div', {
                   className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8642,6 +8642,55 @@ function drainQueuedGroupMessage(group, members = null) {
   return runQueuedGroupMessage(group, members, next)
 }
 
+/** A restored room has no trustworthy renderer-side `running` flag. Check the
+ * durable member sessions before replaying its oldest queued send so a window
+ * reload cannot submit into backend work that survived the renderer. Unknown
+ * session state fails closed and leaves the durable queue untouched. */
+async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId = null) {
+  const before = $groupChats.get()[group] || {}
+  const roster = Array.isArray(members) && members.length ? members : before.members || []
+  const queued = messageId
+    ? before.pending?.find(item => item.id === messageId)
+    : before.pending?.[0]
+
+  if (before.running || before.interruptingQueue || !queued) {
+    return false
+  }
+
+  for (const member of roster) {
+    const sessionId = (before.sessions || {})[groupMemberKey(member)]
+
+    if (!sessionId) {
+      continue
+    }
+
+    let state
+    try {
+      state = await requestForBot(member, 'session.resume', {
+        session_id: sessionId,
+        profile: member.name
+      })
+    } catch {
+      return false
+    }
+
+    if (state?.inflight || state?.running || state?.pending_clarify || state?.pending_approval) {
+      return false
+    }
+  }
+
+  const current = $groupChats.get()[group] || {}
+  if (
+    current.running ||
+    current.interruptingQueue ||
+    !(current.pending || []).some(item => item.id === queued.id)
+  ) {
+    return false
+  }
+
+  return runQueuedGroupMessage(group, roster, queued)
+}
+
 function cancelQueuedGroupMessage(group, messageId) {
   const room = $groupChats.get()[group]
 
@@ -8695,7 +8744,7 @@ async function interruptForQueuedGroupMessage(group, messageId, members = null) 
   const roster = Array.isArray(members) && members.length ? members : room.members || []
 
   if (!room.running) {
-    return runQueuedGroupMessage(group, roster, queued)
+    return drainQueuedGroupMessageWhenIdle(group, roster, messageId)
   }
 
   updateGroupChat(group, current => {
@@ -13649,7 +13698,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   // epoch bump + holds the loop marched on to the next member. Thread scope:
   // the run being stopped is the one the latest activity belongs to.
   const stopRoomRun = async () => {
-    const queuedCount = (room.pending || []).length + (room.interruptingQueue ? 1 : 0)
+    const queuedCount = (room.pending || []).length
     await stopGroupThread(group, latestActivity?.thread || null, memberDescriptors())
     host.notify({
       kind: 'success',
@@ -16058,7 +16107,7 @@ export default {
           scheduleGroupChatServerSync($groupChats.get())
           for (const [roomName, room] of Object.entries($groupChats.get())) {
             if (!room.running && Array.isArray(room.pending) && room.pending.length) {
-              void drainQueuedGroupMessage(roomName, room.members)
+              void drainQueuedGroupMessageWhenIdle(roomName, room.members)
             }
           }
         })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7190,18 +7190,19 @@ async function renameGroupChat(oldName, newName, members) {
     return null
   }
 
+  // Active drives and recovery timers are keyed by the room name. Do not move
+  // that ownership out from under them; once the room and its durable queue
+  // are idle the same rename is safe and preserves the immutable roomId.
+  const currentRoom = $groupChats.get()[oldName]
+  if (currentRoom?.running || currentRoom?.interruptingQueue || currentRoom?.pending?.length) {
+    host.notify({ kind: 'error', message: 'Wait for the room and its queued messages to finish before renaming it.' })
+    return null
+  }
+
   // Move the room record wholesale — log, watermarks, sessions, members,
   // picture, and runtime flags all belong to the same room under its new name.
   const all = { ...$groupChats.get() }
   const room = all[oldName]
-
-  // Active drives and recovery timers are keyed by the room name. Do not move
-  // that ownership out from under them; once the room and its durable queue
-  // are idle the same rename is safe and preserves the immutable roomId.
-  if (room?.running || room?.interruptingQueue || room?.pending?.length) {
-    host.notify({ kind: 'error', message: 'Wait for the room and its queued messages to finish before renaming it.' })
-    return null
-  }
 
   if (room) {
     migrateGroupComposerDraft(groupComposerDraftKey(oldName, room), groupComposerDraftKey(next, room))

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8528,7 +8528,7 @@ async function runGroupChatRounds(group, members, thread) {
       // Busy sends stay outside the live log until the current drive settles,
       // then advance FIFO. This avoids prompt.submit's busy redirect/interrupt
       // policy and gives the UI a real, cancellable queue item meanwhile.
-      void drainQueuedGroupMessage(group, members)
+      scheduleQueuedGroupRecovery(group, members)
 
       // #89545: the loop's harvest pass only ran at the top of each round of
       // an ACTIVE loop — a member whose turn timed out after the final round
@@ -8623,7 +8623,7 @@ function runQueuedGroupMessage(group, members, queued, { claimed = false } = {})
       room.turn = null
       return room
     })
-    void drainQueuedGroupMessage(group, roster)
+    scheduleQueuedGroupRecovery(group, roster)
   })
   return true
 }
@@ -8674,7 +8674,19 @@ async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId 
       return false
     }
 
-    if (state?.inflight || state?.running || state?.pending_clarify || state?.pending_approval) {
+    const hasBusyState =
+      state &&
+      typeof state === 'object' &&
+      (Object.prototype.hasOwnProperty.call(state, 'inflight') ||
+        Object.prototype.hasOwnProperty.call(state, 'running'))
+
+    if (
+      !hasBusyState ||
+      state.inflight ||
+      state.running ||
+      state.pending_clarify ||
+      state.pending_approval
+    ) {
       return false
     }
   }
@@ -8689,6 +8701,73 @@ async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId 
   }
 
   return runQueuedGroupMessage(group, roster, queued)
+}
+
+const groupQueueRecoveryTimers = new Map()
+const GROUP_QUEUE_RECOVERY_INTERVAL_MS = 5000
+const GROUP_QUEUE_RECOVERY_MAX_TRIES = 120
+let groupQueueRecoveryDisposed = false
+
+/** Retry a durable queue after ambiguous submit failures or renderer reloads.
+ * Every attempt rechecks backend session state; the bound prevents a dead
+ * gateway from creating a permanent timer. Manual Send now remains available. */
+function scheduleQueuedGroupRecovery(group, members = null, attempt = 0) {
+  if (
+    groupQueueRecoveryDisposed ||
+    groupQueueRecoveryTimers.has(group) ||
+    typeof setTimeout !== 'function'
+  ) {
+    return
+  }
+
+  const run = async () => {
+    const room = $groupChats.get()[group] || {}
+
+    if (room.running || room.interruptingQueue || !room.pending?.length) {
+      groupQueueRecoveryTimers.delete(group)
+      return
+    }
+
+    if (await drainQueuedGroupMessageWhenIdle(group, members)) {
+      groupQueueRecoveryTimers.delete(group)
+      return
+    }
+
+    const current = $groupChats.get()[group] || {}
+    if (
+      !groupQueueRecoveryDisposed &&
+      attempt + 1 < GROUP_QUEUE_RECOVERY_MAX_TRIES &&
+      !current.running &&
+      !current.interruptingQueue &&
+      current.pending?.length
+    ) {
+      const timer = setTimeout(
+        () => {
+          groupQueueRecoveryTimers.delete(group)
+          scheduleQueuedGroupRecovery(group, members, attempt + 1)
+        },
+        GROUP_QUEUE_RECOVERY_INTERVAL_MS
+      )
+      groupQueueRecoveryTimers.set(group, timer)
+    } else {
+      groupQueueRecoveryTimers.delete(group)
+    }
+  }
+
+  // Reserve the group synchronously so concurrent settle/error paths cannot
+  // launch duplicate status probes before the async attempt starts.
+  groupQueueRecoveryTimers.set(group, null)
+  void run()
+}
+
+function stopQueuedGroupRecovery() {
+  groupQueueRecoveryDisposed = true
+  for (const timer of groupQueueRecoveryTimers.values()) {
+    if (timer !== null) {
+      clearTimeout(timer)
+    }
+  }
+  groupQueueRecoveryTimers.clear()
 }
 
 function cancelQueuedGroupMessage(group, messageId) {
@@ -16107,7 +16186,7 @@ export default {
           scheduleGroupChatServerSync($groupChats.get())
           for (const [roomName, room] of Object.entries($groupChats.get())) {
             if (!room.running && Array.isArray(room.pending) && room.pending.length) {
-              void drainQueuedGroupMessageWhenIdle(roomName, room.members)
+              scheduleQueuedGroupRecovery(roomName, room.members)
             }
           }
         })
@@ -16152,6 +16231,7 @@ export default {
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(() => {
         stopGroupChatServerSync()
+        stopQueuedGroupRecovery()
         if (typeof unbindProfileListener === 'function') {
           unbindProfileListener()
         }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1493,7 +1493,14 @@ function handleSessionsGatewayTransition() {
   // client's stale cache hide a room written by another Desktop/mobile client.
   void pullGroupChatServerState()
     .catch(() => false)
-    .then(() => scheduleGroupChatServerSync($groupChats.get()))
+    .then(() => {
+      scheduleGroupChatServerSync($groupChats.get())
+      for (const [name, room] of Object.entries($groupChats.get())) {
+        if (!room.running && room.pending?.length) {
+          scheduleQueuedGroupRecovery(name, room.members)
+        }
+      }
+    })
 }
 
 // ── cross-connection bot relay ────────────────────────────────────────────
@@ -7188,6 +7195,14 @@ async function renameGroupChat(oldName, newName, members) {
   const all = { ...$groupChats.get() }
   const room = all[oldName]
 
+  // Active drives and recovery timers are keyed by the room name. Do not move
+  // that ownership out from under them; once the room and its durable queue
+  // are idle the same rename is safe and preserves the immutable roomId.
+  if (room?.running || room?.interruptingQueue || room?.pending?.length) {
+    host.notify({ kind: 'error', message: 'Wait for the room and its queued messages to finish before renaming it.' })
+    return null
+  }
+
   if (room) {
     migrateGroupComposerDraft(groupComposerDraftKey(oldName, room), groupComposerDraftKey(next, room))
   }
@@ -8647,6 +8662,7 @@ function drainQueuedGroupMessage(group, members = null) {
  * reload cannot submit into backend work that survived the renderer. Unknown
  * session state fails closed and leaves the durable queue untouched. */
 async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId = null) {
+  const recoveryGeneration = groupQueueRecoveryGeneration
   const before = $groupChats.get()[group] || {}
   const roster = Array.isArray(members) && members.length ? members : before.members || []
   const queued = messageId
@@ -8674,6 +8690,13 @@ async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId 
       return false
     }
 
+    if (
+      groupQueueRecoveryDisposed ||
+      recoveryGeneration !== groupQueueRecoveryGeneration
+    ) {
+      return false
+    }
+
     const hasBusyState =
       state &&
       typeof state === 'object' &&
@@ -8693,6 +8716,8 @@ async function drainQueuedGroupMessageWhenIdle(group, members = null, messageId 
 
   const current = $groupChats.get()[group] || {}
   if (
+    groupQueueRecoveryDisposed ||
+    recoveryGeneration !== groupQueueRecoveryGeneration ||
     current.running ||
     current.interruptingQueue ||
     !(current.pending || []).some(item => item.id === queued.id)
@@ -8707,6 +8732,7 @@ const groupQueueRecoveryTimers = new Map()
 const GROUP_QUEUE_RECOVERY_INTERVAL_MS = 5000
 const GROUP_QUEUE_RECOVERY_MAX_TRIES = 120
 let groupQueueRecoveryDisposed = false
+let groupQueueRecoveryGeneration = 0
 
 /** Retry a durable queue after ambiguous submit failures or renderer reloads.
  * Every attempt rechecks backend session state; the bound prevents a dead
@@ -8719,8 +8745,15 @@ function scheduleQueuedGroupRecovery(group, members = null, attempt = 0) {
   ) {
     return
   }
+  const recoveryGeneration = groupQueueRecoveryGeneration
 
   const run = async () => {
+    if (
+      groupQueueRecoveryDisposed ||
+      recoveryGeneration !== groupQueueRecoveryGeneration
+    ) {
+      return
+    }
     const room = $groupChats.get()[group] || {}
 
     if (room.running || room.interruptingQueue || !room.pending?.length) {
@@ -8728,7 +8761,11 @@ function scheduleQueuedGroupRecovery(group, members = null, attempt = 0) {
       return
     }
 
-    if (await drainQueuedGroupMessageWhenIdle(group, members)) {
+    const drained = await drainQueuedGroupMessageWhenIdle(group, members)
+    if (recoveryGeneration !== groupQueueRecoveryGeneration) {
+      return
+    }
+    if (drained) {
       groupQueueRecoveryTimers.delete(group)
       return
     }
@@ -8762,6 +8799,7 @@ function scheduleQueuedGroupRecovery(group, members = null, attempt = 0) {
 
 function stopQueuedGroupRecovery() {
   groupQueueRecoveryDisposed = true
+  groupQueueRecoveryGeneration += 1
   for (const timer of groupQueueRecoveryTimers.values()) {
     if (timer !== null) {
       clearTimeout(timer)
@@ -8889,13 +8927,16 @@ function sendToGroupChat(group, members, text, thread, images) {
     queuedBehindRun: Math.max(1, Number(room.runSequence || 1))
   }
 
-  if (room.running || room.interruptingQueue) {
+  if (room.running || room.interruptingQueue || room.pending?.length) {
     updateGroupChat(group, current => {
       current.members = durableGroupChatMembers(members)
       current.pending = [...(current.pending || []), queued]
       return current
     })
     recordGroupActivity(group, { kind: 'queued', member: 'You', thread: target })
+    if (!room.running && !room.interruptingQueue) {
+      scheduleQueuedGroupRecovery(group, members)
+    }
   } else {
     runQueuedGroupMessage(group, members, queued)
   }
@@ -15993,6 +16034,8 @@ export default {
   register(ctx) {
     pluginCtx = ctx
     groupChatSyncDisposed = false
+    groupQueueRecoveryDisposed = false
+    groupQueueRecoveryGeneration += 1
     startFaceClock()
     // The cross-connection relay rides every gateway socket this Desktop
     // holds: roster sync + envelope drain/deliver/reply loops.

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -198,7 +198,7 @@ test('an untyped failed member turn keeps the message-classification fallback', 
   assert.equal(Object.values(gc.$botAttention.get())[0]?.reason, 'missing_config')
 })
 
-test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {
+test('a newer send waits behind the previous run and starts only after it settles', async () => {
   const gates = [null, null]
   const gate = n => {
     gates[n] = gates[n] || { promise: null, resolve: null }
@@ -216,23 +216,27 @@ test('a newer send interrupts the previous run and records cancelled in the CURR
   for (let i = 0; i < 50 && gc.calls.length < 1; i++) {
     await new Promise(resolve => setImmediate(resolve))
   }
-  gc.sendToGroupChat('Busy', member, 'second ask, supersede')
-  for (let i = 0; i < 50 && gc.calls.length < 2; i++) {
+  gc.sendToGroupChat('Busy', member, 'second ask, queue')
+  for (let i = 0; i < 10; i++) {
     await new Promise(resolve => setImmediate(resolve))
   }
 
-  gates[2].resolve('from the new run')
+  assert.equal(gc.calls.length, 1, 'the busy member receives no concurrent submit')
+  assert.equal(gc.$groupChats.get().Busy.pending.length, 1)
+
+  gates[1].resolve('from the first run')
+  for (let i = 0; i < 50 && gc.calls.length < 2; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(gc.calls.length, 2, 'the queued send starts after the first run settles')
+  gates[2].resolve('from the queued run')
   await drain(gc, 'Busy')
-  gates[1].resolve('late from the old run')
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
 
   const epoch = (gc.$groupChats.get().Busy || {}).epoch || 0
   const events = feed(gc, 'Busy')
-  assert.equal(events.some(e => e.kind === 'cancelled'), true, 'the superseded loop reports its own interruption')
-  // The view shows only the current run: every visible event is this epoch.
+  assert.equal(events.some(e => e.kind === 'cancelled'), false, 'FIFO draining does not manufacture cancellation')
   assert.equal(gc.currentGroupActivity('Busy').every(e => (e.epoch || 0) === epoch), true)
-  assert.equal(gc.currentGroupActivity('Busy').some(e => e.kind === 'cancelled'), true)
+  assert.equal(gc.$groupChats.get().Busy.pending.length, 0)
 })
 
 test('epoch filtering drops events from a superseded run', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -204,7 +204,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, drainQueuedGroupMessage, cancelQueuedGroupMessage, keepWaitingForQueuedGroupMessage, interruptForQueuedGroupMessage, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -341,6 +341,76 @@ test('delta injection: a second user send only feeds members the NEW messages', 
   const second = prompts.slice(firstCount).find(p => p.prompt.includes('second message'))
   assert.ok(second, 'second turn ran')
   assert.equal(second.prompt.includes('first message'), false, 'first message was already seen — not re-injected')
+})
+
+test('a send behind a busy room is a durable cancellable queue item, not a live-log submit', () => {
+  const gc = load(() => '(pass)')
+  gc.updateGroupChat('Busy', room => {
+    room.running = true
+    room.runSequence = 7
+    room.members = MEMBERS
+    return room
+  })
+
+  const thread = gc.sendToGroupChat('Busy', MEMBERS, 'wait behind the current turn')
+  const queued = gc.$groupChats.get().Busy.pending[0]
+
+  assert.equal(gc.$groupChats.get().Busy.log.length, 0, 'busy send never reaches the live delta')
+  assert.equal(queued.thread, thread)
+  assert.equal(queued.queuedBehindRun, 7)
+  assert.equal(gc.storageWrites.get('group-chats').Busy.pending.length, 1, 'queue survives a window reload')
+  assert.equal(gc.cancelQueuedGroupMessage('Busy', 'missing'), false, 'stale cancel is honest')
+  assert.equal(gc.$groupChats.get().Busy.pending.length, 1, 'failed cancel removes nothing')
+  assert.equal(gc.keepWaitingForQueuedGroupMessage('Busy', queued.id), true)
+  assert.ok(gc.$groupChats.get().Busy.pending[0].decisionAt >= queued.at)
+  assert.equal(gc.cancelQueuedGroupMessage('Busy', queued.id), true)
+  assert.equal(gc.$groupChats.get().Busy.pending.length, 0)
+})
+
+test('a settled room automatically drains queued messages in FIFO order', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('FIFO', room => {
+    room.running = true
+    room.members = roster
+    return room
+  })
+  gc.sendToGroupChat('FIFO', roster, 'first queued')
+  gc.sendToGroupChat('FIFO', roster, 'second queued')
+  gc.updateGroupChat('FIFO', room => {
+    room.running = false
+    return room
+  })
+
+  assert.equal(gc.drainQueuedGroupMessage('FIFO'), true)
+  for (let i = 0; i < 200 && ((gc.$groupChats.get().FIFO || {}).running || (gc.$groupChats.get().FIFO || {}).pending?.length); i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const userText = roomLog(gc, 'FIFO').filter(entry => entry.from.kind === 'user').map(entry => entry.text)
+  assert.equal(JSON.stringify(userText), JSON.stringify(['first queued', 'second queued']))
+  assert.equal(gc.$groupChats.get().FIFO.pending.length, 0)
+})
+
+test('interrupt-and-send promotes only the selected queue item and interrupts the live member', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('Interrupt', room => {
+    room.running = true
+    room.turn = 'research'
+    room.runSequence = 2
+    room.sessions = { research: 'live-research-session' }
+    room.members = roster
+    return room
+  })
+  gc.sendToGroupChat('Interrupt', roster, 'send this now')
+  gc.sendToGroupChat('Interrupt', roster, 'leave this queued')
+  const [selected, waiting] = gc.$groupChats.get().Interrupt.pending
+
+  assert.equal(await gc.interruptForQueuedGroupMessage('Interrupt', selected.id), true)
+  assert.equal(roomLog(gc, 'Interrupt').some(entry => entry.text === 'send this now'), true)
+  assert.equal(gc.$groupChats.get().Interrupt.pending.some(item => item.id === waiting.id), true)
+  assert.equal(await gc.interruptForQueuedGroupMessage('Interrupt', 'missing'), false)
 })
 
 test('concurrent groups sharing one member keep sessions, deltas, and context isolated', async () => {
@@ -532,11 +602,12 @@ test('same-name group dedup reserves suffix length at the 64-char cap', () => {
   assert.equal(next, `${base.slice(0, 62)} 3`)
 })
 
-test('roomId persists with the room record and survives disband of other rooms', async () => {
+test('roomId and pending sends survive disband of another room', async () => {
   const gc = load(() => '(pass)')
 
   gc.updateGroupChat('Keep', r => {
     r.roomId = 'r-keep'
+    r.pending = [{ id: 'queued-1', at: 1, text: 'later', thread: 't1', queuedBehindRun: 1 }]
     return r
   })
   gc.updateGroupChat('Gone', r => {
@@ -548,6 +619,7 @@ test('roomId persists with the room record and survives disband of other rooms',
 
   const durable = gc.storageWrites.get('group-chats')
   assert.equal(durable.Keep.roomId, 'r-keep', 'roomId survives disband of another room')
+  assert.equal(durable.Keep.pending[0].id, 'queued-1', 'another room mutation cannot drop the queue')
   assert.ok(!('Gone' in durable), 'disbanded room not persisted')
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -572,6 +572,29 @@ test('a restored queue waits for durable member sessions to become idle before d
   assert.equal(roomLog(gc, 'Restored').some(entry => entry.text === 'wait for the old backend turn'), true)
 })
 
+test('restored queue replay fails closed on an unknown session status payload', async () => {
+  const gc = load(() => '(pass)')
+  await new Promise(resolve => setImmediate(resolve))
+  const roster = [{ name: 'research', title: '' }]
+  gc.host.request = async () => ({})
+  gc.host.requestProfile = (_route, method, params) => gc.host.request(method, params)
+  gc.updateGroupChat('Unknown', room => {
+    room.running = true
+    room.members = roster
+    room.sessions = { research: 'unknown-status-session' }
+    return room
+  })
+  gc.sendToGroupChat('Unknown', roster, 'do not replay without idle evidence')
+  gc.updateGroupChat('Unknown', room => {
+    room.running = false
+    return room
+  })
+
+  assert.equal(await gc.drainQueuedGroupMessageWhenIdle('Unknown', roster), false)
+  assert.equal(gc.$groupChats.get().Unknown.pending.length, 1)
+  assert.equal(roomLog(gc, 'Unknown').some(entry => entry.text === 'do not replay without idle evidence'), false)
+})
+
 test('send-now promotes the selected non-head item only after session-idle verification', async () => {
   const gc = load(() => '(pass)')
   const roster = [{ name: 'research', title: '' }]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -204,7 +204,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, drainQueuedGroupMessage, cancelQueuedGroupMessage, keepWaitingForQueuedGroupMessage, interruptForQueuedGroupMessage, stopGroupThread, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, drainQueuedGroupMessage, drainQueuedGroupMessageWhenIdle, cancelQueuedGroupMessage, keepWaitingForQueuedGroupMessage, interruptForQueuedGroupMessage, stopGroupThread, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -536,6 +536,69 @@ test('interrupt fencing survives sticky-hold restoration until the old poll exit
   const room = gc.$groupChats.get().Fence
   assert.equal(room.cancelledThroughEpoch, 8, 'the stopped drive remains fenced after promotion')
   assert.equal(room.holds.research.byMessageId, 'sticky', 'the user hold is restored without erasing the fence')
+})
+
+test('a restored queue waits for durable member sessions to become idle before draining', async () => {
+  const gc = load(() => '(pass)')
+  await new Promise(resolve => setImmediate(resolve))
+  const roster = [{ name: 'research', title: '' }]
+  let busy = true
+  const request = gc.host.request
+  gc.host.request = (method, params) => {
+    if (method === 'session.resume' && params.session_id === 'surviving-session') {
+      return Promise.resolve({ messages: [], inflight: busy, running: busy })
+    }
+    return request(method, params)
+  }
+  gc.host.requestProfile = (_route, method, params) => gc.host.request(method, params)
+  gc.updateGroupChat('Restored', room => {
+    room.running = true
+    room.members = roster
+    room.sessions = { research: 'surviving-session' }
+    return room
+  })
+  gc.sendToGroupChat('Restored', roster, 'wait for the old backend turn')
+  gc.updateGroupChat('Restored', room => {
+    room.running = false
+    return room
+  })
+
+  assert.equal(await gc.drainQueuedGroupMessageWhenIdle('Restored', roster), false)
+  assert.equal(gc.$groupChats.get().Restored.pending.length, 1)
+  assert.equal(roomLog(gc, 'Restored').some(entry => entry.text === 'wait for the old backend turn'), false)
+
+  busy = false
+  assert.equal(await gc.drainQueuedGroupMessageWhenIdle('Restored', roster), true)
+  assert.equal(roomLog(gc, 'Restored').some(entry => entry.text === 'wait for the old backend turn'), true)
+})
+
+test('send-now promotes the selected non-head item only after session-idle verification', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research', title: '' }]
+  gc.host.request = async (method, params) => {
+    if (method === 'session.resume' && params.session_id === 'idle-session') {
+      return { messages: [], inflight: false, running: false }
+    }
+    return {}
+  }
+  gc.host.requestProfile = (_route, method, params) => gc.host.request(method, params)
+  gc.updateGroupChat('Select', room => {
+    room.running = true
+    room.members = roster
+    room.sessions = { research: 'idle-session' }
+    return room
+  })
+  gc.sendToGroupChat('Select', roster, 'stay at the head')
+  gc.sendToGroupChat('Select', roster, 'send the selected item')
+  const selected = gc.$groupChats.get().Select.pending[1]
+  gc.updateGroupChat('Select', room => {
+    room.running = false
+    return room
+  })
+
+  assert.equal(await gc.interruptForQueuedGroupMessage('Select', selected.id, roster), true)
+  assert.equal(roomLog(gc, 'Select').some(entry => entry.text === 'send the selected item'), true)
+  assert.equal(gc.$groupChats.get().Select.pending[0].text, 'stay at the head')
 })
 
 test('concurrent groups sharing one member keep sessions, deltas, and context isolated', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -572,6 +572,51 @@ test('a restored queue waits for durable member sessions to become idle before d
   assert.equal(roomLog(gc, 'Restored').some(entry => entry.text === 'wait for the old backend turn'), true)
 })
 
+test('a new composer send stays behind an older restored queue item', async () => {
+  const gc = load(() => '(pass)')
+  await new Promise(resolve => setImmediate(resolve))
+  const roster = [{ name: 'research', title: '' }]
+  gc.host.request = async (method, params) => {
+    if (method === 'session.resume' && params.session_id === 'still-busy-session') {
+      return { messages: [], inflight: true, running: true }
+    }
+    return {}
+  }
+  gc.host.requestProfile = (_route, method, params) => gc.host.request(method, params)
+  gc.updateGroupChat('Backlog', room => {
+    room.running = true
+    room.members = roster
+    room.sessions = { research: 'still-busy-session' }
+    return room
+  })
+  gc.sendToGroupChat('Backlog', roster, 'older durable item')
+  gc.updateGroupChat('Backlog', room => {
+    room.running = false
+    return room
+  })
+
+  gc.sendToGroupChat('Backlog', roster, 'new composer item')
+  assert.equal(
+    JSON.stringify(gc.$groupChats.get().Backlog.pending.map(item => item.text)),
+    JSON.stringify(['older durable item', 'new composer item'])
+  )
+  assert.equal(roomLog(gc, 'Backlog').some(entry => entry.from.kind === 'user'), false)
+})
+
+test('rename waits until an active or queued room has released name-keyed ownership', async () => {
+  const gc = load(() => '(pass)')
+  gc.updateGroupChat('Owned', room => {
+    room.running = true
+    room.members = MEMBERS
+    return room
+  })
+  gc.sendToGroupChat('Owned', MEMBERS, 'queued before rename')
+
+  assert.equal(await gc.renameGroupChat('Owned', 'Moved', MEMBERS), null)
+  assert.ok(gc.$groupChats.get().Owned)
+  assert.equal(gc.$groupChats.get().Moved, undefined)
+})
+
 test('restored queue replay fails closed on an unknown session status payload', async () => {
   const gc = load(() => '(pass)')
   await new Promise(resolve => setImmediate(resolve))

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -441,10 +441,12 @@ test('interrupt-and-send is single-flight while session.interrupt is pending', a
   const first = gc.interruptForQueuedGroupMessage('Claim', selected.id, roster)
   const second = gc.interruptForQueuedGroupMessage('Claim', selected.id, roster)
   assert.equal(gc.$groupChats.get().Claim.interruptingQueue?.id, selected.id, 'claim is installed synchronously')
+  assert.equal(gc.$groupChats.get().Claim.pending[0].id, selected.id, 'the in-flight claim stays in the durable FIFO')
+  assert.equal(gc.storageWrites.get('group-chats').Claim.pending[0].id, selected.id, 'reload cannot lose the claimed send')
   assert.equal(gc.$groupChats.get().Claim.sessions.research, 'live-research-session')
   await Promise.resolve()
   gc.sendToGroupChat('Claim', roster, 'arrived during interrupt')
-  const later = gc.$groupChats.get().Claim.pending[0]
+  const later = gc.$groupChats.get().Claim.pending.at(-1)
 
   assert.equal(gc.$groupChats.get().Claim.interruptingQueue?.id, selected.id, 'the selected send owns the room')
   assert.equal(gc.requests.some(call => call.method === 'session.interrupt'), true, 'the interrupt RPC is in flight')
@@ -461,6 +463,7 @@ test('interrupt-and-send is single-flight while session.interrupt is pending', a
   assert.equal(await first, true)
   assert.equal(roomLog(gc, 'Claim').filter(entry => entry.text === 'promote exactly once').length, 1)
   assert.equal(gc.$groupChats.get().Claim.interruptingQueue, null)
+  assert.equal(gc.$groupChats.get().Claim.pending.some(item => item.id === selected.id), false)
 })
 
 test('explicit Stop cancels queued sends instead of leaving a false busy queue', async () => {
@@ -483,7 +486,7 @@ test('explicit Stop cancels queued sends instead of leaving a false busy queue',
   assert.equal(roomLog(gc, 'Stopped').some(entry => entry.text === 'must not survive Stop'), false)
 })
 
-test('a failed interrupt restores the claimed send without promoting it', async () => {
+test('a failed interrupt preserves the claimed send in its original FIFO position', async () => {
   const gc = load(() => '(pass)')
   // Let the plugin's one-time cold-start queue drain finish before constructing
   // this runtime-only failure state.
@@ -502,13 +505,37 @@ test('a failed interrupt restores the claimed send without promoting it', async 
     room.members = roster
     return room
   })
-  gc.sendToGroupChat('Rollback', roster, 'restore me')
-  const selected = gc.$groupChats.get().Rollback.pending[0]
+  gc.sendToGroupChat('Rollback', roster, 'stay first')
+  gc.sendToGroupChat('Rollback', roster, 'restore me in place')
+  gc.sendToGroupChat('Rollback', roster, 'stay last')
+  const selected = gc.$groupChats.get().Rollback.pending[1]
+  const originalOrder = gc.$groupChats.get().Rollback.pending.map(item => item.id)
 
   assert.equal(await gc.interruptForQueuedGroupMessage('Rollback', selected.id, roster), false)
   assert.equal(gc.$groupChats.get().Rollback.interruptingQueue, null)
-  assert.equal(gc.$groupChats.get().Rollback.pending[0].id, selected.id)
-  assert.equal(roomLog(gc, 'Rollback').some(entry => entry.text === 'restore me'), false)
+  assert.deepEqual(gc.$groupChats.get().Rollback.pending.map(item => item.id), originalOrder)
+  assert.equal(roomLog(gc, 'Rollback').some(entry => entry.text === 'restore me in place'), false)
+})
+
+test('interrupt fencing survives sticky-hold restoration until the old poll exits', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('Fence', room => {
+    room.running = true
+    room.turn = 'research'
+    room.epoch = 8
+    room.sessions = { research: 'live-research-session' }
+    room.members = roster
+    room.holds = { research: { at: 1, byMessageId: 'sticky', thread: 'old' } }
+    return room
+  })
+  gc.sendToGroupChat('Fence', roster, 'promote after interrupt')
+  const selected = gc.$groupChats.get().Fence.pending[0]
+
+  assert.equal(await gc.interruptForQueuedGroupMessage('Fence', selected.id, roster), true)
+  const room = gc.$groupChats.get().Fence
+  assert.equal(room.cancelledThroughEpoch, 8, 'the stopped drive remains fenced after promotion')
+  assert.equal(room.holds.research.byMessageId, 'sticky', 'the user hold is restored without erasing the fence')
 })
 
 test('concurrent groups sharing one member keep sessions, deltas, and context isolated', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -204,7 +204,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, drainQueuedGroupMessage, cancelQueuedGroupMessage, keepWaitingForQueuedGroupMessage, interruptForQueuedGroupMessage, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, drainQueuedGroupMessage, cancelQueuedGroupMessage, keepWaitingForQueuedGroupMessage, interruptForQueuedGroupMessage, stopGroupThread, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -411,6 +411,104 @@ test('interrupt-and-send promotes only the selected queue item and interrupts th
   assert.equal(roomLog(gc, 'Interrupt').some(entry => entry.text === 'send this now'), true)
   assert.equal(gc.$groupChats.get().Interrupt.pending.some(item => item.id === waiting.id), true)
   assert.equal(await gc.interruptForQueuedGroupMessage('Interrupt', 'missing'), false)
+})
+
+test('interrupt-and-send is single-flight while session.interrupt is pending', async () => {
+  let releaseInterrupt
+  const interruptGate = { promise: new Promise(resolve => { releaseInterrupt = resolve }) }
+  const gc = load(() => '(pass)')
+  const request = gc.host.request
+  gc.host.request = (method, params) => {
+    if (method === 'session.interrupt') {
+      gc.requests.push({ method, params })
+      return interruptGate.promise
+    }
+    return request(method, params)
+  }
+  gc.host.requestProfile = (_route, method, params) => gc.host.request(method, params)
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('Claim', room => {
+    room.running = true
+    room.turn = 'research'
+    room.runSequence = 3
+    room.sessions = { research: 'live-research-session' }
+    room.members = roster
+    return room
+  })
+  gc.sendToGroupChat('Claim', roster, 'promote exactly once')
+  const selected = gc.$groupChats.get().Claim.pending[0]
+
+  const first = gc.interruptForQueuedGroupMessage('Claim', selected.id, roster)
+  const second = gc.interruptForQueuedGroupMessage('Claim', selected.id, roster)
+  assert.equal(gc.$groupChats.get().Claim.interruptingQueue?.id, selected.id, 'claim is installed synchronously')
+  assert.equal(gc.$groupChats.get().Claim.sessions.research, 'live-research-session')
+  await Promise.resolve()
+  gc.sendToGroupChat('Claim', roster, 'arrived during interrupt')
+  const later = gc.$groupChats.get().Claim.pending[0]
+
+  assert.equal(gc.$groupChats.get().Claim.interruptingQueue?.id, selected.id, 'the selected send owns the room')
+  assert.equal(gc.requests.some(call => call.method === 'session.interrupt'), true, 'the interrupt RPC is in flight')
+  assert.equal(await second, false, 'a repeated action cannot share or duplicate the claim')
+  assert.equal(gc.cancelQueuedGroupMessage('Claim', selected.id), false, 'the claimed item cannot be cancelled mid-promotion')
+  assert.equal(gc.cancelQueuedGroupMessage('Claim', later.id), true, 'a later queued item remains independently cancellable')
+  assert.equal(
+    roomLog(gc, 'Claim').filter(entry => entry.text === 'promote exactly once').length,
+    0,
+    'the claimed item does not promote before interrupt settles'
+  )
+
+  releaseInterrupt({ ok: true })
+  assert.equal(await first, true)
+  assert.equal(roomLog(gc, 'Claim').filter(entry => entry.text === 'promote exactly once').length, 1)
+  assert.equal(gc.$groupChats.get().Claim.interruptingQueue, null)
+})
+
+test('explicit Stop cancels queued sends instead of leaving a false busy queue', async () => {
+  const gc = load(() => '(pass)')
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('Stopped', room => {
+    room.running = true
+    room.turn = 'research'
+    room.sessions = { research: 'live-research-session' }
+    room.members = roster
+    return room
+  })
+  gc.sendToGroupChat('Stopped', roster, 'must not survive Stop')
+
+  assert.equal(gc.$groupChats.get().Stopped.pending.length, 1)
+  await gc.stopGroupThread('Stopped', null, roster)
+  assert.equal(gc.$groupChats.get().Stopped.running, false)
+  assert.equal(gc.$groupChats.get().Stopped.pending.length, 0)
+  assert.equal(gc.drainQueuedGroupMessage('Stopped'), false)
+  assert.equal(roomLog(gc, 'Stopped').some(entry => entry.text === 'must not survive Stop'), false)
+})
+
+test('a failed interrupt restores the claimed send without promoting it', async () => {
+  const gc = load(() => '(pass)')
+  // Let the plugin's one-time cold-start queue drain finish before constructing
+  // this runtime-only failure state.
+  await new Promise(resolve => setImmediate(resolve))
+  gc.host.request = async method => {
+    if (method === 'session.interrupt') {
+      throw new Error('interrupt unavailable')
+    }
+    return {}
+  }
+  const roster = [{ name: 'research', title: '' }]
+  gc.updateGroupChat('Rollback', room => {
+    room.running = true
+    room.turn = 'research'
+    room.sessions = { research: 'live-research-session' }
+    room.members = roster
+    return room
+  })
+  gc.sendToGroupChat('Rollback', roster, 'restore me')
+  const selected = gc.$groupChats.get().Rollback.pending[0]
+
+  assert.equal(await gc.interruptForQueuedGroupMessage('Rollback', selected.id, roster), false)
+  assert.equal(gc.$groupChats.get().Rollback.interruptingQueue, null)
+  assert.equal(gc.$groupChats.get().Rollback.pending[0].id, selected.id)
+  assert.equal(roomLog(gc, 'Rollback').some(entry => entry.text === 'restore me'), false)
 })
 
 test('concurrent groups sharing one member keep sessions, deltas, and context isolated', async () => {


### PR DESCRIPTION
## Summary

- keep group-chat sends behind an active room turn in a durable FIFO instead of submitting into a busy member session
- expose queued state with cancellation, interrupt-and-send, and keep-waiting actions
- automatically drain queued messages in order when the active room run settles or after a Desktop restart

## Test plan

- `npm run check:lint`
- `npm run check:test:plugins` (628 passed)
- `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs` (93 passed)

## Related Issue

Closes #96569
