### PR TITLE
chore: AUTHOR_MAP — shauneccles (#95433) + fedosis (#94996)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -342,6 +342,8 @@ LEGACY_AUTHOR_MAP = {
     "joelbrilliant1@gmail.com": "joelbrilliant",  # PR #58486 salvage (session-expiry cleanup must not end row as agent_close)
     "bassisho@Mac-mini-bassis.local": "hydracoco7",  # PR #61382 salvage (id-less cron job freeze)
     "AlexFucuson9@users.noreply.github.com": "AlexFucuson9",  # PR #61209 salvage (hygiene compression data loss)
+    "shauneccles@gmail.com": "shauneccles",  # PR #95433 salvage (compression stall-fallback retry on fallback_chain; #78981)
+    "shtorm@fedosis.ru": "fedosis",  # PR #94996 salvage (compression rotation dedupe current-turn rows)
     "email@adambig.gs": "adambiggs",  # PR #43819 salvage (holographic shared SQLite connection)
     "koho.jung@outlook.com": "kohoj",  # PR #61667 salvage (nonce-CSP HTML session export)
     "t.chen@aftership.com": "cypctlinux",  # PR #52403 salvage (Slack bot/workflow auth before no-user-id guard)


### PR DESCRIPTION
## Summary
Adds AUTHOR_MAP entries for two compression contributors whose salvage PRs need attribution CI to pass.

## Changes
- scripts/release.py: `"shauneccles@gmail.com": "shauneccles"` (#95433 — compression stall-fallback retry)
- scripts/release.py: `"shtorm@fedosis.ru": "fedosis"` (#94996 — compression rotation dedupe)

## Why
Both contributors use non-noreply emails, so the auto-skip path doesn't apply. These mappings must be on `main` before the salvage PRs' attribution checks run.
