### PR TITLE
fix(desktop): don't replay earlier turns in voice conversation

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
-import { markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
+import { adoptSpokenReplySession, markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -64,7 +64,14 @@ export function useComposerVoice({
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const ownsWakeIndicatorRef = useRef(false)
+  const previousSessionIdRef = useRef(sessionId)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
+
+  // eslint-disable-next-line no-restricted-syntax -- session-id adopt token, not an atom mirror
+  useEffect(() => {
+    adoptSpokenReplySession(previousSessionIdRef.current, sessionId)
+    previousSessionIdRef.current = sessionId
+  }, [sessionId])
 
   const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1332,6 +1332,19 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
   })
+
+  it('does not replay earlier turns when the spoken id is missing or stale', () => {
+    const messages = [
+      user('u1', 'old question'),
+      assistant('a1', 'Previous output from last turn.'),
+      user('u2', 'new question'),
+      assistant('a2', 'Live reply only.')
+    ]
+
+    expect(collectUnspokenTurnSpeech(messages, null)?.text).toBe('Live reply only.')
+    expect(collectUnspokenTurnSpeech(messages, 'vanished-stream-id')?.text).toBe('Live reply only.')
+    expect(collectUnspokenTurnSpeech(messages, 'a1')?.text).toBe('Live reply only.')
+  })
 })
 
 describe('stripPendingClarifyProjectionForCache', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -68,12 +68,26 @@ export interface UnspokenTurnSpeech {
  * selecting only one bubble silently drops everything after it. The blank-line
  * join is a sentence boundary for the server's cutter, so a sealed bubble's
  * tail is flushed as soon as the next bubble starts.
+ *
+ * If `lastSpokenId` is missing or stale (session id assigned mid-turn,
+ * live-tail rewrite missed), do **not** fall back to index -1 — that replays
+ * every earlier assistant turn as one speech string. Bound to the current
+ * turn (assistant bubbles after the last user message) instead. A slice with
+ * no user row (mid-turn interims only) still collects those assistants.
  */
 export function collectUnspokenTurnSpeech(
   messages: ChatMessage[],
   lastSpokenId: string | null
 ): UnspokenTurnSpeech | null {
-  const spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
+  let spokenIndex = lastSpokenId ? messages.findLastIndex(m => m.id === lastSpokenId) : -1
+
+  if (spokenIndex < 0) {
+    const lastUser = messages.findLastIndex(m => m.role === 'user' && !m.hidden)
+
+    if (lastUser >= 0) {
+      spokenIndex = lastUser
+    }
+  }
 
   let id: string | null = null
   let pending = false

--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   absorbSpokenReplyRewrite,
+  adoptSpokenReplySession,
   assistantReplyOrdinal,
   clearSpokenRepliesForTests,
   isLiveTailReplyId,
@@ -88,5 +89,22 @@ describe('resolveSpokenReply', () => {
     expect(spoken?.id).toBe('durable-1')
     expect(assistantReplyOrdinal(nextTurn, 'assistant-stream-2')).toBe(1)
     expect(spoken?.ordinal).toBe(0)
+  })
+})
+
+describe('adoptSpokenReplySession', () => {
+  it('moves the null-session anchor onto the created session id', () => {
+    markAssistantIdSpoken(null, [assistant('a1')], 'a1')
+    adoptSpokenReplySession(null, 'session-created')
+
+    expect(spokenReplyOf('session-created')?.id).toBe('a1')
+  })
+
+  it('does not leak a spoken anchor from one real session into another', () => {
+    markAssistantIdSpoken('session-a', [assistant('a1')], 'a1')
+    adoptSpokenReplySession('session-a', 'session-b')
+
+    expect(spokenReplyOf('session-b')).toBeNull()
+    expect(spokenReplyOf('session-a')?.id).toBe('a1')
   })
 })

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -111,6 +111,31 @@ export function markAssistantIdSpoken(
   markSpokenReply(sessionId, { id, ordinal })
 }
 
+/**
+ * Carry the spoken anchor when a chat gets a real session id (null → created)
+ * mid voice-conversation. Do not copy across two real sessions — that would
+ * leak "already spoken" into a different transcript.
+ */
+export function adoptSpokenReplySession(
+  fromSessionId: string | null | undefined,
+  toSessionId: string | null | undefined
+): void {
+  const fromKey = sessionKey(fromSessionId)
+  const toKey = sessionKey(toSessionId)
+
+  if (fromKey === toKey || fromKey !== NO_SESSION) {
+    return
+  }
+
+  const from = lastSpokenBySession.get(fromKey)
+
+  if (!from || lastSpokenBySession.has(toKey)) {
+    return
+  }
+
+  lastSpokenBySession.set(toKey, from)
+}
+
 /** Current spoken anchor, migrated in place when the live row was rewritten. */
 export function resolveSpokenReply(
   sessionId: string | null | undefined,


### PR DESCRIPTION
## What does this PR do?

Desktop voice conversation sometimes reads **previous replies** instead of only the live turn. That happens when `collectUnspokenTurnSpeech` loses `lastSpokenId` (session id assigned mid-chat, live-tail id rewrite missed) and falls back to index `-1`, concatenating every earlier assistant bubble into one speech string.

Related open PRs that hit the same class but did not land / conflict with current main: #78194, #64390, #91391.

This PR bounds collection to the **current turn** (assistant bubbles after the last user message) when the spoken id is missing or stale, and carries the spoken anchor from a null session id onto the created session so tracking survives first-message session assignment.

## Related Issue

Related #64390 #78194 #91391

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/chat-messages/parts.ts` — if `lastSpokenId` is missing/stale, bound speech to the last user message instead of replaying the whole transcript
- `apps/desktop/src/lib/spoken-reply.ts` — `adoptSpokenReplySession` copies the null-session spoken anchor onto the created session id only
- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts` — adopt on `sessionId` change
- Tests in `chat-messages.test.ts` and `spoken-reply.test.ts`

## How to Test

1. `cd apps/desktop && npm test -- --run src/lib/chat-messages.test.ts src/lib/spoken-reply.test.ts src/app/chat/composer/hooks/use-voice-conversation.test.tsx src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx`
2. Start a Desktop voice conversation in a chat that already has several assistant replies.
3. Speak a new turn. TTS should speak only the new reply, not earlier history.
4. Repeat a few turns. It should stay a live conversation, not reread previous outputs.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] Desktop vitest on the files above: 5 files, 95 tests, all passing
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Docs N/A (behavior fix, existing voice-mode docs still accurate)
- [x] Config keys N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform: renderer-only TypeScript, no native APIs
- [x] Tool schemas N/A