### PR TITLE
Warn when automatic Hindsight recall is unavailable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -75,6 +75,10 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.6.1"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+_RECALL_FAILURE_WARNING_INTERVAL_S = 600.0
+_RECALL_FAILURE_WARNING = (
+    "Hindsight recall is unavailable; continuing without recalled memory."
+)
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
 # AGENTS.md forbids shipping third-party attribution tags on-by-default until a
 # generic user-facing opt-in exists, so this stays unset unless the user sets it
@@ -800,6 +804,12 @@ class HindsightMemoryProvider(MemoryProvider):
         self._last_recall_returned = False
         self._last_recall_count = 0
         self._recall_indicator = True
+        # Automatic recall degrades to empty context on provider failure. Keep
+        # that behavior while making the outage visible without leaking query,
+        # endpoint, bank, or exception details. The monotonic timestamp is
+        # protected because background and synchronous recall may overlap.
+        self._last_recall_failure_warning_at: float | None = None
+        self._recall_failure_warning_lock = threading.Lock()
         # Deterministic retain indicator: emitted from sync_turn the moment a
         # retain is dispatched to the writer (see _emit_saving_indicator). Uses
         # the agent's status channel, injected via initialize(status_callback=).
@@ -1909,7 +1919,27 @@ class HindsightMemoryProvider(MemoryProvider):
             return _RecallResult(text, num_results)
         except Exception as e:
             logger.debug("Hindsight recall failed: %s", e, exc_info=True)
+            if self._prefetch_method == "recall":
+                self._report_recall_failure()
             return _RecallResult("", 0)
+
+    def _report_recall_failure(self) -> None:
+        """Emit one generic automatic-recall outage signal per ten minutes."""
+        now = time.monotonic()
+        with self._recall_failure_warning_lock:
+            previous = self._last_recall_failure_warning_at
+            if previous is not None and now - previous < _RECALL_FAILURE_WARNING_INTERVAL_S:
+                return
+            self._last_recall_failure_warning_at = now
+        logger.warning(_RECALL_FAILURE_WARNING)
+        if self._status_callback is not None:
+            try:
+                self._status_callback(_RECALL_FAILURE_WARNING)
+            except Exception:
+                logger.debug(
+                    "Hindsight recall failure status callback failed",
+                    exc_info=True,
+                )
 
     def _format_recall(self, result: str) -> str:
         if not result:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,6 +6,7 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import logging
 import os
 import re
 import stat
@@ -882,6 +883,68 @@ class TestRecallStatus:
         assert status is not None
         # Reflect synthesizes across memories → no discrete count (0).
         assert status.count == 0
+
+
+class TestAutomaticRecallFailureWarning:
+    def test_warning_is_generic_rate_limited_and_repeats_after_window(
+        self, provider, monkeypatch, caplog
+    ):
+        clock = 100.0
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.time.monotonic", lambda: clock
+        )
+        provider._run_hindsight_operation = MagicMock(
+            side_effect=RuntimeError("private endpoint and memory detail")
+        )
+        status_messages = []
+        provider._status_callback = status_messages.append
+
+        with caplog.at_level("DEBUG", logger="plugins.memory.hindsight"):
+            assert provider._do_recall("private query").text == ""
+            clock = 699.999
+            assert provider._do_recall("private query").text == ""
+            clock = 700.0
+            assert provider._do_recall("private query").text == ""
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ]
+        assert warnings == [
+            "Hindsight recall is unavailable; continuing without recalled memory.",
+            "Hindsight recall is unavailable; continuing without recalled memory.",
+        ]
+        assert status_messages == warnings
+        assert all("private" not in message for message in warnings)
+        debug = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        ]
+        assert any("private endpoint and memory detail" in message for message in debug)
+
+    def test_reflect_failure_does_not_emit_recall_warning(
+        self, provider, caplog
+    ):
+        provider._prefetch_method = "reflect"
+        provider._run_hindsight_operation = MagicMock(
+            side_effect=RuntimeError("reflect unavailable")
+        )
+        with caplog.at_level("DEBUG", logger="plugins.memory.hindsight"):
+            assert provider._do_recall("query").text == ""
+        assert not [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ]
+
+    def test_healthy_recall_remains_unchanged(self, provider, caplog):
+        with caplog.at_level("WARNING", logger="plugins.memory.hindsight"):
+            result = provider._do_recall("query")
+        assert result.count == 2
+        assert result.text == "- Memory 1\n- Memory 2"
+        assert not caplog.records
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Automatic Hindsight recall failures currently degrade to empty context with DEBUG-only evidence. This adds a generic WARNING (and the same optional status callback) at most once per 600 seconds per provider instance, while preserving empty recall and keeping exception details at DEBUG. Reflect-mode failures remain unchanged.\n\nValidation: 91 Hindsight provider, root-guard, and environment-permission tests passed, including fake-clock rate-limit coverage and healthy/unreachable paths; ruff and git diff checks passed.