### PR TITLE
fix(lazy-deps): bind durable install target to sys.path so pre-installed STT works on sealed-venv installs

### DIFF
--- a/tests/gateway/test_photon_voice_stt_wiring.py
+++ b/tests/gateway/test_photon_voice_stt_wiring.py
@@ -1,0 +1,133 @@
+"""Regression: photon iMessage voice notes route through the central STT engine.
+
+Photon (iMessage) inbound voice notes are dispatched as ``MessageEvent`` with
+``message_type == MessageType.VOICE`` and a ``.caf`` media path — the same
+shape Telegram/Discord voice messages use. They must reach the gateway's
+central inbound STT pipeline (``transcription_tools.transcribe_audio``) and
+have the transcript prepended to the agent-visible text, exactly like every
+other channel.
+
+This guards against the photon path silently bypassing the central engine
+(the bug that left inbound iMessage voice notes un-transcribed on sealed-venv
+installs, where faster-whisper lives in the durable ``HERMES_LAZY_INSTALL_TARGET``
+volume and was never importable by the running interpreter — fixed in
+``tools/lazy_deps`` by binding that target onto ``sys.path`` at import).
+
+Mirrors the harness in ``test_telegram_audio_vs_voice.py``; photon uses the
+dynamic ``Platform("photon")`` member and a ``.caf`` clip path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_runner(stt_enabled: bool = True) -> "GatewayRunner":  # type: ignore[name-defined]
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=stt_enabled)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+def _photon_voice_event(path: str = "/tmp/photon_voice.caf") -> MessageEvent:
+    """Photon iMessage inbound voice note: VOICE type, .caf media path."""
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=SessionSource(
+            platform=Platform("photon"), chat_id="iMessage:+15551234567", chat_type="dm"
+        ),
+        media_urls=[path],
+        media_types=["audio/x-caf"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_photon_voice_note_reaches_central_stt():
+    """A photon VOICE event must be sent to transcribe_audio and get a transcript."""
+    runner = _make_runner(stt_enabled=True)
+    source = SessionSource(
+        platform=Platform("photon"), chat_id="iMessage:+15551234567", chat_type="dm"
+    )
+    event = _photon_voice_event("/tmp/photon_voice.caf")
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hey can you send that file", "provider": "whisper"},
+    ) as mock_transcribe:
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    # Central STT engine was invoked for the photon clip.
+    mock_transcribe.assert_called_once_with("/tmp/photon_voice.caf", None, "gateway")
+    # Transcript lands in the agent-visible text.
+    assert "hey can you send that file" in result
+
+
+@pytest.mark.asyncio
+async def test_photon_voice_with_caption_prepends_transcript():
+    """Voice + caption: transcript is prepended, caption preserved."""
+    runner = _make_runner(stt_enabled=True)
+    source = SessionSource(
+        platform=Platform("photon"), chat_id="iMessage:+15551234567", chat_type="dm"
+    )
+    event = MessageEvent(
+        text="fyi",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/photon_voice2.caf"],
+        media_types=["audio/x-caf"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "call me later", "provider": "whisper"},
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert "call me later" in result
+    assert "fyi" in result
+
+
+@pytest.mark.asyncio
+async def test_photon_voice_stt_disabled_yields_path_note_not_transcript():
+    """With STT disabled, photon voice must NOT reach transcribe_audio."""
+    runner = _make_runner(stt_enabled=False)
+    source = SessionSource(
+        platform=Platform("photon"), chat_id="iMessage:+15551234567", chat_type="dm"
+    )
+    event = _photon_voice_event("/tmp/photon_voice.caf")
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("transcribe_audio must not be called when STT disabled"),
+    ), patch(
+        "tools.credential_files.to_agent_visible_cache_path",
+        side_effect=lambda p: p,
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    # Graceful fallback: a voice-message path note (no transcript), and the
+    # central STT engine was never invoked.
+    assert "voice message" in result.lower()
+    assert "could not be transcribed" not in result.lower()

--- a/tests/test_lazy_install_target_sys_path.py
+++ b/tests/test_lazy_install_target_sys_path.py
@@ -1,0 +1,82 @@
+"""Regression: durable lazy-install target is importable without a restart.
+
+On sealed/immutable deployments (``HERMES_DISABLE_LAZY_INSTALLS=1``) the agent
+venv is read-only and pre-installed optional packages live in the durable
+volume named by ``HERMES_LAZY_INSTALL_TARGET`` (e.g. ``/opt/data/lazy-packages``).
+
+The original code only appended that directory to ``sys.path`` from inside
+``ensure()`` *after* a successful install. With lazy installs disabled the
+install path never runs, so a pre-installed package in the durable target
+stayed invisible to the already-running interpreter — breaking features that
+depend on it (notably local STT / faster-whisper for inbound voice
+transcription across iMessage, Telegram, Discord, …).
+
+``tools.lazy_deps`` now binds the target onto ``sys.path`` at import time,
+independent of the install gate. This test asserts that a package pre-installed
+into a durable target becomes importable the moment ``lazy_deps`` is imported,
+with lazy installs disabled — no restart required.
+"""
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _make_fake_package(directory: Path, name: str) -> None:
+    """Create a trivial importable package ``name`` inside ``directory``."""
+    pkg = directory / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("# fake durable package for sys.path test\n")
+
+
+def test_durable_target_bound_to_sys_path_on_import(monkeypatch, tmp_path):
+    """Importing lazy_deps makes a pre-installed durable package importable.
+
+    Mirrors a sealed-venv install: lazy installs disabled, package already
+    present in the durable target dir.
+    """
+    target = tmp_path / "lazy-packages"
+    target.mkdir()
+    _make_fake_package(target, "fake_durable_stt")
+
+    # Sealed-venv posture: installs disabled, target dir set.
+    monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(target))
+    monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+
+    import importlib
+
+    # Ensure the target is not already importable and the package is fresh.
+    if str(target) in sys.path:
+        sys.path.remove(str(target))
+    sys.modules.pop("fake_durable_stt", None)
+
+    assert "fake_durable_stt" not in sys.modules
+    # Before binding the target the package is NOT importable (old bug).
+    with pytest.raises(ImportError):
+        importlib.import_module("fake_durable_stt")
+
+    # Importing lazy_deps must bind the durable target at import time,
+    # independent of the install gate. Re-import fresh so the bind runs with
+    # the test env (the module may already be cached from another test).
+    sys.modules.pop("tools.lazy_deps", None)
+    importlib.import_module("tools.lazy_deps")
+
+    # Now the pre-installed package is importable without a restart.
+    mod = importlib.import_module("fake_durable_stt")
+    assert isinstance(mod, types.ModuleType)
+    assert str(target) in sys.path
+
+
+def test_no_target_env_is_a_noop(monkeypatch):
+    """When the env var is unset, nothing is appended and import still works."""
+    monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+    before = list(sys.path)
+    import importlib
+
+    sys.modules.pop("tools.lazy_deps", None)
+    importlib.import_module("tools.lazy_deps")
+    # Path unchanged (no spurious append) when the var is absent.
+    assert sys.path[: len(before)] == before

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -85,6 +85,51 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# Durable install-target path binding.
+#
+# On sealed/immutable deployments the Docker image sets
+# ``HERMES_LAZY_INSTALL_TARGET`` (e.g. ``/opt/data/lazy-packages``) and makes
+# the agent venv read-only (``HERMES_DISABLE_LAZY_INSTALLS=1``). Packages that
+# ship pre-installed into that durable volume are SAFE to import — the security
+# model appends (never prepends) the target so it can only ADD modules and can
+# never shadow or downgrade anything the core venv ships.
+#
+# The original design only appended this dir from inside ``ensure()`` *after* a
+# successful install. But when lazy installs are disabled the install path never
+# runs, so a pre-installed package in the durable target stayed invisible to the
+# already-running interpreter — breaking every feature that relied on it (e.g.
+# local STT / faster-whisper for inbound voice transcription on iMessage,
+# Telegram, Discord, …). Bind the target at module import time, independent of
+# the install gate, so pre-installed durable packages are always importable.
+# Idempotent: no-ops if already on sys.path or if the env var is unset.
+# =============================================================================
+
+_LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
+
+
+def _bind_lazy_install_target_to_sys_path() -> None:
+    """Append ``HERMES_LAZY_INSTALL_TARGET`` to ``sys.path`` once, always.
+
+    Safe regardless of ``HERMES_DISABLE_LAZY_INSTALLS``: the directory only
+    ever contains packages the deployment pre-installed, and it is appended
+    (lowest priority) so it cannot shadow core modules. Runs at import time so
+    the running interpreter can import pre-installed durable packages without a
+    restart — this is what makes local STT work on sealed-venv installs.
+    """
+    raw = os.environ.get(_LAZY_TARGET_ENV, "").strip()
+    if not raw:
+        return
+    target = str(Path(raw).resolve())
+    if target in sys.path:
+        return
+    sys.path.append(target)
+    logger.debug("Bound durable lazy-install target %s onto sys.path", target)
+
+
+_bind_lazy_install_target_to_sys_path()
+
+
+# =============================================================================
 # Allowlist of lazy-installable backends.
 #
 # Keys are dot-separated feature names ("namespace.backend"). Values are


### PR DESCRIPTION
## Summary
- On sealed/immutable deployments (`HERMES_DISABLE_LAZY_INSTALLS=1`) the agent venv is read-only and pre-installed optional packages live in the durable volume named by `HERMES_LAZY_INSTALL_TARGET` (e.g. `/opt/data/lazy-packages`).
- The original code only appended that directory to `sys.path` from inside `ensure()` **after a successful install**. With lazy installs disabled the install path never runs, so a pre-installed package in the durable target stayed invisible to the already-running interpreter.
- `tools/lazy_deps` now binds the target onto `sys.path` at import time, independent of the install gate. The directory only ever holds deployment-pre-installed packages and is appended (lowest priority), so it cannot shadow or downgrade core modules.

## Root cause
Inbound voice transcription across iMessage/Telegram/Discord/Signal routes through the central STT engine (`transcription_tools.transcribe_audio`, local provider = faster-whisper). On sealed-venv installs faster-whisper is pre-installed into the durable target but was never importable by the running gateway, so every voice note silently fell back to `[voice message could not be transcribed automatically; the audio is available at: …]`.

## Fix
One-time, idempotent `sys.path.append` of `HERMES_LAZY_INSTALL_TARGET` at `lazy_deps` import. Fixes the whole bug class (any pre-installed durable package: STT, TTS, memory backends) — not just the one channel.

## Test plan
- [x] `tests/test_lazy_install_target_sys_path.py` — asserts a pre-installed durable package becomes importable on `lazy_deps` import with `HERMES_DISABLE_LAZY_INSTALLS=1`, and that no target env is a no-op.
- [x] `ruff check` clean on changed files.
- [x] Existing `test_discord_lazy_install_views.py` / `test_stt_transcript_echo_config.py` still pass (no regression).

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)