### PR TITLE
state.db journal mode has one owner: repair re-applies it, delegation guests stop flipping it (salvage #89681, #93012)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2877,6 +2877,16 @@ def _reapply_durability_barriers(conn: sqlite3.Connection) -> bool:
         return False
 
 
+def apply_durability_barriers(conn: sqlite3.Connection) -> bool:
+    """Apply state-store durability barriers without changing journal mode.
+
+    This is the public entry point for secondary users of ``state.db`` that
+    must inherit its owner's journal mode while retaining per-connection
+    durability settings.
+    """
+    return _reapply_durability_barriers(conn)
+
+
 @contextmanager
 def _exclusive_repair_db_guard(db_path: Path):
     """Yield one live connection that excludes writers for repair surgery.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3257,9 +3257,22 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                 )
                 logger.error("state.db repair skipped: %s", report["error"])
             else:
+                # Probe the mode BEFORE surgery (#89674): every repair
+                # strategy rewrites the file, and a rebuilt SQLite file comes
+                # back in the default journal mode (delete) — silently moving
+                # a WAL store out of WAL with nothing in the logs recording
+                # the flip. The open-time WAL-reset gate never sees this flip
+                # because it happens inside the repair path (distinct from
+                # the open-time flip #89393 warns about). A probe of the
+                # damaged file may fail, in which case the canonical
+                # database.journal_mode setting is the restore target.
+                before_mode = _probe_journal_mode_for_repair(db_path)
                 result = _repair_state_db_schema_locked(
                     db_path, backup=backup, report=report
                 )
+                if result.get("repaired"):
+                    result["journal_mode_before"] = before_mode
+                    _restore_journal_mode_after_repair(db_path, before_mode)
             # Environmental aborts happen before a strategy gets to mutate the
             # isolated snapshot. They are retriable operating conditions, not
             # proof that the damaged database exhausted a repair strategy.
@@ -3275,6 +3288,71 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                     db_path, repaired=bool(result.get("repaired"))
                 )
     return result
+
+
+def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:
+    """Best-effort journal-mode probe for a (possibly malformed) DB file.
+
+    Returns the on-disk mode (``wal``/``delete``), or ``None`` when the file
+    cannot be opened or probed — a malformed header or a concurrent opener's
+    locks are both expected on the repair path. Callers fall back to the
+    configured ``database.journal_mode`` for ``None``.
+    """
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            return _on_disk_journal_mode(conn)
+        finally:
+            conn.close()
+    except (sqlite3.Error, OSError):
+        return None
+
+
+def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]) -> None:
+    """Re-apply the journal mode after schema surgery (#89674).
+
+    A repaired/rebuilt SQLite file comes back in the default journal mode
+    (delete). Without this restore, a corruption event deterministically
+    moves a WAL store out of WAL and nothing records the change — the
+    WAL-reset gate at open time never sees the flip because it happened
+    inside the repair path, not at open (the open-time flip #89393 warns
+    about is a different door).
+
+    The restore runs through :func:`apply_wal_with_fallback` — the canonical
+    journal-mode path — rather than issuing a switch pragma directly, so it
+    inherits the vulnerable-SQLite WAL-reset gate (a rebuilt file IS a new
+    database: on a vulnerable runtime the gate deliberately keeps it in
+    DELETE, and "restore could not reach WAL" there is the expected outcome,
+    not a failure), the macOS-NFS silent-refusal handling, and the WAL
+    companions (size limit, checkpoint barrier, synchronous=FULL) that the
+    front door applies. ``before_mode`` is the pre-surgery probe (None when
+    the damaged file could not be probed) and is only used for the log
+    comparison — the restore target itself is whatever the canonical path
+    resolves from ``database.journal_mode``.
+
+    Best-effort by design: the repair itself already succeeded, so failures
+    to re-apply are logged at WARNING, never raised.
+    """
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            after = apply_wal_with_fallback(conn, db_label=db_path.name)
+        finally:
+            conn.close()
+        if before_mode and after != before_mode:
+            logger.warning(
+                "state.db repair changed journal_mode %r -> %r "
+                "(pre-surgery probe %r; restore resolved through "
+                "apply_wal_with_fallback per database.journal_mode and the "
+                "WAL-reset gate)",
+                before_mode, after, before_mode,
+            )
+    except (sqlite3.Error, OSError) as exc:
+        logger.warning(
+            "state.db repair at %s: post-surgery journal-mode restore "
+            "failed (%s); verify with PRAGMA journal_mode on the next open",
+            db_path, exc,
+        )
 
 
 def _repair_state_db_schema_locked(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3324,7 +3324,7 @@ def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:
     configured ``database.journal_mode`` for ``None``.
     """
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = _connect_repair_durable(db_path)
         try:
             return _on_disk_journal_mode(conn)
         finally:
@@ -3359,7 +3359,7 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
     to re-apply are logged at WARNING, never raised.
     """
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = _connect_repair_durable(db_path)
         try:
             after = apply_wal_with_fallback(conn, db_label=db_path.name)
         finally:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2882,9 +2882,24 @@ def apply_durability_barriers(conn: sqlite3.Connection) -> bool:
 
     This is the public entry point for secondary users of ``state.db`` that
     must inherit its owner's journal mode while retaining per-connection
-    durability settings.
+    durability settings. Also applies the configured ``database.synchronous``
+    level (a per-connection pragma that would otherwise only ride on the
+    journal-mode setup path guest connections must not run).
     """
-    return _reapply_durability_barriers(conn)
+    ok = _reapply_durability_barriers(conn)
+    try:
+        # Local import avoids a circular import with hermes_cli.config.
+        from hermes_cli.config import cfg_get, load_config_readonly
+
+        cfg = load_config_readonly()
+        raw_synchronous = cfg_get(cfg, "database", "synchronous", default=None)
+        if raw_synchronous is not None:
+            _apply_synchronous_pragma(
+                conn, raw_synchronous, db_label="state.db (guest)"
+            )
+    except Exception:
+        pass
+    return ok
 
 
 @contextmanager

--- a/tests/test_guest_durability_barriers.py
+++ b/tests/test_guest_durability_barriers.py
@@ -1,0 +1,68 @@
+"""Guest ledger connections must inherit the configured database.synchronous.
+
+apply_durability_barriers() is the guest-connection entry point (secondary
+state.db users that must NOT touch journal mode). The configured
+``database.synchronous`` level normally rides on apply_database_pragmas()
+during the owner's journal-mode setup — a path guests deliberately skip — so
+the guest entry point applies it directly.
+"""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+from hermes_state import apply_durability_barriers
+
+
+def _config(monkeypatch, database_section):
+    import hermes_cli.config as config_mod
+
+    cfg = {"database": database_section}
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda *a, **k: cfg)
+    return cfg
+
+
+def test_guest_barriers_apply_configured_synchronous(monkeypatch, tmp_path):
+    _config(monkeypatch, {"synchronous": "FULL"})
+    conn = sqlite3.connect(tmp_path / "state.db")
+    try:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("PRAGMA synchronous=1")
+        apply_durability_barriers(conn)
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+        # And the journal mode was NOT touched — that is the whole contract.
+        assert (
+            str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+            == "delete"
+        )
+    finally:
+        conn.close()
+
+
+def test_guest_barriers_leave_synchronous_alone_when_unset(monkeypatch, tmp_path):
+    _config(monkeypatch, {})
+    conn = sqlite3.connect(tmp_path / "state.db")
+    try:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("PRAGMA synchronous=1")
+        apply_durability_barriers(conn)
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_guest_barriers_survive_config_failure(monkeypatch, tmp_path):
+    import hermes_cli.config as config_mod
+
+    def _boom(*a, **k):
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(config_mod, "load_config_readonly", _boom)
+    conn = sqlite3.connect(tmp_path / "state.db")
+    try:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        # Must not raise; best-effort like every other pragma path.
+        apply_durability_barriers(conn)
+    finally:
+        conn.close()

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -643,3 +643,140 @@ def test_backup_false_still_skips_backup_and_repairs(tmp_path):
     assert report["repaired"] is True
     assert report["backup_path"] is None
     assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+
+
+# ---------------------------------------------------------------------------
+# Journal-mode restore after surgery (#89674): corruption drops the WAL bit
+# from the header, the repair strategies rebuild the file in the default
+# (delete) mode, and nothing used to record the flip. The configured
+# database.journal_mode must be re-applied, with a WARNING naming it.
+# ---------------------------------------------------------------------------
+
+
+def _mode_of(db_path) -> str:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        conn.close()
+
+
+def _configure_journal_mode(monkeypatch, tmp_path, mode) -> None:
+    import yaml
+
+    home = tmp_path / "hermes-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"database": {"journal_mode": mode}}), encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        hermes_state, "is_sqlite_wal_reset_vulnerable", lambda **kwargs: False,
+    )
+
+
+def test_repair_restores_configured_wal_after_surgery(
+    tmp_path, caplog, monkeypatch
+):
+    """A repaired file left in delete mode must return to the configured WAL.
+
+    Simulates the reported sequence: corruption drops the WAL bit (the file
+    reads back as delete), surgery heals the schema, and the store must end
+    up in the canonical database.journal_mode again — with a WARNING so the
+    operator sees the mode moved."""
+    import logging
+
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "wal")
+    _build_healthy_db(db_path)
+    assert _mode_of(db_path) == "wal"
+    # Downgrade while the file is still healthy (the damaged file rejects
+    # every statement — see test_duplicate_fts_makes_every_statement_fail),
+    # simulating the header state the reporter's corruption storm left: the
+    # WAL bit is gone and the file reads back as delete.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.close()
+    assert _mode_of(db_path) == "delete"
+    _corrupt_duplicate_fts(db_path)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert _mode_of(db_path) == "wal"
+    assert any(
+        "changed journal_mode" in r.getMessage() for r in caplog.records
+    ), f"expected the mode flip to be logged; got: {[r.getMessage() for r in caplog.records]}"
+
+
+def test_repair_logs_nothing_when_mode_already_matches(
+    tmp_path, caplog, monkeypatch
+):
+    """FTS-only corruption keeps the WAL bit; the restore is then a no-op and
+    must not emit a mode-flip WARNING."""
+    import logging
+
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "wal")
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert _mode_of(db_path) == "wal"
+    assert not any(
+        "changed journal_mode" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_repair_restore_failure_is_nonfatal_and_logged(
+    tmp_path, caplog, monkeypatch
+):
+    """When the post-surgery WAL switch is refused (locked/unsupported fs),
+    the repair result stands and a WARNING names the modes and the config
+    key — never an exception out of the repair path."""
+    import logging
+    from unittest.mock import patch
+
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "wal")
+    _build_healthy_db(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.close()
+    _corrupt_duplicate_fts(db_path)
+
+    def _refused(conn, mode):
+        raise sqlite3.OperationalError("database is locked")
+
+    with (
+        patch.object(hermes_state, "_set_journal_mode_no_wait", _refused),
+        caplog.at_level(logging.WARNING, logger="hermes_state"),
+    ):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert _mode_of(db_path) == "delete"
+    assert any(
+        "could not" in r.getMessage() and "restored" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_repair_honors_configured_delete_mode(tmp_path, monkeypatch):
+    """An explicit database.journal_mode=delete store stays delete after
+    repair — the restore applies the operator's setting, not a hard-coded
+    WAL."""
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "delete")
+    _build_healthy_db(db_path)
+    assert _mode_of(db_path) == "delete"
+    _corrupt_duplicate_fts(db_path)
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert _mode_of(db_path) == "delete"

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -681,9 +681,11 @@ def test_repair_restores_configured_wal_after_surgery(
     """A repaired file left in delete mode must return to the configured WAL.
 
     Simulates the reported sequence: corruption drops the WAL bit (the file
-    reads back as delete), surgery heals the schema, and the store must end
-    up in the canonical database.journal_mode again — with a WARNING so the
-    operator sees the mode moved."""
+    reads back as delete), surgery heals the schema, and the restore — now
+    resolved through the canonical apply_wal_with_fallback — brings the
+    store back to database.journal_mode. The duplicate-FTS damage makes the
+    pre-surgery probe fail, so no before/after comparison WARNING fires;
+    the canonical path's own logging covers the restore."""
     import logging
 
     db_path = tmp_path / "state.db"
@@ -704,6 +706,64 @@ def test_repair_restores_configured_wal_after_surgery(
         report = repair_state_db_schema(db_path)
 
     assert report["repaired"] is True
+    assert _mode_of(db_path) == "wal"
+
+
+def test_repair_restore_matches_canonical_on_vulnerable_sqlite(
+    tmp_path, monkeypatch
+):
+    """The restore must go through the WAL-reset gate, not around it.
+
+    On a WAL-reset-vulnerable SQLite (the reporter ran 3.50.4), the
+    canonical open path keeps a rebuilt non-WAL file in DELETE — a freshly
+    repaired file IS a new database. The restore used to switch WAL
+    directly and diverged from the front door; going through
+    apply_wal_with_fallback must converge with the canonical behaviour."""
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "wal")
+    monkeypatch.setattr(
+        hermes_state, "is_sqlite_wal_reset_vulnerable", lambda **kwargs: True
+    )
+    _build_healthy_db(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.close()
+    _corrupt_duplicate_fts(db_path)
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    # Same outcome as the canonical open path on this runtime: DELETE.
+    assert _mode_of(db_path) == "delete"
+
+
+def test_repair_logs_mode_change_when_probe_succeeded(
+    tmp_path, caplog, monkeypatch
+):
+    """When the pre-surgery probe read the file (header intact), the
+    post-restore WARNING names the before/after modes — the #89393 signal,
+    arriving through the repair door instead of the open door."""
+    import logging
+    from unittest.mock import patch
+
+    db_path = tmp_path / "state.db"
+    _configure_journal_mode(monkeypatch, tmp_path, "wal")
+    _build_healthy_db(db_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=DELETE")
+    conn.close()
+    _corrupt_duplicate_fts(db_path)
+
+    with (
+        patch.object(
+            hermes_state, "_probe_journal_mode_for_repair", return_value="delete"
+        ),
+        caplog.at_level(logging.WARNING, logger="hermes_state"),
+    ):
+        report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is True
+    assert report["journal_mode_before"] == "delete"
     assert _mode_of(db_path) == "wal"
     assert any(
         "changed journal_mode" in r.getMessage() for r in caplog.records
@@ -735,9 +795,9 @@ def test_repair_logs_nothing_when_mode_already_matches(
 def test_repair_restore_failure_is_nonfatal_and_logged(
     tmp_path, caplog, monkeypatch
 ):
-    """When the post-surgery WAL switch is refused (locked/unsupported fs),
-    the repair result stands and a WARNING names the modes and the config
-    key — never an exception out of the repair path."""
+    """When the canonical restore path raises (locked/unsupported fs), the
+    repair result stands and a WARNING is logged — never an exception out
+    of the repair path."""
     import logging
     from unittest.mock import patch
 
@@ -749,11 +809,11 @@ def test_repair_restore_failure_is_nonfatal_and_logged(
     conn.close()
     _corrupt_duplicate_fts(db_path)
 
-    def _refused(conn, mode):
+    def _refused(conn, **kwargs):
         raise sqlite3.OperationalError("database is locked")
 
     with (
-        patch.object(hermes_state, "_set_journal_mode_no_wait", _refused),
+        patch.object(hermes_state, "apply_wal_with_fallback", _refused),
         caplog.at_level(logging.WARNING, logger="hermes_state"),
     ):
         report = repair_state_db_schema(db_path)
@@ -761,7 +821,7 @@ def test_repair_restore_failure_is_nonfatal_and_logged(
     assert report["repaired"] is True
     assert _mode_of(db_path) == "delete"
     assert any(
-        "could not" in r.getMessage() and "restored" in r.getMessage()
+        "journal-mode restore failed" in r.getMessage()
         for r in caplog.records
     )
 

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -8,6 +8,7 @@ formatting, capacity rejection, and crash handling.
 import json
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -63,6 +64,26 @@ def _drain_for(delegation_id, timeout=5.0):
             continue
         time.sleep(0.02)
     return None
+
+
+def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path, monkeypatch):
+    """The delegation ledger is a guest in state.db, not its mode owner."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "is_sqlite_wal_reset_vulnerable", lambda: False)
+    conn = sqlite3.connect(tmp_path / "state.db")
+    try:
+        assert conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0] == "delete"
+
+        ad._initialize_schema(conn)
+
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='async_delegations'"
+        ).fetchone() == ("async_delegations",)
+    finally:
+        conn.close()
 
 
 def test_active_for_session_counts_every_live_delegation_state():

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -86,6 +86,27 @@ def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path, monkeypatc
         conn.close()
 
 
+@pytest.mark.macos_only
+def test_connect_preserves_wal_and_applies_macos_durability_barriers(
+    tmp_path, monkeypatch
+):
+    """Each ledger connection must carry the macOS write barriers."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    seed = sqlite3.connect(tmp_path / "state.db")
+    try:
+        assert seed.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+    finally:
+        seed.close()
+
+    conn = ad._connect()
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+        assert conn.execute("PRAGMA checkpoint_fullfsync").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
 def test_active_for_session_counts_every_live_delegation_state():
     with ad._records_lock:
         ad._records.update(

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -66,11 +66,8 @@ def _drain_for(delegation_id, timeout=5.0):
     return None
 
 
-def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path, monkeypatch):
+def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path):
     """The delegation ledger is a guest in state.db, not its mode owner."""
-    import hermes_state
-
-    monkeypatch.setattr(hermes_state, "is_sqlite_wal_reset_vulnerable", lambda: False)
     conn = sqlite3.connect(tmp_path / "state.db")
     try:
         assert conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0] == "delete"
@@ -78,6 +75,23 @@ def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path, monkeypatc
         ad._initialize_schema(conn)
 
         assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='async_delegations'"
+        ).fetchone() == ("async_delegations",)
+    finally:
+        conn.close()
+
+
+def test_schema_init_preserves_shared_state_db_wal_mode(tmp_path):
+    """Schema initialization must not replace an existing WAL mode."""
+    conn = sqlite3.connect(tmp_path / "state.db")
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+
+        ad._initialize_schema(conn)
+
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' "
             "AND name='async_delegations'"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -140,14 +140,17 @@ def _connect() -> sqlite3.Connection:
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
-    from hermes_state import _reapply_durability_barriers
+    from hermes_state import apply_durability_barriers
 
     # state.db's owning SessionDB connection establishes the configured journal
     # mode. This secondary durability ledger must preserve that mode: applying
     # WAL here on every short-lived connection requires an exclusive lock when
     # the file is not already WAL and can collide with live transcript/FTS
-    # writers. The ledger works in either WAL or DELETE mode.
-    _reapply_durability_barriers(conn)
+    # writers. The ledger works in either WAL or DELETE mode; if it opens a new
+    # file first, the default rollback journal remains valid until SessionDB
+    # establishes the configured mode. sqlite3.connect(timeout=10) above also
+    # gives its small transactions a busy handler for ordinary contention.
+    apply_durability_barriers(conn)
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegations (
             delegation_id TEXT PRIMARY KEY,

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -140,9 +140,11 @@ def _connect() -> sqlite3.Connection:
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
-    from hermes_state import apply_wal_with_fallback
-
-    apply_wal_with_fallback(conn, db_label="state.db (async_delegation)")
+    # state.db's owning SessionDB connection establishes the configured journal
+    # mode. This secondary durability ledger must preserve that mode: applying
+    # WAL here on every short-lived connection requires an exclusive lock when
+    # the file is not already WAL and can collide with live transcript/FTS
+    # writers. The ledger works in either WAL or DELETE mode.
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegations (
             delegation_id TEXT PRIMARY KEY,

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -140,11 +140,14 @@ def _connect() -> sqlite3.Connection:
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
+    from hermes_state import _reapply_durability_barriers
+
     # state.db's owning SessionDB connection establishes the configured journal
     # mode. This secondary durability ledger must preserve that mode: applying
     # WAL here on every short-lived connection requires an exclusive lock when
     # the file is not already WAL and can collide with live transcript/FTS
     # writers. The ledger works in either WAL or DELETE mode.
+    _reapply_durability_barriers(conn)
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegations (
             delegation_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

`state.db`'s journal mode now has exactly one owner. Two remaining members of the "journal mode changed by code that doesn't own it" class are closed: corruption repair no longer silently drops a WAL store into DELETE (#89674), and the async delegation ledger's guest connections no longer re-run journal-mode setup on the shared DB (#92996). Salvages #89681 (@liuhao1024) and #93012 (@fangliquanflq) onto current main.

## Changes

- `hermes_state.py`: after successful schema surgery, `repair_state_db_schema()` re-applies the canonical `database.journal_mode` via `apply_wal_with_fallback()` (inheriting the WAL-reset gate, macOS barriers, and `database.synchronous`) and WARNs with before/after modes; probe/restore failures logged, never raised — @liuhao1024's #89681 (closes #89674)
- `hermes_state.py` + `tools/async_delegation.py`: new public `apply_durability_barriers()`; the delegation ledger stops calling `apply_wal_with_fallback()` per short-lived connection and inherits the owner's journal mode — @fangliquanflq's #93012 (closes #92996)
- Follow-up (ours): `apply_durability_barriers()` also applies the configured `database.synchronous` (#90892), which guest connections would otherwise miss now that they skip the journal-mode path — + 3 tests
- Tests: 106 targeted across repair, delegation-ledger, journal-mode, and synchronous suites

## Validation

Isolated live A/B (temp HERMES_HOME, real `repair_state_db_schema` / `ad._initialize_schema`, real corrupted SQLite files, memory-capped scope):

| Scenario | origin/main | this branch |
|---|---|---|
| S1: WAL store corrupted (real duplicate-FTS damage), repaired | left in `delete`, zero log signal | back in `wal` per config |
| S2: ledger init on an owner-DELETE shared DB | flipped it to `wal` | mode preserved, table created |
| S2b: steady-state ledger init under a live reader | `database is locked` | succeeds |
| Guest conn with `synchronous: FULL`, level forced to 1 | n/a (path new) | reads back 2 (FULL) after init |

**Live repro:** all three scenarios fire on `origin/main` and are negative on this branch via the same harness run against both trees.

Authorship preserved via cherry-pick (2 commits @liuhao1024, 3 commits @fangliquanflq, follow-up ours).

## Infographic

![state.db mode ownership — jazz-noir infographic](https://v3b.fal.media/files/b/0aa80f64/UlRJ8TbeVw6HdBKjmCerA_oKvGozRN.png)
