### PR TITLE
fix(desktop): allow interior spaces in unquoted MEDIA: paths (#96657)

### DIFF
--- a/apps/desktop/src/lib/chat-messages/parts.test.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderMediaTags } from './parts'
+
+describe('renderMediaTags', () => {
+  it('renders a simple unquoted path without spaces', () => {
+    const result = renderMediaTags('MEDIA:/home/user/report.pdf')
+    expect(result).toContain('report.pdf')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('renders a quoted path with spaces', () => {
+    const result = renderMediaTags('MEDIA:"/home/user/My Document.docx"')
+    expect(result).toContain('My Document.docx')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('renders an unquoted path with interior spaces (#96657)', () => {
+    const input = 'MEDIA:/home/hermes/Morten - Nobly Kickoff - Opening and cue cards EN.docx'
+    const result = renderMediaTags(input)
+    // The full path must be captured — not truncated at the first space
+    expect(result).toContain('Morten - Nobly Kickoff - Opening and cue cards EN.docx')
+    expect(result).not.toContain('MEDIA:')
+    // The entire input should be consumed (no leftover literal text)
+    expect(result).toBe(renderMediaTags(input))
+  })
+
+  it('renders a backtick-quoted path with spaces', () => {
+    const result = renderMediaTags('MEDIA:`/home/user/My File.png`')
+    expect(result).toContain('My File.png')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('renders a single-quote path with spaces', () => {
+    const result = renderMediaTags("MEDIA:'/home/user/My Audio.mp3'")
+    expect(result).toContain('My Audio.mp3')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('handles a MEDIA tag on its own line', () => {
+    const text = `Some text\nMEDIA:/home/user/Report Final.pdf\nMore text`
+    const result = renderMediaTags(text)
+    expect(result).toContain('Report Final.pdf')
+    expect(result).toContain('Some text')
+    expect(result).toContain('More text')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('handles multiple MEDIA tags on separate lines', () => {
+    const text = 'MEDIA:/home/user/First File.pdf\nMEDIA:/home/user/Second Image.png'
+    const result = renderMediaTags(text)
+    expect(result).toContain('First File.pdf')
+    expect(result).toContain('Second Image.png')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('renders a Windows path with spaces', () => {
+    const result = renderMediaTags(
+      'MEDIA:C:\\Users\\Morten\\My Report.docx'
+    )
+    expect(result).toContain('My Report.docx')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('renders a ~/-relative path with spaces', () => {
+    const result = renderMediaTags('MEDIA:~/Documents/My Notes.md')
+    expect(result).toContain('My Notes.md')
+    expect(result).not.toContain('MEDIA:')
+  })
+
+  it('leaves non-MEDIA text intact', () => {
+    const result = renderMediaTags('Just some regular text without any media tags.')
+    expect(result).toBe('Just some regular text without any media tags.')
+  })
+})

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -10,9 +10,48 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+/**
+ * Known deliverable file extensions — mirrors the Python-side
+ * `MEDIA_DELIVERY_EXTS` in `gateway/platforms/base.py` so the two surfaces
+ * agree on which `MEDIA:` paths are valid. Used to anchor the end of an
+ * unquoted path that may contain interior spaces (#96657).
+ */
+const MEDIA_DELIVERY_EXTS = [
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tiff', 'svg',
+  'mp4', 'mov', 'avi', 'mkv', 'webm', '3gp',
+  'mp3', 'm2a', 'wav', 'ogg', 'opus', 'm4a', 'flac',
+  'pdf', 'docx', 'doc', 'odt', 'rtf', 'txt', 'md', 'epub',
+  'xlsx', 'xls', 'ods', 'csv', 'tsv', 'json', 'xml', 'yaml', 'yml',
+  'kmz', 'kml', 'geojson', 'gpx',
+  'pptx', 'ppt', 'odp', 'key',
+  'zip', 'tar', 'gz', 'tgz', 'bz2', 'xz', '7z', 'rar', 'apk', 'ipa',
+  'html', 'htm',
+] as const
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+// Sort longest-first so the alternation never matches a shorter ext as a
+// prefix of a longer one (e.g. `tar` before a hypothetical `tar.gz`).
+const _MEDIA_EXT_ALTERNATION = [...MEDIA_DELIVERY_EXTS]
+  .sort((a, b) => b.length - a.length)
+  .join('|')
+
+/**
+ * Unquoted path branch: starts with a path anchor (`~/`, `/`, `X:\` or `X:/`),
+ * allows interior whitespace, and anchors the end on a known deliverable
+ * extension. Matches the Python-side `MEDIA_TAG_CLEANUP_RE` behavior where
+ * `(?:[^\S\n]+\S+?)*?\.(?:EXT)` permits spaces inside filenames (#96657).
+ */
+const _MEDIA_PATH_ANCHORED =
+  `(?:~/|/|[A-Za-z]:[/\\\\])\\S+?(?:[^\\S\\n]+\\S+?)*?\\.(?:${_MEDIA_EXT_ALTERNATION})(?=[\\s\`"'_,;:)\\]}]|MEDIA:|$)`
+
+const MEDIA_LINE_RE = new RegExp(
+  `(^|\\n)[\\t ]*[\`"']?MEDIA:\\s*(?<line>\`[^\`\\n]+\`|"[^"\\n]+"|'[^'\\n]+'|${_MEDIA_PATH_ANCHORED}|\\S+)[\`"']?[\\t ]*(\\n|$)`,
+  'g'
+)
+
+const MEDIA_TAG_RE = new RegExp(
+  `[\`"']?MEDIA:\\s*(?<inline>\`[^\`\\n]+\`|"[^"\\n]+"|'[^'\\n]+'|${_MEDIA_PATH_ANCHORED}|\\S+)[\`"']?`,
+  'g'
+)
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()


### PR DESCRIPTION
## Summary

The Desktop renderer's `MEDIA_TAG_RE` and `MEDIA_LINE_RE` regexes in `apps/desktop/src/lib/chat-messages/parts.ts` used `\S+` for unquoted `MEDIA:` paths, which stops at the first space. When the agent delivers a file whose path contains spaces (e.g. `MEDIA:/home/hermes/Morten - Nobly Kickoff - Opening and cue cards EN.docx`), the Desktop app truncates the path at the first space, renders a link to a nonexistent file, and leaves the rest of the filename as literal text.

The messaging platforms (Telegram, WhatsApp, Slack) handle this correctly — `gateway/platforms/base.py:MEDIA_TAG_CLEANUP_RE` uses a tempered-greedy whitespace-tolerant pattern anchored on a known deliverable extension. This PR ports that approach to the TypeScript side.

### Changes

1. **`MEDIA_DELIVERY_EXTS` constant** — mirrors the Python-side extension list so the two surfaces agree on which paths are valid.
2. **`_MEDIA_PATH_ANCHORED` pattern** — replaces the bare `\S+` branch with `(?:~/|/|[A-Za-z]:[/\\])\S+?(?:[^\S\n]+\S+?)*?\.(?:EXT_ALTERNATION)(?=[\s\`"'_,;:)\]}]|MEDIA:|$)`, which:
   - Starts with a path anchor (`~/`, `/`, `X:\` or `X:/`)
   - Allows interior whitespace via tempered-greedy `(?:[^\S\n]+\S+?)*?` pairs
   - Anchors the end on a known deliverable extension
   - Stops at whitespace/punctuation, `MEDIA:`, or end-of-string (prevents runaway absorption into adjacent tags — same #68773 class the Python side guards against)
3. **Both regexes updated** — `MEDIA_LINE_RE` and `MEDIA_TAG_RE` now use `RegExp` constructors with the anchored path branch inserted before the `\S+` fallback.
4. **Test file** — 10 tests covering: simple paths, quoted paths (backtick/double/single), unquoted paths with interior spaces (the #96657 case), Windows paths, `~/`-relative paths, multi-line multiple tags, and non-MEDIA text passthrough.

### Test plan

- [x] `npx vitest run src/lib/chat-messages/parts.test.ts` — 10/10 pass
- [x] `npx vitest run src/lib/chat-messages/` — all pass
- [x] `npx vitest run src/lib/media` — 22/22 pass (no regressions)

Fixes #96657