### PR TITLE
fix(tui-gateway): unwrap one-question clarify batches

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -516,10 +516,32 @@ def test_clarify_batch_state_cleared_after_resolution(server):
         assert rid not in server._pending
 
 
-def test_clarify_block_helper_builds_batch_payload(capture):
-    """_clarify_block forwards only wire fields (qid/question/choices/
-    multi_select) — the tool-side normalized entries carry extra keys the
-    renderer must not see."""
+def _start_one_question_clarify(server, normalized):
+    box = {}
+
+    def run():
+        box["answer"] = server._clarify_block("s1", "", None, questions=normalized)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 2
+    rid = None
+    while time.monotonic() < deadline and rid is None:
+        with server._prompt_lock:
+            rid = next(iter(server._pending), None)
+        time.sleep(0.01)
+    assert rid
+    return thread, box, rid
+
+
+def test_clarify_block_helper_uses_single_wire_shape_for_one_question(capture):
+    """A one-item tool batch must use the reliable legacy card wire shape.
+
+    A single card needs only its request id; sending a one-item ``questions``
+    payload also makes released clients depend on qids from that request event
+    and can strand a rebound renderer on the batch spinner.  The callback still
+    returns batch-shaped answers to ``clarify_tool``.
+    """
     server, buf = capture
     normalized = [
         {
@@ -528,7 +550,112 @@ def test_clarify_block_helper_builds_batch_payload(capture):
             "multi_select": False,
         },
     ]
+    thread, box, rid = _start_one_question_clarify(server, normalized)
 
+    server.handle_request({
+        "id": "a", "method": "clarify.respond",
+        "params": {"request_id": rid, "answer": "a"},
+    })
+    thread.join(timeout=5)
+
+    messages = [json.loads(line) for line in buf.getvalue().splitlines()]
+    request = messages[0]["params"]
+    assert request["type"] == "clarify.request"
+    assert request["payload"]["question"] == "Which?"
+    assert request["payload"]["choices"] == ["a (Recommended)", "b"]
+    assert "questions" not in request["payload"]
+    assert json.loads(box["answer"]) == {"answers": {"q0": "a"}}
+
+
+def test_one_question_wire_does_not_mistake_json_user_text_for_batch_envelope(capture):
+    server, _ = capture
+    normalized = [{
+        "qid": "q0", "id": "", "question": "Payload?", "choices": None,
+        "choices_offered": None, "multi_select": False,
+    }]
+    thread, box, rid = _start_one_question_clarify(server, normalized)
+
+    literal = '{"answers": "this is my literal answer"}'
+    server.handle_request({
+        "id": "a", "method": "clarify.respond",
+        "params": {"request_id": rid, "answer": literal},
+    })
+    thread.join(timeout=5)
+
+    assert json.loads(box["answer"]) == {"answers": {"q0": literal}}
+
+
+def test_one_question_wire_accepts_extraneous_question_id(capture):
+    """Single-card replies remain answerable even if a client echoes an id."""
+    server, _ = capture
+    normalized = [{
+        "qid": "q0", "id": "", "question": "Which?", "choices": ["a", "b"],
+        "choices_offered": ["a", "b"], "multi_select": False,
+    }]
+    thread, box, rid = _start_one_question_clarify(server, normalized)
+
+    response = server.handle_request({
+        "id": "a", "method": "clarify.respond",
+        "params": {"request_id": rid, "question_id": "client-generated", "answer": "a"},
+    })
+    thread.join(timeout=5)
+
+    assert response["result"] == {"status": "ok"}
+    assert json.loads(box["answer"]) == {"answers": {"q0": "a"}}
+
+
+def test_one_question_wire_preserves_multi_select_json(capture):
+    server, _ = capture
+    normalized = [{
+        "qid": "q0", "id": "", "question": "Which?", "choices": ["a", "b"],
+        "choices_offered": ["a", "b"], "multi_select": True,
+    }]
+    thread, box, rid = _start_one_question_clarify(server, normalized)
+
+    raw = '["a", "b"]'
+    server.handle_request({
+        "id": "a", "method": "clarify.respond",
+        "params": {"request_id": rid, "answer": raw},
+    })
+    thread.join(timeout=5)
+
+    assert json.loads(box["answer"]) == {"answers": {"q0": raw}}
+
+
+def test_one_question_wire_distinguishes_skip_from_timeout(capture, monkeypatch):
+    server, buf = capture
+    normalized = [{
+        "qid": "q0", "id": "", "question": "Which?", "choices": ["a", "b"],
+        "choices_offered": ["a", "b"], "multi_select": False,
+    }]
+    thread, box, rid = _start_one_question_clarify(server, normalized)
+
+    server.handle_request({
+        "id": "skip", "method": "clarify.respond",
+        "params": {"request_id": rid, "answer": ""},
+    })
+    thread.join(timeout=5)
+    assert json.loads(box["answer"]) == {"answers": {}}
+
+    monkeypatch.setattr(server, "_clarify_timeout_seconds", lambda: 0)
+    timed_out = json.loads(server._clarify_block("s1", "", None, questions=normalized))
+    assert timed_out == {"answers": {}, "timed_out": True}
+
+    messages = [json.loads(line) for line in buf.getvalue().splitlines()]
+    assert any(message["params"]["type"] == "clarify.expire" for message in messages)
+
+
+def test_clarify_block_helper_builds_multi_question_batch_payload(capture):
+    """Real multi-question batches keep only their validated wire fields."""
+    server, buf = capture
+    normalized = [
+        {
+            "qid": qid, "id": qid, "question": text,
+            "choices": ["a", "b"], "choices_offered": ["a", "b"],
+            "multi_select": False,
+        }
+        for qid, text in (("q0", "First?"), ("q1", "Second?"))
+    ]
     box = {}
 
     def run():
@@ -544,18 +671,18 @@ def test_clarify_block_helper_builds_batch_payload(capture):
         time.sleep(0.01)
     assert rid
 
-    server.handle_request({
-        "id": "a", "method": "clarify.respond",
-        "params": {"request_id": rid, "question_id": "q0", "answer": "a"},
-    })
+    for qid in ("q0", "q1"):
+        server.handle_request({
+            "id": qid, "method": "clarify.respond",
+            "params": {"request_id": rid, "question_id": qid, "answer": "a"},
+        })
     thread.join(timeout=5)
 
     messages = [json.loads(line) for line in buf.getvalue().splitlines()]
-    request = messages[0]["params"]
-    assert request["type"] == "clarify.request"
-    sent = request["payload"]["questions"][0]
-    assert set(sent) == {"qid", "question", "choices", "multi_select"}
-    assert "id" not in sent and "choices_offered" not in sent
+    sent = messages[0]["params"]["payload"]["questions"]
+    assert len(sent) == 2
+    assert all(set(row) == {"qid", "question", "choices", "multi_select"} for row in sent)
+    assert all("id" not in row and "choices_offered" not in row for row in sent)
 
 
 def test_approval_pending_replays_unresolved_requests(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4526,6 +4526,7 @@ def _block(
     payload: dict,
     timeout: float | None = 300,
     batch_qids: list[str] | None = None,
+    single_batch_qid: str | None = None,
 ) -> str:
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
@@ -4557,6 +4558,22 @@ def _block(
             batch_state = _batch_clarify.pop(rid, None)
             if batch_state is not None:
                 batch_answers = dict(batch_state["answers"])
+
+    if single_batch_qid is not None:
+        # One tool question sent over the single-card wire still owes the
+        # batch caller a qid-keyed result.  Build that envelope from lifecycle
+        # state here; never inspect user text to guess whether it is JSON.
+        result: dict[str, object] = {
+            "answers": {single_batch_qid: answer} if answer_present and answer else {},
+        }
+        if not answered and not answer_present:
+            result["timed_out"] = True
+            _emit(
+                f"{event.removesuffix('.request')}.expire",
+                sid,
+                {"request_id": rid},
+            )
+        return json.dumps(result, ensure_ascii=False)
 
     if batch_qids is not None:
         # Cancel-all (respond with no question_id) resolves via _answers with
@@ -4626,6 +4643,34 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     The tool decodes the JSON reply via its batch answer parser.
     """
     if questions:
+        # A one-item tool batch has no multi-question interaction to preserve.
+        # Send it over the proven single-question wire shape. A one-question
+        # card needs only one request_id; the batch wire shape additionally
+        # requires qids from the request event, so a missed/rebound event can
+        # leave released clients waiting on an unanswerable batch spinner.
+        #
+        # Have _block build the qid-keyed response from its answer/timeout
+        # lifecycle state.  This preserves timeout vs explicit-skip semantics
+        # without parsing user text as an internal JSON envelope.
+        if len(questions) == 1:
+            entry = questions[0]
+            payload = (
+                {
+                    "question": entry["question"],
+                    "choices": entry["choices"],
+                    "multi_select": True,
+                }
+                if entry["multi_select"]
+                else {"question": entry["question"], "choices": entry["choices"]}
+            )
+            return _block(
+                "clarify.request",
+                sid,
+                payload,
+                timeout=_clarify_timeout_seconds(),
+                single_batch_qid=entry["qid"],
+            )
+
         wire = [
             {
                 "qid": entry["qid"],


### PR DESCRIPTION
## What does this PR do?

Routes a one-entry `clarify` batch over the existing single-question TUI gateway wire shape, while preserving the uniform batch response consumed by `clarify_tool`.

The advertised tool interface intentionally remains `questions[]`: a single question is still a one-entry array. Only the internal gateway request shape changes when there is no multi-question interaction to preserve.

## Problem

After #95907 made `questions[]` the sole advertised clarify input, ordinary one-question calls began reaching batch-capable Desktop clients as one-item batch requests. The batch card requires qids from the `clarify.request` event before it can become answerable. In Desktop SSH mode, a missed/rebound request event can therefore leave the transcript on an empty spinner until timeout, even though there is only one question.

A single-question card needs only its request id. It does not need a qid-keyed multi-question handshake.

## Fix

- For exactly one normalized question, emit the established single-question request payload.
- Let `_block` build the qid-keyed envelope directly from its answer/timeout lifecycle state; user text is never parsed to guess whether it is internal JSON.
- Preserve timeout versus explicit-skip semantics, multi-select JSON, and clients that echo an extraneous `question_id`.
- Leave true multi-question requests on the existing qid-keyed batch protocol.

This complements #92547, which fixes `ClarifyToolSinglePending` when `args.choices` are available without a gateway request. This PR covers the distinct one-entry `questions[]` path and released clients that still require an answerable gateway request.

## Regression evidence

The focused test was added before the implementation and failed on `main` because the one-question request was registered/emitted as batch. After the fix, the one-question and multi-question protocol tests both pass.

A live acceptance test was also run on Hermes Desktop v0.20.6 over SSH:

- before: every one-question `clarify` displayed an empty spinner and eventually interrupted;
- after deploying only this gateway change and restarting three independently owned Desktop SSH backends: the card displayed both buttons and returned the selected response successfully.

No Desktop build was changed for that acceptance test.

## Verification

```text
HERMES_PYTHON=/tmp/hermes-pr-venv/bin/python scripts/run_tests.sh \
  tests/tui_gateway/ \
  tests/tools/test_clarify_tool.py \
  tests/tools/test_clarify_gateway.py

750 passed, 0 failed
```

Focused rerun after final edits:

```text
HERMES_PYTHON=/tmp/hermes-pr-venv/bin/python scripts/run_tests.sh \
  tests/tui_gateway/test_protocol.py \
  tests/tools/test_clarify_tool.py \
  tests/tools/test_clarify_gateway.py

148 passed, 0 failed
```

Additional checks:

```text
ruff check tui_gateway/server.py tests/tui_gateway/test_protocol.py
All checks passed!

git diff --check
passed

python scripts/check-windows-footguns.py --all
No Windows footguns found (1019 files scanned)
```

## Type of change

- [x] Bug fix
- [x] Regression tests
- [ ] Feature
- [ ] Configuration change

## Scope

Only these files change:

- `tui_gateway/server.py`
- `tests/tui_gateway/test_protocol.py`
