### PR TITLE
fix(agent): stop blocked tools from retrying until timeout

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1781,12 +1781,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if blocked:
                 effect_disposition = "none"
 
-            if not blocked:
+            # Policy/scope blocks are failed attempts from the model's point
+            # of view and must advance the same-tool failure circuit breaker.
+            # Do not re-observe a block synthesized by the guardrail itself:
+            # _guardrail_block_result has already recorded the turn halt.
+            if not blocked or agent._tool_guardrail_halt_decision is None:
                 function_result = agent._append_guardrail_observation(
                     function_name,
                     function_args,
                     function_result,
-                    failed=is_error,
+                    failed=True if blocked else is_error,
                     tool_call_id=tool_call_id,
                 )
 
@@ -2699,12 +2703,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
-        if not _execution_blocked:
+        # A structural policy block is still a failed model attempt. Count it
+        # toward the existing failure-loop thresholds, while avoiding a second
+        # observation for guardrail-generated synthetic blocks (which already
+        # set the halt decision in _guardrail_block_result).
+        if not _execution_blocked or agent._tool_guardrail_halt_decision is None:
             function_result = agent._append_guardrail_observation(
                 function_name,
                 function_args,
                 function_result,
-                failed=_is_error_result,
+                failed=True if _execution_blocked else _is_error_result,
                 tool_call_id=tool_call_id,
             )
             result_preview = function_result if agent.verbose_logging else (

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -323,11 +323,69 @@ def test_relay_rewrite_is_guarded_before_dispatch_in_concurrent_path():
     assert "repeated_exact_failure_block" in messages[0]["content"]
 
 
-def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
-    agent = _make_agent("web_search")
+def test_repeated_plugin_pre_tool_blocks_halt_sequential_tool_loop():
+    config = _hard_stop_config()
+    config["tool_loop_guardrails"]["hard_stop_after"] = {
+        "exact_failure": 99,
+        "same_tool_failure": 3,
+        "idempotent_no_progress": 99,
+    }
+    agent = _make_agent("web_search", config=config)
     args = {"query": "same"}
-    tc = _mock_tool_call("web_search", json.dumps(args), "c-plugin")
-    msg = SimpleNamespace(content="", tool_calls=[tc])
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("web_search", json.dumps(args), f"c-plugin-{i}")
+            ],
+        )
+        for i in range(1, 5)
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            return_value=("plugin policy", None),
+        ),
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    mock_hfc.assert_not_called()
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert "same_tool_failure_halt" in result["final_response"]
+    tool_contents = [
+        message["content"]
+        for message in result["messages"]
+        if message.get("role") == "tool"
+    ]
+    assert len(tool_contents) == 3
+    assert all("plugin policy" in content for content in tool_contents)
+    assert "same_tool_failure_halt" in tool_contents[-1]
+
+
+def test_repeated_plugin_pre_tool_blocks_halt_concurrent_tool_batch():
+    config = _hard_stop_config()
+    config["tool_loop_guardrails"]["hard_stop_after"] = {
+        "exact_failure": 99,
+        "same_tool_failure": 3,
+        "idempotent_no_progress": 99,
+    }
+    agent = _make_agent("web_search", config=config)
+    calls = [
+        _mock_tool_call(
+            "web_search",
+            json.dumps({"query": f"blocked-{i}"}),
+            f"c-plugin-{i}",
+        )
+        for i in range(1, 4)
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
     messages = []
 
     with (
@@ -337,11 +395,17 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
         ),
         patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc,
     ):
-        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
 
     mock_hfc.assert_not_called()
-    assert "plugin policy" in messages[0]["content"]
-    assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+    assert [message["tool_call_id"] for message in messages] == [
+        "c-plugin-1",
+        "c-plugin-2",
+        "c-plugin-3",
+    ]
+    assert agent._tool_guardrail_halt_decision is not None
+    assert agent._tool_guardrail_halt_decision.code == "same_tool_failure_halt"
+    assert "same_tool_failure_halt" in messages[-1]["content"]
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():


### PR DESCRIPTION
## What does this PR do?

Repeated tool calls that are rejected by a plugin or session scope now reach the existing failure-loop guardrail. This stops unattended turns with a structurally unavailable tool from retrying until an outer timeout, while preserving the no-dispatch semantics of blocked calls and avoiding double-counting guardrail-generated blocks.

### Symptom

When the same tool is structurally blocked on every attempt, the model can retry past `same_tool_failure_halt_after` without the controlled halt response.

### Impact

Affected unattended turns can consume every available iteration or run until an external timeout instead of returning the existing explanation that the tool path is blocked.

### Bug Cause

**Trigger:** `agent/tool_executor.py` / the sequential and concurrent post-execution branches when `blocked` is true

**Causal chain:**
1. A plugin policy or session scope rejects a tool call before dispatch.
2. The executor returns a blocked error result but skips `_append_guardrail_observation`.
3. The per-turn same-tool failure count never advances, so the configured halt threshold cannot fire.

**Why it is wrong:** A blocked call is still a failed model attempt even though the underlying tool did not execute. Excluding it from loop accounting leaves permanently unavailable tool paths unbounded.

**Working sibling / contrast:** Dispatched tool errors already pass through `_append_guardrail_observation` and halt at the configured threshold.

**Ruled out:** The tool implementation is not responsible for this loop because plugin and scope blocks occur before dispatch. Guardrail-generated synthetic blocks must remain excluded from observation because they already set the turn halt decision.

### Fix

Count structural policy and scope blocks as failed guardrail observations in both executor paths. If a guardrail block has already set the halt decision, skip the second observation. Regression tests cover a multi-iteration sequential loop and a concurrent blocked batch without dispatching the tool.

## Related Issue

Fixes #96579

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py` - feed structural block results into the existing failure-loop controller on sequential and concurrent paths.
- `tests/run_agent/test_tool_call_guardrail_runtime.py` - verify repeated plugin blocks halt both paths without dispatch.

## How to Test

1. Configure hard-stop guardrails with `same_tool_failure: 3` and a plugin that blocks `web_search`.
2. Repeat blocked calls and verify the third result carries `same_tool_failure_halt` and the turn exits with `guardrail_halt`.
3. Run the focused automated coverage (13 tests passed locally):

```bash
scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py -q -k 'repeated_plugin_pre_tool_blocks'
scripts/run_tests.sh tests/agent/test_tool_guardrails.py -q
scripts/run_tests.sh tests/run_agent/test_tool_executor_contextvar_propagation.py tests/agent/test_tool_executor_checkpoint_paths.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the change is platform-independent executor state logic
- [x] Tool descriptions/schemas update: N/A - no tool schema changed
