### PR TITLE
fix(desktop): make the conversation timeline rail findable, and let the user bubble wear its theme border

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -124,12 +124,23 @@ describe('ThreadTimeline popover', () => {
 })
 
 describe('ThreadTimeline below the threshold', () => {
-  it('renders nothing for a short thread', () => {
-    messages = transcript(2)
+  it('renders nothing for a single-prompt thread', () => {
+    // One prompt is the only transcript where a "jump between turns" rail has
+    // nothing to jump between; two is the first that does (MIN_ENTRIES).
+    messages = transcript(1)
 
     const { container } = renderTimeline()
 
     expect(container.querySelector('[data-slot="thread-timeline"]')).toBeNull()
+  })
+
+  it('renders the rail as soon as a second prompt exists', () => {
+    messages = transcript(2)
+
+    const { container } = renderTimeline()
+
+    expect(container.querySelector('[data-slot="thread-timeline"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-slot="thread-timeline-ticks"] button')).toHaveLength(2)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -13,7 +13,11 @@ import {
   type TimelineSourceMessage
 } from './timeline-data'
 
-const MIN_ENTRIES = 4
+// Two prompts is the first point at which "jump between my turns" means
+// anything — and the rail has to be present BEFORE a chat is long enough to
+// need it, or nobody ever learns it exists. At 4 the first sighting came deep
+// into a conversation the user was already lost in.
+const MIN_ENTRIES = 2
 const VIEWPORT = '[data-slot="aui_thread-viewport"]'
 const HOVER_CLOSE_MS = 140
 
@@ -408,8 +412,10 @@ const TimelineTicks: FC<{
       >
         <span
           className={cn(
-            'block h-px w-3 transition-opacity duration-100 ease-out',
-            index === activeIndex ? 'bg-(--theme-primary)' : 'dither text-(--ui-text-quaternary) opacity-70'
+            'block h-0.5 rounded-full transition-[opacity,width] duration-100 ease-out',
+            index === activeIndex
+              ? 'w-4 bg-(--theme-primary)'
+              : 'w-3 bg-(--ui-text-tertiary) opacity-80 group-hover/timeline:opacity-100'
           )}
           ref={listRef(tickRefs, index)}
         />

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -408,7 +408,11 @@ export const UserMessage: FC<{
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
     'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
-    'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
+    // The user bubble's border is the only thing separating "what I asked" from
+    // the reply beneath it, so it wears the theme's own bubble stroke
+    // (`--dt-user-bubble-border`, authored per preset) rather than the generic
+    // 5%-alpha tertiary stroke, which several palettes render invisible.
+    'border-(--dt-user-bubble-border) hover:border-(--ui-stroke-secondary)'
   )
 
   const bubbleContent = hasBody && (


### PR DESCRIPTION
## What

Three related discoverability bugs in the desktop chat transcript, found from a real user report: *"I can't tell my messages apart from the reply, and I can't jump back to what I asked."*

### 1. The timeline rail needed 4 prompts before it existed

`MIN_ENTRIES = 4` in `thread/timeline.tsx`. Someone who wants to jump between their own turns wants that from the second turn onward — at 4, the rail's first appearance lands deep inside a conversation the user is already lost in, and nothing hints it's coming. Lowered to **2**, the first transcript where "jump between turns" has two things to jump between.

### 2. The inactive ticks stacked four dimmers and vanished

```
'block h-px w-3 …', 'dither text-(--ui-text-quaternary) opacity-70'
```

That's `h-px` (one physical pixel) → the `dither` conic-gradient screen → `--ui-text-quaternary` (36% alpha) → `opacity-70`, multiplied together. On a Retina panel the result is invisible in practice.

This isn't theoretical: the user had the feature shipped and working in their build and could not find it on screen. An accessibility-tree dump of their running window returned **1516 elements and zero timeline nodes** — which is what pointed at `MIN_ENTRIES` to begin with.

Ticks are now a 2px rounded bar at `--ui-text-tertiary`/80%, the active tick **widens** instead of relying on colour alone, and the rail lifts to full opacity on hover.

### 3. `--dt-user-bubble-border` was defined everywhere and read nowhere

The token is declared in `styles.css`, populated by every theme path — all 17 presets, `skin.ts`, `vscode.ts`, each with a `?? border` fallback — and threaded through `themes/context.tsx:245`.

Nothing consumed it. The user bubble hardcoded `--ui-stroke-tertiary`, a 5%-alpha generic stroke:

```bash
$ grep -rn -- "--dt-user-bubble-border" src/ | grep -v 'styles.css:427\|context.tsx:245'
# (no consumers)
```

So a user chasing a low-contrast bubble could switch themes forever and never fix it — the token each theme author set for exactly this purpose was dead. Now wired to the token that exists for it. Theme presets already carry deliberate values here (e.g. GitHub light `#d0d7de`, Catppuccin `#acb0be`), so this makes existing authored intent visible rather than inventing new colour.

## Test change

`timeline-idle.test.tsx` asserted the threshold with `transcript(2)` as its "too short" case — now exactly at the boundary. Rewritten as a pair pinning the **behaviour** (one prompt → nothing; two → rail with two ticks) instead of freezing a magic number, per the "behaviour contracts over snapshots" rule in AGENTS.md.

## Verification

- `vitest run src/components/assistant-ui/thread/` → **169 passed**
- `eslint` clean on the three touched files
- `tsc --noEmit` clean
- Rebuilt and repackaged the desktop app; confirmed the new bundle carries both changes and the rail renders

+27/−6 across 3 files, no new dependencies, no config surface, no core-tool changes.
