### PR TITLE
fix(tui): fall back to a fresh session when an automatic resume hits a dead id

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -45,6 +45,7 @@ import {
   inlineErrorMessage,
   isProviderSetupError,
   isSessionBusyError,
+  isSessionNotFoundError,
   isTargetSessionBusy,
   releaseSubmitInFlight,
   SessionRecoveryAborted,
@@ -546,8 +547,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // would fork a contextless chat against whichever profile is active.
         try {
           await resumeStoredSession(routedStoredSessionId)
-        } catch {
-          return abortForSessionSwitch(null)
+        } catch (err) {
+          // A definitive "session not found" means the durable row is gone
+          // from every store (deleted or pruned), so no retry of this resume
+          // can ever succeed. Fall through: the direct session.resume rung
+          // below re-verifies against the owning profile and, on the same
+          // verdict, hands the send to the new-chat create instead of parking
+          // the composer against a dead id forever.
+          if (!isSessionNotFoundError(err)) {
+            return abortForSessionSwitch(null)
+          }
         }
 
         const routedResumeDrift = sessionDriftReason()
@@ -585,6 +594,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           seedOptimistic(sessionId)
         }
       }
+
+      // The stored target was proven deleted (resume 4007-ed on the owning
+      // profile). Routes the send to the new-chat create instead of the
+      // "conversation exists, rebind its runtime" tail below.
+      let storedTargetGone = false
 
       if (!sessionId && targetStoredSessionId) {
         // A target stored session exists but its runtime binding is gone (the
@@ -632,28 +646,45 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               activeSessionIdRef.current = sessionId
             }
           }
-        } catch {
+        } catch (err) {
           // A target stored conversation is not a new-chat draft. If its
           // runtime cannot be rebound, stop here rather than silently replacing
           // it with a contextless session (#55578). For a background/queued
           // drain this abort is a no-op on foreground state (both helpers are
           // targetIsCurrentView-guarded) and simply drops the queued send.
-          return abortForSessionSwitch(null)
+          //
+          // One exception: a DEFINITIVE "session not found" from session.resume
+          // means the stored row itself is gone from every store (deleted or
+          // pruned out from under the client), so the rebind can never succeed
+          // — aborting parks the composer against a dead id forever, with the
+          // auto-drain burning its attempts on the same doomed resume. For the
+          // conversation the user is actually looking at, hand the send to the
+          // new-chat create below instead; a drain targeting a background
+          // session keeps the conservative abort.
+          if (!(isSessionNotFoundError(err) && targetIsCurrentView())) {
+            return abortForSessionSwitch(null)
+          }
+
+          storedTargetGone = true
+
+          notify({ kind: 'info', title: copy.sessionUnavailable, message: copy.staleSessionRestarted })
         }
 
-        const resumeSettleDrift = sessionDriftReason()
+        if (!storedTargetGone) {
+          const resumeSettleDrift = sessionDriftReason()
 
-        if (resumeSettleDrift) {
-          console.warn('[submit-drift-abort]', resumeSettleDrift, { phase: 'post-resume-settle' })
+          if (resumeSettleDrift) {
+            console.warn('[submit-drift-abort]', resumeSettleDrift, { phase: 'post-resume-settle' })
 
-          return abortForSessionSwitch(sessionId)
+            return abortForSessionSwitch(sessionId)
+          }
+
+          if (!sessionId) {
+            return abortForSessionSwitch(null)
+          }
+
+          seedOptimistic(sessionId)
         }
-
-        if (!sessionId) {
-          return abortForSessionSwitch(null)
-        }
-
-        seedOptimistic(sessionId)
       }
 
       if (!sessionId) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3385,6 +3385,7 @@ export const en: Translations = {
     audioReadFailed: 'Could not read recorded audio',
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
+    staleSessionRestarted: 'The previous conversation no longer exists — your message was sent in a fresh chat.',
     promptFailed: 'Prompt failed',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2906,6 +2906,7 @@ export interface Translations {
     audioReadFailed: string
     sessionUnavailable: string
     createSessionFailed: string
+    staleSessionRestarted: string
     promptFailed: string
     providerCredentialRequired: string
     emptySlashCommand: string

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1018,7 +1018,7 @@ describe('createGatewayEventHandler', () => {
 
     onEvent({ payload: {}, type: 'gateway.ready' } as any)
 
-    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-crashed'))
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-crashed', { fallbackToNew: true }))
     expect(newSession).not.toHaveBeenCalled()
     // One-shot: the ref is consumed so a later ordinary restart forges/resumes
     // per config instead of re-resuming the recovered session.
@@ -1049,7 +1049,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-most-recent'))
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-most-recent', { fallbackToNew: true }))
     expect(newSession).not.toHaveBeenCalled()
   })
 
@@ -1145,7 +1145,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('env-explicit'))
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('env-explicit', { fallbackToNew: true }))
     expect(newSession).not.toHaveBeenCalled()
   })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -694,7 +694,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     if (recoverSidRef && recoverSid) {
       recoverSidRef.current = null
-      resumeById(recoverSid)
+      resumeById(recoverSid, { fallbackToNew: true })
       // After resumeById: it synchronously sets status to 'resuming…' on entry,
       // so override it here to keep the distinct "recovering" label visible for
       // the duration of the resume RPC (which later flips status to 'ready').
@@ -705,7 +705,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     if (STARTUP_RESUME_ID) {
       patchUiState({ status: 'resuming…' })
-      resumeById(STARTUP_RESUME_ID)
+      resumeById(STARTUP_RESUME_ID, { fallbackToNew: true })
       scheduleStartupPrompt()
 
       return
@@ -732,7 +732,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
           if (target) {
             patchUiState({ status: 'resuming most recent…' })
-            resumeById(target)
+            resumeById(target, { fallbackToNew: true })
             scheduleStartupPrompt()
 
             return

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -479,7 +479,7 @@ export interface GatewayEventHandlerContext {
     // respawn resumes that session instead of forging a fresh one.
     recoverSidRef?: MutableRefObject<null | string>
     resetSession: () => void
-    resumeById: (id: string) => void
+    resumeById: (id: string, opts?: { fallbackToNew?: boolean }) => void
     setCatalog: StateSetter<null | SlashCatalog>
   }
   submission: {
@@ -530,7 +530,7 @@ export interface SlashHandlerContext {
     newLiveSession: (msg?: string, title?: string) => void
     newSession: (msg?: string, title?: string) => void
     resetVisibleHistory: (info?: null | SessionInfo) => void
-    resumeById: (id: string) => void
+    resumeById: (id: string, opts?: { fallbackToNew?: boolean }) => void
     setSessionStartedAt: StateSetter<number>
   }
   slashFlightRef: MutableRefObject<number>
@@ -561,7 +561,7 @@ export interface AppLayoutActions {
   newLiveSession: () => void
   newPromptSession: (prompt: string, modelArg?: string) => void
   onModelSelect: (value: string) => void
-  resumeById: (id: string) => void
+  resumeById: (id: string, opts?: { fallbackToNew?: boolean }) => void
   setStickyPrompt: (value: string) => void
 }
 

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -327,7 +327,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   )
 
   const resumeById = useCallback(
-    (id: string) => {
+    (id: string, opts?: { fallbackToNew?: boolean }) => {
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'resuming…' })
 
@@ -377,12 +377,29 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             }
           })
           .catch((e: Error) => {
+            // A definitive "session not found" cannot heal on retry: the id is
+            // gone from the gateway's in-memory registry AND every store (a ui
+            // session reaped after a WS drop or gateway restart, or a row
+            // deleted out from under the dashboard's breadcrumb file). The
+            // automatic resume paths (startup breadcrumb, gateway-respawn
+            // recovery, auto-resume-recent) opt in to forging a fresh session
+            // instead — without this the TUI sits at "ready" with no sid and
+            // every prompt queues forever against a dead id. Explicit /resume
+            // and the session picker keep the plain error.
+            if (opts?.fallbackToNew && /session not found/i.test(e.message)) {
+              sys('previous session no longer exists — forging a fresh one')
+              patchUiState({ status: 'forging session…' })
+              void newSession()
+
+              return
+            }
+
             sys(`error: ${e.message}`)
             patchUiState({ status: 'ready' })
           })
       })
     },
-    [closeSession, colsRef, gw, panel, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [closeSession, colsRef, gw, newSession, panel, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const guardBusySessionSwitch = useCallback(


### PR DESCRIPTION
## What does this PR do?

The dashboard Chat tab (ui-tui in a pty) auto-resumes a per-channel breadcrumb id at boot (`HERMES_TUI_ACTIVE_SESSION_FILE` → `HERMES_TUI_RESUME`). When that id can no longer be resolved — the ui session was orphan-reaped after a WS drop or gateway restart, or the stored row was deleted out from under the breadcrumb — `session.resume` definitively 404s. `resumeById` printed `error: session not found`, went back to `ready` with **no sid bound**, and every subsequent prompt queued forever against the dead id (`queued (N)` in the status row). The breadcrumb never heals, so every reconnect on that channel repeats the failure.

Fix: `resumeById` gains an opt-in `fallbackToNew`. The three **automatic** resume paths (startup breadcrumb, gateway-respawn recovery, `tui_auto_resume_recent`) forge a fresh session on a definitive not-found — which also rewrites the breadcrumb, so the channel self-heals. Explicit `/resume <id>` and the session picker keep the plain error, preserving the #55578 "never silently fork a contextless chat" intent for user-initiated resumes.

The desktop renderer has the same bug class in its submit pipeline: a stored target whose `session.resume` 4007s on the owning profile hit an unconditional abort, parking the composer queue (auto-drain burns its `MAX_AUTO_DRAIN_ATTEMPTS` on the same doomed resume). A definitive not-found for the *foreground* conversation now falls through to the new-chat create with an info toast; background drains keep the conservative abort.

## Related Issue

Related: #79001 (desktop renderer storage never drops dead session ids), #39013 / #39123 (TUI gateway-respawn resume — this PR makes that recovery path resilient when the recovered sid itself is gone).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/useSessionLifecycle.ts` — `resumeById(id, opts?)`: on `fallbackToNew` + `/session not found/i`, sys-notice + `newSession()` instead of stranding the TUI sid-less
- `ui-tui/src/app/createGatewayEventHandler.ts` — the three automatic resume call sites pass `{ fallbackToNew: true }`
- `ui-tui/src/app/interfaces.ts` — signature update (3 sites)
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — assertions updated for the new call shape
- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` — both resume rungs treat a definitive not-found on the current view as "hand the send to `createBackendSessionForSend`" instead of `abortForSessionSwitch`
- `apps/desktop/src/i18n/en.ts`, `apps/desktop/src/i18n/types.ts` — new `staleSessionRestarted` string (other locales fall back to en via `defineLocale`)

## How to Test

1. Open the dashboard Chat tab, send a message, then kill the pty's ws (close the tab) and wait for the ui session to be orphan-reaped (or restart the gateway, or delete the session row) so the channel breadcrumb points at an unresolvable id.
2. Reopen the Chat tab. Before: `error: session not found`, status `ready`, no sid; every prompt queues forever. After: `previous session no longer exists — forging a fresh one`, and a working composer.
3. Headless repro of the fixed path: `HERMES_TUI_RESUME=bogus_id node --expose-gc ui-tui/dist/entry.js` — boots into a fresh session instead of the dead-queue state.
4. `cd ui-tui && npm run build:ink && npm run typecheck && npx vitest run` — 1713/1713 pass (verified on both the v0.20.5 base and current `main`).

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` — not run: the change is TypeScript-only (ui-tui + desktop renderer); the full ui-tui vitest suite passes
- [x] I've added tests for my changes — call-site assertions updated; the fallback branch lives inside the `useSessionLifecycle` hook, for which the suite has no render harness, so it was verified end-to-end (step 3 above)
- [x] I've tested on my platform: Linux x86_64 (dashboard chat pty)

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior fix, no config/API surface change)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (no platform-specific code paths touched)
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)