### PR TITLE
feat(browser): allow pinning real-profile browser

### DIFF
--- a/apps/desktop/src/app/settings/config-field.tsx
+++ b/apps/desktop/src/app/settings/config-field.tsx
@@ -151,7 +151,9 @@ export function ConfigField({
                   ? c.none
                   : schemaKey === 'memory.provider'
                     ? c.builtinOnly
-                    : c.noneParen}
+                    : schemaKey === 'browser.real_profile_browser'
+                      ? c.systemDefault
+                      : c.noneParen}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -233,6 +233,7 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
 export const ENUM_OPTIONS: Record<string, string[]> = {
   'agent.image_input_mode': ['auto', 'native', 'text'],
   'approvals.mode': ['manual', 'smart', 'off'],
+  'browser.real_profile_browser': ['', 'chrome', 'edge', 'brave', 'brave-origin', 'chromium'],
   'code_execution.mode': ['project', 'strict'],
   'context.engine': ['compressor', 'default', 'custom'],
   // '' = inherit the agent's own effort; the rest is the shared scale.
@@ -428,7 +429,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   browser: {
     allowPrivateUrls: 'Browser Private URLs',
     autoLocalForPrivateUrls: 'Local Browser For Private URLs',
-    useRealProfile: 'Use My Real Browser Profile'
+    useRealProfile: 'Use My Real Browser Profile',
+    realProfileBrowser: 'Real Profile Browser'
   },
   checkpoints: {
     enabled: 'File Checkpoints',
@@ -558,7 +560,9 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
   browser: {
     useRealProfile:
-      "Local browsing uses your real logins. Hermes copies your default browser's profile (cookies, logins, preferences) into a managed snapshot and drives it with its packaged Chromium — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chromium browsers (Chrome, Edge, Brave, Brave Origin, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
+      "Local browsing uses your real logins. Hermes copies the selected Chromium browser's profile (cookies, logins, preferences) into a managed snapshot and launches that browser on the copy — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chrome, Edge, Brave, Brave Origin, and Chromium are supported. Off by default.",
+    realProfileBrowser:
+      'Choose which Chromium browser profile to copy. Leave empty to follow the OS default; Hermes never guesses another installed browser.'
   },
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',
@@ -680,7 +684,12 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'browser',
     label: 'Browser',
     icon: Globe,
-    keys: ['browser.use_real_profile', 'browser.allow_private_urls', 'browser.auto_local_for_private_urls']
+    keys: [
+      'browser.use_real_profile',
+      'browser.real_profile_browser',
+      'browser.allow_private_urls',
+      'browser.auto_local_for_private_urls'
+    ]
   },
   {
     id: 'memory',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -193,6 +193,7 @@ describe('settings helpers', () => {
         'chrome',
         'edge',
         'brave',
+        'brave-origin',
         'chromium'
       ])
     })
@@ -203,6 +204,7 @@ describe('settings helpers', () => {
         'chrome',
         'edge',
         'brave',
+        'brave-origin',
         'chromium'
       ])
     })

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -187,6 +187,16 @@ describe('settings helpers', () => {
   describe('enumOptionsFor — backend selector dropdowns', () => {
     const config: HermesConfigRecord = {}
 
+    it('renders an explicit real-profile browser pin with an OS-default option', () => {
+      expect(enumOptionsFor('browser.real_profile_browser', '', config)).toEqual([
+        '',
+        'chrome',
+        'edge',
+        'brave',
+        'chromium'
+      ])
+    })
+
     it('renders a dropdown for the TTS provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('tts.provider', 'edge', config)
       expect(opts).toBeDefined()

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -197,6 +197,16 @@ describe('settings helpers', () => {
       ])
     })
 
+    it('does not offer an invalid current real-profile browser pin', () => {
+      expect(enumOptionsFor('browser.real_profile_browser', 'firefox', config)).toEqual([
+        '',
+        'chrome',
+        'edge',
+        'brave',
+        'chromium'
+      ])
+    })
+
     it('renders a dropdown for the TTS provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('tts.provider', 'edge', config)
       expect(opts).toBeDefined()

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -380,6 +380,13 @@ export function enumOptionsFor(
     return undefined
   }
 
+  // This is a closed, security-sensitive selector. Preserve the runtime's
+  // fail-closed contract instead of appending a malformed current value as if
+  // it were another supported browser choice.
+  if (key === 'browser.real_profile_browser') {
+    return opts
+  }
+
   const current = asText(value)
 
   return current && !opts.includes(current) ? [...opts, current] : opts

--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -127,4 +127,18 @@ describe('ConfigField searchable routing', () => {
 
     expect(onChange).toHaveBeenCalledWith('')
   })
+
+  it('labels an empty real-profile browser pin as the system default', () => {
+    render(
+      <ConfigField
+        enumOptions={['', 'chrome', 'edge', 'brave', 'chromium']}
+        onChange={vi.fn()}
+        schema={{ type: 'string' }}
+        schemaKey="browser.real_profile_browser"
+        value=""
+      />
+    )
+
+    expect(screen.getByRole('combobox').textContent).toContain('System default')
+  })
 })

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -575,6 +575,7 @@ export const ar = defineLocale({
       'security.allowPrivateUrls': 'السماح بالروابط الخاصة',
       'browser.allowPrivateUrls': 'روابط المتصفح الخاصة',
       'browser.autoLocalForPrivateUrls': 'متصفح محلي للروابط الخاصة',
+      'browser.realProfileBrowser': 'متصفح الملف الشخصي الحقيقي',
       'checkpoints.enabled': 'نقاط حفظ الملفات',
       'checkpoints.maxSnapshots': 'حد نقاط الحفظ',
       'voice.recordKey': 'اختصار الصوت',
@@ -635,6 +636,8 @@ export const ar = defineLocale({
       'display.personality': 'أسلوب المساعد الافتراضي للجلسات الجديدة.',
       'display.showReasoning': 'يعرض أقسام التفكير عندما توفرها الخلفية.',
       timezone: 'تستخدم عندما يحتاج Hermes إلى سياق الوقت المحلي. اتركها فارغة لاستخدام منطقة النظام.',
+      'browser.realProfileBrowser':
+        'اختر متصفح Chromium الذي تريد نسخ ملفه الشخصي. اتركه فارغاً لاستخدام متصفح النظام الافتراضي؛ لن يخمّن Hermes متصفحاً آخر مثبتاً.',
       'agent.imageInputMode': 'يتحكم في طريقة إرسال مرفقات الصور إلى النموذج.',
       'agent.maxTurns': 'الحد الأعلى لدورات استدعاء الأدوات قبل أن يوقف Hermes التشغيل.',
       'terminal.cwd': 'مجلد المشروع الافتراضي لعمل الأدوات والطرفية.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -541,7 +541,8 @@ export const ja = defineLocale({
       },
       browser: {
         allowPrivateUrls: 'ブラウザーのプライベート URL',
-        autoLocalForPrivateUrls: 'プライベート URL にはローカルブラウザーを使用'
+        autoLocalForPrivateUrls: 'プライベート URL にはローカルブラウザーを使用',
+        realProfileBrowser: '実プロファイルのブラウザー'
       },
       checkpoints: {
         enabled: 'ファイルチェックポイント',
@@ -664,6 +665,10 @@ export const ja = defineLocale({
       },
       timezone:
         'Hermes がローカル時刻のコンテキストを必要とするときに使用します。空欄ならシステムのタイムゾーンを使います。',
+      browser: {
+        realProfileBrowser:
+          'コピーするプロファイルの Chromium ブラウザーを選びます。空欄なら OS のデフォルトを使用し、Hermes が別のインストール済みブラウザーを推測することはありません。'
+      },
       agent: {
         imageInputMode: '画像添付をモデルへ送る方法を制御します。',
         maxTurns: 'Hermes が 1 回の実行を停止するまでのツール呼び出しターン上限です。'

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -525,7 +525,8 @@ export const zhHant = defineLocale({
       },
       browser: {
         allowPrivateUrls: '瀏覽器私有 URL',
-        autoLocalForPrivateUrls: '私有 URL 使用本機瀏覽器'
+        autoLocalForPrivateUrls: '私有 URL 使用本機瀏覽器',
+        realProfileBrowser: '真實設定檔瀏覽器'
       },
       checkpoints: {
         enabled: '檔案檢查點',
@@ -647,6 +648,10 @@ export const zhHant = defineLocale({
         repoScanExcludePaths: '探索程式碼儲存庫時略過這些資料夾及其子目錄。'
       },
       timezone: 'Hermes 需要本機時間上下文時使用。留空則使用系統時區。',
+      browser: {
+        realProfileBrowser:
+          '選擇要複製設定檔的 Chromium 瀏覽器。留空則使用作業系統預設瀏覽器；Hermes 不會猜測其他已安裝的瀏覽器。'
+      },
       agent: {
         imageInputMode: '控制圖片附件如何傳送給模型。',
         maxTurns: 'Hermes 停止一次執行前的工具呼叫輪次上限。'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -699,7 +699,8 @@ export const zh: Translations = {
       },
       browser: {
         allowPrivateUrls: '浏览器私有 URL',
-        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器'
+        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器',
+        realProfileBrowser: '真实配置文件浏览器'
       },
       checkpoints: {
         enabled: '文件检查点',
@@ -821,6 +822,10 @@ export const zh: Translations = {
         repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。'
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
+      browser: {
+        realProfileBrowser:
+          '选择要复制配置文件的 Chromium 浏览器。留空则使用操作系统默认浏览器；Hermes 不会猜测其他已安装的浏览器。'
+      },
       agent: {
         imageInputMode: '控制图片附件如何发送给模型。',
         maxTurns: 'Hermes 停止一次运行前工具调用轮次的上限。'

--- a/contributors/emails/bear@bearhuddleston.dev
+++ b/contributors/emails/bear@bearhuddleston.dev
@@ -1,1 +1,2 @@
 BearHuddleston
+# PR #96679

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -101,14 +101,13 @@ _LINUX_INSTALL_PATHS = tuple(path for _, paths in _LINUX_BROWSER_GROUPS for path
 
 
 # ---------------------------------------------------------------------------
-# Real-profile (default Chromium) resolution
+# Real-profile Chromium resolution
 #
 # Used by the browser tool's ``browser.use_real_profile`` consent path: when a
-# local Chromium is launched, point agent-browser at the user's REAL default
-# browser profile (``--profile <user-data-dir>`` + ``--executable-path``) so
-# their live logins/cookies are available. Only Chromium-family browsers are
-# supported; a non-Chromium default (Firefox, Safari) resolves to None and the
-# caller fails closed with a clear message.
+# local Chromium is launched, point agent-browser at the user's selected real
+# browser profile so their live logins/cookies are available. The explicit
+# config pin wins; otherwise the OS default is used. Only Chromium-family
+# browsers are supported, and neither path guesses among installed browsers.
 # ---------------------------------------------------------------------------
 
 # Canonical Chromium browser keys we support for real-profile driving.
@@ -491,6 +490,67 @@ def detect_default_chromium(system: str | None = None) -> str | None:
     if system == "Darwin":
         return _detect_default_darwin()
     return _detect_default_linux()
+
+
+def _read_real_profile_config_uncached() -> dict | None:
+    """Read config.yaml without defaults/cache; None means malformed/unreadable."""
+    try:
+        from hermes_cli.config import fast_safe_load, get_config_path
+
+        with open(get_config_path(), encoding="utf-8") as fh:
+            cfg = fast_safe_load(fh)
+    except FileNotFoundError:
+        return {}
+    except Exception as e:
+        logger.debug("could not read browser.real_profile_browser: %s", e)
+        return None
+    if cfg is None:
+        return {}
+    return cfg if isinstance(cfg, dict) else None
+
+
+def configured_real_profile_browser() -> str | None:
+    """Return the normalized pin, or None for malformed browser config.
+
+    The config is deliberately read on every call. This choice is adjacent to
+    real-profile consent, so a long-lived Hermes process must observe an edit
+    without relying on a process-lifetime config cache.
+    """
+    cfg = _read_real_profile_config_uncached()
+    if cfg is None:
+        return None
+    browser_cfg = cfg.get("browser", {})
+    if not isinstance(browser_cfg, dict):
+        return None
+    configured = browser_cfg.get("real_profile_browser", "")
+    if not isinstance(configured, str):
+        return None
+    return configured.strip().lower()
+
+
+def resolve_real_profile_browser() -> tuple[str | None, str | None]:
+    """Resolve an explicit browser pin, then the OS default, fail-closed.
+
+    An empty pin preserves the existing default-browser detection behavior. A
+    non-empty pin is the user's explicit browser choice; invalid values never
+    fall through to detection or an installed-browser guess.
+    """
+    configured = configured_real_profile_browser()
+    if configured is None:
+        allowed = ", ".join(_CHROMIUM_BROWSERS)
+        return None, (
+            "Invalid browser.real_profile_browser configuration. "
+            f"Allowed values: {allowed} (or empty to follow the OS default)."
+        )
+    if not configured:
+        return detect_default_chromium(), None
+    if configured not in _CHROMIUM_BROWSERS:
+        allowed = ", ".join(_CHROMIUM_BROWSERS)
+        return None, (
+            f"Invalid browser.real_profile_browser value {configured!r}. "
+            f"Allowed values: {allowed} (or empty to follow the OS default)."
+        )
+    return configured, None
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -498,14 +498,15 @@ def _read_real_profile_config_uncached() -> dict | None:
         from hermes_cli.config import fast_safe_load, get_config_path
 
         with open(get_config_path(), encoding="utf-8") as fh:
-            cfg = fast_safe_load(fh)
+            raw = fh.read()
+        if not raw.strip():
+            return {}
+        cfg = fast_safe_load(raw)
     except FileNotFoundError:
         return {}
     except Exception as e:
         logger.debug("could not read browser.real_profile_browser: %s", e)
         return None
-    if cfg is None:
-        return {}
     return cfg if isinstance(cfg, dict) else None
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -627,20 +627,27 @@ DEFAULT_CONFIG = {
         # Consent to browse with the user's REAL logins for local browsing.
         # When true, local browsing (the Browser Use CLI, or the built-in
         # browser tools) runs on a Hermes-managed SNAPSHOT of the user's
-        # ACTIVE default-Chromium profile (Local State -> profile.last_used) —
+        # ACTIVE selected-Chromium profile (Local State -> profile.last_used) —
         # its cookies, logins and preferences copied in and re-synced when a
-        # fresh session launches — driven by Hermes' packaged Chromium. Only
+        # fresh session launches — driven by the selected browser's executable. Only
         # the active profile is copied. The snapshot is a non-default dir, so it
         # sidesteps Chrome 136+'s block on debugging the default profile and
         # never contends with the user's running browser. Turning this back off
         # deletes the snapshot store (~/.hermes/browser-profile/) so copied
-        # credentials don't outlive consent. Only Chromium-family default
-        # browsers are supported (Chrome, Edge, Brave, Brave Origin, Chromium); a non-Chromium
-        # default (e.g. Firefox) fails closed with a clear message. Default
-        # false. Also gates the browser_exec ``local`` argument, which forces a
-        # real-profile local session even under a cloud browser backend. Toggle
-        # in the desktop Settings → Browser section.
+        # credentials don't outlive consent. Only Chromium-family browsers are
+        # supported (Chrome, Edge, Brave, Brave Origin, Chromium); an explicit
+        # browser pin selects one, while an empty pin follows the OS default and
+        # fails closed if that is non-Chromium. Default false. Also gates the browser_exec ``local``
+        # argument, which forces a real-profile local session even under a cloud
+        # browser backend. Toggle in the desktop Capabilities → Tools → Browser
+        # section or configure it in Settings → Config → browser.
         "use_real_profile": False,
+        # Explicitly pin the Chromium-family profile Hermes snapshots. Empty
+        # follows the OS default. This is never a silent "first installed
+        # Chromium wins" fallback: non-empty means the user chose that browser.
+        # Allowed values: chrome, edge, brave, brave-origin, chromium
+        # (case-insensitive).
+        "real_profile_browser": "",
         # When real-profile browsing needs the browser closed (Windows: a
         # running Chrome/Edge/Brave locks its cookie DB deny-all, so it must be
         # fully quit before its profile can be copied), arm the "offer to close

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13361,7 +13361,7 @@ def main():
         description=(
             "Helpers for real-profile browsing (browser.use_real_profile). "
             "close-profile terminates the browser process tree holding your "
-            "default profile so Hermes can copy it — DESTRUCTIVE (unsaved tabs "
+            "selected profile so Hermes can copy it — DESTRUCTIVE (unsaved tabs "
             "in that browser are lost). The agent runs this only after you "
             "approve closing the browser."
         ),
@@ -13374,24 +13374,36 @@ def main():
     )
     browser_close.add_argument(
         "--browser",
-        help="Override detected default browser (chrome/edge/brave/brave-origin/chromium)",
+        help="Override configured/OS-default browser (chrome/edge/brave/brave-origin/chromium)",
     )
 
     def _dispatch_browser(_args):
         from hermes_cli.browser_connect import (
             UNSUPPORTED_CHANNEL,
             close_browser_holding_profile,
-            detect_default_chromium,
             real_profile_data_dir,
+            resolve_real_profile_browser,
         )
 
         action = getattr(_args, "browser_action", None)
         if action != "close-profile":
             browser_parser.print_help()
             return 2
-        browser = getattr(_args, "browser", None) or detect_default_chromium()
+        browser = getattr(_args, "browser", None)
+        resolve_error = None
+        if not browser:
+            browser, resolve_error = resolve_real_profile_browser()
+        if resolve_error:
+            print(f"✗ {resolve_error}", file=sys.stderr)
+            return 1
         if not browser or browser == UNSUPPORTED_CHANNEL:
-            print("✗ No supported Chromium default browser detected.", file=sys.stderr)
+            print(
+                "✗ No supported Chromium default browser detected. Set "
+                "browser.real_profile_browser to chrome, edge, brave, brave-origin, "
+                "or chromium "
+                "to pin one without changing your OS default.",
+                file=sys.stderr,
+            )
             return 1
         src = real_profile_data_dir(browser)
         if not src:

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,6 +1,6 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 class TestScreenshotPathRecovery:
@@ -65,6 +65,34 @@ class TestBrowserCleanup:
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
 
+
+    def test_cleanup_all_reaps_only_owned_real_profile_browser(self):
+        browser_tool = self.browser_tool
+        owned_chrome = Mock()
+        owned_chrome.poll.return_value = None
+        unrelated_chrome = Mock()
+
+        with (
+            patch.object(browser_tool, "_active_sessions", {}),
+            patch.object(browser_tool, "_real_profile_chrome_procs", [owned_chrome]),
+            patch.object(
+                browser_tool,
+                "_real_profile_cdp_cache",
+                {"cdp": "http://127.0.0.1:41000"},
+            ),
+            patch.object(browser_tool, "_agent_browser_close_session") as close,
+            patch("tools.browser_supervisor.SUPERVISOR_REGISTRY.stop_all"),
+        ):
+            browser_tool.cleanup_all_browsers()
+
+            close.assert_called_once_with(browser_tool._REAL_PROFILE_SESSION)
+            owned_chrome.terminate.assert_called_once_with()
+            owned_chrome.wait.assert_called_once_with(timeout=5)
+            owned_chrome.kill.assert_not_called()
+            assert browser_tool._real_profile_chrome_procs == []
+
+        unrelated_chrome.terminate.assert_not_called()
+        unrelated_chrome.kill.assert_not_called()
 
     def test_emergency_cleanup_clears_all_tracking_state(self):
         browser_tool = self.browser_tool

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -124,7 +124,7 @@ class TestRealProfileResolvers:
         assert err and "browser.real_profile_browser" in err
         detect.assert_not_called()
 
-    @pytest.mark.parametrize("config_text", ["browser: [", "- browser\n"])
+    @pytest.mark.parametrize("config_text", ["browser: [", "- browser\n", "null\n"])
     def test_malformed_config_file_fails_closed(
         self, config_text, tmp_path, monkeypatch
     ):
@@ -359,6 +359,35 @@ class TestRealProfileCdpLaunch:
         snapshot.assert_called_once_with("chrome")
         self._reset()
 
+    def test_cached_cdp_requires_profile_copy_identity(self):
+        """A ready cached endpoint is not trusted without live CDP identity."""
+        import tools.browser_tool as bt
+
+        self._reset()
+        cached = "http://127.0.0.1:41000"
+        copy_dir = "/profile-a/browser-profile/chrome"
+        bt._real_profile_cdp_cache.update({
+            "cdp": cached,
+            "browser": "chrome",
+            "copy_dir": copy_dir,
+        })
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.resolve_real_profile_browser",
+                   return_value=("chrome", None)), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir",
+                   return_value=copy_dir), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=False) as identity, \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(None, "snapshot reached")):
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None
+        assert err and "snapshot reached" in err
+        identity.assert_called_once_with(cached, copy_dir)
+        assert bt._real_profile_cdp_cache == {}
+
     def test_snapshot_failure_fails_closed(self):
         import tools.browser_tool as bt
         self._reset()
@@ -511,11 +540,46 @@ class TestRealProfileCdpLaunch:
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
 
-    def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
+    def test_cdp_on_data_dir_matches_devtools_identity(self, tmp_path):
         import tools.browser_tool as bt
-        (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
-        assert bt._cdp_on_data_dir("http://127.0.0.1:41000", str(tmp_path))
-        assert not bt._cdp_on_data_dir("http://127.0.0.1:9999", str(tmp_path))
+
+        (tmp_path / "DevToolsActivePort").write_text(
+            "41000\n/devtools/browser/expected\n"
+        )
+        version = Mock()
+        version.json.return_value = {
+            "webSocketDebuggerUrl": (
+                "ws://127.0.0.1:41000/devtools/browser/expected"
+            )
+        }
+        with patch("requests.get", return_value=version) as get_version:
+            assert bt._cdp_on_data_dir("http://127.0.0.1:41000", str(tmp_path))
+            assert not bt._cdp_on_data_dir(
+                "http://127.0.0.1:9999", str(tmp_path)
+            )
+
+        get_version.assert_called_once_with(
+            "http://127.0.0.1:41000/json/version", timeout=1.0
+        )
+
+    def test_cdp_on_data_dir_rejects_same_port_wrong_browser_id(self, tmp_path):
+        import tools.browser_tool as bt
+
+        (tmp_path / "DevToolsActivePort").write_text(
+            "41000\n/devtools/browser/expected\n"
+        )
+        version = Mock()
+        version.json.return_value = {
+            "webSocketDebuggerUrl": "ws://127.0.0.1:41000/devtools/browser/other"
+        }
+        with patch("requests.get", return_value=version) as get_version:
+            assert not bt._cdp_on_data_dir(
+                "http://127.0.0.1:41000", str(tmp_path)
+            )
+
+        get_version.assert_called_once_with(
+            "http://127.0.0.1:41000/json/version", timeout=1.0
+        )
 
 
 class TestConsentConfigRead:

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -71,6 +71,97 @@ class TestRealProfileResolvers:
         with patch.object(bc, "_detect_default_linux", return_value=None):
             assert bc.detect_default_chromium("Linux") is None
 
+    def test_configured_chrome_pin_wins_over_non_chromium_default(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.browser_connect as bc
+
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "browser:\n  real_profile_browser: '  ChRoMe  '\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        with patch.object(bc, "detect_default_chromium", return_value=None) as detect:
+            browser, err = bc.resolve_real_profile_browser()
+        assert browser == "chrome"
+        assert err is None
+        detect.assert_not_called()
+
+    def test_invalid_configured_browser_pin_fails_closed(self):
+        import hermes_cli.browser_connect as bc
+        with patch.object(bc, "_read_real_profile_config_uncached", return_value={
+            "browser": {"real_profile_browser": "firefox"}
+        }), patch.object(bc, "detect_default_chromium", return_value="chrome") as detect:
+            browser, err = bc.resolve_real_profile_browser()
+        assert browser is None
+        assert err and "browser.real_profile_browser" in err
+        for allowed in ("chrome", "edge", "brave", "chromium"):
+            assert allowed in err
+        detect.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "browser_config",
+        [
+            None,
+            [],
+            "chrome",
+            {"real_profile_browser": None},
+            {"real_profile_browser": True},
+            {"real_profile_browser": ["chrome"]},
+        ],
+    )
+    def test_malformed_browser_config_fails_closed(self, browser_config):
+        import hermes_cli.browser_connect as bc
+
+        with patch.object(bc, "_read_real_profile_config_uncached", return_value={
+            "browser": browser_config
+        }), patch.object(bc, "detect_default_chromium", return_value="chrome") as detect:
+            browser, err = bc.resolve_real_profile_browser()
+        assert browser is None
+        assert err and "browser.real_profile_browser" in err
+        detect.assert_not_called()
+
+    @pytest.mark.parametrize("config_text", ["browser: [", "- browser\n"])
+    def test_malformed_config_file_fails_closed(
+        self, config_text, tmp_path, monkeypatch
+    ):
+        import hermes_cli.browser_connect as bc
+
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        (home / "config.yaml").write_text(config_text, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        with patch.object(bc, "detect_default_chromium", return_value="chrome") as detect:
+            browser, err = bc.resolve_real_profile_browser()
+        assert browser is None
+        assert err and "browser.real_profile_browser" in err
+        detect.assert_not_called()
+
+    @pytest.mark.parametrize("browser_config", [{}, {"real_profile_browser": ""}])
+    def test_empty_or_unset_browser_pin_uses_os_default(self, browser_config):
+        import hermes_cli.browser_connect as bc
+        with patch.object(bc, "_read_real_profile_config_uncached", return_value={
+            "browser": browser_config
+        }), patch.object(bc, "detect_default_chromium", return_value="brave") as detect:
+            browser, err = bc.resolve_real_profile_browser()
+        assert browser == "brave"
+        assert err is None
+        detect.assert_called_once_with()
+
+    def test_browser_pin_is_read_uncached_on_each_resolve(self):
+        import hermes_cli.browser_connect as bc
+        configs = [
+            {"browser": {"real_profile_browser": "chrome"}},
+            {"browser": {"real_profile_browser": "edge"}},
+        ]
+        with patch.object(bc, "_read_real_profile_config_uncached", side_effect=configs):
+            assert bc.resolve_real_profile_browser() == ("chrome", None)
+            assert bc.resolve_real_profile_browser() == ("edge", None)
+
 
 class TestSnapshotRealProfile:
     """Real file I/O: the snapshot copier against a synthetic profile tree."""
@@ -209,6 +300,64 @@ class TestRealProfileCdpLaunch:
             cdp, err = bt._real_profile_cdp()
         assert cdp is None
         assert err and "not a supported Chromium" in err
+        assert "browser.real_profile_browser" in err
+
+    def test_configured_pin_reaches_snapshot_when_os_default_is_firefox(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect._read_real_profile_config_uncached", return_value={
+                 "browser": {"real_profile_browser": "chrome"}
+             }), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value="/copy/chrome"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(None, "snapshot reached")) as snapshot:
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "snapshot reached" in err
+        snapshot.assert_called_once_with("chrome")
+
+    def test_invalid_configured_pin_blocks_snapshot(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect._read_real_profile_config_uncached", return_value={
+                 "browser": {"real_profile_browser": "firefox"}
+             }), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile") as snapshot:
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "browser.real_profile_browser" in err
+        snapshot.assert_not_called()
+        self._reset()
+
+    def test_cached_cdp_is_scoped_to_the_profile_copy_dir(self):
+        """A multiplexed profile must not inherit another profile's cookies."""
+        import tools.browser_tool as bt
+
+        self._reset()
+        bt._real_profile_cdp_cache.update({
+            "cdp": "http://127.0.0.1:41000",
+            "browser": "chrome",
+            "copy_dir": "/profile-a/browser-profile/chrome",
+        })
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.resolve_real_profile_browser",
+                   return_value=("chrome", None)), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir",
+                   return_value="/profile-b/browser-profile/chrome"), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(None, "snapshot reached")) as snapshot:
+            cdp, err = bt._real_profile_cdp()
+        assert cdp is None
+        assert err and "snapshot reached" in err
+        snapshot.assert_called_once_with("chrome")
+        self._reset()
 
     def test_snapshot_failure_fails_closed(self):
         import tools.browser_tool as bt
@@ -368,6 +517,38 @@ class TestConsentConfigRead:
         with patch("hermes_cli.config.read_raw_config",
                    return_value={"browser": {"use_real_profile": False}}):
             assert bt._use_real_profile() is False
+
+
+class TestCloseProfileCommand:
+    def test_without_browser_flag_uses_configured_pin(self, monkeypatch):
+        import sys
+        import hermes_cli.browser_connect as bc
+        import hermes_cli.main as cli
+
+        monkeypatch.setattr(sys, "argv", ["hermes", "browser", "close-profile"])
+        monkeypatch.setattr(cli, "_set_process_title", lambda: None)
+        monkeypatch.setattr(cli, "_cleanup_quarantined_exes", lambda: None)
+        monkeypatch.setattr(cli, "_sweep_stale_bytecode_if_checkout_changed", lambda: None)
+        monkeypatch.setattr(cli, "_recover_from_interrupted_install", lambda: None)
+        monkeypatch.setattr(cli, "_warn_pending_fleet_restart_on_startup", lambda: None)
+        monkeypatch.setattr(cli, "_try_termux_fast_tui_launch", lambda: False)
+        monkeypatch.setattr(cli, "_try_termux_fast_cli_launch", lambda: False)
+        monkeypatch.setattr(cli, "_try_fast_chat_launch", lambda: False)
+        monkeypatch.setattr(cli, "_prepare_agent_startup", lambda args: None)
+
+        with patch("hermes_cli.config.get_container_exec_info", return_value=None), \
+             patch.object(bc, "_read_real_profile_config_uncached", return_value={
+                 "browser": {"real_profile_browser": "chrome"}
+             }), \
+             patch.object(bc, "detect_default_chromium", return_value=None) as detect, \
+             patch.object(bc, "real_profile_data_dir", return_value="/profiles/chrome") as data_dir, \
+             patch.object(bc, "close_browser_holding_profile",
+                          return_value=(True, "closed")) as close:
+            cli.main()
+
+        detect.assert_not_called()
+        data_dir.assert_called_once_with("chrome")
+        close.assert_called_once_with("/profiles/chrome")
 
 
 class TestLocalSessionRealProfile:

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -389,6 +389,7 @@ class TestRealProfileCdpLaunch:
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=True), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):
@@ -396,6 +397,30 @@ class TestRealProfileCdpLaunch:
         assert err is None
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
+
+    def test_post_launch_cdp_must_match_profile_copy(self, tmp_path):
+        """A stale shared session must never be relabeled as this profile."""
+        import tools.browser_tool as bt
+
+        self._reset()
+        proc = Mock(returncode=0, stdout="", stderr="")
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session") as close, \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None
+        assert err and "profile copy" in err
+        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+        assert bt._real_profile_cdp_cache == {}
 
     def test_launch_is_headless_and_agent_browser_attaches(self, tmp_path):
         """Real-profile browsing runs headless (no focus-stealing window).
@@ -439,6 +464,7 @@ class TestRealProfileCdpLaunch:
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=True), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", side_effect=fake_run), \
              patch.object(bt, "_is_headed_mode", return_value=False):
@@ -474,7 +500,7 @@ class TestRealProfileCdpLaunch:
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=["http://127.0.0.1:5000", "http://127.0.0.1:41000"]), \
              patch.object(bt, "_cdp_http_ready", return_value=True), \
-             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+             patch.object(bt, "_cdp_on_data_dir", side_effect=[False, True]), \
              patch.object(bt, "_agent_browser_close_session",
                           side_effect=lambda s: closed.__setitem__("n", closed["n"] + 1)), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
@@ -1153,6 +1179,7 @@ class TestReviewRound3:
                    return_value=(str(tmp_path), None)) as snap, \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:9251"]), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=True), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -283,6 +283,7 @@ class TestRealProfileCdpLaunch:
 
     def _reset(self):
         import tools.browser_tool as bt
+        bt._terminate_real_profile_chrome()
         bt._real_profile_cdp_cache.clear()
 
     def test_consent_off_is_noop(self):
@@ -291,6 +292,65 @@ class TestRealProfileCdpLaunch:
         with patch.object(bt, "_use_real_profile", return_value=False):
             cdp, err = bt._real_profile_cdp()
         assert cdp is None and err is None
+
+    def test_consent_revocation_reaps_owned_browser_before_snapshot_cleanup(self):
+        import tools.browser_tool as bt
+
+        owned_chrome = Mock()
+        owned_chrome.poll.return_value = None
+        unrelated_chrome = Mock()
+
+        def cleanup_snapshots():
+            owned_chrome.terminate.assert_called_once_with()
+            owned_chrome.wait.assert_called_once_with(timeout=5)
+
+        with patch.object(bt, "_use_real_profile", return_value=False), \
+             patch.object(bt, "_real_profile_chrome_procs", [owned_chrome]), \
+             patch.object(bt, "_real_profile_cdp_cache", {
+                 "cdp": "old", "scope": "profile-a"
+             }), \
+             patch.object(bt, "hermes_home_key", return_value="profile-a"), \
+             patch.object(bt, "_agent_browser_close_session") as close, \
+             patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots",
+                   side_effect=cleanup_snapshots) as cleanup:
+            cdp, err = bt._real_profile_cdp()
+
+            assert bt._real_profile_chrome_procs == []
+            assert bt._real_profile_cdp_cache == {}
+
+        assert cdp is None and err is None
+        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+        cleanup.assert_called_once_with()
+        owned_chrome.kill.assert_not_called()
+        unrelated_chrome.terminate.assert_not_called()
+        unrelated_chrome.kill.assert_not_called()
+
+    def test_consent_off_does_not_reap_another_profile_browser(self):
+        import tools.browser_tool as bt
+
+        other_profile_chrome = Mock()
+        other_profile_chrome.poll.return_value = None
+        cached = {
+            "cdp": "http://127.0.0.1:41000",
+            "scope": "profile-a",
+        }
+        procs = [other_profile_chrome]
+
+        with patch.object(bt, "_use_real_profile", return_value=False), \
+             patch.object(bt, "_real_profile_chrome_procs", procs), \
+             patch.object(bt, "_real_profile_cdp_cache", cached), \
+             patch.object(bt, "hermes_home_key", return_value="profile-b"), \
+             patch.object(bt, "_agent_browser_close_session") as close, \
+             patch("hermes_cli.browser_connect.cleanup_real_profile_snapshots"):
+            cdp, err = bt._real_profile_cdp()
+
+            assert bt._real_profile_chrome_procs == [other_profile_chrome]
+            assert bt._real_profile_cdp_cache == cached
+
+        assert cdp is None and err is None
+        close.assert_not_called()
+        other_profile_chrome.terminate.assert_not_called()
+        other_profile_chrome.kill.assert_not_called()
 
     def test_non_chromium_default_fails_closed(self):
         import tools.browser_tool as bt
@@ -357,6 +417,43 @@ class TestRealProfileCdpLaunch:
         assert cdp is None
         assert err and "snapshot reached" in err
         snapshot.assert_called_once_with("chrome")
+        self._reset()
+
+    def test_changed_browser_pin_reaps_owned_copy_browser(self):
+        """Switching principals must stop the old credential-bearing browser."""
+        import tools.browser_tool as bt
+
+        self._reset()
+        old_chrome = Mock()
+        old_chrome.poll.return_value = None
+        bt._real_profile_chrome_procs.append(old_chrome)
+        old_cdp = "http://127.0.0.1:41000"
+        bt._real_profile_cdp_cache.update({
+            "cdp": old_cdp,
+            "browser": "chrome",
+            "copy_dir": "/profile-a/browser-profile/chrome",
+        })
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.resolve_real_profile_browser",
+                   return_value=("edge", None)), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir",
+                   return_value="/profile-a/browser-profile/edge"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=old_cdp), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session") as close, \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(None, "snapshot reached")):
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None
+        assert err and "snapshot reached" in err
+        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+        old_chrome.terminate.assert_called_once_with()
+        old_chrome.wait.assert_called_once_with(timeout=5)
+        old_chrome.kill.assert_not_called()
+        assert bt._real_profile_chrome_procs == []
         self._reset()
 
     def test_cached_cdp_requires_profile_copy_identity(self):
@@ -433,10 +530,22 @@ class TestRealProfileCdpLaunch:
 
         self._reset()
         proc = Mock(returncode=0, stdout="", stderr="")
+        chrome = Mock()
+        chrome.poll.return_value = None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text(
+                "41000\n/devtools/browser/x\n", encoding="utf-8"
+            )
+            return chrome
+
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.snapshot_real_profile",
                    return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable",
+                   return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:41000"]), \
              patch.object(bt, "_cdp_on_data_dir", return_value=False), \
@@ -450,6 +559,11 @@ class TestRealProfileCdpLaunch:
         assert err and "profile copy" in err
         close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
         assert bt._real_profile_cdp_cache == {}
+        chrome.terminate.assert_called_once_with()
+        chrome.wait.assert_called_once_with(timeout=5)
+        chrome.kill.assert_not_called()
+        assert bt._real_profile_chrome_procs == []
+        self._reset()
 
     def test_launch_is_headless_and_agent_browser_attaches(self, tmp_path):
         """Real-profile browsing runs headless (no focus-stealing window).

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -456,6 +456,185 @@ class TestRealProfileCdpLaunch:
         assert bt._real_profile_chrome_procs == []
         self._reset()
 
+    def test_invalidation_evicts_only_real_profile_task_attachments(self):
+        """No task may retain the CDP URL of a reaped profile browser."""
+        import tools.browser_tool as bt
+
+        profile_session = {
+            "session_name": "rp_old",
+            "cdp_url": "ws://127.0.0.1:41000/devtools/browser/old",
+            "features": {"local": True, "real_profile": True},
+        }
+        throwaway_session = {
+            "session_name": "h_keep",
+            "cdp_url": None,
+            "features": {"local": True},
+        }
+        active = {"task-profile": profile_session, "task-throwaway": throwaway_session}
+        activity = {"task-profile": 1.0, "task-throwaway": 2.0}
+        last_active = {
+            "task-profile": "task-profile",
+            "task-throwaway": "task-throwaway",
+        }
+        recordings = {"task-profile", "task-throwaway"}
+        suspect = {"task-profile": "old endpoint", "task-throwaway": "keep"}
+        generation = bt._real_profile_generation
+
+        with patch.object(bt, "_active_sessions", active), \
+             patch.object(bt, "_session_last_activity", activity), \
+             patch.object(bt, "_last_active_session_key", last_active), \
+             patch.object(bt, "_recording_sessions", recordings), \
+             patch.object(bt, "_suspect_browser_sessions", suspect), \
+             patch.object(bt, "_stop_cdp_supervisor") as stop, \
+             patch.object(bt, "_agent_browser_close_session") as close:
+            bt._invalidate_real_profile_browser()
+
+        assert active == {"task-throwaway": throwaway_session}
+        assert activity == {"task-throwaway": 2.0}
+        assert last_active == {"task-throwaway": "task-throwaway"}
+        assert recordings == {"task-throwaway"}
+        assert suspect == {"task-throwaway": "keep"}
+        stop.assert_called_once_with("task-profile")
+        close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+        assert bt._real_profile_generation == generation + 1
+
+    def test_cached_task_rechecks_replaced_real_profile_lifecycle(self):
+        """A task attachment follows the current shared browser generation."""
+        import tools.browser_tool as bt
+
+        old_session = {
+            "session_name": "rp_old",
+            "cdp_url": "ws://127.0.0.1:41000/devtools/browser/old",
+            "real_profile_cdp": "http://127.0.0.1:41000",
+            "real_profile_scope": "profile-a",
+            "real_profile_generation": 6,
+            "features": {"local": True, "real_profile": True},
+        }
+        replacement = {
+            "session_name": "rp_new",
+            "cdp_url": "ws://127.0.0.1:42000/devtools/browser/new",
+            "real_profile_cdp": "http://127.0.0.1:42000",
+            "real_profile_scope": "profile-a",
+            "real_profile_generation": 7,
+            "features": {"local": True, "real_profile": True},
+        }
+        active = {"task-a": old_session}
+
+        with patch.object(bt, "_active_sessions", active), \
+             patch.object(bt, "_session_last_activity", {"task-a": 1.0}), \
+             patch.object(bt, "_last_active_session_key", {"task-a": "task-a"}), \
+             patch.object(bt, "_recording_sessions", set()), \
+             patch.object(bt, "_suspect_browser_sessions", {}), \
+             patch.object(bt, "_start_browser_cleanup_thread"), \
+             patch.object(bt, "_update_session_activity") as update_activity, \
+             patch.object(bt, "_real_profile_cdp_locked",
+                          return_value=("http://127.0.0.1:42000", None)) as lifecycle, \
+             patch.object(bt, "_real_profile_generation", 7), \
+             patch.object(bt, "hermes_home_key", return_value="profile-a"), \
+             patch.object(bt, "_stop_cdp_supervisor") as stop, \
+             patch.object(bt, "_get_cdp_override", return_value=""), \
+             patch.object(bt, "_get_cloud_provider", return_value=None), \
+             patch.object(bt, "_create_local_session", return_value=replacement) as create, \
+             patch.object(bt, "_ensure_cdp_supervisor"):
+            result = bt._get_session_info("task-a")
+
+        assert result["real_profile_cdp"] == "http://127.0.0.1:42000"
+        assert active["task-a"] is result
+        assert active["task-a"] is not old_session
+        assert lifecycle.call_count == 2
+        stop.assert_called_once_with("task-a")
+        create.assert_called_once_with("task-a")
+        assert update_activity.call_count == 2
+
+    def test_unpublished_real_profile_generation_is_revalidated(self):
+        """A profile switch before publication cannot resurrect a dead CDP."""
+        import tools.browser_tool as bt
+
+        stale = {
+            "session_name": "rp_stale",
+            "cdp_url": "ws://127.0.0.1:41000/devtools/browser/stale",
+            "real_profile_cdp": "http://127.0.0.1:41000",
+            "real_profile_scope": "profile-a",
+            "real_profile_generation": 6,
+            "features": {"local": True, "real_profile": True},
+        }
+        current = {
+            "session_name": "rp_current",
+            "cdp_url": "ws://127.0.0.1:42000/devtools/browser/current",
+            "real_profile_cdp": "http://127.0.0.1:42000",
+            "real_profile_scope": "profile-a",
+            "real_profile_generation": 7,
+            "features": {"local": True, "real_profile": True},
+        }
+        active = {}
+
+        with patch.object(bt, "_active_sessions", active), \
+             patch.object(bt, "_session_last_activity", {}), \
+             patch.object(bt, "_last_active_session_key", {}), \
+             patch.object(bt, "_recording_sessions", set()), \
+             patch.object(bt, "_suspect_browser_sessions", {}), \
+             patch.object(bt, "_start_browser_cleanup_thread"), \
+             patch.object(bt, "_update_session_activity"), \
+             patch.object(bt, "_real_profile_cdp_locked",
+                          return_value=("http://127.0.0.1:42000", None)), \
+             patch.object(bt, "_real_profile_generation", 7), \
+             patch.object(bt, "hermes_home_key", return_value="profile-a"), \
+             patch.object(bt, "_get_cdp_override", return_value=""), \
+             patch.object(bt, "_get_cloud_provider", return_value=None), \
+             patch.object(bt, "_create_local_session",
+                          side_effect=[stale, current]) as create, \
+             patch.object(bt, "_ensure_cdp_supervisor"):
+            result = bt._get_session_info("task-a")
+
+        assert result["real_profile_generation"] == 7
+        assert result["real_profile_cdp"] == "http://127.0.0.1:42000"
+        assert active["task-a"] is result
+        assert create.call_count == 2
+
+    def test_real_profile_supervisor_starts_inside_lifecycle_generation(self):
+        """Invalidation cannot pass supervisor startup before it publishes."""
+        import tools.browser_tool as bt
+
+        class TrackingLock:
+            held = False
+
+            def __enter__(self):
+                assert not self.held
+                self.held = True
+                return self
+
+            def __exit__(self, *_exc):
+                self.held = False
+
+        lifecycle_lock = TrackingLock()
+        session = {
+            "session_name": "rp_current",
+            "cdp_url": "ws://127.0.0.1:42000/devtools/browser/current",
+            "real_profile_cdp": "http://127.0.0.1:42000",
+            "real_profile_scope": "profile-a",
+            "real_profile_generation": 7,
+            "features": {"local": True, "real_profile": True},
+        }
+
+        def start(_task_id, _cdp_url):
+            assert lifecycle_lock.held
+
+        with patch.object(bt, "_real_profile_cdp_lock", lifecycle_lock), \
+             patch.object(bt, "_real_profile_cdp_cache",
+                          {"cdp": "http://127.0.0.1:42000"}), \
+             patch.object(bt, "_real_profile_generation", 7), \
+             patch.object(bt, "_active_sessions", {"task-a": session}), \
+             patch.object(bt, "hermes_home_key", return_value="profile-a"), \
+             patch.object(bt, "_get_cdp_override", return_value=""), \
+             patch.object(bt, "_resolve_cdp_override", side_effect=lambda url: url), \
+             patch.object(bt, "_start_cdp_supervisor", side_effect=start) as start_mock:
+            bt._ensure_cdp_supervisor("task-a")
+
+        start_mock.assert_called_once_with(
+            "task-a", "ws://127.0.0.1:42000/devtools/browser/current"
+        )
+        assert not lifecycle_lock.held
+
     def test_cached_cdp_requires_profile_copy_identity(self):
         """A ready cached endpoint is not trusted without live CDP identity."""
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1632,7 +1632,7 @@ def _agent_browser_close_session(session_name: str) -> None:
 def _real_profile_cdp() -> tuple:
     """Resolve ``(cdp_url, error)`` for consented real-profile browsing.
 
-    Snapshots the user's default-Chromium profile into a hermes-owned copy
+    Snapshots the user's selected Chromium profile into a hermes-owned copy
     (auth/login state only), then has agent-browser launch its packaged
     Chromium on that copy and returns the HTTP CDP endpoint for the browser-use
     harness to attach to. The copy is a non-default dir, so it sidesteps the
@@ -1642,7 +1642,7 @@ def _real_profile_cdp() -> tuple:
 
     A single shared agent-browser session is reused across calls (its CDP URL
     is cached and re-validated). Returns ``(None, message)`` fail-closed when
-    the default browser is non-Chromium or the snapshot/launch fails;
+    browser resolution fails or the snapshot/launch fails;
     ``(None, None)`` when consent is off.
     """
     if not _use_real_profile():
@@ -1657,6 +1657,8 @@ def _real_profile_cdp() -> tuple:
         except Exception as e:
             logger.debug("real-profile cleanup-on-consent-off failed: %s", e)
         _real_profile_cdp_cache.pop("cdp", None)
+        _real_profile_cdp_cache.pop("browser", None)
+        _real_profile_cdp_cache.pop("copy_dir", None)
         return None, None
 
     # Lightpanda cannot load a Chromium profile — agent-browser rejects
@@ -1674,26 +1676,24 @@ def _real_profile_cdp() -> tuple:
 
     from hermes_cli.browser_connect import (
         UNSUPPORTED_CHANNEL,
-        detect_default_chromium,
         real_profile_copy_dir,
+        resolve_real_profile_browser,
         snapshot_real_profile,
     )
 
-    with _real_profile_cdp_lock:
-        # Reuse a live copy-browser from an earlier call this process made.
-        cached = _real_profile_cdp_cache.get("cdp")
-        if cached and _cdp_http_ready(cached):
-            return cached, None
-        _real_profile_cdp_cache.pop("cdp", None)
+    browser, resolve_error = resolve_real_profile_browser()
+    if resolve_error:
+        return None, resolve_error
 
-        browser = detect_default_chromium()
+    with _real_profile_cdp_lock:
         if browser is None:
             return None, (
                 "browser.use_real_profile is on, but your default browser is not a "
                 "supported Chromium browser (Chrome, Edge, Brave, Brave Origin, "
                 "Chromium). "
-                "Real-profile browsing requires a Chromium default; set one or turn "
-                "the toggle off."
+                "Set browser.real_profile_browser to chrome, edge, brave, "
+                "brave-origin, or chromium to pin one without changing your OS default, or turn the "
+                "toggle off."
             )
         if browser == UNSUPPORTED_CHANNEL:
             # A recognized pre-release channel (Beta/Dev/Canary) is the OS
@@ -1704,10 +1704,32 @@ def _real_profile_cdp() -> tuple:
             return None, (
                 "browser.use_real_profile is on, but your default browser is a "
                 "pre-release Chromium channel (Beta / Dev / Canary), which "
-                "real-profile browsing does not support. Set your default to a "
-                "stable Chrome / Edge / Brave / Brave Origin / Chromium, or turn "
+                "real-profile browsing does not support. Set "
+                "browser.real_profile_browser to chrome, edge, brave, brave-origin, "
+                "or chromium to pin a stable browser, change your OS default, or turn "
                 "the toggle off."
             )
+
+        # The same browser family can be selected by multiple multiplexed Hermes
+        # profiles, whose snapshots live under different HERMES_HOME roots. Bind
+        # reuse to the selected copy path as well as the browser key so one
+        # profile can never inherit another profile's snapshotted credentials.
+        copy_dir = real_profile_copy_dir(browser)
+
+        # Reuse a live copy-browser from an earlier call this process made only
+        # when it belongs to the browser selected by the current uncached config
+        # read. A changed pin must never keep driving the previous principal.
+        cached = _real_profile_cdp_cache.get("cdp")
+        if (
+            cached
+            and _real_profile_cdp_cache.get("browser") == browser
+            and _real_profile_cdp_cache.get("copy_dir") == copy_dir
+            and _cdp_http_ready(cached)
+        ):
+            return cached, None
+        _real_profile_cdp_cache.pop("cdp", None)
+        _real_profile_cdp_cache.pop("browser", None)
+        _real_profile_cdp_cache.pop("copy_dir", None)
 
         # Reuse BEFORE writing anything. A shared copy-browser may already be up
         # from a previous hermes process; if it is driving OUR copy dir, hand it
@@ -1718,10 +1740,11 @@ def _real_profile_cdp() -> tuple:
         # as a PATH only (no copy), probe reuse, and return early on a hit. The
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
-        copy_dir = real_profile_copy_dir(browser)
         existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             _real_profile_cdp_cache["cdp"] = existing
+            _real_profile_cdp_cache["browser"] = browser
+            _real_profile_cdp_cache["copy_dir"] = copy_dir
             return existing, None
         if existing:
             # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
@@ -1906,6 +1929,8 @@ def _real_profile_cdp() -> tuple:
                 "the toggle off."
             )
         _real_profile_cdp_cache["cdp"] = cdp
+        _real_profile_cdp_cache["browser"] = browser
+        _real_profile_cdp_cache["copy_dir"] = copy_dir
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1524,7 +1524,7 @@ def _use_real_profile() -> bool:
 # tasks reuse the same copy-browser instead of each launching a rival Chromium
 # on the same copied user-data-dir.
 _REAL_PROFILE_SESSION = "hermes-real-profile"
-_real_profile_cdp_lock = threading.Lock()
+_real_profile_cdp_lock = threading.RLock()
 _real_profile_cdp_cache: dict = {}
 _real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
 
@@ -1650,7 +1650,38 @@ def _agent_browser_close_session(session_name: str) -> None:
         logger.debug("real-profile session close failed: %s", e)
 
 
+def _real_profile_state_belongs_to_current_scope() -> bool:
+    """Return whether the shared browser state belongs to this Hermes profile."""
+    scope = _real_profile_cdp_cache.get("scope")
+    return scope is not None and scope == hermes_home_key()
+
+
+def _invalidate_real_profile_browser(*, close_session: bool = True) -> None:
+    """Drop real-profile state and stop only Chrome processes launched here."""
+    _real_profile_cdp_cache.clear()
+    try:
+        if close_session:
+            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+    finally:
+        # agent-browser only attaches to the directly-launched process, so
+        # closing its session cannot reap Chrome. The Popen handles are the
+        # ownership boundary: never scan for or terminate an unrelated browser.
+        _terminate_real_profile_chrome()
+
+
+def _real_profile_launch_error(message: str) -> tuple:
+    """Return a launch error after fully releasing the owned browser."""
+    _invalidate_real_profile_browser()
+    return None, message
+
+
 def _real_profile_cdp() -> tuple:
+    """Serialize the shared real-profile browser lifecycle across local tasks."""
+    with _real_profile_cdp_lock:
+        return _real_profile_cdp_locked()
+
+
+def _real_profile_cdp_locked() -> tuple:
     """Resolve ``(cdp_url, error)`` for consented real-profile browsing.
 
     Snapshots the user's selected Chromium profile into a hermes-owned copy
@@ -1667,6 +1698,8 @@ def _real_profile_cdp() -> tuple:
     ``(None, None)`` when consent is off.
     """
     if not _use_real_profile():
+        if _real_profile_state_belongs_to_current_scope():
+            _invalidate_real_profile_browser()
         # Consent is off. If a snapshot store from a previous consented run is
         # still on disk, it holds copies of the user's cookies/logins — delete
         # it so revoking consent actually removes the credential copies. Cheap
@@ -1677,9 +1710,6 @@ def _real_profile_cdp() -> tuple:
             cleanup_real_profile_snapshots()
         except Exception as e:
             logger.debug("real-profile cleanup-on-consent-off failed: %s", e)
-        _real_profile_cdp_cache.pop("cdp", None)
-        _real_profile_cdp_cache.pop("browser", None)
-        _real_profile_cdp_cache.pop("copy_dir", None)
         return None, None
 
     # Lightpanda cannot load a Chromium profile — agent-browser rejects
@@ -1688,6 +1718,8 @@ def _real_profile_cdp() -> tuple:
     # even a host with no Chromium default reports the actionable conflict (the
     # engine setting) rather than a generic launch failure.
     if _using_lightpanda_engine():
+        if _real_profile_state_belongs_to_current_scope():
+            _invalidate_real_profile_browser()
         return None, (
             "browser.use_real_profile is on, but browser.engine is set to "
             "'lightpanda', which cannot load a real Chromium profile. Set "
@@ -1704,10 +1736,14 @@ def _real_profile_cdp() -> tuple:
 
     browser, resolve_error = resolve_real_profile_browser()
     if resolve_error:
+        if _real_profile_state_belongs_to_current_scope():
+            _invalidate_real_profile_browser()
         return None, resolve_error
 
     with _real_profile_cdp_lock:
         if browser is None:
+            if _real_profile_state_belongs_to_current_scope():
+                _invalidate_real_profile_browser()
             return None, (
                 "browser.use_real_profile is on, but your default browser is not a "
                 "supported Chromium browser (Chrome, Edge, Brave, Brave Origin, "
@@ -1717,6 +1753,8 @@ def _real_profile_cdp() -> tuple:
                 "toggle off."
             )
         if browser == UNSUPPORTED_CHANNEL:
+            if _real_profile_state_belongs_to_current_scope():
+                _invalidate_real_profile_browser()
             # A recognized pre-release channel (Beta/Dev/Canary) is the OS
             # default. Its profile lives in a channel-specific directory we
             # don't resolve, and normalizing it to the stable family would
@@ -1748,10 +1786,9 @@ def _real_profile_cdp() -> tuple:
             and _cdp_http_ready(cached)
             and _cdp_on_data_dir(cached, copy_dir)
         ):
+            _real_profile_cdp_cache["scope"] = hermes_home_key()
             return cached, None
-        _real_profile_cdp_cache.pop("cdp", None)
-        _real_profile_cdp_cache.pop("browser", None)
-        _real_profile_cdp_cache.pop("copy_dir", None)
+        _real_profile_cdp_cache.clear()
 
         # Reuse BEFORE writing anything. A shared copy-browser may already be up
         # from a previous hermes process; if it is driving OUR copy dir, hand it
@@ -1767,11 +1804,12 @@ def _real_profile_cdp() -> tuple:
             _real_profile_cdp_cache["cdp"] = existing
             _real_profile_cdp_cache["browser"] = browser
             _real_profile_cdp_cache["copy_dir"] = copy_dir
+            _real_profile_cdp_cache["scope"] = hermes_home_key()
             return existing, None
-        if existing:
-            # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
-            # close it so nothing holds the dir open before we overlay + relaunch.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+        # A stale/wrong-dir agent-browser session cannot reap Chrome when it was
+        # attached to a process we launched directly. Invalidate both lifecycle
+        # layers before overlaying credentials or launching the replacement.
+        _invalidate_real_profile_browser(close_session=bool(existing))
 
         # No live browser owns the dir now — safe to (re)snapshot + overlay.
         snap_dir, err = snapshot_real_profile(browser)
@@ -1881,15 +1919,13 @@ def _real_profile_cdp() -> tuple:
             except OSError:
                 pass
             if chrome_proc.poll() is not None:
-                _terminate_real_profile_chrome()
-                return None, (
+                return _real_profile_launch_error(
                     "browser.use_real_profile is on, but Chrome exited during "
                     "startup (another instance may hold the profile copy)."
                 )
             _time.sleep(0.25)
         if port is None:
-            _terminate_real_profile_chrome()
-            return None, (
+            return _real_profile_launch_error(
                 "browser.use_real_profile is on, but the real-profile browser "
                 "did not expose a debug port in time. Retry, or turn the toggle off."
             )
@@ -1899,7 +1935,7 @@ def _real_profile_cdp() -> tuple:
         try:
             browser_cmd = _find_agent_browser()
         except FileNotFoundError as e:
-            return None, (
+            return _real_profile_launch_error(
                 "browser.use_real_profile is on, but the local browser engine "
                 f"(agent-browser) is not installed: {e}"
             )
@@ -1916,16 +1952,18 @@ def _real_profile_cdp() -> tuple:
                 env=_build_browser_env(),
             )
         except subprocess.TimeoutExpired:
-            return None, (
+            return _real_profile_launch_error(
                 "browser.use_real_profile is on, but the real-profile browser "
                 "took too long to start. Retry, or turn the toggle off."
             )
         except (subprocess.SubprocessError, OSError) as e:
-            return None, f"browser.use_real_profile is on, but the launch failed: {e}"
+            return _real_profile_launch_error(
+                f"browser.use_real_profile is on, but the launch failed: {e}"
+            )
         if proc.returncode != 0:
             tail = (proc.stderr or proc.stdout or "").strip().splitlines()
             reason = tail[-1] if tail else f"exit {proc.returncode}"
-            return None, (
+            return _real_profile_launch_error(
                 f"browser.use_real_profile is on, but the real-profile browser "
                 f"failed to start: {reason}"
             )
@@ -1945,7 +1983,7 @@ def _real_profile_cdp() -> tuple:
         except (OSError, ValueError):
             pass
         if not cdp:
-            return None, (
+            return _real_profile_launch_error(
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
@@ -1955,8 +1993,7 @@ def _real_profile_cdp() -> tuple:
             # session raced or failed, ``open --profile`` can return that old
             # session's endpoint instead of the requested profile copy. Never
             # relabel another profile's credential-bearing browser as ours.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
-            return None, (
+            return _real_profile_launch_error(
                 "browser.use_real_profile is on, but the local browser opened a "
                 "different profile copy than requested. Hermes refused to attach; "
                 "retry, or turn the toggle off."
@@ -1964,6 +2001,7 @@ def _real_profile_cdp() -> tuple:
         _real_profile_cdp_cache["cdp"] = cdp
         _real_profile_cdp_cache["browser"] = browser
         _real_profile_cdp_cache["copy_dir"] = copy_dir
+        _real_profile_cdp_cache["scope"] = hermes_home_key()
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
 
@@ -6017,6 +6055,13 @@ def cleanup_all_browsers() -> None:
         task_ids = list(_active_sessions.keys())
     for task_id in task_ids:
         cleanup_browser(task_id)
+
+    # The real-profile session attaches to Chrome launched directly by Hermes,
+    # so task/session cleanup cannot reap that process. Stop only the Popen
+    # handles owned by this process when the complete browser lifecycle resets.
+    with _real_profile_cdp_lock:
+        if _real_profile_cdp_cache or _real_profile_chrome_procs:
+            _invalidate_real_profile_browser()
 
     # Tear down CDP supervisors for all tasks so background threads exit.
     try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1598,19 +1598,40 @@ def _agent_browser_get_cdp(session_name: str) -> Optional[str]:
 def _cdp_on_data_dir(http_cdp: str, data_dir: str) -> bool:
     """True when the CDP endpoint's browser is running on ``data_dir``.
 
-    agent-browser's launched Chrome writes ``DevToolsActivePort`` into its
-    user-data-dir with the live debug port on the first line. Matching that
-    port against the CDP endpoint's port confirms the running browser is our
-    profile copy — not a throwaway temp dir a raced/stale launch fell back to.
+    Chrome writes ``DevToolsActivePort`` with the live debug port and browser
+    websocket path. Both must match the endpoint's current ``/json/version``
+    identity so a recycled port cannot bind a different browser/profile.
     """
-    m = re.search(r":(\d+)", http_cdp or "")
-    if not m:
+    from urllib.parse import urlparse
+
+    try:
+        endpoint = urlparse(http_cdp or "")
+        endpoint_port = endpoint.port
+    except ValueError:
         return False
+    if endpoint.scheme not in {"http", "https"} or endpoint_port is None:
+        return False
+
     try:
         with open(os.path.join(data_dir, "DevToolsActivePort"), encoding="utf-8") as fh:
             port_line = fh.readline().strip()
-        return port_line == m.group(1)
-    except OSError:
+            browser_path = fh.readline().strip()
+        if port_line != str(endpoint_port) or not browser_path:
+            return False
+
+        import requests
+
+        version_url = f"{endpoint.scheme}://{endpoint.netloc}/json/version"
+        response = requests.get(version_url, timeout=1.0)
+        response.raise_for_status()
+        payload = response.json()
+        websocket = urlparse(str(payload.get("webSocketDebuggerUrl") or ""))
+        return (
+            websocket.scheme in {"ws", "wss"}
+            and websocket.port == endpoint_port
+            and websocket.path == browser_path
+        )
+    except Exception:
         return False
 
 
@@ -1725,6 +1746,7 @@ def _real_profile_cdp() -> tuple:
             and _real_profile_cdp_cache.get("browser") == browser
             and _real_profile_cdp_cache.get("copy_dir") == copy_dir
             and _cdp_http_ready(cached)
+            and _cdp_on_data_dir(cached, copy_dir)
         ):
             return cached, None
         _real_profile_cdp_cache.pop("cdp", None)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -653,6 +653,26 @@ def _get_dialog_policy_config() -> Tuple[str, float]:
         return DEFAULT_DIALOG_POLICY, DEFAULT_DIALOG_TIMEOUT_S
 
 
+def _start_cdp_supervisor(task_id: str, cdp_url: str) -> None:
+    """Start one supervisor, swallowing attachment failures."""
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
+
+        policy, timeout_s = _get_dialog_policy_config()
+        SUPERVISOR_REGISTRY.get_or_start(
+            task_id=task_id,
+            cdp_url=cdp_url,
+            dialog_policy=policy,
+            dialog_timeout_s=timeout_s,
+        )
+    except Exception as exc:
+        logger.debug(
+            "CDP supervisor attach for task=%s failed (non-fatal): %s",
+            task_id,
+            exc,
+        )
+
+
 def _ensure_cdp_supervisor(task_id: str) -> None:
     """Start a CDP supervisor for ``task_id`` if an endpoint is reachable.
 
@@ -672,6 +692,7 @@ def _ensure_cdp_supervisor(task_id: str) -> None:
     the browser session itself.  The agent simply won't see
     ``pending_dialogs`` / ``frame_tree`` fields in snapshots.
     """
+    session_info: Dict[str, Any] = {}
     cdp_url = _get_cdp_override()
     if not cdp_url:
         # Fallback: active session may carry a per-session CDP URL from a
@@ -683,22 +704,30 @@ def _ensure_cdp_supervisor(task_id: str) -> None:
             cdp_url = _resolve_cdp_override(maybe)
     if not cdp_url:
         return
-    try:
-        from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
 
-        policy, timeout_s = _get_dialog_policy_config()
-        SUPERVISOR_REGISTRY.get_or_start(
-            task_id=task_id,
-            cdp_url=cdp_url,
-            dialog_policy=policy,
-            dialog_timeout_s=timeout_s,
-        )
-    except Exception as exc:
-        logger.debug(
-            "CDP supervisor attach for task=%s failed (non-fatal): %s",
-            task_id,
-            exc,
-        )
+    if _is_real_profile_session(session_info):
+        # Supervisor startup publishes to its own registry after connecting.
+        # Keep that publication in the same lifecycle critical section as task
+        # publication/invalidation: otherwise invalidation can stop an empty
+        # registry while startup is in flight, after which the stale supervisor
+        # becomes visible against a browser generation that was already reaped.
+        with _real_profile_cdp_lock:
+            with _cleanup_lock:
+                current_session = _active_sessions.get(task_id)
+            if current_session is not session_info:
+                return
+            if (
+                session_info.get("real_profile_generation")
+                != _real_profile_generation
+                or session_info.get("real_profile_scope") != hermes_home_key()
+                or session_info.get("real_profile_cdp")
+                != _real_profile_cdp_cache.get("cdp")
+            ):
+                return
+            _start_cdp_supervisor(task_id, cdp_url)
+        return
+
+    _start_cdp_supervisor(task_id, cdp_url)
 
 
 def _stop_cdp_supervisor(task_id: str) -> None:
@@ -1526,6 +1555,7 @@ def _use_real_profile() -> bool:
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.RLock()
 _real_profile_cdp_cache: dict = {}
+_real_profile_generation = 0
 _real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
 
 
@@ -1656,17 +1686,78 @@ def _real_profile_state_belongs_to_current_scope() -> bool:
     return scope is not None and scope == hermes_home_key()
 
 
+def _is_real_profile_session(session_info: Dict[str, Any]) -> bool:
+    """Return whether a task session attaches to the shared profile browser."""
+    features = session_info.get("features")
+    return isinstance(features, dict) and features.get("real_profile") is True
+
+
+def _evict_real_profile_task_sessions(
+    *, expected: Optional[tuple[str, Dict[str, Any]]] = None,
+) -> None:
+    """Forget task sessions whose CDP endpoint is about to become invalid.
+
+    ``_active_sessions`` caches the per-task attachment separately from the
+    process-global real-profile lifecycle. Reaping or replacing the shared
+    Chrome without evicting those attachments leaves tasks pointing at a dead
+    (and potentially recycled) CDP port. The next command must recreate its
+    attachment against the current profile instead.
+
+    ``expected`` limits eviction to one exact cached generation. It is used by
+    the reuse path so a concurrent replacement is never removed accidentally.
+    """
+    with _cleanup_lock:
+        if expected is None:
+            stale = [
+                (session_key, session_info)
+                for session_key, session_info in _active_sessions.items()
+                if _is_real_profile_session(session_info)
+            ]
+        else:
+            session_key, session_info = expected
+            stale = (
+                [(session_key, session_info)]
+                if _active_sessions.get(session_key) is session_info
+                and _is_real_profile_session(session_info)
+                else []
+            )
+
+        for session_key, _session_info in stale:
+            _active_sessions.pop(session_key, None)
+            _session_last_activity.pop(session_key, None)
+            _recording_sessions.discard(session_key)
+            _suspect_browser_sessions.pop(session_key, None)
+            owner_task_id = _bare_task_id_for_session_key(session_key)
+            if _last_active_session_key.get(owner_task_id) == session_key:
+                _last_active_session_key.pop(owner_task_id, None)
+
+    # Supervisors own background threads and sockets, so stop them after the
+    # cache mutation and before Chrome is terminated. Never call the normal
+    # task cleanup here: it routes through _get_session_info(), which would
+    # recursively recreate the endpoint that this invalidation is removing.
+    for session_key, _session_info in stale:
+        _stop_cdp_supervisor(session_key)
+
+
 def _invalidate_real_profile_browser(*, close_session: bool = True) -> None:
     """Drop real-profile state and stop only Chrome processes launched here."""
-    _real_profile_cdp_cache.clear()
-    try:
-        if close_session:
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
-    finally:
-        # agent-browser only attaches to the directly-launched process, so
-        # closing its session cannot reap Chrome. The Popen handles are the
-        # ownership boundary: never scan for or terminate an unrelated browser.
-        _terminate_real_profile_chrome()
+    global _real_profile_generation
+
+    # Serialize generation changes with both lifecycle resolution and task
+    # publication. An attachment created before this point must never become
+    # visible after the browser it names has been reaped.
+    with _real_profile_cdp_lock:
+        _real_profile_generation += 1
+        _evict_real_profile_task_sessions()
+        _real_profile_cdp_cache.clear()
+        try:
+            if close_session:
+                _agent_browser_close_session(_REAL_PROFILE_SESSION)
+        finally:
+            # agent-browser only attaches to the directly-launched process, so
+            # closing its session cannot reap Chrome. The Popen handles are the
+            # ownership boundary: never scan for or terminate an unrelated browser.
+            _terminate_real_profile_chrome()
 
 
 def _real_profile_launch_error(message: str) -> tuple:
@@ -3026,7 +3117,7 @@ BROWSER_TOOL_SCHEMAS = [
 # Utility Functions
 # ============================================================================
 
-def _create_local_session(task_id: str, allow_real_profile: bool = True) -> Dict[str, str]:
+def _create_local_session(task_id: str, allow_real_profile: bool = True) -> Dict[str, Any]:
     import uuid
 
     # Real-profile consent: instead of an agent-browser-managed throwaway
@@ -3044,7 +3135,12 @@ def _create_local_session(task_id: str, allow_real_profile: bool = True) -> Dict
     # profile. (Also keeps a real-profile resolve failure from breaking
     # private-URL routing, which has nothing to do with the real profile.)
     if allow_real_profile:
-        cdp_url, err = _real_profile_cdp()
+        # Capture the browser generation under the same lock that owns its
+        # lifecycle. Publication rechecks this token so a profile switch in the
+        # resolve-to-publish gap cannot resurrect an attachment to reaped Chrome.
+        with _real_profile_cdp_lock:
+            cdp_url, err = _real_profile_cdp()
+            real_profile_generation = _real_profile_generation
         if err:
             raise RuntimeError(err)
         if cdp_url:
@@ -3056,6 +3152,9 @@ def _create_local_session(task_id: str, allow_real_profile: bool = True) -> Dict
                 "session_name": session_name,
                 "bb_session_id": None,
                 "cdp_url": _resolve_cdp_override(cdp_url),
+                "real_profile_cdp": cdp_url,
+                "real_profile_scope": hermes_home_key(),
+                "real_profile_generation": real_profile_generation,
                 "features": {"local": True, "real_profile": True},
             }
 
@@ -3125,6 +3224,29 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
     }
 
 
+def _publish_session_info(
+    task_id: str,
+    session_info: Dict[str, Any],
+) -> tuple[Dict[str, Any], bool]:
+    """Atomically publish one task session, preserving a concurrent winner."""
+    with _cleanup_lock:
+        # Another thread may have created a session while this one performed a
+        # network or browser lifecycle call. Preserve that winner rather than
+        # replacing it.
+        existing = _active_sessions.get(task_id)
+        if existing is not None:
+            return existing, False
+
+        published = dict(session_info)
+        published.setdefault("session_key", task_id)
+        published.setdefault("owner_task_id", _bare_task_id_for_session_key(task_id))
+        _active_sessions[task_id] = published
+        # A brand-new session is healthy by definition — drop any stale
+        # suspect flag left by a wedged-path eviction of its predecessor.
+        _suspect_browser_sessions.pop(task_id, None)
+        return published, True
+
+
 def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     """
     Get or create session info for the given session key.
@@ -3155,6 +3277,33 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     with _cleanup_lock:
         # Check if we already have a session for this task
         existing_session = _active_sessions.get(task_id)
+
+    # A real-profile task entry is only an attachment to the process-global
+    # copy-browser. Re-resolve that lifecycle before reuse so consent/profile
+    # changes take effect immediately and replacement of the shared Chrome
+    # cannot leave this task driving a dead or recycled CDP endpoint.
+    if existing_session is not None and _is_real_profile_session(existing_session):
+        with _real_profile_cdp_lock:
+            real_profile_cdp, real_profile_error = _real_profile_cdp_locked()
+            real_profile_generation = _real_profile_generation
+            if real_profile_error:
+                raise RuntimeError(real_profile_error)
+            with _cleanup_lock:
+                still_current = _active_sessions.get(task_id) is existing_session
+            if (
+                still_current
+                and real_profile_cdp
+                and existing_session.get("real_profile_cdp") == real_profile_cdp
+                and existing_session.get("real_profile_scope") == hermes_home_key()
+                and existing_session.get("real_profile_generation")
+                == real_profile_generation
+            ):
+                return existing_session
+            _evict_real_profile_task_sessions(expected=(task_id, existing_session))
+            # Eviction removes this task's activity metadata. Track the replacement
+            # just like an initial session so the inactivity reaper still owns it.
+            _update_session_activity(task_id)
+            existing_session = None
 
     # Suspect-session recycle (#72205 / #85125 3b): a previous command
     # timeout marked this cached session suspect via the SuspectableBackend
@@ -3249,19 +3398,41 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
                     session_info["fallback_reason"] = str(e)
                     session_info["fallback_provider"] = provider_name
 
-    with _cleanup_lock:
-        # Double-check: another thread may have created a session while we
-        # were doing the network call. Use the existing one to avoid leaking
-        # orphan cloud sessions.
-        if task_id in _active_sessions:
-            return _active_sessions[task_id]
-        session_info = dict(session_info)
-        session_info.setdefault("session_key", task_id)
-        session_info.setdefault("owner_task_id", _bare_task_id_for_session_key(task_id))
-        _active_sessions[task_id] = session_info
-        # A brand-new session is healthy by definition — drop any stale
-        # suspect flag left by a wedged-path eviction of its predecessor.
-        _suspect_browser_sessions.pop(task_id, None)
+    if _is_real_profile_session(session_info):
+        # Creation deliberately happens outside the lifecycle lock so CDP URL
+        # normalization cannot block all profiles. Re-enter here and re-resolve
+        # the uncached config before publication. Holding the lock through the
+        # atomic store closes the gap where another profile could reap Chrome
+        # and this thread could then publish its dead generation afterward.
+        with _real_profile_cdp_lock:
+            real_profile_cdp, real_profile_error = _real_profile_cdp_locked()
+            real_profile_generation = _real_profile_generation
+            if real_profile_error:
+                raise RuntimeError(real_profile_error)
+            if (
+                not real_profile_cdp
+                or session_info.get("real_profile_cdp") != real_profile_cdp
+                or session_info.get("real_profile_scope") != hermes_home_key()
+                or session_info.get("real_profile_generation")
+                != real_profile_generation
+            ):
+                fallback_metadata = {
+                    key: session_info[key]
+                    for key in (
+                        "fallback_from_cloud",
+                        "fallback_reason",
+                        "fallback_provider",
+                    )
+                    if key in session_info
+                }
+                session_info = _create_local_session(task_id)
+                session_info.update(fallback_metadata)
+            session_info, published = _publish_session_info(task_id, session_info)
+    else:
+        session_info, published = _publish_session_info(task_id, session_info)
+
+    if not published:
+        return session_info
 
     # Lazy-start the CDP supervisor now that the session exists (if the
     # backend surfaces a CDP URL via override or session_info["cdp_url"]).

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1928,6 +1928,17 @@ def _real_profile_cdp() -> tuple:
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
             )
+        if not _cdp_on_data_dir(cdp, copy_dir):
+            # agent-browser multiplexes sessions by name. If closing a stale
+            # session raced or failed, ``open --profile`` can return that old
+            # session's endpoint instead of the requested profile copy. Never
+            # relabel another profile's credential-bearing browser as ours.
+            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+            return None, (
+                "browser.use_real_profile is on, but the local browser opened a "
+                "different profile copy than requested. Hermes refused to attach; "
+                "retry, or turn the toggle off."
+            )
         _real_profile_cdp_cache["cdp"] = cdp
         _real_profile_cdp_cache["browser"] = browser
         _real_profile_cdp_cache["copy_dir"] = copy_dir

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -664,7 +664,7 @@ def _resolve_real_profile_cdp(env: dict, force_local: bool) -> Optional[str]:
     """Point the harness at the user's real-profile copy-browser when consented.
 
     With ``browser.use_real_profile`` on, local browsing must mean the user's
-    default Chromium with their logins — a browser Hermes launches on a
+    selected Chromium profile with their logins — a browser Hermes launches on a
     SNAPSHOT of their real profile (see hermes_cli.browser_connect). Two ways
     in:
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -168,9 +168,19 @@ as *you*, with your existing logins and cookies:
 # ~/.hermes/config.yaml
 browser:
   use_real_profile: true
+  # Optional explicit pin: chrome | edge | brave | brave-origin | chromium
+  # Leave empty to follow the OS default browser.
+  real_profile_browser: chrome
 ```
 
-When enabled, Hermes copies your default browser's **active** profile — the one
+`browser.real_profile_browser` is an explicit choice, not an installed-browser
+fallback. Use it when you want Hermes to snapshot Chrome, Edge, Brave, Brave
+Origin, or Chromium while keeping Firefox or Safari as your OS default. Values are
+case-insensitive and whitespace is ignored. An empty value follows the OS
+default; an invalid value fails closed and lists the allowed values. Hermes never
+silently chooses the first installed Chromium browser.
+
+When enabled, Hermes copies the selected browser's **active** profile — the one
 you actually browse (`Local State → profile.last_used`), with its cookies, saved
 logins, and preferences — into a managed snapshot under
 `~/.hermes/browser-profile/<browser>/`, then launches your **real browser
@@ -235,9 +245,10 @@ losing unsaved tabs), then retries. If the profile is still locked after that
 to fully quit the browser — it won't loop or kill again on its own.
 :::
 
-- **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium (whichever is your OS
-  default). A non-Chromium default (e.g. Firefox) fails closed with a clear
-  message rather than guessing.
+- **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium. With an empty
+  `browser.real_profile_browser`, Hermes follows the OS default. A non-Chromium
+  default (e.g. Firefox) fails closed unless you explicitly pin one of the
+  supported browsers; Hermes never guesses.
 - **Works on any backend.** On a local backend it's automatic once the toggle
   is on. Under a **cloud** browser backend, the agent can still open a
   real-profile local session on demand via the `browser_exec` tool's `local`
@@ -247,8 +258,10 @@ to fully quit the browser — it won't loop or kill again on its own.
   boundary. A page the agent visits runs with your real logins, so only enable
   it when you want the agent acting as you. Off by default.
 - **Desktop:** toggle it in **Capabilities → Tools → Browser → Use My Real
-  Browser Profile** (the switch sits above the backend options), or in
-  Settings → Config under the `browser` section.
+  Browser Profile** (the switch sits above the backend options). The toggle and
+  optional **Real Profile Browser** selector are also in Settings → Config under
+  the `browser` section; **System default** leaves
+  `browser.real_profile_browser` empty.
 
 ### Camofox local mode
 


### PR DESCRIPTION
## Summary

- add `browser.real_profile_browser` as an explicit Chrome / Edge / Brave / Chromium profile pin
- share one fail-closed resolver across real-profile snapshots and `hermes browser close-profile`
- expose the pin in Desktop Settings and document how to keep Firefox or Safari as the OS default

## Motivation

`browser.use_real_profile` previously depended entirely on the OS default browser. A user with Firefox or Safari as the default could not choose an installed Chromium profile without changing that OS-wide preference, even though Hermes supports snapshotting Chrome, Edge, Brave, and Chromium.

This remains an explicit-choice flow: an empty pin follows the OS default, while Hermes never guesses among installed Chromium browsers.

## Changes

- add uncached `configured_real_profile_browser()` and `resolve_real_profile_browser()` helpers
- normalize explicit pins case-insensitively after trimming whitespace
- fail closed on invalid, malformed, unreadable, and non-mapping config, including a top-level YAML `null`
- make `_real_profile_cdp` resolve the pin before the OS default and bind cached CDP reuse to both the selected browser and profile-aware snapshot directory
- verify cached, reused, and newly launched CDP endpoints match the requested profile copy's DevToolsActivePort port and browser identity before caching or attaching
- make `hermes browser close-profile` use `--browser` first, then the config pin, then the OS default
- add the config default and Desktop Browser selector (`System default`, Chrome, Edge, Brave, Chromium), without surfacing malformed current values as valid choices
- update localized Desktop labels/descriptions and browser documentation
- preserve the existing `browser-profile/<browser>/` snapshot path; the live profile is still never driven directly

## Test Plan

- [x] `scripts/run_tests.sh tests/tools/test_browser_*.py tests/hermes_cli/test_browser_connect_*.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_set_coercion.py -q` (766 passed, 4 Windows-only skipped on Linux)
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k schema_types_match_config_values -q` (1 passed)
- [x] `npm run check --workspace apps/desktop`
- [x] `ruff check` on touched Python files
- [x] `python3 scripts/check-windows-footguns.py --all` (1,019 files scanned)
- [x] `python3 scripts/audit_pr_attribution.py`
- [x] `git diff --check origin/main`

## Platforms Tested

- Linux (CachyOS), Python 3.11, Node 26
- GitHub-hosted Windows-only and macOS-only lanes passed on final head `0b51f9ca73c726001157ca3b2ed2dc30004f468d`

## Security Impact

The real-profile consent boundary is unchanged and remains off by default. Invalid or malformed pins fail closed, no installed browser is selected implicitly, cache reuse is scoped to the profile-aware snapshot path, and every reuse/launch path verifies both the DevToolsActivePort port and browser identifier before accepting a CDP endpoint. Snapshots remain under the profile-aware Hermes home rather than driving the live browser profile. No secrets or live profile data are included in this PR or its tests.

Related to #95620 and the wrong-principal invariant documented in #95549.
