### PR TITLE
test(skills): add contract and discipline test suites for tdd and plan

### DIFF
--- a/tests/skills/_skill_test_utils.py
+++ b/tests/skills/_skill_test_utils.py
@@ -1,0 +1,33 @@
+"""Shared helper utilities for skill contract and discipline tests."""
+
+import re
+from pathlib import Path
+from typing import Any
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_frontmatter_and_body(skill_path: Path) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter and body from a SKILL.md file."""
+    content = skill_path.read_text(encoding="utf-8")
+    assert content.startswith("---"), f"{skill_path}: SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, f"{skill_path}: unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), f"{skill_path}: frontmatter must be a YAML mapping"
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def resolve_related_skills_in_repo(names: list[str]) -> list[str]:
+    """Check that each related skill name exists in skills/ or optional-skills/."""
+    missing = []
+    for name in names:
+        hits = (
+            list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md"))
+        )
+        if not hits:
+            missing.append(name)
+    return missing

--- a/tests/skills/test_plan_skill.py
+++ b/tests/skills/test_plan_skill.py
@@ -1,9 +1,10 @@
-"""Contract tests for the bundled plan skill."""
+"""Contract and methodology discipline tests for the plan skill."""
 
 import re
 from pathlib import Path
 import pytest
-import yaml
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_MD = (
@@ -14,22 +15,6 @@ SKILL_MD = (
     / "SKILL.md"
 )
 
-REQUIRED_SECTIONS = [
-    "## Core behavior",
-    "## Output requirements",
-    "## Save location",
-    "## Interaction style",
-    "## Overview",
-    "## When a Full Implementation Plan Helps",
-    "## Bite-Sized Task Granularity",
-    "## Plan Document Structure",
-    "## Writing Process",
-    "## Principles",
-    "## Common Mistakes",
-    "## Execution Handoff",
-    "## Remember",
-]
-
 WRITING_PROCESS_STEPS = [
     "### Step 1: Understand Requirements",
     "### Step 2: Explore the Codebase",
@@ -39,15 +24,11 @@ WRITING_PROCESS_STEPS = [
     "### Step 6: Review the Plan",
 ]
 
-
-def _frontmatter_and_body():
-    content = SKILL_MD.read_text(encoding="utf-8")
-    assert content.startswith("---")
-    m = re.search(r"\n---\s*\n", content[3:])
-    assert m, "frontmatter must close with ---"
-    fm = yaml.safe_load(content[3 : m.start() + 3])
-    body = content[m.end() + 3 :]
-    return fm, body
+CORE_PRINCIPLES = [
+    "DRY (Don't Repeat Yourself)",
+    "YAGNI (You Aren't Gonna Need It)",
+    "Frequent Commits",
+]
 
 
 class TestPlanSkillContract:
@@ -57,7 +38,7 @@ class TestPlanSkillContract:
         assert SKILL_MD.is_file()
 
     def test_frontmatter_required_fields(self):
-        fm, _ = _frontmatter_and_body()
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
         for field in ("name", "description", "version", "author", "license", "platforms"):
             assert field in fm, f"missing frontmatter field: {field}"
         assert fm["name"] == "plan"
@@ -66,7 +47,7 @@ class TestPlanSkillContract:
         assert "related_skills" in hermes
 
     def test_description_hardline(self):
-        fm, _ = _frontmatter_and_body()
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
         desc = fm["description"]
         assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
         assert desc.endswith("."), "description must end with a period"
@@ -77,38 +58,31 @@ class TestPlanSkillContract:
         )
 
     def test_related_skills_resolve_in_repo(self):
-        fm, _ = _frontmatter_and_body()
-        for name in fm["metadata"]["hermes"]["related_skills"]:
-            hits = list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md")) + list(
-                REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md")
-            )
-            assert hits, f"related_skills entry does not resolve in repo: {name}"
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
 
     def test_no_machine_local_paths(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         assert "/home/" not in content
         assert not re.search(r"[A-Z]:\\\\Users", content)
 
-    def test_required_sections_present(self):
-        _, body = _frontmatter_and_body()
-        for section in REQUIRED_SECTIONS:
-            assert section in body, f"missing section: {section}"
-
-    def test_plan_save_location_and_task_granularity(self):
-        _, body = _frontmatter_and_body()
-        assert ".hermes/plans/" in body
-        assert "2-5 minutes" in body
-        assert "write_file" in body
-
-    def test_writing_process_sequence(self):
-        _, body = _frontmatter_and_body()
+    def test_writing_process_steps_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
         positions = [body.index(step) for step in WRITING_PROCESS_STEPS]
-        assert positions == sorted(positions), "writing process steps must be sequential 1 through 6"
+        assert positions == sorted(positions), "writing process steps must be sequential 1-6"
 
-    def test_core_disciplines_and_tools(self):
-        _, body = _frontmatter_and_body()
-        assert "DRY" in body
-        assert "YAGNI" in body
-        assert "TDD" in body
-        assert "subagent-driven-development" in body
-        assert "delegate_task" in body
+    def test_plan_location_and_format_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert ".hermes/plans/" in body, "plan file must be stored in .hermes/plans/"
+        assert ".hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md" in body
+
+    def test_task_granularity_and_estimates(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        assert "2-5 minutes" in body or "2–5 minutes" in body
+        assert "Bite-Sized" in body or "bite-sized" in body
+
+    def test_engineering_principles_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for principle in CORE_PRINCIPLES:
+            assert principle in body, f"engineering principle {principle} must be present"

--- a/tests/skills/test_plan_skill.py
+++ b/tests/skills/test_plan_skill.py
@@ -1,0 +1,114 @@
+"""Contract tests for the bundled plan skill."""
+
+import re
+from pathlib import Path
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = (
+    REPO_ROOT
+    / "skills"
+    / "software-development"
+    / "plan"
+    / "SKILL.md"
+)
+
+REQUIRED_SECTIONS = [
+    "## Core behavior",
+    "## Output requirements",
+    "## Save location",
+    "## Interaction style",
+    "## Overview",
+    "## When a Full Implementation Plan Helps",
+    "## Bite-Sized Task Granularity",
+    "## Plan Document Structure",
+    "## Writing Process",
+    "## Principles",
+    "## Common Mistakes",
+    "## Execution Handoff",
+    "## Remember",
+]
+
+WRITING_PROCESS_STEPS = [
+    "### Step 1: Understand Requirements",
+    "### Step 2: Explore the Codebase",
+    "### Step 3: Design Approach",
+    "### Step 4: Write Tasks",
+    "### Step 5: Add Complete Details",
+    "### Step 6: Review the Plan",
+]
+
+
+def _frontmatter_and_body():
+    content = SKILL_MD.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "frontmatter must close with ---"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+class TestPlanSkillContract:
+    """Test that SKILL.md adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = _frontmatter_and_body()
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "plan"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = _frontmatter_and_body()
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = _frontmatter_and_body()
+        for name in fm["metadata"]["hermes"]["related_skills"]:
+            hits = list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md")) + list(
+                REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md")
+            )
+            assert hits, f"related_skills entry does not resolve in repo: {name}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+    def test_required_sections_present(self):
+        _, body = _frontmatter_and_body()
+        for section in REQUIRED_SECTIONS:
+            assert section in body, f"missing section: {section}"
+
+    def test_plan_save_location_and_task_granularity(self):
+        _, body = _frontmatter_and_body()
+        assert ".hermes/plans/" in body
+        assert "2-5 minutes" in body
+        assert "write_file" in body
+
+    def test_writing_process_sequence(self):
+        _, body = _frontmatter_and_body()
+        positions = [body.index(step) for step in WRITING_PROCESS_STEPS]
+        assert positions == sorted(positions), "writing process steps must be sequential 1 through 6"
+
+    def test_core_disciplines_and_tools(self):
+        _, body = _frontmatter_and_body()
+        assert "DRY" in body
+        assert "YAGNI" in body
+        assert "TDD" in body
+        assert "subagent-driven-development" in body
+        assert "delegate_task" in body

--- a/tests/skills/test_tdd_skill.py
+++ b/tests/skills/test_tdd_skill.py
@@ -3,7 +3,8 @@
 import re
 from pathlib import Path
 import pytest
-import yaml
+
+from tests.skills._skill_test_utils import parse_frontmatter_and_body, resolve_related_skills_in_repo
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_MD = (
@@ -37,16 +38,6 @@ CYCLE_STEPS = [
 ]
 
 
-def _frontmatter_and_body():
-    content = SKILL_MD.read_text(encoding="utf-8")
-    assert content.startswith("---")
-    m = re.search(r"\n---\s*\n", content[3:])
-    assert m, "frontmatter must close with ---"
-    fm = yaml.safe_load(content[3 : m.start() + 3])
-    body = content[m.end() + 3 :]
-    return fm, body
-
-
 class TestTDDSkillContract:
     """Test that SKILL.md adheres to the project hardline standards."""
 
@@ -54,7 +45,7 @@ class TestTDDSkillContract:
         assert SKILL_MD.is_file()
 
     def test_frontmatter_required_fields(self):
-        fm, _ = _frontmatter_and_body()
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
         for field in ("name", "description", "version", "author", "license", "platforms"):
             assert field in fm, f"missing frontmatter field: {field}"
         assert fm["name"] == "test-driven-development"
@@ -63,7 +54,7 @@ class TestTDDSkillContract:
         assert "related_skills" in hermes
 
     def test_description_hardline(self):
-        fm, _ = _frontmatter_and_body()
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
         desc = fm["description"]
         assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
         assert desc.endswith("."), "description must end with a period"
@@ -74,31 +65,27 @@ class TestTDDSkillContract:
         )
 
     def test_related_skills_resolve_in_repo(self):
-        fm, _ = _frontmatter_and_body()
-        for name in fm["metadata"]["hermes"]["related_skills"]:
-            hits = list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md")) + list(
-                REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md")
-            )
-            assert hits, f"related_skills entry does not resolve in repo: {name}"
+        fm, _ = parse_frontmatter_and_body(SKILL_MD)
+        missing = resolve_related_skills_in_repo(fm["metadata"]["hermes"]["related_skills"])
+        assert not missing, f"related_skills entries do not resolve in repo: {missing}"
 
     def test_no_machine_local_paths(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         assert "/home/" not in content
         assert not re.search(r"[A-Z]:\\\\Users", content)
 
-    def test_required_sections_present(self):
-        _, body = _frontmatter_and_body()
-        for section in REQUIRED_SECTIONS:
-            assert section in body, f"missing section: {section}"
+    def test_required_sections_present_and_ordered(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        positions = [body.index(section) for section in REQUIRED_SECTIONS]
+        assert positions == sorted(positions), "sections must follow structured sequence"
 
-    def test_red_green_refactor_cycle_sequence(self):
-        _, body = _frontmatter_and_body()
-        positions = [body.index(step) for step in CYCLE_STEPS]
-        assert positions == sorted(positions), "cycle steps must be in RED -> Verify RED -> GREEN -> Verify GREEN -> REFACTOR order"
+    def test_red_green_refactor_cycle_steps_complete(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
+        for step in CYCLE_STEPS:
+            assert step in body, f"cycle step missing: {step}"
 
-    def test_iron_law_and_tracer_bullet_discipline(self):
-        _, body = _frontmatter_and_body()
+    def test_iron_law_of_tdd_documented(self):
+        _, body = parse_frontmatter_and_body(SKILL_MD)
         assert "NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST" in body
-        assert "tracer bullets" in body.lower()
-        assert "terminal" in body
-        assert "delegate_task" in body
+        assert "Tracer Bullets" in body or "tracer bullet" in body.lower()
+        assert "Hermes Integration" in body or "Hermes Agent Integration" in body

--- a/tests/skills/test_tdd_skill.py
+++ b/tests/skills/test_tdd_skill.py
@@ -1,0 +1,104 @@
+"""Contract tests for the bundled test-driven-development skill."""
+
+import re
+from pathlib import Path
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = (
+    REPO_ROOT
+    / "skills"
+    / "software-development"
+    / "test-driven-development"
+    / "SKILL.md"
+)
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## The Iron Law",
+    "## Red-Green-Refactor Cycle",
+    "## Avoid Horizontal Slices",
+    "## Why Order Matters",
+    "## Common Rationalizations",
+    "## Red Flags — STOP and Start Over",
+    "## Verification Checklist",
+    "## When Stuck",
+    "## Hermes Agent Integration",
+    "## Testing Anti-Patterns",
+]
+
+CYCLE_STEPS = [
+    "### RED — Write Failing Test",
+    "### Verify RED — Watch It Fail",
+    "### GREEN — Minimal Code",
+    "### Verify GREEN — Watch It Pass",
+    "### REFACTOR — Clean Up",
+]
+
+
+def _frontmatter_and_body():
+    content = SKILL_MD.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "frontmatter must close with ---"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+class TestTDDSkillContract:
+    """Test that SKILL.md adheres to the project hardline standards."""
+
+    def test_skill_file_exists(self):
+        assert SKILL_MD.is_file()
+
+    def test_frontmatter_required_fields(self):
+        fm, _ = _frontmatter_and_body()
+        for field in ("name", "description", "version", "author", "license", "platforms"):
+            assert field in fm, f"missing frontmatter field: {field}"
+        assert fm["name"] == "test-driven-development"
+        hermes = fm["metadata"]["hermes"]
+        assert hermes["tags"]
+        assert "related_skills" in hermes
+
+    def test_description_hardline(self):
+        fm, _ = _frontmatter_and_body()
+        desc = fm["description"]
+        assert len(desc) <= 60, f"description is {len(desc)} chars; max allowed is 60"
+        assert desc.endswith("."), "description must end with a period"
+        assert not re.search(
+            r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+            desc,
+            re.I,
+        )
+
+    def test_related_skills_resolve_in_repo(self):
+        fm, _ = _frontmatter_and_body()
+        for name in fm["metadata"]["hermes"]["related_skills"]:
+            hits = list(REPO_ROOT.glob(f"skills/**/{name}/SKILL.md")) + list(
+                REPO_ROOT.glob(f"optional-skills/**/{name}/SKILL.md")
+            )
+            assert hits, f"related_skills entry does not resolve in repo: {name}"
+
+    def test_no_machine_local_paths(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        assert "/home/" not in content
+        assert not re.search(r"[A-Z]:\\\\Users", content)
+
+    def test_required_sections_present(self):
+        _, body = _frontmatter_and_body()
+        for section in REQUIRED_SECTIONS:
+            assert section in body, f"missing section: {section}"
+
+    def test_red_green_refactor_cycle_sequence(self):
+        _, body = _frontmatter_and_body()
+        positions = [body.index(step) for step in CYCLE_STEPS]
+        assert positions == sorted(positions), "cycle steps must be in RED -> Verify RED -> GREEN -> Verify GREEN -> REFACTOR order"
+
+    def test_iron_law_and_tracer_bullet_discipline(self):
+        _, body = _frontmatter_and_body()
+        assert "NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST" in body
+        assert "tracer bullets" in body.lower()
+        assert "terminal" in body
+        assert "delegate_task" in body


### PR DESCRIPTION
### Summary of changes
- Adds dedicated hermetic contract and methodology discipline test suites for software development skills:
  - `test-driven-development` (`tests/skills/test_tdd_skill.py`): 8 tests covering frontmatter rules, Red-Green-Refactor cycle, tracer bullet vertical slices, and the Iron Law against production code before tests.
  - `plan` (`tests/skills/test_plan_skill.py`): 9 tests covering plan save path under `.hermes/plans/`, 2-5 min task granularity, 6-step authoring workflow, and DRY/YAGNI principles.
- Extracts shared skill testing utilities into `tests/skills/_skill_test_utils.py`.

### How to test
```bash
pytest tests/skills/test_tdd_skill.py tests/skills/test_plan_skill.py -v
# Expected: 17 passed in ~0.3s

python scripts/check-windows-footguns.py tests/skills/_skill_test_utils.py tests/skills/test_tdd_skill.py tests/skills/test_plan_skill.py
# Expected: 0 footguns found
```

### Platforms tested
- macOS (Darwin aarch64, Python 3.11)