### PR TITLE
feat(mcp): forward opt-in request context metadata

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3151,6 +3151,12 @@ def cmd_chat(args):
         except OSError as e:
             print(f"Error: cannot enter --in directory {in_dir}: {e}")
             sys.exit(1)
+        # Pin the logical agent cwd as well as the process cwd. Without this,
+        # a configured TERMINAL_CWD can override --in for tools and opt-in MCP
+        # request metadata even though session lookup already uses _target_dir.
+        from agent.runtime_cwd import set_session_cwd
+
+        set_session_cwd(_target_dir)
         args.no_restore_cwd = True
 
     # --resume latest: keyword for "most recent session" — same resolution

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -193,16 +193,22 @@ def test_in_dir_chdirs_before_session_resolution(main_mod, launched, monkeypatch
 
 def test_in_dir_sets_no_restore_cwd(main_mod, launched, monkeypatch, tmp_path):
     import os
+    from agent.runtime_cwd import clear_session_cwd, resolve_agent_cwd
 
     target = tmp_path / "pin-here"
     target.mkdir()
+    configured = tmp_path / "configured-cwd"
+    configured.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(configured))
     start = os.getcwd()
 
     args = _args(resume=None, in_dir=str(target))
     try:
         with pytest.raises(SystemExit):
             main_mod.cmd_chat(args)
+        assert resolve_agent_cwd() == target
     finally:
+        clear_session_cwd()
         os.chdir(start)
 
     assert args.no_restore_cwd is True

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -576,6 +576,49 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_opt_in_request_context_is_forwarded_as_mcp_metadata(self, tmp_path):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result("hello world", is_error=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        server._config = {"request_context": True}
+        _servers["test_srv"] = server
+
+        session_values = {
+            "HERMES_SESSION_PLATFORM": "tui",
+            "HERMES_SESSION_SOURCE": "",
+            "HERMES_SESSION_ID": "session-123",
+            "HERMES_SESSION_KEY": "fallback-key",
+        }
+
+        try:
+            handler = _make_tool_handler("test_srv", "greet", 120)
+            with patch(
+                "agent.runtime_cwd.resolve_agent_cwd", return_value=tmp_path
+            ), patch(
+                "gateway.session_context.get_session_env",
+                side_effect=lambda name, default="": session_values.get(name, default),
+            ), self._patch_mcp_loop():
+                result = json.loads(handler({"name": "world"}))
+            assert result["result"] == "hello world"
+            mock_session.call_tool.assert_called_once_with(
+                "greet",
+                arguments={"name": "world"},
+                meta={
+                    "host_context": {
+                        "cwd": str(tmp_path),
+                        "host": "hermes",
+                        "source": "tui",
+                        "session_id": "session-123",
+                    }
+                },
+            )
+        finally:
+            _servers.pop("test_srv", None)
+
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6067,6 +6067,44 @@ def _ensure_healthy_or_recycle(server: Any, server_name: str) -> None:
         _signal_reconnect(server)
 
 
+def _build_request_context_meta(server) -> dict | None:
+    """Build opt-in MCP request metadata from the active Hermes session.
+
+    Cwd and session identifiers are private execution context, so they are
+    forwarded only when the server explicitly sets ``request_context: true``.
+    The metadata uses MCP's standard ``_meta`` channel and does not change tool
+    arguments or schemas.
+    """
+    config = getattr(server, "_config", None)
+    if not isinstance(config, dict) or config.get("request_context") is not True:
+        return None
+
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+        from gateway.session_context import get_session_env
+
+        platform = str(get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip()
+        source = str(get_session_env("HERMES_SESSION_SOURCE", "") or "").strip()
+        session_id = str(get_session_env("HERMES_SESSION_ID", "") or "").strip()
+        if not session_id:
+            session_id = str(
+                get_session_env("HERMES_SESSION_KEY", "") or ""
+            ).strip()
+        cwd = str(resolve_agent_cwd())
+    except Exception as exc:
+        logger.warning("Could not build opt-in MCP request context: %s", exc)
+        return None
+
+    hermes = {
+        "cwd": cwd,
+        "host": "hermes",
+        "source": platform or source or "hermes",
+    }
+    if session_id:
+        hermes["session_id"] = session_id
+    return {"host_context": hermes}
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -6111,6 +6149,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         if not server:
             _bump_server_error(server_name)
             return tool_error(f"MCP server '{server_name}' is not connected")
+
+        request_meta = _build_request_context_meta(server)
 
         if not server.session:
             # No live session. A reconnect may already be completing (the
@@ -6182,7 +6222,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             f"exited; failing the call fast instead of "
                             f"waiting {float(tool_timeout):.0f}s"
                         )
-                    _call_coro = server.session.call_tool(tool_name, arguments=args)
+                    call_kwargs = {"arguments": args}
+                    if request_meta is not None:
+                        call_kwargs["meta"] = request_meta
+                    _call_coro = server.session.call_tool(tool_name, **call_kwargs)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -33,6 +33,7 @@ mcp_servers:
     enabled: true
     timeout: 120
     connect_timeout: 60
+    request_context: false          # opt in to cwd/session metadata on tool calls
     supports_parallel_tool_calls: false
     tools:
       include: []
@@ -56,6 +57,7 @@ mcp_servers:
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
+| `request_context` | bool | both | When `true`, attach the active Hermes project cwd, session ID (when present), and source to each `tools/call` request under MCP `_meta.host_context`. Defaults to `false` because this can disclose local paths and session identifiers to the server. Use only with a trusted server that needs project-scoped routing. |
 | `protocol` | string | both | Protocol-era negotiation: `auto` (default — legacy `initialize` handshake first, falling back to the 2026-07-28 `server/discover` stateless probe when the server rejects the handshake as modern-only), `stateless` (probe `server/discover` first; one legacy retry), or `legacy` (handshake only, no fallback) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |


### PR DESCRIPTION
## Summary
- add an opt-in `request_context: true` MCP server setting
- forward the active project cwd, session identity, and host source through standard `tools/call` `_meta.host_context`
- keep metadata disabled by default so unrelated MCP servers receive no new data
- make explicit `hermes chat --in DIR` authoritative for tool cwd, even when `terminal.cwd` is configured
- fail open (with a warning) if runtime context cannot be resolved

## Why
Long-lived MCP clients may serve multiple project/session contexts while a server process has only one cwd. Request-scoped metadata lets trusted servers resolve the correct project and isolate session-local state without changing tool schemas or arguments. The `--in` fix closes the real CLI path where configured `TERMINAL_CWD` previously overrode the requested project for tools.

## Verification
- `uv run --extra dev pytest tests/hermes_cli/test_resume_latest_and_in_dir.py tests/tools/test_mcp_tool.py -q` — 112 passed
- `uv run --extra dev ruff check hermes_cli/main.py tools/mcp_tool.py tests/hermes_cli/test_resume_latest_and_in_dir.py tests/tools/test_mcp_tool.py` — passed

## Privacy
The setting defaults to `false`. Documentation explicitly warns that enabling it discloses local paths and session identifiers to that specific MCP server.