### PR TITLE
fix(tools): drop PYTHONPATH for command TTS/STT provider children

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -259,6 +259,46 @@ class TestTranscribeLocalCommand:
         assert "OPENAI_API_KEY" not in env
         assert env["MY_SAFE_STT_VAR"] == "keep"
 
+    def test_command_stt_strips_pythonpath_from_child_env(self, monkeypatch):
+        """Command STT providers must not inherit PYTHONPATH.
+
+        The template pins its own interpreter (often a different CPython
+        version than the gateway's); an inherited launcher-injected
+        PYTHONPATH makes the child import foreign-version compiled
+        extensions and crash (mirror of the TTS-side fix in
+        tools/tts_tool.py).
+        """
+        monkeypatch.setenv("PYTHONPATH", "/opt/hermes-shims/py313/site-packages")
+
+        captured = {}
+
+        class _Stream:
+            def read(self, size):
+                return ""
+
+        class Proc:
+            returncode = 0
+            stdout = _Stream()
+            stderr = _Stream()
+
+            def wait(self, timeout=None):
+                return 0
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Proc()
+
+        monkeypatch.setattr(
+            "tools.transcription_tools.subprocess.Popen", fake_popen
+        )
+
+        from tools.transcription_tools import _run_command_stt
+
+        result = _run_command_stt("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        assert "PYTHONPATH" not in captured["env"]
+
     def test_local_whisper_subprocess_uses_sanitized_env(
         self, monkeypatch, sample_wav, tmp_path
     ):

--- a/tests/tools/test_tts_command_pythonpath_isolation.py
+++ b/tests/tools/test_tts_command_pythonpath_isolation.py
@@ -1,0 +1,119 @@
+"""
+Regression tests for command-provider interpreter isolation.
+
+Command TTS/STT providers (``tts.providers.<name>.type: "command"`` and
+the STT equivalent) run user-configured shell templates that pin their own
+interpreter (e.g. ``~/.chatterbox-venv/bin/python wrapper.py``). These
+child interpreters are frequently a DIFFERENT CPython version than the
+gateway's, so a ``PYTHONPATH`` entry built for the gateway interpreter
+(launcher-injected site-packages shims, layered Docker filesystems) is a
+foreign-version hazard: the child imports the gateway-version compiled
+extension (``PIL._imaging``, ``numpy._core``, ``cryptography``) and
+crashes at startup.
+
+The existing Hermes-owned PYTHONPATH scrub
+(``_strip_hermes_owned_pythonpath``) deliberately preserves such entries
+(user-owned provenance, #74817 follow-up) — correct for generic children,
+wrong for pinned-interpreter command providers where the template names
+its interpreter explicitly and PYTHONPATH can only hurt.
+
+Regression for the local-whisper STT crash reported against 3.13-shim
+PYTHONPATH + 3.11 provider venv (ImportError: cannot import name
+'_imaging' from 'PIL').
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+from tools.tts_tool import _run_command_tts
+
+
+class _Stream:
+    def read(self, size):
+        return ""
+
+
+class _Proc:
+    returncode = 0
+    stdout = _Stream()
+    stderr = _Stream()
+
+    def wait(self, timeout=None):
+        return 0
+
+
+class TestCommandTtsStripsForeignPythonpath:
+    def test_command_tts_strips_pythonpath_from_child_env(self, monkeypatch):
+        """Command TTS providers must not inherit PYTHONPATH at all.
+
+        The template pins its own interpreter; a launcher-injected
+        PYTHONPATH built for the gateway interpreter makes a different-
+        version child import foreign compiled extensions and crash.
+        """
+        monkeypatch.setenv("PYTHONPATH", "/opt/hermes-shims/py313/site-packages")
+
+        captured = {}
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return _Proc()
+
+        with patch("tools.tts_tool.subprocess.Popen", fake_popen):
+            result = _run_command_tts("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        assert "PYTHONPATH" not in captured["env"]
+
+    def test_command_tts_env_scrub_is_unaffected(self, monkeypatch):
+        """The PYTHONPATH strip must not weaken the #56332 secret scrub."""
+        monkeypatch.setenv("PYTHONPATH", "/some/foreign/shims")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MY_SAFE_TTS_VAR", "keep")
+
+        captured = {}
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return _Proc()
+
+        with patch("tools.tts_tool.subprocess.Popen", fake_popen):
+            _run_command_tts("echo hi", timeout=1)
+
+        env = captured["env"]
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_SAFE_TTS_VAR"] == "keep"
+
+    def test_command_tts_without_pythonpath_unchanged(self, monkeypatch):
+        """No PYTHONPATH set: child env is built exactly as before."""
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        monkeypatch.setenv("MY_SAFE_TTS_VAR", "keep")
+
+        captured = {}
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return _Proc()
+
+        with patch("tools.tts_tool.subprocess.Popen", fake_popen):
+            _run_command_tts("echo hi", timeout=1)
+
+        env = captured["env"]
+        assert "PYTHONPATH" not in env
+        assert env["MY_SAFE_TTS_VAR"] == "keep"
+
+    def test_env_passthrough_still_works_alongside_strip(self, monkeypatch):
+        """env_passthrough allowlist entries survive the PYTHONPATH strip."""
+        monkeypatch.setenv("PYTHONPATH", "/foreign/shims")
+        monkeypatch.setenv("MY_TTS_KEY", "tts-key-value")
+
+        captured = {}
+
+        def fake_popen(command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return _Proc()
+
+        with patch("tools.tts_tool.subprocess.Popen", fake_popen):
+            _run_command_tts("echo hi", timeout=1, env_passthrough=["MY_TTS_KEY"])
+
+        assert captured["env"]["MY_TTS_KEY"] == "tts-key-value"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -720,12 +720,18 @@ def _run_command_stt(
     (same progress-based stuck detection as the TTS runner, #50081).
     Child env is scrubbed of Hermes secrets (salvage of #56332) while still
     propagating delegated-child lineage markers when applicable.
+    ``PYTHONPATH`` is dropped like the TTS runner: command templates pin
+    their own interpreter, so inherited foreign-version path entries crash
+    the child at import (see _run_command_tts in tools/tts_tool.py).
     """
     from agent.delegation_context import delegated_child_subprocess_env
     from tools.environments.local import hermes_subprocess_env
 
     scrubbed = hermes_subprocess_env(inherit_credentials=False)
+    scrubbed.pop("PYTHONPATH", None)
     for key in env_passthrough or []:
+        if key == "PYTHONPATH":
+            continue
         value = os.environ.get(key)
         if value is not None:
             scrubbed[key] = value
@@ -2125,10 +2131,14 @@ def _transcribe_local_command(
             )
             # Scrub Hermes secrets from the child env (sibling path to #56332 /
             # _run_command_stt — this local-whisper path previously inherited
-            # the full process environment).
+            # the full process environment). PYTHONPATH is dropped too: the
+            # template runs a pinned whisper interpreter, and inherited
+            # foreign-version path entries crash it at import (see
+            # _run_command_tts in tools/tts_tool.py).
             from tools.environments.local import hermes_subprocess_env
 
             child_env = hermes_subprocess_env(inherit_credentials=False)
+            child_env.pop("PYTHONPATH", None)
             subprocess.run(
                 shlex.split(command),
                 check=True,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1194,12 +1194,27 @@ def _run_command_tts(
 
     Child env is scrubbed of Hermes secrets (salvage of #56332) while still
     propagating delegated-child lineage markers when applicable.
+
+    ``PYTHONPATH`` is always dropped from the child env: command templates
+    pin their own interpreter (often a different CPython version than the
+    gateway's), so a launcher-injected ``PYTHONPATH`` entry built for the
+    gateway interpreter makes the child import foreign-version compiled
+    extensions and crash (``PIL._imaging``, ``numpy._core._multiarray_umath``,
+    ``cryptography``). The Hermes-owned entries are already stripped by
+    ``hermes_subprocess_env``; the remaining user-owned entries are exactly
+    the foreign-shim class a pinned-interpreter template cannot survive.
+    Config templates that genuinely need a path on the child's ``sys.path``
+    can add it in the command itself (``PYTHONPATH=/path cmd``) — explicit
+    and version-matched, unlike an inherited value.
     """
     from agent.delegation_context import delegated_child_subprocess_env
     from tools.environments.local import hermes_subprocess_env
 
     scrubbed = hermes_subprocess_env(inherit_credentials=False)
+    scrubbed.pop("PYTHONPATH", None)
     for key in env_passthrough or []:
+        if key == "PYTHONPATH":
+            continue
         value = os.environ.get(key)
         if value is not None:
             scrubbed[key] = value


### PR DESCRIPTION
## What does this PR do?

Command-based TTS/STT providers (`tts.providers.<name>.type: "command"` and the STT equivalent) run user-configured shell templates that pin their **own** interpreter — frequently a **different CPython version** than the gateway's (e.g. a 3.11 venv hosting a local neural TTS engine while the gateway runs 3.13).

When the gateway spawns these providers, the child inherits the gateway's `PYTHONPATH`. If any entry on it was built for the gateway interpreter (launcher-injected site-packages shims, layered Docker filesystems, `HERMES_LAZY_INSTALL_TARGET` style bundles), the child imports foreign-version compiled extensions and **crashes at startup**:

```
ImportError: cannot import name '_imaging' from 'PIL' (/…/py313-shim/PIL/__init__.py)
```

The existing `hermes_subprocess_env` scrub strips *Hermes-owned* `PYTHONPATH` entries but deliberately preserves user-owned ones (#74817 follow-up). That's correct for generic children — but a command template that names its interpreter explicitly (`~/.myengine-venv/bin/python wrapper.py`) is the one child class that can never survive a foreign-version path: the template already pins its interpreter, so an inherited `PYTHONPATH` can only hurt.

**Fix:** drop `PYTHONPATH` unconditionally in the three command-provider spawn sites. Templates that genuinely need a path on the child's `sys.path` can set it explicitly in the command itself (`PYTHONPATH=/path cmd`) — explicit and version-matched, unlike an inherited value. `env_passthrough` entries (API keys in curl templates) are unaffected; `PYTHONPATH` is ignored even if listed there, since inheriting it is precisely the failure mode.

## Related Issue

<!-- No existing issue found; reproducing requires the exact mixed-version setup. -->

Fixes the crash class described above. Happy to file a standalone issue if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` — `_run_command_tts`: pop `PYTHONPATH` from the scrubbed child env after `hermes_subprocess_env`; ignore `PYTHONPATH` in `env_passthrough`; docstring documents the rationale
- `tools/transcription_tools.py` — `_run_command_stt`: same drop (mirrors the TTS runner by design); and the local-whisper `subprocess.run` sibling path (the "#56332 gap" comment site) gets the same `pop`
- `tests/tools/test_tts_command_pythonpath_isolation.py` — new: 4 regression tests (strip works, secret scrub #56332 still intact, no-PYTHONPATH case unchanged, `env_passthrough` still works alongside the strip)
- `tests/tools/test_transcription_tools.py` — STT-side regression test mirroring the TTS one

## How to Test

1. Reproduce on `main`: set `PYTHONPATH` to a site-packages dir built for a different CPython version, configure a command TTS provider that runs an interpreter of the original version, trigger any TTS → child crashes with a compiled-extension `ImportError`.
2. Apply this PR → same command now succeeds; the child sees no `PYTHONPATH` at all.
3. Run the new tests:
   ```
   pytest tests/tools/test_tts_command_pythonpath_isolation.py -v
   pytest "tests/tools/test_transcription_tools.py::TestTranscribeLocalCommand::test_command_stt_strips_pythonpath_from_child_env" -v
   ```
   Verified: all 5 fail on unpatched `main`, pass with the fix. A real-subprocess E2E (child python probes its own env) confirms the child sees `PYTHONPATH=None` and no foreign entry on `sys.path`.
4. Existing env-scrub tests (`TestCommandTtsEnv`, `TestTranscribeLocalCommand`) still pass — the #56332 secret scrub is unchanged. Pre-existing failures in these files are identical on pristine `main` (optional-dependency-dependent) and unrelated.

Tested on Ubuntu (Docker container, gateway process with poisoned `PYTHONPATH` → command TTS provider in a 3.11 venv).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Docker)

<!-- Full-suite pytest was not run in the contribution sandbox (targeted test files only, per fork constraints); the touched test files pass except failures identical on pristine main. -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — docstrings updated on all three spawn sites
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `env` handling is cross-platform; no shell-specific changes
