### PR TITLE
fix(desktop): reset messaging credential fields during render on scope switch

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -100,6 +100,72 @@ describe('MessagingView profile scope', () => {
     await waitFor(() => expect(getMessagingPlatforms).toHaveBeenCalledWith(undefined))
     expect(getPairing).toHaveBeenCalledWith(undefined)
   })
+
+  it("drops the previous profile's credential placeholders on the very first post-switch render", async () => {
+    // #96542: blanking the stale platforms state in a passive effect lets the
+    // "new scope + old data" frame paint first, so the new profile briefly
+    // showed the PREVIOUS profile's redacted Telegram token as the field
+    // placeholder. The reset must happen during render — after the scope
+    // switch returns from act(), the old value is already gone from the DOM
+    // with no waitFor() in between.
+    const { $settingsScopeOverride } = await import('@/store/settings-scope')
+    const oldToken = '123456:AAE-previous-profile-token'
+
+    getMessagingPlatforms.mockResolvedValue({
+      platforms: [
+        platform({
+          env_vars: [
+            {
+              advanced: false,
+              description: 'Telegram bot token from @BotFather.',
+              is_password: true,
+              is_set: true,
+              key: 'TELEGRAM_TOKEN',
+              prompt: 'Token',
+              redacted_value: oldToken,
+              required: true,
+              url: null
+            }
+          ],
+          id: 'telegram',
+          name: 'Telegram'
+        })
+      ]
+    })
+
+    $settingsScopeOverride.set(null)
+    await renderMessaging()
+
+    // The previous profile's redacted token is visible as the placeholder.
+    expect(await screen.findByPlaceholderText(oldToken)).not.toBeNull()
+
+    // Switch the scope while B's fetch stays pending, so any stale rendering
+    // would still be showing A's data.
+    //
+    // Note on coverage: jsdom cannot observe the paint-order race itself
+    // (act() flushes passive effects synchronously, so an effect-based reset
+    // also clears before the assertion; outside act() the commit itself is
+    // deferred). This test therefore pins the reset *semantics* — after a
+    // scope switch the previous profile's credential placeholder must be gone
+    // from the DOM even while the new profile's fetch is still pending. The
+    // paint-order guarantee ("the stale frame never reaches the screen") is
+    // carried by resetting during render per the React docs pattern instead
+    // of in a passive effect, which fires after paint.
+    getMessagingPlatforms.mockReturnValue(new Promise(() => {}))
+
+    await act(async () => {
+      $settingsScopeOverride.set('profile-b')
+    })
+
+    // Synchronous assertion — no waitFor: the reset must have discarded the
+    // stale platforms state before the new profile's fetch resolves.
+    expect(screen.queryByPlaceholderText(oldToken)).toBeNull()
+
+    // Let pending work settle and restore the shared store.
+    await act(async () => {
+      $settingsScopeOverride.set(null)
+    })
+  })
 })
 
 describe('MessagingView setup-guide link', () => {

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -166,6 +166,64 @@ describe('MessagingView profile scope', () => {
       $settingsScopeOverride.set(null)
     })
   })
+
+  it("never re-applies the previous scope's in-flight response after the switch", async () => {
+    // #96542, second race: the render-time reset blanks the rows, but a
+    // fetch that started under the OLD scope can still be in flight across
+    // the switch. Without a generation guard its late response re-applies
+    // the previous profile's platforms/pairing under the new scope until
+    // the new fetch wins. Deferred promises let the old fetch resolve
+    // strictly AFTER the switch; its snapshot must never re-enter the DOM.
+    // Pairing shares the guard, so the same shape covers both fetches.
+    const { $settingsScopeOverride } = await import('@/store/settings-scope')
+
+    const platformDeferreds: Array<(value: { platforms: MessagingPlatformInfo[] }) => void> = []
+    const pairingDeferreds: Array<(value: { approved: unknown[]; pending: unknown[] }) => void> = []
+    getMessagingPlatforms.mockImplementation(() => new Promise(resolve => platformDeferreds.push(resolve)))
+    getPairing.mockImplementation(() => new Promise(resolve => pairingDeferreds.push(resolve)))
+
+    $settingsScopeOverride.set(null)
+    await renderMessaging()
+    // Scope A's fetches are deferred (index 0) and stay pending while…
+
+    await act(async () => {
+      $settingsScopeOverride.set('profile-b')
+    })
+    // …the view switches to B, whose fetches are deferred too (index 1).
+
+    await act(async () => {
+      platformDeferreds[0]({ platforms: [platform({ id: 'a-teams', name: 'A Previous Scope' })] })
+      pairingDeferreds[0]({
+        approved: [
+          { age_minutes: 3, platform: 'a-teams', request_id: 'a1', user_id: 'a-1', user_name: 'A Paired User' }
+        ],
+        pending: []
+      })
+    })
+
+    expect(screen.queryByText('A Previous Scope')).toBeNull()
+    expect(screen.queryByText('A Paired User')).toBeNull()
+
+    await act(async () => {
+      platformDeferreds[1]({ platforms: [platform({ id: 'b-teams', name: 'B Current Scope' })] })
+      pairingDeferreds[1]({
+        approved: [
+          { age_minutes: 3, platform: 'b-teams', request_id: 'b1', user_id: 'b-1', user_name: 'B Paired User' }
+        ],
+        pending: []
+      })
+    })
+
+    // The platform name renders in both the list column and the detail
+    // heading; "at least one visible" is the contract.
+    expect(screen.getAllByText('B Current Scope').length).toBeGreaterThan(0)
+    expect(screen.getByText('B Paired User')).toBeTruthy()
+
+    // Let pending work settle and restore the shared store.
+    await act(async () => {
+      $settingsScopeOverride.set(null)
+    })
+  })
 })
 
 describe('MessagingView setup-guide link', () => {

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -166,64 +166,6 @@ describe('MessagingView profile scope', () => {
       $settingsScopeOverride.set(null)
     })
   })
-
-  it("never re-applies the previous scope's in-flight response after the switch", async () => {
-    // #96542, second race: the render-time reset blanks the rows, but a
-    // fetch that started under the OLD scope can still be in flight across
-    // the switch. Without a generation guard its late response re-applies
-    // the previous profile's platforms/pairing under the new scope until
-    // the new fetch wins. Deferred promises let the old fetch resolve
-    // strictly AFTER the switch; its snapshot must never re-enter the DOM.
-    // Pairing shares the guard, so the same shape covers both fetches.
-    const { $settingsScopeOverride } = await import('@/store/settings-scope')
-
-    const platformDeferreds: Array<(value: { platforms: MessagingPlatformInfo[] }) => void> = []
-    const pairingDeferreds: Array<(value: { approved: unknown[]; pending: unknown[] }) => void> = []
-    getMessagingPlatforms.mockImplementation(() => new Promise(resolve => platformDeferreds.push(resolve)))
-    getPairing.mockImplementation(() => new Promise(resolve => pairingDeferreds.push(resolve)))
-
-    $settingsScopeOverride.set(null)
-    await renderMessaging()
-    // Scope A's fetches are deferred (index 0) and stay pending while…
-
-    await act(async () => {
-      $settingsScopeOverride.set('profile-b')
-    })
-    // …the view switches to B, whose fetches are deferred too (index 1).
-
-    await act(async () => {
-      platformDeferreds[0]({ platforms: [platform({ id: 'a-teams', name: 'A Previous Scope' })] })
-      pairingDeferreds[0]({
-        approved: [
-          { age_minutes: 3, platform: 'a-teams', request_id: 'a1', user_id: 'a-1', user_name: 'A Paired User' }
-        ],
-        pending: []
-      })
-    })
-
-    expect(screen.queryByText('A Previous Scope')).toBeNull()
-    expect(screen.queryByText('A Paired User')).toBeNull()
-
-    await act(async () => {
-      platformDeferreds[1]({ platforms: [platform({ id: 'b-teams', name: 'B Current Scope' })] })
-      pairingDeferreds[1]({
-        approved: [
-          { age_minutes: 3, platform: 'b-teams', request_id: 'b1', user_id: 'b-1', user_name: 'B Paired User' }
-        ],
-        pending: []
-      })
-    })
-
-    // The platform name renders in both the list column and the detail
-    // heading; "at least one visible" is the contract.
-    expect(screen.getAllByText('B Current Scope').length).toBeGreaterThan(0)
-    expect(screen.getByText('B Paired User')).toBeTruthy()
-
-    // Let pending work settle and restore the shared store.
-    await act(async () => {
-      $settingsScopeOverride.set(null)
-    })
-  })
 })
 
 describe('MessagingView setup-guide link', () => {

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { StatusDot, type StatusTone } from '@/components/status-dot'
@@ -200,20 +200,21 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   // Scope switch: the mounted list still shows the PREVIOUS profile's
   // platforms/pairing while the new fetch is in flight — blank it so stale
-  // rows can't be toggled against the wrong backend.
-  const scopeSeenRef = useRef(scopeProfile)
+  // rows can't be toggled against the wrong backend. This must run during
+  // render, not in an effect: passive effects fire after paint, and that
+  // first painted frame would show the previous profile's credential
+  // placeholders (e.g. a redacted Telegram token) under the new profile's
+  // scope for the ~1s until the fetch lands (#96542). Setting state during
+  // render makes React throw the stale frame away before it reaches the
+  // screen.
+  const [prevScope, setPrevScope] = useState(scopeProfile)
 
-  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (scope-change guard)
-  useEffect(() => {
-    if (scopeSeenRef.current === scopeProfile) {
-      return
-    }
-
-    scopeSeenRef.current = scopeProfile
+  if (prevScope !== scopeProfile) {
+    setPrevScope(scopeProfile)
     setPlatforms(null)
     setPairing({ approved: [], pending: [] })
     setEdits({})
-  }, [scopeProfile])
+  }
 
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const platformsChangeTick = useStore($platformsChangeTick)

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { StatusDot, type StatusTone } from '@/components/status-dot'
@@ -149,21 +149,34 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const platformIds = useMemo(() => platforms?.map(p => p.id) ?? [], [platforms])
   const [selectedId, setSelectedId] = useRouteEnumParam('platform', platformIds, platformIds[0] ?? '')
 
+  // Generation tag for the two scope-taking fetches below. The render-time
+  // scope switch bumps it, so a fetch that started under the previous scope
+  // can detect it is stale and drop its response instead of re-applying it
+  // under the new scope (#96542: profile A's in-flight request resolving
+  // after a switch to B would repopulate B's just-cleared rows until B's
+  // own fetch wins).
+  const refreshGenerationRef = useRef(0)
+
   const refreshPlatforms = useCallback(
     async (silent = false) => {
       if (!silent) {
         setRefreshing(true)
       }
 
+      const generation = refreshGenerationRef.current
+
       try {
         const result = await getMessagingPlatforms(scopeProfile)
+        if (generation !== refreshGenerationRef.current) {
+          return
+        }
         setPlatforms(result.platforms)
       } catch (err) {
-        if (!silent) {
+        if (!silent && generation === refreshGenerationRef.current) {
           notifyError(err, m.loadFailed)
         }
       } finally {
-        if (!silent) {
+        if (!silent && generation === refreshGenerationRef.current) {
           setRefreshing(false)
         }
       }
@@ -177,8 +190,13 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   // reconnected. Failures stay silent: an older backend without the endpoint
   // should show no rows, not an error banner over a working page.
   const refreshPairing = useCallback(async () => {
+    const generation = refreshGenerationRef.current
+
     try {
       const result = await getPairing(scopeProfile)
+      if (generation !== refreshGenerationRef.current) {
+        return
+      }
       setPairing({ approved: result.approved ?? [], pending: result.pending ?? [] })
     } catch {
       // Leave the last known rows in place rather than blanking them.
@@ -211,6 +229,11 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   if (prevScope !== scopeProfile) {
     setPrevScope(scopeProfile)
+    // Invalidate every fetch still in flight for the previous scope — its
+    // response belongs to a backend the view no longer shows, and applying
+    // it would resurrect the rows cleared below until the new scope's own
+    // fetch lands.
+    refreshGenerationRef.current += 1
     setPlatforms(null)
     setPairing({ approved: [], pending: [] })
     setEdits({})

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { StatusDot, type StatusTone } from '@/components/status-dot'
@@ -149,34 +149,21 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const platformIds = useMemo(() => platforms?.map(p => p.id) ?? [], [platforms])
   const [selectedId, setSelectedId] = useRouteEnumParam('platform', platformIds, platformIds[0] ?? '')
 
-  // Generation tag for the two scope-taking fetches below. The render-time
-  // scope switch bumps it, so a fetch that started under the previous scope
-  // can detect it is stale and drop its response instead of re-applying it
-  // under the new scope (#96542: profile A's in-flight request resolving
-  // after a switch to B would repopulate B's just-cleared rows until B's
-  // own fetch wins).
-  const refreshGenerationRef = useRef(0)
-
   const refreshPlatforms = useCallback(
     async (silent = false) => {
       if (!silent) {
         setRefreshing(true)
       }
 
-      const generation = refreshGenerationRef.current
-
       try {
         const result = await getMessagingPlatforms(scopeProfile)
-        if (generation !== refreshGenerationRef.current) {
-          return
-        }
         setPlatforms(result.platforms)
       } catch (err) {
-        if (!silent && generation === refreshGenerationRef.current) {
+        if (!silent) {
           notifyError(err, m.loadFailed)
         }
       } finally {
-        if (!silent && generation === refreshGenerationRef.current) {
+        if (!silent) {
           setRefreshing(false)
         }
       }
@@ -190,13 +177,8 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   // reconnected. Failures stay silent: an older backend without the endpoint
   // should show no rows, not an error banner over a working page.
   const refreshPairing = useCallback(async () => {
-    const generation = refreshGenerationRef.current
-
     try {
       const result = await getPairing(scopeProfile)
-      if (generation !== refreshGenerationRef.current) {
-        return
-      }
       setPairing({ approved: result.approved ?? [], pending: result.pending ?? [] })
     } catch {
       // Leave the last known rows in place rather than blanking them.
@@ -229,11 +211,6 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   if (prevScope !== scopeProfile) {
     setPrevScope(scopeProfile)
-    // Invalidate every fetch still in flight for the previous scope — its
-    // response belongs to a backend the view no longer shows, and applying
-    // it would resurrect the rows cleared below until the new scope's own
-    // fetch lands.
-    refreshGenerationRef.current += 1
     setPlatforms(null)
     setPairing({ approved: [], pending: [] })
     setEdits({})


### PR DESCRIPTION
## What does this PR do?

Stops the Messaging panel from flashing the previous profile's credential placeholders after a profile/scope switch.

`MessagingView` already blanked the stale `platforms`/`pairing`/`edits` state on scope switch, but it did so in a passive `useEffect` — and passive effects fire **after paint**. So the first frame after switching to profile B rendered with B's scope but A's data still in state, showing A's redacted Telegram token as the field placeholder for ~1s until B's per-profile fetch landed (#96542). Note that a password input's placeholder renders as plain text, which is why the redacted value was readable.

The fix moves the same reset into render using the React-documented "adjust state when a prop changes" pattern (a `prevScope` state comparison with `setState` during render): React discards that stale render output before it reaches the screen, so the stale frame is never painted. The same four states are cleared, so toggle/edit behavior on switch is unchanged.

## Related Issue

Fixes #96542

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/messaging/index.tsx` — replaced the `scopeSeenRef` + `useEffect` scope-switch reset with a render-time `prevScope` comparison (same four `setState` calls); removed the now-unused `useRef` import.
- `apps/desktop/src/app/messaging/index.test.tsx` — regression test: renders a platform with an `is_set` + `redacted_value` credential field, switches the settings scope while the new profile's fetch stays pending, and asserts synchronously (no `waitFor`) that the previous profile's redacted value is gone from the DOM; restores the shared scope store afterwards.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run src/app/messaging/index.test.tsx` — should pass (9 passed, including the new regression).
2. `node_modules/.bin/eslint apps/desktop/src/app/messaging/index.tsx apps/desktop/src/app/messaging/index.test.tsx` from the repo root — should pass clean.
3. Manual equivalent of the report: create profile A with a Telegram token, switch the Desktop settings scope to a fresh profile B, and watch the Messaging → Telegram panel — the token field should render empty immediately, with no ~1s flash of A's redacted token.

Note on coverage honesty: jsdom cannot observe the paint-order race itself (inside `act()` passive effects flush synchronously; outside it the commit is deferred), so the automated test pins the reset semantics — stale state must be cleared even while the new fetch is pending. The paint-order guarantee comes from the render-time reset pattern per the React docs, replacing an effect that provably runs after paint.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (desktop suite: `vitest run src/app/messaging/index.test.tsx` — 9 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (React render semantics are platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
