### PR TITLE
fix(desktop): gate transcript budget cap so Show earlier works (supersedes #87686)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -9,6 +9,7 @@ import {
   liveTailStart,
   type MessageGroup,
   resolveThreadScrollTarget,
+  shouldClampTranscriptBudget,
   subscribeToThreadForeground,
   transcriptPaneBudget
 } from './list'
@@ -95,6 +96,18 @@ describe('transcriptPaneBudget', () => {
     expect(transcriptPaneBudget(1, true)).toBe(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
     expect(transcriptPaneBudget(4, true)).toBe(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
     expect(transcriptPaneBudget(1, false)).toBeGreaterThan(HIDDEN_TRANSCRIPT_RENDER_BUDGET)
+  })
+})
+
+describe('shouldClampTranscriptBudget', () => {
+  it('never snaps a visible pane back after Show earlier', () => {
+    expect(shouldClampTranscriptBudget(false, 10, 5)).toBe(false)
+    expect(shouldClampTranscriptBudget(false, 5, 5)).toBe(false)
+  })
+
+  it('snaps only a hot-hidden pane that outgrew the retention budget', () => {
+    expect(shouldClampTranscriptBudget(true, 10, 5)).toBe(true)
+    expect(shouldClampTranscriptBudget(true, 5, 5)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -105,6 +105,13 @@ export const transcriptPaneBudget = (mountedPanes: number, hidden: boolean): num
   hidden
     ? HIDDEN_TRANSCRIPT_RENDER_BUDGET
     : Math.max(Math.ceil(RENDER_BUDGET / Math.max(1, mountedPanes)), RENDER_BUDGET / 4)
+
+// "Show earlier" raises renderBudget ABOVE paneBudget (one pane page per click).
+// The render-phase cap must only snap a hot-hidden pane down to its retention
+// budget — a visible pane's growth has to survive the next render or the click
+// is a no-op. Parked panes are unmounted, so they never hit this path.
+export const shouldClampTranscriptBudget = (hidden: boolean, renderBudget: number, paneBudget: number): boolean =>
+  hidden && renderBudget > paneBudget
 // Units the backfill adds per committed step (see the backfill effect). ~8-15
 // ordinary turns or 1-2 tool-heavy ones per frame — big enough to fill a page
 // in ~10 frames, small enough that no single commit approaches a frame budget.
@@ -433,7 +440,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     setBudgetSessionKey(sessionKey)
     setHadGroups(hasGroups)
     setRenderBudget(FIRST_PAINT_BUDGET)
-  } else if (renderBudget > paneBudget) {
+  } else if (shouldClampTranscriptBudget(paneLifecycle === 'hot-hidden', renderBudget, paneBudget)) {
     // Apply the hidden budget during render so React never first commits the
     // stale full transcript after this pane moves to the background.
     setRenderBudget(paneBudget)
@@ -692,14 +699,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
 
     anchorBeforePrepend()
+    // Both paths grow the DOM budget by one pane page. Windowed rows are older
+    // than the current page, so expand-without-grow paints nothing.
+    setRenderBudget(budget => budget + paneBudget)
 
-    if (action === 'dom') {
-      setRenderBudget(budget => budget + paneBudget)
-
-      return
+    if (action === 'window') {
+      expandWindow()
     }
-
-    expandWindow()
   }, [anchorBeforePrepend, expandWindow, hiddenCount, olderAvailable, paneBudget])
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Supersedes [#87686](https://github.com/NousResearch/hermes-agent/pull/87686).

"Show earlier messages" in a long desktop session rendered and did nothing. Each click raises the transcript DOM budget above `paneBudget`; the render-phase cap from `62eefff697` snapped that growth back on the next render.

The cap is for hot-hidden panes (keep a live tail; don't commit the full transcript when a tab backgrounds). This gates it on `paneLifecycle === 'hot-hidden'`. Parked panes are unmounted, so they never hit the path.

A click that only expands the store window still painted nothing, because the new older rows sit outside the current DOM budget. Both paths now grow `renderBudget` by one pane page.

The clamp helper and tests come from [#87972](https://github.com/NousResearch/hermes-agent/pull/87972). Timeline reveal from that PR is left alone.

### What this PR does
- Gate the render-phase budget cap so a visible pane keeps Show-earlier growth
- Grow `renderBudget` when expanding the store window
- Pin the clamp invariant (visible/over-budget does not clamp; hot-hidden/over-budget does)

### What was dropped from [#87686](https://github.com/NousResearch/hermes-agent/pull/87686)
- `expect(transcriptPaneBudget(1, false)).toBe(600)` — freezes an internal tuning value
- Tests that only re-asserted `transcriptPaneBudget()` and would still pass without the gate

## Related Issue

Refs [#90473](https://github.com/NousResearch/hermes-agent/issues/90473), [#95906](https://github.com/NousResearch/hermes-agent/issues/95906)

Does not close [#90473](https://github.com/NousResearch/hermes-agent/issues/90473) — compacted-history reachability and the paging UX are separate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)
- [x] ✅ Tests (adding or improving test coverage)

## How to Test

1. Open a long session so "Show earlier messages" appears at the top.
2. Click it. Older turns prepend; the view stays anchored.
3. From `apps/desktop`: `npx vitest run src/components/assistant-ui/thread/list.test.ts`

## Checklist

- [x] Commit follows Conventional Commits (`fix(desktop):`)
- [x] Searched existing PRs
- [x] PR contains only changes related to this fix
- [x] Tests added for the change

Credit: @chukirk-svg (clamp gate). @Per0-1 (`shouldClampTranscriptBudget` helper and tests).