### PR TITLE
chore(contributors): map smakis330@gmail.com -> Oc2cO

### DIFF
--- a/contributors/emails/smakis330@gmail.com
+++ b/contributors/emails/smakis330@gmail.com
@@ -1,0 +1,2 @@
+Oc2cO
+# PRs #84936 / #86678 — Windows console-flash fixes (hide flags on subprocess spawns)


### PR DESCRIPTION
Adds the `contributors/emails/` mapping for my commit-author address, per `contributors/README.md`.

My two open PRs (#84936, #86678) carry commits authored as `smakis330@gmail.com`, which isn't a GitHub noreply address and so doesn't auto-resolve. Without this file the release tooling can't map those commits to my GitHub login.

- File name: `smakis330@gmail.com` — exact commit-author email as shown by `git log --format='%ae'`
- Content: `Oc2cO` — my GitHub login

One file, no code changes. Happy to close this if you'd rather I re-author the commits onto `262716700+Oc2cO@users.noreply.github.com` instead — I'll do whichever you prefer.
