### PR TITLE
fix(auth): self-heal expiring codex pool access tokens from CLI

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -647,6 +647,11 @@ def _pool_codex_access_token() -> str:
     """First non-empty pool access_token not in an exhaustion cooldown window, else "".
 
     Fallback for ``resolve_codex_runtime_credentials`` when the singleton has no creds.
+    When the selected entry's token is within ``CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS``
+    of expiry, adopt a fresh pair from ``~/.codex/auth.json`` (kept current by the Codex
+    CLI) via ``_recover_codex_tokens_from_cli`` — the self-heal the singleton path already
+    has (issue #63413). A recovery failure must not swallow the entry token: it may still
+    have up to the skew window of life left, so it falls through instead of escaping.
     """
     from hermes_cli.auth import _nonempty_str
     try:
@@ -654,7 +659,17 @@ def _pool_codex_access_token() -> str:
             token, reset_at = entry.get("access_token"), entry.get("last_error_reset_at")
             in_cooldown = isinstance(reset_at, (int, float)) and reset_at > time.time()
             if _nonempty_str(token) and not in_cooldown:
-                return token.strip()
+                token = token.strip()
+                if _codex_access_token_is_expiring(token, CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+                    try:
+                        recovered = _recover_codex_tokens_from_cli("pool access_token expiring")
+                    except Exception:
+                        logger.debug("Codex pool self-heal failed; falling back to the "
+                                     "entry access_token", exc_info=True)
+                        recovered = None
+                    if recovered and _nonempty_str(recovered.get("access_token")):
+                        return _stripped(recovered.get("access_token"))
+                return token
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -10,15 +10,26 @@ surfacing a hard 401 — but ONLY for relogin-required failures, never for trans
 ones (e.g. 429 quota, where the stored token is still valid).
 """
 
+import base64
 import json
+import time
 
 import pytest
 
 import hermes_cli.auth as auth
 import hermes_cli.auth_codex as auth_codex
 from hermes_cli.auth import AuthError, _refresh_codex_auth_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth_codex import _pool_codex_access_token
 
 STALE = {"access_token": "stale-access", "refresh_token": "stale-refresh"}
+
+
+def _jwt_with_exp(exp_epoch: int) -> str:
+    payload = {"exp": exp_epoch}
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(payload).encode("utf-8")
+    ).rstrip(b"=").decode("utf-8")
+    return f"h.{encoded}.s"
 
 
 def test_self_heals_on_stale_refresh_token(monkeypatch):
@@ -94,5 +105,137 @@ def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monk
     tokens = stored["providers"]["openai-codex"]["tokens"]
     assert tokens["access_token"] == "fresh-access"
     assert tokens["refresh_token"] == "fresh-refresh"
+
+
+def _seed_pool(hermes_home, access_token):
+    """Write a HERMES_HOME auth.json whose ONLY Codex credential is one pool entry."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},  # force the pool fallback path
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": access_token,
+                    "refresh_token": "stale-refresh",
+                    "last_status": "ok",
+                },
+            ],
+        },
+    }), encoding="utf-8")
+
+
+def test_pool_self_heals_when_access_token_expiring(tmp_path, monkeypatch):
+    """Pool fallback recovers from ~/.codex/auth.json when the entry's access_token is expiring.
+
+    The singleton path self-heals in ``_refresh_codex_auth_tokens`` (refresh
+    rejected) and ``resolve_codex_runtime_credentials`` (missing/malformed), but
+    ``_pool_codex_access_token`` historically returned the first non-empty
+    pool entry with no expiry check, so an aged access_token surfaced as a
+    bare HTTP 401. Mirror the singleton recovery here: when the selected
+    entry's access_token is within the refresh skew window of expiry, adopt
+    a fresh pair from the Codex CLI instead of returning the stale JWT.
+    """
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex"
+    _seed_pool(hermes_home, _jwt_with_exp(int(time.time()) + 30))  # within 120s skew
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "fresh-access",
+            "refresh_token": "fresh-refresh",
+        },
+    }), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    saved = {}
+    monkeypatch.setattr(auth, "_save_codex_tokens", lambda t, *a, **k: saved.update(t))
+
+    token = _pool_codex_access_token()
+
+    assert token == "fresh-access"
+    # the recovered pair was persisted to the Hermes auth store
+    assert saved.get("access_token") == "fresh-access"
+    assert saved.get("refresh_token") == "fresh-refresh"
+
+
+def test_pool_returns_stale_token_when_not_expiring(tmp_path, monkeypatch):
+    """Pool fallback returns the entry token as-is when it is not near expiry.
+
+    Ensures the self-heal only fires within the refresh skew window — a token
+    with plenty of life left must NOT trigger a CLI import on every call.
+    """
+    hermes_home = tmp_path / "hermes"
+    fresh_jwt = _jwt_with_exp(int(time.time()) + 3600)  # well outside skew
+    _seed_pool(hermes_home, fresh_jwt)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import_calls = []
+    monkeypatch.setattr(
+        auth_codex, "_recover_codex_tokens_from_cli",
+        lambda *a, **k: import_calls.append((a, k)) or None,
+    )
+
+    token = _pool_codex_access_token()
+
+    assert token == fresh_jwt
+    assert import_calls == []  # no recovery attempted
+
+
+def test_pool_returns_stale_token_when_cli_has_no_fresh_tokens(tmp_path, monkeypatch):
+    """Pool fallback falls back to the stale entry when the CLI import yields nothing.
+
+    If ``~/.codex/auth.json`` is itself expired or absent, recovery returns
+    None and the pool entry's (expired) token is returned as-is so the caller
+    raises the original AuthError rather than a confusing empty-credential one.
+    """
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex"
+    expiring_jwt = _jwt_with_exp(int(time.time()) + 30)
+    _seed_pool(hermes_home, expiring_jwt)
+    codex_home.mkdir(parents=True, exist_ok=True)
+    # Codex CLI auth.json is stale (expired) → _import_codex_cli_tokens returns None
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_exp(int(time.time()) - 10),
+            "refresh_token": "dead-refresh",
+        },
+    }), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    token = _pool_codex_access_token()
+
+    # Recovery yielded nothing → fall through to the stale entry token.
+    assert token == expiring_jwt
+
+
+def test_pool_falls_back_to_entry_token_when_recovery_raises(tmp_path, monkeypatch):
+    """Pool fallback returns the entry token when recovery raises.
+
+    ``_recover_codex_tokens_from_cli`` calls ``_save_codex_tokens``, which
+    acquires the auth-store lock and can raise (lock timeout, disk error).
+    Such a failure must NOT swallow the still-present entry token — a token
+    within the skew window may have up to ``CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS``
+    of life left and work fine on the wire. The recovery attempt is isolated
+    from the outer lookup so the entry token is returned on failure.
+    """
+    hermes_home = tmp_path / "hermes"
+    expiring_jwt = _jwt_with_exp(int(time.time()) + 30)  # within 120s skew
+    _seed_pool(hermes_home, expiring_jwt)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("auth store lock timed out")
+
+    monkeypatch.setattr(auth_codex, "_recover_codex_tokens_from_cli", _boom)
+
+    token = _pool_codex_access_token()
+
+    # Recovery raised → fall through to the entry token, not "".
+    assert token == expiring_jwt
 
 


### PR DESCRIPTION
## What does this PR do?

Hermes stores Codex (OpenAI) credentials in two places: a **singleton** (the primary login in `auth.json`) and a **pool** (a list of entries in `auth.json` used as fallbacks when the singleton is empty or unavailable). At runtime the pool is what actually serves `openai-codex` requests. Both stores hold an OAuth `access_token` that expires on a ~10-hour window; an expired token surfaces as a bare HTTP 401 on the next request.

A third file on disk — `~/.codex/auth.json` — is kept continuously fresh by the Codex CLI. The **singleton path already self-heals** from it: when the singleton'\''s token is rejected on refresh (`_refresh_codex_auth_tokens`) or missing/malformed (`resolve_codex_runtime_credentials`), Hermes adopts a fresh pair from `~/.codex/auth.json` via `_recover_codex_tokens_from_cli`.

The **pool fallback had no equivalent.** `_pool_codex_access_token()` in `hermes_cli/auth.py` — the function the runtime calls to read a pool entry'\''s `access_token` — returned the first non-empty token with **no expiry check and no recovery**. So a pool entry whose `access_token` had aged past expiry kept handing back the dead token, and every request failed with a 401 even though a valid token sat on disk in `~/.codex/auth.json`.

This PR mirrors the singleton recovery on the pool read path: when the selected pool entry'\''s `access_token` is within `CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS` (120s) of expiry, adopt a fresh pair from `~/.codex/auth.json` via `_recover_codex_tokens_from_cli`. Two safety properties:

- **Recovery runs outside the auth-store lock** and can raise (lock timeout, disk error). It'\''s wrapped in its own `try/except` that logs with `exc_info=True` and falls through to `return token` — the entry token may still have up to 120s of life left, so we never destroy a still-usable credential by letting a recovery failure escape.
- **If the CLI import yields nothing** (its tokens are also stale), we fall through to the stale entry so the caller raises the original `AuthError` rather than a confusing empty-credential one.

## Related Issue

Fixes #63413

**Note on #63549:** that PR closes the same issue with a different, complementary approach. It operates in `agent/credential_pool.py` on the **write/sync path** — when a pool entry is already in `EXHAUSTED`/`DEAD` status, it copies fresh tokens from `~/.codex/auth.json` into the entry on disk and clears the status, plus marks `manual:device_code` entries `DEAD` for the 24h prune. This PR is the narrower **read-path** fix in `hermes_cli/auth.py`: it checks expiry at the point of use and swaps the token in flight. The two are complementary (a synced shelf + a careful reader); they could coexist. #63549 is currently `CONFLICTING` and has had no review activity since 2026-07-16.

**Note on #58186:** different bug — it clears a stuck `EXHAUSTED` status flag after a 429 + same-token refresh, and does not touch the expiry/self-heal gap. No overlap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth_codex.py` — `_pool_codex_access_token()`: add expiry check via `_codex_access_token_is_expiring(token, CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS)`; when expiring, call `_recover_codex_tokens_from_cli` and return the fresh `access_token`; wrap recovery in its own `try/except Exception` that logs with `exc_info=True` and falls through to the entry token on failure; fall through to the stale entry when the CLI import yields nothing. Trimmed docstring to state behavior/constraints rather than review history.
  (Rebased 2026-09-09 onto the Sep-2026 auth decomposition: the function moved from `hermes_cli/auth.py` to the `auth_codex.py` sibling, so the patch was retargeted there — same fix, new address. Tests repointed at the new module and re-verified: the self-heal test is provably red on clean `main`, green with the patch.)
- `tests/hermes_cli/test_auth_codex_self_heal.py` — +4 regression tests + `_jwt_with_exp` helper:
  - `test_pool_self_heals_when_access_token_expiring` — expiring JWT → recovers from CLI, returns fresh, persists
  - `test_pool_returns_stale_token_when_not_expiring` — healthy JWT → no recovery attempted
  - `test_pool_returns_stale_token_when_cli_has_no_fresh_tokens` — expiring pool + stale CLI → falls through to stale entry
  - `test_pool_falls_back_to_entry_token_when_recovery_raises` — recovery raises → entry token returned, not `""`

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_quota_probe.py tests/hermes_cli/test_runtime_provider_resolution.py` → 85 passed (post-rebase, CI-parity runner)
2. Repro: seed `HERMES_HOME/auth.json` with an `openai-codex` pool entry whose `access_token` is an expired JWT; run any turn → previously 401, now self-heals from `~/.codex/auth.json`

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits (`fix(auth):`)
- [x] Searched for existing PRs (found #63549, #58186 — documented above)
- [x] PR contains only changes related to this fix (2 files)
- [x] Run `pytest tests/ -q` (full suite via `scripts/run_tests.sh -j 4`): 39,035 passed, 112 failed — all 112 failures are pre-existing environment issues (missing `acp` extra, browser binaries, macOS launchd specifics, network-dependent tests); zero caused by this change. The 5 `tests/hermes_cli/` failures reproduce identically on clean `main`.
- [x] Added tests for the change
- [x] Tested on platform: macOS 15 (Sequoia), Python 3.11.15
