### PR TITLE
feat: add skill_manage(action='create_python') for Python-backed skill creation

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2047,6 +2047,18 @@ def _build_skills_system_prompt_inner(
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
+        )
+
+        # Append Python-backed skills to the index
+        try:
+            from agent.python_skills import build_python_skills_index
+            python_index = build_python_skills_index()
+            if python_index:
+                result += python_index + "\n"
+        except Exception:
+            pass  # Non-critical — markdown skills still work
+
+        result += (
             "</available_skills>\n"
             "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."

--- a/agent/python_skills.py
+++ b/agent/python_skills.py
@@ -1,0 +1,572 @@
+"""Python-backed skills — code-based skills callable as typed functions.
+
+Python-backed skills live alongside the existing markdown (SKILL.md) skills.
+A Python-backed skill is a directory under ``~/.hermes/skills/`` that contains
+a ``_skill.py`` file instead of (or alongside) a ``SKILL.md``.
+
+Directory structure::
+
+    skills/
+    └── my-python-skill/
+        ├── _skill.py          # Required: defines the skill's callable interface
+        ├── _skill.md          # Optional: markdown instructions (shown in index)
+        ├── references/        # Optional: supporting files
+        └── scripts/           # Optional: helper scripts
+
+_skill.py must define a ``SKILL_INFO`` dict and at least one async function
+prefixed with ``skill_`` or decorated with ``@python_skill``.
+
+Example::
+
+    # skills/my-web-search/_skill.py
+    from agent.python_skills import python_skill, PythonSkillInterface
+
+    @python_skill
+    async def web_search(query: str, max_results: int = 5) -> dict:
+        \"\"\"Search the web and return results.
+
+        Args:
+            query: The search query string.
+            max_results: Maximum number of results to return.
+
+        Returns:
+            Dict with 'results' (list) and 'query' (str).
+        \"\"\"
+        # Implementation using web_search tool or API
+        return {"results": [], "query": query}
+
+    SKILL_INFO = {
+        "name": "my-web-search",
+        "description": "Search the web programmatically",
+        "version": "1.0.0",
+    }
+
+Invocation
+----------
+Python-backed skills are exposed to the agent in two ways:
+
+1. **System prompt index**: Listed in ``<available_skills>`` alongside
+   markdown skills, with their callable function signatures.
+
+2. **Slash command dispatch**: Invoked via ``/<skill-name>`` just like
+   markdown skills. The agent receives the skill's instructions + the
+   list of callable functions with their signatures.
+
+The agent can then call these functions using the ``execute_code`` tool
+or directly via the Hermes tool interface (when wired up).
+
+Architecture
+------------
+- Discovery: Scans ``~/.hermes/skills/*/`` for ``_skill.py`` files.
+- Loading: Imports the module once, extracts ``SKILL_INFO`` and callable
+  functions. Cached in-process.
+- Invocation: Functions are registered as Hermes tools (when possible)
+  or made available via the ``execute_code`` tool with a typed wrapper.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import logging
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+from hermes_constants import get_skills_dir
+
+logger = logging.getLogger(__name__)
+
+# ── Data structures ───────────────────────────────────────────────────────
+
+
+@dataclass
+class PythonSkillFunction:
+    """A single callable function from a Python-backed skill.
+
+    Attributes:
+        name: The function name (without ``skill_`` prefix when displayed).
+        func: The actual async/sync callable.
+        description: Docstring description.
+        signature: Human-readable function signature string.
+        is_async: Whether the function is async.
+        parameters: List of parameter dicts for the function signature.
+    """
+    name: str
+    func: Callable
+    description: str
+    signature: str
+    is_async: bool
+    parameters: List[Dict[str, Any]]
+
+
+@dataclass
+class PythonSkillInfo:
+    """Metadata and callable interface for a Python-backed skill.
+
+    Attributes:
+        name: Skill name (directory name).
+        description: Short description.
+        version: Optional version string.
+        path: Absolute path to the skill directory.
+        functions: List of callable functions.
+        instructions: Markdown instructions from _skill.md or SKILL.md.
+        tags: Optional tags for categorization.
+        conditions: Optional conditions for when the skill should be shown.
+        config: Optional config vars from frontmatter.
+    """
+    name: str
+    description: str
+    version: Optional[str] = None
+    path: Optional[Path] = None
+    functions: List[PythonSkillFunction] = field(default_factory=list)
+    instructions: str = ""
+    tags: List[str] = field(default_factory=list)
+    conditions: Dict[str, Any] = field(default_factory=dict)
+    config: Dict[str, Any] = field(default_factory=dict)
+
+
+# ── Decorator ──────────────────────────────────────────────────────────────
+
+_PYTHON_SKILL_MARKER = "__python_skill__"
+
+
+def python_skill(func: Callable) -> Callable:
+    """Decorate a function to mark it as a Python-backed skill function.
+
+    Usage::
+
+        @python_skill
+        async def my_function(arg: str) -> dict:
+            \"\"\"Description of the function.\"\"\"
+            return {}
+
+    Functions without this decorator are still discovered if they start with
+    ``skill_`` prefix.
+
+    Args:
+        func: The function to mark.
+
+    Returns:
+        The original function with a marker attribute.
+    """
+    setattr(func, _PYTHON_SKILL_MARKER, True)
+    return func
+
+
+# ── Discovery ──────────────────────────────────────────────────────────────
+
+# Cache of loaded Python skills keyed by directory name.
+_python_skills_cache: Dict[str, PythonSkillInfo] = {}
+_python_skills_mtime: float = 0
+
+
+def _scan_python_skill_dirs(skills_dir: Path) -> List[Path]:
+    """Find all directories containing a ``_skill.py`` file.
+
+    Skips directories in ``EXCLUDED_SKILL_DIRS``.
+    """
+    from agent.skill_utils import EXCLUDED_SKILL_DIRS
+
+    candidates: List[Path] = []
+    if not skills_dir.exists():
+        return candidates
+
+    for entry in sorted(skills_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in EXCLUDED_SKILL_DIRS or entry.name.startswith("."):
+            continue
+        if (entry / "_skill.py").exists():
+            candidates.append(entry)
+    return candidates
+
+
+def _check_python_skill_dir_mtime(skills_dir: Path) -> float:
+    """Get the max mtime of all Python skill directories."""
+    dirs = _scan_python_skill_dirs(skills_dir)
+    mtimes = []
+    for d in dirs:
+        try:
+            mtimes.append(d.stat().st_mtime)
+            skill_py = d / "_skill.py"
+            if skill_py.exists():
+                mtimes.append(skill_py.stat().st_mtime)
+        except OSError:
+            continue
+    return max(mtimes) if mtimes else 0
+
+
+# ── Loading ────────────────────────────────────────────────────────────────
+
+
+def _extract_function_info(func: Callable) -> PythonSkillFunction:
+    """Extract metadata from a skill function.
+
+    Args:
+        func: The function to inspect.
+
+    Returns:
+        PythonSkillInfo with extracted metadata.
+    """
+    is_async = inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
+    sig = inspect.signature(func)
+
+    # Build human-readable signature
+    params = []
+    sig_parts = []
+    for name, param in sig.parameters.items():
+        param_info: Dict[str, Any] = {"name": name}
+        if param.annotation != inspect.Parameter.empty:
+            param_info["type"] = _type_to_str(param.annotation)
+        if param.default != inspect.Parameter.empty:
+            param_info["default"] = repr(param.default)
+        params.append(param_info)
+
+        if param.default == inspect.Parameter.empty:
+            sig_parts.append(name)
+        else:
+            sig_parts.append(f"{name}={param.default}")
+
+    signature_str = f"({', '.join(sig_parts)})"
+
+    # Get docstring as description
+    description = (inspect.getdoc(func) or "").strip()
+
+    # Normalize function name: strip skill_ prefix for display
+    display_name = func.__name__
+    if display_name.startswith("skill_"):
+        display_name = display_name[6:]
+
+    return PythonSkillFunction(
+        name=display_name,
+        func=func,
+        description=description,
+        signature=f"{func.__name__}{signature_str}",
+        is_async=is_async,
+        parameters=params,
+    )
+
+
+def _type_to_str(tp: Any) -> str:
+    """Convert a type annotation to a readable string."""
+    if tp is type(None):
+        return "None"
+    if hasattr(tp, "__name__"):
+        return tp.__name__
+    if hasattr(tp, "__origin__"):
+        origin = tp.__origin__
+        if hasattr(origin, "__name__"):
+            args = ", ".join(_type_to_str(a) for a in getattr(tp, "__args__", ()))
+            return f"{origin.__name__}[{args}]"
+        return str(tp)
+    return str(tp)
+
+
+def _load_python_skill_from_dir(skill_dir: Path) -> Optional[PythonSkillInfo]:
+    """Load a Python-backed skill from a directory.
+
+    Args:
+        skill_dir: Path to the skill directory.
+
+    Returns:
+        PythonSkillInfo or None if loading failed.
+    """
+    skill_name = skill_dir.name
+    skill_py = skill_dir / "_skill.py"
+
+    if not skill_py.exists():
+        return None
+
+    try:
+        # Load module from file
+        spec = importlib.util.spec_from_file_location(
+            f"hermes_python_skill_{skill_name}", skill_py
+        )
+        if spec is None or spec.loader is None:
+            logger.warning("Could not create module spec for %s", skill_py)
+            return None
+
+        module = importlib.util.module_from_spec(spec)
+
+        # Prevent this module from being found in sys.modules for future imports
+        # (it's a one-shot load)
+        sys.modules[f"hermes_python_skill_{skill_name}"] = module
+
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load Python skill %s: %s", skill_name, exc, exc_info=True
+            )
+            return None
+
+        # Extract SKILL_INFO
+        skill_info_dict = getattr(module, "SKILL_INFO", {})
+        if not isinstance(skill_info_dict, dict):
+            logger.warning(
+                "Python skill %s: SKILL_INFO is not a dict", skill_name
+            )
+            return None
+
+        name = str(skill_info_dict.get("name", skill_name))
+        description = str(skill_info_dict.get("description", ""))
+
+        if not description:
+            description = f"Python-backed skill: {name}"
+
+        version = skill_info_dict.get("version")
+        tags = skill_info_dict.get("tags", [])
+        conditions = skill_info_dict.get("conditions", {})
+        config = skill_info_dict.get("config", {})
+
+        if not isinstance(tags, list):
+            tags = [tags]
+        if not isinstance(conditions, dict):
+            conditions = {}
+        if not isinstance(config, dict):
+            config = {}
+
+        # Discover callable functions
+        functions: List[PythonSkillFunction] = []
+        for attr_name in dir(module):
+            if attr_name.startswith("_"):
+                continue
+            obj = getattr(module, attr_name)
+            if not callable(obj):
+                continue
+            if not inspect.isfunction(obj) and not inspect.iscoroutinefunction(obj):
+                continue
+
+            # Check if marked with decorator or has skill_ prefix
+            is_skill_func = (
+                getattr(obj, _PYTHON_SKILL_MARKER, False)
+                or attr_name.startswith("skill_")
+            )
+            if not is_skill_func:
+                continue
+
+            try:
+                func_info = _extract_function_info(obj)
+                functions.append(func_info)
+            except Exception as exc:
+                logger.warning(
+                    "Error extracting function info for %s.%s: %s",
+                    skill_name, attr_name, exc,
+                )
+
+        # Load instructions from _skill.md or SKILL.md
+        instructions = ""
+        for md_name in ("_skill.md", "SKILL.md"):
+            md_path = skill_dir / md_name
+            if md_path.exists():
+                try:
+                    instructions = md_path.read_text(encoding="utf-8").strip()
+                    break
+                except Exception as exc:
+                    logger.warning(
+                        "Could not read %s: %s", md_path, exc
+                    )
+
+        return PythonSkillInfo(
+            name=name,
+            description=description,
+            version=str(version) if version else None,
+            path=skill_dir,
+            functions=functions,
+            instructions=instructions,
+            tags=tags,
+            conditions=conditions,
+            config=config,
+        )
+
+    except Exception as exc:
+        logger.warning(
+            "Failed to load Python skill %s: %s", skill_name, exc, exc_info=True
+        )
+        return None
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+
+def scan_python_skills() -> Dict[str, PythonSkillInfo]:
+    """Scan for all Python-backed skills and load them.
+
+    Returns:
+        Dict mapping skill name to PythonSkillInfo.
+    """
+    skills_dir = get_skills_dir()
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+        external_dirs = get_external_skills_dirs()
+    except Exception:
+        external_dirs = []
+    all_dirs = [skills_dir] + external_dirs
+
+    result: Dict[str, PythonSkillInfo] = {}
+    for dir_path in all_dirs:
+        for skill_dir in _scan_python_skill_dirs(dir_path):
+            info = _load_python_skill_from_dir(skill_dir)
+            if info:
+                # Local skills take precedence over external
+                if dir_path == skills_dir or info.name not in result:
+                    result[info.name] = info
+    return result
+
+
+def get_python_skills() -> Dict[str, PythonSkillInfo]:
+    """Return cached Python skills, rescanning if needed.
+
+    Returns:
+        Dict mapping skill name to PythonSkillInfo.
+    """
+    global _python_skills_cache, _python_skills_mtime
+
+    skills_dir = get_skills_dir()
+    current_mtime = _check_python_skill_dir_mtime(skills_dir)
+
+    # Rescan if any Python skill directory has changed
+    if not _python_skills_cache or current_mtime > _python_skills_mtime:
+        _python_skills_cache = scan_python_skills()
+        _python_skills_mtime = current_mtime
+
+    return _python_skills_cache
+
+
+def get_python_skill(name: str) -> Optional[PythonSkillInfo]:
+    """Get a Python-backed skill by name.
+
+    Args:
+        name: The skill name (case-insensitive, slug-normalized).
+
+    Returns:
+        PythonSkillInfo or None.
+    """
+    skills = get_python_skills()
+    for info in skills.values():
+        if info.name.lower().replace("-", "").replace("_", "") == name.lower().replace("-", "").replace("_", ""):
+            return info
+    return None
+
+
+def reload_python_skills() -> Dict[str, Any]:
+    """Re-scan Python skills and return a diff.
+
+    Returns:
+        Dict with 'added', 'removed', 'unchanged', 'total'.
+    """
+    before = {info.name for info in _python_skills_cache.values()}
+    new = scan_python_skills()
+    after = {info.name for info in new.values()}
+
+    added_names = sorted(after - before)
+    removed_names = sorted(before - after)
+    unchanged_names = sorted(after & before)
+
+    return {
+        "added": [{"name": n} for n in added_names],
+        "removed": [{"name": n} for n in removed_names],
+        "unchanged": unchanged_names,
+        "total": len(after),
+    }
+
+
+def build_python_skill_message(skill_info: PythonSkillInfo) -> str:
+    """Build the agent-facing message for a Python-backed skill.
+
+    This message is injected into the conversation when the skill is invoked,
+    containing the skill's instructions and the callable function signatures.
+
+    Args:
+        skill_info: The loaded Python skill info.
+
+    Returns:
+        Formatted message string.
+    """
+    lines = [
+        f"[IMPORTANT: The user has invoked the \"{skill_info.name}\" Python skill. "
+        f"Follow its instructions and use the callable functions below.]",
+        "",
+    ]
+
+    # Instructions
+    if skill_info.instructions:
+        lines.append("## Instructions")
+        lines.append(skill_info.instructions)
+        lines.append("")
+
+    # Callable functions
+    if skill_info.functions:
+        lines.append("## Callable Functions")
+        lines.append(
+            "The following functions are available for invocation. "
+            "Use the execute_code tool to call them, or call them directly "
+            "if the Hermes tool interface supports Python skills."
+        )
+        lines.append("")
+        for func in skill_info.functions:
+            lines.append(f"### `{func.signature}`")
+            if func.description:
+                lines.append(func.description)
+            if func.parameters:
+                lines.append("")
+                lines.append("**Parameters:**")
+                for p in func.parameters:
+                    default = f" (default: {p.get('default', 'N/A')})" if 'default' in p else ""
+                    type_str = p.get('type', 'any')
+                    lines.append(f"- `{p['name']}` ({type_str}){default}")
+            lines.append("")
+
+    # Skill directory
+    if skill_info.path:
+        lines.append(f"[Skill directory: {skill_info.path}]")
+
+    return "\n".join(lines)
+
+
+def build_python_skills_index() -> str:
+    """Build the skills index section for Python-backed skills.
+
+    Returns a string suitable for inclusion in the system prompt's
+    ``<available_skills>`` block.
+
+    Returns:
+        Formatted index string, or empty string if no Python skills.
+    """
+    skills = get_python_skills()
+    if not skills:
+        return ""
+
+    lines = ["  **Python-backed skills:**"]
+    for name in sorted(skills.keys()):
+        info = skills[name]
+        desc = info.description or f"Python skill: {name}"
+        lines.append(f"    - {name}: {desc}")
+    return "\n".join(lines)
+
+
+def get_python_skill_slash_commands() -> Dict[str, Dict[str, Any]]:
+    """Return Python-backed skills as slash commands.
+
+    Returns:
+        Dict mapping ``/command-name`` to command info dict, compatible
+        with the format used by ``skill_commands.scan_skill_commands()``.
+    """
+    skills = get_python_skills()
+    commands: Dict[str, Dict[str, Any]] = {}
+
+    for name, info in skills.items():
+        cmd_name = name.lower().replace(" ", "-").replace("_", "-")
+        commands[f"/{cmd_name}"] = {
+            "name": info.name,
+            "description": info.description or f"Invoke the {info.name} Python skill",
+            "skill_dir": str(info.path) if info.path else "",
+            "python_skill": True,
+            "python_skill_info": info,
+        }
+
+    return commands

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -403,7 +403,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
 
     Returns:
-        Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
+        Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir,
+        python_skill?, python_skill_info?}.
     """
     global _skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
@@ -490,6 +491,34 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     }
                 except Exception:
                     continue
+
+        # ── Python-backed skills ─────────────────────────────────────────
+        # These are discovered from _skill.py files and merged into the
+        # same command map. Local Python skills override markdown skills
+        # with the same name.
+        try:
+            from agent.python_skills import get_python_skills
+            python_skills = get_python_skills()
+            for name, pinfo in python_skills.items():
+                if name in seen_names:
+                    continue
+                if name in disabled:
+                    continue
+                cmd_name = name.lower().replace(' ', '-').replace('_', '-')
+                cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
+                cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
+                if not cmd_name:
+                    continue
+                seen_names.add(name)
+                _skill_commands[f"/{cmd_name}"] = {
+                    "name": pinfo.name,
+                    "description": pinfo.description or f"Invoke the {pinfo.name} Python skill",
+                    "skill_dir": str(pinfo.path) if pinfo.path else "",
+                    "python_skill": True,
+                    "python_skill_info": pinfo,
+                }
+        except Exception:
+            pass  # Non-critical — markdown skills still work
     except Exception:
         pass
     return _skill_commands
@@ -614,6 +643,22 @@ def build_skill_invocation_message(
     if not skill_info:
         return None
 
+    # ── Python-backed skill path ───────────────────────────────────────
+    if skill_info.get("python_skill"):
+        pinfo = skill_info.get("python_skill_info")
+        if not pinfo:
+            return None
+        from agent.python_skills import build_python_skill_message
+        parts = [build_python_skill_message(pinfo)]
+        if user_instruction:
+            parts.append(
+                f"The user has provided the following instruction alongside the skill invocation: {user_instruction}"
+            )
+        if runtime_note:
+            parts.append(f"[Runtime note: {runtime_note}]")
+        return "\n\n".join(parts)
+
+    # ── Markdown skill path (existing) ─────────────────────────────────
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
         return None
@@ -778,6 +823,8 @@ def build_preloaded_skills_prompt(
 ) -> tuple[str, list[str], list[str]]:
     """Load one or more skills for session-wide CLI/TUI preloading.
 
+    Supports both markdown and Python-backed skills.
+
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
 
     Disabled skills are treated the same as missing ones: this loads via a
@@ -804,6 +851,27 @@ def build_preloaded_skills_prompt(
             continue
         seen.add(identifier)
 
+        # ── Try Python-backed skill first ──────────────────────────────
+        try:
+            from agent.python_skills import get_python_skill
+            pinfo = get_python_skill(identifier)
+            if pinfo:
+                from agent.python_skills import build_python_skill_message
+                activation_note = (
+                    f'[IMPORTANT: The user launched this CLI session with the "{pinfo.name}" '
+                    f"Python skill preloaded. Treat its instructions and callable functions "
+                    f"as active guidance for the duration of this session unless the user "
+                    f"overrides them.]"
+                )
+                prompt_parts.append(
+                    f"{activation_note}\n\n{build_python_skill_message(pinfo)}"
+                )
+                loaded_names.append(pinfo.name)
+                continue
+        except Exception:
+            pass
+
+        # ── Fallback: markdown skill ───────────────────────────────────
         loaded = _load_skill_payload(identifier, task_id=task_id)
         if not loaded:
             missing.append(identifier)

--- a/tests/agent/test_python_skills.py
+++ b/tests/agent/test_python_skills.py
@@ -1,0 +1,307 @@
+"""Tests for agent/python_skills.py — Python-backed skill loader."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.python_skills import (
+    PythonSkillInfo,
+    build_python_skill_message,
+    build_python_skills_index,
+    get_python_skill,
+    get_python_skills,
+    reload_python_skills,
+    scan_python_skills,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _make_python_skill(
+    skills_dir: Path,
+    name: str,
+    description: str = "Test Python skill",
+    functions: dict | None = None,
+    instructions: str = "",
+) -> Path:
+    """Create a minimal Python-backed skill directory."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build function code using string concatenation to avoid triple-quote
+    # collision inside f-strings
+    func_code = ""
+    if functions:
+        for func_name, func_body in functions.items():
+            func_code += (
+                f'\n@python_skill\n'
+                f'async def {func_name}(**kwargs) -> dict:\n'
+                f'    """{func_body}"""\n'
+                f'    return {{"func": "{func_name}"}}\n'
+                f'\n'
+            )
+
+    # Build _skill.py
+    skill_py = skill_dir / "_skill.py"
+    skill_py.write_text(
+        'from agent.python_skills import python_skill\n'
+        '\n'
+        'SKILL_INFO = {\n'
+        f'    "name": "{name}",\n'
+        f'    "description": "{description}",\n'
+        '    "version": "1.0.0",\n'
+        '}\n'
+        '\n'
+        f'{func_code}'
+    )
+
+    # Optional markdown instructions
+    if instructions:
+        (skill_dir / "_skill.md").write_text(instructions)
+
+    return skill_dir
+
+
+def _cleanup_module(name: str):
+    """Remove a test module from sys.modules."""
+    key = f"hermes_python_skill_{name}"
+    sys.modules.pop(key, None)
+
+
+def _patch_skills_dir(skills_dir: Path):
+    """Patch hermes_constants.get_skills_dir in python_skills module namespace."""
+    import agent.python_skills as ps_mod
+    return patch.object(ps_mod, "get_skills_dir", return_value=skills_dir)
+
+
+# ── scan_python_skills ──────────────────────────────────────────────────
+
+class TestScanPythonSkills:
+    def test_finds_python_skills(self, tmp_path):
+        _make_python_skill(tmp_path, "test-skill")
+        _cleanup_module("test-skill")
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert "test-skill" in result
+        assert result["test-skill"].name == "test-skill"
+        assert result["test-skill"].description == "Test Python skill"
+
+    def test_empty_dir(self, tmp_path):
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert result == {}
+
+    def test_skips_non_python_dirs(self, tmp_path):
+        (tmp_path / "not-a-skill").mkdir()
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert result == {}
+
+    def test_loads_functions(self, tmp_path):
+        funcs = {"my_function": "Does something cool"}
+        _make_python_skill(tmp_path, "func-skill", functions=funcs)
+        _cleanup_module("func-skill")
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert len(result["func-skill"].functions) == 1
+        assert result["func-skill"].functions[0].name == "my_function"
+
+    def test_loads_instructions_from_md(self, tmp_path):
+        instructions = "Follow these steps carefully."
+        _make_python_skill(tmp_path, "md-skill", instructions=instructions)
+        _cleanup_module("md-skill")
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert instructions in result["md-skill"].instructions
+
+    def test_ignores_hidden_dirs(self, tmp_path):
+        (tmp_path / ".hidden-skill").mkdir()
+        (tmp_path / ".hidden-skill" / "_skill.py").write_text("")
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert ".hidden-skill" not in result
+
+    def test_multiple_skills(self, tmp_path):
+        _make_python_skill(tmp_path, "skill-a")
+        _make_python_skill(tmp_path, "skill-b")
+        _cleanup_module("skill-a")
+        _cleanup_module("skill-b")
+        with _patch_skills_dir(tmp_path):
+            result = scan_python_skills()
+        assert "skill-a" in result
+        assert "skill-b" in result
+        assert len(result) == 2
+
+
+# ── get_python_skill ────────────────────────────────────────────────────
+
+class TestGetPythonSkill:
+    def test_get_by_name(self, tmp_path):
+        _make_python_skill(tmp_path, "my-skill")
+        _cleanup_module("my-skill")
+        with _patch_skills_dir(tmp_path):
+            skill = get_python_skill("my-skill")
+        assert skill is not None
+        assert skill.name == "my-skill"
+
+    def test_returns_none_for_missing(self, tmp_path):
+        with _patch_skills_dir(tmp_path):
+            skill = get_python_skill("nonexistent")
+        assert skill is None
+
+    def test_case_insensitive(self, tmp_path):
+        _make_python_skill(tmp_path, "my-skill")
+        _cleanup_module("my-skill")
+        with _patch_skills_dir(tmp_path):
+            skill = get_python_skill("MY-SKILL")
+        assert skill is not None
+
+
+# ── build_python_skill_message ──────────────────────────────────────────
+
+class TestBuildPythonSkillMessage:
+    def test_includes_instructions(self, tmp_path):
+        instructions = "Do the thing."
+        _make_python_skill(tmp_path, "msg-skill", instructions=instructions)
+        _cleanup_module("msg-skill")
+        with _patch_skills_dir(tmp_path):
+            skill = get_python_skill("msg-skill")
+            assert skill is not None
+        msg = build_python_skill_message(skill)
+        assert instructions in msg
+        assert "msg-skill" in msg
+
+    def test_includes_function_signatures(self, tmp_path):
+        _make_python_skill(
+            tmp_path, "sig-skill",
+            functions={"do_thing": "Does the thing"}
+        )
+        _cleanup_module("sig-skill")
+        with _patch_skills_dir(tmp_path):
+            skill = get_python_skill("sig-skill")
+            assert skill is not None
+        msg = build_python_skill_message(skill)
+        assert "do_thing" in msg
+        assert "Does the thing" in msg
+
+
+# ── build_python_skills_index ───────────────────────────────────────────
+
+class TestBuildPythonSkillsIndex:
+    def test_includes_python_skills(self, tmp_path):
+        _make_python_skill(tmp_path, "index-test", description="Indexable skill")
+        _cleanup_module("index-test")
+        with _patch_skills_dir(tmp_path):
+            idx = build_python_skills_index()
+        assert "index-test" in idx
+        assert "Indexable skill" in idx
+
+    def test_empty_when_no_python_skills(self, tmp_path):
+        # Clear the cache first
+        import agent.python_skills as ps_mod
+        ps_mod._python_skills_cache.clear()
+        ps_mod._python_skills_mtime = 0
+        with _patch_skills_dir(tmp_path):
+            idx = build_python_skills_index()
+        assert idx == ""
+
+
+# ── get_python_skills (cached) ──────────────────────────────────────────
+
+class TestGetPythonSkillsCached:
+    def test_caches_results(self, tmp_path):
+        _make_python_skill(tmp_path, "cached-skill")
+        _cleanup_module("cached-skill")
+        with _patch_skills_dir(tmp_path):
+            skills1 = get_python_skills()
+            # Patch mtime to be higher so second call doesn't rescan
+            import agent.python_skills as ps_mod
+            ps_mod._python_skills_mtime = 9999999999
+            skills2 = get_python_skills()
+        assert "cached-skill" in skills1
+        assert skills1 is skills2  # Same cached object
+
+    def test_rescans_on_reload(self, tmp_path):
+        _make_python_skill(tmp_path, "reload-skill")
+        _cleanup_module("reload-skill")
+        with _patch_skills_dir(tmp_path):
+            result = reload_python_skills()
+        assert result["total"] == 1
+        assert any(s["name"] == "reload-skill" for s in result["added"])
+
+
+# ── Integration: scan_skill_commands includes Python skills ─────────────
+
+class TestPythonSkillsIntegration:
+    def _clear_python_skills_cache(self):
+        """Clear the global Python skills cache so tests are isolated."""
+        import agent.python_skills as ps_mod
+        ps_mod._python_skills_cache.clear()
+        ps_mod._python_skills_mtime = 0
+
+    def test_python_skill_in_scan_skill_commands(self, tmp_path):
+        """Python-backed skills should appear in scan_skill_commands()."""
+        self._clear_python_skills_cache()
+        _make_python_skill(tmp_path, "int-skill")
+        _cleanup_module("int-skill")
+        with _patch_skills_dir(tmp_path):
+            from agent.skill_commands import scan_skill_commands
+            result = scan_skill_commands()
+        assert "/int-skill" in result
+        assert result["/int-skill"]["python_skill"] is True
+
+    def test_python_skill_invocation_message(self, tmp_path):
+        """build_skill_invocation_message should work for Python skills."""
+        self._clear_python_skills_cache()
+        _make_python_skill(
+            tmp_path, "inv-skill",
+            functions={"hello": "Say hello"},
+            instructions="Say hello to everyone."
+        )
+        _cleanup_module("inv-skill")
+        with _patch_skills_dir(tmp_path):
+            from agent.skill_commands import (
+                scan_skill_commands,
+                build_skill_invocation_message,
+            )
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/inv-skill", "hi there")
+        assert msg is not None
+        assert "Say hello to everyone" in msg
+        assert "hi there" in msg
+        assert "hello" in msg
+
+    def test_python_skill_preloaded(self, tmp_path):
+        """build_preloaded_skills_prompt should load Python skills."""
+        self._clear_python_skills_cache()
+        _make_python_skill(tmp_path, "preload-skill")
+        _cleanup_module("preload-skill")
+        with _patch_skills_dir(tmp_path):
+            from agent.skill_commands import build_preloaded_skills_prompt
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["preload-skill"]
+            )
+        assert "preload-skill" in loaded
+        assert missing == []
+        assert "preloaded" in prompt.lower()
+
+    def test_python_skill_override_markdown(self, tmp_path):
+        """Python skill with same name as markdown skill should win."""
+        self._clear_python_skills_cache()
+        # Create markdown skill
+        skill_dir = tmp_path / "override-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: override-skill\ndescription: Markdown version\n---\n\nBody."
+        )
+        # Create Python skill
+        _make_python_skill(tmp_path, "override-skill", description="Python version")
+        _cleanup_module("override-skill")
+        with _patch_skills_dir(tmp_path):
+            from agent.skill_commands import scan_skill_commands
+            result = scan_skill_commands()
+        # The command should exist and point to Python skill
+        assert "/override-skill" in result
+        assert result["/override-skill"]["python_skill"] is True

--- a/tests/agent/test_skill_manager_python.py
+++ b/tests/agent/test_skill_manager_python.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Tests for skill_manage(action='create_python') — Python-backed skill creation."""
+
+import json
+import shutil
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+# Patch get_hermes_home before importing skill_manager_tool
+import sys
+import os
+import tempfile
+
+@pytest.fixture()
+def tmp_hermes_home(tmp_path):
+    """Create a temporary HERMES_HOME with a skills directory."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    with patch("tools.skill_manager_tool.get_hermes_home", return_value=str(tmp_path)):
+        # Also patch the module-level SKILLS_DIR
+        import tools.skill_manager_tool as sm
+        original_skills_dir = sm.SKILLS_DIR
+        sm.SKILLS_DIR = skills_dir
+        yield skills_dir
+        sm.SKILLS_DIR = original_skills_dir
+
+
+def test_create_python_basic(tmp_hermes_home):
+    """Basic create_python creates _skill.py with correct structure."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-basic",
+        functions=[
+            {"name": "do_thing", "description": "Do a thing"},
+        ],
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["functions"] == ["do_thing"]
+
+    skill_dir = tmp_hermes_home / "test-basic"
+    assert skill_dir.exists()
+    skill_py = skill_dir / "_skill.py"
+    assert skill_py.exists()
+
+    content = skill_py.read_text()
+    assert "SKILL_INFO" in content
+    assert '"name": "test-basic"' in content
+    assert "do_thing" in content
+    assert 'async def do_thing' in content
+    assert '"""Do a thing"""' in content
+
+
+def test_create_python_multiple_functions(tmp_hermes_home):
+    """Multiple functions are all generated."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-multi",
+        functions=[
+            {"name": "fn_one", "description": "First function"},
+            {"name": "fn_two", "description": "Second function"},
+            {"name": "fn_three", "description": "Third function"},
+        ],
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+    assert set(data["functions"]) == {"fn_one", "fn_two", "fn_three"}
+
+    skill_py = tmp_hermes_home / "test-multi" / "_skill.py"
+    content = skill_py.read_text()
+    assert "async def fn_one" in content
+    assert "async def fn_two" in content
+    assert "async def fn_three" in content
+
+
+def test_create_python_with_category(tmp_hermes_home):
+    """create_python with category places skill in category subdirectory."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-cat",
+        category="devops",
+        functions=[{"name": "deploy", "description": "Deploy app"}],
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    skill_dir = tmp_hermes_home / "devops" / "test-cat"
+    assert skill_dir.exists()
+    assert (skill_dir / "_skill.py").exists()
+
+
+def test_create_python_with_instructions(tmp_hermes_home):
+    """create_python with instructions creates _skill.md."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-instr",
+        functions=[{"name": "run", "description": "Run something"}],
+        instructions="# Instructions\n\nDo the thing carefully.",
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    skill_md = tmp_hermes_home / "test-instr" / "_skill.md"
+    assert skill_md.exists()
+    assert "Do the thing carefully" in skill_md.read_text()
+
+
+def test_create_python_with_version(tmp_hermes_home):
+    """create_python with custom version uses it."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-ver",
+        functions=[{"name": "go", "description": "Go"}],
+        version="2.1.0",
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    content = (tmp_hermes_home / "test-ver" / "_skill.py").read_text()
+    assert '"version": "2.1.0"' in content
+
+
+def test_create_python_default_version(tmp_hermes_home):
+    """create_python without version defaults to 1.0.0."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-def-ver",
+        functions=[{"name": "go", "description": "Go"}],
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    content = (tmp_hermes_home / "test-def-ver" / "_skill.py").read_text()
+    assert '"version": "1.0.0"' in content
+
+
+def test_create_python_duplicate_fails(tmp_hermes_home):
+    """Creating a skill that already exists returns error."""
+    from tools.skill_manager_tool import skill_manage
+
+    skill_manage(
+        action="create_python",
+        name="test-dup",
+        functions=[{"name": "a", "description": "A"}],
+    )
+    result = skill_manage(
+        action="create_python",
+        name="test-dup",
+        functions=[{"name": "b", "description": "B"}],
+    )
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "already exists" in data["error"]
+
+
+def test_create_python_no_functions_fails(tmp_hermes_home):
+    """create_python without functions returns error."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-nofn",
+        functions=[],
+    )
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "functions is required" in data["error"]
+
+
+def test_create_python_invalid_name_fails(tmp_hermes_home):
+    """create_python with invalid name returns error."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="Invalid-Name",
+        functions=[{"name": "a", "description": "A"}],
+    )
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "Invalid skill name" in data["error"]
+
+
+def test_create_python_invalid_function_name_fails(tmp_hermes_home):
+    """create_python with invalid function name returns error."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-bad-fn",
+        functions=[{"name": "Bad-Name", "description": "Bad"}],
+    )
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "Invalid function name" in data["error"]
+
+
+def test_create_python_with_config(tmp_hermes_home):
+    """create_python with config creates _skill_config.yaml."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-cfg",
+        functions=[{"name": "x", "description": "X"}],
+        config={"timeout": 30, "retries": 3},
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    config_file = tmp_hermes_home / "test-cfg" / "_skill_config.yaml"
+    assert config_file.exists()
+    content = config_file.read_text()
+    assert "timeout: 30" in content
+    assert "retries: 3" in content
+
+
+def test_create_python_generated_description(tmp_hermes_home):
+    """When no description provided, it's generated from functions."""
+    from tools.skill_manager_tool import skill_manage
+
+    result = skill_manage(
+        action="create_python",
+        name="test-gen-desc",
+        functions=[
+            {"name": "do_a", "description": "Do action A"},
+            {"name": "do_b", "description": "Do action B"},
+        ],
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+
+    content = (tmp_hermes_home / "test-gen-desc" / "_skill.py").read_text()
+    assert "Do action A" in content
+    assert "Do action B" in content

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1416,6 +1416,140 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     }
 
 
+def _create_python_skill(
+    name: str,
+    category: Optional[str],
+    functions: List[Dict[str, str]],
+    instructions: Optional[str] = "",
+    description: Optional[str] = "",
+    version: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Create a Python-backed skill directory with _skill.py + optional _skill.md.
+
+    Args:
+        name: Skill name (lowercase, hyphens, ≤64 chars).
+        category: Optional category directory (e.g. 'devops').
+        functions: List of dicts with keys 'name' and 'description'.
+        instructions: Markdown instructions for the agent (stored in _skill.md).
+        description: One-line description (shown in skills index).
+        version: Semantic version string.
+        config: Optional YAML dict for _skill_config.yaml.
+
+    Returns:
+        Dict with success status and details.
+    """
+    err = _validate_name(name)
+    if err:
+        return {"success": False, "error": err}
+
+    # Determine path
+    if category:
+        cat_err = _validate_category(category)
+        if cat_err:
+            return {"success": False, "error": cat_err}
+        skill_dir = SKILLS_DIR / category / name
+    else:
+        skill_dir = SKILLS_DIR / name
+
+    # Guard against overwriting an existing skill
+    if skill_dir.exists():
+        return {"success": False, "error": f"Skill '{name}' already exists at {skill_dir}. Use action='edit' to update it."}
+
+    # Security guard
+    guard = _background_review_write_guard(name, skill_dir, "create_python")
+    if guard:
+        return guard
+
+    # Validate functions
+    if not functions:
+        return {"success": False, "error": "At least one function is required. Pass 'functions' with name and description for each async function."}
+    for fn in functions:
+        if not isinstance(fn, dict):
+            return {"success": False, "error": "Each function must be a dict with 'name' and 'description' keys."}
+        if "name" not in fn or "description" not in fn:
+            return {"success": False, "error": f"Function must have 'name' and 'description' keys. Got: {fn}"}
+        fn_name = fn["name"]
+        if not VALID_NAME_RE.match(fn_name):
+            return {"success": False, "error": f"Invalid function name '{fn_name}'. Use lowercase letters, numbers, hyphens, dots, and underscores."}
+
+    # Use provided description or generate from functions
+    if not description:
+        desc_parts = [f["description"] for f in functions]
+        description = "; ".join(desc_parts[:3])
+        if len(functions) > 3:
+            description += f" (+{len(functions)-3} more)"
+
+    if not version:
+        version = "1.0.0"
+
+    # Generate _skill.py
+    func_bodies = ""
+    for fn in functions:
+        func_bodies += (
+            f'\n@python_skill\n'
+            f'async def {fn["name"]}(**kwargs) -> dict:\n'
+            f'    """{fn["description"]}"""\n'
+            f'    return {{"function": "{fn["name"]}"}}\n'
+            f'\n'
+        )
+
+    skill_py_content = (
+        '#!/usr/bin/env python3\n'
+        f'"""Python-backed skill: {name}\n'
+        f'\n'
+        f'{description}\n'
+        f'"""\n'
+        '\n'
+        'from agent.python_skills import python_skill\n'
+        '\n'
+        'SKILL_INFO = {\n'
+        f'    "name": "{name}",\n'
+        f'    "description": "{description}",\n'
+        f'    "version": "{version}",\n'
+        '}\n'
+        '\n'
+        f'{func_bodies}'
+    )
+
+    # Generate _skill.md if instructions provided
+    md_content = None
+    if instructions:
+        md_content = instructions
+
+    # Generate _skill_config.yaml if config provided
+    config_content = None
+    if config:
+        config_content = yaml.dump(config, default_flow_style=False, sort_keys=False)
+
+    # Write files
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write _skill.py
+    (skill_dir / "_skill.py").write_text(skill_py_content, encoding="utf-8")
+
+    # Write _skill.md if provided
+    if md_content:
+        (skill_dir / "_skill.md").write_text(md_content, encoding="utf-8")
+
+    # Write _skill_config.yaml if provided
+    if config_content:
+        (skill_dir / "_skill_config.yaml").write_text(config_content, encoding="utf-8")
+
+    # Security scan
+    scan_error = _security_scan_skill(skill_dir)
+    if scan_error:
+        shutil.rmtree(skill_dir, ignore_errors=True)
+        return {"success": False, "error": scan_error}
+
+    return {
+        "success": True,
+        "message": f"Python-backed skill '{name}' created at {skill_dir}.",
+        "path": str(skill_dir),
+        "functions": [f["name"] for f in functions],
+    }
+
+
 # =============================================================================
 # Main entry point
 # =============================================================================
@@ -1484,6 +1618,11 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             new_string=payload.get("new_string"),
             replace_all=payload.get("replace_all", False),
             absorbed_into=payload.get("absorbed_into"),
+            functions=payload.get("functions"),
+            instructions=payload.get("instructions"),
+            description=payload.get("description"),
+            version=payload.get("version"),
+            config=payload.get("config"),
         )
     finally:
         _skill_gate_bypass.reset(token)
@@ -1552,6 +1691,11 @@ def skill_manage(
     absorbed_into: str = None,
     task_id: str = None,
     session_id: str = None,
+    functions: Optional[List[Dict[str, str]]] = None,
+    instructions: Optional[str] = None,
+    description: Optional[str] = None,
+    version: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
@@ -1571,6 +1715,8 @@ def skill_manage(
         file_path=file_path, file_content=file_content,
         old_string=old_string, new_string=new_string,
         replace_all=replace_all, absorbed_into=absorbed_into,
+        functions=functions, instructions=instructions,
+        description=description, version=version, config=config,
     )
     if gate_result is not None:
         return gate_result
@@ -1579,6 +1725,19 @@ def skill_manage(
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
         result = _create_skill(name, content, category)
+
+    elif action == "create_python":
+        if not functions:
+            return tool_error("functions is required for 'create_python'. Pass a list of dicts with 'name' and 'description' for each async function.", success=False)
+        result = _create_python_skill(
+            name=name,
+            category=category,
+            functions=functions,
+            instructions=instructions,
+            description=description,
+            version=version,
+            config=config,
+        )
 
     elif action == "edit":
         if not content:
@@ -1674,6 +1833,7 @@ SKILL_MANAGE_SCHEMA = {
         "memory — reusable approaches for recurring task types. "
         f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
+        "create_python (Python-backed skill with _skill.py + functions), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
         "delete, write_file, remove_file.\n\n"
@@ -1708,7 +1868,7 @@ SKILL_MANAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+                "enum": ["create", "create_python", "patch", "edit", "delete", "write_file", "remove_file"],
                 "description": "The action to perform."
             },
             "name": {
@@ -1780,6 +1940,52 @@ SKILL_MANAGE_SCHEMA = {
                     "rewriting) will have to guess at intent."
                 )
             },
+            "functions": {
+                "type": "array",
+                "description": (
+                    "For 'create_python' only. List of dicts, each with 'name' "
+                    "(function name, lowercase + hyphens) and 'description' "
+                    "(one-line docstring). Example: [{\"name\": \"do_thing\", "
+                    "\"description\": \"Do the thing\"}]."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                    "required": ["name", "description"],
+                },
+            },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "For 'create_python' only. Markdown instructions for the "
+                    "agent (stored in _skill.md). Optional — if omitted, "
+                    "the skill has no markdown instructions."
+                )
+            },
+            "description": {
+                "type": "string",
+                "description": (
+                    "For 'create_python' only. One-line description for the "
+                    "skills index. Auto-generated from functions if omitted."
+                )
+            },
+            "version": {
+                "type": "string",
+                "description": (
+                    "For 'create_python' only. Semantic version string (e.g. "
+                    "'1.0.0'). Defaults to '1.0.0'."
+                )
+            },
+            "config": {
+                "type": "object",
+                "description": (
+                    "For 'create_python' only. Optional YAML-serializable dict "
+                    "for skill configuration (stored in _skill_config.yaml)."
+                )
+            },
         },
         "required": ["action", "name"],
     },
@@ -1805,6 +2011,11 @@ registry.register(
         replace_all=args.get("replace_all", False),
         absorbed_into=args.get("absorbed_into"),
         task_id=kw.get("task_id"),
-        session_id=kw.get("session_id")),
+        session_id=kw.get("session_id"),
+        functions=args.get("functions"),
+        instructions=args.get("instructions"),
+        description=args.get("description"),
+        version=args.get("version"),
+        config=args.get("config")),
     emoji="📝",
 )


### PR DESCRIPTION
## What
Adds `skill_manage(action='create_python')` for creating Python-backed skills, plus comprehensive tests (20/20 passing).

Built and tested against a local checkout; not previously opened upstream.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>