### PR TITLE
feat(gateway): isolate durable messaging sessions

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
+_SESSION_CWD_REQUIRED: ContextVar = ContextVar(
+    "HERMES_SESSION_CWD_REQUIRED", default=False
+)
+
+
+class SessionCwdUnavailableError(RuntimeError):
+    """A fail-closed session workspace disappeared after it was bound."""
+
 
 # The Python package/source root (this file lives at <root>/agent/runtime_cwd.py).
 # When a backend is launched from, or self-spawns into, this tree (the desktop
@@ -41,13 +49,15 @@ def _is_install_tree(p: Path) -> bool:
     return p == _PACKAGE_ROOT or _PACKAGE_ROOT in p.parents
 
 
-def set_session_cwd(cwd: str | None) -> Token:
+def set_session_cwd(cwd: str | None, *, required: bool = False) -> Token:
     """Pin the logical cwd for the current context."""
+    _SESSION_CWD_REQUIRED.set(bool(required))
     return _SESSION_CWD.set((cwd or "").strip())
 
 
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
+    _SESSION_CWD_REQUIRED.set(False)
 
 
 def _session_cwd_override() -> str:
@@ -57,12 +67,21 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+def get_session_cwd_override() -> str:
+    """Return only the task-local CWD, without process-env fallback."""
+    return _session_cwd_override()
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
         if p.is_dir():
             return p
+        if _SESSION_CWD_REQUIRED.get():
+            raise SessionCwdUnavailableError(
+                "The bound session workspace is unavailable; local file work is blocked."
+            )
         logger.warning("configured working directory does not exist: %s", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
@@ -86,6 +105,10 @@ def resolve_context_cwd() -> Path | None:
     if override:
         p = Path(override).expanduser()
         if not p.is_dir():
+            if _SESSION_CWD_REQUIRED.get():
+                raise SessionCwdUnavailableError(
+                    "The bound session workspace is unavailable; local file work is blocked."
+                )
             logger.warning("configured working directory does not exist: %s", override)
         else:
             return p

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19665,6 +19665,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
+
+        # Resolve the task-local working directory only after the durable
+        # session row exists. Enabled/eligible sessions fail closed here;
+        # disabled, non-eligible and cron surfaces keep the static terminal.cwd.
+        try:
+            await self._bind_session_workspace(context)
+        except Exception as exc:
+            from gateway.session_workspace import SessionWorkspaceError
+
+            if not isinstance(exc, SessionWorkspaceError):
+                logger.exception("Unexpected session workspace binding failure")
+            else:
+                logger.error(
+                    "Session workspace binding failed for profile=%s platform=%s: %s",
+                    getattr(source, "profile", None) or self._active_profile_name(),
+                    source.platform.value if source.platform else "unknown",
+                    exc,
+                )
+            return (
+                "⚠️ This session's private workspace is unavailable, so local "
+                "terminal and file work is blocked. Check "
+                "terminal.session_workspace in the serving profile and retry."
+            )
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
@@ -25127,6 +25150,110 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
 
+    async def _bind_session_workspace(self, context: SessionContext) -> str:
+        """Resolve, validate, and persist this gateway session's CWD."""
+        from gateway.cwd_placeholder import CWD_PLACEHOLDERS
+        from gateway.session_workspace import (
+            SessionWorkspaceError,
+            resolve_session_workspace,
+            session_workspace_is_eligible,
+        )
+
+        try:
+            runtime_config = _load_gateway_config()
+        except Exception as exc:
+            raise SessionWorkspaceError(
+                "serving profile configuration could not be loaded"
+            ) from exc
+
+        terminal_cfg = runtime_config.get("terminal", {})
+        if not isinstance(terminal_cfg, dict):
+            terminal_cfg = {}
+        configured_static = str(terminal_cfg.get("cwd") or "").strip()
+        if not configured_static or configured_static in CWD_PLACEHOLDERS:
+            static_cwd = str(os.environ.get("TERMINAL_CWD") or "").strip()
+        else:
+            static_cwd = os.path.expanduser(configured_static)
+
+        platform = context.source.platform.value if context.source.platform else ""
+        if not session_workspace_is_eligible(
+            runtime_config, platform=platform, cron_session=False
+        ):
+            binding = resolve_session_workspace(
+                config=runtime_config,
+                profile=getattr(context.source, "profile", "") or "default",
+                session_id=context.session_id,
+                platform=platform,
+                static_cwd=static_cwd,
+            )
+            context.cwd = binding.cwd
+            context.cwd_required = False
+            return binding.cwd
+
+        profile = str(
+            getattr(context.source, "profile", "") or self._active_profile_name()
+        ).strip() or "default"
+        session_db = self._session_db
+        if session_db is None:
+            raise SessionWorkspaceError(
+                "session database is unavailable; workspace binding was not persisted"
+            )
+        try:
+            row = await session_db.get_session(context.session_id)
+        except Exception as exc:
+            raise SessionWorkspaceError(
+                "session record could not be loaded for workspace validation"
+            ) from exc
+        if not row:
+            raise SessionWorkspaceError(
+                "session record is missing; workspace binding was not persisted"
+            )
+
+        stored_cwd = str(row.get("cwd") or "").strip()
+        allow_inherited_workspace = False
+        parent_session_id = str(row.get("parent_session_id") or "").strip()
+        if stored_cwd and parent_session_id:
+            try:
+                parent = await session_db.get_session(parent_session_id)
+            except Exception as exc:
+                raise SessionWorkspaceError(
+                    "session workspace lineage could not be validated"
+                ) from exc
+            allow_inherited_workspace = bool(
+                parent
+                and parent.get("ended_at")
+                and str(parent.get("end_reason") or "") == "compression"
+            )
+
+        binding = resolve_session_workspace(
+            config=runtime_config,
+            profile=profile,
+            session_id=context.session_id,
+            platform=platform,
+            static_cwd=static_cwd,
+            stored_cwd=stored_cwd,
+            allow_inherited_workspace=allow_inherited_workspace,
+        )
+        if stored_cwd != binding.cwd:
+            try:
+                generation = await session_db.update_session_cwd(
+                    context.session_id,
+                    binding.cwd,
+                    replace_git_meta=True,
+                )
+            except Exception as exc:
+                raise SessionWorkspaceError(
+                    "session workspace binding could not be persisted"
+                ) from exc
+            if generation is None:
+                raise SessionWorkspaceError(
+                    "session workspace binding was not accepted by the session store"
+                )
+
+        context.cwd = binding.cwd
+        context.cwd_required = True
+        return binding.cwd
+
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.
 
@@ -25147,7 +25274,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
-        return set_session_vars(
+        tokens = set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_type=(
@@ -25160,11 +25287,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=context.cwd,
+            cwd_required=context.cwd_required,
             async_delivery=_async_delivery,
             cron_session="",
         )
+        if context.cwd and context.session_id:
+            try:
+                from tools.terminal_tool import register_task_env_overrides
+
+                register_task_env_overrides(
+                    context.session_id,
+                    {
+                        "cwd": context.cwd,
+                        "cwd_source": (
+                            "session" if context.cwd_required else "process"
+                        ),
+                    },
+                )
+            except Exception:
+                if context.cwd_required:
+                    from gateway.session_context import clear_session_vars
+
+                    clear_session_vars(tokens)
+                    raise
+                logger.debug("static session cwd registration failed", exc_info=True)
+        return tokens
 
     def _clear_session_env(self, tokens: list) -> None:
         """Restore session context variables to their pre-handler values."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25223,6 +25223,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 parent
                 and parent.get("ended_at")
                 and str(parent.get("end_reason") or "") == "compression"
+                and str(parent.get("cwd") or "").strip() == stored_cwd
             )
 
         binding = resolve_session_workspace(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19078,8 +19078,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length_async
+                from agent.runtime_cwd import resolve_agent_cwd
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                _msg_cwd = str(resolve_agent_cwd())
                 _msg_config_ctx = None
                 _msg_cfg = None
                 _msg_model_cfg = {}

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -333,6 +333,8 @@ class SessionContext:
     session_id: str = ""
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    cwd: str = ""
+    cwd_required: bool = False
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -346,6 +348,8 @@ class SessionContext:
             "session_id": self.session_id,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "cwd": self.cwd,
+            "cwd_required": self.cwd_required,
         }
 
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -102,6 +102,9 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+_SESSION_WORKSPACE: ContextVar = ContextVar(
+    "HERMES_SESSION_WORKSPACE", default=_UNSET
+)
 _BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
     "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
 )
@@ -157,6 +160,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_SESSION_WORKSPACE": _SESSION_WORKSPACE,
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
@@ -239,6 +243,7 @@ def set_session_vars(
     browser_control_principal: str = "",
     browser_control_transport_family: str = "",
     cwd: str = "",
+    cwd_required: bool = False,
     async_delivery: bool = True,
     ui_session_id: str = "",
     cron_session: Any = _UNSET,
@@ -283,6 +288,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _SESSION_WORKSPACE.set(cwd if cwd_required else ""),
         _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
         _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
         _CRON_SESSION.set(cron_session),
@@ -291,7 +297,7 @@ def set_session_vars(
     try:
         from agent.runtime_cwd import set_session_cwd
 
-        set_session_cwd(cwd)
+        set_session_cwd(cwd, required=cwd_required)
     except Exception:
         pass
     return tokens
@@ -324,6 +330,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _SESSION_WORKSPACE,
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,

--- a/gateway/session_workspace.py
+++ b/gateway/session_workspace.py
@@ -194,6 +194,47 @@ def _enforce_workspace_mode(path: Path) -> None:
         ) from exc
 
 
+def _initialize_expected_workspace(
+    path: Path,
+    *,
+    root: Path,
+    profile_fingerprint: str,
+    workspace_fingerprint: str,
+) -> bool:
+    """Create or recover the exact deterministic workspace safely."""
+    created = _mkdir_checked(path, label="directory")
+    manifest_path = path / _MANIFEST_NAME
+    if created:
+        _write_manifest(
+            path,
+            profile_fingerprint=profile_fingerprint,
+            workspace_fingerprint=workspace_fingerprint,
+        )
+    elif not manifest_path.exists():
+        try:
+            if any(path.iterdir()):
+                raise SessionWorkspaceError(
+                    "session workspace manifest is missing from a non-empty directory"
+                )
+        except SessionWorkspaceError:
+            raise
+        except OSError as exc:
+            raise SessionWorkspaceError(
+                "session workspace directory could not be inspected"
+            ) from exc
+        _write_manifest(
+            path,
+            profile_fingerprint=profile_fingerprint,
+            workspace_fingerprint=workspace_fingerprint,
+        )
+
+    _validate_managed_workspace(
+        path, root=root, profile_fingerprint=profile_fingerprint
+    )
+    _enforce_workspace_mode(path)
+    return created
+
+
 def _install_instructions_link(workspace: Path, raw_path: Any) -> None:
     text = str(raw_path or "").strip()
     if not text:
@@ -295,11 +336,25 @@ def resolve_session_workspace(
         stored_path = Path(stored_text)
         if not stored_path.is_absolute():
             raise SessionWorkspaceError("stored session workspace must be absolute")
-        if stored_path == workspace or allow_inherited_workspace:
-            _enforce_workspace_mode(stored_path)
+        if stored_path == workspace:
+            created = _initialize_expected_workspace(
+                stored_path,
+                root=root,
+                profile_fingerprint=profile_fingerprint,
+                workspace_fingerprint=workspace_fingerprint,
+            )
+            _install_instructions_link(stored_path, cfg.get("instructions_path"))
+            return SessionWorkspaceBinding(
+                cwd=str(stored_path),
+                path=stored_path,
+                isolated=True,
+                created=created,
+            )
+        if allow_inherited_workspace:
             _validate_managed_workspace(
                 stored_path, root=root, profile_fingerprint=profile_fingerprint
             )
+            _enforce_workspace_mode(stored_path)
             _install_instructions_link(stored_path, cfg.get("instructions_path"))
             return SessionWorkspaceBinding(
                 cwd=str(stored_path), path=stored_path, isolated=True
@@ -308,16 +363,11 @@ def resolve_session_workspace(
             "stored session workspace does not match the current persistent session"
         )
 
-    created = _mkdir_checked(workspace, label="directory")
-    _enforce_workspace_mode(workspace)
-    if created:
-        _write_manifest(
-            workspace,
-            profile_fingerprint=profile_fingerprint,
-            workspace_fingerprint=workspace_fingerprint,
-        )
-    _validate_managed_workspace(
-        workspace, root=root, profile_fingerprint=profile_fingerprint
+    created = _initialize_expected_workspace(
+        workspace,
+        root=root,
+        profile_fingerprint=profile_fingerprint,
+        workspace_fingerprint=workspace_fingerprint,
     )
     _install_instructions_link(workspace, cfg.get("instructions_path"))
     return SessionWorkspaceBinding(

--- a/gateway/session_workspace.py
+++ b/gateway/session_workspace.py
@@ -1,0 +1,329 @@
+"""Opt-in, profile-scoped workspaces for durable messaging sessions.
+
+The workspace is a collision/lifecycle boundary, not an OS sandbox.  Names are
+opaque hashes of trusted profile and persistent session identity; the manifest
+contains hashes only so a directory listing never exposes a raw chat/session
+identifier.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_MANIFEST_NAME = ".hermes-session-workspace.json"
+_INSTRUCTIONS_LINK = "AGENTS.md"
+_SCHEMA_VERSION = 1
+
+
+class SessionWorkspaceError(RuntimeError):
+    """An enabled eligible session could not be bound safely."""
+
+
+@dataclass(frozen=True)
+class SessionWorkspaceBinding:
+    cwd: str
+    path: Path
+    isolated: bool
+    created: bool = False
+    migrated_legacy: bool = False
+
+
+def _workspace_config(config: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    terminal = config.get("terminal", {}) if isinstance(config, Mapping) else {}
+    if not isinstance(terminal, Mapping):
+        return {}
+    value = terminal.get("session_workspace", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def session_workspace_is_eligible(
+    config: Mapping[str, Any] | None,
+    *,
+    platform: str,
+    cron_session: bool = False,
+) -> bool:
+    cfg = _workspace_config(config)
+    if cron_session or not _enabled(cfg.get("enabled", False)):
+        return False
+    raw_platforms = cfg.get("platforms", ["slack"])
+    if not isinstance(raw_platforms, (list, tuple, set, frozenset)):
+        raise SessionWorkspaceError(
+            "terminal.session_workspace.platforms must be a list"
+        )
+    eligible = {
+        str(item).strip().lower() for item in raw_platforms if str(item).strip()
+    }
+    return str(platform or "").strip().lower() in eligible
+
+
+def _fingerprint(*parts: str) -> str:
+    digest = hashlib.sha256()
+    for part in parts:
+        digest.update(part.encode("utf-8", errors="strict"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _lstat_directory(path: Path, *, label: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise SessionWorkspaceError(
+            f"session workspace {label} is unavailable"
+        ) from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise SessionWorkspaceError(f"session workspace {label} must not be a symlink")
+    if not stat.S_ISDIR(info.st_mode):
+        raise SessionWorkspaceError(f"session workspace {label} is not a directory")
+
+
+def _mkdir_checked(path: Path, *, label: str, mode: int = 0o700) -> bool:
+    created = False
+    try:
+        path.mkdir(mode=mode)
+        created = True
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        raise SessionWorkspaceError(
+            f"could not create session workspace {label}"
+        ) from exc
+    _lstat_directory(path, label=label)
+    return created
+
+
+def _write_manifest(
+    path: Path, *, profile_fingerprint: str, workspace_fingerprint: str
+) -> None:
+    manifest = {
+        "schema_version": _SCHEMA_VERSION,
+        "profile_fingerprint": profile_fingerprint,
+        "workspace_fingerprint": workspace_fingerprint,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    target = path / _MANIFEST_NAME
+    try:
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return
+    except OSError as exc:
+        raise SessionWorkspaceError(
+            "could not write session workspace manifest"
+        ) from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(manifest, handle, sort_keys=True)
+            handle.write("\n")
+    except Exception:
+        try:
+            target.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _read_manifest(path: Path) -> Mapping[str, Any]:
+    target = path / _MANIFEST_NAME
+    try:
+        if target.is_symlink():
+            raise SessionWorkspaceError(
+                "session workspace manifest must not be a symlink"
+            )
+        value = json.loads(target.read_text(encoding="utf-8"))
+    except SessionWorkspaceError:
+        raise
+    except Exception as exc:
+        raise SessionWorkspaceError(
+            "session workspace manifest is missing or invalid"
+        ) from exc
+    if not isinstance(value, Mapping) or value.get("schema_version") != _SCHEMA_VERSION:
+        raise SessionWorkspaceError(
+            "session workspace manifest has an unsupported schema"
+        )
+    return value
+
+
+def _validate_managed_workspace(
+    path: Path, *, root: Path, profile_fingerprint: str
+) -> Mapping[str, Any]:
+    _lstat_directory(path, label="binding")
+    try:
+        resolved = path.resolve(strict=True)
+        root_resolved = root.resolve(strict=True)
+        resolved.relative_to(root_resolved)
+    except Exception as exc:
+        raise SessionWorkspaceError(
+            "stored session workspace escapes the configured root"
+        ) from exc
+    manifest = _read_manifest(path)
+    workspace_fingerprint = str(manifest.get("workspace_fingerprint") or "")
+    if (
+        manifest.get("profile_fingerprint") != profile_fingerprint
+        or not workspace_fingerprint
+        or path.name != workspace_fingerprint
+        or path.parent.name != profile_fingerprint
+    ):
+        raise SessionWorkspaceError(
+            "stored session workspace does not match its managed identity"
+        )
+    return manifest
+
+
+def _enforce_workspace_mode(path: Path) -> None:
+    try:
+        os.chmod(path, 0o700)
+    except OSError as exc:
+        raise SessionWorkspaceError(
+            "could not enforce session workspace permissions"
+        ) from exc
+
+
+def _install_instructions_link(workspace: Path, raw_path: Any) -> None:
+    text = str(raw_path or "").strip()
+    if not text:
+        return
+    source = Path(text)
+    if not source.is_absolute():
+        raise SessionWorkspaceError(
+            "terminal.session_workspace.instructions_path must be absolute"
+        )
+    try:
+        if source.is_symlink() or not source.is_file():
+            raise SessionWorkspaceError(
+                "session workspace instructions_path must be a regular file"
+            )
+        source = source.resolve(strict=True)
+    except SessionWorkspaceError:
+        raise
+    except Exception as exc:
+        raise SessionWorkspaceError(
+            "session workspace instructions_path is unavailable"
+        ) from exc
+
+    link = workspace / _INSTRUCTIONS_LINK
+    if link.is_symlink():
+        try:
+            if link.resolve(strict=True) == source:
+                return
+        except Exception:
+            pass
+        raise SessionWorkspaceError("session workspace AGENTS.md link is invalid")
+    if link.exists():
+        raise SessionWorkspaceError(
+            "session workspace AGENTS.md collides with an existing path"
+        )
+    try:
+        link.symlink_to(source)
+    except OSError as exc:
+        raise SessionWorkspaceError(
+            "could not create session workspace AGENTS.md link"
+        ) from exc
+
+
+def resolve_session_workspace(
+    *,
+    config: Mapping[str, Any] | None,
+    profile: str,
+    session_id: str,
+    platform: str,
+    static_cwd: str = "",
+    stored_cwd: str | None = None,
+    cron_session: bool = False,
+    allow_inherited_workspace: bool = False,
+) -> SessionWorkspaceBinding:
+    """Resolve, validate and create the workspace for one durable session.
+
+    Disabled, ineligible and cron callers retain ``static_cwd`` verbatim.
+    Eligible callers fail closed on every invalid binding.  A stored static CWD
+    is the one intentional migration: a fresh workspace is created without
+    copying scratch.  Compression children may reuse a verified managed parent
+    workspace when the gateway has independently verified their lineage.
+    """
+    static = str(static_cwd or "").strip()
+    if not session_workspace_is_eligible(
+        config, platform=platform, cron_session=cron_session
+    ):
+        return SessionWorkspaceBinding(
+            cwd=static,
+            path=Path(static) if static else Path(),
+            isolated=False,
+        )
+
+    profile_text = str(profile or "").strip()
+    session_text = str(session_id or "").strip()
+    if not profile_text or not session_text:
+        raise SessionWorkspaceError("eligible session workspace identity is incomplete")
+
+    cfg = _workspace_config(config)
+    root_text = str(cfg.get("root") or "").strip()
+    root = Path(root_text)
+    if not root_text or not root.is_absolute():
+        raise SessionWorkspaceError("terminal.session_workspace.root must be absolute")
+
+    # Do not permit a configured symlink root.  Its parent may legitimately
+    # contain platform-managed symlinks (e.g. macOS /tmp -> /private/tmp), but
+    # the configured boundary itself must remain a real directory.
+    if not root.parent.is_dir():
+        raise SessionWorkspaceError("session workspace root parent is unavailable")
+    _mkdir_checked(root, label="root")
+
+    profile_fingerprint = _fingerprint("profile", profile_text)
+    workspace_fingerprint = _fingerprint("workspace", profile_text, session_text)
+    profile_dir = root / profile_fingerprint
+    workspace = profile_dir / workspace_fingerprint
+    _mkdir_checked(profile_dir, label="profile directory")
+
+    stored_text = str(stored_cwd or "").strip()
+    migrated_legacy = bool(stored_text and static and stored_text == static)
+    if stored_text and not migrated_legacy:
+        stored_path = Path(stored_text)
+        if not stored_path.is_absolute():
+            raise SessionWorkspaceError("stored session workspace must be absolute")
+        if stored_path == workspace or allow_inherited_workspace:
+            _enforce_workspace_mode(stored_path)
+            _validate_managed_workspace(
+                stored_path, root=root, profile_fingerprint=profile_fingerprint
+            )
+            _install_instructions_link(stored_path, cfg.get("instructions_path"))
+            return SessionWorkspaceBinding(
+                cwd=str(stored_path), path=stored_path, isolated=True
+            )
+        raise SessionWorkspaceError(
+            "stored session workspace does not match the current persistent session"
+        )
+
+    created = _mkdir_checked(workspace, label="directory")
+    _enforce_workspace_mode(workspace)
+    if created:
+        _write_manifest(
+            workspace,
+            profile_fingerprint=profile_fingerprint,
+            workspace_fingerprint=workspace_fingerprint,
+        )
+    _validate_managed_workspace(
+        workspace, root=root, profile_fingerprint=profile_fingerprint
+    )
+    _install_instructions_link(workspace, cfg.get("instructions_path"))
+    return SessionWorkspaceBinding(
+        cwd=str(workspace),
+        path=workspace,
+        isolated=True,
+        created=created,
+        migrated_legacy=migrated_legacy,
+    )

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -382,6 +382,16 @@ DEFAULT_CONFIG = {
         # preserves the historical error + traceback behavior.
         "degraded_mode": "warn",
         "cwd": ".",  # Use current directory
+        # Optional per-durable-session workspace isolation for messaging
+        # gateways. Disabled by default; non-eligible platforms and cron keep
+        # using terminal.cwd. The root and optional instruction link must be
+        # absolute paths when enabled.
+        "session_workspace": {
+            "enabled": False,
+            "root": "",
+            "platforms": ["slack"],
+            "instructions_path": "",
+        },
         # Terminal font family for the desktop app's embedded xterm.js terminal.
         # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),
         # the desktop terminal uses this as the CSS font-family value, with the

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -16,6 +16,8 @@ These tests pin the fix: the block must resolve model/provider/base_url via
 the hygiene-compression block already uses) and must actually reach
 ``preprocess_context_references_async`` with a real context length.
 """
+
+import asyncio
 import logging
 import threading
 from contextlib import contextmanager
@@ -28,6 +30,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
+from gateway.session_context import clear_session_vars, set_session_vars
 
 
 def _make_runner() -> GatewayRunner:
@@ -97,7 +100,9 @@ async def test_at_reference_reaches_preprocessor_with_real_context_length(
 
     captured: dict = {}
 
-    async def _fake_preprocess(message, *, cwd, context_length, url_fetcher=None, allowed_root=None):
+    async def _fake_preprocess(
+        message, *, cwd, context_length, url_fetcher=None, allowed_root=None
+    ):
         captured["message"] = message
         captured["cwd"] = cwd
         captured["context_length"] = context_length
@@ -110,7 +115,9 @@ async def test_at_reference_reaches_preprocessor_with_real_context_length(
 
     import agent.context_references as ctx_mod
 
-    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _fake_preprocess)
+    monkeypatch.setattr(
+        ctx_mod, "preprocess_context_references_async", _fake_preprocess
+    )
 
     caplog.set_level(logging.DEBUG, logger="gateway.run")
 
@@ -142,7 +149,65 @@ async def test_at_reference_reaches_preprocessor_with_real_context_length(
 
 
 @pytest.mark.asyncio
-async def test_at_reference_ignores_global_context_for_runtime_route_override(monkeypatch):
+async def test_at_reference_uses_each_concurrent_sessions_task_local_cwd(
+    monkeypatch, tmp_path
+):
+    """Concurrent sessions must never expand @file from another thread's cwd."""
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+    fallback = tmp_path / "shared-fallback"
+    first_workspace = tmp_path / "first-workspace"
+    second_workspace = tmp_path / "second-workspace"
+    for directory in (fallback, first_workspace, second_workspace):
+        directory.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(fallback))
+
+    captured = {}
+
+    async def _fake_preprocess(
+        message, *, cwd, context_length, url_fetcher=None, allowed_root=None
+    ):
+        await asyncio.sleep(0)
+        captured[message] = (cwd, allowed_root)
+        return ContextReferenceResult(message=message, original_message=message)
+
+    import agent.context_references as ctx_mod
+
+    monkeypatch.setattr(
+        ctx_mod, "preprocess_context_references_async", _fake_preprocess
+    )
+
+    async def _prepare(label, workspace):
+        tokens = set_session_vars(cwd=str(workspace), cwd_required=True)
+        try:
+            await runner._prepare_inbound_message_text(
+                event=MessageEvent(text=f"@file:{label}.txt", source=source),
+                source=source,
+                history=[],
+            )
+        finally:
+            clear_session_vars(tokens)
+
+    await asyncio.gather(
+        _prepare("first", first_workspace),
+        _prepare("second", second_workspace),
+    )
+
+    assert captured["@file:first.txt"] == (
+        str(first_workspace),
+        str(first_workspace),
+    )
+    assert captured["@file:second.txt"] == (
+        str(second_workspace),
+        str(second_workspace),
+    )
+
+
+@pytest.mark.asyncio
+async def test_at_reference_ignores_global_context_for_runtime_route_override(
+    monkeypatch,
+):
     """Context expansion must not inherit a global pin from another route."""
     runner = _make_runner()
     source = _source()
@@ -183,7 +248,9 @@ async def test_at_reference_ignores_global_context_for_runtime_route_override(mo
     async def _passthrough(message, **_kwargs):
         return ContextReferenceResult(message=message, original_message=message)
 
-    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_context)
+    monkeypatch.setattr(
+        model_meta_mod, "get_model_context_length_async", _fake_get_context
+    )
     monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough)
 
     await runner._prepare_inbound_message_text(

--- a/tests/gateway/test_session_workspace.py
+++ b/tests/gateway/test_session_workspace.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+from agent.runtime_cwd import (
+    SessionCwdUnavailableError,
+    get_session_cwd_override,
+    resolve_agent_cwd,
+)
+from gateway.config import Platform
+from gateway.session import SessionContext, SessionSource
+from gateway.session_context import clear_session_vars, set_session_vars
+from gateway.session_context import get_session_env
+from gateway.session_workspace import (
+    SessionWorkspaceError,
+    resolve_session_workspace,
+)
+from tools.delegate_tool import _resolve_workspace_hint
+
+
+def _config(root, *, enabled=True, platforms=("slack",), instructions_path=""):
+    return {
+        "terminal": {
+            "cwd": "/shared/static",
+            "session_workspace": {
+                "enabled": enabled,
+                "root": str(root),
+                "platforms": list(platforms),
+                "instructions_path": str(instructions_path),
+            },
+        }
+    }
+
+
+def _resolve(tmp_path, *, profile="campaign", session_id="session-a", **kwargs):
+    root = tmp_path / "workspaces"
+    return resolve_session_workspace(
+        config=_config(root),
+        profile=profile,
+        session_id=session_id,
+        platform="slack",
+        static_cwd="/shared/static",
+        **kwargs,
+    )
+
+
+def test_stable_opaque_profile_scoped_mode_0700_workspace(tmp_path):
+    first = _resolve(tmp_path)
+    again = _resolve(tmp_path)
+    other_session = _resolve(tmp_path, session_id="session-b")
+    other_profile = _resolve(tmp_path, profile="client-operations")
+
+    assert first.cwd == again.cwd
+    assert first.cwd != other_session.cwd
+    assert first.cwd != other_profile.cwd
+    assert "campaign" not in first.cwd
+    assert "session-a" not in first.cwd
+    if sys.platform != "win32":
+        assert stat.S_IMODE(os.stat(first.cwd).st_mode) == 0o700
+
+    manifest = json.loads(
+        (first.path / ".hermes-session-workspace.json").read_text(encoding="utf-8")
+    )
+    assert manifest["profile_fingerprint"] not in {"campaign", "session-a"}
+    assert "session" not in json.dumps(manifest).lower()
+
+
+def test_new_persistent_session_identity_gets_fresh_workspace(tmp_path):
+    old = _resolve(tmp_path, session_id="old-id")
+    new = _resolve(tmp_path, session_id="new-id")
+    assert new.cwd != old.cwd
+    assert new.migrated_legacy is False
+
+
+def test_legacy_static_cwd_migrates_without_copying_scratch(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "scratch.txt").write_text("do not copy", encoding="utf-8")
+    binding = resolve_session_workspace(
+        config=_config(tmp_path / "workspaces"),
+        profile="campaign",
+        session_id="new-id",
+        platform="slack",
+        stored_cwd=str(legacy),
+        static_cwd=str(legacy),
+    )
+    assert binding.migrated_legacy is True
+    assert not (binding.path / "scratch.txt").exists()
+
+
+def test_compression_child_may_reuse_verified_parent_workspace(tmp_path):
+    parent = _resolve(tmp_path, session_id="parent")
+    child = _resolve(
+        tmp_path,
+        session_id="compressed-child",
+        stored_cwd=parent.cwd,
+        allow_inherited_workspace=True,
+    )
+    assert child.cwd == parent.cwd
+
+
+@pytest.mark.parametrize("collision", ["root", "profile", "workspace"])
+@pytest.mark.skipif(sys.platform == "win32", reason="symlinks require privileges")
+def test_symlink_or_non_directory_collisions_fail_closed(tmp_path, collision):
+    root = tmp_path / "workspaces"
+    config = _config(root)
+    if collision == "root":
+        target = tmp_path / "outside"
+        target.mkdir()
+        root.symlink_to(target, target_is_directory=True)
+        with pytest.raises(SessionWorkspaceError):
+            resolve_session_workspace(
+                config=config,
+                profile="campaign",
+                session_id="session-a",
+                platform="slack",
+                static_cwd="/shared/static",
+            )
+        return
+
+    root.mkdir()
+    expected = resolve_session_workspace(
+        config=config,
+        profile="campaign",
+        session_id="session-a",
+        platform="slack",
+        static_cwd="/shared/static",
+    )
+    # Rebuild the selected component as an unsafe collision.
+    if collision == "profile":
+        workspace = expected.path
+        (workspace / ".hermes-session-workspace.json").unlink()
+        workspace.rmdir()
+        profile_dir = workspace.parent
+        profile_dir.rmdir()
+        target = tmp_path / "outside-profile"
+        target.mkdir()
+        profile_dir.symlink_to(target, target_is_directory=True)
+    else:
+        workspace = expected.path
+        (workspace / ".hermes-session-workspace.json").unlink()
+        workspace.rmdir()
+        target = tmp_path / "outside-workspace"
+        target.mkdir()
+        workspace.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(SessionWorkspaceError):
+        resolve_session_workspace(
+            config=config,
+            profile="campaign",
+            session_id="session-a",
+            platform="slack",
+            static_cwd="/shared/static",
+        )
+
+
+def test_disabled_ineligible_and_cron_keep_static_cwd(tmp_path):
+    root = tmp_path / "workspaces"
+    cases = [
+        (_config(root, enabled=False), "slack", False),
+        (_config(root), "telegram", False),
+        (_config(root), "slack", True),
+    ]
+    for config, platform, cron_session in cases:
+        binding = resolve_session_workspace(
+            config=config,
+            profile="campaign",
+            session_id="session-a",
+            platform=platform,
+            static_cwd="/shared/static",
+            cron_session=cron_session,
+        )
+        assert binding.cwd == "/shared/static"
+        assert binding.isolated is False
+    assert not root.exists()
+
+
+def test_enabled_invalid_platform_config_fails_closed(tmp_path):
+    config = _config(tmp_path / "workspaces")
+    config["terminal"]["session_workspace"]["platforms"] = "slack"
+    with pytest.raises(SessionWorkspaceError, match="must be a list"):
+        resolve_session_workspace(
+            config=config,
+            profile="campaign",
+            session_id="session-a",
+            platform="slack",
+            static_cwd="/shared/static",
+        )
+
+
+def test_invalid_root_and_unexpected_stored_binding_fail_closed(tmp_path):
+    with pytest.raises(SessionWorkspaceError, match="absolute"):
+        resolve_session_workspace(
+            config=_config("relative/root"),
+            profile="campaign",
+            session_id="session-a",
+            platform="slack",
+            static_cwd="/shared/static",
+        )
+
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    with pytest.raises(SessionWorkspaceError, match="stored"):
+        _resolve(tmp_path, stored_cwd=str(foreign))
+
+    root_collision = tmp_path / "root-collision"
+    root_collision.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(SessionWorkspaceError, match="not a directory"):
+        resolve_session_workspace(
+            config=_config(root_collision),
+            profile="campaign",
+            session_id="session-a",
+            platform="slack",
+            static_cwd="/shared/static",
+        )
+
+
+def test_optional_instruction_link_is_safe_and_workspace_local(tmp_path):
+    instructions = tmp_path / "repo-AGENTS.md"
+    instructions.write_text("repository rules", encoding="utf-8")
+    binding = resolve_session_workspace(
+        config=_config(tmp_path / "workspaces", instructions_path=instructions),
+        profile="campaign",
+        session_id="session-a",
+        platform="slack",
+        static_cwd="/shared/static",
+    )
+    link = binding.path / "AGENTS.md"
+    assert link.is_symlink()
+    assert link.resolve() == instructions.resolve()
+
+
+def test_concurrent_contexts_and_delegate_hint_use_task_local_cwd(
+    tmp_path, monkeypatch
+):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "global"))
+
+    async def read(bound):
+        tokens = set_session_vars(session_id=bound.name, cwd=str(bound))
+        try:
+            await asyncio.sleep(0)
+            return get_session_cwd_override(), _resolve_workspace_hint(object())
+        finally:
+            clear_session_vars(tokens)
+
+    async def main():
+        return await asyncio.gather(read(a), read(b))
+
+    results = asyncio.run(main())
+    assert results == [(str(a), str(a)), (str(b), str(b))]
+
+
+def test_session_context_round_trips_bound_cwd():
+    context = SessionContext(
+        source=SessionSource(platform=Platform.SLACK, chat_id="C1"),
+        connected_platforms=[Platform.SLACK],
+        home_channels={},
+        session_id="sid",
+        cwd="/private/workspace",
+        cwd_required=True,
+    )
+    payload = context.to_dict()
+    assert payload["cwd"] == "/private/workspace"
+    assert payload["cwd_required"] is True
+
+
+def test_managed_workspace_identity_is_task_local_and_cleared(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tokens = set_session_vars(session_id="sid", cwd=str(workspace), cwd_required=True)
+    try:
+        assert get_session_env("HERMES_SESSION_WORKSPACE") == str(workspace)
+    finally:
+        clear_session_vars(tokens)
+    assert get_session_env("HERMES_SESSION_WORKSPACE") == ""
+
+
+def test_required_workspace_disappearance_never_falls_back(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(fallback))
+    tokens = set_session_vars(session_id="sid", cwd=str(workspace), cwd_required=True)
+    workspace.rmdir()
+    try:
+        with pytest.raises(SessionCwdUnavailableError):
+            resolve_agent_cwd()
+    finally:
+        clear_session_vars(tokens)
+
+
+class _FakeAsyncSessionDB:
+    def __init__(self, rows):
+        self.rows = rows
+        self.updates = []
+
+    async def get_session(self, session_id):
+        row = self.rows.get(session_id)
+        return dict(row) if row else None
+
+    async def update_session_cwd(self, session_id, cwd, **kwargs):
+        if session_id not in self.rows:
+            return None
+        self.rows[session_id]["cwd"] = cwd
+        self.updates.append((session_id, cwd, kwargs))
+        return len(self.updates)
+
+
+def _slack_context(session_id="sid"):
+    return SessionContext(
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C1",
+            thread_id="T1",
+            profile="campaign",
+        ),
+        connected_platforms=[Platform.SLACK],
+        home_channels={},
+        session_key="slack:C1:T1",
+        session_id=session_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_persists_and_restores_workspace_after_restart(
+    tmp_path, monkeypatch
+):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    config = _config(tmp_path / "workspaces")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+    rows = {"sid": {"id": "sid", "cwd": None, "parent_session_id": None}}
+    db = _FakeAsyncSessionDB(rows)
+
+    first_runner = object.__new__(GatewayRunner)
+    first_runner._session_db = db
+    first_runner._active_profile_name = lambda: "campaign"
+    first_context = _slack_context()
+    first = await first_runner._bind_session_workspace(first_context)
+
+    restarted_runner = object.__new__(GatewayRunner)
+    restarted_runner._session_db = db
+    restarted_runner._active_profile_name = lambda: "campaign"
+    restarted_context = _slack_context()
+    restored = await restarted_runner._bind_session_workspace(restarted_context)
+
+    assert restored == first
+    assert restarted_context.cwd_required is True
+    assert db.rows["sid"]["cwd"] == first
+    assert len(db.updates) == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_compression_child_keeps_parent_workspace(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    config = _config(tmp_path / "workspaces")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+    parent = resolve_session_workspace(
+        config=config,
+        profile="campaign",
+        session_id="parent",
+        platform="slack",
+        static_cwd="/shared/static",
+    )
+    rows = {
+        "parent": {
+            "id": "parent",
+            "cwd": parent.cwd,
+            "ended_at": 1,
+            "end_reason": "compression",
+            "parent_session_id": None,
+        },
+        "child": {
+            "id": "child",
+            "cwd": parent.cwd,
+            "parent_session_id": "parent",
+        },
+    }
+    db = _FakeAsyncSessionDB(rows)
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = db
+    runner._active_profile_name = lambda: "campaign"
+    context = _slack_context("child")
+
+    assert await runner._bind_session_workspace(context) == parent.cwd
+    assert db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_binding_seeds_terminal_file_and_code_cwds_independently(
+    tmp_path,
+):
+    from gateway.run import GatewayRunner
+    from tools import code_execution_tool, file_tools, terminal_tool
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    contexts = []
+    for name in ("one", "two"):
+        workspace = tmp_path / name
+        workspace.mkdir()
+        context = _slack_context(name)
+        context.cwd = str(workspace)
+        context.cwd_required = True
+        contexts.append((context, workspace))
+
+    async def resolve(context, workspace):
+        tokens = runner._set_session_env(context)
+        try:
+            await asyncio.sleep(0)
+            return (
+                file_tools._resolve_path_for_task(
+                    "relative.txt", task_id=context.session_id
+                ),
+                terminal_tool._resolve_command_cwd(
+                    workdir=None,
+                    default_cwd="/shared/static",
+                    session_key=context.session_id,
+                ),
+                code_execution_tool._resolve_child_cwd(
+                    "project", str(tmp_path / "staging"), context.session_id
+                ),
+                get_session_env("HERMES_SESSION_WORKSPACE"),
+            )
+        finally:
+            runner._clear_session_env(tokens)
+
+    results = await asyncio.gather(
+        *(resolve(context, workspace) for context, workspace in contexts)
+    )
+    for (context, workspace), result in zip(contexts, results):
+        file_path, terminal_cwd, code_cwd, trusted_workspace = result
+        assert file_path == workspace / "relative.txt"
+        assert terminal_cwd == str(workspace)
+        assert code_cwd == str(workspace)
+        assert trusted_workspace == str(workspace)

--- a/tests/gateway/test_session_workspace.py
+++ b/tests/gateway/test_session_workspace.py
@@ -105,9 +105,7 @@ def test_compression_child_may_reuse_verified_parent_workspace(tmp_path):
     assert child.cwd == parent.cwd
 
 
-@pytest.mark.parametrize("collision", ["root", "profile", "workspace"])
-@pytest.mark.skipif(sys.platform == "win32", reason="symlinks require privileges")
-def test_symlink_or_non_directory_collisions_fail_closed(tmp_path, collision):
+def _assert_symlink_or_non_directory_collision_fails_closed(tmp_path, collision):
     root = tmp_path / "workspaces"
     config = _config(root)
     if collision == "root":
@@ -158,6 +156,18 @@ def test_symlink_or_non_directory_collisions_fail_closed(tmp_path, collision):
             platform="slack",
             static_cwd="/shared/static",
         )
+
+
+@pytest.mark.parametrize("collision", ["root", "profile", "workspace"])
+@pytest.mark.linux_only
+def test_linux_symlink_or_non_directory_collisions_fail_closed(tmp_path, collision):
+    _assert_symlink_or_non_directory_collision_fails_closed(tmp_path, collision)
+
+
+@pytest.mark.parametrize("collision", ["root", "profile", "workspace"])
+@pytest.mark.macos_only
+def test_macos_symlink_or_non_directory_collisions_fail_closed(tmp_path, collision):
+    _assert_symlink_or_non_directory_collision_fails_closed(tmp_path, collision)
 
 
 def test_disabled_ineligible_and_cron_keep_static_cwd(tmp_path):
@@ -219,6 +229,50 @@ def test_invalid_root_and_unexpected_stored_binding_fail_closed(tmp_path):
             platform="slack",
             static_cwd="/shared/static",
         )
+
+
+def test_empty_interrupted_workspace_initialization_recovers_but_nonempty_does_not(
+    tmp_path,
+):
+    binding = _resolve(tmp_path)
+    manifest = binding.path / ".hermes-session-workspace.json"
+    manifest.unlink()
+
+    recovered = _resolve(tmp_path)
+    assert recovered.cwd == binding.cwd
+    assert manifest.is_file()
+
+    manifest.unlink()
+    (binding.path / "partial-output.txt").write_text("keep", encoding="utf-8")
+    with pytest.raises(SessionWorkspaceError, match="non-empty"):
+        _resolve(tmp_path)
+
+
+def test_deleted_expected_stored_workspace_is_rehydrated(tmp_path):
+    binding = _resolve(tmp_path)
+    (binding.path / ".hermes-session-workspace.json").unlink()
+    binding.path.rmdir()
+
+    restored = _resolve(tmp_path, stored_cwd=binding.cwd)
+    assert restored.cwd == binding.cwd
+    assert restored.created is True
+    assert (restored.path / ".hermes-session-workspace.json").is_file()
+
+
+def test_invalid_inherited_workspace_is_rejected_before_permissions_change(tmp_path):
+    foreign = tmp_path / "foreign-inherited"
+    foreign.mkdir(mode=0o755)
+    before = stat.S_IMODE(foreign.stat().st_mode)
+
+    with pytest.raises(SessionWorkspaceError, match="escapes"):
+        _resolve(
+            tmp_path,
+            session_id="compressed-child",
+            stored_cwd=str(foreign),
+            allow_inherited_workspace=True,
+        )
+
+    assert stat.S_IMODE(foreign.stat().st_mode) == before
 
 
 def test_optional_instruction_link_is_safe_and_workspace_local(tmp_path):
@@ -398,6 +452,51 @@ async def test_gateway_compression_child_keeps_parent_workspace(tmp_path, monkey
 
     assert await runner._bind_session_workspace(context) == parent.cwd
     assert db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_compression_child_rejects_a_cwd_not_bound_to_its_parent(
+    tmp_path, monkeypatch
+):
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    config = _config(tmp_path / "workspaces")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+    parent = resolve_session_workspace(
+        config=config,
+        profile="campaign",
+        session_id="parent",
+        platform="slack",
+        static_cwd="/shared/static",
+    )
+    unrelated = resolve_session_workspace(
+        config=config,
+        profile="campaign",
+        session_id="unrelated",
+        platform="slack",
+        static_cwd="/shared/static",
+    )
+    rows = {
+        "parent": {
+            "id": "parent",
+            "cwd": parent.cwd,
+            "ended_at": 1,
+            "end_reason": "compression",
+            "parent_session_id": None,
+        },
+        "child": {
+            "id": "child",
+            "cwd": unrelated.cwd,
+            "parent_session_id": "parent",
+        },
+    }
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = _FakeAsyncSessionDB(rows)
+    runner._active_profile_name = lambda: "campaign"
+
+    with pytest.raises(SessionWorkspaceError, match="does not match"):
+        await runner._bind_session_workspace(_slack_context("child"))
 
 
 @pytest.mark.asyncio

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1283,7 +1283,14 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     teaching subagents a fake container path while still helping them avoid
     guessing `/workspace/...` for local repo tasks.
     """
+    try:
+        from agent.runtime_cwd import get_session_cwd_override
+
+        task_local_cwd = get_session_cwd_override()
+    except Exception:
+        task_local_cwd = None
     candidates = [
+        task_local_cwd,
         os.getenv("TERMINAL_CWD"),
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None


### PR DESCRIPTION
## What does this PR do?

Opt-in messaging profiles can now bind each durable session to its own private working directory. Concurrent Slack threads no longer share mutable scratch state or resolve local context references from another session's directory.

The workspace identity is deterministic but opaque. Existing sessions recover their stored binding, concurrent tasks use task-local CWD state, and an unavailable managed workspace fails closed instead of silently falling back to a shared directory.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an opt-in `terminal.session_workspace` binding for eligible messaging platforms.
- Carry the bound CWD through gateway session context, delegated tools, and local context-reference expansion.
- Recover persisted workspaces across restarts and reject invalid, missing, or escaping bindings.
- Cover concurrent session isolation, recovery, permissions, symlink defense, and task-local `@file` expansion.

## How to Test

1. Enable `terminal.session_workspace` for Slack with an absolute root and instructions path.
2. Start two concurrent root-thread sessions and confirm each receives a different mode-0700 workspace.
3. Restart the gateway and confirm both sessions recover the same workspace while `@file` expansion remains bound to each task-local CWD.

Automated focused result: 47 passed, 3 skipped on macOS. The broader gateway/session regression run passed 170 tests with 3 skips before the final task-local CWD regression was added.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this changes runtime session isolation and has no visual surface.
