### PR TITLE
fix(config): recognize nested open config mappings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5484,6 +5484,14 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
             # Accept it (set_config_value's coercion will replace the
             # leaf with a dict, matching pre-existing behavior).
             return True, None
+        if not node:
+            # An empty mapping in DEFAULT_CONFIG declares the container but
+            # cannot enumerate its runtime-owned children. Treat it as open,
+            # just like the named open-dict roots above. This covers nested
+            # shapes such as auxiliary.<task>.extra_body.* and
+            # terminal.docker_env.* without weakening validation in populated
+            # schema mappings.
+            return True, None
         if seg not in node:
             # Suggest the closest sibling at this depth.
             sibling_suggestion = _suggest_closest_key(seg, set(node.keys()))

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,23 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_nested_open_mapping_key_is_recognized_and_resolved(
+        self, _isolated_hermes_home, capsys
+    ):
+        """Declared empty mappings accept runtime-owned nested fields."""
+        set_config_value(
+            "auxiliary.compression.extra_body.reasoning.effort",
+            "low",
+        )
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+        from agent.auxiliary_client import _get_task_extra_body
+
+        assert _get_task_extra_body("compression") == {
+            "reasoning": {"effort": "low"}
+        }
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)
@@ -544,6 +561,7 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "terminal.docker_env.PYTHONUNBUFFERED",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key


### PR DESCRIPTION
## Summary

- Treat empty mappings declared in `DEFAULT_CONFIG` as open validation containers.
- Stop false “not a recognized config key” notices for runtime-owned nested fields.
- Cover both the compression `extra_body` path end to end and a sibling `terminal.docker_env` path.

## Problem

This command writes the intended nested YAML and the compression runtime consumes it:

```bash
hermes config set auxiliary.compression.extra_body.reasoning.effort low
```

However, the validator reaches `auxiliary.compression.extra_body: {}` in `DEFAULT_CONFIG`, cannot find the next segment in that empty mapping, and prints a warning that Hermes may not read the value. The notice is a false positive: `extra_body` deliberately accepts provider-owned request fields.

The same validator shape affects other declared empty mappings such as `terminal.docker_env`.

## Approach

When schema traversal reaches an empty mapping in `DEFAULT_CONFIG`, stop validating deeper segments and recognize the path as valid. Populated schema mappings still retain typo detection and sibling suggestions.

Follow-up to #67988, whose validator contract accepts fields below open-dict shapes. Related: #34067

## Tests

- `python -m pytest tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_aux_config.py -o 'addopts=' -q` — 95 passed
- `ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py` — passed
- `python -m py_compile hermes_cli/config.py tests/hermes_cli/test_set_config_value.py` — passed
- `git diff --check origin/main...HEAD` — passed
- Manual isolated CLI smoke: the nested command emitted no warning and `_get_task_extra_body("compression")` resolved `{"reasoning": {"effort": "low"}}`
- Validator class probe: all 40 declared empty mappings accepted nested fields while representative typos under populated mappings remained rejected

The repository test wrapper could not provide a broader signal because the selected local Python environment did not include pytest; the affected suites were run directly with temporary test dependencies.
