### PR TITLE
fix(slack): authorize invited members in scoped channels

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -509,6 +509,42 @@ class GatewayAuthorizationMixin:
         if not user_id:
             return False
 
+        # Slack may grant specific users access in one channel without adding
+        # them to the platform-wide SLACK_ALLOWED_USERS allowlist. This keeps a
+        # private workflow channel usable by invited collaborators while
+        # preserving default-deny everywhere else. The map is intentionally
+        # channel -> explicit user IDs; no wildcard is honored here.
+        if (
+            source.platform == Platform.SLACK
+            and source.chat_type in {"group", "forum", "channel"}
+            and source.chat_id
+        ):
+            adapter = self._authorization_adapter(
+                source.platform,
+                profile=getattr(source, "profile", None),
+            )
+            extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+            channel_allowed_users = extra.get("channel_allowed_users")
+            if isinstance(channel_allowed_users, dict):
+                channel_allowed = _coerce_allow_set(
+                    channel_allowed_users.get(source.chat_id)
+                )
+                if user_id in channel_allowed:
+                    return True
+
+            # Private trigger-only reporting channels: Slack membership is the
+            # human access boundary. Honor invited members only when the same
+            # channel also has a hard trigger_only_channels gate, so this never
+            # opens DMs or other Slack channels.
+            trigger_only_channels = extra.get("trigger_only_channels")
+            member_channels = extra.get("trigger_only_member_channels")
+            if (
+                isinstance(trigger_only_channels, dict)
+                and source.chat_id in trigger_only_channels
+                and source.chat_id in _coerce_allow_set(member_channels)
+            ):
+                return True
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",

--- a/tests/gateway/test_slack_channel_allowed_users_authz.py
+++ b/tests/gateway/test_slack_channel_allowed_users_authz.py
@@ -1,0 +1,91 @@
+"""Channel-scoped Slack sender authorization."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+EXECUTIVE = "C_EXECUTIVE"
+OTHER = "C_OTHER"
+SOPHIE = "U_SOPHIE"
+VIRGINIA = "U_VIRGINIA"
+TROY = "U_TROY"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for name in (
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _runner(channel_users=None):
+    from gateway.run import GatewayRunner
+
+    extra = {}
+    if channel_users is not None:
+        extra["channel_allowed_users"] = channel_users
+    adapter = SimpleNamespace(config=SimpleNamespace(extra=extra))
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.SLACK: adapter}  # type: ignore[assignment]
+    runner.pairing_store = SimpleNamespace(  # type: ignore[assignment]
+        is_approved=lambda *_a, **_kw: False
+    )
+    return runner
+
+
+def _source(*, channel=EXECUTIVE, user=SOPHIE, chat_type="group"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=channel,
+        chat_type=chat_type,
+        user_id=user,
+        user_name="Tester",
+        is_bot=False,
+    )
+
+
+def test_explicit_users_are_authorized_only_in_mapped_channel(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", TROY)
+    runner = _runner({EXECUTIVE: [TROY, SOPHIE, VIRGINIA]})
+
+    assert runner._is_user_authorized(_source(user=SOPHIE)) is True
+    assert runner._is_user_authorized(_source(user=VIRGINIA)) is True
+    assert runner._is_user_authorized(_source(channel=OTHER, user=SOPHIE)) is False
+
+
+def test_channel_map_does_not_open_dms(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", TROY)
+    runner = _runner({EXECUTIVE: [SOPHIE]})
+
+    assert runner._is_user_authorized(_source(user=SOPHIE, chat_type="dm")) is False
+
+
+def test_unlisted_channel_member_remains_denied(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", TROY)
+    runner = _runner({EXECUTIVE: [VIRGINIA]})
+
+    assert runner._is_user_authorized(_source(user=SOPHIE)) is False
+
+
+def test_comma_separated_channel_users_are_supported(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", TROY)
+    runner = _runner({EXECUTIVE: f"{SOPHIE},{VIRGINIA}"})
+
+    assert runner._is_user_authorized(_source(user=SOPHIE)) is True
+    assert runner._is_user_authorized(_source(user=VIRGINIA)) is True
+
+
+def test_channel_map_does_not_honor_wildcard(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", TROY)
+    runner = _runner({EXECUTIVE: ["*"]})
+
+    assert runner._is_user_authorized(_source(user=SOPHIE)) is False

--- a/tests/gateway/test_slack_trigger_only_member_authz.py
+++ b/tests/gateway/test_slack_trigger_only_member_authz.py
@@ -1,0 +1,77 @@
+"""Authorization for Slack trigger-only reporting-channel members."""
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+LOCKED = "C_LOCKED"
+OTHER = "C_OTHER"
+UPDATE_PATTERN = r"(?i)^\s*update\s*[.!]?\s*$"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for name in (
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _runner(*, trigger_only=True, member_channels=LOCKED):
+    from gateway.run import GatewayRunner
+
+    extra = {"trigger_only_member_channels": member_channels}
+    if trigger_only:
+        extra["trigger_only_channels"] = {LOCKED: UPDATE_PATTERN}
+    adapter = SimpleNamespace(config=SimpleNamespace(extra=extra))
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.SLACK: adapter}
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _source(channel=LOCKED, *, chat_type="group", user="U_NEW_MEMBER"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=channel,
+        chat_type=chat_type,
+        user_id=user,
+        user_name="Invited Member",
+        is_bot=False,
+    )
+
+
+def test_invited_member_authorized_only_in_locked_trigger_channel(monkeypatch):
+    runner = _runner()
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    assert runner._is_user_authorized(_source()) is True
+    assert runner._is_user_authorized(_source(OTHER)) is False
+
+
+def test_member_channel_setting_requires_hard_trigger_gate(monkeypatch):
+    runner = _runner(trigger_only=False)
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    assert runner._is_user_authorized(_source()) is False
+
+
+def test_member_authorization_never_opens_dms(monkeypatch):
+    runner = _runner()
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    assert runner._is_user_authorized(_source(chat_type="dm")) is False
+
+
+def test_string_and_list_channel_configuration_are_supported(monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    assert _runner(member_channels=LOCKED)._is_user_authorized(_source()) is True
+    assert _runner(member_channels=[LOCKED])._is_user_authorized(_source()) is True


### PR DESCRIPTION
## Summary
Slack currently default-denies anyone not on `SLACK_ALLOWED_USERS`, even in a private channel they were invited to. That makes on-demand reporting triggers fail while scheduled posts still work.

This adds two channel-scoped gates in gateway auth, without opening DMs or other channels:

- `platforms.slack.extra.channel_allowed_users`: explicit user IDs for one channel (no wildcard)
- `platforms.slack.extra.trigger_only_member_channels`: authorize invited members only when the same channel also has `trigger_only_channels`

Default-deny everywhere else is unchanged.

## Tests
`pytest tests/gateway/test_slack_channel_allowed_users_authz.py tests/gateway/test_slack_trigger_only_member_authz.py` — 9 passed