### PR TITLE
fix(desktop): Cronjobs pane collapses to a ribbon instead of vanishing (salvage #95956)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
@@ -12,6 +12,8 @@ import {
   isHideOnlyPane,
   revealTreePane,
   setStripTabHidden,
+  setTreeGroupTabStrip,
+  tabStripVisibleForGroup,
   treeTabCloseTargets
 } from './store'
 
@@ -100,6 +102,16 @@ describe('hide-only strip tabs', () => {
       { hidden: true, id: 'hermes-bots:pane', title: 'hermes-bots:pane' }
     ])
     expect(hideOnlyZoneTabs('g-main')).toEqual([])
+  })
+
+  it('refuses to hide the strip that is the only handle for hide-only tabs', () => {
+    sessionsBotsTree()
+    setTreeGroupTabStrip('g-side', 'never')
+
+    const side = $layoutTree.get()
+    const group = side && side.type === 'split' ? side.children[0] : side
+
+    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : false).toBe(true)
   })
 
   it('excludes hide-only tabs from every close verb', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -1,0 +1,232 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, type GroupNode, split } from '../model'
+import {
+  $dismissedPanes,
+  $hiddenTreePanes,
+  $layoutTree,
+  collapseTreePane,
+  markCollapsePane,
+  registerPaneCloser,
+  setTreeGroupMinimized,
+  setTreeGroupTabStrip,
+  tabStripVisibleForGroup
+} from '../store'
+
+import { TreeGroup } from './tree-group'
+
+/**
+ * A collapsed pane must leave a visible way back. Two live repros, one
+ * invariant:
+ *   1. #91223 — double-clicking Sessions/Bots must not hide the strip (and
+ *      an explicit `never` still cannot, because hide-only chrome's only
+ *      handle lives on that strip).
+ *   2. Clicking the active tab of a docked tool/plugin tile must not fold
+ *      the zone; if the zone *is* collapsed (chevron), the tab chip stays.
+ */
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+beforeEach(async () => {
+  window.localStorage.clear()
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+function registerPane(id: string, data: Record<string, unknown>, title = id) {
+  disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title }))
+}
+
+function LiveTreeGroup({ index = 0, parentAxis }: { index?: number; parentAxis: 'column' | 'row' }) {
+  useStore($layoutTree)
+
+  const node = $layoutTree.get()!
+  const zone = (node.type === 'split' ? node.children[index] : node) as GroupNode
+
+  return <TreeGroup node={zone} parentAxis={parentAxis} />
+}
+
+const tablist = () => globalThis.document.querySelector('[role="tablist"]')
+const tabEl = (paneId: string) => globalThis.document.querySelector(`[data-tree-tab="${paneId}"]`)
+
+const tap = (target: Element) => {
+  fireEvent.pointerDown(target, { button: 0, clientX: 10, clientY: 10, pointerType: 'mouse' })
+  fireEvent.pointerUp(window, { button: 0, clientX: 10, clientY: 10, pointerType: 'mouse' })
+}
+
+const doubleTap = (target: Element) => {
+  tap(target)
+  tap(target)
+}
+
+const zoneAt = (index: number) => {
+  const node = $layoutTree.get()!
+
+  return (node.type === 'split' ? node.children[index] : node) as GroupNode
+}
+
+describe('Sessions/Bots strip — #91223', () => {
+  beforeEach(() => {
+    registerPane('sessions', { hideOnly: true, placement: 'left' }, 'Sessions')
+    registerPane('hermes-bots:pane', { hideOnly: true, placement: 'left' }, 'Bots')
+    registerPane('workspace', { placement: 'main', uncloseable: true }, 'Chat')
+    $layoutTree.set(
+      split('row', [
+        group(['sessions', 'hermes-bots:pane'], { active: 'sessions', id: 'g-side' }),
+        group(['workspace'], { active: 'workspace', id: 'g-main' })
+      ])
+    )
+  })
+
+  it('double-clicking the Sessions tab leaves the strip and both chips', () => {
+    render(<LiveTreeGroup parentAxis="row" />)
+
+    doubleTap(tabEl('sessions')!)
+
+    expect(tablist()).toBeTruthy()
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+    expect(zoneAt(0).minimized).toBeFalsy()
+    expect(zoneAt(0).tabStrip).toBeUndefined()
+  })
+
+  it('double-clicking the Bots tab leaves the strip too', () => {
+    render(<LiveTreeGroup parentAxis="row" />)
+
+    tap(tabEl('hermes-bots:pane')!)
+    doubleTap(tabEl('hermes-bots:pane')!)
+
+    expect(tablist()).toBeTruthy()
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+  })
+
+  it('tapping the strip gutter does not collapse the sidebar', () => {
+    render(<LiveTreeGroup parentAxis="row" />)
+
+    tap(globalThis.document.querySelector('[data-zone-tabstrip="g-side"]')!)
+
+    expect(zoneAt(0).minimized).toBeFalsy()
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+  })
+
+  it('an explicit never still paints the strip — hide-only chrome has no other handle', () => {
+    setTreeGroupTabStrip('g-side', 'never')
+    expect(tabStripVisibleForGroup(zoneAt(0))).toBe(true)
+
+    render(<LiveTreeGroup parentAxis="row" />)
+
+    expect(tablist()).toBeTruthy()
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+  })
+})
+
+describe('docked tool tile — collapsing keeps the restore chip', () => {
+  beforeEach(() => {
+    registerPane('workspace', { placement: 'main', uncloseable: true }, 'Chat')
+    registerPane('hermes-bots:routines', { placement: 'main', width: '250px' }, 'Cronjobs')
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['hermes-bots:routines'], { active: 'hermes-bots:routines', id: 'g-routines' })
+      ])
+    )
+  })
+
+  it('clicking the active tab does not collapse the tile or drop its label', () => {
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    expect(tabEl('hermes-bots:routines')).toBeTruthy()
+    tap(tabEl('hermes-bots:routines')!)
+
+    expect(zoneAt(1).minimized).toBeFalsy()
+    expect(tabEl('hermes-bots:routines')).toBeTruthy()
+    expect(tabEl('hermes-bots:routines')?.textContent).toMatch(/cronjobs/i)
+  })
+
+  it('tapping the strip gutter does not collapse a lone docked tile', () => {
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    tap(globalThis.document.querySelector('[data-zone-tabstrip="g-routines"]')!)
+
+    expect(zoneAt(1).minimized).toBeFalsy()
+    expect(tabEl('hermes-bots:routines')).toBeTruthy()
+  })
+
+  it('chevron-collapse of a row-docked tile keeps the tab as a restore handle', () => {
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    fireEvent.click(
+      globalThis.document.querySelector('[data-tree-group="g-routines"] button[aria-label="Minimize"]')!
+    )
+
+    expect(zoneAt(1).minimized).toBe(true)
+    expect(tabEl('hermes-bots:routines')).toBeTruthy()
+    expect(tabEl('hermes-bots:routines')?.textContent).toMatch(/cronjobs/i)
+  })
+
+  it('collapsing via the store does not dismiss the pane from the tree', () => {
+    collapseTreePane('hermes-bots:routines')
+
+    expect(zoneAt(1).minimized).toBe(true)
+    expect($dismissedPanes.get().has('hermes-bots:routines')).toBe(false)
+    expect(zoneAt(1).panes).toContain('hermes-bots:routines')
+
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    expect(tabEl('hermes-bots:routines')).toBeTruthy()
+  })
+})
+
+describe('a stacked tool zone collapsed in a row keeps the horizontal strip', () => {
+  beforeEach(() => {
+    registerPane('workspace', { placement: 'main', uncloseable: true }, 'Chat')
+    registerPane('terminal', { placement: 'bottom' }, 'Terminal')
+    registerPane('logs', { placement: 'bottom' }, 'Logs')
+    markCollapsePane('terminal')
+    markCollapsePane('logs')
+    registerPaneCloser('terminal', () => undefined)
+    registerPaneCloser('logs', () => undefined)
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['terminal', 'logs'], { active: 'terminal', id: 'g-tools' })
+      ])
+    )
+  })
+
+  it('keeps both tab labels after minimize so either pane can be restored', () => {
+    setTreeGroupMinimized('g-tools', true)
+    render(<LiveTreeGroup index={1} parentAxis="row" />)
+
+    expect(tabEl('terminal')).toBeTruthy()
+    expect(tabEl('logs')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-zone-tabstrip="g-tools"]')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -9,6 +9,7 @@ const tile = (): StripPane => ({ collapsePane: false, placement: 'main' })
 const workspace = (): StripPane => ({ collapsePane: false, placement: 'main', uncloseable: true })
 const toolPanel = (): StripPane => ({ collapsePane: true, placement: 'bottom' })
 const sideChrome = (): StripPane => ({ collapsePane: false, placement: 'right' })
+const hideOnlyChrome = (): StripPane => ({ collapsePane: false, hideOnly: true, placement: 'left' })
 
 describe('auto (no stored choice)', () => {
   it('gives a lone workspace no strip and a stack of two a strip', () => {
@@ -42,6 +43,13 @@ describe('no dead zone', () => {
 
   it('keeps the strip for a lone tool panel even when the zone says never', () => {
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel()] })).toBe(true)
+  })
+
+  it('keeps the strip for hide-only chrome even when the zone says never', () => {
+    // Sessions / Bots: the Show/Hide rows and the chips themselves live on
+    // the strip. Hiding it is the #91223 trap — nothing left to click.
+    expect(resolveTabStripVisible({ mode: 'never', shown: [hideOnlyChrome()] })).toBe(true)
+    expect(resolveTabStripVisible({ mode: 'never', shown: [hideOnlyChrome(), hideOnlyChrome()] })).toBe(true)
   })
 
   it('still hides a zone that cannot strand anything', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -19,6 +19,9 @@ import { paneChrome } from './track-model'
 export interface StripPane {
   /** A tool panel (terminal / logs) that collapses rather than closes. */
   collapsePane: boolean
+  /** Standing chrome (sessions / Bots) whose only handle is the strip:
+   *  show/hide replaces Close, and the Show/Hide rows live on the strip. */
+  hideOnly?: boolean
   /** Contribution placement — `'main'` marks a docked tile (session, page,
    *  preview) as opposed to standing side chrome. */
   placement?: string
@@ -39,7 +42,8 @@ export interface StripZone {
 /**
  * A pane is STRANDED without a strip when the strip is the only thing carrying
  * its handle: a closeable tile needs its ✕, a lone tool panel needs a chip to
- * grab. The uncloseable workspace is not strandable — it cannot be closed or
+ * grab, hide-only chrome (sessions / Bots) needs the chip that show/hide lives
+ * on. The uncloseable workspace is not strandable — it cannot be closed or
  * lost, so a lone chat is free to be chromeless.
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
@@ -49,6 +53,10 @@ export interface StripZone {
  */
 function stranded(shown: readonly StripPane[]): boolean {
   if (shown.some(pane => !pane.uncloseable && pane.placement === 'main')) {
+    return true
+  }
+
+  if (shown.some(pane => pane.hideOnly)) {
     return true
   }
 
@@ -99,10 +107,15 @@ export function tabStripVisibleForZone(zone: {
   return resolveTabStripVisible({
     headerVeto: paneChrome(zone.paneFor(zone.active)).headerVeto,
     mode: effectiveTabStripMode(zone.mode),
-    shown: zone.shown.map(id => ({
-      collapsePane: zone.isCollapsePane(id),
-      placement: paneChrome(zone.paneFor(id)).placement,
-      uncloseable: paneChrome(zone.paneFor(id)).uncloseable
-    }))
+    shown: zone.shown.map(id => {
+      const chrome = paneChrome(zone.paneFor(id))
+
+      return {
+        collapsePane: zone.isCollapsePane(id),
+        hideOnly: chrome.hideOnly,
+        placement: chrome.placement,
+        uncloseable: chrome.uncloseable
+      }
+    })
   })
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -344,7 +344,12 @@ export function TreeGroup({
   // empty column, so the minimized form is a narrow vertical rail instead
   // (tabs reading top-to-bottom). In a column (stacked zones) the horizontal
   // header IS the collapsed form, exactly as before.
-  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty
+  //
+  // EXCEPTION: when the zone has ≥2 shown panes, keep the horizontal tab bar
+  // even when minimized — the user can still switch (and restore) without
+  // expanding first. The vertical rail is only for a lone pane, where it
+  // still renders that pane's tab as the restore handle.
+  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
   // A minimized group IS its header, so it shows one regardless.
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || stripVisible)
 
@@ -397,7 +402,9 @@ export function TreeGroup({
   const tabLabel = (paneId: string) => paneChrome(paneFor(paneId)).tabTitle?.() ?? paneFor(paneId)?.title ?? paneId
 
   // Collapse/restore a tool panel (or plain minimize elsewhere) — the header
-  // chevron + tap gesture, routed so ⌃`/the titlebar toggle stay truthful.
+  // chevron, routed so ⌃`/the titlebar toggle stay truthful. The strip itself
+  // does not collapse: a tap on the header of a lone docked tile used to fold
+  // the zone and take the tab with it.
   const toggleCollapse = () => (node.minimized ? restoreTreePane(activeId) : collapseTreePane(activeId))
 
   // Same menu on the header strip and the edit veil — one prop bag.
@@ -444,7 +451,7 @@ export function TreeGroup({
         <ZoneMenu {...zoneMenu}>
           <div
             className={cn(
-              'flex h-full w-7 shrink-0 cursor-pointer select-none flex-col items-stretch bg-(--ui-sidebar-surface-background)',
+              'flex h-full min-h-7 w-7 min-w-7 shrink-0 cursor-pointer select-none flex-col items-stretch bg-(--ui-sidebar-surface-background)',
               // Strip line faces the content the zone collapsed away from.
               railSide === 'right' ? PANE_TAB_STRIP_LINE_LEFT : PANE_TAB_STRIP_LINE_RIGHT
             )}
@@ -491,12 +498,19 @@ export function TreeGroup({
             data-zone-tabstrip={node.id}
             listRef={tabsRef}
             onPointerDown={e =>
-              // Tap the header to collapse to it / expand back — the DetailPane
-              // / sidebar-section gesture (never for the main zone). Drag still
-              // moves the pane. No double-tap hide belongs here: hiding the
-              // strip unmounts every affordance the zone has, including the
-              // menu offering "Show", so it stays a named command.
-              startPaneDrag(activeId, e, () => minimizable && toggleCollapse(), undefined, active?.title ?? activeId)
+              // Drag still moves the pane. Tapping the strip never collapses:
+              // the chevron is the collapse affordance. Overloading the header
+              // (and, in a lone-tab zone, the tab sitting in it) made a click
+              // on the active chip fold the zone — and on a row-docked tile
+              // the chip vanished with the body, leaving no mouse path back.
+              // A minimized strip still restores on tap (it IS the handle).
+              startPaneDrag(
+                activeId,
+                e,
+                node.minimized ? () => restoreTreePane(activeId) : undefined,
+                undefined,
+                active?.title ?? activeId
+              )
             }
             ref={stripRef}
             style={{ cursor: 'grab' }}
@@ -555,10 +569,10 @@ export function TreeGroup({
                     }
 
                     // Tabs ACTIVATE (restoring a collapsed group). Minimize
-                    // lives on the chevron / single-pane label — overloading
-                    // the active tab made double-click a minimize/restore/hide
-                    // lottery. A plain click also collapses any multi-tab
-                    // selection back to the one tab (Chrome semantics).
+                    // lives on the chevron — overloading the active tab made
+                    // double-click a minimize/restore/hide lottery. A plain
+                    // click also collapses any multi-tab selection back to the
+                    // one tab (Chrome semantics).
                     const onTap = () => {
                       clearTabSelection()
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -31,7 +31,7 @@ import {
   setTreeSplitWeights
 } from '../store'
 
-import {
+import { MINIMIZED_TRACK,
   allFixedAbsorberIndex,
   COLLAPSED_ZONE_PX,
   computedPx,
@@ -595,7 +595,7 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
               collapsed
                 ? { display: 'none' }
                 : minimized
-                  ? { flex: '0 0 auto' }
+                  ? { flex: `0 0 ${MINIMIZED_TRACK}` }
                   : {
                       // One flexbox formula for everything: a sized zone is
                       // grow-0 shrink-1 from its preferred basis (it yields

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -31,7 +31,7 @@ import {
   setTreeSplitWeights
 } from '../store'
 
-import { MINIMIZED_TRACK,
+import {
   allFixedAbsorberIndex,
   COLLAPSED_ZONE_PX,
   computedPx,
@@ -39,6 +39,7 @@ import { MINIMIZED_TRACK,
   edgeFixedZone,
   fixedTrackSize,
   MIN_PANE_PX,
+  MINIMIZED_TRACK,
   paneChrome,
   type PaneSizing,
   resolveCssPx,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -15924,6 +15924,13 @@ export default {
         if (botChatOwnsWorkspace()) {
           unregisterRoutines ??= registerRoutinesPane()
         } else if (unregisterRoutines) {
+          // Clicking the Cronjobs tile moves focus onto the tile itself, which
+          // drops bot-chat workspace ownership for a beat. While Bot Mode is
+          // still on screen and the tile is the one holding focus, keep it —
+          // a pane must never unregister itself out from under its own click.
+          // Leaving Bot Mode ($botsPaneVisible false) still unregisters.
+          const $self = host.paneVisibility(`${ID}:routines`)
+          if ($botsPaneVisible.get() && $self && typeof $self.get === 'function' && $self.get()) return
           unregisterRoutines()
           unregisterRoutines = null
         }

--- a/contributors/emails/thomasbekkers@Thomass-Mac-mini-2.local
+++ b/contributors/emails/thomasbekkers@Thomass-Mac-mini-2.local
@@ -1,0 +1,1 @@
+thomasbek3


### PR DESCRIPTION
## Summary
A collapsed Desktop pane now always leaves a visible way back — the Cronjobs tile in Bot Mode collapses to a ribbon/restore tab instead of vanishing (layout-reset was the only recovery), and the Sessions/Bots strip can no longer be stranded (#91223 class).

Salvage of #95956 by @thomasbek3 onto current main (AI-workspace debris files dropped; authorship preserved).

Root causes:
- Pane shell: the "hiding the strip must never make a surface unreachable" invariant had two holes — hide-only chrome (Sessions/Bots) wasn't counted as strandable, and a minimized row-docked lone tile dropped its tab with the body. Tap-on-strip also overloaded collapse, so clicking the active chip could fold the zone.
- Bot Mode: clicking the Cronjobs tile shifts focus onto the tile, momentarily dropping bot-chat workspace ownership; `syncRoutinesPane` then unregistered the pane out from under the user's own click.

## Changes
- `strip-visibility.ts`: hide-only chrome counts as stranded → strip stays even on explicit `never`
- `tree-group.tsx`: minimized zones with 2+ panes keep the horizontal strip; strip tap no longer collapses (chevron only; tap restores when minimized)
- `tree-split.tsx`: minimized track sized to `MINIMIZED_TRACK` so the restore affordance has room
- `plugins/hermes-bots/plugin.js`: Cronjobs tile stays registered while Bot Mode is visible and the tile holds focus; leaving Bot Mode still unregisters
- Tests: new `collapse-restore-affordance.test.tsx` (232 lines, both repros) + extensions to `strip-visibility.test.ts` and `hide-only-strip-tabs.test.ts`

## Validation
| | Before | After |
|---|---|---|
| Collapse Cronjobs tile in Bot Mode | pane + label vanish; Bots home takes over; layout-reset only recovery | collapses to restore tab; click restores |
| Double-click Sessions/Bots tab | strip could vanish (#91223) | strip + chips remain |
| pane-shell vitest | — | 28 files / 151 tests pass |
| hermes-bots vitest | — | pass |

Related: #91223 (closed), #65867 (stalled sibling), reported live in Discord support (Aymane, Windows Desktop).

## Infographic

![Collapsed panes always leave a way back](https://v3b.fal.media/files/b/0aa80fd8/HIKljfDB0hQgL0JFxIn-V_4T5u0BXY.png)
