### PR TITLE
fix(linux): resolve venv symlink chain when generating desktop entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -98,16 +98,25 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
-    # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
+    # A python shebang pointing at the running interpreter — directly or via
+    # a symlink chain (uv venvs: bin/python3 -> python -> uv-managed python) —
+    # already resolves correctly. Compare resolved paths, not raw strings:
+    # the shebang may name the venv symlink while sys.executable resolves it.
+    shebang_path = shebang[2:].strip().split()[0]
+    try:
+        if Path(shebang_path).resolve() == Path(sys.executable).resolve():
+            return False
+    except OSError:
+        pass
+    # Anything else (``/usr/bin/env python3``, a system path) would escape
+    # the venv when spawned by the DE.
     exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    return exe_dir not in shebang.lower()
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -149,6 +149,32 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     assert exec_line == f"{hermes_bin} desktop"
 
 
+def test_exec_leaves_symlinked_venv_shebang_alone(tmp_path, xdg_home, monkeypatch):
+    """uv venvs: bin/python3 -> python -> uv-managed python. The shebang names
+    the venv symlink while sys.executable resolves it — resolved-path
+    comparison must treat them as the same interpreter, not prefix the
+    uv-managed python (which runs without venv activation and dies on
+    ``ModuleNotFoundError: hermes_cli``)."""
+    import sys
+
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    real_interpreter = Path(sys.executable).resolve()
+    venv_symlink = tmp_path / "venv" / "bin" / "python3"
+    venv_symlink.parent.mkdir(parents=True)
+    venv_symlink.symlink_to(real_interpreter)
+    hermes_bin.write_text(f"#!{venv_symlink}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{hermes_bin} desktop"
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")


### PR DESCRIPTION
## Problem

On Linux installs using a uv-managed venv, the generated desktop entry has a non-runnable `Exec` line, so launching Hermes from the dock/menu icon silently fails. Fixes #90292.

## Root cause

uv venvs chain their interpreter symlinks: `venv/bin/python3 -> python -> uv-managed python`. `_needs_interpreter()` compared the shebang path against `sys.executable`'s directory as **raw strings**, so the uv-managed interpreter was not recognized as the running interpreter and got prefixed explicitly:

```
Exec=/home/user/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/bin/python3.11 /home/user/.hermes/hermes-agent/venv/bin/hermes desktop
```

That interpreter runs **without venv activation** and dies on `ModuleNotFoundError: No module named 'hermes_cli'` — silently, since `Terminal=false`.

## Fix

Compare **resolved** paths instead of raw strings, so the venv symlink chain is recognized as the running interpreter and the entry stays a plain `hermes desktop` launch.

## Test

Adds `test_exec_leaves_symlinked_venv_shebang_alone` covering the uv-venv symlink chain case. Full suite: 16 passed, 2 skipped.