### PR TITLE
fix(auxiliary_client): stop closing in-flight clients on cache key collision (#96491)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7670,7 +7670,13 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
         if old_entry is not None and old_entry[0] is not client:
-            _close_cached_client(old_entry[0])
+            # Do NOT close the old client — another caller may be mid-request
+            # with it (see #96491). Closing an in-flight client tears down its
+            # socket, causing a spurious APIConnectionError on the concurrent
+            # caller. Instead, drop the cache reference and let normal refcount/
+            # GC cleanup happen after in-flight users release it — matching the
+            # eviction policy in _get_cached_client (lines ~8030-8034).
+            pass
         _client_cache[cache_key] = (client, default_model, bound_loop)
 
 


### PR DESCRIPTION
## Summary

Fixes a spurious `Connection error` during concurrent auxiliary compression calls that share the same provider+model cache key (#96491).

**Root cause:** `_store_cached_client()` in `agent/auxiliary_client.py` unconditionally closes the old cached client when a new client with the same cache key is stored. When two concurrent calls (e.g. main conversation + compression) use the same provider+model combination, the second call's `_store_cached_client()` closes the first call's client **while it is still mid-stream**, tearing down the socket and causing a spurious `APIConnectionError`. The upstream request itself succeeds (HTTP 200 with full SSE body), but the Hermes-side client aborts with `deferred_close=stranger_thread`.

**Fix:** Stop closing the old client in `_store_cached_client()`. Instead, simply overwrite the cache entry and let normal refcount/GC cleanup handle the old client after any in-flight users release it. This matches the eviction policy already used in `_get_cached_client()` (lines ~8030-8034: "Do not close an evicted client here: another caller may be mid-request").

This is a one-line behavioral change (`_close_cached_client(old_entry[0])` → `pass`) with a detailed comment explaining why.

## Test Plan

- [ ] Existing auxiliary client tests pass
- [ ] Concurrent compression + main conversation with same provider+model no longer produces spurious `Connection error`

Closes #96491