### PR TITLE
fix(desktop): preserve existing files on failed gateway download

### DIFF
--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -61,16 +61,26 @@ class FakeWriteStream extends EventEmitter {
   }
 }
 
-test('pumpStreamToFile streams chunks to the destination without buffering the whole body', async () => {
+test('pumpStreamToFile stages chunks and promotes only after the whole body succeeds', async () => {
   const res = new FakeResponse()
   const ws = new FakeWriteStream()
+  const created: string[] = []
   const unlinked: string[] = []
+  const renamed: Array<[string, string]> = []
 
   const promise = pumpStreamToFile(res as never, '/tmp/out.bin', {
-    createWriteStream: () => ws as never,
+    createWriteStream: p => {
+      created.push(p)
+
+      return ws as never
+    },
     unlink: async p => {
       unlinked.push(p)
-    }
+    },
+    rename: async (from, to) => {
+      renamed.push([from, to])
+    },
+    temporaryPath: () => '/tmp/out.bin.download'
   })
 
   res.emit('data', Buffer.from('abc'))
@@ -79,9 +89,11 @@ test('pumpStreamToFile streams chunks to the destination without buffering the w
 
   await promise
 
+  assert.deepEqual(created, ['/tmp/out.bin.download'])
   assert.equal(Buffer.concat(ws.chunks).toString('utf8'), 'abcdef')
   assert.equal(ws.ended, true)
-  assert.deepEqual(unlinked, []) // success -> no cleanup
+  assert.deepEqual(renamed, [['/tmp/out.bin.download', '/tmp/out.bin']])
+  assert.deepEqual(unlinked, [])
 })
 
 test('pumpStreamToFile applies backpressure: pauses on a full buffer and resumes on drain', async () => {
@@ -90,7 +102,9 @@ test('pumpStreamToFile applies backpressure: pauses on a full buffer and resumes
 
   const promise = pumpStreamToFile(res as never, '/tmp/out.bin', {
     createWriteStream: () => ws as never,
-    unlink: async () => {}
+    unlink: async () => {},
+    rename: async () => {},
+    temporaryPath: () => '/tmp/out.bin.download'
   })
 
   res.emit('data', Buffer.from('big-chunk'))
@@ -104,43 +118,84 @@ test('pumpStreamToFile applies backpressure: pauses on a full buffer and resumes
   await promise
 })
 
-test('pumpStreamToFile unlinks the partial file and rejects on a write error', async () => {
+test('pumpStreamToFile cleans only its staging file on a write error', async () => {
   const res = new FakeResponse()
   const ws = new FakeWriteStream()
+  const created: string[] = []
   const unlinked: string[] = []
+  const renamed: Array<[string, string]> = []
 
-  const promise = pumpStreamToFile(res as never, '/tmp/partial.bin', {
-    createWriteStream: () => ws as never,
+  const promise = pumpStreamToFile(res as never, '/tmp/existing.bin', {
+    createWriteStream: p => {
+      created.push(p)
+
+      return ws as never
+    },
     unlink: async p => {
       unlinked.push(p)
-    }
+    },
+    rename: async (from, to) => {
+      renamed.push([from, to])
+    },
+    temporaryPath: () => '/tmp/existing.bin.download'
   })
 
   res.emit('data', Buffer.from('abc'))
   ws.emit('error', new Error('ENOSPC: disk full'))
 
   await assert.rejects(promise, /disk full/)
-  assert.deepEqual(unlinked, ['/tmp/partial.bin'])
+  assert.deepEqual(created, ['/tmp/existing.bin.download'])
+  assert.deepEqual(unlinked, ['/tmp/existing.bin.download'])
+  assert.deepEqual(renamed, [])
   assert.equal(res.destroyed, true, 'source should be torn down on write failure')
 })
 
-test('pumpStreamToFile unlinks the partial file and rejects on a response error', async () => {
+test('pumpStreamToFile preserves the selected destination when the response fails', async () => {
   const res = new FakeResponse()
   const ws = new FakeWriteStream()
   const unlinked: string[] = []
+  const renamed: Array<[string, string]> = []
 
-  const promise = pumpStreamToFile(res as never, '/tmp/partial.bin', {
+  const promise = pumpStreamToFile(res as never, '/tmp/existing.bin', {
     createWriteStream: () => ws as never,
     unlink: async p => {
       unlinked.push(p)
-    }
+    },
+    rename: async (from, to) => {
+      renamed.push([from, to])
+    },
+    temporaryPath: () => '/tmp/existing.bin.download'
   })
 
   res.emit('data', Buffer.from('abc'))
   res.emit('error', new Error('socket hang up'))
 
   await assert.rejects(promise, /socket hang up/)
-  assert.deepEqual(unlinked, ['/tmp/partial.bin'])
+  assert.deepEqual(unlinked, ['/tmp/existing.bin.download'])
+  assert.deepEqual(renamed, [])
+})
+
+test('pumpStreamToFile removes staging and rejects if final promotion fails', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const unlinked: string[] = []
+
+  const promise = pumpStreamToFile(res as never, '/tmp/existing.bin', {
+    createWriteStream: () => ws as never,
+    unlink: async p => {
+      unlinked.push(p)
+    },
+    rename: async () => {
+      throw new Error('rename failed')
+    },
+    temporaryPath: () => '/tmp/existing.bin.download'
+  })
+
+  res.emit('data', Buffer.from('complete'))
+  res.emit('end')
+
+  await assert.rejects(promise, /rename failed/)
+  assert.deepEqual(unlinked, ['/tmp/existing.bin.download'])
 })
 
 test('parseDataUrlToBuffer decodes base64 payloads', () => {
@@ -174,7 +229,7 @@ test('filenameFromContentDisposition prefers filename* and reduces to a basename
 test('gatewayFilePath normalizes bare paths and file:// URLs', () => {
   assert.equal(gatewayFilePath('/Users/me/report.md'), '/Users/me/report.md')
   assert.equal(gatewayFilePath('file:///Users/me/a%20b.md'), '/Users/me/a b.md')
-  assert.equal(gatewayFilePath(''), '')
+  assert.equal(gatewayFilePath('',), '')
   assert.equal(gatewayFilePath(null), '')
 })
 

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -5,10 +5,11 @@
 // The transport wrappers (token / OAuth) live in main.ts because they need
 // main-process singletons (https/http, electronNet, the OAuth session). They
 // delegate the byte-moving to `pumpStreamToFile` here, which streams the
-// response to a user-selected destination with backpressure and cleans up a
-// partial file on error — so a large download never has to be buffered whole in
-// the native process.
+// response to an operation-owned temporary file with backpressure and only
+// replaces the user-selected destination after the stream finishes.
 
+import { randomUUID } from 'node:crypto'
+import { rename as renameFile } from 'node:fs/promises'
 import path from 'node:path'
 
 // Minimal shape of the response objects we consume. Both Node's
@@ -33,6 +34,8 @@ export interface WriteStreamLike {
 export interface PumpDeps {
   createWriteStream: (destPath: string) => WriteStreamLike
   unlink: (destPath: string) => Promise<unknown>
+  rename?: (sourcePath: string, destPath: string) => Promise<unknown>
+  temporaryPath?: (destPath: string) => string
 }
 
 export interface GatewayFileBackendDeps<T> {
@@ -79,13 +82,14 @@ export async function resolveGatewayFileBackend<T>(
   return { connection, connectionId, profile }
 }
 
-// Stream `res` into `destPath`, honoring backpressure. On any read/write error
-// the write stream is torn down and the (partial) destination file is removed
-// before the returned promise rejects, so a failed download never leaves a
-// truncated file behind.
+// Stream `res` into an operation-owned sibling file, honoring backpressure.
+// Only after the stream closes successfully do we rename that staging file onto
+// `destPath`. Failures clean up only the staging file, so an existing destination
+// can never be truncated or deleted by a failed gateway transfer.
 export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: PumpDeps): Promise<void> {
   return new Promise((resolve, reject) => {
-    const ws = deps.createWriteStream(destPath)
+    const partialPath = deps.temporaryPath?.(destPath) ?? `${destPath}.${randomUUID()}.download`
+    const ws = deps.createWriteStream(partialPath)
     let failed = false
 
     const fail = (err: Error) => {
@@ -107,7 +111,7 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
         // best effort
       }
 
-      Promise.resolve(deps.unlink(destPath))
+      Promise.resolve(deps.unlink(partialPath))
         .catch(() => {})
         .then(() => reject(err))
     }
@@ -140,7 +144,11 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
         return
       }
 
-      ws.end(() => resolve())
+      ws.end(() => {
+        const rename = deps.rename ?? renameFile
+
+        Promise.resolve(rename(partialPath, destPath)).then(() => resolve(), error => fail(error as Error))
+      })
     })
   })
 }


### PR DESCRIPTION
Fixes #96597.

## Problem

`pumpStreamToFile()` opened the final save path before the gateway stream settled. `createWriteStream()` can truncate an existing same-named file immediately, and the failure path then unlinked that user-owned destination.

## Fix

- stream gateway responses into a unique operation-owned sibling `.download` file;
- preserve the existing backpressure behavior;
- clean up only the staging file on read, write, or promotion failure;
- rename the completed staging file onto the selected destination only after the response and file stream finish successfully.

## Regression coverage

Focused tests now verify that read/write failures never promote or unlink the selected destination, successful downloads promote staging only after completion, and a failed final rename cleans only staging.

## Validation

The branch is based directly on current upstream `main` (`b39d76d902b0891457bc73a6eb43aa136f26d7a8`). The final duplicate search found no direct open implementation for #96597; the existing broad package/update drafts only reference this issue as an adjacent invariant and do not touch this download path.

Hosted PR CI is the execution gate for these focused Desktop tests in this automation environment.