### PR TITLE
fix(kanban): keep initially-blocked tasks sticky (fail-closed)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3565,6 +3565,25 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # ``recompute_ready`` treats an explicit ``blocked`` event as
+                # the durable marker that an operator block is sticky.  A task
+                # created directly in ``blocked`` previously had only the
+                # status in its row / ``created`` payload, so the next
+                # dispatcher tick promoted parentless gates to ``ready`` and
+                # could spawn them.  Record the same lifecycle marker used by
+                # ``block_task`` so initial blocked gates remain fail-closed.
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial_status=blocked",
+                            "kind": None,
+                            "recurrences": 0,
+                            "source_status": "created",
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,40 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initially_blocked_parentless_task_is_sticky(kanban_home: Path) -> None:
+    """A task intentionally created blocked must not become dispatchable.
+
+    ``recompute_ready`` distinguishes deliberate blocks from recoverable
+    circuit-breaker blocks through lifecycle events.  Creation therefore has
+    to record an explicit ``blocked`` event, not only ``status='blocked'`` in
+    the task row / ``created`` payload.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="operator gate",
+            assignee="architect",
+            initial_status="blocked",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        kinds = [
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (tid,),
+            ).fetchall()
+        ]
+        assert kinds == ["created", "blocked"]
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A task created directly in blocked status previously had only the status in its row, so the next dispatcher tick promoted parentless gates to ready and could spawn them. This records the same lifecycle marker used by block_task (an explicit blocked event) so initial blocked gates remain fail-closed. Includes regression test.