### PR TITLE
fix(mcp): oauth.user_agent never reached discovery or registration

### DIFF
--- a/tests/tools/test_mcp_oauth_user_agent.py
+++ b/tests/tools/test_mcp_oauth_user_agent.py
@@ -175,3 +175,163 @@ def test_user_agent_does_not_disturb_token_auth_preparation(tmp_path, monkeypatc
 
     assert exchange.headers["User-Agent"] == "UA/1"
     assert exchange.headers.get("Authorization", "").startswith("Basic ")
+
+
+# ---------------------------------------------------------------------------
+# Discovery and dynamic registration (the whole auth flow)
+#
+# The SDK builds metadata-discovery and /register requests as bare
+# httpx.Request objects, so they carry NO User-Agent at all. A WAF that
+# rejects UA-less requests answers 403 to /.well-known/oauth-* and
+# /register, and the flow dies with "Registration failed: 403" before the
+# browser ever opens.
+# ---------------------------------------------------------------------------
+
+
+def _drive_flow_until_authorize(provider, responses):
+    """Run the provider's real async_auth_flow, replying from ``responses``.
+
+    Returns the list of outbound requests the flow produced. ``responses`` maps
+    a URL suffix to the httpx.Response to feed back; an unscripted URL ends the
+    drive, so the flow is stopped at the dynamic-registration POST rather than
+    proceeding into the browser/loopback-callback step.
+    """
+    import httpx
+
+    sent = []
+
+    async def _run():
+        initial = httpx.Request(
+            "POST", "https://mcp.example.com/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+        gen = provider.async_auth_flow(initial)
+        outbound = await gen.__anext__()
+        for _ in range(12):
+            sent.append(outbound)
+            reply = None
+            for needle, response in responses.items():
+                if str(outbound.url).endswith(needle):
+                    reply = response
+                    break
+            if reply is None:  # unscripted (the /register POST) — stop here
+                await gen.aclose()
+                return
+            reply.request = outbound
+            try:
+                outbound = await gen.asend(reply)
+            except StopAsyncIteration:
+                return
+
+    asyncio.run(_run())
+    return sent
+
+
+def _waf_responses():
+    """A 401 challenge, then metadata/registration replies."""
+    import httpx
+
+    return {
+        "/mcp": httpx.Response(
+            401,
+            headers={
+                "www-authenticate": 'Bearer error="invalid_token", '
+                'resource_metadata='
+                '"https://mcp.example.com/.well-known/oauth-protected-resource"'
+            },
+        ),
+        "oauth-protected-resource": httpx.Response(
+            200,
+            json={
+                "resource": "https://mcp.example.com",
+                "authorization_servers": ["https://mcp.example.com"],
+            },
+        ),
+        "oauth-authorization-server": httpx.Response(
+            200,
+            json={
+                "issuer": "https://mcp.example.com",
+                "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
+                "token_endpoint": "https://mcp.example.com/oauth/token",
+                "registration_endpoint": "https://mcp.example.com/register",
+                "response_types_supported": ["code"],
+            },
+        ),
+    }
+
+
+def _assert_registration_reached(sent):
+    """The drive must have gotten as far as the /register POST."""
+    assert any(str(r.url).endswith("/register") for r in sent), (
+        f"flow never reached dynamic registration; sent={[str(r.url) for r in sent]}"
+    )
+
+
+@pytest.mark.parametrize("builder", [
+    pytest.param(build_oauth_auth, id="build_oauth_auth"),
+    pytest.param(_manager_builder, id="oauth_manager"),
+])
+def test_discovery_and_registration_carry_the_configured_user_agent(
+    builder, tmp_path, monkeypatch
+):
+    """Every request in the flow gets the UA — not just the token endpoint.
+
+    Without this, a UA-rejecting WAF 403s discovery/registration and the
+    OAuth flow fails before the browser step.
+    """
+    provider = _build_provider_via(
+        builder, monkeypatch, tmp_path,
+        {"user_agent": "hermes-agent/1.0", "cimd": False},
+    )
+
+    sent = _drive_flow_until_authorize(provider, _waf_responses())
+
+    _assert_registration_reached(sent)
+    for request in sent:
+        assert request.headers.get("User-Agent") == "hermes-agent/1.0", (
+            f"{request.url} went out without the configured User-Agent"
+        )
+
+
+@pytest.mark.parametrize("builder", [
+    pytest.param(build_oauth_auth, id="build_oauth_auth"),
+    pytest.param(_manager_builder, id="oauth_manager"),
+])
+def test_flow_requests_keep_their_own_user_agent(builder, tmp_path, monkeypatch):
+    """A UA already on the request is never overwritten."""
+    import httpx
+
+    provider = _build_provider_via(
+        builder, monkeypatch, tmp_path,
+        {"user_agent": "hermes-agent/1.0", "cimd": False},
+    )
+
+    async def _run():
+        initial = httpx.Request(
+            "POST", "https://mcp.example.com/mcp",
+            headers={"User-Agent": "caller/9"},
+        )
+        gen = provider.async_auth_flow(initial)
+        first = await gen.__anext__()
+        return first
+
+    assert asyncio.run(_run()).headers["User-Agent"] == "caller/9"
+
+
+@pytest.mark.parametrize("builder", [
+    pytest.param(build_oauth_auth, id="build_oauth_auth"),
+    pytest.param(_manager_builder, id="oauth_manager"),
+])
+def test_unconfigured_user_agent_leaves_flow_requests_untouched(
+    builder, tmp_path, monkeypatch
+):
+    """No oauth.user_agent → the flow behaves exactly as before."""
+    provider = _build_provider_via(builder, monkeypatch, tmp_path, {"cimd": False})
+
+    sent = _drive_flow_until_authorize(provider, _waf_responses())
+
+    _assert_registration_reached(sent)
+    for request in sent:
+        if str(request.url).endswith("/mcp"):
+            continue  # the caller's own request, not built by the SDK
+        assert request.headers.get("User-Agent") is None

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1217,6 +1217,39 @@ def _get_hermes_oauth_provider_class() -> type | None:
             request = await super()._refresh_token()
             return self._stamp_token_user_agent(request)
 
+        def _stamp_flow_user_agent(self, request):
+            """Stamp ``oauth.user_agent`` onto any UA-less SDK request.
+
+            The SDK builds metadata-discovery and dynamic-registration
+            requests as bare ``httpx.Request`` objects, so they never inherit
+            the client's default ``User-Agent``. A WAF that rejects UA-less
+            requests then 403s ``/.well-known/oauth-*`` and ``/register``,
+            failing the flow before the browser step with a misleading
+            ``Registration failed: 403``. ``_stamp_token_user_agent`` covers
+            only the token endpoint, so extend the configured value to the
+            whole flow — never overriding a UA the request already carries.
+            """
+            ua = getattr(self, "_hermes_token_user_agent", None)
+            if ua and request is not None and not request.headers.get("User-Agent"):
+                request.headers["User-Agent"] = ua
+            return request
+
+        async def async_auth_flow(self, request):
+            # Bridge the SDK's bidirectional generator so each outbound
+            # request can be stamped. httpx feeds responses back with
+            # ``asend(response)``; a naive ``async for`` wrapper would drop
+            # them and the SDK's ``response = yield request`` would see None.
+            inner = super().async_auth_flow(self._stamp_flow_user_agent(request))
+            try:
+                outgoing = self._stamp_flow_user_agent(await inner.__anext__())
+                while True:
+                    incoming = yield outgoing
+                    outgoing = self._stamp_flow_user_agent(
+                        await inner.asend(incoming)
+                    )
+            except StopAsyncIteration:
+                return
+
         async def _handle_token_response(self, response):
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -189,6 +189,22 @@ def _make_hermes_provider_class() -> Optional[type]:
             request = await super()._refresh_token()
             return self._stamp_token_user_agent(request)
 
+        def _stamp_flow_user_agent(self, request):
+            """Stamp ``oauth.user_agent`` onto any UA-less SDK request.
+
+            The SDK builds metadata-discovery and dynamic-registration
+            requests as bare ``httpx.Request`` objects, so they never inherit
+            the client's default ``User-Agent``. WAFs that reject UA-less
+            requests (Revealed's ALB answers 403 to every such call, including
+            ``/.well-known/oauth-*`` and ``/register``) break the flow before
+            the browser step, so extend the configured value to the whole
+            flow — never overriding a UA the request already carries.
+            """
+            ua = getattr(self, "_hermes_token_user_agent", None)
+            if ua and request is not None and not request.headers.get("User-Agent"):
+                request.headers["User-Agent"] = ua
+            return request
+
         async def _handle_token_response(self, response):
             """Accept any 2xx token response and avoid leaking token bodies in errors."""
             if 200 <= response.status_code < 300:
@@ -530,15 +546,17 @@ def _make_hermes_provider_class() -> Optional[type]:
             # generator via inner.asend(incoming), preserving the bidirectional
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
-            inner = super().async_auth_flow(request)
+            inner = super().async_auth_flow(self._stamp_flow_user_agent(request))
             try:
-                outgoing = await inner.__anext__()
+                outgoing = self._stamp_flow_user_agent(await inner.__anext__())
                 while True:
                     incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
-                    outgoing = await inner.asend(incoming)
+                    outgoing = self._stamp_flow_user_agent(
+                        await inner.asend(incoming)
+                    )
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the
                 # 401 branch so a subsequent cold-load skips discovery.


### PR DESCRIPTION
## Symptom

`oauth.user_agent` is documented and implemented as a per-server escape hatch for authorization servers and WAFs that reject httpx's default `User-Agent` (#75576). It is stamped onto the two token-endpoint requests only.

The MCP SDK builds metadata discovery (`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`) and dynamic client registration (`/register`) as bare `httpx.Request` objects. Those never pass through an `AsyncClient`'s default headers, so they go out with **no `User-Agent` header at all** — not the client default, and not the configured one.

A WAF that rejects UA-less requests therefore 403s the entire discovery chain, and the flow dies here:

```
✗ Failed to connect: Registration failed: 403 <html>
<head><title>403 Forbidden</title></head>
```

before the browser ever opens. Setting `oauth.user_agent` looks like exactly the right remedy and changes nothing, because the option never applies to the requests being blocked.

## Reproduction

Against a hosted MCP server behind an AWS ALB (`https://mcp.revealed.ai/mcp/`), which answers 403 to any request with no `User-Agent` and 200 to the byte-identical request with one:

```console
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST https://mcp.revealed.ai/register \
    -H "User-Agent:" -H "Content-Type: application/json" \
    -d '{"client_name":"x","redirect_uris":["http://127.0.0.1:3341/callback"]}'
403

$ curl -s -o /dev/null -w "%{http_code}\n" -X POST https://mcp.revealed.ai/register \
    -A "hermes-agent/1.0" -H "Content-Type: application/json" \
    -d '{"client_name":"x","redirect_uris":["http://127.0.0.1:3341/callback"]}'
200
```

The same 403-without-UA / 200-with-UA split holds for both `.well-known` documents. Hermes' own log shows every hop the SDK builds getting rejected:

```
httpx2: HTTP Request: POST https://mcp.revealed.ai/mcp/ "HTTP/1.1 401 Unauthorized"
httpx2: HTTP Request: GET https://mcp.revealed.ai/.well-known/oauth-protected-resource "HTTP/1.1 403 Forbidden"
httpx2: HTTP Request: GET https://mcp.revealed.ai/.well-known/oauth-protected-resource/mcp/ "HTTP/1.1 403 Forbidden"
httpx2: HTTP Request: GET https://mcp.revealed.ai/.well-known/oauth-authorization-server "HTTP/1.1 403 Forbidden"
```

Note the failure mode is *misdiagnosing*: `Registration failed: 403` points at dynamic client registration support or an unapproved OAuth client, when the actual cause is a missing request header. Worth calling out because the existing guidance in `_make_callback_waiter` for a rejected CIMD (`set cimd: false`) does not apply and does not help here.

With `oauth.user_agent: hermes-agent/1.0` and this change, the same config completes discovery, resolves the correct `authorization_endpoint`, opens the browser, and authenticates — 18 tools discovered, `hermes mcp test revealed` green.

## Fix

Extend the existing stamp from the token endpoint to the whole auth flow, in both provider classes, applying it **only when the outbound request carries no `User-Agent` of its own**:

- a caller-supplied header is never overwritten
- servers without `oauth.user_agent` configured are byte-identical to before

`tools/mcp_oauth_manager.py` already bridges the SDK's bidirectional generator (the `#11383` regression contract, covered by `tests/tools/test_mcp_oauth_bidirectional.py`), so the stamp hooks into that existing bridge rather than duplicating it. The `tools/mcp_oauth.py` provider gains an equivalent bridge, preserving the same `asend(response)` semantics — a naive `async for` wrapper would swallow httpx's fed-back responses and the SDK's `response = yield request` would see `None`.

This is scoped deliberately narrowly: no new config key, no behavior change for any server that has not opted in, and no heuristic about which hosts need a UA.

## Tests

`tests/tools/test_mcp_oauth_user_agent.py` gains coverage that drives the **real** `async_auth_flow` of both provider classes (`build_oauth_auth` and `MCPOAuthManager.get_or_build_provider`) through a scripted `401 → PRM → OASM → /register` sequence, asserting:

1. the configured UA is present on every SDK-built hop, through registration
2. requests are untouched when `oauth.user_agent` is unset
3. a UA already on the request is never overridden

Assertion 1 fails on current `main` — verified by stashing only the production diff and re-running:

```
FAILED tests/tools/test_mcp_oauth_user_agent.py::test_discovery_and_registration_carry_the_configured_user_agent[build_oauth_auth]
FAILED tests/tools/test_mcp_oauth_user_agent.py::test_discovery_and_registration_carry_the_configured_user_agent[oauth_manager]
2 failed, 16 passed
```

With the fix: `18 passed`.

Wider MCP suite on this branch: `653 passed, 3 failed`. All three failures reproduce on unmodified `deb1f6dbbe` with `tools/mcp_oauth*.py` reverted to their `main` contents, so they are pre-existing and unrelated to this change (Windows environment: `KeyError: 'ProgramFiles'` in `TestBuildSafeEnv`, a `0600` permissions assertion in `test_mcp_schema_cache.py`, and a DCR auth-method assertion in `test_mcp_oauth.py`).

Environment: Windows 11, `mcp` SDK with `httpx2` 2.7.0, HTTP/streamable transport.
