### PR TITLE
feat(desktop): collapse Yesterday / Last week groups in the sessions sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarDateDivider } from './chrome'
+
+afterEach(cleanup)
+
+describe('SidebarDateDivider', () => {
+  it('collapses the group when the caption is clicked', () => {
+    const onToggle = vi.fn()
+
+    render(
+      <SidebarDateDivider
+        label="Yesterday"
+        toggle={{ ariaLabel: 'Hide Yesterday sessions', onToggle, open: true }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Yesterday sessions' }))
+    expect(onToggle).toHaveBeenCalledOnce()
+    expect(screen.getByRole('button', { name: 'Hide Yesterday sessions' }).getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('stays a static caption when it is not collapsible', () => {
+    render(<SidebarDateDivider label="Yesterday" />)
+
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.getByText('Yesterday')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -43,23 +43,54 @@ export function SidebarRowNest({ className, ...props }: React.ComponentProps<'di
 
 /**
  * Chronological date-bucket separator ("Yesterday" / "Last week" / "June") for
- * the session list. One flat row — a small caption plus a hairline rule — so it
- * groups sessions by recency without adding a level of indentation.
+ * the session list. Caption-shaped — a small label plus a hairline — so it
+ * groups sessions by recency without adding a level of indentation. When
+ * `toggle` is set the whole caption collapses the sessions beneath it, same
+ * gesture as a repo header (the hover caret is the tell).
  */
 export function SidebarDateDivider({
   action,
   className,
   label,
+  toggle,
   ...props
-}: React.ComponentProps<'div'> & { action?: React.ReactNode; label: string }) {
+}: React.ComponentProps<'div'> & {
+  action?: React.ReactNode
+  label: string
+  toggle?: { ariaLabel: string; onToggle: () => void; open: boolean }
+}) {
+  const caption = (
+    <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+      {label}
+    </span>
+  )
+  const rule = <span aria-hidden="true" className="h-px min-w-4 flex-1 bg-(--ui-stroke-tertiary)" />
+
   return (
     // group/workspace: a divider heads a group the same way a repo header does,
     // so it borrows the header's hover-revealed "+" verbatim.
     <div className={cn('group/workspace flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
-      <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
-        {label}
-      </span>
-      <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+      {toggle ? (
+        <button
+          aria-expanded={toggle.open}
+          aria-label={toggle.ariaLabel}
+          className="flex min-w-0 flex-1 items-center gap-2 bg-transparent text-left"
+          onClick={toggle.onToggle}
+          type="button"
+        >
+          {caption}
+          <DisclosureCaret
+            className="text-(--ui-text-tertiary) opacity-0 transition group-hover/workspace:opacity-100"
+            open={toggle.open}
+          />
+          {rule}
+        </button>
+      ) : (
+        <>
+          {caption}
+          {rule}
+        </>
+      )}
       {action}
     </div>
   )
@@ -140,8 +171,9 @@ export interface SidebarGroupTotals {
 /**
  * Header for a group of sessions that hangs its rows underneath — a project, a
  * profile. Row-shaped rather than caption-shaped (that's {@link SidebarDateDivider},
- * for groupings that only separate), so a group header lines up with the session
- * rows it heads. `toggle` omitted keeps the caret's space with nothing to reveal.
+ * which still collapses, just without a lead glyph), so a group header lines up
+ * with the session rows it heads. `toggle` omitted keeps the caret's space with
+ * nothing to reveal.
  */
 export function SidebarGroupRow({
   actions,

--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -25,6 +25,7 @@ import {
   $sidebarCardRows,
   $sidebarFiltersActive,
   $sidebarGrouping,
+  $sidebarListGroupIds,
   $sidebarOrdering,
   $sidebarPrFilter,
   $sidebarProfileFilter,
@@ -165,6 +166,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   const filtersActive = useStore($sidebarFiltersActive)
   const viewCustomized = useStore($sidebarViewCustomized)
   const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
+  const listGroupIds = useStore($sidebarListGroupIds)
   const projects = useStore($projectTree)
   const hasCost = useStore($sessionsHaveCost)
   const unreadIds = useStore($unreadFinishedSessionIds)
@@ -172,9 +174,16 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   // locally, the gateway's REST mirror remotely. Resolved per render, not once
   // at module load: switching to a remote profile swaps the bridge underneath.
   const prAvailable = Boolean(desktopGit()?.review?.prList)
-  // Project rows default open, so "all collapsed" means every one of them has
-  // been explicitly shut.
-  const projectsCollapsed = projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
+  // Fold the level in view: project rows, or the date/status buckets. Project
+  // rows default open, so "all collapsed" means every one of them has been
+  // explicitly shut. Never sweeps Pinned or Cron.
+  const foldIds =
+    grouping === 'project'
+      ? projects.map(project => project.id)
+      : grouping === 'date' || grouping === 'status'
+        ? listGroupIds
+        : []
+  const foldCollapsed = foldIds.length > 0 && foldIds.every(id => nodeOpen[id] === false)
 
   const groupingLabel = GROUPINGS.find(option => option.id === grouping)?.label
 
@@ -392,20 +401,9 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
 
         <DropdownMenuSeparator />
 
-        {/* Only the project rows fold, and only when they're what you're
-            looking at — sweeping Pinned and Cron shut alongside them is not
-            what "collapse all" means here. Their lanes underneath keep their
-            own state, so re-opening a project shows it as you left it. */}
-        {grouping === 'project' && projects.length > 0 && (
-          <DropdownMenuItem
-            onSelect={() =>
-              setWorkspaceNodesOpen(
-                projects.map(project => project.id),
-                projectsCollapsed
-              )
-            }
-          >
-            {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+        {foldIds.length > 0 && (
+          <DropdownMenuItem onSelect={() => setWorkspaceNodesOpen(foldIds, foldCollapsed)}>
+            {foldCollapsed ? 'Expand all' : 'Collapse all'}
           </DropdownMenuItem>
         )}
         <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -4,6 +4,7 @@ import type { SidebarListRow } from '@/lib/session-date-groups'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
+  mergeVisibleReorder,
   orderByIds,
   orderRowsWithinGroups,
   rankSessions,
@@ -169,5 +170,17 @@ describe('reorderableRowIds', () => {
     const rows = [session('a'), session('branch', '├─ '), divider('yesterday'), session('b')]
 
     expect(reorderableRowIds(rows)).toEqual(['a', 'b'])
+  })
+})
+
+describe('mergeVisibleReorder', () => {
+  it('returns the visible order when nothing is hidden', () => {
+    expect(mergeVisibleReorder(['a', 'b', 'c'], ['c', 'a', 'b'])).toEqual(['c', 'a', 'b'])
+  })
+
+  it('keeps hidden ids in their original slots', () => {
+    // 'c' and 'd' sit under a collapsed divider; a drag of the open group
+    // must not forget the ranking that group already had.
+    expect(mergeVisibleReorder(['a', 'b', 'c', 'd'], ['b', 'a'])).toEqual(['b', 'a', 'c', 'd'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -226,3 +226,17 @@ function clusterId(rows: SidebarListRow[]): string {
 export function reorderableRowIds(rows: SidebarListRow[]): string[] {
   return rows.flatMap(row => (row.kind === 'session' && !row.entry.branchStem ? [row.entry.session.id] : []))
 }
+
+/** Splice a new visible-id order back into the full id list, keeping hidden
+ *  ids in their original slots. A drag while some date groups are collapsed
+ *  must not wipe those groups' saved ranking. */
+export function mergeVisibleReorder(allIds: string[], nextVisibleIds: string[]): string[] {
+  if (nextVisibleIds.length === allIds.length) {
+    return nextVisibleIds
+  }
+
+  const visible = new Set(nextVisibleIds)
+  let i = 0
+
+  return allIds.map(id => (visible.has(id) ? (nextVisibleIds[i++] ?? id) : id))
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,7 +1,7 @@
 import type { useSensors } from '@dnd-kit/core'
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -13,16 +13,23 @@ import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import {
   groupEntriesByRecency,
   groupEntriesByStatus,
+  hideCollapsedGroupRows,
   type SidebarListRow,
   toSessionRows
 } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import {
+  $sidebarListGroupIds,
+  $sidebarWorkspaceNodeOpen,
+  listGroupNodeId,
+  toggleWorkspaceNodeCollapsed
+} from '@/store/layout'
 import { sessionPinId } from '@/store/session'
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
-import { orderRowsWithinGroups, reorderableRowIds } from './order'
+import { mergeVisibleReorder, orderRowsWithinGroups, reorderableRowIds } from './order'
 import {
   EnteredProjectContent,
   ProjectOverviewRow,
@@ -218,6 +225,8 @@ export function SidebarSessionsSection({
   const dividerLabels = t.sidebar.dateDivider
   const statusDividerLabels = t.sidebar.statusDivider
   const dotStates = useStore($sessionDotStateById)
+  const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
+  const isListGroupOpen = useCallback((key: string) => nodeOpen[listGroupNodeId(key)] ?? true, [nodeOpen])
   const sectionOpen = collapsible ? open : true
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
   // A defined project list is itself content (even an empty project should
@@ -297,6 +306,15 @@ export function SidebarSessionsSection({
       <WorkspaceAddButton label={t.sidebar.nav['new-session']} onClick={() => onNewSessionInWorkspace(null)} />
     ) : null
 
+  const dividerToggle = useMemo(
+    () => ({
+      ariaLabel: (label: string, open: boolean) => t.sidebar.projects.toggle(label, !open),
+      onToggle: (key: string) => toggleWorkspaceNodeCollapsed(listGroupNodeId(key)),
+      open: isListGroupOpen
+    }),
+    [isListGroupOpen, t]
+  )
+
   // A single flat/virtual/lane list row — either a divider or a session.
   const renderListRow = useCallback(
     (row: SidebarListRow, draggable: boolean, action?: React.ReactNode) => {
@@ -304,15 +322,23 @@ export function SidebarSessionsSection({
         return renderRow(row.entry.session, draggable, row.entry.branchStem)
       }
 
+      const label = 'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)
+      const open = dividerToggle.open(row.key)
+
       return (
         <SidebarDateDivider
           action={action}
           key={row.key}
-          label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+          label={label}
+          toggle={{
+            ariaLabel: dividerToggle.ariaLabel(label, open),
+            onToggle: () => dividerToggle.onToggle(row.key),
+            open
+          }}
         />
       )
     },
-    [dividerLabels, renderRow]
+    [dividerLabels, dividerToggle, renderRow]
   )
 
   // Sessions inside repos/worktrees are date-ordered and static.
@@ -329,11 +355,11 @@ export function SidebarSessionsSection({
     (items: SessionInfo[]) => {
       const entries = flattenSessionsWithBranches(items)
 
-      return (grouping === 'date' ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row =>
-        renderListRow(row, false)
-      )
+      const rows = grouping === 'date' ? groupEntriesByRecency(entries) : toSessionRows(entries)
+
+      return hideCollapsedGroupRows(rows, isListGroupOpen).map(row => renderListRow(row, false))
     },
-    [grouping, renderListRow]
+    [grouping, isListGroupOpen, renderListRow]
   )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
@@ -355,11 +381,38 @@ export function SidebarSessionsSection({
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
   }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
 
+  // Closed date/status buckets keep their divider and drop the sessions under
+  // it. Same array when nothing is collapsed so the virtualizer's rows ref
+  // stays stable across parent re-renders.
+  const visibleRows = useMemo(
+    () => hideCollapsedGroupRows(flatRows, isListGroupOpen),
+    [flatRows, isListGroupOpen]
+  )
+
   // dnd-kit must see exactly the ids it renders, in render order: the sortable
   // set is derived from the rows, not from `sessions`. Feeding it the unrendered
   // session order made a drop compute its target index against a list the user
   // wasn't looking at — the drag that landed a row in the wrong slot.
-  const sortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
+  const sortableRowIds = useMemo(() => reorderableRowIds(visibleRows), [visibleRows])
+  const allSortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
+  const persistSessionOrder = useCallback(
+    (ids: string[]) => onReorderSessions?.(mergeVisibleReorder(allSortableRowIds, ids)),
+    [allSortableRowIds, onReorderSessions]
+  )
+
+  useEffect(() => {
+    if (grouping !== 'date' && grouping !== 'status') {
+      return
+    }
+
+    $sidebarListGroupIds.set(
+      flatRows.flatMap(row => (row.kind === 'divider' ? [listGroupNodeId(row.key)] : []))
+    )
+
+    return () => {
+      $sidebarListGroupIds.set([])
+    }
+  }, [flatRows, grouping])
 
   // Pinned never virtualizes. Virtualization needs a bounded viewport to
   // measure against, and Pinned deliberately has none — however many chats you
@@ -463,6 +516,7 @@ export function SidebarSessionsSection({
         card={card}
         className={contentClassName}
         dividerAction={dividerAction}
+        dividerToggle={dividerToggle}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
@@ -470,7 +524,7 @@ export function SidebarSessionsSection({
         onTogglePin={onTogglePin}
         onToggleUnread={onToggleUnread}
         pinned={pinned}
-        rows={flatRows}
+        rows={visibleRows}
         showProfileTags={showProfileTags}
         sortable={sessionsDraggable}
       />
@@ -478,7 +532,7 @@ export function SidebarSessionsSection({
 
     inner =
       sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
+        <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
           {virtual}
         </ReorderableList>
       ) : (
@@ -486,12 +540,12 @@ export function SidebarSessionsSection({
       )
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
-      <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
-        {flatRows.map(row => renderListRow(row, true, dividerAction))}
+      <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
+        {visibleRows.map(row => renderListRow(row, true, dividerAction))}
       </ReorderableList>
     )
   } else {
-    inner = flatRows.map(row => renderListRow(row, false, dividerAction))
+    inner = visibleRows.map(row => renderListRow(row, false, dividerAction))
   }
 
   // The virtualizer owns its own scroller, so suppress the wrapper's overflow

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -530,15 +530,14 @@ export function SidebarSessionsSection({
       />
     )
 
-    inner =
-      sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
-          {virtual}
-        </ReorderableList>
-      ) : (
-        virtual
-      )
-  } else if (sessionsDraggable && onReorderSessions) {
+    inner = sessionsDraggable ? (
+      <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
+        {virtual}
+      </ReorderableList>
+    ) : (
+      virtual
+    )
+  } else if (sessionsDraggable) {
     inner = (
       <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
         {visibleRows.map(row => renderListRow(row, true, dividerAction))}

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -40,6 +40,12 @@ export interface VirtualSessionListProps {
   className?: string
   /** Hover-revealed control for date dividers (the group-level "+"). */
   dividerAction?: React.ReactNode
+  /** Collapse/expand the sessions under a date or status divider. */
+  dividerToggle?: {
+    ariaLabel: (label: string, open: boolean) => string
+    onToggle: (key: string) => void
+    open: (key: string) => boolean
+  }
   rows: SidebarListRow[]
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
@@ -64,6 +70,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   card = false,
   className,
   dividerAction,
+  dividerToggle,
   rows: listRows,
   onArchiveSession,
   onBranchSession,
@@ -126,11 +133,23 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
     // Dividers are non-sortable, self-measured rows interleaved with sessions.
     if (row.kind === 'divider') {
+      const label = 'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)
+      const open = dividerToggle?.open(row.key) ?? true
+
       return (
         <div data-index={virtualItem.index} key={row.key} ref={virtualizer.measureElement} style={itemStyle}>
           <SidebarDateDivider
             action={dividerAction}
-            label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+            label={label}
+            toggle={
+              dividerToggle
+                ? {
+                    ariaLabel: dividerToggle.ariaLabel(label, open),
+                    onToggle: () => dividerToggle.onToggle(row.key),
+                    open
+                  }
+                : undefined
+            }
           />
         </div>
       )

--- a/apps/desktop/src/lib/session-date-groups.test.ts
+++ b/apps/desktop/src/lib/session-date-groups.test.ts
@@ -5,7 +5,7 @@ import type { SessionInfo } from '@/types/hermes'
 import { makeSessionInfo } from '../test/session-info'
 
 import type { SidebarSessionEntry } from './session-branch-tree'
-import { groupEntriesByRecency, toSessionRows } from './session-date-groups'
+import { groupEntriesByRecency, hideCollapsedGroupRows, toSessionRows } from './session-date-groups'
 
 const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
   makeSessionInfo({ id, message_count: 1, source: 'cli', title: id, ...overrides })
@@ -188,6 +188,55 @@ describe('groupEntriesByRecency', () => {
     ])
 
     expect(dividerKeys(rows)).toEqual(['last-week'])
+  })
+})
+
+describe('hideCollapsedGroupRows', () => {
+  it('returns the same array when every group is open', () => {
+    const rows = [
+      { entry: entry(session('a')), kind: 'session' as const },
+      { key: 'yesterday', kind: 'divider' as const, label: 'Yesterday' },
+      { entry: entry(session('b')), kind: 'session' as const }
+    ]
+
+    expect(hideCollapsedGroupRows(rows, () => true)).toBe(rows)
+  })
+
+  it('keeps the divider and drops sessions under a closed group', () => {
+    const rows = [
+      { entry: entry(session('head')), kind: 'session' as const },
+      { key: 'yesterday', kind: 'divider' as const, label: 'Yesterday' },
+      { entry: entry(session('y1')), kind: 'session' as const },
+      { entry: entry(session('y2'), '└─ '), kind: 'session' as const },
+      { key: 'last-week', kind: 'divider' as const, label: 'Last week' },
+      { entry: entry(session('lw')), kind: 'session' as const }
+    ]
+
+    const visible = hideCollapsedGroupRows(rows, key => key !== 'yesterday')
+
+    expect(visible).toEqual([
+      rows[0],
+      rows[1],
+      rows[4],
+      rows[5]
+    ])
+  })
+
+  it('never hides the unlabelled head above the first divider', () => {
+    const rows = [
+      { entry: entry(session('a')), kind: 'session' as const },
+      { entry: entry(session('b')), kind: 'session' as const },
+      { key: 'yesterday', kind: 'divider' as const, label: 'Yesterday' },
+      { entry: entry(session('c')), kind: 'session' as const }
+    ]
+
+    const visible = hideCollapsedGroupRows(rows, () => false)
+
+    expect(visible.map(row => (row.kind === 'session' ? row.entry.session.id : row.key))).toEqual([
+      'a',
+      'b',
+      'yesterday'
+    ])
   })
 })
 

--- a/apps/desktop/src/lib/session-date-groups.ts
+++ b/apps/desktop/src/lib/session-date-groups.ts
@@ -179,3 +179,29 @@ export function groupEntriesByStatus(
 export function toSessionRows(entries: readonly SidebarSessionEntry[]): SidebarListRow[] {
   return entries.map(entry => ({ entry, kind: 'session' }))
 }
+
+/** Drop session rows that sit under a closed divider. The divider itself stays
+ *  so the group can be opened again. Sessions above the first divider (the
+ *  unlabelled head) are never gated. Returns the input array when nothing is
+ *  hidden so callers keep a stable reference. */
+export function hideCollapsedGroupRows(
+  rows: readonly SidebarListRow[],
+  isOpen: (key: string) => boolean
+): SidebarListRow[] {
+  const out: SidebarListRow[] = []
+  let hiding = false
+
+  for (const row of rows) {
+    if (row.kind === 'divider') {
+      hiding = !isOpen(row.key)
+      out.push(row)
+      continue
+    }
+
+    if (!hiding) {
+      out.push(row)
+    }
+  }
+
+  return out.length === rows.length ? (rows as SidebarListRow[]) : out
+}

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -399,6 +399,18 @@ export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Co
 export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
+// Live date/status divider ids (`list-group:yesterday`, …) currently in the
+// recents list. Not persisted — the open/closed choice lives on
+// `$sidebarWorkspaceNodeOpen`; this just names what's on screen so "Collapse
+// all" can fold every labelled bucket, including ones never toggled.
+export const $sidebarListGroupIds = atom<string[]>([])
+
+// Date/status dividers share `$sidebarWorkspaceNodeOpen` under this prefix so
+// they don't collide with repo paths.
+export function listGroupNodeId(key: string): string {
+  return `list-group:${key}`
+}
+
 // Resolve a node's open state against its default (absent = follow default).
 export function workspaceNodeOpen(id: string, defaultOpen = true): boolean {
   return $sidebarWorkspaceNodeOpen.get()[id] ?? defaultOpen


### PR DESCRIPTION
## What does this PR do?

Projects and profiles in the sessions sidebar already fold. Date labels (Yesterday, Last week, June) and status labels (Working, Done) were just separators. Clicking one now hides the sessions under it. Collapse all in the filter menu covers those buckets too.

The newest unlabelled run at the top stays visible — there's no header to click.

## Related Issue

n/a

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How to Test

1. Desktop sessions sidebar, grouped by date.
2. Click **Yesterday** (or Last week / a month). Sessions under it hide; the label stays.
3. Reload — still collapsed.
4. Filters → Collapse all / Expand all.
5. Group by Status and do the same for Working / Done.
6. Collapse a group, drag a visible session, expand the group — its previous order is still there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A