### PR TITLE
fix(telegram): rewire plugin handlers after app rebuild

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2843,7 +2843,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     old_app = self._app
                     self._app = builder.build()
                     self._bot = self._app.bot
-                    self._register_handlers(self._app)  # keep core and observer handlers in lockstep
+                    # Reapply plugin, core, and observer handlers: the old Application — and every
+                    # handler wired to it — is discarded above. Plugin handlers go first, matching
+                    # normal startup, because PTB dispatches the first match per group.
+                    self._wire_plugin_handlers(self._app)
+                    self._register_handlers(self._app)
                     with contextlib.suppress(Exception):
                         await _shutdown_abandoned_app(old_app)
 

--- a/tests/gateway/test_platform_plugin_handlers.py
+++ b/tests/gateway/test_platform_plugin_handlers.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -220,6 +221,52 @@ class TestAdapterPluginWiring:
         with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
             adapter._wire_plugin_handlers(None)
         assert seen == [None]
+
+    @pytest.mark.asyncio
+    async def test_transient_init_rebuild_rewires_plugin_handlers(self, monkeypatch):
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra={})
+        )
+        first_app = MagicMock()
+        first_app.bot = MagicMock()
+        first_app.initialize = AsyncMock(side_effect=OSError("transient"))
+        rebuilt_app = MagicMock()
+        rebuilt_app.bot = MagicMock()
+        rebuilt_app.initialize = AsyncMock(
+            side_effect=RuntimeError("stop after rebuild")
+        )
+
+        builder = MagicMock()
+        builder.token.return_value = builder
+        builder.request.return_value = builder
+        builder.get_updates_request.return_value = builder
+        builder.build.side_effect = [first_app, rebuilt_app]
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.Application",
+            SimpleNamespace(builder=MagicMock(return_value=builder)),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.HTTPXRequest", MagicMock
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.discover_fallback_ips",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.asyncio.sleep", AsyncMock()
+        )
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        adapter._register_handlers = MagicMock()
+        adapter._wire_plugin_handlers = MagicMock()
+
+        assert await adapter.connect() is False
+        assert adapter._wire_plugin_handlers.call_args_list == [
+            ((first_app,), {}),
+            ((rebuilt_app,), {}),
+        ]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- re-run Telegram plugin handler factories when a transient initialization failure rebuilds the PTB `Application`
- keep plugin handlers ordered before the core Telegram handlers on both the initial and rebuilt applications
- add regression coverage proving both application instances receive plugin wiring

## Why

`ctx.register_platform_handler("telegram", factory)` factories are wired to the initial PTB `Application`. If `Application.initialize()` fails transiently, the adapter discards that object and builds a fresh one, but previously restored only core handlers. The rebuilt application therefore lost all plugin-provided handlers.

This also preserves native plugin handlers used alongside the callback-query work in #96053 across the same rebuild path.

## Testing

- `scripts/run_tests.sh -j 1 tests/gateway/test_platform_plugin_handlers.py -q` — 17 passed
- `scripts/run_tests.sh -j 2 tests/gateway/test_gateway_platform_event_hook.py tests/gateway/test_telegram_connect.py -q` — 35 passed
- `scripts/run_tests.sh -j 2 tests/gateway/test_telegram_conflict.py tests/test_telegram_polling_progress_ptb.py -q` — 16 passed
- `/home/cohen/.hermes/hermes-agent/venv/bin/ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_platform_plugin_handlers.py`
- `git diff --check`

## Platform

- Linux
