### PR TITLE
fix(tools): disclose search match truncation

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -208,6 +208,60 @@ class TestSearchResultDensify:
         # path with spaces survives as a header line verbatim
         assert "my dir/a b.py" in text.split("\n")[0]
 
+    def test_content_truncation_metadata_preserves_densification(self):
+        matches = self._matches(6)
+        result = SearchResult(
+            matches=matches, total_count=6, content_truncated=True
+        ).to_dict(densify=True)
+
+        assert "matches_text" in result
+        assert result["content_truncated"] is True
+
+
+class TestSearchMatchContentLimit:
+    def test_default_limit_discloses_truncated_match_content(self, mock_env):
+        long_line = "A" * 500 + "TARGET_AFTER_LIMIT"
+        mock_env.execute.return_value = {
+            "output": f"notes.md:1:{long_line}\n",
+            "returncode": 0,
+        }
+        ops = ShellFileOperations(mock_env)
+        ops._has_command = MagicMock(side_effect=lambda command: command == "rg")
+
+        result = ops.search("TARGET_AFTER_LIMIT")
+
+        assert result.matches[0].content == "A" * 500
+        assert result.content_truncated is True
+        assert result.to_dict()["content_truncated"] is True
+
+    def test_larger_limit_returns_complete_match_content(self, mock_env):
+        long_line = "A" * 10_000 + "TARGET_AFTER_LIMIT"
+        mock_env.execute.return_value = {
+            "output": f"notes.md:1:{long_line}\n",
+            "returncode": 0,
+        }
+        ops = ShellFileOperations(mock_env)
+        ops._has_command = MagicMock(side_effect=lambda command: command == "rg")
+
+        result = ops.search("TARGET_AFTER_LIMIT", max_content_chars=20_000)
+
+        assert result.matches[0].content == long_line
+        assert result.content_truncated is False
+        assert "content_truncated" not in result.to_dict()
+
+    def test_grep_reports_the_same_truncation_metadata(self, mock_env):
+        long_line = "B" * 500 + "TARGET_AFTER_LIMIT"
+        mock_env.execute.return_value = {
+            "output": f"notes.md:1:{long_line}\n",
+            "returncode": 0,
+        }
+        ops = ShellFileOperations(mock_env)
+        ops._has_command = MagicMock(side_effect=lambda command: command == "grep")
+
+        result = ops.search("TARGET_AFTER_LIMIT")
+
+        assert result.matches[0].content == "B" * 500
+        assert result.content_truncated is True
 
 class TestLintResult:
     def test_skipped(self):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -295,6 +295,23 @@ class TestSearchHandler:
         assert "matches" in result
         mock_ops.search.assert_called_once()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_rejects_invalid_match_content_limit(self, mock_get):
+        from tools.file_tools import search_tool
+
+        result = json.loads(search_tool(pattern="TODO", max_content_chars=0))
+
+        assert "max_content_chars must be an integer" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools.search_tool")
+    def test_registry_handler_forwards_match_content_limit(self, mock_search):
+        from tools.file_tools import _handle_search_files
+
+        _handle_search_files({"pattern": "TODO", "max_content_chars": 1200})
+
+        assert mock_search.call_args.kwargs["max_content_chars"] == 1200
+
 
     @patch("tools.file_tools._get_file_ops")
     def test_search_exception_returns_error(self, mock_get):
@@ -424,6 +441,31 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_match_content_truncation_hint_explains_retry(self, mock_get):
+        from tools.file_operations import SearchMatch, SearchResult
+
+        match = SearchMatch(
+            path="notes.md",
+            line_number=1,
+            content="A" * 500,
+        )
+        mock_ops = MagicMock()
+        mock_ops.search.return_value = SearchResult(
+            matches=[match], total_count=1, content_truncated=True
+        )
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import search_tool
+        raw = search_tool(pattern="TARGET_AFTER_LIMIT")
+
+        result_json, hint = raw.split("\n\n", 1)
+        result = json.loads(result_json)
+        assert result["content_truncated"] is True
+        assert "max_content_chars=500" in hint
+        assert "Increase max_content_chars to retrieve more" in hint
+        assert "You can reduce limit or narrow the search" in hint
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -308,6 +308,7 @@ class SearchResult:
     counts: Dict[str, int] = field(default_factory=dict)
     total_count: int = 0
     truncated: bool = False
+    content_truncated: bool = False
     limit_reason: Optional[str] = None
     warning: Optional[str] = None
     error: Optional[str] = None
@@ -368,6 +369,8 @@ class SearchResult:
             result["counts"] = self.counts
         if self.truncated:
             result["truncated"] = True
+        if self.content_truncated:
+            result["content_truncated"] = True
         if self.limit_reason:
             result["limit_reason"] = self.limit_reason
         if self.warning:
@@ -623,7 +626,8 @@ class FileOperations(ABC):
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               max_content_chars: int = 500) -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -843,6 +847,7 @@ DEFAULT_READ_OFFSET = 1
 DEFAULT_READ_LIMIT = 2000
 DEFAULT_SEARCH_OFFSET = 0
 DEFAULT_SEARCH_LIMIT = 50
+DEFAULT_SEARCH_CONTENT_CHARS = 500
 
 # Echoed by the size probe when the path exists but is not a regular file.
 # `wc -c` prints only digits, so this can never collide with a real size.
@@ -882,6 +887,17 @@ def normalize_search_pagination(offset: Any = DEFAULT_SEARCH_OFFSET,
     normalized_offset = max(0, _coerce_int(offset, DEFAULT_SEARCH_OFFSET))
     normalized_limit = max(1, _coerce_int(limit, DEFAULT_SEARCH_LIMIT))
     return normalized_offset, normalized_limit
+
+
+def _bound_search_match_content(
+    result: SearchResult, max_content_chars: int
+) -> SearchResult:
+    """Clip returned line content and record whether anything was dropped."""
+    for match in result.matches:
+        if len(match.content) > max_content_chars:
+            match.content = match.content[:max_content_chars]
+            result.content_truncated = True
+    return result
 
 
 _REGEX_NEWLINE_ESCAPE_RE = re.compile(r"(?<!\\)(?:\\\\)*\\n")
@@ -2809,7 +2825,8 @@ class ShellFileOperations(FileOperations):
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               max_content_chars: int = DEFAULT_SEARCH_CONTENT_CHARS) -> SearchResult:
         """
         Search for content or files.
         
@@ -2822,6 +2839,7 @@ class ShellFileOperations(FileOperations):
             offset: Skip first N results
             output_mode: "content", "files_only", or "count"
             context: Lines of context around matches
+            max_content_chars: Maximum characters returned per matching or context line
         
         Returns:
             SearchResult with matches or file list
@@ -2842,7 +2860,7 @@ class ShellFileOperations(FileOperations):
                 pattern, path, target, file_glob, limit, offset, output_mode, context
             )
             if multi is not None:
-                return multi
+                return _bound_search_match_content(multi, max_content_chars)
             # Try to suggest nearby paths
             parent = os.path.dirname(path) or "."
             basename_query = os.path.basename(path)
@@ -2878,6 +2896,7 @@ class ShellFileOperations(FileOperations):
         else:
             result = self._search_content(pattern, path, file_glob, limit, offset,
                                           output_mode, context)
+        result = _bound_search_match_content(result, max_content_chars)
 
         exclusions = self._macos_search_exclusions(path)
         if exclusions and not result.error:
@@ -3348,7 +3367,7 @@ class ShellFileOperations(FileOperations):
                     matches.append(SearchMatch(
                         path=(m.group(1) or '') + m.group(2),
                         line_number=int(m.group(3)),
-                        content=m.group(4)[:500]
+                        content=m.group(4),
                     ))
                     continue
                 
@@ -3360,7 +3379,7 @@ class ShellFileOperations(FileOperations):
                         matches.append(SearchMatch(
                             path=parsed[0],
                             line_number=parsed[1],
-                            content=parsed[2][:500]
+                            content=parsed[2],
                         ))
             
             total = len(matches)
@@ -3554,7 +3573,7 @@ class ShellFileOperations(FileOperations):
                     matches.append(SearchMatch(
                         path=(m.group(1) or '') + m.group(2),
                         line_number=int(m.group(3)),
-                        content=m.group(4)[:500]
+                        content=m.group(4),
                     ))
                     continue
                 
@@ -3564,7 +3583,7 @@ class ShellFileOperations(FileOperations):
                         matches.append(SearchMatch(
                             path=parsed[0],
                             line_number=parsed[1],
-                            content=parsed[2][:500]
+                            content=parsed[2],
                         ))
 
             

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -18,6 +18,7 @@ from tools.binary_extensions import (
     is_pdf_path,
 )
 from tools.file_operations import (
+    DEFAULT_SEARCH_CONTENT_CHARS,
     ShellFileOperations,
     normalize_read_pagination,
     normalize_search_pagination,
@@ -2547,10 +2548,18 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
+                max_content_chars: int = DEFAULT_SEARCH_CONTENT_CHARS,
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+        if (not isinstance(max_content_chars, int)
+                or isinstance(max_content_chars, bool)
+                or max_content_chars < 1):
+            return tool_error(
+                "max_content_chars must be an integer greater than or equal to 1. "
+                "Choose the number of characters to return per matching or context line."
+            )
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
@@ -2563,6 +2572,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             file_glob or "",
             limit,
             offset,
+            max_content_chars,
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -2608,7 +2618,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            limit=limit, offset=offset, output_mode=output_mode, context=context,
+            max_content_chars=max_content_chars,
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):
@@ -2643,6 +2654,13 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if result_dict.get("truncated"):
             next_offset = offset + limit
             result_json += f"\n\n[Hint: Results truncated. Use offset={next_offset} to see more, or narrow with a more specific pattern or file_glob.]"
+        if result_dict.get("content_truncated"):
+            result_json += (
+                f"\n\n[Hint: Matching line content was truncated at "
+                f"max_content_chars={max_content_chars}. Increase "
+                "max_content_chars to retrieve more. You can reduce limit or "
+                "narrow the search to keep the response smaller.]"
+            )
         return result_json
     except Exception as e:
         return tool_error(str(e))
@@ -2757,7 +2775,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "max_content_chars": {"type": "integer", "description": f"Maximum characters returned per matching or context line (content mode, default {DEFAULT_SEARCH_CONTENT_CHARS}). Results with clipped lines set content_truncated=true.", "default": DEFAULT_SEARCH_CONTENT_CHARS, "minimum": 1}
         },
         "required": ["pattern"]
     }
@@ -2815,7 +2834,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        max_content_chars=args.get("max_content_chars", DEFAULT_SEARCH_CONTENT_CHARS), task_id=tid)
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)


### PR DESCRIPTION
## What does this PR do?

`search_files` currently clips every matching or context line at 500 characters without telling the agent. A search can therefore match text near the end of a long Markdown paragraph while returning only the beginning of the line. The agent sees a result that looks complete and cannot retrieve the omitted suffix with the existing parameters.

This change keeps the 500-character default. It adds `content_truncated: true` to results containing clipped lines and exposes a positive integer `max_content_chars` parameter so the agent can retry when it needs more of a line. The parameter has no upper bound, so the tool does not replace one unrecoverable content ceiling with another. Invalid values return an explicit error instead of being silently changed. The response tells the agent to increase `max_content_chars` and notes that it can reduce `limit` or narrow the search to keep the response smaller. Default searches retain their existing output bound, compact representation, and shell execution behavior.

## Related Issue

Fixes #96630

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add result-level `content_truncated` metadata when any matching or context line is clipped.
- Add `max_content_chars` to the `search_files` schema and propagate it through single-path and multi-path searches.
- Keep the default at 500 characters, document a minimum of 1, and reject invalid values explicitly.
- Allow the agent to request longer lines without imposing another arbitrary ceiling.
- Apply the limit once after the final result page is assembled.
- Preserve the existing densified output and tell the agent how to request more content.
- Add regression coverage for both search backends, schema dispatch, bounds, output metadata, retry behavior, and the model-facing hint.

## How to Test

1. Run the regression tests:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_tools.py -k 'SearchMatchContentLimit or content_truncation_metadata_preserves_densification or match_content_truncation_hint_explains_retry or registry_handler_forwards_match_content_limit or search_rejects_invalid_match_content_limit' -q
   ```

2. Run the affected file-tool suites:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_tools.py -k 'not test_writes_content and not test_replace_mode_calls_patch_replace' -q
   ```

   Result on macOS 15.6.1 with Python 3.11.11: 138 passed and 4 skipped. The two excluded tests compare `/tmp` with its resolved macOS path, `/private/tmp`, and are unrelated to this change.

3. Run lint and whitespace checks:

   ```bash
   ruff check tools/file_operations.py tools/file_tools.py tests/tools/test_file_operations.py tests/tools/test_file_tools.py
   git diff --check main...HEAD
   ```

4. The full repository suite was started in an isolated development environment. It reached 1,180 passing tests before the run was stopped. The environment lacked optional `acp` and `anthropic` SDKs, which caused unrelated collection and provider-client failures. The complete suite still needs to run in the project’s standard development environment or CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1, Python 3.11.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A: N/A beyond the tool schema and docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: N/A, no config key added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Baseline regression on current `main`:

```text
AttributeError: 'SearchResult' object has no attribute 'content_truncated'
```

The same regression test passes on this branch. The tests verify that the default response marks omitted content and that a retry with `max_content_chars=1000` returns the matching text.