### PR TITLE
fix(tests): stop agent tests from calling live LLMs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
+dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
@@ -465,6 +465,8 @@ plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+timeout = 120
+timeout_method = "thread"
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,88 @@
+"""Isolation guarantees shared by all agent unit tests."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def agent_network_attempts() -> list[object]:
+    """Return public-network addresses blocked during the current test."""
+    return []
+
+
+def _is_loopback_socket_address(sock: socket.socket, address: object) -> bool:
+    if sock.family not in {socket.AF_INET, socket.AF_INET6}:
+        return True
+    if not isinstance(address, tuple) or not address:
+        return False
+
+    host = str(address[0]).strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _block_agent_public_network(monkeypatch, agent_network_attempts):
+    """Fail closed before agent unit tests can contact public services."""
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+    original_create_connection = socket.create_connection
+
+    def guarded_connect(sock, address):
+        if not _is_loopback_socket_address(sock, address):
+            agent_network_attempts.append(address)
+            raise RuntimeError(
+                f"network disabled in agent unit tests: {address!r}"
+            )
+        return original_connect(sock, address)
+
+    def guarded_connect_ex(sock, address):
+        if not _is_loopback_socket_address(sock, address):
+            agent_network_attempts.append(address)
+            raise RuntimeError(
+                f"network disabled in agent unit tests: {address!r}"
+            )
+        return original_connect_ex(sock, address)
+
+    def guarded_create_connection(address, *args, **kwargs):
+        host = str(address[0]).strip().lower() if isinstance(address, tuple) and address else ""
+        try:
+            is_loopback = host == "localhost" or ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            is_loopback = False
+        if not is_loopback:
+            agent_network_attempts.append(address)
+            raise RuntimeError(
+                f"network disabled in agent unit tests: {address!r}"
+            )
+        return original_create_connection(address, *args, **kwargs)
+
+    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", guarded_connect_ex)
+    monkeypatch.setattr(socket, "create_connection", guarded_create_connection)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_auxiliary_state():
+    """Prevent runtime bindings and cached clients from crossing test cases."""
+
+    def reset() -> None:
+        auxiliary_client = sys.modules.get("agent.auxiliary_client")
+        if auxiliary_client is None:
+            return
+        auxiliary_client.shutdown_cached_clients()
+        auxiliary_client.clear_runtime_main()
+        auxiliary_client._reset_aux_unhealthy_cache()
+
+    reset()
+    yield
+    reset()

--- a/tests/agent/test_agent_test_isolation.py
+++ b/tests/agent/test_agent_test_isolation.py
@@ -1,0 +1,56 @@
+"""Behavior contracts for agent-test network and auxiliary-state isolation."""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+import agent.auxiliary_client as auxiliary_client
+
+
+def test_agent_tests_block_public_network(agent_network_attempts):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match="network disabled in agent unit tests"):
+            sock.connect(("203.0.113.1", 443))
+    finally:
+        sock.close()
+
+    assert agent_network_attempts == [("203.0.113.1", 443)]
+
+
+def test_agent_tests_allow_loopback_network(agent_network_attempts):
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        client.connect(listener.getsockname())
+        accepted, _ = listener.accept()
+        accepted.close()
+    finally:
+        client.close()
+        listener.close()
+
+    assert agent_network_attempts == []
+
+
+def test_auxiliary_state_can_be_dirtied_for_cleanup_regression():
+    auxiliary_client.set_runtime_main(
+        provider="custom:test",
+        model="test-model",
+        base_url="https://provider.example/v1",
+        api_key="test-key",
+        api_mode="chat_completions",
+    )
+    assert auxiliary_client._normalize_main_runtime(None)["provider"] == "custom:test"
+
+
+def test_auxiliary_state_is_clean_after_previous_test():
+    assert auxiliary_client._normalize_main_runtime(None) == {}
+    assert auxiliary_client._client_cache == {}
+
+
+def test_each_test_has_a_positive_timeout(pytestconfig):
+    assert float(pytestconfig.getini("timeout")) > 0

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -180,6 +180,12 @@ model:
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
         _fresh_modules()
 
+        from agent.models_dev import ModelCapabilities
+
+        monkeypatch.setattr(
+            "agent.models_dev.get_model_capabilities",
+            lambda *_args, **_kwargs: ModelCapabilities(supports_vision=False),
+        )
         from agent.auxiliary_client import resolve_vision_provider_client
         provider, client, _model = resolve_vision_provider_client(provider="auto")
         assert client is None, (

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -209,13 +209,16 @@ model:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         _fresh_modules()
 
-        monkeypatch.setattr(
-            "agent.anthropic_adapter.resolve_anthropic_token",
-            lambda: "sk-ant-test",
-        )
+        import agent.auxiliary_client as auxiliary_client
 
-        from agent.auxiliary_client import resolve_vision_provider_client
-        provider, client, _model = resolve_vision_provider_client(provider="auto")
+        monkeypatch.setattr(
+            auxiliary_client,
+            "_try_anthropic",
+            lambda **_kwargs: (object(), "claude-sonnet-4-6"),
+        )
+        provider, client, _model = auxiliary_client.resolve_vision_provider_client(
+            provider="auto"
+        )
         assert client is not None
         assert provider == "anthropic"
 

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -182,9 +182,14 @@ model:
 
         from agent.models_dev import ModelCapabilities
 
+        def get_model_capabilities(provider, model, *, allow_network=False):
+            assert (provider, model) == ("deepseek", "deepseek-v4-pro")
+            assert allow_network is True
+            return ModelCapabilities(supports_vision=False)
+
         monkeypatch.setattr(
             "agent.models_dev.get_model_capabilities",
-            lambda *_args, **_kwargs: ModelCapabilities(supports_vision=False),
+            get_model_capabilities,
         )
         from agent.auxiliary_client import resolve_vision_provider_client
         provider, client, _model = resolve_vision_provider_client(provider="auto")
@@ -203,6 +208,11 @@ model:
 """)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         _fresh_modules()
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "sk-ant-test",
+        )
 
         from agent.auxiliary_client import resolve_vision_provider_client
         provider, client, _model = resolve_vision_provider_client(provider="auto")

--- a/uv.lock
+++ b/uv.lock
@@ -1651,6 +1651,7 @@ dev = [
     { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "starlette" },
@@ -1908,6 +1909,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.4.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.9,<1" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = "==0.0.32" },
@@ -3596,6 +3598,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Agent tests can currently inherit auxiliary runtime/client state, reach a live LLM provider, and wait indefinitely. This change makes those tests fail closed on public network access, resets auxiliary state around every test, and adds a 120-second per-test timeout while preserving loopback servers used by unit tests.

### Symptom

A multi-file `tests/agent` run can stop producing output while an affected compression test waits inside an OpenAI provider call. The same test passes in isolation.

### Impact

The stalled test can wedge a suite until it is killed manually. If ambient credentials resolve, it can also spend provider credits and send test prompt content to a third party.

### Bug Cause

**Trigger:** `tests/agent` tests that mutate `agent.auxiliary_client` runtime bindings or cached clients before a later compression test resolves its auxiliary provider.

**Causal chain:**
1. Auxiliary tests populate process-level runtime and client state.
2. A later compression path resolves that retained state and opens a public provider socket instead of staying inside its test double.
3. With no public-network guard and no per-test timeout, the provider request can block the entire pytest process indefinitely.

**Why it is wrong:** Unit tests must not depend on ambient provider availability, credentials, or network timing, and test-local state must not survive into sibling tests.

**Working sibling / contrast:** The canonical `scripts/run_tests.sh` path already isolates files in subprocesses and applies a per-file timeout, so isolated target tests complete normally. Direct multi-file pytest runs do not receive that cross-file isolation.

**Ruled out:** The reported target tests and the auxiliary test files pass when run separately, which rules out a deterministic failure in any single target test and points to accumulated process state.

### Fix

- Add an agent-suite autouse fixture that blocks non-loopback socket connections while allowing local mock HTTP servers.
- Close cached auxiliary clients and clear runtime/unhealthy state before and after each test.
- Add the pinned `pytest-timeout` development dependency and a cross-platform 120-second per-test timeout.
- Add behavior tests for public network blocking, loopback access, state cleanup, and timeout activation.

## Related Issue

Fixes #96653

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/agent/conftest.py` - enforce public-network and auxiliary-state isolation for agent tests.
- `tests/agent/test_agent_test_isolation.py` - cover the isolation contracts.
- `pyproject.toml` - enable the per-test timeout and declare its pinned dev dependency.
- `uv.lock` - lock `pytest-timeout==2.4.0` and its hashes.

## How to Test

1. Run the new isolation contracts.
2. Run the affected auxiliary and compression test files together.

```bash
scripts/run_tests.sh tests/agent/test_agent_test_isolation.py tests/agent/test_auxiliary_runtime_cache_key.py tests/agent/test_auxiliary_client.py tests/agent/test_pre_compress_memory_context.py tests/agent/test_ghost_skill_pruning.py -q --file-retries 0
```

Result: 212 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior and fixture docstrings cover the test-only contract
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no production architecture changed
- [x] Cross-platform impact considered: socket handling covers IPv4, IPv6, loopback, and non-IP socket families
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed
