### PR TITLE
fix(browser): bound the real-profile auth backup so a locked source falls through to raw copy

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -564,34 +564,43 @@ _SQLITE_AUTH_DBS = frozenset({
     "Cookies", "Login Data", "Login Data For Account", "Web Data",
 })
 
+# Total time budget for one auth-DB online-backup before falling through to
+# the raw-copy path. A running Chrome holds Login Data / Web Data with
+# exclusive SQLite locks, and CPython's backup() retries SQLITE_BUSY forever
+# without a bound — 10 s matches the backup walker's default (#96646).
+_AUTH_BACKUP_TIMEOUT_SECONDS = 10.0
+
 
 def _copy_auth_file(src_file: str, dst_file: str) -> bool:
     """Copy one auth file, lock-aware. Returns True on success.
 
-    For SQLite DBs (Cookies/Login Data/…), use the online-backup API so the
-    copy works even while the browser holds the file's write lock (Windows).
-    Everything else is a plain copy. A DB whose backup fails falls through to a
-    raw copy attempt; only if BOTH fail do we report failure to the caller.
+    For SQLite DBs (Cookies/Login Data/…), use a deadline-bounded online
+    backup so the copy works even while the browser holds the file's write
+    lock (Windows) and never hangs on a wedged source (POSIX, running
+    Chrome). Everything else is a plain copy. A DB whose backup fails falls
+    through to a raw copy attempt; only if BOTH fail do we report failure to
+    the caller.
     """
     os.makedirs(os.path.dirname(dst_file), exist_ok=True)
     if os.path.basename(src_file) in _SQLITE_AUTH_DBS:
         try:
-            import sqlite3
+            # The online-backup API must be bounded: CPython's backup()
+            # retries SQLITE_BUSY forever unless a progress callback
+            # interrupts it, and a running Chrome holds Login Data / Web
+            # Data exclusively on POSIX too — so a plain source.backup(out)
+            # hangs the launch until the tool times out (#96646). Reuse the
+            # bounded family helper from the backup walker
+            # (#82042/#92495/#84475): read-only connect, deadline-bounded
+            # progress callback, fail-closed False. On failure the raw-copy
+            # fallback below runs — file-level copies don't need SQLite's
+            # cross-process locks on POSIX.
+            from hermes_cli.backup import _safe_copy_db
 
-            # Read-only URI + immutable-free: we want a consistent committed
-            # snapshot, not to fight the writer. Short busy timeout so a truly
-            # wedged DB fails fast rather than hanging the launch.
-            source = sqlite3.connect(f"file:{src_file}?mode=ro", uri=True, timeout=5)
-            try:
-                out = sqlite3.connect(dst_file)
-                try:
-                    with out:
-                        source.backup(out)
-                finally:
-                    out.close()
-            finally:
-                source.close()
-            return True
+            if _safe_copy_db(Path(src_file), Path(dst_file),
+                             timeout_seconds=_AUTH_BACKUP_TIMEOUT_SECONDS):
+                return True
+            logger.debug("real-profile: bounded sqlite-backup of %s failed; trying raw copy",
+                         src_file)
         except Exception as e:
             logger.debug("real-profile: sqlite-backup of %s failed (%s); trying raw copy",
                          src_file, e)

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -929,3 +929,47 @@ class TestWindowsLockedProfileCopy:
         dst, err = bc.snapshot_real_profile("chrome", src=str(root))
         assert dst is None
         assert err and "login data" in err.lower() and "close" in err.lower()
+
+    def test_copy_auth_file_bounded_when_locked_falls_back_to_raw(self, tmp_path, monkeypatch):
+        """A wedged source DB (running Chrome holds Login Data exclusively on
+        POSIX too) must abort the online backup within the deadline and fall
+        through to the raw copy instead of hanging the launch forever (#96646).
+
+        Regression: CPython's sqlite3.Connection.backup() retries SQLITE_BUSY
+        indefinitely when no progress callback bounds it, so the old unbounded
+        source.backup(out) never returned and the raw-copy fallback was
+        unreachable — this test times out rather than failing fast on the
+        old code.
+        """
+        import hermes_cli.browser_connect as bc
+        import sqlite3
+        import time
+        monkeypatch.setattr(bc, "_AUTH_BACKUP_TIMEOUT_SECONDS", 0.5)
+        src = str(tmp_path / "Login Data")
+        con = sqlite3.connect(src)
+        con.execute("create table logins(x)")
+        con.execute("insert into logins values(1)")
+        con.commit()
+        # Hold the exclusive SQLite lock the way a running Chrome does.
+        con.execute("BEGIN EXCLUSIVE")
+        try:
+            dst = str(tmp_path / "out" / "Login Data")
+            started = time.monotonic()
+            ok = bc._copy_auth_file(src, dst)
+            elapsed = time.monotonic() - started
+            assert elapsed < 5.0, (
+                f"_copy_auth_file took {elapsed:.1f}s on a locked source — "
+                "the backup is no longer deadline-bounded"
+            )
+            # On POSIX the raw-copy fallback needs no SQLite locks, so the
+            # copy still lands and the launch can proceed.
+            assert ok is True
+            assert os.path.isfile(dst)
+            check = sqlite3.connect(dst)
+            try:
+                assert check.execute("select count(*) from logins").fetchone()[0] == 1
+            finally:
+                check.close()
+        finally:
+            con.rollback()
+            con.close()


### PR DESCRIPTION
## What does this PR do?

Bounds the online-backup call in `_copy_auth_file()` so a locked auth DB can no longer hang the first consented real-profile session forever.

With `browser.use_real_profile: true` and the user's Chrome running, Chrome holds `Login Data` / `Web Data` with exclusive SQLite locks on POSIX too. The old code called `source.backup(out)` with no progress callback, and CPython's `backup()` retries `SQLITE_BUSY` in a loop with no total timeout and no exception — so the copy never returned, the `except` never fired, the raw-copy fallback was unreachable, and `browser_exec` died at the ~420 s tool timeout with no error (#96646). The `timeout=5` on the source connection the old comment relied on only bounds statement-level busy waits, not `backup()` retries.

The fix reuses `hermes_cli.backup._safe_copy_db` — the deadline-bounded helper that already fixed this exact hazard class in the backup walker (#82042 / #92495 / #84475): read-only connect with `timeout=0.0`, a progress-callback deadline (`_AUTH_BACKUP_TIMEOUT_SECONDS`, 10 s, matching the walker's default), fail-closed `False`. On failure, control returns to the existing raw-copy fallback, which needs no SQLite cross-process locks on POSIX, so the launch proceeds instead of hanging.

## Related Issue

Fixes #96646

Fixes #96661 (independent re-report of the same `_copy_auth_file()` hang, filed with its own per-DB probe data; same root cause and same fix path)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/browser_connect.py` — `_copy_auth_file()`'s SQLite branch now calls `hermes_cli.backup._safe_copy_db` with a 10 s budget instead of an unbounded `source.backup(out)`; added module constant `_AUTH_BACKUP_TIMEOUT_SECONDS` (monkeypatch-able for tests) and updated the docstring.
- `tests/tools/test_browser_real_profile.py` — regression `test_copy_auth_file_bounded_when_locked_falls_back_to_raw`: holds an exclusive SQLite lock on a real `Login Data` DB (the way a running Chrome does), asserts `_copy_auth_file` returns well within 5 s and succeeds via the raw-copy fallback with the copied DB readable.

## How to Test

1. `python -m pytest tests/tools/test_browser_real_profile.py -q` — should pass (74 passed, including the new regression).
2. `python -m pytest tests/hermes_cli/test_backup_all_profiles.py tests/hermes_cli/test_backup_path_errors.py tests/hermes_cli/test_backup_stability.py -q` — should pass (16 passed; the shared helper's own suite).
3. Red/green observed locally: on the pre-fix code the new test's exact scenario hangs — a direct probe (`BEGIN EXCLUSIVE` on the source, then `_copy_auth_file`) was still blocked after 90 s and had to be killed; on this branch the same call returns in ~0.6 s with `True` and a readable snapshot DB.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: real-profile suite 74 passed; backup family 16 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — on Windows the bounded backup fails fast and the fail-closed path behaves as before; no behavior change for unlocked DBs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

