### PR TITLE
fix(kanban): guard budget-exhausted recording to dispatcher-owned workers

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -70,7 +70,27 @@ def _record_kanban_budget_exhausted(
     (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
     already closed the run this is a no-op — so it is safe to call from
     multiple exit paths.
+
+    Iron Rod, garde d identite (portee le 2026-08-23 depuis le correctif
+    local du 2026-08-13, cartes t_0b0c1a02 et t_649cea95).
+    HERMES_KANBAN_TASK est present dans l environnement de TOUT ce qui
+    tourne dans le processus du worker, y compris un enfant delegate_task
+    ou un cron declenche en cours de carte. Sans ce predicat,
+    l epuisement du budget de n importe quel agent du processus est impute
+    a la carte du worker. La garde est posee ici, au point de passage
+    unique des deux chemins appelants, plutot que dupliquee sur chaque
+    site d appel.
     """
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    if not is_dispatcher_owned_worker_context():
+        logger.info(
+            "budget exhausted in a non dispatcher-owned context; "
+            "not recording a failure on task %s",
+            kanban_task,
+        )
+        return
+
     try:
         from hermes_cli import kanban_db as _kb
         _conn = _kb.connect()


### PR DESCRIPTION
## Problem

`HERMES_KANBAN_TASK` is present in the environment of everything running inside the worker process, including a `delegate_task` child agent or a cron job triggered while a card is active. Without a guard, `_record_kanban_budget_exhausted` attributes the budget exhaustion of *any* agent in the process to the worker's card, recording a spurious `timed_out` failure on the wrong task.

## Approach

Add an early guard at the top of `_record_kanban_budget_exhausted` using the existing `is_dispatcher_owned_worker_context()` helper (from `agent/delegation_context.py`). If the current context is not dispatcher-owned, log and return without recording. The guard is placed at the single choke point shared by both call sites, rather than duplicated at each caller.

## Test

No new test file: the guard is a pure early-return predicate on an existing upstream helper. The change is covered by the existing kanban budget-exhaustion tests, which exercise the dispatcher-owned path.

## Risk

Low. The guard only suppresses recording in non-dispatcher-owned contexts (child agents, cron), which is exactly the intended behavior; the dispatcher-owned worker path is unchanged.