### PR TITLE
fix(provider): stop custom GLM sessions from looping through fallbacks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8765,10 +8765,25 @@ def _build_call_kwargs(
     profile_top_level: Dict[str, Any] = {}
     profile_handles_reasoning = False
     try:
+        from hermes_cli.runtime_provider import request_policy_provider
         from providers import get_provider_profile
         from providers.base import ProviderProfile
 
-        profile = get_provider_profile(str(provider or "").strip().lower())
+        provider_norm = str(provider or "").strip().lower()
+        requested_provider = ""
+        runtime_provider = str(_runtime_main_value("provider") or "").strip().lower()
+        runtime_base_url = str(_runtime_main_value("base_url") or "").strip().rstrip("/")
+        if provider_norm == runtime_provider and (
+            not effective_base
+            or not runtime_base_url
+            or str(effective_base).strip().rstrip("/") == runtime_base_url
+        ):
+            requested_provider = str(
+                _runtime_main_value("requested_provider") or ""
+            ).strip()
+        profile = get_provider_profile(
+            request_policy_provider(provider_norm, requested_provider)
+        )
         if profile is not None:
             profile_body = profile.build_extra_body(
                 model=model,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1822,6 +1822,22 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _request_policy_provider(provider: str, requested_provider: str) -> str:
+    """Return the identity used to select request-shaping policy.
+
+    Named custom providers share the canonical ``custom`` wire transport, but
+    must not inherit the generic custom profile's endpoint-specific request
+    fields.  Keep transport and policy identities separate just as capability
+    routing does; an unregistered ``custom:<name>`` then uses the conservative
+    legacy path instead of Ollama-style custom policy.
+    """
+    provider = str(provider or "").strip().lower()
+    requested_provider = str(requested_provider or "").strip().lower()
+    if provider == "custom" and requested_provider.startswith("custom:"):
+        return requested_provider
+    return provider
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
@@ -2025,7 +2041,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # found, delegate fully; otherwise fall through to the legacy flag path.
     try:
         from providers import get_provider_profile
-        _profile = get_provider_profile(agent.provider)
+        _profile = get_provider_profile(
+            _request_policy_provider(
+                agent.provider,
+                getattr(agent, "requested_provider", ""),
+            )
+        )
     except Exception:
         _profile = None
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1822,22 +1822,6 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
-def _request_policy_provider(provider: str, requested_provider: str) -> str:
-    """Return the identity used to select request-shaping policy.
-
-    Named custom providers share the canonical ``custom`` wire transport, but
-    must not inherit the generic custom profile's endpoint-specific request
-    fields.  Keep transport and policy identities separate just as capability
-    routing does; an unregistered ``custom:<name>`` then uses the conservative
-    legacy path instead of Ollama-style custom policy.
-    """
-    provider = str(provider or "").strip().lower()
-    requested_provider = str(requested_provider or "").strip().lower()
-    if provider == "custom" and requested_provider.startswith("custom:"):
-        return requested_provider
-    return provider
-
-
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
@@ -2040,9 +2024,10 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # Profiles handle per-provider quirks via hooks. When a profile is
     # found, delegate fully; otherwise fall through to the legacy flag path.
     try:
+        from hermes_cli.runtime_provider import request_policy_provider
         from providers import get_provider_profile
         _profile = get_provider_profile(
-            _request_policy_provider(
+            request_policy_provider(
                 agent.provider,
                 getattr(agent, "requested_provider", ""),
             )
@@ -3095,9 +3080,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             provider_preferences = _provider_preferences_for_agent(agent)
             profile_extra_body = {}
             try:
+                from hermes_cli.runtime_provider import request_policy_provider
                 from providers import get_provider_profile
 
-                provider_profile = get_provider_profile(agent.provider)
+                provider_profile = get_provider_profile(
+                    request_policy_provider(
+                        agent.provider,
+                        getattr(agent, "requested_provider", ""),
+                    )
+                )
                 if provider_profile is not None:
                     profile_extra_body = provider_profile.build_extra_body(
                         session_id=getattr(agent, "session_id", None),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1165,6 +1165,14 @@ def _resolve_named_custom_runtime(
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
+        # The pool reports the shared billing class ("custom"), but runtime
+        # policy needs the configured endpoint identity.  Keep the same stable
+        # slug used by model selection/session persistence so a pooled named
+        # provider cannot silently acquire bare-custom request semantics.
+        pool_result["provider"] = custom_provider_slug(
+            str(custom_provider.get("name") or requested_provider),
+            str(custom_provider.get("provider_key") or ""),
+        )
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
         # An explicit ``target_model`` wins (same rule as the non-pool path).

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -777,6 +777,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
+                        "provider_key": str(ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -777,7 +777,6 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
-                        "provider_key": str(ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
@@ -1166,14 +1165,6 @@ def _resolve_named_custom_runtime(
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
-        # The pool reports the shared billing class ("custom"), but runtime
-        # policy needs the configured endpoint identity.  Keep the same stable
-        # slug used by model selection/session persistence so a pooled named
-        # provider cannot silently acquire bare-custom request semantics.
-        pool_result["provider"] = custom_provider_slug(
-            str(custom_provider.get("name") or requested_provider),
-            str(custom_provider.get("provider_key") or ""),
-        )
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
         # An explicit ``target_model`` wins (same rule as the non-pool path).

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -777,6 +777,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
+                        "provider_key": str(ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
@@ -853,6 +854,33 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         return result
 
     return None
+
+
+def request_policy_provider(provider: str, requested_provider: str = "") -> str:
+    """Return the identity used to select request-shaping policy.
+
+    ``provider`` remains the canonical wire transport. A configured named
+    custom endpoint needs a distinct policy identity, however, or it inherits
+    generic custom/Ollama request fields. Resolve raw legacy names through the
+    same config lookup as runtime resolution so aliases such as ``local`` are
+    only treated as named endpoints when the user actually configured one.
+    """
+    provider_norm = str(provider or "").strip().lower()
+    requested_norm = _normalize_custom_provider_name(requested_provider or "")
+    if provider_norm != "custom":
+        return provider_norm
+    if requested_norm.startswith("custom:"):
+        return requested_norm
+    try:
+        custom_provider = _get_named_custom_provider(requested_norm)
+    except Exception:
+        custom_provider = None
+    if custom_provider:
+        return custom_provider_slug(
+            str(custom_provider.get("name") or requested_norm),
+            str(custom_provider.get("provider_key") or ""),
+        )
+    return provider_norm
 
 
 def has_named_custom_provider(requested_provider: str) -> bool:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -359,6 +359,43 @@ class TestMoaAggregatorSharedResolution:
         assert mock_resolve.call_args.kwargs["model"] == "anthropic/claude-opus-4.8"
 
 
+def test_named_custom_runtime_avoids_generic_custom_auxiliary_fields():
+    from agent.auxiliary_client import reset_runtime_main, set_runtime_main
+
+    token = set_runtime_main(
+        "custom",
+        "glm-custom",
+        requested_provider="custom:zhipuai",
+        base_url="https://proxy.example/v1",
+    )
+    try:
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="glm-custom",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+            base_url="https://proxy.example/v1",
+        )
+    finally:
+        reset_runtime_main(token)
+
+    assert "reasoning_effort" not in kwargs
+    assert kwargs.get("extra_body", {}).get("think") is None
+
+
+def test_bare_custom_runtime_keeps_generic_custom_auxiliary_fields():
+    kwargs = _build_call_kwargs(
+        provider="custom",
+        model="ollama-model",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False},
+        base_url="http://127.0.0.1:11434/v1",
+    )
+
+    assert kwargs["reasoning_effort"] == "none"
+    assert kwargs["extra_body"]["think"] is False
+
+
 class TestBuildCallKwargsMaxTokens:
     """_build_call_kwargs should not cap output by default (#34530).
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1609,8 +1609,8 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
         },
     )
 
-    # Exercise the public resolver: it is responsible for preserving the
-    # original named identity after the pool path canonicalizes to "custom".
+    # Exercise the public resolver: pooled credentials must not collapse the
+    # configured provider identity into the shared "custom" billing class.
     resolved = rp.resolve_runtime_provider(requested="custom:lmstudio")
 
     assert resolved is not None
@@ -1620,7 +1620,7 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
-    assert resolved["provider"] == "custom"
+    assert resolved["provider"] == "custom:lmstudio"
     assert resolved["requested_provider"] == "custom:lmstudio"
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1624,6 +1624,40 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["requested_provider"] == "custom:lmstudio"
 
 
+def test_pooled_providers_entry_preserves_config_key_identity(monkeypatch):
+    """A display name must not replace the durable ``providers`` mapping key."""
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "zhipuai": {
+                    "name": "Zhipu GLM",
+                    "api": "https://open.bigmodel.cn/api/paas/v4",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4",
+            "api_key": "pooled-key",
+            "source": "pool:zhipuai",
+            "credential_pool": "fake-pool",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:zhipuai")
+
+    assert resolved["provider"] == "custom:zhipuai"
+    assert resolved["requested_provider"] == "custom:zhipuai"
+    assert resolved["api_key"] == "pooled-key"
+
+
 def test_resolve_runtime_provider_opencode_free_keyless_despite_exhausted_pool(monkeypatch):
     """OpenCode Free is keyless: an exhausted credential pool must not raise
     a missing-credential error. The provider resolves with the keyless

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1658,10 +1658,9 @@ def test_pooled_providers_entry_keeps_transport_and_policy_identity_separate(mon
 
 
 def test_named_custom_runtime_avoids_generic_custom_request_policy():
-    from agent.chat_completion_helpers import _request_policy_provider
     from providers import get_provider_profile
 
-    policy_provider = _request_policy_provider("custom", "custom:zhipuai")
+    policy_provider = rp.request_policy_provider("custom", "custom:zhipuai")
 
     assert policy_provider == "custom:zhipuai"
     assert get_provider_profile(policy_provider) is None
@@ -1669,9 +1668,24 @@ def test_named_custom_runtime_avoids_generic_custom_request_policy():
 
 
 def test_bare_custom_runtime_keeps_generic_custom_request_policy():
-    from agent.chat_completion_helpers import _request_policy_provider
+    assert rp.request_policy_provider("custom", "custom") == "custom"
 
-    assert _request_policy_provider("custom", "custom") == "custom"
+
+def test_unqualified_named_custom_uses_config_key_for_request_policy(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "myproxy": {
+                    "name": "Local",
+                    "api": "https://proxy.example/v1",
+                }
+            }
+        },
+    )
+
+    assert rp.request_policy_provider("custom", "local") == "custom:myproxy"
 
 
 def test_resolve_runtime_provider_opencode_free_keyless_despite_exhausted_pool(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1609,8 +1609,8 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
         },
     )
 
-    # Exercise the public resolver: pooled credentials must not collapse the
-    # configured provider identity into the shared "custom" billing class.
+    # Exercise the public resolver: the wire transport stays canonical while
+    # requested_provider carries the configured endpoint identity.
     resolved = rp.resolve_runtime_provider(requested="custom:lmstudio")
 
     assert resolved is not None
@@ -1620,12 +1620,11 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
-    assert resolved["provider"] == "custom:lmstudio"
+    assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
 
 
-def test_pooled_providers_entry_preserves_config_key_identity(monkeypatch):
-    """A display name must not replace the durable ``providers`` mapping key."""
+def test_pooled_providers_entry_keeps_transport_and_policy_identity_separate(monkeypatch):
     monkeypatch.setattr(
         rp,
         "load_config",
@@ -1653,9 +1652,26 @@ def test_pooled_providers_entry_preserves_config_key_identity(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="custom:zhipuai")
 
-    assert resolved["provider"] == "custom:zhipuai"
+    assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:zhipuai"
     assert resolved["api_key"] == "pooled-key"
+
+
+def test_named_custom_runtime_avoids_generic_custom_request_policy():
+    from agent.chat_completion_helpers import _request_policy_provider
+    from providers import get_provider_profile
+
+    policy_provider = _request_policy_provider("custom", "custom:zhipuai")
+
+    assert policy_provider == "custom:zhipuai"
+    assert get_provider_profile(policy_provider) is None
+    assert get_provider_profile("custom") is not None
+
+
+def test_bare_custom_runtime_keeps_generic_custom_request_policy():
+    from agent.chat_completion_helpers import _request_policy_provider
+
+    assert _request_policy_provider("custom", "custom") == "custom"
 
 
 def test_resolve_runtime_provider_opencode_free_keyless_despite_exhausted_pool(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Custom providers backed by credential pools now keep their qualified `custom:<name>` runtime identity instead of collapsing to bare `custom`. This prevents provider-specific sessions such as custom GLM endpoints from inheriting generic custom request policy on every restored turn and repeatedly entering fallback.

### Symptom

A session configured with a qualified custom provider can fail with an endpoint-specific HTTP 400, fall back successfully, then repeat the same failure after runtime restoration on the next turn.

### Impact

Affected credential-pool sessions can enter a self-sustaining per-turn fallback loop instead of using the configured provider consistently.

### Bug Cause

**Trigger:** `hermes_cli/runtime_provider.py:1166` / `_resolve_named_custom_runtime()` when a named custom provider resolves credentials from its pool.

**Causal chain:**
1. The user selects a durable `custom:<name>` provider identity.
2. `_try_resolve_from_custom_pool()` returns the shared `custom` billing label, and the named-custom branch previously forwarded it unchanged as the runtime provider.
3. Downstream provider policy sees bare `custom`, applies generic custom request semantics, and the restored primary runtime repeats that behavior on every turn.

**Why it is wrong:** The credential source is an implementation detail and must not replace the configured routing identity used by runtime policy.

**Working sibling / contrast:** The configured `requested_provider` remains qualified; only the pool-produced runtime `provider` was downgraded.

**Ruled out:** Credential selection and endpoint selection are unchanged. The failing regression test isolates the provider label while retaining the same pooled key, base URL, headers, source, and pool object.

### Fix

After a named custom provider obtains a pool runtime, rebuild its provider field with the same canonical `custom_provider_slug()` used by model selection and session persistence. The resolver regression test now requires the qualified identity while continuing to verify pooled headers and credentials.

## Related Issue

Closes #96584

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` - restore the canonical named-custom slug after credential-pool resolution.
- `tests/hermes_cli/test_runtime_provider_resolution.py` - cover qualified identity preservation without weakening existing pool assertions.

## How to Test

1. Resolve a configured named custom provider through a credential pool.
2. Confirm both `provider` and `requested_provider` retain `custom:<name>` while credentials, endpoint, headers, and pool metadata are unchanged.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/cli/test_cli_provider_resolution.py tests/agent/test_custom_provider_extra_body.py -q
```

Result: 81 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: the change is platform-independent provider resolution
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

N/A - covered by the resolver regression test and related provider-resolution suites.
