### PR TITLE
fix(cron): decode script output as UTF-8 on all platforms (not just win32)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4374,7 +4374,13 @@ def _run_job_script(
     try:
         from tools.environments.local import build_subprocess_env
 
-        popen_kwargs: dict[str, Any] = {"start_new_session": True}
+        # Iron Rod: la sortie d un script cron est un protocole TEXTE,
+        # decodee en UTF-8 sur tous les OS (pas la locale fr_FR/ISO-8859-1).
+        popen_kwargs: dict[str, Any] = {
+            "start_new_session": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+        }
         if sys.platform == "win32":
             popen_kwargs = {
                 "creationflags": windows_hide_flags()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -281,7 +281,7 @@ class TestRunJobScript:
         sys.platform == "win32",
         reason="Windows always takes the overlay/creationflags branch",
     )
-    def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
+    def test_non_windows_script_uses_utf8_text_decoding(self, cron_env, monkeypatch):
         # No platform patching: the Linux CI host already takes this branch.
         from cron import scheduler as sched_mod
         from cron.scheduler import _run_job_script
@@ -318,8 +318,23 @@ class TestRunJobScript:
         assert captured["argv"] == [sys.executable, str(script.resolve())]
         assert captured["kwargs"]["text"] is True
         assert "creationflags" not in captured["kwargs"]
-        assert "encoding" not in captured["kwargs"]
-        assert "errors" not in captured["kwargs"]
+        # Iron Rod : l encodage est force en UTF-8 sur TOUS les OS, la
+        # sortie d un script cron etant un protocole texte relivre tel quel
+        # (persistee, puis delivree verbatim sur Telegram).
+        #
+        # C est CE controle qui couvre le cas de la locale non UTF-8 : des
+        # lors qu un ``encoding`` explicite est passe a Popen, le
+        # TextIOWrapper ne consulte plus du tout la locale du processus.
+        # Le cas fr_FR/ISO-8859-1 devient donc impossible par construction,
+        # et c est la presence de cette cle qui le prouve.  Un test d aller-
+        # retour sur du texte accentue a ete essaye puis RETIRE le
+        # 2026-08-23 : il passait au vert meme sans le correctif, la locale
+        # etant resolue au niveau C, hors de portee d un monkeypatch.
+        assert captured["kwargs"]["encoding"] == "utf-8"
+        assert captured["kwargs"]["errors"] == "replace"
+        # start_new_session doit survivre au correctif : il porte le groupe
+        # de processus dont depend la terminaison propre du script.
+        assert captured["kwargs"]["start_new_session"] is True
 
     def test_non_overlay_branch_keeps_plain_argv(self, cron_env, monkeypatch):
         """When the Windows uv-venv overlay is NOT active, the invocation must


### PR DESCRIPTION
## Problem

A cron script's stdout/stderr is a text protocol that is decoded as UTF-8 and later delivered verbatim (e.g. on Telegram). Upstream only forces `encoding="utf-8"` / `errors="replace"` in the `sys.platform == "win32"` branch of `_run_job_script`. On Linux the general branch leaves `popen_kwargs` without an explicit encoding, so `subprocess.Popen` falls back to the process locale. On a `fr_FR`/ISO-8859-1 host this decodes the script output with the wrong codec and produces mojibake.

## Approach

Apply the same `encoding="utf-8"` and `errors="replace"` flags to the general (non-win32) `popen_kwargs`, so the text protocol is decoded as UTF-8 on every platform regardless of locale. `start_new_session` is preserved (it carries the process group needed for clean termination).

## Test

Updated `tests/cron/test_cron_script.py::test_non_windows_script_uses_utf8_text_decoding` to assert `encoding == "utf-8"` and `errors == "replace"` are present in the captured `Popen` kwargs (and that `start_new_session` survives). An explicit `encoding` makes the `TextIOWrapper` ignore the process locale entirely, so the non-UTF-8 locale case is impossible by construction.

## Risk

Low. The change only affects how cron script output is decoded on non-Windows platforms; it does not alter argv, environment, or process-group handling.