### PR TITLE
fix(install): never adopt a pre-release Node.js build

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -797,9 +797,18 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
                     timeout=10,
                     creationflags=windows_hide_flags(),
                 )
-                major = int(result.stdout.decode().strip().lstrip("v").split(".")[0])
+                version = result.stdout.decode().strip().lstrip("v")
+                major = int(version.split(".")[0])
             except (OSError, subprocess.TimeoutExpired, ValueError, IndexError):
                 return False  # broken, not outdated — the runnable probe handles it
+            # A pre-release tree counts as outdated however high its major:
+            # nodejs.org publishes a headers tarball only for final releases, so
+            # node-gyp cannot build node-pty against one. Without this, an
+            # install that adopted such a tree stays broken forever — the heal
+            # only fires below the target major, and a pre-release is above it.
+            # Mirrors node_satisfies_build() in scripts/install.sh.
+            if "-" in version:
+                return True
             return major < _HERMES_NODE_TARGET_MAJOR
     return False
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -891,6 +891,19 @@ check_cxx_compiler() {
 # with the Hermes-managed Node $NODE_VERSION.
 node_satisfies_build() {
     local ver="${1#v}"
+    # Pre-release builds are rejected outright, however new they are. `node-pty`
+    # ships no Linux prebuild, so every install compiles it with node-gyp, which
+    # fetches the headers named by `process.release.headersUrl` — a URL only
+    # published for final releases. nodejs.org/dist/latest-v26.x currently
+    # serves node-v26.8.0-<os>-<arch>.tar.xz whose binary reports
+    # v26.8.0-alpha.0.0.0; its headers 404, and the install dies at
+    # `node-gyp rebuild` with the underlying error swallowed by the
+    # `node scripts/prebuild.js || node-gyp rebuild` fallback.
+    #
+    # This line is also present, verbatim, in the open #84397 — install_node()
+    # below calls this function, so the fix needs it. Drop this hunk if #84397
+    # lands first; the rest of this change is independent of it.
+    case "$ver" in *-*) return 1 ;; esac
     local major="${ver%%.*}"
     local minor="${ver#*.}"; minor="${minor%%.*}"
     case "$major" in ''|*[!0-9]*) return 1 ;; esac
@@ -972,6 +985,106 @@ check_node() {
     install_node
 }
 
+# Download and adopt one Node release line (e.g. 26) into ~/.hermes/node/.
+#
+# Split out of install_node() so the caller can walk a list of candidate lines.
+# A line is rejected — and the caller should try an older one — when nodejs.org
+# publishes no tarball for this platform, when the download or extraction
+# fails, or when the tree it ships fails node_satisfies_build.
+#
+# Returns 0 with the tree in place, PATH exported and HAS_NODE=true; 1 when the
+# line is unusable. Nothing on disk is replaced until the candidate passes, so
+# a rejected line leaves any existing managed Node untouched.
+install_node_line() {
+    local node_line="$1"
+    local node_os="$2"
+    local node_arch="$3"
+
+    # Resolve the latest v${node_line}.x.x tarball name from the index page
+    local index_url="https://nodejs.org/dist/latest-v${node_line}.x/"
+    local tarball_name
+    tarball_name=$(curl -fsSL "$index_url" \
+        | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
+        | head -1)
+
+    # Fallback to .tar.gz if .tar.xz not available
+    if [ -z "$tarball_name" ]; then
+        tarball_name=$(curl -fsSL "$index_url" \
+            | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \
+            | head -1)
+    fi
+
+    if [ -z "$tarball_name" ]; then
+        log_warn "Could not find Node.js $node_line binary for $node_os-$node_arch"
+        return 1
+    fi
+
+    local download_url="${index_url}${tarball_name}"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    log_info "Downloading $tarball_name..."
+    if ! curl -fsSL "$download_url" -o "$tmp_dir/$tarball_name"; then
+        log_warn "Download failed"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    log_info "Extracting to ~/.hermes/node/..."
+    if [[ "$tarball_name" == *.tar.xz ]]; then
+        tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+    else
+        tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
+    fi
+
+    local extracted_dir
+    extracted_dir=$(ls -d "$tmp_dir"/node-v* 2>/dev/null | head -1)
+
+    if [ ! -d "$extracted_dir" ]; then
+        log_warn "Extraction failed"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    # Trust the binary, not the filename. A tarball named for a final release
+    # can still carry a pre-release build — latest-v26.x serves
+    # node-v26.8.0-<os>-<arch>.tar.xz whose `node --version` is
+    # v26.8.0-alpha.0.0.0 — and adopting it leaves node-pty unbuildable for the
+    # life of the install. Probe the extracted tree before it replaces anything.
+    local candidate_ver
+    candidate_ver=$("$extracted_dir/bin/node" --version 2>/dev/null)
+    if ! node_satisfies_build "$candidate_ver"; then
+        log_warn "Node.js ${candidate_ver:-unreadable} from ${index_url} cannot build native modules — trying an older release line..."
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    # Place into ~/.hermes/node/ and symlink binaries into the same bin dir
+    # the hermes command uses (get_command_link_dir): /usr/local/bin for root
+    # FHS installs, $PREFIX/bin on Termux, ~/.local/bin otherwise.
+    rm -rf "$HERMES_HOME/node"
+    mkdir -p "$HERMES_HOME"
+    mv "$extracted_dir" "$HERMES_HOME/node"
+    rm -rf "$tmp_dir"
+
+    local node_link_dir
+    node_link_dir="$(get_command_link_dir)"
+    mkdir -p "$node_link_dir"
+    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
+    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
+    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+
+    configure_managed_node_npm_prefix
+
+    export PATH="$HERMES_HOME/node/bin:$PATH"
+
+    local installed_ver
+    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
+    log_success "Node.js $installed_ver installed to ~/.hermes/node/"
+    HAS_NODE=true
+    return 0
+}
+
 install_node() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Installing Node.js via pkg..."
@@ -1012,79 +1125,21 @@ install_node() {
             ;;
     esac
 
-    # Resolve the latest v${NODE_VERSION}.x.x tarball name from the index page
-    local index_url="https://nodejs.org/dist/latest-v${NODE_VERSION}.x/"
-    local tarball_name
-    tarball_name=$(curl -fsSL "$index_url" \
-        | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
-        | head -1)
+    # Try the target line first, then the two previous even-numbered (LTS)
+    # lines. Whether a line is usable cannot be known from its index page —
+    # see install_node_line — and stepping down beats adopting a Node that
+    # leaves every native dependency unbuildable.
+    local node_line
+    for node_line in "$NODE_VERSION" "$((NODE_VERSION - 2))" "$((NODE_VERSION - 4))"; do
+        if install_node_line "$node_line" "$node_os" "$node_arch"; then
+            return 0
+        fi
+    done
 
-    # Fallback to .tar.gz if .tar.xz not available
-    if [ -z "$tarball_name" ]; then
-        tarball_name=$(curl -fsSL "$index_url" \
-            | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \
-            | head -1)
-    fi
-
-    if [ -z "$tarball_name" ]; then
-        log_warn "Could not find Node.js $NODE_VERSION binary for $node_os-$node_arch"
-        log_info "Install manually: https://nodejs.org/en/download/"
-        HAS_NODE=false
-        return 0
-    fi
-
-    local download_url="${index_url}${tarball_name}"
-    local tmp_dir
-    tmp_dir=$(mktemp -d)
-
-    log_info "Downloading $tarball_name..."
-    if ! curl -fsSL "$download_url" -o "$tmp_dir/$tarball_name"; then
-        log_warn "Download failed"
-        rm -rf "$tmp_dir"
-        HAS_NODE=false
-        return 0
-    fi
-
-    log_info "Extracting to ~/.hermes/node/..."
-    if [[ "$tarball_name" == *.tar.xz ]]; then
-        tar xf "$tmp_dir/$tarball_name" -C "$tmp_dir"
-    else
-        tar xzf "$tmp_dir/$tarball_name" -C "$tmp_dir"
-    fi
-
-    local extracted_dir
-    extracted_dir=$(ls -d "$tmp_dir"/node-v* 2>/dev/null | head -1)
-
-    if [ ! -d "$extracted_dir" ]; then
-        log_warn "Extraction failed"
-        rm -rf "$tmp_dir"
-        HAS_NODE=false
-        return 0
-    fi
-
-    # Place into ~/.hermes/node/ and symlink binaries into the same bin dir
-    # the hermes command uses (get_command_link_dir): /usr/local/bin for root
-    # FHS installs, $PREFIX/bin on Termux, ~/.local/bin otherwise.
-    rm -rf "$HERMES_HOME/node"
-    mkdir -p "$HERMES_HOME"
-    mv "$extracted_dir" "$HERMES_HOME/node"
-    rm -rf "$tmp_dir"
-
-    local node_link_dir
-    node_link_dir="$(get_command_link_dir)"
-    mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
-
-    configure_managed_node_npm_prefix
-
-    export PATH="$HERMES_HOME/node/bin:$PATH"
-
-    local installed_ver
-    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
-    log_success "Node.js $installed_ver installed to ~/.hermes/node/"
-    HAS_NODE=true
+    log_warn "No usable Node.js release line found for $node_os-$node_arch"
+    log_info "Install manually: https://nodejs.org/en/download/"
+    HAS_NODE=false
+    return 0
 }
 
 check_network_prerequisites() {

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -163,8 +163,20 @@ _nb_ensure_bundled_npm_range() {
     return 1
 }
 
+# A pre-release Node (…-alpha/-beta/-rc/-pre/-nightly) never counts as modern,
+# however high its major. nodejs.org publishes a headers tarball only for final
+# releases, so node-gyp cannot build node-pty — which has no Linux prebuild —
+# against one. Mirrors node_satisfies_build() in install.sh.
+_nb_node_is_prerelease() {
+    case "$(node --version 2>/dev/null)" in
+        *-*) return 0 ;;
+        *)   return 1 ;;
+    esac
+}
+
 _nb_have_modern_node() {
     command -v node >/dev/null 2>&1 || return 1
+    _nb_node_is_prerelease && return 1
     [ "$(_nb_node_major)" -ge "$HERMES_NODE_MIN_VERSION" ]
 }
 
@@ -294,6 +306,18 @@ _nb_install_bundled_node() {
         rm -rf "$tmp"
         return 1
     fi
+
+    # Trust the binary, not the filename: a tarball named for a final release
+    # can still carry a pre-release build (latest-v26.x serves
+    # node-v26.8.0-<os>-<arch>.tar.xz stamped v26.8.0-alpha.0.0.0). Probe it
+    # before it replaces a working managed tree.
+    case "$("$extracted/bin/node" --version 2>/dev/null)" in
+        *-*)
+            _nb_warn "Node $("$extracted/bin/node" --version 2>/dev/null) is a pre-release build — native modules cannot be built against it"
+            rm -rf "$tmp"
+            return 1
+            ;;
+    esac
 
     mkdir -p "$HERMES_HOME"
     rm -rf "$HERMES_HOME/node"

--- a/tests/test_install_sh_node_prerelease.py
+++ b/tests/test_install_sh_node_prerelease.py
@@ -1,0 +1,122 @@
+"""The installer must never adopt a pre-release Node.js build.
+
+`nodejs.org/dist/latest-v26.x/` serves `node-v26.8.0-<os>-<arch>.tar.xz` — a
+filename that looks like a final release — whose binary reports
+`v26.8.0-alpha.0.0.0`. Node publishes a headers tarball only for final
+releases, so `process.release.headersUrl` 404s for that build and node-gyp
+cannot compile against it.
+
+That is fatal rather than cosmetic: `node-pty` ships prebuilds for darwin and
+win32 only, so every Linux install compiles it, and the failure surfaces as an
+opaque `node-pty@1.1.0 install: command failed` because the package's
+`node scripts/prebuild.js || node-gyp rebuild` fallback swallows gyp's stderr.
+
+These tests drive the real blocks out of `scripts/install.sh` rather than
+asserting on a copy, so the guard cannot drift away from the test.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
+
+
+def _extract_function(text: str, name: str) -> str:
+    match = re.search(
+        rf"^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text, re.M | re.S
+    )
+    assert match, (
+        f"could not locate {name}() in scripts/install.sh — "
+        "if it was renamed, update this test with it"
+    )
+    return match.group(0)
+
+
+def _node_satisfies_build(version: str) -> bool:
+    """Run the real node_satisfies_build() against one `node --version` string."""
+    script = (
+        _extract_function(INSTALL_SH.read_text(encoding="utf-8"), "node_satisfies_build")
+        + f'\nnode_satisfies_build "{version}"\n'
+    )
+    return subprocess.run(["bash", "-c", script]).returncode == 0
+
+
+def test_prerelease_node_never_satisfies_the_build_floor() -> None:
+    """The exact build that breaks node-pty, plus the other pre-release tags."""
+    assert not _node_satisfies_build("v26.8.0-alpha.0.0.0")
+    assert not _node_satisfies_build("v24.0.0-rc.1")
+    assert not _node_satisfies_build("v23.5.0-nightly20260101abcdef")
+    assert not _node_satisfies_build("v22.22.0-pre")
+
+
+def test_final_releases_still_satisfy_the_build_floor() -> None:
+    """The guard must not cost us any version that actually works."""
+    assert _node_satisfies_build("v22.22.0")  # the floor itself
+    assert _node_satisfies_build("v24.20.0")
+    assert _node_satisfies_build("v26.8.0")  # a real 26 release, once one ships
+
+
+def test_versions_below_the_floor_are_still_rejected() -> None:
+    assert not _node_satisfies_build("v22.21.0")
+    assert not _node_satisfies_build("v20.19.0")
+    assert not _node_satisfies_build("not-a-version")
+
+
+def test_install_node_falls_back_to_an_older_release_line(tmp_path: Path) -> None:
+    """A rejected line must not end the install — the next one is tried.
+
+    install_node_line() cannot be exercised here (it downloads), so it is
+    stubbed to reject 26 the way a pre-release tarball does and accept 24.
+    """
+    body = _extract_function(INSTALL_SH.read_text(encoding="utf-8"), "install_node")
+    script = f"""
+set -e
+NODE_VERSION=26
+DISTRO=linux
+OS=linux
+uname() {{ echo x86_64; }}
+log_info(){{ :; }}; log_warn(){{ :; }}; log_success(){{ :; }}
+install_node_line() {{
+    echo "$1" >> "$TRIED"
+    [ "$1" = 24 ]
+}}
+{body}
+install_node
+"""
+    tried = tmp_path / "tried"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={"PATH": "/usr/bin:/bin", "TRIED": str(tried)},
+    )
+    assert result.returncode == 0, result.stderr
+    # 26 first, then the previous even (LTS) line; stops once one works.
+    assert tried.read_text(encoding="utf-8").split() == ["26", "24"]
+
+
+def test_downloaded_tree_is_probed_before_it_replaces_anything() -> None:
+    """The filename is not evidence — the extracted binary must be checked.
+
+    Guarded as a text assertion because the surrounding block downloads; the
+    fallback behaviour it feeds is covered functionally above.
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    probe = text.index('candidate_ver=$("$extracted_dir/bin/node" --version 2>/dev/null)')
+    reject = text.index('if ! node_satisfies_build "$candidate_ver"; then', probe)
+    # The probe has to run before the tree is moved into place, or a bad build
+    # has already clobbered a working managed Node.
+    assert reject < text.index('mv "$extracted_dir" "$HERMES_HOME/node"', probe)
+
+
+def test_node_bootstrap_mirrors_the_prerelease_guard() -> None:
+    """The sourceable helper answers the same question and must agree."""
+    text = NODE_BOOTSTRAP.read_text(encoding="utf-8")
+    assert "_nb_node_is_prerelease" in text
+    assert "_nb_node_is_prerelease && return 1" in text
+


### PR DESCRIPTION
## What does this PR do?

`install_node()` downloads the newest tarball listed at
`https://nodejs.org/dist/latest-v${NODE_VERSION}.x/` and installs it **without
ever asking whether the binary inside is usable**. Today that index serves

```
node-v26.8.0-linux-x64.tar.xz
```

a filename that looks like a final release. The binary inside reports:

```
$ ./node-v26.8.0-linux-x64/bin/node --version
v26.8.0-alpha.0.0.0
```

Node publishes the headers tarball named by `process.release.headersUrl` only
for **final** releases. For this build it 404s:

```
$ curl -sI "$(node -p 'process.release.headersUrl')" | head -1
HTTP/2 404
```

node-gyp fetches exactly that URL, so **no native module can be compiled** on
the runtime the installer just adopted. `node-pty` ships prebuilds for
`darwin-*` and `win32-*` only, so on Linux it always compiles — and its install
script is `node scripts/prebuild.js || node-gyp rebuild`, which swallows gyp's
stderr. The user sees only:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
```

The root cause is not the filename regex, which matched correctly. It is that
the installer trusts the *name* and never asks the *binary*.

### Why not just change `NODE_VERSION`?

Pinning away from 26 hides this instance and leaves the mechanism intact — the
next line to publish a pre-release under `latest-v*.x` reintroduces it. The
tarball also has to be adopted before anyone notices, because the check that
would have caught it (`node_satisfies_build`) is only applied to a *system*
Node in `check_node()`, never to the one we download ourselves.

## Related Issue

No existing issue covers this specific cause. Closest existing reports of the
same *symptom*, with different causes:

- **#96072** — `install.sh: npm install --silent hides node-gyp failure when python3 is missing`. Same swallowed-stderr surface, different missing prerequisite.
- **#88442** *(open PR)* — a CLI install builds `apps/desktop`'s `node-pty` because the root `npm install` resolves the `apps/*` workspace glob. That removes the *trigger* for CLI-only installs; it does not stop the installer adopting an unbuildable runtime, which still breaks `--include-desktop` and every other native dependency.

### Overlap with open PRs — please read before reviewing

I searched open and merged PRs first, per CONTRIBUTING. Two open PRs touch
adjacent code, and this PR is written to stay out of their way:

- **#84397** (`fix(dashboard): stop Node 25 installs from failing at nanoid`) already adds `case "$ver" in *-*) return 1 ;;` to `node_satisfies_build`, and the matching `if ($Version -match '-')` to `install.ps1`'s `Test-NodeVersionOk`. **This PR repeats that one line and nothing else from #84397**, because the new probe calls `node_satisfies_build`. The hunk is commented as such; drop it if #84397 lands first and the rest of this change still applies cleanly. I deliberately did **not** duplicate #84397's `install.ps1` change or its warning-text change.
- **#78589** (`fix(install): honor the full engines.node floor in the managed-Node staleness checks`) rewrites `_managed_node_tree_outdated()` and `_nb_managed_node_outdated()` — but both its new parsers *strip* the pre-release suffix (`split("-", 1)[0]`, `ver="${ver%%-*}"`), so a pre-release tree still reads as current there. The change here is complementary, not a duplicate; it will need a trivial merge if #78589 lands first.

The gap neither of them closes is the one this PR fixes: **the Node we download ourselves is never checked at all.**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`scripts/install.sh`**
  - `node_satisfies_build()` — reject any version carrying a pre-release tag. (One line, also in #84397; see above.)
  - `install_node()` split into `install_node_line()` (the existing download/extract/place body, parameterised on the release line, returning `1` instead of setting `HAS_NODE=false`) plus a fallback loop over `$NODE_VERSION`, `$((NODE_VERSION - 2))`, `$((NODE_VERSION - 4))`.
  - **New probe** inside `install_node_line()`: run `"$extracted_dir/bin/node" --version` and reject the tree if `node_satisfies_build` says no. It runs **before** the `mv` into `$HERMES_HOME/node`, so a bad build never clobbers a working managed Node.
- **`scripts/lib/node-bootstrap.sh`** — `_nb_node_is_prerelease()`, used by `_nb_have_modern_node()`, plus the same pre-`mv` probe in `_nb_install_bundled_node()`. The sourceable helper has to answer the same question as the installer.
- **`hermes_constants.py`** — `_managed_node_tree_outdated()` now reports a pre-release tree as outdated regardless of its major, so installs already holding an alpha self-heal on next launch. Without this the heal never fires: it only triggers *below* `_HERMES_NODE_TARGET_MAJOR`, and a pre-release sits above it.
- **`tests/test_install_sh_node_prerelease.py`** *(new)* — 6 tests.

## How to Test

**Reproduce on main** (any Linux host with no system Node):

```bash
curl -fsSL https://nodejs.org/dist/latest-v26.x/ | grep -o 'node-v[0-9.]*-linux-x64\.tar\.xz' | head -1
# node-v26.8.0-linux-x64.tar.xz          <- looks final
# ...after install.sh adopts it:
node --version                            # v26.8.0-alpha.0.0.0
curl -sI "$(node -p 'process.release.headersUrl')" | head -1   # HTTP/2 404
```

**Verify the fix:**

```bash
scripts/run_tests.sh tests/test_install_sh_node_prerelease.py -q
```

`test_install_node_falls_back_to_an_older_release_line` executes the **real**
`install_node` body extracted from `scripts/install.sh`, with
`install_node_line` stubbed to reject 26 and accept 24, and asserts the recorded
call order is exactly `["26", "24"]`. The tests drive the real functions out of
the script rather than asserting on a copy, matching the existing
`tests/test_install_sh_*.py` convention, so the guard cannot drift from the
test. 4 of the 6 fail on unpatched `main`.

**End to end**, on the host that hit this: the reduced install now provisions
Node 24 LTS (checksum-verified), `npm install` completes, `node-pty` compiles,
and Playwright's chromium launches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see **Overlap with open PRs** above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see **Test suite status** below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04.1 LTS, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — see below
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

### Cross-platform notes

`scripts/check-windows-footguns.py --diff main` is clean.

The probe is `bin/node --version` on the extracted tree, so it behaves the same
on macOS; the fallback lines are release lines, not platform-specific.

`scripts/install.ps1` has the same structural gap — `Install-Node` scrapes the
`latest-v${NodeVersion}.x/` index and trusts the filename — but it pins
`$NodeVersion = "22"`, a final LTS line, so it cannot currently reach a
pre-release through that path. #84397 already guards the PATH-node side there.
I left `install.ps1` alone rather than patch a path I cannot execute; flagging
it for maintainers.

### Note for reviewers: `NODE_VERSION` is inconsistent in-tree

Worth a separate look — not changed here:

| Location | Target major |
|---|---|
| `scripts/install.sh` | `NODE_VERSION=26` |
| `scripts/lib/node-bootstrap.sh` | `HERMES_NODE_TARGET_MAJOR=22` |
| `hermes_constants.py` | `_HERMES_NODE_TARGET_MAJOR=22` |
| `scripts/install.ps1` | `$NodeVersion = "22"` |

`install.sh` aiming at 26 is what walks into the pre-release line at all; the
other three would not. That divergence looks unintended.

### Test suite status

The `pytest tests/ -q` box is left unchecked deliberately, because it would not
be true as written. What I actually ran, and what it showed:

`scripts/run_tests.sh` over the full tree, then the failing subset re-run twice
— once with this patch applied, once against pristine `main`:

| | failing files |
|---|---|
| this branch | 31 |
| clean `main`, same file list | 31 |
| **files failing only with the patch** | **0** |

The two sets are identical, so this change introduces no failure. The 31 are
pre-existing in my environment and are missing optional dependencies rather
than real defects — 27 of them are `The 'anthropic' package is required for the
Anthropic provider` and 4 are `ModuleNotFoundError: No module named
'hindsight_client_api'`. I installed via the standard installer rather than
`uv pip install -e ".[all,dev]"`, which is what those tests need.

The new tests, and the existing `tests/test_install_sh_*.py` and
`tests/test_install_ps1_*.py` files, all pass:

```
scripts/run_tests.sh tests/test_install_sh_node_prerelease.py -q
```

One caveat on methodology, in case it helps someone else: running
`pytest tests/` directly in large batches produced 207 failures across 69
files. Under `scripts/run_tests.sh`'s per-file isolation the same tree produces
31. The extra 176 were cross-file state leakage, not defects — the wrapper's
isolation is doing real work, and the README's advice to prefer it over bare
`pytest` is worth taking literally.