### PR TITLE
fix(kanban): repair UTF-8 mojibake in task/comment/run text

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3166,6 +3166,32 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+_MOJIBAKE_MARKERS = re.compile(r"Ã.|Â.|â[\x80-\xbf]|ð[\x80-\xbf]")
+
+
+def _repair_utf8_mojibake(value: Optional[str]) -> Optional[str]:
+    """Repair one accidental UTF-8-as-Latin-1/CP1252 decode, conservatively.
+
+    Agent/tool boundaries occasionally hand the Kanban DB text such as
+    ``demandÃ©`` or ``schemaâ\x86\x94migrations``. SQLite then stores those
+    Unicode code points faithfully, so the corruption survives every later
+    surface. Only accept a round-trip candidate when it is valid UTF-8 and
+    strictly reduces the characteristic marker count; legitimate text such as
+    ``Âge`` or ``SÃO`` therefore remains unchanged.
+    """
+    if value is None or not _MOJIBAKE_MARKERS.search(value):
+        return value
+    before = len(_MOJIBAKE_MARKERS.findall(value))
+    for source_encoding in ("latin-1", "cp1252"):
+        try:
+            candidate = value.encode(source_encoding).decode("utf-8")
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            continue
+        if len(_MOJIBAKE_MARKERS.findall(candidate)) < before:
+            return candidate
+    return value
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3234,6 +3260,8 @@ def create_task(
     board can supply the repo and branch convention. Its literal worktree is
     never reused; the new task still gets its own task-id-keyed path.
     """
+    title = _repair_utf8_mojibake(title) or ""
+    body = _repair_utf8_mojibake(body)
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
@@ -3993,6 +4021,7 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 def add_comment(
     conn: sqlite3.Connection, task_id: str, author: str, body: str
 ) -> int:
+    body = _repair_utf8_mojibake(body) or ""
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
@@ -5403,6 +5432,8 @@ def complete_task(
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
     """
+    result = _repair_utf8_mojibake(result)
+    summary = _repair_utf8_mojibake(summary)
     now = int(time.time())
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
@@ -6289,6 +6320,7 @@ def block_task(
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
+    reason = _repair_utf8_mojibake(reason)
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -39,6 +39,60 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
 
 
+def test_kanban_writes_repair_utf8_mojibake_without_touching_legitimate_text(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="IRON ROD TRAINING â\x80\x94 contrat des Ã©quipements",
+            body="schemaâ\x86\x94migrations sur une rÃ©plique",
+        )
+        kb.add_comment(
+            conn,
+            task_id,
+            author="amber",
+            body="Rodrigue a demandÃ© la procÃ©dure",
+        )
+        legitimate_id = kb.create_task(
+            conn,
+            title="Âge et SÃO restent intacts",
+        )
+
+        repaired = kb.get_task(conn, task_id)
+        legitimate = kb.get_task(conn, legitimate_id)
+        assert repaired is not None
+        assert legitimate is not None
+        assert repaired.title == "IRON ROD TRAINING — contrat des équipements"
+        assert repaired.body == "schema↔migrations sur une réplique"
+        assert kb.list_comments(conn, task_id)[0].body == "Rodrigue a demandé la procédure"
+        assert legitimate.title == "Âge et SÃO restent intacts"
+
+
+def test_block_and_completion_repair_mojibake_in_run_summaries(kanban_home):
+    with kb.connect() as conn:
+        blocked_id = kb.create_task(conn, title="blocked", assignee="ops")
+        assert kb.block_task(
+            conn,
+            blocked_id,
+            kind="needs_input",
+            reason="aucune rÃ©ponse requise avant rÃ©plique",
+        )
+        blocked_runs = kb.list_runs(conn, blocked_id)
+        assert blocked_runs[-1].summary == "aucune réponse requise avant réplique"
+
+        completed_id = kb.create_task(conn, title="completed", assignee="ops")
+        assert kb.complete_task(
+            conn,
+            completed_id,
+            result="livrable validÃ©",
+            summary="recette terminÃ©e",
+        )
+        completed = kb.get_task(conn, completed_id)
+        assert completed is not None
+        assert completed.result == "livrable validé"
+        completed_runs = kb.list_runs(conn, completed_id)
+        assert completed_runs[-1].summary == "recette terminée"
+
+
 # ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Repairs accidental UTF-8-as-Latin-1/CP1252 mojibake (e.g. demandÃÂ©, schemaÃ¢\x86\x94migrations) that agent/tool boundaries occasionally hand to the Kanban DB. SQLite stores those code points faithfully, so corruption survives every later surface. The repair is conservative: only accepts a round-trip candidate that is valid UTF-8 AND strictly reduces the characteristic marker count, so legitimate text (Ãge, SÃO) is untouched. Applied to create_task, add_comment, complete_task, block_task. Includes regression tests.