### PR TITLE
fix(desktop): invalidate warm-cache runtime bindings on connection switch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -14,6 +14,7 @@ import {
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
+  setConnection,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
@@ -688,5 +689,35 @@ describe('useSessionStateCache — reconnect busy reconcile (#93059)', () => {
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.busy).toBe(false)
     expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-1')?.awaitingResponse).toBe(false)
     expect($sessionStates.get()['runtime-1']?.busy).toBe(false)
+  })
+})
+
+describe('useSessionStateCache — warm-cache invalidation on connection switch (#93888)', () => {
+  afterEach(() => {
+    setConnection(null)
+    cleanup()
+  })
+
+  it('clears stale stored→runtime bindings when the connection changes', () => {
+    let cache!: Cache
+
+    setConnection({ connectionId: 'local', mode: 'local' } as never)
+    render(<Harness activeSessionId="runtime-local" onReady={value => (cache = value)} selectedStoredSessionId="stored-local" />)
+
+    // Populate the warm cache under the local backend.
+    act(() => {
+      cache.ensureSessionState('runtime-local', 'stored-local')
+    })
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-local')).toBe('runtime-local')
+
+    // Switch to a remote gateway: the previous backend's runtime ids are
+    // meaningless to it, so they must not survive (a stale local runtime id
+    // sent to a remote gateway is rejected as "Session not found").
+    act(() => {
+      setConnection({ connectionId: 'remote', mode: 'remote' } as never)
+    })
+
+    expect(cache.runtimeIdByStoredSessionIdRef.current.size).toBe(0)
+    expect(cache.sessionStateByRuntimeIdRef.current.size).toBe(0)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -9,6 +9,7 @@ import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $activeSessionId,
+  $connection,
   $messages,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
@@ -127,6 +128,30 @@ export function useSessionStateCache({
   // Runtime id whose transcript currently occupies `$messages` — lets the
   // flush below tell a same-session refresh from a thread switch.
   const viewSessionIdRef = useRef<string | null>(null)
+
+  // A runtime id is owned by the backend that minted it. Switching the active
+  // connection (local ↔ remote gateway, or one remote to another) changes
+  // which backend owns every stored session, so the cached stored→runtime
+  // bindings from the PREVIOUS backend must not survive the switch: sending a
+  // stale local runtime id to a remote gateway makes it reject the resume as
+  // "Session not found" (#93888). Wipe both warm-cache refs on connection
+  // change so the next resume resolves a fresh runtime from the new backend
+  // (the cold `session.resume` path, which correctly uses the durable stored
+  // id, repopulates them).
+  const connection = useStore($connection)
+  const connectionScopeKey = connection?.connectionId ?? connection?.mode ?? 'default'
+  const prevConnectionScopeKeyRef = useRef(connectionScopeKey)
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    if (prevConnectionScopeKeyRef.current === connectionScopeKey) {
+      return
+    }
+
+    prevConnectionScopeKeyRef.current = connectionScopeKey
+    runtimeIdByStoredSessionIdRef.current.clear()
+    sessionStateCache.clear()
+  }, [connectionScopeKey, sessionStateCache])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {


### PR DESCRIPTION
Refs #93888 — defensive hardening for the warm-cache path, which can replay a stale runtime session ID from a previous backend after a connection switch.

## What

Desktop keeps per-backend runtime identities in the warm cache (`runtimeIdByStoredSessionIdRef` / `sessionStateByRuntimeIdRef`). A runtime ID is owned by the backend that minted it and is not meaningful to a different gateway. On a local → remote (or one remote → another) connection switch, the stored→runtime bindings from the PREVIOUS backend survive, so the next `session.activate` can send an 8-character runtime ID to the remote gateway (`use-session-actions/index.ts:926`).

`useSessionStateCache` now clears both warm-cache refs when the active connection changes (scoped by `connectionId`/`mode`), so the next resume falls to the cold `session.resume` path (which uses the durable stored ID) instead of attempting a stale-runtime `session.activate`.

## Scope

As cervantesh notes, current main already recovers the two stale-cache outcomes at `session.activate` time (#39819 drops a gone runtime → durable resume; #54503 rejects a cross-wired runtime whose `session_key` mismatches → durable resume). This PR is the smaller-footprint hardening that removes the unnecessary activation attempt up front — it does not claim to close the full #93888 stored-session restore failure, whose current evidence points to SSH registry drift / owner resolution before resume dispatch. Hence `Refs #93888`, not `Fixes`.

## Validation

- New regression: populate the warm cache under a local backend, switch to a remote gateway, assert both refs are cleared (stale local runtime ID no longer resolvable).
- `use-session-state-cache.test.tsx` (17 tests) passes; `tsc --noEmit` and eslint clean.
