### PR TITLE
feat(optional-skills): add pre-publish security review

### DIFF
--- a/optional-skills/security/pre-publish-security-review/SKILL.md
+++ b/optional-skills/security/pre-publish-security-review/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: pre-publish-security-review
+description: Review code and artifacts safely before publishing.
+version: 0.1.0
+author: Mark S. (unsupportedpastels), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [security, code-review, publishing, owasp, secrets, sast]
+    category: security
+    related_skills: [github-code-review, publish-site, cloudflare-temporary-deploy]
+---
+
+# Pre-Publish Security Review Skill
+
+Review the exact code and files about to become public before a GitHub push or
+site deployment. This is a short, evidence-based safety gate for secret
+exposure and common web risks; like Hermes' other in-process checks, it is a
+review aid, not a security boundary. It does not replace OS-level isolation, a
+full security assessment, penetration test, or project-specific SAST workflow.
+
+## When to Use
+
+- Before `publish-site`, `cloudflare-temporary-deploy`, a public repository
+  push, or another action that makes code or build output externally reachable.
+- After a meaningful change to authentication, authorization, database access,
+  templates, command execution, URL fetching, dependencies, or error handling.
+- When the user asks for a friendly security check rather than a full audit.
+
+Do not use this as proof that an application is secure. For a full-repository
+review, use a dedicated project security skill when one is available. For an
+ordinary PR-only review with no pending publication, use `github-code-review`.
+Use this skill when the PR's code or generated artifact is about to become
+public, or upon the user's direct request.
+
+## Prerequisites
+
+- A local repository or publish directory.
+- The `terminal`, `read_file`, and `search_files` tools.
+- Python 3 for the bundled artifact inventory helper.
+- Optional project-declared tests and already-installed scanners. Do not install
+  or upload source to a third-party scanner without approval.
+
+The OWASP mapping below follows the
+[OWASP Top 10:2025](https://owasp.org/Top10/2025/). The list is an awareness
+baseline, not an exhaustive vulnerability taxonomy.
+
+## How to Run
+
+Use `terminal` from the project root. First identify both review surfaces:
+
+1. **Code surface:** the staged diff or branch diff that will be pushed.
+2. **Publish surface:** the exact directory a hosting command will upload, such
+   as `dist/`, `build/`, or the repository root.
+
+Inventory the publish surface without printing matched secret values:
+
+```text
+python "${HERMES_SKILL_DIR}/scripts/inventory_publish_surface.py" <publish-dir>
+```
+
+Exit `1` means the helper found a blocking sensitive path or high-confidence
+credential signature. Exit `0` means no deterministic blocker was found; it is
+not a clean bill of health. Then inspect the code diff and apply the review
+lenses below.
+
+## Quick Reference
+
+| Task | Command or evidence |
+| --- | --- |
+| Inventory artifact | `python "${HERMES_SKILL_DIR}/scripts/inventory_publish_surface.py" <publish-dir>` |
+| Review staged code | `git diff --cached --stat` then `git diff --cached` through `terminal` |
+| Review branch code | `git diff <base>...HEAD --stat` then the full diff through `terminal` |
+| Trace a finding | `read_file` around the changed source-to-sink path |
+| Run project checks | Repository-declared tests/scanners through `terminal` |
+| Set the outcome | Confirmed evidence + residual risk → `Ready to publish`, `Fix before publishing`, or `Need your input` |
+
+Use `Fix before publishing` for a secret or private key in the publish surface,
+a confirmed reachable high-impact vulnerability, a failing affected security
+test, or an unresolved injection/access-control path. Use `Need your input` when
+a safe fix requires the user's choice or a coverage gap cannot be closed. Scanner
+absence alone is a coverage warning, not a vulnerability.
+
+## Review Lenses
+
+### Publish-surface exposure
+
+- Treat every file in a static bundle as public, including source maps, comments,
+  JSON, client configuration, and files hidden by a leading dot.
+- A `.gitignore` entry is not evidence that a deploy CLI excludes the file.
+  Review the actual upload directory.
+- Browser-delivered environment values are public by design. Server-side secrets
+  belong in provider secret storage, never in source or generated JavaScript.
+- Do not paste suspected values into chat or reports. Record only path, line,
+  rule label, and remediation.
+
+### OWASP Top 10:2025 changed-code pass
+
+Review categories that intersect the diff. Mark a category `N/A` only with a
+short reason; do not imply whole-repository coverage.
+
+| Category | Focus on changed code |
+| --- | --- |
+| A01 Broken Access Control | Ownership/tenant checks, role gates, IDOR, deny-by-default server routes |
+| A02 Security Misconfiguration | Debug modes, permissive CORS/CSP, public admin paths, source maps, unsafe defaults, and the real public HTTPS path rather than local HTTP alone |
+| A03 Software Supply Chain Failures | New dependencies, lockfile drift, unpinned actions, install/build scripts |
+| A04 Cryptographic Failures | Hardcoded keys, weak randomness/hashing, custom crypto, sensitive transport/storage |
+| A05 Injection | Parameterized SQL, argument-safe process calls, output encoding, template/DOM sinks, path input |
+| A06 Insecure Design | Missing abuse limits, trust-boundary assumptions, unsafe business workflow |
+| A07 Authentication Failures | Session lifecycle, account recovery, credential checks, brute-force controls |
+| A08 Software or Data Integrity Failures | Unsafe deserialization, unsigned updates, untrusted build or webhook data |
+| A09 Security Logging and Alerting Failures | Security-event coverage without tokens, passwords, or personal data in logs |
+| A10 Mishandling of Exceptional Conditions | Fail-open authorization, partial writes, insecure fallback, leaked stack traces |
+
+#### HTTPS and edge termination (A02)
+
+Judge transport security from the deployment users actually have. Choose the
+smallest matching path instead of assuming a server backend:
+
+- **Managed static site or SPA (the common path):** when `publish-site` sends a
+  static output directory to GitHub Pages, Cloudflare Pages, or Netlify, the
+  provider owns the public origin and HTTPS. Check the final HTTPS URL,
+  HTTP-to-HTTPS redirect, mixed content, and accidental secret files. There is
+  no application server origin, proxy trust, ops cookie, or backend port to
+  review; do not invent those findings.
+- **Server-rendered app or API:** use the origin/proxy checks below only when the
+  project actually runs a Node/Python/Ruby/etc. server, exposes an API, or keeps
+  a long-running container behind the HTTPS provider.
+
+For either path:
+
+- `http://localhost` and other local preview URLs are expected and are not a
+  finding by themselves.
+- The public/share URL must use HTTPS. When the provider exposes a public HTTP
+  URL, verify that it redirects to the same host over HTTPS.
+- Flag browser-visible `http://` assets, API URLs, form actions, or `ws://`
+  sockets in production output. They create mixed content or bypass the HTTPS
+  page; use relative URLs, HTTPS, or WSS instead.
+
+For a server runtime only:
+
+- An origin may use HTTP when a trusted platform owns or isolates that hop and
+  terminates HTTPS at the edge. Do not tell the user to add application-level
+  TLS solely to pass this review.
+- Flag a directly reachable HTTP origin that bypasses the intended edge,
+  authentication, rate limits, or headers. If edge-to-origin traffic crosses an
+  untrusted network, require HTTPS on that hop rather than treating edge TLS as
+  end-to-end protection.
+- Confirm that forwarded scheme handling is trusted correctly and session
+  cookies are still marked `Secure`.
+
+If a live URL already exists, use `terminal` to verify the HTTPS response and
+HTTP-to-HTTPS redirect. Keep the user-facing result simple: a managed static
+site with provider HTTPS, or local HTTP behind a verified HTTPS server host,
+needs no transport fix; public HTTP or mixed content does.
+
+Also inspect changed outbound URL fetching for SSRF and redirect abuse even
+though SSRF is not a standalone 2025 category.
+
+## Procedure
+
+1. **Resolve and classify the external action.** Start with the common static
+   path: if the host receives only an output directory containing HTML/CSS/JS,
+   use the managed-static checks and do not inspect imaginary server controls.
+   Switch to the server-runtime path only when the project actually runs a
+   server/API/container after deployment. Record the target, branch/commit, and
+   exact upload directory or image. Stop if the publish surface is unknown.
+   Done when every file that can become public belongs to a named surface and
+   only relevant security controls are in scope.
+
+2. **Inspect repository instructions and status.** Use `read_file` for relevant
+   `AGENTS.md`, `CONTRIBUTING.md`, and security guidance; use `terminal` for
+   branch, status, and diff metadata. Do not discard unrelated local changes.
+   Done when the base revision and working-tree ownership are clear.
+
+3. **Inventory the publish surface.** Run the bundled helper against the exact
+   upload directory. Read its JSON labels, never secret values. Treat
+   `sensitive_paths` and `secret_candidates` as blockers until inspected and
+   removed or proven to be inert test/example data outside the upload surface.
+   Manually disposition every `review_candidates` entry and every
+   `skipped_files` entry before choosing `Ready to publish`; they are coverage
+   gaps, not passes. Done when blockers are cleared, review gaps have
+   dispositions, and the corrected surface has been rescanned.
+
+4. **Build a changed-code map.** Review the complete staged or branch diff, then
+   use `read_file` around changed security-sensitive functions. Group changes
+   by input, authorization, data store, template/DOM output, process execution,
+   outbound network, dependencies/build, logging, and error handling. Done when
+   each changed trust boundary has an owner and data flow.
+
+5. **Run the applicable OWASP pass.** For each intersecting category, trace a
+   plausible untrusted input to its security-sensitive sink and verify the
+   control in source. For SQL, prove parameter binding at the final query call;
+   ORM use alone is not proof. For shell calls, prove arguments do not cross an
+   unsafe shell-string boundary. Done when each applicable category has source
+   evidence, a confirmed finding, or a meaningful negative result.
+
+6. **Run project-native checks.** Prefer repository-declared tests, linters,
+   dependency audits, and existing scanners through `terminal`. Keep scanner
+   installs isolated and ask before adding dependencies or sending code to an
+   external service. A scanner match is a lead until source review confirms
+   reachability and impact. Done when each selected command has its actual
+   result and each unavailable check is recorded as a coverage gap.
+
+7. **Choose a plain-language outcome.** Use `Fix before publishing` when a
+   confirmed problem remains. Use `Need your input` when the agent needs the
+   user to rotate a key, choose a provider setting, approve a dependency change,
+   or accept a coverage gap. Use `Ready to publish` only when the selected
+   surfaces and affected security paths are verified. Never publish merely
+   because a scanner returned zero findings. Done when the outcome follows from
+   evidence and the next action is obvious to a non-security specialist.
+
+8. **Fix what the agent safely can.** When remediation is already authorized,
+   use `patch` or `write_file` for narrow local fixes, run affected tests,
+   rebuild the artifact, and repeat the inventory. Group similar issues under
+   one fix instead of producing a long findings catalog. Ask the user only for
+   actions the agent cannot safely complete, such as rotating a real credential
+   or choosing whether a public feature should remain exposed. Done when the
+   final reviewed artifact is the unchanged artifact sent to the provider.
+
+## Pitfalls
+
+- Reviewing source while deploying stale or separately generated output.
+- Scanning while a build or watcher can replace files. Stop concurrent writers,
+  rebuild once, scan, and publish that unchanged artifact.
+- Checking only tracked files; `.env.production` may be untracked yet still sit
+  inside `dist/`.
+- Printing the matched token as evidence. A rule label and location are enough.
+- Treating minified code, an ORM, escaping middleware, or a WAF as automatic
+  proof that injection is impossible.
+- Reporting every regex or scanner match as a vulnerability without a reachable
+  source-to-sink path.
+- Claiming all OWASP categories were reviewed when the work covered only a diff.
+- Blocking publication only because an optional scanner is unavailable; report
+  the coverage gap and increase manual review instead.
+- Running active probes against a live target without separate authorization.
+
+## Verification
+
+Keep the default result short and practical. Do not lead with severity tables,
+OWASP category names, scanner rule IDs, raw command output, or a long findings
+index. Keep that evidence in working notes and show it only when the user asks
+or when it is needed to explain a fix.
+
+Use one of these outcomes exactly:
+
+- **Ready to publish** — no obvious blocker remains in the reviewed surfaces.
+- **Fix before publishing** — the agent found a confirmed problem it can explain
+  and fix or hand back clearly.
+- **Need your input** — a safe next step requires a user decision or action.
+
+Group findings that share one fix. Include only confirmed items that change what
+happens next. Each item needs a file or component, one plain-language sentence
+about the problem, and the exact fix. Never include a matched secret value.
+
+Use this default shape, omitting empty sections:
+
+```markdown
+## Publish safety check
+
+**Result:** Ready to publish | Fix before publishing | Need your input
+
+<One or two sentences explaining the result in everyday language.>
+
+### Fixes I can make
+- `<path or component>` — <what is wrong>. I will <specific fix and check>.
+
+### What you need to do
+- <one concrete user step, such as rotate a key or choose a visibility setting>
+
+### Next step
+- <what the agent will do after the fix or decision>
+```
+
+Examples of useful wording:
+
+- `dist/.env.production` would become public. Remove it from the upload, move
+  real values to provider secret storage, rebuild, and scan again.
+- `server/users.ts:84` builds SQL from user input. Change it to a parameterized
+  query and add a regression test before publishing.
+- A real key may have been exposed. The user must revoke or rotate it; deleting
+  the file alone does not make the old key safe.
+- The app uses HTTP only for local preview, while the verified public URL uses
+  provider-managed HTTPS. No transport fix is needed.
+- The production bundle calls `http://api.example.com`. Change it to HTTPS or a
+  relative URL so the browser does not block or downgrade the request.
+
+When the outcome is `Ready to publish`, say that no obvious blockers were found
+in the reviewed code and artifact, that this is not a guarantee, and whether the
+user has any remaining step. Before returning that outcome, verify that the
+inventory helper exits `0`, every review/skipped item has a disposition, the
+artifact was rebuilt after any fix, affected tests pass, and the reported paths
+still match the exact artifact that will be published.

--- a/optional-skills/security/pre-publish-security-review/scripts/inventory_publish_surface.py
+++ b/optional-skills/security/pre-publish-security-review/scripts/inventory_publish_surface.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Inventory a publish directory for deterministic secret-exposure risks.
+
+The script reports paths, line numbers, and rule labels only. It never emits a
+matched value or source snippet. It is intentionally a narrow preflight, not a
+replacement for SAST or manual review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_MAX_FILE_BYTES = 2_000_000
+VCS_DIRECTORIES = {".git", ".hg", ".svn"}
+CREDENTIAL_DIRECTORIES = {".aws", ".gnupg", ".ssh", ".wrangler"}
+SAFE_ENV_SUFFIXES = (".example", ".sample", ".template")
+SENSITIVE_EXACT_NAMES = {
+    ".dev.vars",
+    ".envrc",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    ".secrets",
+    "auth.json",
+    "credentials.json",
+    "credentials.yaml",
+    "credentials.yml",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa",
+    "secrets.json",
+    "secrets.yaml",
+    "secrets.yml",
+}
+SENSITIVE_SUFFIXES = (
+    ".jks",
+    ".key",
+    ".kdbx",
+    ".keystore",
+    ".p12",
+    ".pem",
+    ".pfx",
+)
+
+
+@dataclass(frozen=True)
+class Signature:
+    rule: str
+    pattern: re.Pattern[str]
+    blocking: bool
+
+
+SIGNATURES = (
+    Signature(
+        "private-key-header",
+        re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----"),
+        True,
+    ),
+    Signature(
+        "github-token",
+        re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"),
+        True,
+    ),
+    Signature("aws-access-key-id", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"), True),
+    Signature("google-api-key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"), True),
+    Signature("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"), True),
+    Signature("stripe-live-key", re.compile(r"\b[rs]k_live_[A-Za-z0-9]{16,}\b"), True),
+    Signature(
+        "credential-in-url",
+        re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s/:@]+:[^\s/@]+@", re.IGNORECASE),
+        True,
+    ),
+    Signature(
+        "literal-credential-assignment",
+        re.compile(
+            r"(?im)\b(?:api[_-]?key|client[_-]?secret|password|passwd|secret|token)"
+            r"\s*[:=]\s*['\"][^'\"\r\n]{8,}['\"]"
+        ),
+        False,
+    ),
+)
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _is_sensitive_path(relative_path: str, *, is_directory: bool = False) -> str | None:
+    path = Path(relative_path)
+    name = path.name.lower()
+
+    if name in VCS_DIRECTORIES:
+        return "version-control-metadata"
+    if is_directory and name in CREDENTIAL_DIRECTORIES:
+        return "credential-directory"
+    if (
+        name == ".env"
+        or name.endswith(".env")
+        or (name.startswith("env.") and not name.endswith(SAFE_ENV_SUFFIXES))
+        or (name.startswith(".env.") and not name.endswith(SAFE_ENV_SUFFIXES))
+    ):
+        return "environment-file"
+    if name in SENSITIVE_EXACT_NAMES:
+        return "credential-file"
+    if name.endswith(SENSITIVE_SUFFIXES):
+        return "private-key-or-keystore"
+    if "service-account" in name and name.endswith(".json"):
+        return "service-account-file"
+    return None
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _iter_files(root: Path) -> tuple[list[Path], list[dict[str, object]]]:
+    files: list[Path] = []
+    path_findings: list[dict[str, object]] = []
+
+    root_rule = _is_sensitive_path(root.name, is_directory=True)
+    if root_rule:
+        path_findings.append({"path": ".", "rule": root_rule})
+
+    def on_walk_error(error: OSError) -> None:
+        relative = "."
+        if error.filename:
+            try:
+                relative = Path(error.filename).relative_to(root).as_posix()
+            except ValueError:
+                pass
+        display_path = f"{relative}/" if relative != "." else relative
+        path_findings.append({"path": display_path, "rule": "directory-read-error"})
+
+    for current, dirnames, filenames in os.walk(
+        root,
+        topdown=True,
+        followlinks=False,
+        onerror=on_walk_error,
+    ):
+        current_path = Path(current)
+        kept_dirs: list[str] = []
+        for dirname in sorted(dirnames):
+            full_path = current_path / dirname
+            relative = _relative(full_path, root)
+            rule = _is_sensitive_path(relative, is_directory=True)
+            if rule:
+                path_findings.append({"path": f"{relative}/", "rule": rule})
+                continue
+            if full_path.is_symlink():
+                path_findings.append({"path": relative, "rule": "symlink-directory"})
+                continue
+            kept_dirs.append(dirname)
+        dirnames[:] = kept_dirs
+
+        for filename in sorted(filenames):
+            path = current_path / filename
+            relative = _relative(path, root)
+            if path.is_symlink():
+                path_findings.append({"path": relative, "rule": "symlink-file"})
+                continue
+            if path.is_file():
+                files.append(path)
+            else:
+                path_findings.append({"path": relative, "rule": "non-regular-file"})
+
+    files.sort(key=lambda path: _relative(path, root))
+    path_findings.sort(key=lambda finding: (str(finding["path"]), str(finding["rule"])))
+    return files, path_findings
+
+
+def _scan_text(
+    text: str,
+    *,
+    relative_path: str,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    blockers: list[dict[str, object]] = []
+    review: list[dict[str, object]] = []
+
+    for signature in SIGNATURES:
+        for match in signature.pattern.finditer(text):
+            finding: dict[str, object] = {
+                "path": relative_path,
+                "line": _line_number(text, match.start()),
+                "rule": signature.rule,
+            }
+            (blockers if signature.blocking else review).append(finding)
+
+    return blockers, review
+
+
+def inventory(root: Path, max_file_bytes: int) -> dict[str, Any]:
+    root = root.resolve()
+    files, path_findings = _iter_files(root)
+    secret_candidates: list[dict[str, object]] = []
+    review_candidates: list[dict[str, object]] = []
+    skipped_files: list[dict[str, object]] = []
+    scanned_files = 0
+
+    for path in files:
+        relative = _relative(path, root)
+        path_rule = _is_sensitive_path(relative)
+        if path_rule:
+            path_findings.append({"path": relative, "rule": path_rule})
+
+        if path.suffix.lower() == ".map":
+            review_candidates.append({"path": relative, "rule": "source-map"})
+
+        try:
+            with path.open("rb") as handle:
+                data = handle.read(max_file_bytes + 1)
+        except OSError:
+            skipped_files.append({"path": relative, "reason": "read-error"})
+            continue
+
+        if len(data) > max_file_bytes:
+            skipped_files.append({"path": relative, "reason": "size-limit"})
+            review_candidates.append({"path": relative, "rule": "unscanned-oversize-file"})
+            continue
+        if b"\x00" in data[:8192]:
+            skipped_files.append({"path": relative, "reason": "binary"})
+            continue
+
+        scanned_files += 1
+        text = data.decode("utf-8", errors="replace")
+        blockers, review = _scan_text(text, relative_path=relative)
+        secret_candidates.extend(blockers)
+        review_candidates.extend(review)
+
+    path_findings.sort(key=lambda finding: (str(finding["path"]), str(finding["rule"])))
+    def finding_key(finding: dict[str, object]) -> tuple[str, int, str]:
+        line = finding.get("line", 0)
+        return (
+            str(finding["path"]),
+            line if isinstance(line, int) else 0,
+            str(finding["rule"]),
+        )
+
+    secret_candidates.sort(key=finding_key)
+    review_candidates.sort(key=finding_key)
+    skipped_files.sort(key=lambda finding: (str(finding["path"]), str(finding["reason"])))
+
+    blockers = len(path_findings) + len(secret_candidates)
+    return {
+        "root": str(root),
+        "summary": {
+            "files_discovered": len(files),
+            "files_scanned_as_text": scanned_files,
+            "blocking_findings": blockers,
+            "review_findings": len(review_candidates),
+            "skipped_files": len(skipped_files),
+        },
+        "sensitive_paths": path_findings,
+        "secret_candidates": secret_candidates,
+        "review_candidates": review_candidates,
+        "skipped_files": skipped_files,
+        "decision": "HOLD" if blockers else "REVIEW",
+        "note": (
+            "Locations and rule labels only; matched values are never emitted. "
+            "Zero blockers is not proof that the artifact is secure."
+        ),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inventory a publish directory without printing matched secret values."
+    )
+    parser.add_argument("root", type=Path, help="Exact directory that will be published")
+    parser.add_argument(
+        "--max-file-bytes",
+        type=int,
+        default=DEFAULT_MAX_FILE_BYTES,
+        help=f"Maximum bytes scanned per text file (default: {DEFAULT_MAX_FILE_BYTES})",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.max_file_bytes < 1:
+        print("error: --max-file-bytes must be positive", file=sys.stderr)
+        return 2
+    if not args.root.is_dir():
+        print(f"error: publish directory does not exist: {args.root}", file=sys.stderr)
+        return 2
+
+    report = inventory(args.root, args.max_file_bytes)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if report["summary"]["blocking_findings"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_pre_publish_security_review_skill.py
+++ b/tests/skills/test_pre_publish_security_review_skill.py
@@ -1,0 +1,352 @@
+"""Contract and behavior tests for pre-publish-security-review."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = (
+    REPO_ROOT
+    / "optional-skills"
+    / "security"
+    / "pre-publish-security-review"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPT = SKILL_DIR / "scripts" / "inventory_publish_surface.py"
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Review Lenses",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+OWASP_2025_CATEGORIES = {
+    "A01 Broken Access Control",
+    "A02 Security Misconfiguration",
+    "A03 Software Supply Chain Failures",
+    "A04 Cryptographic Failures",
+    "A05 Injection",
+    "A06 Insecure Design",
+    "A07 Authentication Failures",
+    "A08 Software or Data Integrity Failures",
+    "A09 Security Logging and Alerting Failures",
+    "A10 Mishandling of Exceptional Conditions",
+}
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter_and_body(skill_text: str) -> tuple[str, str]:
+    match = re.match(r"^---\n(.*?)\n---\n(.*)$", skill_text, re.DOTALL)
+    assert match, "SKILL.md must begin with YAML frontmatter"
+    return match.group(1), match.group(2)
+
+
+def _frontmatter_value(frontmatter: str, key: str) -> str:
+    match = re.search(
+        rf"^[ \t]*{re.escape(key)}:\s*(.+)$", frontmatter, re.MULTILINE
+    )
+    assert match, f"missing frontmatter field: {key}"
+    return match.group(1).strip().strip('"')
+
+
+def _run_inventory(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _load_inventory_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("inventory_publish_surface", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_frontmatter_meets_repo_standard(frontmatter_and_body: tuple[str, str]) -> None:
+    frontmatter, body = frontmatter_and_body
+    assert _frontmatter_value(frontmatter, "name") == "pre-publish-security-review"
+    description = _frontmatter_value(frontmatter, "description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert _frontmatter_value(frontmatter, "version") == "0.1.0"
+    assert _frontmatter_value(frontmatter, "author") == (
+        "Mark S. (unsupportedpastels), Hermes Agent"
+    )
+    assert _frontmatter_value(frontmatter, "license") == "MIT"
+    assert _frontmatter_value(frontmatter, "category") == "security"
+    platforms = _frontmatter_value(frontmatter, "platforms").strip("[]").split(",")
+    assert {platform.strip() for platform in platforms} == {"linux", "macos", "windows"}
+    assert body.strip()
+
+
+def test_modern_sections_are_in_order(skill_text: str) -> None:
+    positions = [skill_text.index(section) for section in REQUIRED_SECTIONS]
+    assert positions == sorted(positions)
+
+
+def test_related_skills_resolve_in_repo(frontmatter_and_body: tuple[str, str]) -> None:
+    frontmatter, _ = frontmatter_and_body
+    raw = _frontmatter_value(frontmatter, "related_skills").strip("[]")
+    for name in (part.strip() for part in raw.split(",")):
+        hits = list((REPO_ROOT / "skills").glob(f"**/{name}/SKILL.md"))
+        hits += list((REPO_ROOT / "optional-skills").glob(f"**/{name}/SKILL.md"))
+        assert hits, f"related skill does not ship: {name}"
+
+
+def test_owasp_2025_changed_code_categories_are_complete(skill_text: str) -> None:
+    assert "OWASP Top 10:2025" in skill_text
+    for category in OWASP_2025_CATEGORIES:
+        assert category in skill_text
+    assert "SSRF" in skill_text
+
+
+def test_a02_distinguishes_edge_https_from_local_http(skill_text: str) -> None:
+    normalized = " ".join(skill_text.split())
+    for phrase in (
+        "HTTPS and edge termination (A02)",
+        "Managed static site or SPA (the common path)",
+        "`publish-site` sends a static output directory",
+        "provider owns the public origin and HTTPS",
+        "do not invent those findings",
+        "Server-rendered app or API",
+        "`http://localhost`",
+        "terminates HTTPS at the edge",
+        "public/share URL must use HTTPS",
+        "redirects to the same host over HTTPS",
+        "mixed content",
+        "`ws://`",
+        "directly reachable HTTP origin",
+        "session cookies are still marked `Secure`",
+        "managed static site with provider HTTPS",
+        "Start with the common static path",
+    ):
+        assert phrase in normalized
+    assert "Do not tell the user to add application-level TLS solely" in normalized
+
+
+def test_pr_only_reviews_route_to_github_code_review(skill_text: str) -> None:
+    normalized = " ".join(skill_text.split())
+    assert "ordinary PR-only review with no pending publication" in normalized
+    assert "use `github-code-review`" in normalized
+    assert "PR's code or generated artifact is about to become public" in normalized
+    assert "or upon the user's direct request" in normalized
+
+
+def test_gate_distinguishes_blockers_from_coverage_gaps(skill_text: str) -> None:
+    normalized = " ".join(skill_text.split())
+    assert 'python "${HERMES_SKILL_DIR}/scripts/inventory_publish_surface.py"' in skill_text
+    assert "review aid, not a security boundary" in normalized
+    assert "OS-level isolation" in normalized
+    for outcome in ("Ready to publish", "Fix before publishing", "Need your input"):
+        assert outcome in skill_text
+    assert "Scanner absence alone is a coverage warning" in normalized
+    assert "Never publish merely because a scanner returned zero findings" in normalized
+    assert "`review_candidates` entry" in normalized
+    assert "every `skipped_files` entry" in normalized
+    assert "Stop concurrent writers" in normalized
+    assert "git diff --cached --stat" in skill_text
+
+
+def test_default_report_is_plain_and_actionable(skill_text: str) -> None:
+    normalized = " ".join(skill_text.split())
+    for heading in ("## Publish safety check", "### Fixes I can make", "### What you need to do", "### Next step"):
+        assert heading in skill_text
+    assert "Do not lead with severity tables" in normalized
+    assert "Group findings that share one fix" in normalized
+    assert "one plain-language sentence" in normalized
+    assert "Never include a matched secret value" in normalized
+    assert "OWASP Changed-Code Pass" not in skill_text
+
+
+def test_inventory_holds_sensitive_paths_without_reading_vcs_contents(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    (publish / "index.html").write_text("<h1>Safe</h1>\n", encoding="utf-8")
+    (publish / ".env.production").write_text("PUBLIC_FLAG=true\n", encoding="utf-8")
+    (publish / ".dev.vars").write_text("LOCAL_ONLY=true\n", encoding="utf-8")
+    (publish / "production.env").write_text("LOCAL_ONLY=true\n", encoding="utf-8")
+    (publish / "secrets.yaml").write_text("placeholder: true\n", encoding="utf-8")
+    (publish / "client.pem").write_text("public-or-private-pem\n", encoding="utf-8")
+    git_dir = publish / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("secret-value-must-not-appear\n", encoding="utf-8")
+    ssh_dir = publish / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_rsa").write_text("another-value-must-not-appear\n", encoding="utf-8")
+
+    result = _run_inventory(publish)
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report["decision"] == "HOLD"
+    assert {(item["path"], item["rule"]) for item in report["sensitive_paths"]} == {
+        (".dev.vars", "credential-file"),
+        (".env.production", "environment-file"),
+        (".git/", "version-control-metadata"),
+        (".ssh/", "credential-directory"),
+        ("client.pem", "private-key-or-keystore"),
+        ("production.env", "environment-file"),
+        ("secrets.yaml", "credential-file"),
+    }
+    assert "secret-value-must-not-appear" not in result.stdout
+    assert "another-value-must-not-appear" not in result.stdout
+
+
+def test_sensitive_file_name_and_sensitive_root_hold(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    (publish / ".git").write_text("gitdir: hidden-location\n", encoding="utf-8")
+
+    result = _run_inventory(publish)
+    report = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert {item["rule"] for item in report["sensitive_paths"]} == {
+        "version-control-metadata"
+    }
+
+    sensitive_root = tmp_path / ".ssh"
+    sensitive_root.mkdir()
+    (sensitive_root / "notice.txt").write_text("no credential here\n", encoding="utf-8")
+    root_result = _run_inventory(sensitive_root)
+    root_report = json.loads(root_result.stdout)
+    assert root_result.returncode == 1
+    assert {item["path"]: item["rule"] for item in root_report["sensitive_paths"]}["."] == (
+        "credential-directory"
+    )
+
+
+def test_non_regular_entries_and_walk_errors_hold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_inventory_module()
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    special = publish / "special-entry"
+    special.write_text("placeholder\n", encoding="utf-8")
+    original_is_file = Path.is_file
+
+    def fake_is_file(path: Path) -> bool:
+        return False if path == special else original_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", fake_is_file)
+    report = module.inventory(publish, module.DEFAULT_MAX_FILE_BYTES)
+    assert report["decision"] == "HOLD"
+    assert report["sensitive_paths"] == [
+        {"path": "special-entry", "rule": "non-regular-file"}
+    ]
+
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+
+    def fake_walk(root: Path, **kwargs: object):
+        onerror = kwargs["onerror"]
+        assert callable(onerror)
+        onerror(PermissionError(13, "denied", str(Path(root) / "blocked")))
+        return iter(())
+
+    monkeypatch.setattr(module.os, "walk", fake_walk)
+    error_report = module.inventory(unreadable, module.DEFAULT_MAX_FILE_BYTES)
+    assert error_report["decision"] == "HOLD"
+    assert error_report["sensitive_paths"] == [
+        {"path": "blocked/", "rule": "directory-read-error"}
+    ]
+
+
+def test_inventory_reports_secret_locations_but_never_values(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    token = "gh" + "p_" + ("A" * 32)
+    source = publish / "app.js"
+    source.write_text(
+        "const harmless = true;\n"
+        f"const deployedToken = '{token}';\n"
+        "const password = 'review-only-value';\n",
+        encoding="utf-8",
+    )
+
+    result = _run_inventory(publish)
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report["secret_candidates"] == [
+        {"line": 2, "path": "app.js", "rule": "github-token"}
+    ]
+    assert {item["rule"] for item in report["review_candidates"]} == {
+        "literal-credential-assignment"
+    }
+    assert token not in result.stdout
+    assert "review-only-value" not in result.stdout
+
+
+def test_clean_artifact_returns_review_not_security_claim(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    (publish / "index.html").write_text("<h1>Hello</h1>\n", encoding="utf-8")
+    assets = publish / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("console.log('hello');\n", encoding="utf-8")
+
+    result = _run_inventory(publish)
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert report["decision"] == "REVIEW"
+    assert report["summary"]["blocking_findings"] == 0
+    assert "not proof" in report["note"]
+
+
+def test_oversize_text_file_is_a_review_gap(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    (publish / "large.js").write_text("0123456789", encoding="utf-8")
+
+    result = _run_inventory(publish, "--max-file-bytes", "5")
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert report["skipped_files"] == [{"path": "large.js", "reason": "size-limit"}]
+    assert report["review_candidates"] == [
+        {"path": "large.js", "rule": "unscanned-oversize-file"}
+    ]
+
+
+def test_binary_file_is_an_explicit_coverage_gap(tmp_path: Path) -> None:
+    publish = tmp_path / "dist"
+    publish.mkdir()
+    token = "gh" + "p_" + ("B" * 32)
+    (publish / "opaque.bin").write_bytes(b"\x00" + token.encode("ascii"))
+
+    result = _run_inventory(publish)
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert report["decision"] == "REVIEW"
+    assert report["skipped_files"] == [{"path": "opaque.bin", "reason": "binary"}]
+    assert token not in result.stdout
+
+
+def test_inventory_module_imports_without_third_party_dependencies() -> None:
+    module = _load_inventory_module()
+    assert module.DEFAULT_MAX_FILE_BYTES > 0

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -222,6 +222,7 @@ hermes skills uninstall <skill-name>
 | [**1password**](/docs/user-guide/skills/optional/security/security-1password) | Set up op CLI, sign in, and read or inject secrets. |
 | [**godmode**](/docs/user-guide/skills/optional/security/security-godmode) | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
 | [**oss-forensics**](/docs/user-guide/skills/optional/security/security-oss-forensics) | GitHub supply-chain forensics: recovery, IOCs, reporting. |
+| [**pre-publish-security-review**](/docs/user-guide/skills/optional/security/security-pre-publish-security-review) | Review code and artifacts safely before publishing. |
 | [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | Find accounts for a username across 400+ platforms. |
 | [**unbroker**](/docs/user-guide/skills/optional/security/security-unbroker) | Autonomously remove your info from data-broker sites. |
 | [**web-pentest**](/docs/user-guide/skills/optional/security/security-web-pentest) | Authorized web pentest: recon, proof-based exploits, report. |

--- a/website/docs/user-guide/skills/optional/security/security-pre-publish-security-review.md
+++ b/website/docs/user-guide/skills/optional/security/security-pre-publish-security-review.md
@@ -1,0 +1,311 @@
+---
+title: "Pre Publish Security Review — Review code and artifacts safely before publishing"
+sidebar_label: "Pre Publish Security Review"
+description: "Review code and artifacts safely before publishing"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Pre Publish Security Review
+
+Review code and artifacts safely before publishing.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/security/pre-publish-security-review` |
+| Path | `optional-skills/security/pre-publish-security-review` |
+| Version | `0.1.0` |
+| Author | Mark S. (unsupportedpastels), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `security`, `code-review`, `publishing`, `owasp`, `secrets`, `sast` |
+| Related skills | [`github-code-review`](/docs/user-guide/skills/bundled/github/github-github-code-review), [`publish-site`](/docs/user-guide/skills/optional/web-development/web-development-publish-site), [`cloudflare-temporary-deploy`](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Pre-Publish Security Review Skill
+
+Review the exact code and files about to become public before a GitHub push or
+site deployment. This is a short, evidence-based safety gate for secret
+exposure and common web risks; like Hermes' other in-process checks, it is a
+review aid, not a security boundary. It does not replace OS-level isolation, a
+full security assessment, penetration test, or project-specific SAST workflow.
+
+## When to Use
+
+- Before `publish-site`, `cloudflare-temporary-deploy`, a public repository
+  push, or another action that makes code or build output externally reachable.
+- After a meaningful change to authentication, authorization, database access,
+  templates, command execution, URL fetching, dependencies, or error handling.
+- When the user asks for a friendly security check rather than a full audit.
+
+Do not use this as proof that an application is secure. For a full-repository
+review, use a dedicated project security skill when one is available. For an
+ordinary PR-only review with no pending publication, use `github-code-review`.
+Use this skill when the PR's code or generated artifact is about to become
+public, or upon the user's direct request.
+
+## Prerequisites
+
+- A local repository or publish directory.
+- The `terminal`, `read_file`, and `search_files` tools.
+- Python 3 for the bundled artifact inventory helper.
+- Optional project-declared tests and already-installed scanners. Do not install
+  or upload source to a third-party scanner without approval.
+
+The OWASP mapping below follows the
+[OWASP Top 10:2025](https://owasp.org/Top10/2025/). The list is an awareness
+baseline, not an exhaustive vulnerability taxonomy.
+
+## How to Run
+
+Use `terminal` from the project root. First identify both review surfaces:
+
+1. **Code surface:** the staged diff or branch diff that will be pushed.
+2. **Publish surface:** the exact directory a hosting command will upload, such
+   as `dist/`, `build/`, or the repository root.
+
+Inventory the publish surface without printing matched secret values:
+
+```text
+python "${HERMES_SKILL_DIR}/scripts/inventory_publish_surface.py" <publish-dir>
+```
+
+Exit `1` means the helper found a blocking sensitive path or high-confidence
+credential signature. Exit `0` means no deterministic blocker was found; it is
+not a clean bill of health. Then inspect the code diff and apply the review
+lenses below.
+
+## Quick Reference
+
+| Task | Command or evidence |
+| --- | --- |
+| Inventory artifact | `python "${HERMES_SKILL_DIR}/scripts/inventory_publish_surface.py" <publish-dir>` |
+| Review staged code | `git diff --cached --stat` then `git diff --cached` through `terminal` |
+| Review branch code | `git diff <base>...HEAD --stat` then the full diff through `terminal` |
+| Trace a finding | `read_file` around the changed source-to-sink path |
+| Run project checks | Repository-declared tests/scanners through `terminal` |
+| Set the outcome | Confirmed evidence + residual risk → `Ready to publish`, `Fix before publishing`, or `Need your input` |
+
+Use `Fix before publishing` for a secret or private key in the publish surface,
+a confirmed reachable high-impact vulnerability, a failing affected security
+test, or an unresolved injection/access-control path. Use `Need your input` when
+a safe fix requires the user's choice or a coverage gap cannot be closed. Scanner
+absence alone is a coverage warning, not a vulnerability.
+
+## Review Lenses
+
+### Publish-surface exposure
+
+- Treat every file in a static bundle as public, including source maps, comments,
+  JSON, client configuration, and files hidden by a leading dot.
+- A `.gitignore` entry is not evidence that a deploy CLI excludes the file.
+  Review the actual upload directory.
+- Browser-delivered environment values are public by design. Server-side secrets
+  belong in provider secret storage, never in source or generated JavaScript.
+- Do not paste suspected values into chat or reports. Record only path, line,
+  rule label, and remediation.
+
+### OWASP Top 10:2025 changed-code pass
+
+Review categories that intersect the diff. Mark a category `N/A` only with a
+short reason; do not imply whole-repository coverage.
+
+| Category | Focus on changed code |
+| --- | --- |
+| A01 Broken Access Control | Ownership/tenant checks, role gates, IDOR, deny-by-default server routes |
+| A02 Security Misconfiguration | Debug modes, permissive CORS/CSP, public admin paths, source maps, unsafe defaults, and the real public HTTPS path rather than local HTTP alone |
+| A03 Software Supply Chain Failures | New dependencies, lockfile drift, unpinned actions, install/build scripts |
+| A04 Cryptographic Failures | Hardcoded keys, weak randomness/hashing, custom crypto, sensitive transport/storage |
+| A05 Injection | Parameterized SQL, argument-safe process calls, output encoding, template/DOM sinks, path input |
+| A06 Insecure Design | Missing abuse limits, trust-boundary assumptions, unsafe business workflow |
+| A07 Authentication Failures | Session lifecycle, account recovery, credential checks, brute-force controls |
+| A08 Software or Data Integrity Failures | Unsafe deserialization, unsigned updates, untrusted build or webhook data |
+| A09 Security Logging and Alerting Failures | Security-event coverage without tokens, passwords, or personal data in logs |
+| A10 Mishandling of Exceptional Conditions | Fail-open authorization, partial writes, insecure fallback, leaked stack traces |
+
+#### HTTPS and edge termination (A02)
+
+Judge transport security from the deployment users actually have. Choose the
+smallest matching path instead of assuming a server backend:
+
+- **Managed static site or SPA (the common path):** when `publish-site` sends a
+  static output directory to GitHub Pages, Cloudflare Pages, or Netlify, the
+  provider owns the public origin and HTTPS. Check the final HTTPS URL,
+  HTTP-to-HTTPS redirect, mixed content, and accidental secret files. There is
+  no application server origin, proxy trust, ops cookie, or backend port to
+  review; do not invent those findings.
+- **Server-rendered app or API:** use the origin/proxy checks below only when the
+  project actually runs a Node/Python/Ruby/etc. server, exposes an API, or keeps
+  a long-running container behind the HTTPS provider.
+
+For either path:
+
+- `http://localhost` and other local preview URLs are expected and are not a
+  finding by themselves.
+- The public/share URL must use HTTPS. When the provider exposes a public HTTP
+  URL, verify that it redirects to the same host over HTTPS.
+- Flag browser-visible `http://` assets, API URLs, form actions, or `ws://`
+  sockets in production output. They create mixed content or bypass the HTTPS
+  page; use relative URLs, HTTPS, or WSS instead.
+
+For a server runtime only:
+
+- An origin may use HTTP when a trusted platform owns or isolates that hop and
+  terminates HTTPS at the edge. Do not tell the user to add application-level
+  TLS solely to pass this review.
+- Flag a directly reachable HTTP origin that bypasses the intended edge,
+  authentication, rate limits, or headers. If edge-to-origin traffic crosses an
+  untrusted network, require HTTPS on that hop rather than treating edge TLS as
+  end-to-end protection.
+- Confirm that forwarded scheme handling is trusted correctly and session
+  cookies are still marked `Secure`.
+
+If a live URL already exists, use `terminal` to verify the HTTPS response and
+HTTP-to-HTTPS redirect. Keep the user-facing result simple: a managed static
+site with provider HTTPS, or local HTTP behind a verified HTTPS server host,
+needs no transport fix; public HTTP or mixed content does.
+
+Also inspect changed outbound URL fetching for SSRF and redirect abuse even
+though SSRF is not a standalone 2025 category.
+
+## Procedure
+
+1. **Resolve and classify the external action.** Start with the common static
+   path: if the host receives only an output directory containing HTML/CSS/JS,
+   use the managed-static checks and do not inspect imaginary server controls.
+   Switch to the server-runtime path only when the project actually runs a
+   server/API/container after deployment. Record the target, branch/commit, and
+   exact upload directory or image. Stop if the publish surface is unknown.
+   Done when every file that can become public belongs to a named surface and
+   only relevant security controls are in scope.
+
+2. **Inspect repository instructions and status.** Use `read_file` for relevant
+   `AGENTS.md`, `CONTRIBUTING.md`, and security guidance; use `terminal` for
+   branch, status, and diff metadata. Do not discard unrelated local changes.
+   Done when the base revision and working-tree ownership are clear.
+
+3. **Inventory the publish surface.** Run the bundled helper against the exact
+   upload directory. Read its JSON labels, never secret values. Treat
+   `sensitive_paths` and `secret_candidates` as blockers until inspected and
+   removed or proven to be inert test/example data outside the upload surface.
+   Manually disposition every `review_candidates` entry and every
+   `skipped_files` entry before choosing `Ready to publish`; they are coverage
+   gaps, not passes. Done when blockers are cleared, review gaps have
+   dispositions, and the corrected surface has been rescanned.
+
+4. **Build a changed-code map.** Review the complete staged or branch diff, then
+   use `read_file` around changed security-sensitive functions. Group changes
+   by input, authorization, data store, template/DOM output, process execution,
+   outbound network, dependencies/build, logging, and error handling. Done when
+   each changed trust boundary has an owner and data flow.
+
+5. **Run the applicable OWASP pass.** For each intersecting category, trace a
+   plausible untrusted input to its security-sensitive sink and verify the
+   control in source. For SQL, prove parameter binding at the final query call;
+   ORM use alone is not proof. For shell calls, prove arguments do not cross an
+   unsafe shell-string boundary. Done when each applicable category has source
+   evidence, a confirmed finding, or a meaningful negative result.
+
+6. **Run project-native checks.** Prefer repository-declared tests, linters,
+   dependency audits, and existing scanners through `terminal`. Keep scanner
+   installs isolated and ask before adding dependencies or sending code to an
+   external service. A scanner match is a lead until source review confirms
+   reachability and impact. Done when each selected command has its actual
+   result and each unavailable check is recorded as a coverage gap.
+
+7. **Choose a plain-language outcome.** Use `Fix before publishing` when a
+   confirmed problem remains. Use `Need your input` when the agent needs the
+   user to rotate a key, choose a provider setting, approve a dependency change,
+   or accept a coverage gap. Use `Ready to publish` only when the selected
+   surfaces and affected security paths are verified. Never publish merely
+   because a scanner returned zero findings. Done when the outcome follows from
+   evidence and the next action is obvious to a non-security specialist.
+
+8. **Fix what the agent safely can.** When remediation is already authorized,
+   use `patch` or `write_file` for narrow local fixes, run affected tests,
+   rebuild the artifact, and repeat the inventory. Group similar issues under
+   one fix instead of producing a long findings catalog. Ask the user only for
+   actions the agent cannot safely complete, such as rotating a real credential
+   or choosing whether a public feature should remain exposed. Done when the
+   final reviewed artifact is the unchanged artifact sent to the provider.
+
+## Pitfalls
+
+- Reviewing source while deploying stale or separately generated output.
+- Scanning while a build or watcher can replace files. Stop concurrent writers,
+  rebuild once, scan, and publish that unchanged artifact.
+- Checking only tracked files; `.env.production` may be untracked yet still sit
+  inside `dist/`.
+- Printing the matched token as evidence. A rule label and location are enough.
+- Treating minified code, an ORM, escaping middleware, or a WAF as automatic
+  proof that injection is impossible.
+- Reporting every regex or scanner match as a vulnerability without a reachable
+  source-to-sink path.
+- Claiming all OWASP categories were reviewed when the work covered only a diff.
+- Blocking publication only because an optional scanner is unavailable; report
+  the coverage gap and increase manual review instead.
+- Running active probes against a live target without separate authorization.
+
+## Verification
+
+Keep the default result short and practical. Do not lead with severity tables,
+OWASP category names, scanner rule IDs, raw command output, or a long findings
+index. Keep that evidence in working notes and show it only when the user asks
+or when it is needed to explain a fix.
+
+Use one of these outcomes exactly:
+
+- **Ready to publish** — no obvious blocker remains in the reviewed surfaces.
+- **Fix before publishing** — the agent found a confirmed problem it can explain
+  and fix or hand back clearly.
+- **Need your input** — a safe next step requires a user decision or action.
+
+Group findings that share one fix. Include only confirmed items that change what
+happens next. Each item needs a file or component, one plain-language sentence
+about the problem, and the exact fix. Never include a matched secret value.
+
+Use this default shape, omitting empty sections:
+
+```markdown
+## Publish safety check
+
+**Result:** Ready to publish | Fix before publishing | Need your input
+
+<One or two sentences explaining the result in everyday language.>
+
+### Fixes I can make
+- `<path or component>` — <what is wrong>. I will <specific fix and check>.
+
+### What you need to do
+- <one concrete user step, such as rotate a key or choose a visibility setting>
+
+### Next step
+- <what the agent will do after the fix or decision>
+```
+
+Examples of useful wording:
+
+- `dist/.env.production` would become public. Remove it from the upload, move
+  real values to provider secret storage, rebuild, and scan again.
+- `server/users.ts:84` builds SQL from user input. Change it to a parameterized
+  query and add a regression test before publishing.
+- A real key may have been exposed. The user must revoke or rotate it; deleting
+  the file alone does not make the old key safe.
+- The app uses HTTP only for local preview, while the verified public URL uses
+  provider-managed HTTPS. No transport fix is needed.
+- The production bundle calls `http://api.example.com`. Change it to HTTPS or a
+  relative URL so the browser does not block or downgrade the request.
+
+When the outcome is `Ready to publish`, say that no obvious blockers were found
+in the reviewed code and artifact, that this is not a guarantee, and whether the
+user has any remaining step. Before returning that outcome, verify that the
+inventory helper exits `0`, every review/skipped item has a disposition, the
+artifact was rebuilt after any fix, affected tests pass, and the reported paths
+still match the exact artifact that will be published.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -588,6 +588,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/security/security-1password',
                     'user-guide/skills/optional/security/security-godmode',
                     'user-guide/skills/optional/security/security-oss-forensics',
+                    'user-guide/skills/optional/security/security-pre-publish-security-review',
                     'user-guide/skills/optional/security/security-sherlock',
                     'user-guide/skills/optional/security/security-unbroker',
                     'user-guide/skills/optional/security/security-web-pentest',


### PR DESCRIPTION
## What does this PR do?

Adds an optional pre-publish security review skill for code and artifacts that are about to become public, or when the user directly requests the review.

The skill keeps the common site-publishing path short:

- For static sites and SPAs published through `publish-site`, it relies on provider-managed HTTPS and checks the exact output directory for secrets, sensitive files, mixed content, and unsafe changed-code paths.
- It applies origin, proxy, API, and secure-cookie checks only when the project actually contains a server runtime.
- It maps relevant changed code to the OWASP Top 10:2025 without presenting the user with a long security report.
- It returns one plain-language outcome: `Ready to publish`, `Fix before publishing`, or `Need your input`, followed by the fixes and user actions that matter.

The bundled standard-library helper inventories the exact publish directory. It reports only file paths, line numbers, and rule labels; it never prints matched secret values. The skill explicitly describes this as a review aid rather than a security boundary, consistent with `SECURITY.md`.

## Related Issue

Related to #72189, which added the optional `publish-site` workflow this skill can run before.

Ordinary PR-only reviews continue to route to `github-code-review`; this skill is limited to code and concrete artifacts that are about to become public, or to a direct user request.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-skills/security/pre-publish-security-review/SKILL.md` with:
  - static-site-first and server-runtime review paths;
  - OWASP Top 10:2025 changed-code guidance;
  - HTTPS edge-termination and mixed-content checks;
  - simple user-facing outcomes and remediation steps.
- Added `scripts/inventory_publish_surface.py`, a cross-platform stdlib helper that:
  - detects environment files, credentials, private keys, VCS metadata, symlinks, unreadable paths, and high-confidence credential signatures;
  - treats skipped/oversized/binary files as explicit coverage gaps;
  - emits locations and rule labels without matched values.
- Added fixture-based tests for metadata, authoring rules, redaction, sensitive paths, binary/oversize files, traversal errors, cross-platform invocation, HTTPS classification, and report wording.
- Generated the optional-skill documentation page, catalog row, and sidebar entry.

## Security and privacy

- The helper never emits matched secret values or source snippets.
- It does not deploy, actively probe a live target, install project dependencies, or upload source to an external scanner.
- Zero findings are not presented as proof that a project is secure.
- Managed static hosting does not receive irrelevant server-origin findings.
- Server-runtime checks distinguish legitimate internal HTTP behind a trusted HTTPS edge from mixed content or a directly reachable HTTP origin.

## How to Test

1. Run the skill and authoring tests:

   ```bash
   scripts/run_tests.sh tests/skills/test_pre_publish_security_review_skill.py tests/skills/test_authoring_standards.py -q
   ```

2. Run lint and type checks for the helper:

   ```bash
   uvx --from 'ruff==0.15.10' ruff check \
     optional-skills/security/pre-publish-security-review/scripts/inventory_publish_surface.py \
     tests/skills/test_pre_publish_security_review_skill.py
   uvx --from 'ty==0.0.21' ty check \
     optional-skills/security/pre-publish-security-review/scripts/inventory_publish_surface.py
   ```

3. Build the generated documentation:

   ```bash
   cd website && npm run build
   ```

4. Run the helper against an exact publish directory:

   ```bash
   python "optional-skills/security/pre-publish-security-review/scripts/inventory_publish_surface.py" <publish-dir>
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused skill and authoring suites pass; full repository suite not run
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no core architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool changes

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — N/A, submitted as an optional skill
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available; the helper uses Python's standard library
- [ ] I've tested the skill end-to-end with `hermes --toolsets skills -q "Use the pre-publish-security-review skill to review <project>"` — manual end-to-end exercise completed; exact command still pending

## Screenshots / Logs

N/A. The generated documentation site builds successfully for English and Simplified Chinese.
