### PR TITLE
fix(tui): preserve shift capitalization for CSI-u and modifyOtherKeys keys

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import { INITIAL_STATE, parseMultipleKeypresses } from '../parse-keypress.js'
+
+import { InputEvent } from './input-event.js'
+
+/**
+ * Regression tests for #37680: Shift+letter must insert the capital, not the
+ * lowercase codepoint reported by the terminal.
+ *
+ * Both extended-key protocols encode the *unshifted* codepoint plus a Shift
+ * modifier bit:
+ *   - kitty CSI u:            ESC [ 105 ; 2 u   (Shift+i)
+ *   - xterm modifyOtherKeys:  ESC [ 27 ; 2 ; 105 ~
+ * The input layer previously inserted the decoded name verbatim ("i"),
+ * dropping the capital. These tests pin the InputEvent text for both
+ * encodings, chorded modifiers, and non-Latin scripts.
+ */
+
+const inputFor = (sequence: string): { input: string; shift: boolean } => {
+  const [keys] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+  expect(keys).toHaveLength(1)
+  expect(keys[0]!.kind).toBe('key')
+
+  const event = new InputEvent(keys[0] as Extract<(typeof keys)[number], { kind: 'key' }>)
+
+  return { input: event.input, shift: event.key.shift }
+}
+
+describe('InputEvent shift+letter capitalization (modifyOtherKeys level 2)', () => {
+  it('inserts the capital for Shift+I (CSI 27;2;105~)', () => {
+    expect(inputFor('\x1b[27;2;105~')).toEqual({ input: 'I', shift: true })
+  })
+
+  it('inserts the capital for a burst of Shift+letters in one stdin read', () => {
+    // Ghostty coalesces rapid typing into one read; the tokenizer must keep
+    // decoding each sequence and the input layer must uppercase each one.
+    // Codes 73/85/80/80/69 = I U P P E (Ghostty reports the shifted codepoint).
+    const [keys] = parseMultipleKeypresses(
+      INITIAL_STATE,
+      '\x1b[27;2;73~\x1b[27;2;85~\x1b[27;2;80~\x1b[27;2;80~\x1b[27;2;69~'
+    )
+
+    expect(keys).toHaveLength(5)
+
+    const text = keys
+      .filter((key): key is Extract<typeof key, { kind: 'key' }> => key.kind === 'key')
+      .map(key => new InputEvent(key).input)
+      .join('')
+
+    expect(text).toBe('IUPPE')
+  })
+
+  it('inserts the capital for uppercase-locked letter (modifier reports shift on the capital codepoint)', () => {
+    // Some terminals report Shift on the shifted codepoint already (105 vs 73):
+    // CSI 27;2;73~ — 'I' (73) with shift bit. The capital must survive either way.
+    expect(inputFor('\x1b[27;2;73~')).toEqual({ input: 'I', shift: true })
+  })
+
+  it('keeps digits/symbols from Shift+digit untouched where the terminal reports the shifted codepoint', () => {
+    // Ghostty mOK L2 sends the *resulting* character codepoint for printable
+    // keys: Shift+1 arrives as CSI 27;2;33~ (33 = '!'). Name resolution gives
+    // '!', input must stay '!' — not uppercased garbage.
+    expect(inputFor('\x1b[27;2;33~')).toEqual({ input: '!', shift: true })
+  })
+
+  it('does not uppercase chorded Ctrl+Shift+letter (binding, not text)', () => {
+    // modifier 6 = ctrl+shift. Name is the letter; input for ctrl keys is the
+    // name itself — the uppercase guard must not mangle it.
+    const { input, shift } = inputFor('\x1b[27;6;105~')
+
+    expect(shift).toBe(true)
+    expect(input).toBe('i')
+  })
+
+  it('does not uppercase Alt+Shift+letter', () => {
+    // modifier 4 = alt+shift (1 + shift 1 + alt 2... decodeModifier: shift=1, alt=2 → 1+1+2=4)
+    const { input } = inputFor('\x1b[27;4;105~')
+
+    expect(input).toBe('i')
+  })
+})
+
+describe('InputEvent shift+letter capitalization (kitty CSI u)', () => {
+  it('inserts the capital for Shift+i (CSI 105;2u)', () => {
+    expect(inputFor('\x1b[105;2u')).toEqual({ input: 'I', shift: true })
+  })
+
+  it('inserts the capital for Shift+A (CSI 97;2u)', () => {
+    expect(inputFor('\x1b[97;2u')).toEqual({ input: 'A', shift: true })
+  })
+
+  it('does not uppercase chorded Ctrl+Shift+letter (CSI u modifier 6)', () => {
+    const { input, shift } = inputFor('\x1b[105;6u')
+
+    expect(shift).toBe(true)
+    expect(input).toBe('i')
+  })
+
+  it('keeps Shift+Enter as return, not a shifted glyph', () => {
+    const { input } = inputFor('\x1b[13;2u')
+
+    expect(input).toBe('')
+  })
+
+  it('keeps Shift+Tab as tab name, not a shifted glyph', () => {
+    const { input } = inputFor('\x1b[9;2u')
+
+    expect(input).toBe('tab')
+  })
+
+  it('keeps Shift+Space as a single space', () => {
+    const { input } = inputFor('\x1b[32;2u')
+
+    expect(input).toBe(' ')
+  })
+})
+
+describe('InputEvent shift capitalization must not affect plain typing', () => {
+  it('plain lowercase letters keep their case and do not set shift', () => {
+    const { input, shift } = inputFor('q')
+
+    expect(input).toBe('q')
+    expect(shift).toBe(false)
+  })
+
+  it('plain capital letters keep their case and set shift (legacy input path)', () => {
+    const { input, shift } = inputFor('Q')
+
+    expect(input).toBe('Q')
+    expect(shift).toBe(true)
+  })
+
+  it('does not double-apply shift to an already-capital codepoint (CSI 73;2u)', () => {
+    // Kitty may report the shifted codepoint directly when the layout's
+    // shifted key has no distinct lowercase (or terminals that ignore the
+    // "report unshifted" guidance). 'I'.toUpperCase() === 'I' — idempotent.
+    expect(inputFor('\x1b[73;2u')).toEqual({ input: 'I', shift: true })
+  })
+})
+
+describe('InputEvent shift capitalization across scripts', () => {
+  // NOTE: codepoints outside ASCII 32-126 (Cyrillic, CJK, ß) currently return
+  // undefined from keycodeToName(), so the CSI-u branch swallows them (the
+  // #38781 unmapped-key guard). Non-Latin layouts under CSI-u insert nothing
+  // today — a separate gap from #37680, tracked for follow-up. These tests
+  // pin the CURRENT behavior so any later Unicode keycodeToName extension
+  // consciously updates them.
+  it('swallows unmapped non-ASCII codepoints today (documented gap, see #38781/#87631)', () => {
+    // ф = U+0444 = 1092 — beyond keycodeToName's printable-ASCII default.
+    expect(inputFor('\x1b[1092;2u')).toEqual({ input: '', shift: true })
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -5,6 +5,46 @@ import { Event } from './event.js'
 const inputForSpecialSequence = (name: string): string =>
   name === 'space' ? ' ' : name === 'return' || name === 'escape' ? '' : name
 
+/**
+ * Input text for a CSI-u / modifyOtherKeys-encoded key, preserving the
+ * shifted character. Both protocols report the *unshifted* codepoint (kitty
+ * reports the lowercase letter; xterm modifyOtherKeys reports the lowercase
+ * ASCII value), so a Shift+letter arrives as name='i', shift=true. Inserting
+ * `name` verbatim drops the capital (#37680). When Shift is the SOLE
+ * modifier, uppercase the decoded character instead — toUpperCase() handles
+ * every cased script, not just a-z (non-Latin layouts, #87631). Chorded
+ * Shift (ctrl/alt/meta/super) keys are bindings, not text, and keep the
+ * plain name so existing keymap lookups still match.
+ */
+const inputForShiftedKey = (keypress: ParsedKey): string => {
+  const soleShift =
+    keypress.shift && !keypress.ctrl && !keypress.meta && !keypress.option && !keypress.super
+
+  if (!soleShift) {
+    return inputForSpecialSequence(keypress.name ?? '')
+  }
+
+  const base = inputForSpecialSequence(keypress.name ?? '')
+
+  // Only single characters can be case-shifted; multi-char names ('return',
+  // 'space', arrows) have no shifted glyph. space is already resolved to ' '
+  // by inputForSpecialSequence and has no case.
+  if (base.length !== 1) {
+    return base
+  }
+
+  const shifted = base.toUpperCase()
+
+  // Guard against scripts where toUpperCase() changes string length (e.g.
+  // ß → SS, ﬁ → FI): inserting multi-char text for one keypress would
+  // corrupt the composer buffer, so keep the base character there.
+  if (shifted.length !== 1) {
+    return base
+  }
+
+  return shifted
+}
+
 export type Key = {
   upArrow: boolean
   downArrow: boolean
@@ -112,7 +152,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // so the raw "[57358u" doesn't leak into the prompt. See #38781.
       input = ''
     } else {
-      input = inputForSpecialSequence(keypress.name)
+      input = inputForShiftedKey(keypress)
     }
 
     processedAsSpecialSequence = true
@@ -130,7 +170,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // guards against future terminal behavior.
       input = ''
     } else {
-      input = inputForSpecialSequence(keypress.name)
+      input = inputForShiftedKey(keypress)
     }
 
     processedAsSpecialSequence = true


### PR DESCRIPTION
## What does this PR do?

Fixes #37680: Shift+letter inserts the capital in the Ink TUI on terminals with extended key reporting.

Both extended-key protocols encode Shift+letter as the **unshifted** codepoint plus a shift modifier bit:

- xterm modifyOtherKeys L2 (Ghostty): `ESC[27;2;73~` → `name='i'`, `shift=true`
- kitty CSI u (kitty, WezTerm, iTerm2): `ESC[105;2u` → `name='i'`, `shift=true`

The CSI-u and modifyOtherKeys branches in `input-event.ts` inserted the decoded name verbatim, so every capital typed on those terminals arrived lowercase in the composer. #87511 fixed the classic CLI's prompt_toolkit path (`hermes_cli/pt_input_extras.py`) — the Ink TUI never routes through prompt_toolkit, so the TUI path stayed broken on `main` (verified on `a24c12d14`; repro in the issue comment).

The fix routes both branches through a new `inputForShiftedKey()` that uppercases the decoded character when **shift is the sole modifier**:

- `toUpperCase()` covers every cased script, not just a–z (relevant to the non-Latin gap in #87631)
- chorded Shift (ctrl/alt/meta/super) keeps the plain name so existing keymap lookups still match
- single-char length guard keeps one keypress = one character (`ß`.toUpperCase() expands to `SS`)
- multi-char names (`return`, arrows) and space are unaffected

A CSI-u/mOK capital now reaches the composer identically to a legacy-typed one (`input='Q'`, `key.shift=true`) — the same event shape a terminal without extended key reporting produces — so no `textInput.tsx` composer change is needed. This fixes the bug one layer below #37687's composer guard and covers both protocols; either approach alone closes #37680, and this one also normalizes the event shape across terminals. Paste safety is by construction: bracketed-paste content never produces CSI-u/mOK tokens, so the uppercasing path cannot touch pasted text.

## Related Issue

Fixes #37680

Complements #37687 (composer-side guard) — either closes the issue; see "What does this PR do?" for why the input-event layer was chosen.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/events/input-event.ts` — new `inputForShiftedKey()` helper; the CSI-u and modifyOtherKeys special-sequence branches now use it instead of inserting the decoded name verbatim
- `ui-tui/packages/hermes-ink/src/ink/events/input-event.test.ts` — new regression suite (16 tests)

## How to Test

1. `cd ui-tui && npm run test -- packages/hermes-ink/src/ink/events/input-event.test.ts` — 16 new tests pass alongside the existing 228
2. Manual (needs an extended-keys terminal, e.g. Ghostty):
   1. `hermes --tui` in Ghostty (`TERM=xterm-ghostty`)
   2. Type `Shift+I` `Shift+U` … — capitals appear in the composer
   3. `Shift+Enter` still inserts a newline; `Ctrl+Shift+<letter>` chords still hit their bindings (not uppercased)
   4. Paste text containing lowercase letters — unchanged, no case rewriting
3. In a terminal *without* extended key reporting (e.g. Konsole), plain typing behaves exactly as before (covered by tests)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — **N/A: change is TypeScript-only** (`ui-tui/`); equivalent gates run instead: `vitest run packages/hermes-ink/src` → 244/244 passed, `tsc --noEmit` clean, `eslint` clean on changed files (2 pre-existing warnings in `src/components/textInput.tsx` on base `main`, untouched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 43, Ghostty 1.x (`TERM=xterm-ghostty`), kernel 7.1.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — input-event layer is platform-neutral (macOS Ghostty/kitty affected identically; Windows Terminal is not in the extended-keys allowlist and never emits these sequences)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Repro before/after through the real pipeline (`parseMultipleKeypresses` → `InputEvent`), Ghostty mOK L2 burst `\x1b[27;2;73~\x1b[27;2;85~\x1b[27;2;80~…` (Shift+I U P P E):

```
main:   input="i" shift=true → "iuppe" in the composer
this PR: input="I" shift=true → "IUPPE" in the composer
```

Full analysis and repro snippet: https://github.com/NousResearch/hermes-agent/issues/37680#issuecomment-5444981967
