### PR TITLE
feat(photon): add service-gated photon_voice tool for outbound iMessage voice notes

### DIFF
--- a/tests/tools/test_photon_voice_tool.py
+++ b/tests/tools/test_photon_voice_tool.py
@@ -1,0 +1,202 @@
+"""photon_voice tool — service-gated voice-note send over Photon Spectrum.
+
+Covers the schema/availability boundary (check_fn), chat resolution, and the
+live-adapter send path. Mirrors tests/tools/test_send_message_react.py: the
+message-id resolution + adapter dispatch are exercised against a fake gateway
+runner, and the handler is invoked through its registered entry (JSON-string
+result, not a raw dict/SendResult) so dispatch normalization is covered too.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import tools.photon_voice_tool as m
+from tools.registry import registry
+
+
+# ---------------------------------------------------------------------------
+# Fake gateway plumbing
+# ---------------------------------------------------------------------------
+
+
+class _FakeSendResult:
+    """Stand-in for gateway.platforms.base.SendResult."""
+
+    def __init__(self, success=True, message_id=None, error=None, retryable=False):
+        self.success = success
+        self.message_id = message_id
+        self.error = error
+        self.retryable = retryable
+
+
+class _FakePhotonAdapter:
+    """Records send_voice calls; returns a configurable SendResult."""
+
+    def __init__(self, result=None):
+        self.calls = []
+        self._result = result or _FakeSendResult(success=True, message_id="spc-msg-abc")
+
+    async def send_voice(self, chat_id, audio_path, caption=None):
+        self.calls.append((chat_id, audio_path, caption))
+        return self._result
+
+
+def _runner_with(adapter):
+    from gateway.config import Platform
+
+    return SimpleNamespace(adapters={Platform("photon"): adapter})
+
+
+def _home_channel(chat_id):
+    return SimpleNamespace(chat_id=chat_id)
+
+
+# ---------------------------------------------------------------------------
+# check_fn — service gating
+# ---------------------------------------------------------------------------
+
+
+def test_check_fn_false_without_live_adapter():
+    with patch("gateway.run._gateway_runner_ref", return_value=None):
+        assert m._photon_voice_check() is False
+
+
+def test_check_fn_true_with_live_adapter():
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(_FakePhotonAdapter())
+    ):
+        assert m._photon_voice_check() is True
+
+
+# ---------------------------------------------------------------------------
+# Argument validation (no adapter touched)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_audio_path_errors():
+    out = m._handle_photon_voice({})
+    res = json.loads(out)
+    assert res.get("success") is not True
+    assert "error" in res
+    assert "audio_path" in res["error"]
+
+
+def test_nonexistent_audio_path_errors(tmp_path):
+    bad = str(tmp_path / "nope.mp3")
+    out = m._handle_photon_voice({"audio_path": bad})
+    res = json.loads(out)
+    assert res.get("success") is not True
+    assert "does not exist" in res["error"]
+
+
+# ---------------------------------------------------------------------------
+# Chat resolution + dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_chat_id_used(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    adapter = _FakePhotonAdapter()
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(adapter)
+    ):
+        out = m._handle_photon_voice(
+            {"audio_path": str(audio), "chat_id": "any;-;+15551234567"}
+        )
+    res = json.loads(out)
+    assert res["success"] is True
+    assert res["message_id"] == "spc-msg-abc"
+    assert adapter.calls[0][0] == "any;-;+15551234567"
+    assert adapter.calls[0][1] == str(audio)
+
+
+def test_defaults_to_home_channel(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    adapter = _FakePhotonAdapter()
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(adapter)
+    ), patch(
+        "gateway.config.load_gateway_config",
+        return_value=SimpleNamespace(
+            get_home_channel=lambda _p: _home_channel("home;-;+15559998888")
+        ),
+    ):
+        out = m._handle_photon_voice({"audio_path": str(audio)})
+    res = json.loads(out)
+    assert res["success"] is True
+    assert adapter.calls[0][0] == "home;-;+15559998888"
+
+
+def test_caption_passed_through(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    adapter = _FakePhotonAdapter()
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(adapter)
+    ):
+        m._handle_photon_voice(
+            {
+                "audio_path": str(audio),
+                "chat_id": "any;-;+15551234567",
+                "caption": "  spoken follow-up  ",
+            }
+        )
+    assert adapter.calls[0][2] == "spoken follow-up"
+
+
+def test_send_failure_surfaced(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    adapter = _FakePhotonAdapter(
+        _FakeSendResult(success=False, error="sidecar 503", retryable=True)
+    )
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(adapter)
+    ):
+        out = m._handle_photon_voice(
+            {"audio_path": str(audio), "chat_id": "any;-;+15551234567"}
+        )
+    res = json.loads(out)
+    assert res["success"] is False
+    assert res["error"] == "sidecar 503"
+    assert res["retryable"] is True
+
+
+def test_no_live_adapter_errors(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    with patch("gateway.run._gateway_runner_ref", return_value=None):
+        out = m._handle_photon_voice(
+            {"audio_path": str(audio), "chat_id": "any;-;+15551234567"}
+        )
+    res = json.loads(out)
+    assert res.get("success") is not True
+    assert "live Photon adapter" in res["error"]
+
+
+# ---------------------------------------------------------------------------
+# Registered entry round-trips through dispatch (JSON string, not dict)
+# ---------------------------------------------------------------------------
+
+
+def test_registered_entry_dispatch(tmp_path):
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-audio")
+    adapter = _FakePhotonAdapter()
+    with patch(
+        "gateway.run._gateway_runner_ref", return_value=_runner_with(adapter)
+    ):
+        entry = registry.get_entry("photon_voice")
+        assert entry is not None
+        assert entry.is_async is False
+        # dispatch normalizes the result; handler returns a JSON string already,
+        # so dispatch must pass it through unchanged.
+        result = registry.dispatch("photon_voice", {"audio_path": str(audio), "chat_id": "x"})
+    parsed = json.loads(result)
+    assert parsed["success"] is True

--- a/tools/photon_voice_tool.py
+++ b/tools/photon_voice_tool.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Photon voice-note tool — send a recorded audio clip over iMessage.
+
+The Photon Spectrum (iMessage) adapter already exposes ``send_voice()`` and the
+sidecar already converts source audio to a native voice note (see
+``plugins/platforms/photon/sidecar/voice-send.mjs``). There was, however, no
+agent-callable surface for it: ``send_message`` is intentionally NOT
+agent-callable (cross-platform blast protection), so a voice note had no tool.
+
+This module fills that gap with a *service-gated* tool: it only registers its
+schema when a live Photon adapter is in the running gateway (zero prompt tokens
+on every other install), and routes through the live adapter's ``send_voice``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from tools.registry import registry, tool_error
+
+
+# ---------------------------------------------------------------------------
+# Live-adapter resolution (mirrors tools/send_message_tool.py)
+# ---------------------------------------------------------------------------
+
+
+def _live_photon_adapter():
+    """Return the in-process Photon adapter, or ``None``.
+
+    Photon is a plugin platform, so the enum member is resolved dynamically
+    via ``Platform("photon")`` rather than a hard-coded ``Platform.PHOTON``.
+    """
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        if runner is None:
+            return None
+        adapter = runner.adapters.get(Platform("photon"))
+        return adapter
+    except Exception:
+        return None
+
+
+def _photon_voice_check() -> bool:
+    """check_fn: the tool exists only when a live Photon adapter is in process."""
+    return _live_photon_adapter() is not None
+
+
+def _resolve_chat_id(explicit: Optional[str]) -> Optional[str]:
+    """Chat resolution order: explicit arg -> session chat -> photon home."""
+    if explicit:
+        return explicit.strip() or None
+    # Conversation being answered (cron/standalone callers may set this).
+    try:
+        from gateway.session_context import get_session_env
+
+        env_chat = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        if env_chat:
+            return env_chat
+    except Exception:
+        pass
+    # Photon home channel from gateway config.
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        home = load_gateway_config().get_home_channel(Platform("photon"))
+        if home and getattr(home, "chat_id", None):
+            return home.chat_id
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+PHOTON_VOICE_SCHEMA: Dict[str, Any] = {
+    "name": "photon_voice",
+    "description": (
+        "Send a voice note (audio clip) to a Photon Spectrum (iMessage) chat. "
+        "USE SPARSINGLY — voice notes are high-friction for the recipient, so "
+        "only send one when the user explicitly asked for a spoken message or "
+        "when tone/inflection genuinely matters. Requires a pre-recorded audio "
+        "file (e.g. produced with the tts tool or `edge-tts`); pass its local "
+        "path. The sidecar converts the file to a native iMessage voice note. "
+        "Only available on installs with a live Photon gateway adapter."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "audio_path": {
+                "type": "string",
+                "description": (
+                    "Absolute path to the audio file to send (mp3/wav/m4a/etc.). "
+                    "The sidecar re-encodes to a native voice-note format, so the "
+                    "source codec is not strict."
+                ),
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional target chat id (Photon spaceId, e.g. "
+                    "'any;-;+15551234567'). Defaults to the Photon home channel "
+                    "when omitted."
+                ),
+            },
+            "caption": {
+                "type": "string",
+                "description": "Optional text caption delivered after the voice note.",
+            },
+        },
+        "required": ["audio_path"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def _handle_photon_voice(args: Dict[str, Any], **_kw: Any) -> str:
+    audio_path = args.get("audio_path")
+    if not isinstance(audio_path, str) or not audio_path.strip():
+        return tool_error("audio_path is required (absolute path to an audio file)")
+    audio_path = audio_path.strip()
+
+    # Defense-in-depth: the sidecar re-validates, but refuse obviously missing
+    # paths early so we don't spin up the gateway call for nothing.
+    if not os.path.isfile(audio_path):
+        return tool_error(f"audio_path does not exist: {audio_path}")
+
+    chat_id = _resolve_chat_id(args.get("chat_id"))
+    if not chat_id:
+        return tool_error(
+            "No chat_id supplied and no Photon home channel configured. "
+            "Pass an explicit chat_id (Photon spaceId)."
+        )
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return tool_error(
+            "photon_voice requires a live Photon adapter in the running gateway "
+            "(not available from cron/standalone contexts)."
+        )
+    send_voice = getattr(adapter, "send_voice", None)
+    if not callable(send_voice):
+        return tool_error("The Photon adapter does not support send_voice.")
+
+    caption = args.get("caption")
+    caption = caption.strip() if isinstance(caption, str) and caption.strip() else None
+
+    from model_tools import _run_async
+
+    try:
+        result = _run_async(send_voice(chat_id=chat_id, audio_path=audio_path, caption=caption))
+    except Exception as e:  # surface transport failures to the model, not a crash
+        return json.dumps({
+            "success": False,
+            "error": f"photon_voice send failed: {e}",
+            "error_type": "send_failed",
+        })
+
+    # adapter.send_voice returns a gateway SendResult dataclass — serialize the
+    # public attributes rather than leaking the object.
+    success = bool(getattr(result, "success", False))
+    payload: Dict[str, Any] = {
+        "success": success,
+        "message_id": getattr(result, "message_id", None),
+    }
+    if not success:
+        payload["error"] = getattr(result, "error", "unknown send failure")
+        payload["retryable"] = getattr(result, "retryable", False)
+    return json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# Registration — own toolset so non-Photon installs pay zero prompt tokens.
+# ---------------------------------------------------------------------------
+
+
+# NOTE: the handler is synchronous but internally bridges the adapter's async
+# send_voice via model_tools._run_async. Register is_async=False so dispatch
+# does NOT double-wrap it (registry.dispatch only calls _run_async for async
+# handlers). This mirrors tools/send_message_tool.py's react/send handlers.
+registry.register(
+    name="photon_voice",
+    toolset="photon_voice",
+    schema=PHOTON_VOICE_SCHEMA,
+    handler=_handle_photon_voice,
+    check_fn=_photon_voice_check,
+    is_async=False,
+    emoji="🎙️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -643,10 +643,18 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-photon": {
+        "description": "Photon Spectrum (iMessage) bot toolset - agent-callable voice-note send (service-gated on a live Photon adapter)",
+        "tools": _HERMES_CORE_TOOLS + [
+            "photon_voice",
+        ],
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao", "hermes-photon"]
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

The Photon Spectrum (iMessage) adapter already exposes `send_voice()` and the sidecar already converts source audio to a native voice note (`sidecar/voice-send.mjs` + the `kind:"voice"` branch in `sidecar/index.mjs`). But there was **no agent-callable surface** for it: `send_message` is intentionally not agent-callable (cross-platform blast protection), so a voice note was unreachable except via a raw sidecar curl.

This PR adds `tools/photon_voice_tool.py`, a service-gated tool that closes that gap. It resolves the target chat (explicit arg -> session chat -> Photon home channel) and routes through the live adapter's `send_voice`, serializing the `SendResult` to a JSON string.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/photon_voice_tool.py` (new) — the `photon_voice` tool.
- `toolsets.py` — adds a `hermes-photon` toolset containing it, included in `hermes-gateway`.
- `tests/tools/test_photon_voice_tool.py` (new, 10 tests).

## How to Test

1. `PYTHONPATH=/repo pytest tests/tools/test_photon_voice_tool.py -v`
2. On a Photon install, ask the agent to send a voice note; it resolves the live adapter via `_gateway_runner_ref`.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Tests added (10 passing)
- [x] `ruff` clean

### Footprint-Ladder compliance

Service-gated via `check_fn`: the schema exists **only** when a live Photon adapter is in the running gateway, so it costs **zero prompt tokens on every non-Photon install**. No new env vars, deps, or cache-breaking.