### PR TITLE
fix(tests): block live s6 profile mutations

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import re
+from functools import wraps
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
@@ -603,35 +604,81 @@ class S6CommandError(S6Error):
         super().__init__(message, service=service)
 
 
-def _refuse_live_s6_mutation_under_test(
-    scandir: Path, *, operation: str, profile: str
-) -> Optional[Path]:
-    """Deny live test mutations; return a stable safe scandir when active."""
-    if not os.environ.get("HERMES_TEST_ISOLATION"):
-        return None
-    service = f"{S6_SERVICE_PREFIX}{profile}"
-    if scandir == S6_DYNAMIC_SCANDIR:
-        raise S6TestIsolationError(
-            f"refusing to {operation} {service!r} in the live s6 scandir "
-            "while Hermes test isolation is active",
-            service=service,
-        )
-    try:
-        resolved_scandir = scandir.resolve()
-        resolved_live = S6_DYNAMIC_SCANDIR.resolve()
-    except (OSError, RuntimeError) as exc:
-        raise S6TestIsolationError(
-            "refusing s6 mutation under test isolation: could not prove "
-            "the target scandir is separate from the live canonical scandir",
-            service=service,
-        ) from exc
-    if resolved_scandir == resolved_live:
-        raise S6TestIsolationError(
-            f"refusing to {operation} {service!r} in the live s6 scandir "
-            "while Hermes test isolation is active",
-            service=service,
-        )
-    return resolved_scandir
+def _with_test_bound_scandir(operation: str):
+    """Bind test-only s6 mutations to an open non-live directory inode."""
+    def decorate(method):
+        @wraps(method)
+        def wrapped(self, profile, *args, **kwargs):
+            if not os.environ.get("HERMES_TEST_ISOLATION"):
+                return method(self, profile, *args, **kwargs)
+
+            service = f"{S6_SERVICE_PREFIX}{profile}"
+            scandir = self.scandir
+            if scandir == S6_DYNAMIC_SCANDIR:
+                raise S6TestIsolationError(
+                    f"refusing to {operation} {service!r} in the live s6 scandir "
+                    "while Hermes test isolation is active",
+                    service=service,
+                )
+            try:
+                resolved_scandir = scandir.resolve()
+                resolved_live = S6_DYNAMIC_SCANDIR.resolve()
+            except (OSError, RuntimeError) as exc:
+                raise S6TestIsolationError(
+                    "refusing s6 mutation under test isolation: could not prove "
+                    "the target scandir is separate from the live canonical scandir",
+                    service=service,
+                ) from exc
+            if resolved_scandir == resolved_live:
+                raise S6TestIsolationError(
+                    f"refusing to {operation} {service!r} in the live s6 scandir "
+                    "while Hermes test isolation is active",
+                    service=service,
+                )
+
+            flags = os.O_RDONLY
+            flags |= getattr(os, "O_DIRECTORY", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            try:
+                directory_fd = os.open(resolved_scandir, flags)
+                opened = os.fstat(directory_fd)
+                try:
+                    live = os.stat(S6_DYNAMIC_SCANDIR)
+                except FileNotFoundError:
+                    live = None
+                if live is not None and os.path.samestat(opened, live):
+                    raise S6TestIsolationError(
+                        f"refusing to {operation} {service!r} in the live s6 scandir "
+                        "while Hermes test isolation is active",
+                        service=service,
+                    )
+                fd_root = Path(f"/proc/{os.getpid()}/fd/{directory_fd}")
+                if not fd_root.is_dir():
+                    fd_root = Path(f"/dev/fd/{directory_fd}")
+                if not fd_root.is_dir():
+                    raise OSError("no stable fd path is available for the s6 scandir")
+            except S6TestIsolationError:
+                if "directory_fd" in locals():
+                    os.close(directory_fd)
+                raise
+            except (OSError, RuntimeError) as exc:
+                if "directory_fd" in locals():
+                    os.close(directory_fd)
+                raise S6TestIsolationError(
+                    "refusing s6 mutation under test isolation: could not bind "
+                    "the target scandir to a stable non-live directory",
+                    service=service,
+                ) from exc
+
+            self.scandir = fd_root
+            try:
+                return method(self, profile, *args, **kwargs)
+            finally:
+                self.scandir = resolved_scandir
+                os.close(directory_fd)
+
+        return wrapped
+    return decorate
 
 
 class S6ServiceManager:
@@ -981,6 +1028,7 @@ class S6ServiceManager:
     def supports_runtime_registration(self) -> bool:
         return True
 
+    @_with_test_bound_scandir("register")
     def register_profile_gateway(
         self,
         profile: str,
@@ -1001,12 +1049,6 @@ class S6ServiceManager:
                 directory already exists.
             RuntimeError: if ``s6-svscanctl`` fails.
         """
-        safe_scandir = _refuse_live_s6_mutation_under_test(
-            self.scandir, operation="register", profile=profile
-        )
-        if safe_scandir is not None:
-            self.scandir = safe_scandir
-
         import shutil
         import subprocess
 
@@ -1091,6 +1133,7 @@ class S6ServiceManager:
                 f"s6-svscanctl failed: {result.stderr or result.stdout}"
             )
 
+    @_with_test_bound_scandir("unregister")
     def unregister_profile_gateway(self, profile: str) -> None:
         """Stop the profile gateway service and remove its directory.
 
@@ -1107,12 +1150,6 @@ class S6ServiceManager:
         rmtree races s6-supervise on a set of root-owned files inside
         the supervise dir and the dir is left half-removed.
         """
-        safe_scandir = _refuse_live_s6_mutation_under_test(
-            self.scandir, operation="unregister", profile=profile
-        )
-        if safe_scandir is not None:
-            self.scandir = safe_scandir
-
         import shutil
         import subprocess
         import time

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -16,6 +16,7 @@ profile create/delete hooks (Phase 4) and the s6 dispatch path in
 """
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
@@ -557,6 +558,10 @@ class S6Error(RuntimeError):
         self.service = service
 
 
+class S6TestIsolationError(S6Error):
+    """Raised before a test process can mutate the live s6 scandir."""
+
+
 class GatewayNotRegisteredError(S6Error):
     """Raised when a lifecycle method targets a slot that doesn't exist.
 
@@ -596,6 +601,29 @@ class S6CommandError(S6Error):
         if stderr.strip():
             message += f": {stderr.strip()}"
         super().__init__(message, service=service)
+
+
+def _refuse_live_s6_mutation_under_test(
+    scandir: Path, *, operation: str, profile: str
+) -> None:
+    """Fail before effects when test isolation targets the live scandir."""
+    if not os.environ.get("HERMES_TEST_ISOLATION"):
+        return
+    is_live = scandir == S6_DYNAMIC_SCANDIR
+    if not is_live:
+        try:
+            is_live = scandir.resolve() == S6_DYNAMIC_SCANDIR.resolve()
+        except OSError:
+            # Lexical equality was checked above. Resolution failures for a
+            # different path do not make it the canonical live scandir.
+            is_live = False
+    if is_live:
+        service = f"{S6_SERVICE_PREFIX}{profile}"
+        raise S6TestIsolationError(
+            f"refusing to {operation} {service!r} in the live s6 scandir "
+            "while Hermes test isolation is active",
+            service=service,
+        )
 
 
 class S6ServiceManager:
@@ -965,6 +993,10 @@ class S6ServiceManager:
                 directory already exists.
             RuntimeError: if ``s6-svscanctl`` fails.
         """
+        _refuse_live_s6_mutation_under_test(
+            self.scandir, operation="register", profile=profile
+        )
+
         import shutil
         import subprocess
 
@@ -1065,6 +1097,10 @@ class S6ServiceManager:
         rmtree races s6-supervise on a set of root-owned files inside
         the supervise dir and the dir is left half-removed.
         """
+        _refuse_live_s6_mutation_under_test(
+            self.scandir, operation="unregister", profile=profile
+        )
+
         import shutil
         import subprocess
         import time

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -619,7 +619,7 @@ def _refuse_live_s6_mutation_under_test(
     try:
         resolved_scandir = scandir.resolve()
         resolved_live = S6_DYNAMIC_SCANDIR.resolve()
-    except OSError as exc:
+    except (OSError, RuntimeError) as exc:
         raise S6TestIsolationError(
             "refusing s6 mutation under test isolation: could not prove "
             "the target scandir is separate from the live canonical scandir",

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -605,25 +605,33 @@ class S6CommandError(S6Error):
 
 def _refuse_live_s6_mutation_under_test(
     scandir: Path, *, operation: str, profile: str
-) -> None:
-    """Fail before effects when test isolation targets the live scandir."""
+) -> Optional[Path]:
+    """Deny live test mutations; return a stable safe scandir when active."""
     if not os.environ.get("HERMES_TEST_ISOLATION"):
-        return
-    is_live = scandir == S6_DYNAMIC_SCANDIR
-    if not is_live:
-        try:
-            is_live = scandir.resolve() == S6_DYNAMIC_SCANDIR.resolve()
-        except OSError:
-            # Lexical equality was checked above. Resolution failures for a
-            # different path do not make it the canonical live scandir.
-            is_live = False
-    if is_live:
-        service = f"{S6_SERVICE_PREFIX}{profile}"
+        return None
+    service = f"{S6_SERVICE_PREFIX}{profile}"
+    if scandir == S6_DYNAMIC_SCANDIR:
         raise S6TestIsolationError(
             f"refusing to {operation} {service!r} in the live s6 scandir "
             "while Hermes test isolation is active",
             service=service,
         )
+    try:
+        resolved_scandir = scandir.resolve()
+        resolved_live = S6_DYNAMIC_SCANDIR.resolve()
+    except OSError as exc:
+        raise S6TestIsolationError(
+            "refusing s6 mutation under test isolation: could not prove "
+            "the target scandir is separate from the live canonical scandir",
+            service=service,
+        ) from exc
+    if resolved_scandir == resolved_live:
+        raise S6TestIsolationError(
+            f"refusing to {operation} {service!r} in the live s6 scandir "
+            "while Hermes test isolation is active",
+            service=service,
+        )
+    return resolved_scandir
 
 
 class S6ServiceManager:
@@ -993,9 +1001,11 @@ class S6ServiceManager:
                 directory already exists.
             RuntimeError: if ``s6-svscanctl`` fails.
         """
-        _refuse_live_s6_mutation_under_test(
+        safe_scandir = _refuse_live_s6_mutation_under_test(
             self.scandir, operation="register", profile=profile
         )
+        if safe_scandir is not None:
+            self.scandir = safe_scandir
 
         import shutil
         import subprocess
@@ -1097,9 +1107,11 @@ class S6ServiceManager:
         rmtree races s6-supervise on a set of root-owned files inside
         the supervise dir and the dir is left half-removed.
         """
-        _refuse_live_s6_mutation_under_test(
+        safe_scandir = _refuse_live_s6_mutation_under_test(
             self.scandir, operation="unregister", profile=profile
         )
+        if safe_scandir is not None:
+            self.scandir = safe_scandir
 
         import shutil
         import subprocess

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -249,6 +249,78 @@ def test_s6_test_isolation_binds_safe_scandir_before_unregister(
     assert manager.scandir == safe.resolve()
 
 
+def test_s6_test_isolation_binds_open_directory_when_resolved_referent_is_retargeted(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    canonical = tmp_path / "canonical-service"
+    canonical.mkdir()
+    sentinel = canonical / "sentinel"
+    sentinel.write_text("untouched")
+    safe = tmp_path / "safe-scandir"
+    safe.mkdir()
+    moved = tmp_path / "safe-scandir-moved"
+    alias = tmp_path / "mutable-alias"
+    alias.symlink_to(safe, target_is_directory=True)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", canonical)
+    manager = S6ServiceManager(scandir=alias)
+    original_service_dir = manager._service_dir
+    retargeted = False
+
+    def retarget_referent_then_resolve(profile):
+        nonlocal retargeted
+        if not retargeted:
+            safe.rename(moved)
+            safe.symlink_to(canonical, target_is_directory=True)
+            retargeted = True
+        return original_service_dir(profile)
+
+    monkeypatch.setattr(manager, "_service_dir", retarget_referent_then_resolve)
+
+    manager.register_profile_gateway("coder", start_now=False)
+
+    assert sentinel.read_text() == "untouched"
+    assert not (canonical / "gateway-coder").exists()
+    assert (moved / "gateway-coder").is_dir()
+
+
+def test_s6_test_isolation_unregister_uses_open_directory_when_referent_is_retargeted(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    canonical = tmp_path / "canonical-service"
+    canonical_service = canonical / "gateway-coder"
+    canonical_service.mkdir(parents=True)
+    sentinel = canonical_service / "sentinel"
+    sentinel.write_text("untouched")
+    safe = tmp_path / "safe-scandir"
+    safe_service = safe / "gateway-coder"
+    safe_service.mkdir(parents=True)
+    moved = tmp_path / "safe-scandir-moved"
+    alias = tmp_path / "mutable-alias"
+    alias.symlink_to(safe, target_is_directory=True)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", canonical)
+    manager = S6ServiceManager(scandir=alias)
+    original_service_dir = manager._service_dir
+    retargeted = False
+
+    def retarget_referent_then_resolve(profile):
+        nonlocal retargeted
+        if not retargeted:
+            safe.rename(moved)
+            safe.symlink_to(canonical, target_is_directory=True)
+            retargeted = True
+        return original_service_dir(profile)
+
+    monkeypatch.setattr(manager, "_service_dir", retarget_referent_then_resolve)
+
+    manager.unregister_profile_gateway("coder")
+
+    assert sentinel.read_text() == "untouched"
+    assert canonical_service.is_dir()
+    assert not (moved / "gateway-coder").exists()
+
+
 def test_s6_test_isolation_denies_resolved_alias_of_canonical_scandir(
     monkeypatch, tmp_path, fake_subprocess_run
 ):
@@ -330,7 +402,9 @@ def test_s6_test_isolation_guard_allows_noncanonical_tmp_scandir(
     manager.register_profile_gateway("coder", start_now=False)
 
     assert (s6_scandir / "gateway-coder").is_dir()
-    assert fake_subprocess_run == [["s6-svscanctl", "-a", str(s6_scandir)]]
+    assert len(fake_subprocess_run) == 1
+    assert fake_subprocess_run[0][:2] == ["s6-svscanctl", "-a"]
+    assert "/fd/" in fake_subprocess_run[0][2]
 
 
 def test_s6_live_guard_is_inactive_outside_test_context(

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hermes_cli import service_manager as service_manager_module
@@ -149,6 +151,101 @@ def test_windows_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) ->
 # ---------------------------------------------------------------------------
 # S6ServiceManager — unit tests against a tmp-path scandir (no real s6)
 # ---------------------------------------------------------------------------
+
+
+def test_s6_test_isolation_denies_when_scandir_identity_cannot_be_resolved(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    scandir = tmp_path / "uncertain-scandir"
+    scandir.mkdir()
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(
+        service_manager_module, "S6_DYNAMIC_SCANDIR", tmp_path / "canonical"
+    )
+
+    def fail_resolve(self, *args, **kwargs):
+        raise OSError("identity unavailable")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+    manager = S6ServiceManager(scandir=scandir)
+
+    with pytest.raises(S6TestIsolationError, match="could not prove"):
+        manager.register_profile_gateway("coder", start_now=False)
+
+    assert not (scandir / "gateway-coder").exists()
+    assert fake_subprocess_run == []
+
+
+def test_s6_test_isolation_binds_safe_resolved_scandir_before_mutation(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    canonical = tmp_path / "canonical-service"
+    canonical.mkdir()
+    sentinel = canonical / "sentinel"
+    sentinel.write_text("untouched")
+    safe = tmp_path / "safe-scandir"
+    safe.mkdir()
+    alias = tmp_path / "mutable-alias"
+    alias.symlink_to(safe, target_is_directory=True)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", canonical)
+    manager = S6ServiceManager(scandir=alias)
+    original_service_dir = manager._service_dir
+    retargeted = False
+
+    def retarget_then_resolve(profile):
+        nonlocal retargeted
+        if not retargeted:
+            alias.unlink()
+            alias.symlink_to(canonical, target_is_directory=True)
+            retargeted = True
+        return original_service_dir(profile)
+
+    monkeypatch.setattr(manager, "_service_dir", retarget_then_resolve)
+
+    manager.register_profile_gateway("coder", start_now=False)
+
+    assert sentinel.read_text() == "untouched"
+    assert not (canonical / "gateway-coder").exists()
+    assert (safe / "gateway-coder").is_dir()
+    assert manager.scandir == safe.resolve()
+
+
+def test_s6_test_isolation_binds_safe_scandir_before_unregister(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    canonical = tmp_path / "canonical-service"
+    canonical_service = canonical / "gateway-coder"
+    canonical_service.mkdir(parents=True)
+    canonical_sentinel = canonical_service / "sentinel"
+    canonical_sentinel.write_text("untouched")
+    safe = tmp_path / "safe-scandir"
+    safe_service = safe / "gateway-coder"
+    safe_service.mkdir(parents=True)
+    alias = tmp_path / "mutable-alias"
+    alias.symlink_to(safe, target_is_directory=True)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", canonical)
+    manager = S6ServiceManager(scandir=alias)
+    original_service_dir = manager._service_dir
+    retargeted = False
+
+    def retarget_then_resolve(profile):
+        nonlocal retargeted
+        if not retargeted:
+            alias.unlink()
+            alias.symlink_to(canonical, target_is_directory=True)
+            retargeted = True
+        return original_service_dir(profile)
+
+    monkeypatch.setattr(manager, "_service_dir", retarget_then_resolve)
+
+    manager.unregister_profile_gateway("coder")
+
+    assert canonical_sentinel.read_text() == "untouched"
+    assert canonical_service.is_dir()
+    assert not safe_service.exists()
+    assert manager.scandir == safe.resolve()
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import pytest
 
+from hermes_cli import service_manager as service_manager_module
 from hermes_cli.service_manager import (
     LaunchdServiceManager,
+    S6Error,
     S6ServiceManager,
+    S6TestIsolationError,
     ServiceManager,
     ServiceManagerKind,
     SystemdServiceManager,
@@ -154,6 +157,75 @@ def s6_scandir(tmp_path):
     d = tmp_path / "service"
     d.mkdir()
     return d
+
+
+def test_s6_register_refuses_canonical_scandir_under_test_isolation_before_write(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, fake_subprocess_run
+) -> None:
+    canonical_scandir = tmp_path / "canonical-service"
+    canonical_scandir.mkdir()
+    monkeypatch.setattr(
+        service_manager_module, "S6_DYNAMIC_SCANDIR", canonical_scandir
+    )
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test-register")
+    manager = S6ServiceManager(scandir=canonical_scandir)
+
+    with pytest.raises(S6TestIsolationError, match="test isolation"):
+        manager.register_profile_gateway("coder", start_now=False)
+
+    assert not (canonical_scandir / "gateway-coder").exists()
+    assert fake_subprocess_run == []
+
+
+def test_s6_unregister_refuses_canonical_scandir_under_test_isolation_before_effect(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, fake_subprocess_run
+) -> None:
+    canonical_scandir = tmp_path / "canonical-service"
+    service_dir = canonical_scandir / "gateway-coder"
+    service_dir.mkdir(parents=True)
+    sentinel = service_dir / "sentinel"
+    sentinel.write_bytes(b"owned-before-test")
+    monkeypatch.setattr(
+        service_manager_module, "S6_DYNAMIC_SCANDIR", canonical_scandir
+    )
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test-unregister")
+    manager = S6ServiceManager(scandir=canonical_scandir)
+
+    with pytest.raises(S6TestIsolationError, match="test isolation"):
+        manager.unregister_profile_gateway("coder")
+
+    assert sentinel.read_bytes() == b"owned-before-test"
+    assert fake_subprocess_run == []
+
+
+def test_s6_test_isolation_guard_allows_noncanonical_tmp_scandir(
+    tmp_path, s6_scandir, monkeypatch: pytest.MonkeyPatch, fake_subprocess_run
+) -> None:
+    canonical_scandir = tmp_path / "canonical-service"
+    canonical_scandir.mkdir()
+    monkeypatch.setattr(
+        service_manager_module, "S6_DYNAMIC_SCANDIR", canonical_scandir
+    )
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test-temp")
+    manager = S6ServiceManager(scandir=s6_scandir)
+
+    manager.register_profile_gateway("coder", start_now=False)
+
+    assert (s6_scandir / "gateway-coder").is_dir()
+    assert fake_subprocess_run == [["s6-svscanctl", "-a", str(s6_scandir)]]
+
+
+def test_s6_live_guard_is_inactive_outside_test_context(
+    s6_scandir, monkeypatch: pytest.MonkeyPatch, fake_subprocess_run
+) -> None:
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", s6_scandir)
+    monkeypatch.delenv("HERMES_TEST_ISOLATION", raising=False)
+    manager = S6ServiceManager(scandir=s6_scandir)
+
+    manager.register_profile_gateway("coder", start_now=False)
+
+    assert (s6_scandir / "gateway-coder").is_dir()
+    assert fake_subprocess_run == [["s6-svscanctl", "-a", str(s6_scandir)]]
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -153,8 +153,9 @@ def test_windows_manager_lifecycle_delegates(monkeypatch: pytest.MonkeyPatch) ->
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("resolution_error", [OSError("io"), RuntimeError("loop")])
 def test_s6_test_isolation_denies_when_scandir_identity_cannot_be_resolved(
-    monkeypatch, tmp_path, fake_subprocess_run
+    monkeypatch, tmp_path, fake_subprocess_run, resolution_error
 ):
     scandir = tmp_path / "uncertain-scandir"
     scandir.mkdir()
@@ -164,7 +165,7 @@ def test_s6_test_isolation_denies_when_scandir_identity_cannot_be_resolved(
     )
 
     def fail_resolve(self, *args, **kwargs):
-        raise OSError("identity unavailable")
+        raise resolution_error
 
     monkeypatch.setattr(Path, "resolve", fail_resolve)
     manager = S6ServiceManager(scandir=scandir)
@@ -246,6 +247,26 @@ def test_s6_test_isolation_binds_safe_scandir_before_unregister(
     assert canonical_service.is_dir()
     assert not safe_service.exists()
     assert manager.scandir == safe.resolve()
+
+
+def test_s6_test_isolation_denies_resolved_alias_of_canonical_scandir(
+    monkeypatch, tmp_path, fake_subprocess_run
+):
+    canonical = tmp_path / "canonical-service"
+    canonical.mkdir()
+    sentinel = canonical / "sentinel"
+    sentinel.write_text("untouched")
+    alias = tmp_path / "canonical-alias"
+    alias.symlink_to(canonical, target_is_directory=True)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "run:test")
+    monkeypatch.setattr(service_manager_module, "S6_DYNAMIC_SCANDIR", canonical)
+    manager = S6ServiceManager(scandir=alias)
+
+    with pytest.raises(S6TestIsolationError):
+        manager.unregister_profile_gateway("coder")
+
+    assert sentinel.read_text() == "untouched"
+    assert fake_subprocess_run == []
 
 
 @pytest.fixture


### PR DESCRIPTION
## Status

**Draft while generation 4 receives exact-byte independent review.** Generation 3 was blocked by a resolved-referent retarget TOCTOU. Do not merge the currently published generation 2 head.

## Scope
- deny profile gateway register/unregister when pytest isolation targets the canonical s6 scandir
- bind approved fixture mutations to a checked non-live directory inode
- preserve injected temporary scandirs and behavior when test isolation is absent

## Root cause
Profile tests can reach `S6ServiceManager.register_profile_gateway(..., start_now=False)`. Under s6-overlay, creating `down` prevents the gateway child but does not prevent `s6-supervise`/logging supervisors from being published under `/run/service`.

## Current remote head
The remote head is generation 3 (`2f9a703`). A later adversarial review showed the resolved pathname itself could be renamed and replaced with a symlink to the canonical scandir. Generation 4 uses an open directory descriptor for inode-stable binding and is still under immutable review; it has not yet been pushed.

No live `/run/service` mutation or historical-process cleanup was performed.
