### PR TITLE
feat(telegram): add Bot API 10.3 rich button messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -206,6 +206,10 @@ from gateway.platforms.base import (
     _TEXT_INJECT_EXTENSIONS,
     utf16_len,
 )
+from plugins.platforms.telegram.rich_buttons import (
+    RichMessageValidationError,
+    validate_input_rich_message,
+)
 from plugins.platforms.telegram.telegram_ids import (
     normalize_telegram_chat_id,
 )
@@ -2232,22 +2236,36 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
+        *,
+        rich_message: Optional[Dict[str, Any]] = None,
+        allow_fallback: bool = True,
     ) -> Optional[SendResult]:
         """Attempt a single ``sendRichMessage`` send.
 
-        Returns a :class:`SendResult` (success, or a transient failure that the
-        caller must NOT legacy-resend), or ``None`` to signal "fall back to the
-        legacy MarkdownV2 path" (permanent/capability error or DM-topic skip).
+        The automatic markdown path leaves ``rich_message`` unset and uses
+        ``allow_fallback=True``. Public plugin calls pass a validated
+        ``InputRichMessage`` and disable legacy fallback because structured
+        blocks have no lossless MarkdownV2 equivalent.
         """
         thread_id = self._metadata_thread_id(metadata)
         routing = self._compute_single_send_routing(chat_id, reply_to, metadata, thread_id)
         if routing is None:
-            return None
+            if allow_fallback:
+                return None
+            return SendResult(
+                success=False,
+                error=self._dm_topic_missing_anchor_error(),
+                retryable=False,
+            )
         reply_to_id, thread_kwargs = routing
 
         payload: Dict[str, Any] = {
             "chat_id": normalize_telegram_chat_id(chat_id),
-            "rich_message": self._rich_message_payload(content),
+            "rich_message": (
+                rich_message
+                if rich_message is not None
+                else self._rich_message_payload(content)
+            ),
         }
         # Only forward non-None routing keys: when direct_messages_topic_id is
         # present _thread_kwargs_for_send pairs it with message_thread_id=None,
@@ -2277,9 +2295,23 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Endpoint missing (old PTB/server) — latch rich off so
                     # every later send doesn't pay a doomed extra roundtrip.
                     self._rich_send_disabled = True
+                safe_error = _redact_telegram_error_text(exc)
+                if not allow_fallback:
+                    error_kind = classify_send_error(exc)
+                    logger.debug(
+                        "[%s] explicit sendRichMessage rejected (%s)",
+                        self.name,
+                        error_kind,
+                    )
+                    return SendResult(
+                        success=False,
+                        error="rich_message_rejected",
+                        retryable=False,
+                        error_kind=error_kind,
+                    )
                 logger.debug(
                     "[%s] sendRichMessage rejected (%s) — falling back to MarkdownV2",
-                    self.name, _redact_telegram_error_text(exc),
+                    self.name, safe_error,
                 )
                 return None
             # Transient / network / unknown: the request may have reached
@@ -2302,6 +2334,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 if _m:
                     _retry_after = float(_m.group(1))
             safe_error = _redact_telegram_error_text(exc)
+            if not allow_fallback:
+                error_kind = classify_send_error(exc)
+                logger.warning(
+                    "[%s] explicit sendRichMessage transport failure "
+                    "(%s; no legacy resend)",
+                    self.name,
+                    exc.__class__.__name__,
+                )
+                return SendResult(
+                    success=False,
+                    error="rich_message_transport_failure",
+                    retryable=(is_connect_timeout or not is_timeout),
+                    retry_after=_retry_after,
+                    error_kind=error_kind,
+                )
             logger.warning(
                 "[%s] sendRichMessage transient failure (no legacy resend): %s",
                 self.name, safe_error,
@@ -2320,9 +2367,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_id = (msg.get("result") or {}).get("message_id")
         else:
             message_id = getattr(msg, "message_id", None)
-        if message_id is not None:
+        if message_id is not None and content:
             # Telegram won't echo rich content in reply_to_message, so remember
-            # what we sent — replies to this message resolve via this index.
+            # only the explicit plain-text context supplied by the caller.
             try:
                 from gateway import rich_sent_store
                 rich_sent_store.record(str(chat_id), str(message_id), content)
@@ -2339,24 +2386,24 @@ class TelegramAdapter(BasePlatformAdapter):
         message_id: str,
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
+        *,
+        rich_message: Optional[Dict[str, Any]] = None,
+        allow_fallback: bool = True,
     ) -> Optional[SendResult]:
-        """Edit an existing message in place as a rich message (Bot API 10.1).
+        """Edit an existing message in place as a rich message.
 
-        Uses ``editMessageText`` with the ``rich_message`` parameter so a
-        streamed preview can finalize as rich (tables/task lists/details/math)
-        WITHOUT a fresh send + delete — no duplicate preview.  Mirrors
-        :meth:`_try_send_rich`'s error contract:
-
-        - success → ``SendResult(success=True, message_id=...)``
-        - permanent / capability error → ``None`` (caller falls back to the
-          legacy MarkdownV2 edit; capability errors latch rich off)
-        - transient / unknown → ``SendResult(success=False)`` with retry
-          semantics (the message may already be edited; do NOT legacy-resend)
+        Automatic finalization keeps the legacy-fallback contract. Public
+        plugin calls pass a validated ``InputRichMessage`` and disable fallback
+        so a structured card is never silently flattened.
         """
         payload: Dict[str, Any] = {
             "chat_id": normalize_telegram_chat_id(chat_id),
             "message_id": int(message_id),
-            "rich_message": self._rich_message_payload(content),
+            "rich_message": (
+                rich_message
+                if rich_message is not None
+                else self._rich_message_payload(content)
+            ),
         }
         # Edits target an existing message by chat_id + message_id. Topic
         # routing belongs only on send endpoints; forwarding message_thread_id
@@ -2374,13 +2421,26 @@ class TelegramAdapter(BasePlatformAdapter):
                 if self._is_rich_capability_error(exc):
                     self._rich_send_disabled = True
                 # "Message is not modified" — content identical to the current
-                # rich message; treat as a successful no-op so the caller does
-                # not fall through to a redundant legacy edit.
+                # rich message; treat as a successful no-op.
                 if "not modified" in str(exc).lower():
                     return SendResult(success=True, message_id=message_id)
+                safe_error = _redact_telegram_error_text(exc)
+                if not allow_fallback:
+                    error_kind = classify_send_error(exc)
+                    logger.debug(
+                        "[%s] explicit rich edit rejected (%s)",
+                        self.name,
+                        error_kind,
+                    )
+                    return SendResult(
+                        success=False,
+                        error="rich_message_rejected",
+                        retryable=False,
+                        error_kind=error_kind,
+                    )
                 logger.debug(
                     "[%s] rich editMessageText rejected (%s) — falling back to MarkdownV2 edit",
-                    self.name, _redact_telegram_error_text(exc),
+                    self.name, safe_error,
                 )
                 return None
             if "not modified" in str(exc).lower():
@@ -2393,6 +2453,20 @@ class TelegramAdapter(BasePlatformAdapter):
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
             safe_error = _redact_telegram_error_text(exc)
+            if not allow_fallback:
+                error_kind = classify_send_error(exc)
+                logger.warning(
+                    "[%s] explicit rich edit transport failure "
+                    "(%s; no legacy resend)",
+                    self.name,
+                    exc.__class__.__name__,
+                )
+                return SendResult(
+                    success=False,
+                    error="rich_message_transport_failure",
+                    retryable=(is_connect_timeout or not is_timeout),
+                    error_kind=error_kind,
+                )
             logger.warning(
                 "[%s] rich editMessageText transient failure (no legacy resend): %s",
                 self.name, safe_error,
@@ -2402,15 +2476,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 error=safe_error,
                 retryable=(is_connect_timeout or not is_timeout),
             )
-        # Telegram won't echo rich content for messages that predate the bot's
-        # first rich send, so mirror the fresh-send index here too: a streamed
-        # final finalized via editMessageText is otherwise never recorded, and
-        # replies to it would have no native echo to recover from.
-        try:
-            from gateway import rich_sent_store
-            rich_sent_store.record(str(chat_id), str(message_id), content)
-        except Exception:
-            pass
+        if content:
+            # Keep only caller-provided plain-text reply context, never the
+            # serialized structured payload.
+            try:
+                from gateway import rich_sent_store
+                rich_sent_store.record(str(chat_id), str(message_id), content)
+            except Exception:
+                pass
         return SendResult(success=True, message_id=message_id)
 
     def _should_attempt_rich_draft(self, content: str) -> bool:
@@ -5258,6 +5331,198 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         else:  # "first" (default)
             return chunk_index == 0
+
+    async def send_rich_message(
+        self,
+        chat_id: str,
+        rich_message: Dict[str, Any],
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        context_text: Optional[str] = None,
+    ) -> SendResult:
+        """Send a JSON-compatible Telegram ``InputRichMessage``.
+
+        This is the plugin-facing path for Bot API rich blocks, including 10.3
+        buttons. Callback handling remains on ``register_platform_handler``;
+        this method owns only delivery, routing, and safe failure semantics.
+        ``context_text`` is optional plain text stored locally for replies to a
+        rich message, whose content Telegram does not echo back to bots.
+        """
+        try:
+            validated = validate_input_rich_message(rich_message)
+            if context_text is not None and not isinstance(context_text, str):
+                raise RichMessageValidationError(
+                    "context_text must be a string when provided"
+                )
+            if metadata is not None and not isinstance(metadata, dict):
+                raise RichMessageValidationError(
+                    "metadata must be an object when provided"
+                )
+            if reply_to is not None:
+                int(reply_to)
+        except (RichMessageValidationError, TypeError, ValueError) as exc:
+            if isinstance(exc, RichMessageValidationError):
+                detail = str(exc)
+            else:
+                detail = "reply_to must be an integer"
+            return SendResult(
+                success=False,
+                error=f"invalid_rich_message: {detail}",
+                retryable=False,
+                error_kind="bad_format",
+            )
+
+        if not self._bot:
+            live = self._replacement_telegram_adapter()
+            if live is not None:
+                return await live.send_rich_message(
+                    chat_id,
+                    validated,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                    context_text=context_text,
+                )
+            if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+                return SendResult(
+                    success=False,
+                    error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            live = self._replacement_telegram_adapter()
+            if not self._bot and live is not None:
+                return await live.send_rich_message(
+                    chat_id,
+                    validated,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                    context_text=context_text,
+                )
+            if not self._bot:
+                return SendResult(success=False, error="Not connected", retryable=True)
+
+        if getattr(self, "_send_path_degraded", False):
+            return SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            )
+        if not self._rich_delivery_enabled():
+            return SendResult(
+                success=False,
+                error="rich_messages_disabled",
+                retryable=False,
+            )
+        if getattr(self, "_rich_send_disabled", False) or not self._bot_supports_rich():
+            return SendResult(
+                success=False,
+                error="rich_messages_unavailable",
+                retryable=False,
+            )
+
+        result = await self._try_send_rich(
+            chat_id,
+            context_text or "",
+            reply_to,
+            metadata,
+            rich_message=validated,
+            allow_fallback=False,
+        )
+        if result is None:  # Defensive: explicit sends never request fallback.
+            return SendResult(
+                success=False,
+                error="rich_message_rejected",
+                retryable=False,
+            )
+        return result
+
+    async def edit_rich_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        rich_message: Dict[str, Any],
+        *,
+        context_text: Optional[str] = None,
+    ) -> SendResult:
+        """Edit an existing Telegram message with an ``InputRichMessage``."""
+        try:
+            validated = validate_input_rich_message(rich_message)
+            if context_text is not None and not isinstance(context_text, str):
+                raise RichMessageValidationError(
+                    "context_text must be a string when provided"
+                )
+            int(message_id)
+        except (RichMessageValidationError, TypeError, ValueError) as exc:
+            if isinstance(exc, RichMessageValidationError):
+                detail = str(exc)
+            else:
+                detail = "message_id must be an integer"
+            return SendResult(
+                success=False,
+                error=f"invalid_rich_message: {detail}",
+                retryable=False,
+                error_kind="bad_format",
+            )
+
+        if not self._bot:
+            live = self._replacement_telegram_adapter()
+            if live is not None:
+                return await live.edit_rich_message(
+                    chat_id,
+                    message_id,
+                    validated,
+                    context_text=context_text,
+                )
+            if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+                return SendResult(
+                    success=False,
+                    error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            live = self._replacement_telegram_adapter()
+            if not self._bot and live is not None:
+                return await live.edit_rich_message(
+                    chat_id,
+                    message_id,
+                    validated,
+                    context_text=context_text,
+                )
+            if not self._bot:
+                return SendResult(success=False, error="Not connected", retryable=True)
+
+        if getattr(self, "_send_path_degraded", False):
+            return SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+            )
+        if not self._rich_delivery_enabled():
+            return SendResult(
+                success=False,
+                error="rich_messages_disabled",
+                retryable=False,
+            )
+        if getattr(self, "_rich_send_disabled", False) or not self._bot_supports_rich():
+            return SendResult(
+                success=False,
+                error="rich_messages_unavailable",
+                retryable=False,
+            )
+
+        result = await self._try_edit_rich(
+            chat_id,
+            message_id,
+            context_text or "",
+            rich_message=validated,
+            allow_fallback=False,
+        )
+        if result is None:  # Defensive: explicit edits never request fallback.
+            return SendResult(
+                success=False,
+                error="rich_message_rejected",
+                retryable=False,
+            )
+        return result
 
     async def send(
         self,

--- a/plugins/platforms/telegram/rich_buttons.py
+++ b/plugins/platforms/telegram/rich_buttons.py
@@ -1,0 +1,324 @@
+"""Validation helpers for Telegram Bot API rich-message buttons.
+
+The adapter accepts JSON-compatible ``InputRichMessage`` dictionaries so
+plugins can use new Bot API fields before python-telegram-bot models them.
+Only the Bot API 10.3 button contract is validated here; unrelated rich block
+schemas remain Telegram's responsibility.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+_CONTENT_MODES = ("html", "markdown", "blocks")
+_BUTTON_ACTIONS = (
+    "url",
+    "callback_data",
+    "web_app",
+    "login_url",
+    "switch_inline_query",
+    "switch_inline_query_current_chat",
+    "switch_inline_query_chosen_chat",
+    "copy_text",
+    "disabled",
+)
+_BUTTON_STYLES = {"danger", "success", "primary", "link"}
+_ROW_ALIGNMENTS = {"left", "center", "right"}
+_MAX_VISITED_CONTAINERS = 10_000
+_MAX_TRAVERSAL_DEPTH = 32
+_MAX_RICH_TEXT_CHARS = 32_768
+
+
+class RichMessageValidationError(ValueError):
+    """A JSON rich-message payload violates Hermes' local safety contract."""
+
+
+def _require_mapping(value: Any, message: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RichMessageValidationError(message)
+    return value
+
+
+def _validate_button_text(value: Any) -> None:
+    """Validate the restricted RichText grammar allowed in button labels.
+
+    Bot API 10.3 permits only plain strings, RichTextCustomEmoji, and
+    RichTextDateTime inside RichMessageButton.text.
+    """
+    stack = [(value, 0, True)]
+    seen = set()
+    visited = 0
+
+    while stack:
+        item, depth, allow_sequence = stack.pop()
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise RichMessageValidationError("rich button text nesting is too deep")
+        if isinstance(item, str):
+            if not item:
+                raise RichMessageValidationError(
+                    "rich button text must not contain empty text"
+                )
+            continue
+        if not isinstance(item, (dict, list)) or not item:
+            raise RichMessageValidationError(
+                "rich button text must be non-empty plain text, custom emoji, or date-time text"
+            )
+
+        identity = id(item)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        visited += 1
+        if visited > _MAX_VISITED_CONTAINERS:
+            raise RichMessageValidationError("rich button text structure is too large")
+
+        if isinstance(item, list):
+            if not allow_sequence:
+                raise RichMessageValidationError(
+                    "rich button text sequences must not contain nested sequences"
+                )
+            stack.extend((child, depth + 1, False) for child in item)
+            continue
+
+        item_type = item.get("type")
+        if item_type == "custom_emoji":
+            if set(item) != {"type", "custom_emoji_id", "alternative_text"}:
+                raise RichMessageValidationError(
+                    "rich button custom emoji has an invalid shape"
+                )
+            if not isinstance(item.get("custom_emoji_id"), str) or not item[
+                "custom_emoji_id"
+            ]:
+                raise RichMessageValidationError(
+                    "rich button custom emoji requires custom_emoji_id"
+                )
+            if not isinstance(item.get("alternative_text"), str) or not item[
+                "alternative_text"
+            ]:
+                raise RichMessageValidationError(
+                    "rich button custom emoji requires alternative_text"
+                )
+        elif item_type == "date_time":
+            if set(item) != {"type", "text", "unix_time", "date_time_format"}:
+                raise RichMessageValidationError(
+                    "rich button date-time text has an invalid shape"
+                )
+            unix_time = item.get("unix_time")
+            if not isinstance(unix_time, int) or isinstance(unix_time, bool):
+                raise RichMessageValidationError(
+                    "rich button date-time text requires an integer unix_time"
+                )
+            if not isinstance(item.get("date_time_format"), str) or not item[
+                "date_time_format"
+            ]:
+                raise RichMessageValidationError(
+                    "rich button date-time text requires date_time_format"
+                )
+            stack.append((item.get("text"), depth + 1, True))
+        else:
+            raise RichMessageValidationError(
+                "rich button text contains a RichText type not allowed by Bot API 10.3"
+            )
+
+
+def _validate_button(button: Any) -> None:
+    button = _require_mapping(button, "rich button must be an object")
+    _validate_button_text(button.get("text"))
+
+    allowed_fields = {"text", "style", *_BUTTON_ACTIONS}
+    if any(name not in allowed_fields for name in button):
+        raise RichMessageValidationError(
+            "rich button contains fields outside the Bot API 10.3 contract"
+        )
+
+    actions = [name for name in _BUTTON_ACTIONS if name in button]
+    if len(actions) != 1:
+        raise RichMessageValidationError(
+            "rich button must contain exactly one Bot API 10.3 action"
+        )
+    action = actions[0]
+    action_value = button[action]
+
+    style = button.get("style")
+    if style is not None and style not in _BUTTON_STYLES:
+        raise RichMessageValidationError("rich button style is not supported")
+    if style == "link" and action != "callback_data":
+        raise RichMessageValidationError(
+            "rich button style 'link' requires callback_data"
+        )
+
+    action_object: Dict[str, Any] | None = None
+    if action in {"url", "callback_data"}:
+        if not isinstance(action_value, str) or not action_value:
+            raise RichMessageValidationError(
+                f"rich button {action} must be a non-empty string"
+            )
+    elif action in {"switch_inline_query", "switch_inline_query_current_chat"}:
+        if not isinstance(action_value, str):
+            raise RichMessageValidationError(
+                f"rich button {action} must be a string"
+            )
+    else:
+        action_object = _require_mapping(
+            action_value,
+            f"rich button {action} must be an object",
+        )
+
+    if action == "callback_data":
+        callback_size = len(action_value.encode("utf-8"))
+        if not 1 <= callback_size <= 64:
+            raise RichMessageValidationError(
+                "rich button callback_data must be 1-64 UTF-8 bytes"
+            )
+    elif action == "copy_text":
+        assert action_object is not None
+        copy_text = action_object.get("text")
+        if not isinstance(copy_text, str) or not 1 <= len(copy_text) <= 256:
+            raise RichMessageValidationError(
+                "rich button copy_text.text must be 1-256 characters"
+            )
+    elif action in {"web_app", "login_url"}:
+        assert action_object is not None
+        url = action_object.get("url")
+        if not isinstance(url, str) or not url:
+            raise RichMessageValidationError(
+                f"rich button {action}.url must be a non-empty string"
+            )
+    elif action == "disabled" and action_object:
+        raise RichMessageValidationError(
+            "rich button disabled must be an empty object"
+        )
+
+
+def _validate_button_row(block: Dict[str, Any]) -> None:
+    buttons = block.get("buttons")
+    if not isinstance(buttons, list) or not 1 <= len(buttons) <= 8:
+        raise RichMessageValidationError(
+            "rich button row must contain 1-8 buttons"
+        )
+    align = block.get("align")
+    if align is not None and align not in _ROW_ALIGNMENTS:
+        raise RichMessageValidationError(
+            "rich button row align must be left, center, or right"
+        )
+    for button in buttons:
+        _validate_button(button)
+
+
+def _validate_buttons_bounded(root: Any) -> None:
+    stack = [("enter", root, 0, "root")]
+    active = set()
+    visited = 0
+
+    while stack:
+        phase, value, depth, role = stack.pop()
+        if phase == "exit":
+            active.remove(id(value))
+            continue
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise RichMessageValidationError("rich message nesting is too deep")
+        if not isinstance(value, (dict, list)):
+            if value is None or isinstance(value, (str, bool, int, float)):
+                continue
+            raise RichMessageValidationError(
+                "rich_message must contain only JSON-native values"
+            )
+
+        identity = id(value)
+        if identity in active:
+            raise RichMessageValidationError(
+                "rich_message must not contain container cycles"
+            )
+        active.add(identity)
+        visited += 1
+        if visited > _MAX_VISITED_CONTAINERS:
+            raise RichMessageValidationError("rich message structure is too large")
+
+        stack.append(("exit", value, depth, role))
+        child_entries = []
+        if isinstance(value, dict):
+            if any(not isinstance(key, str) for key in value):
+                raise RichMessageValidationError(
+                    "rich_message object keys must be strings"
+                )
+            node_type = value.get("type")
+            if role == "block" and node_type == "buttons":
+                _validate_button_row(value)
+            elif role == "rich_text" and node_type == "button":
+                _validate_button(value.get("button"))
+
+            for key, child in value.items():
+                if key == "blocks" and role in {
+                    "root",
+                    "block",
+                    "block_container",
+                }:
+                    child_role = "block_list"
+                elif key == "items" and role == "block":
+                    child_role = "block_container"
+                elif key == "text" and role in {"block", "rich_text"}:
+                    child_role = "rich_text"
+                elif role == "block_container":
+                    child_role = "block_container"
+                else:
+                    child_role = "opaque"
+                child_entries.append((child, child_role))
+        else:
+            if role == "block_list":
+                child_role = "block"
+            elif role in {"rich_text", "block_container"}:
+                child_role = role
+            else:
+                child_role = "opaque"
+            child_entries.extend((child, child_role) for child in value)
+
+        stack.extend(
+            ("enter", child, depth + 1, child_role)
+            for child, child_role in reversed(child_entries)
+        )
+
+
+def validate_input_rich_message(rich_message: Any) -> Dict[str, Any]:
+    """Validate JSON transport and Bot API 10.3 button invariants.
+
+    Returns the original dictionary without mutating or copying it. Error text is
+    deliberately structural and never includes caller-provided values.
+    """
+    rich_message = _require_mapping(
+        rich_message, "rich_message must be a JSON object"
+    )
+    modes = [name for name in _CONTENT_MODES if name in rich_message]
+    if len(modes) != 1:
+        raise RichMessageValidationError(
+            "rich_message must contain exactly one of html, markdown, or blocks"
+        )
+
+    mode = modes[0]
+    content = rich_message[mode]
+    if mode in {"html", "markdown"}:
+        if not isinstance(content, str) or not content:
+            raise RichMessageValidationError(
+                f"rich_message {mode} must be a non-empty string"
+            )
+        if len(content) > _MAX_RICH_TEXT_CHARS:
+            raise RichMessageValidationError(
+                f"rich_message {mode} exceeds the 32768-character limit"
+            )
+    elif not isinstance(content, list) or not content:
+        raise RichMessageValidationError(
+            "rich_message blocks must be a non-empty list"
+        )
+
+    # Bound depth/container work before asking the JSON encoder to traverse the
+    # entire payload. The encoder then supplies the final acyclic/type check.
+    _validate_buttons_bounded(rich_message)
+    try:
+        json.dumps(rich_message, ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError, RecursionError):
+        raise RichMessageValidationError(
+            "rich_message must be finite, acyclic, and JSON-compatible"
+        ) from None
+
+    return rich_message

--- a/tests/gateway/test_telegram_rich_buttons.py
+++ b/tests/gateway/test_telegram_rich_buttons.py
@@ -1,0 +1,724 @@
+"""Focused contract tests for Telegram Bot API 10.3 rich buttons."""
+
+import logging
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import rich_sent_store
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from telegram.error import BadRequest, NetworkError
+
+
+def _make_adapter(*, rich_messages=True):
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"rich_messages": rich_messages},
+    )
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    bot.edit_message_text = AsyncMock(return_value=True)
+    adapter._bot = bot
+    return adapter
+
+
+def _button(text, action, value, *, style=None):
+    button = {"text": text, action: value}
+    if style is not None:
+        button["style"] = style
+    return button
+
+
+VALID_CARD = {
+    "blocks": [
+        {
+            "type": "paragraph",
+            "text": [
+                {"type": "plain", "text": "Choose "},
+                {
+                    "type": "button",
+                    "button": _button(
+                        "Inline", "callback_data", "demo:inline", style="primary"
+                    ),
+                },
+            ],
+        },
+        {
+            "type": "buttons",
+            "align": "center",
+            "buttons": [
+                _button(
+                    [
+                        {
+                            "type": "custom_emoji",
+                            "custom_emoji_id": "1",
+                            "alternative_text": "⭐",
+                        },
+                        " URL",
+                    ],
+                    "url",
+                    "https://example.com",
+                ),
+                _button("Callback", "callback_data", "demo:callback", style="link"),
+                _button("Web app", "web_app", {"url": "https://example.com/app"}),
+                _button(
+                    {
+                        "type": "date_time",
+                        "text": "Now",
+                        "unix_time": 1_800_000_000,
+                        "date_time_format": "day_month_year hour_minute",
+                    },
+                    "login_url",
+                    {"url": "https://example.com/login"},
+                ),
+                _button("Inline", "switch_inline_query", "search"),
+                _button("Here", "switch_inline_query_current_chat", "search"),
+                _button(
+                    "Choose chat",
+                    "switch_inline_query_chosen_chat",
+                    {"query": "search", "allow_user_chats": True},
+                ),
+                _button("Copy", "copy_text", {"text": "copied"}, style="success"),
+            ],
+        },
+        {
+            "type": "buttons",
+            "align": "right",
+            "buttons": [_button("Unavailable", "disabled", {}, style="danger")],
+        },
+    ]
+}
+
+
+def _mock_bot(adapter):
+    bot = adapter._bot
+    assert bot is not None
+    return cast(Any, bot)
+
+
+def _api_kwargs(adapter, endpoint):
+    call = _mock_bot(adapter).do_api_request.call_args
+    assert call.args[0] == endpoint
+    return call.kwargs["api_kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_preserves_all_actions_and_routing():
+    adapter = _make_adapter()
+    card = deepcopy(VALID_CARD)
+
+    result = await adapter.send_rich_message(
+        "-100123",
+        card,
+        reply_to="42",
+        metadata={"thread_id": "77"},
+        context_text="Approval card",
+    )
+
+    assert result.success is True
+    assert result.message_id == "123"
+    payload = _api_kwargs(adapter, "sendRichMessage")
+    assert payload["chat_id"] == -100123
+    assert payload["rich_message"] == card
+    assert payload["rich_message"] is card
+    assert payload["message_thread_id"] == 77
+    assert payload["reply_parameters"] == {"message_id": 42}
+    assert payload["disable_notification"] is True
+    _mock_bot(adapter).send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_edit_rich_message_preserves_payload_and_omits_send_routing():
+    adapter = _make_adapter()
+    card = deepcopy(VALID_CARD)
+
+    result = await adapter.edit_rich_message(
+        "-100123", "456", card, context_text="Updated approval card"
+    )
+
+    assert result.success is True
+    assert result.message_id == "456"
+    payload = _api_kwargs(adapter, "editMessageText")
+    assert payload == {
+        "chat_id": -100123,
+        "message_id": 456,
+        "rich_message": card,
+    }
+    _mock_bot(adapter).edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_context_text_is_the_only_content_recorded(monkeypatch):
+    adapter = _make_adapter()
+    record = MagicMock()
+    monkeypatch.setattr(rich_sent_store, "record", record)
+
+    await adapter.send_rich_message(
+        "123", deepcopy(VALID_CARD), context_text="Safe reply context"
+    )
+    record.assert_called_once_with("123", "123", "Safe reply context")
+
+    record.reset_mock()
+    await adapter.edit_rich_message("123", "456", deepcopy(VALID_CARD))
+    record.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {},
+        {"markdown": "one", "blocks": []},
+        {"markdown": ""},
+        {"blocks": []},
+        {"blocks": [object()]},
+    ],
+)
+async def test_invalid_top_level_payload_fails_before_api(payload):
+    adapter = _make_adapter()
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error_kind == "bad_format"
+    assert result.error.startswith("invalid_rich_message:")
+    _mock_bot(adapter).do_api_request.assert_not_called()
+    _mock_bot(adapter).send_message.assert_not_called()
+
+
+def _card_for(button, *, align="left", row_size=1):
+    return {
+        "blocks": [
+            {
+                "type": "buttons",
+                "align": align,
+                "buttons": [deepcopy(button) for _ in range(row_size)],
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _card_for({"callback_data": "x"}),
+        _card_for({"text": 1, "callback_data": "x"}),
+        _card_for({"text": [], "callback_data": "x"}),
+        _card_for({"text": {}, "callback_data": "x"}),
+        _card_for(_button([["nested"]], "callback_data", "x")),
+        _card_for(_button({"unexpected": True}, "callback_data", "x")),
+        _card_for(
+            _button(
+                {"type": "custom_emoji", "custom_emoji_id": "1"},
+                "callback_data",
+                "x",
+            )
+        ),
+        _card_for(
+            _button(
+                {
+                    "type": "date_time",
+                    "text": "Now",
+                    "unix_time": True,
+                    "date_time_format": "day_month_year",
+                },
+                "callback_data",
+                "x",
+            )
+        ),
+        _card_for(
+            {"text": "Unknown", "callback_data": "x", "future_action": {}}
+        ),
+        _card_for(_button("No action", "callback_data", "x") | {"url": "https://x"}),
+        _card_for(_button("Bad style", "callback_data", "x", style="secondary")),
+        _card_for(_button("Wrong link", "url", "https://x", style="link")),
+        _card_for(_button("Copy", "copy_text", {"text": "x" * 257})),
+        _card_for(_button("Web", "web_app", {})),
+        _card_for(_button("Disabled", "disabled", None)),
+        _card_for(_button("Disabled", "disabled", {"unexpected": True})),
+        _card_for(_button("Nine", "callback_data", "x"), row_size=9),
+        _card_for(_button("Align", "callback_data", "x"), align="justify"),
+    ],
+)
+async def test_invalid_button_contract_fails_before_api(payload):
+    adapter = _make_adapter()
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error_kind == "bad_format"
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callback_data", "expected_success"),
+    [
+        ("", False),
+        ("x", True),
+        ("x" * 64, True),
+        ("x" * 65, False),
+        ("🙂" * 16, True),
+        ("🙂" * 16 + "x", False),
+    ],
+)
+async def test_callback_data_exact_utf8_boundaries(callback_data, expected_success):
+    adapter = _make_adapter()
+    payload = _card_for(_button("Callback", "callback_data", callback_data))
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_inline_button_uses_the_same_callback_byte_validation():
+    adapter = _make_adapter()
+    payload = {
+        "blocks": [
+            {
+                "type": "paragraph",
+                "text": [
+                    {
+                        "type": "button",
+                        "button": _button(
+                            "Too large", "callback_data", "🙂" * 16 + "x"
+                        ),
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "1-64 UTF-8 bytes" in result.error
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("length", "expected_success"),
+    [(0, False), (1, True), (256, True), (257, False)],
+)
+async def test_copy_text_exact_character_boundaries(length, expected_success):
+    adapter = _make_adapter()
+    payload = _card_for(
+        _button("Copy", "copy_text", {"text": "x" * length})
+    )
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("row_size", "expected_success"),
+    [(0, False), (1, True), (8, True), (9, False)],
+)
+async def test_button_row_exact_size_boundaries(row_size, expected_success):
+    adapter = _make_adapter()
+    payload = _card_for(
+        _button("Choice", "callback_data", "x"), row_size=row_size
+    )
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("align", ["left", "center", "right"])
+async def test_all_button_row_alignments_are_accepted(align):
+    adapter = _make_adapter()
+    result = await adapter.send_rich_message(
+        "123", _card_for(_button("Choice", "callback_data", "x"), align=align)
+    )
+
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("style", [None, "danger", "success", "primary", "link"])
+async def test_all_button_styles_are_accepted_for_callbacks(style):
+    adapter = _make_adapter()
+    result = await adapter.send_rich_message(
+        "123", _card_for(_button("Choice", "callback_data", "x", style=style))
+    )
+
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [{"html": "<b>Hello</b>"}, {"markdown": "**Hello**"}],
+)
+async def test_valid_html_and_markdown_modes_pass_through(payload):
+    adapter = _make_adapter()
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is True
+    assert _api_kwargs(adapter, "sendRichMessage")["rich_message"] == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["html", "markdown"])
+@pytest.mark.parametrize(
+    ("length", "expected_success"), [(32_768, True), (32_769, False)]
+)
+async def test_rich_text_mode_exact_character_boundary(
+    mode, length, expected_success
+):
+    adapter = _make_adapter()
+
+    result = await adapter.send_rich_message("123", {mode: "x" * length})
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_json_container_and_non_string_key_fail_before_api():
+    adapter = _make_adapter()
+    invalid_button = _button("Bad", "callback_data", "")
+    tuple_payload = {"blocks": [("wrapper", {"type": "button", "button": invalid_button})]}
+    keyed_payload = {"blocks": [{1: "not-json-object-key"}]}
+
+    for payload in (tuple_payload, keyed_payload):
+        result = await adapter.send_rich_message("123", payload)
+        assert result.success is False
+        assert result.error_kind == "bad_format"
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_button_like_objects_in_unknown_block_fields_pass_through():
+    adapter = _make_adapter()
+    payload = {
+        "blocks": [
+            {
+                "type": "future_block",
+                "metadata": {
+                    "type": "button",
+                    "button": {"not": "a rich-text button at this position"},
+                },
+                "opaque": {"type": "buttons", "buttons": []},
+            }
+        ]
+    }
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is True
+    assert _api_kwargs(adapter, "sendRichMessage")["rich_message"] == payload
+
+
+@pytest.mark.asyncio
+async def test_button_rows_nested_in_list_item_blocks_are_validated():
+    valid = {
+        "blocks": [
+            {
+                "type": "list",
+                "items": [
+                    {
+                        "blocks": [
+                            _card_for(
+                                _button("Nested", "callback_data", "nested")
+                            )["blocks"][0]
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+    invalid = {
+        "blocks": [
+            {
+                "type": "list",
+                "items": [
+                    {"blocks": [{"type": "buttons", "buttons": []}]}
+                ],
+            }
+        ]
+    }
+
+    valid_adapter = _make_adapter()
+    valid_result = await valid_adapter.send_rich_message("123", valid)
+    assert valid_result.success is True
+
+    invalid_adapter = _make_adapter()
+    invalid_result = await invalid_adapter.send_rich_message("123", invalid)
+    assert invalid_result.success is False
+    assert invalid_result.error_kind == "bad_format"
+    _mock_bot(invalid_adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shared_container_identity_is_valid_json_and_is_preserved():
+    adapter = _make_adapter()
+    shared = {"type": "paragraph", "text": "shared"}
+    payload = {"blocks": [shared, shared]}
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is True
+    assert _api_kwargs(adapter, "sendRichMessage")["rich_message"] is payload
+
+
+@pytest.mark.asyncio
+async def test_shared_reference_dag_is_bounded_by_occurrence_count():
+    adapter = _make_adapter()
+    node = {}
+    for _ in range(13):
+        node = {"left": node, "right": node}
+    payload = {"blocks": [node]}
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is False
+    assert result.error == "invalid_rich_message: rich message structure is too large"
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+def _nested_blocks_payload(wrapper_count):
+    node = {}
+    for _ in range(wrapper_count):
+        node = {"child": node}
+    return {"blocks": [node]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("wrapper_count", "expected_success"), [(30, True), (31, False)]
+)
+async def test_traversal_depth_exact_boundary(wrapper_count, expected_success):
+    adapter = _make_adapter()
+
+    result = await adapter.send_rich_message(
+        "123", _nested_blocks_payload(wrapper_count)
+    )
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("block_count", "expected_success"), [(9_998, True), (9_999, False)]
+)
+async def test_container_count_exact_boundary(block_count, expected_success):
+    adapter = _make_adapter()
+    payload = {"blocks": [{} for _ in range(block_count)]}
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is expected_success
+    if expected_success:
+        _mock_bot(adapter).do_api_request.assert_awaited_once()
+    else:
+        _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cyclic_payload_fails_closed_without_echoing_payload():
+    adapter = _make_adapter()
+    payload = {"blocks": []}
+    payload["blocks"].append(payload)
+
+    result = await adapter.send_rich_message("123", payload)
+
+    assert result.success is False
+    assert result.error == (
+        "invalid_rich_message: rich_message must not contain container cycles"
+    )
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disabled_and_unavailable_rich_messages_fail_without_api_call():
+    disabled = _make_adapter(rich_messages=False)
+    disabled_result = await disabled.send_rich_message("123", deepcopy(VALID_CARD))
+    assert disabled_result.success is False
+    assert disabled_result.error == "rich_messages_disabled"
+    assert disabled_result.retryable is False
+    disabled._bot.do_api_request.assert_not_called()
+
+    unavailable = _make_adapter()
+    unavailable._rich_send_disabled = True
+    unavailable_result = await unavailable.send_rich_message(
+        "123", deepcopy(VALID_CARD)
+    )
+    assert unavailable_result.success is False
+    assert unavailable_result.error == "rich_messages_unavailable"
+    assert unavailable_result.retryable is False
+    unavailable._bot.do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_routing_metadata_fails_before_api_call():
+    adapter = _make_adapter()
+
+    bad_reply = await adapter.send_rich_message(
+        "123", deepcopy(VALID_CARD), reply_to="not-an-int"
+    )
+    assert bad_reply.success is False
+    assert bad_reply.error_kind == "bad_format"
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+    bad_metadata = await adapter.send_rich_message(
+        "123",
+        deepcopy(VALID_CARD),
+        metadata=cast(Any, ["not", "an", "object"]),
+    )
+    assert bad_metadata.success is False
+    assert bad_metadata.error_kind == "bad_format"
+    _mock_bot(adapter).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_permanent_rejection_never_legacy_resends_or_echoes_payload(caplog):
+    adapter = _make_adapter()
+    marker = "private-callback-marker"
+    caplog.set_level(logging.DEBUG)
+    _mock_bot(adapter).do_api_request = AsyncMock(
+        side_effect=BadRequest(f"can't parse rich message: {marker}")
+    )
+
+    result = await adapter.send_rich_message("123", deepcopy(VALID_CARD))
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error == "rich_message_rejected"
+    assert marker not in caplog.text
+    _mock_bot(adapter).do_api_request.assert_awaited_once()
+    _mock_bot(adapter).send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_never_duplicates_or_echoes_payload(caplog):
+    adapter = _make_adapter()
+    marker = "private-callback-marker"
+    caplog.set_level(logging.WARNING)
+    _mock_bot(adapter).do_api_request = AsyncMock(
+        side_effect=NetworkError(f"temporary failure: {marker}")
+    )
+
+    result = await adapter.send_rich_message("123", deepcopy(VALID_CARD))
+
+    assert result.success is False
+    assert result.retryable is True
+    assert result.error == "rich_message_transport_failure"
+    assert marker not in caplog.text
+    _mock_bot(adapter).do_api_request.assert_awaited_once()
+    _mock_bot(adapter).send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_capability_failure_latches_and_does_not_legacy_resend():
+    endpoint_not_found = type("EndPointNotFound", (Exception,), {})
+    adapter = _make_adapter()
+    _mock_bot(adapter).do_api_request = AsyncMock(
+        side_effect=endpoint_not_found("endpoint unavailable")
+    )
+
+    result = await adapter.send_rich_message("123", deepcopy(VALID_CARD))
+
+    assert result.success is False
+    assert result.retryable is False
+    assert adapter._rich_send_disabled is True
+    _mock_bot(adapter).send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_edit_rich_message_connection_and_availability_states():
+    permanent = _make_adapter()
+    permanent._bot = None
+    permanent._replacement_telegram_adapter = MagicMock(return_value=None)
+    permanent._is_permanent_fatal = MagicMock(return_value=True)
+    permanent._wait_for_reconnection = AsyncMock(return_value=True)
+
+    disconnected = await permanent.edit_rich_message(
+        "123", "456", deepcopy(VALID_CARD)
+    )
+    assert disconnected.success is False
+    assert disconnected.error == "Not connected"
+    assert disconnected.retryable is False
+    permanent._wait_for_reconnection.assert_not_awaited()
+
+    degraded = _make_adapter()
+    degraded._send_path_degraded = True
+    degraded_result = await degraded.edit_rich_message(
+        "123", "456", deepcopy(VALID_CARD)
+    )
+    assert degraded_result.success is False
+    assert degraded_result.error == "send_path_degraded"
+    assert degraded_result.retryable is True
+    _mock_bot(degraded).do_api_request.assert_not_called()
+
+    unavailable = _make_adapter()
+    unavailable._rich_send_disabled = True
+    unavailable_result = await unavailable.edit_rich_message(
+        "123", "456", deepcopy(VALID_CARD)
+    )
+    assert unavailable_result.success is False
+    assert unavailable_result.error == "rich_messages_unavailable"
+    assert unavailable_result.retryable is False
+    _mock_bot(unavailable).do_api_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_edit_not_modified_is_success_and_invalid_id_never_calls_api():
+    adapter = _make_adapter()
+    _mock_bot(adapter).do_api_request = AsyncMock(
+        side_effect=BadRequest("Message is not modified")
+    )
+
+    unchanged = await adapter.edit_rich_message(
+        "123", "456", deepcopy(VALID_CARD)
+    )
+    assert unchanged.success is True
+    assert unchanged.message_id == "456"
+
+    _mock_bot(adapter).do_api_request.reset_mock()
+    invalid = await adapter.edit_rich_message(
+        "123", "not-an-int", deepcopy(VALID_CARD)
+    )
+    assert invalid.success is False
+    assert invalid.error_kind == "bad_format"
+    _mock_bot(adapter).do_api_request.assert_not_called()

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1346,6 +1346,148 @@ def register(ctx):
     ctx.register_platform_handler("telegram", _wire)
 ```
 
+### Telegram rich buttons (Bot API 10.3)
+
+Telegram plugins can combine that same pattern-scoped handler with the public
+`TelegramAdapter.send_rich_message()` and `edit_rich_message()` methods. The
+adapter keeps Hermes' topic/reply routing, notification mode, link-preview
+policy, capability latch, redacted failures, and no-duplicate retry semantics;
+plugins don't need to call `Bot.do_api_request()` themselves.
+
+Enable `gateway.platforms.telegram.extra.rich_messages: true`, then pass a
+JSON-compatible [`InputRichMessage`](https://core.telegram.org/bots/api#inputrichmessage).
+This complete example binds each one-time callback nonce to the user who opened
+the card before changing state:
+
+```python
+import secrets
+
+
+def register(ctx):
+    def _wire(application, adapter):
+        from telegram.ext import CallbackQueryHandler, CommandHandler
+
+        # Demo-only in-memory state. Persist + expire this binding for workflows
+        # that must survive a gateway restart.
+        owners = {}  # (chat_id, message_id) -> (user_id, nonce)
+
+        async def _show_card(update, context):
+            nonce = secrets.token_urlsafe(8)
+            prefix = f"myplugin:{nonce}:"
+            card = {
+                "blocks": [
+                    {
+                        "type": "paragraph",
+                        "text": [{"type": "plain", "text": "Deploy release?"}],
+                    },
+                    {
+                        "type": "buttons",
+                        "align": "center",
+                        "buttons": [
+                            {
+                                "text": "Deploy",
+                                "style": "success",
+                                "callback_data": prefix + "yes",
+                            },
+                            {
+                                "text": "Cancel",
+                                "style": "danger",
+                                "callback_data": prefix + "no",
+                            },
+                        ],
+                    },
+                ]
+            }
+            result = await adapter.send_rich_message(
+                str(update.effective_chat.id),
+                card,
+                reply_to=str(update.effective_message.message_id),
+                context_text="Deploy release approval",
+            )
+            if result.success and result.message_id:
+                owners[(str(update.effective_chat.id), result.message_id)] = (
+                    update.effective_user.id,
+                    nonce,
+                )
+
+        async def _on_button(update, context):
+            query = update.callback_query
+            message = query.message
+            if message is None or query.from_user is None:
+                return
+
+            key = (str(message.chat.id), str(message.message_id))
+            owner = owners.get(key)
+            data = query.data or ""
+            if (
+                owner is None
+                or owner[0] != query.from_user.id
+                or data not in {f"myplugin:{owner[1]}:yes", f"myplugin:{owner[1]}:no"}
+            ):
+                await query.answer("This action isn't yours or has expired.", show_alert=True)
+                return
+
+            owners.pop(key, None)  # consume before the state-changing action
+            choice = "Deploying" if data.endswith(":yes") else "Cancelled"
+            await query.answer(choice)
+            await adapter.edit_rich_message(
+                str(message.chat.id),
+                str(message.message_id),
+                {
+                    "blocks": [
+                        {
+                            "type": "paragraph",
+                            "text": [{"type": "plain", "text": choice}],
+                        }
+                    ]
+                },
+                context_text=choice,
+            )
+
+        application.add_handler(CommandHandler("rich_demo", _show_card))
+        application.add_handler(
+            CallbackQueryHandler(
+                _on_button,
+                pattern=r"^myplugin:[A-Za-z0-9_-]{11}:(?:yes|no)$",
+            )
+        )
+
+    ctx.register_platform_handler("telegram", _wire)
+```
+
+`RichMessageButton` requires non-empty button text (plain text, custom emoji,
+or date-time RichText only) and exactly one of these mutually exclusive actions:
+
+| Action | Value |
+|---|---|
+| `url` | URL string |
+| `callback_data` | 1–64 UTF-8 bytes |
+| `web_app` | `WebAppInfo` object |
+| `login_url` | `LoginUrl` object |
+| `switch_inline_query` | Query string |
+| `switch_inline_query_current_chat` | Query string |
+| `switch_inline_query_chosen_chat` | `SwitchInlineQueryChosenChat` object |
+| `copy_text` | `CopyTextButton` object (`text`: 1–256 characters) |
+| `disabled` | Empty `DisabledButton` object |
+
+Styles are `primary`, `success`, `danger`, and `link`; `link` is valid only
+with `callback_data`. A `type: "buttons"` row contains 1–8 buttons and can use
+`align: "left" | "center" | "right"`. Buttons can also appear inline as a
+`type: "button"` rich-text node.
+
+:::warning
+Native platform handlers are privileged. Always use a narrow callback pattern
+and bind every state-changing callback to an authorized user plus an expiring,
+one-time nonce. Web Apps work only in private user↔bot chats; Login URLs must
+use HTTPS and aren't supported in ephemeral messages; inline-query actions
+require the bot's inline mode. Old Telegram clients show an update placeholder
+instead of silently mis-rendering rich buttons.
+:::
+
+The adapter accepts JSON-compatible input only; direct multipart file uploads
+aren't supported by this helper. Validation/rejection returns a failed
+`SendResult` and never silently flattens a structured card into MarkdownV2.
+
 Example — Discord, reaction events:
 
 ```python

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -963,6 +963,8 @@ gateway:
 
 The rich path is skipped automatically when content exceeds the 32,768-character rich text limit, and any rejection from Telegram (unsupported endpoint on an older `python-telegram-bot`, parser error, oversized blocks/columns) **transparently falls back** to the MarkdownV2 path — your message is never lost. Transient/network errors are *not* silently re-sent (no duplicate final message).
 
+**Buttons inside Rich Messages (Bot API 10.3).** Telegram plugins can use the public `TelegramAdapter.send_rich_message()` and `edit_rich_message()` methods with JSON-compatible `InputRichMessage` blocks, including inline `RichTextButton` nodes and 1–8-button `InputRichBlockButtons` rows. Clicks are handled through the existing pattern-scoped `register_platform_handler("telegram", ...)` surface, so a plugin can answer the callback and update the same message in place. Structured plugin payloads are explicit: Hermes validates the Bot API 10.3 button contract locally and returns a failed `SendResult` instead of silently flattening a rejected card to MarkdownV2. See [Telegram rich buttons in the plugin guide](/developer-guide/plugins#telegram-rich-buttons-bot-api-103) for all actions, limits, and an authorization-safe callback → edit example.
+
 **MarkdownV2 fallback.** When the rich path is unavailable for a message, Hermes converts markdown to MarkdownV2. Since MarkdownV2 has no native table syntax, pipe tables are normalized:
 
 - **Small tables** are flattened into **row-group bullets** — each row becomes a readable bulleted list under the column headings. Good for 2–4 columns and short cells.


### PR DESCRIPTION
## What does this PR do?

Adds a public, plugin-facing Telegram API for Bot API 10.3 `InputRichMessage`
blocks and rich buttons:

```python
await adapter.send_rich_message(chat_id, rich_message, ...)
await adapter.edit_rich_message(chat_id, message_id, rich_message, ...)
```

Hermes already had an internal rich-message transport and a public
`register_platform_handler("telegram", ...)` extension seam, but plugins could
not send or edit structured rich-block messages. This PR connects those two
existing surfaces without adding another callback registry, gateway event type,
config key, model tool, or legacy inline-keyboard abstraction.

The implementation deliberately keeps structured delivery fail-closed:

- validates the Bot API 10.3 button contract locally before network I/O;
- bounds traversal depth/container expansion and rejects cycles/non-JSON values;
- preserves Telegram routing, reply, topic, notification, link-preview,
  reconnection, and capability-latch behavior;
- never retries a rejected structured card as plain Markdown/serialized JSON;
- stores only explicit `context_text` in the reply-context cache, never the
  serialized button payload;
- redacts Telegram errors without echoing user payloads.

Callbacks continue to use the existing pattern-scoped platform handler API.
The docs include user binding, one-time nonce consumption, `query.answer()`, and
edit-in-place guidance for state-changing actions.

### Relationship to existing Telegram button PRs

This complements, rather than replaces, the open inline-keyboard work in
#16544, #69153, and #95594. Those PRs expose classic `reply_markup` buttons or a
generic callback-dispatch abstraction. This PR is narrowly scoped to Bot API
10.3 `InputRichMessage` blocks plus explicit rich send/edit methods, and it
intentionally adds no competing callback bus.

## Related Issue

No issue. Telegram Bot API 10.3 introduced rich message buttons after the
existing Hermes rich-message transport was implemented.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - adds `send_rich_message()` and `edit_rich_message()`;
  - reuses the existing Bot API request, routing, reconnection, redaction, and
    rich-capability machinery;
  - preserves automatic Markdown rich-message behavior.
- `plugins/platforms/telegram/rich_buttons.py`
  - validates content mode, inline and row buttons, all current 10.3 actions,
    styles, UTF-8 callback limits, copy-text limits, and restricted button
    RichText;
  - performs cycle-safe, bounded, JSON-native traversal while allowing valid
    shared Python container references.
- `tests/gateway/test_telegram_rich_buttons.py`
  - covers send/edit contracts, all button actions, inline/nested rows,
    routing, context storage, reconnect/degraded states, exact boundaries,
    adversarial object graphs, failure classification, and payload redaction.
- `website/docs/developer-guide/plugins/index.md`
  - documents a complete authorized callback → answer → edit plugin flow.
- `website/docs/user-guide/messaging/telegram.md`
  - documents Bot API 10.3 rich-button availability and fallback behavior.

## How to Test

1. Run the canonical focused and adjacent suite:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_telegram_rich_buttons.py \
     tests/gateway/test_telegram_rich_messages.py \
     tests/gateway/test_platform_plugin_handlers.py
   ```

   Result: **127 passed**.

2. Run static and syntax checks:

   ```bash
   python -m ruff check \
     plugins/platforms/telegram/adapter.py \
     plugins/platforms/telegram/rich_buttons.py \
     tests/gateway/test_telegram_rich_buttons.py
   python -m ty check \
     plugins/platforms/telegram/rich_buttons.py \
     tests/gateway/test_telegram_rich_buttons.py
   python -m py_compile \
     plugins/platforms/telegram/adapter.py \
     plugins/platforms/telegram/rich_buttons.py \
     tests/gateway/test_telegram_rich_buttons.py
   git diff --check origin/main...HEAD
   ```

   Result: **all passed**.

3. Build the docs:

   ```bash
   cd website && npm run build:fast
   ```

   Result: **passed**.

A full local repository suite was also launched. This live host produced
unrelated isolation/timing failures in untouched updater, provider, video, and
memory tests; the focused/adjacent suites above are clean, and GitHub CI is the
clean-room full-suite gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and documented the related, non-duplicate scopes above
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused/adjacent suites pass; clean-room CI pending
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact; implementation is platform-neutral Python/JSON validation
- [x] Tool descriptions/schemas — N/A; no model tool changed

## Screenshots / Logs

A throwaway Bot API 10.3 prototype was live-verified separately before this
branch: button callbacks were answered and edited the same rich message in
place. The branch itself contains no tokens, chat identifiers, live plugin, or
production configuration.
