### PR TITLE
fix(cron): keep deleted profiles from returning

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -28,8 +28,10 @@ _PROCESS_ID = uuid.uuid4().hex
 
 
 def _connect() -> sqlite3.Connection:
+    from cron.jobs import _ensure_cron_dir
+
     path = EXECUTIONS_FILE or (get_hermes_home().resolve() / "cron" / "executions.db")
-    path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_cron_dir(path.parent)
     return sqlite3.connect(path, timeout=5)
 
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -695,11 +695,23 @@ def _preserve_file_ownership(path: Path, before: Optional[os.stat_result]) -> No
         )
 
 
+def _ensure_cron_dir(cron_dir: Path) -> None:
+    """Create a cron directory without resurrecting a deleted profile home."""
+    profile_home = cron_dir.parent
+    if profile_home.parent.name == "profiles":
+        # Named profiles are created by the profile lifecycle, not cron.  A
+        # stale multiplex scheduler may still hold this path after deletion;
+        # parents=False makes that race fail closed instead of restoring it.
+        cron_dir.mkdir(exist_ok=True)
+        return
+    cron_dir.mkdir(parents=True, exist_ok=True)
+
+
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
     store = _current_cron_store()
-    store.cron_dir.mkdir(parents=True, exist_ok=True)
-    store.output_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_cron_dir(store.cron_dir)
+    store.output_dir.mkdir(exist_ok=True)
     _secure_dir(store.cron_dir)
     _secure_dir(store.output_dir)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -640,6 +640,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import (
+    _ensure_cron_dir,
     advance_next_runs,
     claim_dispatch,
     claim_job_for_fire,
@@ -7687,7 +7688,7 @@ def tick(
         Number of jobs executed (0 if another tick is already running)
     """
     lock_dir, lock_file = _get_lock_paths()
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_cron_dir(lock_dir)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows.
     # Only genuine lock contention (another ticker holds the lock) skips the

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -656,9 +657,28 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
+        removed_profiles = set()
+
+        def active_profile_homes():
+            for entry in profile_homes:
+                if isinstance(entry, tuple):
+                    name, raw_home = entry
+                    home = Path(raw_home)
+                    if name != "default" and not home.is_dir():
+                        if name not in removed_profiles:
+                            logger.info(
+                                "Skipping removed profile %r in multiplex cron scheduler",
+                                name,
+                            )
+                            removed_profiles.add(name)
+                        continue
+                    removed_profiles.discard(name)
+                else:
+                    home = Path(entry)
+                yield entry, home
+
         # Recovery + initial heartbeat for every profile.
-        for entry in profile_homes:
-            home = entry[1] if isinstance(entry, tuple) else entry
+        for _entry, home in active_profile_homes():
             home_token = set_hermes_home_override(str(home))
             try:
                 with use_cron_store(home):
@@ -681,8 +701,7 @@ class InProcessCronScheduler(CronScheduler):
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
-                    for entry in profile_homes:
-                        home = entry[1] if isinstance(entry, tuple) else entry
+                    for _entry, home in active_profile_homes():
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
@@ -704,8 +723,7 @@ class InProcessCronScheduler(CronScheduler):
             else:
                 _tick_error = None
             # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
+            for _entry, home in active_profile_homes():
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1128,6 +1128,29 @@ class TestLateEnvRepointScopesStore:
             store = jobs._current_cron_store()
             assert store.jobs_file == (tmp_path / "override-home").resolve() / "cron" / "jobs.json"
 
+    def test_heartbeat_does_not_recreate_deleted_named_profile(self, tmp_path):
+        import cron.jobs as jobs
+
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        deleted_home = profiles_dir / "deleted"
+
+        with jobs.use_cron_store(deleted_home):
+            jobs.record_ticker_heartbeat()
+
+        assert not deleted_home.exists()
+
+    def test_heartbeat_initializes_existing_named_profile(self, tmp_path):
+        import cron.jobs as jobs
+
+        profile_home = tmp_path / "profiles" / "active"
+        profile_home.mkdir(parents=True)
+
+        with jobs.use_cron_store(profile_home):
+            jobs.record_ticker_heartbeat()
+
+        assert (profile_home / "cron" / "ticker_heartbeat").is_file()
+
 
     def test_public_io_after_late_env_repoint_leaves_old_file_untouched(
         self, tmp_path, monkeypatch

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,37 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_skips_deleted_profile_from_startup_snapshot(tmp_path):
+    """A stale profile_homes entry must not recreate a deleted profile."""
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / "default"
+    (default_home / "cron").mkdir(parents=True)
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir()
+    deleted_home = profiles_dir / "deleted"
+    profile_homes = [("default", default_home), ("deleted", deleted_home)]
+
+    ticked_homes = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        ticked_homes.append(jobs._current_cron_store().cron_dir.parent)
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert ticked_homes == [default_home.resolve()]
+    assert not deleted_home.exists()


### PR DESCRIPTION
## What does this PR do?

Prevents a multiplex cron scheduler from recreating a named profile after the profile has been deleted.

The Desktop backend captures the served profile homes when its cron scheduler starts. If a named profile is deleted while that backend is still running, the stale scheduler entry can recreate the profile directory through heartbeat, execution-ledger, or tick-lock directory creation. This change skips named profile homes that no longer exist and makes cron directory creation fail closed if deletion races with a tick. Default/custom Hermes homes keep their existing first-run directory creation behavior.

## Related Issue

No public issue. Reproduced from a support diagnostic against current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip missing named-profile homes in the multiplex scheduler's recovery, tick, and heartbeat passes.
- Refuse to recreate a deleted named-profile parent from cron storage, execution-ledger, or tick-lock setup.
- Add behavioral regressions for a stale scheduler snapshot and heartbeat directory creation.

## How to Test

1. Start the multiplex scheduler with an existing default home and a stale named-profile home that no longer exists.
2. Allow one tick cycle to run.
3. Verify only the default profile is ticked and the deleted named-profile directory is not recreated.
4. Verify an existing named profile can still initialize its cron heartbeat directory normally.

Local Python tests were not run under this workstation's test-execution policy. Focused regression tests are included for GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Not run locally; GitHub CI requested

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The regression is covered by isolated temporary-profile tests without customer data.
