### PR TITLE
fix(cli): keep journey labels readable

### DIFF
--- a/hermes_cli/journey.py
+++ b/hermes_cli/journey.py
@@ -18,6 +18,7 @@ from functools import lru_cache
 from typing import Any, Optional
 
 _TITLE_COLOR = "#E8C463"
+_CHARTED_SIGNAL_MIN_CONTRAST = 4.5
 
 
 def _build_payload() -> dict[str, Any]:
@@ -58,6 +59,57 @@ def _fade(base: Optional[str], alpha: float) -> Optional[str]:
 def _resolve(style: str, alpha: float) -> Optional[str]:
     """Fade the style's base ink toward the background by ``alpha`` (rgba-over-bg)."""
     return _fade(_palette().get(style), alpha)
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    def channel(value: int) -> float:
+        normalized = value / 255
+        return (
+            normalized / 12.92
+            if normalized <= 0.03928
+            else ((normalized + 0.055) / 1.055) ** 2.4
+        )
+
+    red, green, blue = (channel(value) for value in rgb)
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+def _contrast_ratio(
+    foreground: tuple[int, int, int], background: tuple[int, int, int]
+) -> float:
+    foreground_luminance = _relative_luminance(foreground)
+    background_luminance = _relative_luminance(background)
+    high, low = sorted((foreground_luminance, background_luminance), reverse=True)
+    return (high + 0.05) / (low + 0.05)
+
+
+def _ensure_contrast(
+    color: Optional[str], background: str, minimum: float
+) -> Optional[str]:
+    """Lift a foreground toward the readable pole until it clears ``minimum``."""
+    if not color:
+        return None
+
+    from agent.learning_graph_render import hex_to_rgb, mix_rgb, rgb_to_hex
+
+    foreground_rgb = hex_to_rgb(color)
+    background_rgb = hex_to_rgb(background)
+    if _contrast_ratio(foreground_rgb, background_rgb) >= minimum:
+        return color
+
+    pole = (0, 0, 0) if _relative_luminance(background_rgb) > 0.5 else (255, 255, 255)
+    for step in range(1, 21):
+        candidate = mix_rgb(foreground_rgb, pole, step * 0.05)
+        if _contrast_ratio(candidate, background_rgb) >= minimum:
+            return rgb_to_hex(candidate)
+    return rgb_to_hex(pole)
+
+
+def _resolve_charted_signal(style: str, alpha: float) -> Optional[str]:
+    """Keep age tinting without allowing explanatory labels to disappear."""
+    return _ensure_contrast(
+        _resolve(style, alpha), _palette()["bg"], _CHARTED_SIGNAL_MIN_CONTRAST
+    )
 
 
 def _row_to_text(row: list, color: bool):
@@ -155,8 +207,13 @@ def _frame_renderable(payload, *, cols, rows, reveal, color):
         def label_row(item) -> Text:
             row = Text("  ")
             row.append(f"{item['key']} ", style="grey70" if color else None)
-            row.append(f"{item['glyph']} ", style=_resolve(item["style"], float(item.get("alpha", 1.0))) if color else None)
-            row.append(str(item["label"]), style=_resolve(item["style"], float(item.get("alpha", 1.0))) if color else None)
+            signal_style = (
+                _resolve_charted_signal(item["style"], float(item.get("alpha", 1.0)))
+                if color
+                else None
+            )
+            row.append(f"{item['glyph']} ", style=signal_style)
+            row.append(str(item["label"]), style=signal_style)
             meta = str(item["meta"])
             row.append(f"  {meta if len(meta) <= 32 else meta[:29] + '…'}", style="grey54" if color else None)
             return row

--- a/tests/hermes_cli/test_journey_render.py
+++ b/tests/hermes_cli/test_journey_render.py
@@ -12,6 +12,23 @@ import contextlib
 import io
 
 
+def _relative_luminance(color: str) -> float:
+    value = color.lstrip("#")
+    channels = [int(value[index : index + 2], 16) / 255 for index in (0, 2, 4)]
+    red, green, blue = (
+        channel / 12.92 if channel <= 0.03928 else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    )
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    high, low = sorted(
+        (_relative_luminance(foreground), _relative_luminance(background)), reverse=True
+    )
+    return (high + 0.05) / (low + 0.05)
+
+
 def _capture(argv: list[str], *, force: bool) -> str:
     from hermes_cli.journey import register_cli
 
@@ -36,3 +53,65 @@ def test_default_capture_is_plain_for_chat_bubbles():
     # Rich auto-detects the StringIO as non-tty → no color, no raw escapes.
     assert "\x1b[" not in _capture([], force=False)
     assert "\x1b[" not in _capture(["list"], force=False)
+
+
+def test_charted_signal_labels_clear_readable_contrast_floor(monkeypatch):
+    from rich.text import Text
+
+    from hermes_cli import journey
+
+    palette = {
+        "bg": "#08080C",
+        "dim": "#525255",
+        "label": "#A9A9AA",
+        "memory": "#FFDC1F",
+        "skill": "#043D92",
+    }
+    monkeypatch.setattr(journey, "_palette", lambda: palette)
+    payload = {
+        "nodes": [
+            {
+                "id": "old-skill",
+                "label": "old-skill",
+                "kind": "skill",
+                "timestamp": 1_700_000_000,
+                "category": "research",
+                "useCount": 0,
+            },
+            {
+                "id": "new-skill",
+                "label": "new-skill",
+                "kind": "skill",
+                "timestamp": 1_800_000_000,
+                "category": "research",
+                "useCount": 1,
+            },
+        ],
+        "edges": [],
+        "clusters": [{"category": "research", "count": 2}],
+        "stats": {
+            "learned_skills": 2,
+            "memory_nodes": 0,
+            "related_edges": 0,
+            "memory_skill_edges": 0,
+        },
+    }
+
+    output = journey._frame_renderable(
+        payload, cols=72, rows=24, reveal=1.0, color=True
+    )
+    label_row = next(
+        renderable
+        for renderable in output.renderables
+        if isinstance(renderable, Text) and "old-skill" in renderable.plain
+    )
+    label_offset = label_row.plain.index("old-skill")
+    label_span = next(
+        span for span in label_row.spans if span.start <= label_offset < span.end
+    )
+
+    assert isinstance(label_span.style, str)
+    assert (
+        _contrast_ratio(label_span.style, palette["bg"])
+        >= journey._CHARTED_SIGNAL_MIN_CONTRAST
+    )


### PR DESCRIPTION
## What does this PR do?

Keeps the human-readable labels under `charted signals` legible when `/journey` renders old skill entries.

Journey intentionally fades timeline marks by age. The CLI was also applying that same low recency alpha to the explanatory skill labels. With the default palette, an old skill label fell from `#043D92` to roughly `#061E44` against `#08080C`, which is about 1.2:1 contrast.

This preserves the age tint, then lifts only the charted-signal foreground toward the readable pole until it reaches a 4.5:1 contrast floor. Timeline bars and their recency gradient are unchanged. Colors that already pass remain byte-for-byte unchanged.

## Related Issue

N/A. Reported through support; no GitHub issue exists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/journey.py`: apply a WCAG contrast floor only to charted-signal glyphs and labels after the existing age fade.
- `tests/hermes_cli/test_journey_render.py`: exercise the real frame-rendering path and verify that an old skill label clears the contrast floor.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_journey_render.py -q -j 4`.
2. Populate Journey with skills at widely separated timestamps and run `hermes journey --force-color` in a dark terminal.
3. Confirm old skill labels under `charted signals` remain readable while timeline bars still fade by age.

Local static verification completed:

- `uv tool run --offline ruff check hermes_cli/journey.py tests/hermes_cli/test_journey_render.py`
- `python scripts/check-windows-footguns.py hermes_cli/journey.py tests/hermes_cli/test_journey_render.py`
- `git diff --check`

The focused Python test was not run locally; GitHub CI should execute it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11 static checks only; runtime test not run locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user procedure changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

N/A. The regression test inspects the actual Rich label span produced by the Journey frame renderer.
