### PR TITLE
feat(commands): establish unified versioned command catalog

### DIFF
--- a/hermes_cli/command_catalog.py
+++ b/hermes_cli/command_catalog.py
@@ -1,0 +1,237 @@
+"""Versioned command catalog contract shared by Hermes surfaces.
+
+This module is deliberately transport-free.  It converts the legacy
+``COMMAND_REGISTRY`` into a stable, JSON-serializable semantic catalog with
+canonical command identities and a deterministic revision fingerprint.
+
+Dynamic contributors (plugins, skills, bundles, quick commands, client-local
+commands) are layered by callers through ``build_command_catalog``.  Duplicate
+IDs, names, or aliases fail closed unless a future explicit override authority
+is added here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from hermes_cli.commands import COMMAND_REGISTRY, CommandDef
+
+SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    schema_version: int
+    command_id: str
+    name: str
+    aliases: tuple[str, ...]
+    description_fallback: str
+    category: str
+    args_hint: str
+    subcommands: tuple[str, ...]
+    execution_owner: str
+    handler_id: str
+    origin: str
+    availability: Mapping[str, Any]
+    visibility: Mapping[str, bool]
+    busy_policy: str
+    live_session_requirement: str
+    authorization_policy: str
+    confirmation_policy: str
+    mutation_scope: str
+    idempotency_policy: str
+    retry_policy: str
+    result_capabilities: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "command_id": self.command_id,
+            "name": self.name,
+            "aliases": list(self.aliases),
+            "description_fallback": self.description_fallback,
+            "category": self.category,
+            "argument_schema": {
+                "kind": "legacy",
+                "hint": self.args_hint,
+                "subcommands": list(self.subcommands),
+            },
+            "execution_owner": self.execution_owner,
+            "handler_id": self.handler_id,
+            "origin": self.origin,
+            "availability": dict(self.availability),
+            "visibility": dict(self.visibility),
+            "busy_policy": self.busy_policy,
+            "live_session_requirement": self.live_session_requirement,
+            "authorization_policy": self.authorization_policy,
+            "confirmation_policy": self.confirmation_policy,
+            "mutation_scope": self.mutation_scope,
+            "idempotency_policy": self.idempotency_policy,
+            "retry_policy": self.retry_policy,
+            "result_capabilities": list(self.result_capabilities),
+        }
+
+
+@dataclass(frozen=True)
+class CommandCatalog:
+    schema_version: int
+    revision: str
+    commands: tuple[CommandSpec, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "revision": self.revision,
+            "commands": [command.to_dict() for command in self.commands],
+        }
+
+
+def _command_id(name: str) -> str:
+    return "command." + name.replace("_", "-")
+
+
+def _legacy_spec(command: CommandDef) -> CommandSpec:
+    if command.cli_only:
+        surfaces = ["cli", "desktop", "tui"]
+    elif command.gateway_only:
+        surfaces = ["gateway", "discord", "telegram", "slack", "matrix"]
+    else:
+        surfaces = [
+            "cli",
+            "desktop",
+            "tui",
+            "gateway",
+            "discord",
+            "telegram",
+            "slack",
+            "matrix",
+        ]
+
+    return CommandSpec(
+        schema_version=SCHEMA_VERSION,
+        command_id=_command_id(command.name),
+        name=command.name,
+        aliases=tuple(command.aliases),
+        description_fallback=command.description,
+        category=command.category,
+        args_hint=command.args_hint,
+        subcommands=tuple(command.subcommands),
+        execution_owner="server",
+        handler_id=command.execute or command.name,
+        origin="core",
+        availability={
+            "surfaces": surfaces,
+            "gateway_config_gate": command.gateway_config_gate,
+        },
+        visibility={
+            "help": True,
+            "completion": True,
+            "native_menu": not command.cli_only,
+            "hidden": False,
+        },
+        busy_policy=command.busy_policy,
+        live_session_requirement="session",
+        authorization_policy="existing",
+        confirmation_policy="existing",
+        mutation_scope="existing",
+        idempotency_policy="existing",
+        retry_policy="existing",
+        result_capabilities=("text",),
+    )
+
+
+def _normalize_external_spec(value: Mapping[str, Any], origin: str) -> CommandSpec:
+    name = str(value.get("name") or "").lstrip("/").strip()
+    if not name:
+        raise ValueError(f"{origin} command contribution missing name")
+    command_id = str(value.get("command_id") or f"{origin}.{name}")
+    aliases = tuple(str(item).lstrip("/") for item in value.get("aliases", ()) or ())
+    subcommands = tuple(str(item) for item in value.get("subcommands", ()) or ())
+    availability = value.get("availability") or {}
+    visibility = value.get("visibility") or {}
+    if not isinstance(availability, Mapping) or not isinstance(visibility, Mapping):
+        raise ValueError(f"{command_id}: availability/visibility must be mappings")
+    return CommandSpec(
+        schema_version=SCHEMA_VERSION,
+        command_id=command_id,
+        name=name,
+        aliases=aliases,
+        description_fallback=str(value.get("description_fallback") or value.get("description") or ""),
+        category=str(value.get("category") or "Extensions"),
+        args_hint=str(value.get("args_hint") or ""),
+        subcommands=subcommands,
+        execution_owner=str(value.get("execution_owner") or origin),
+        handler_id=str(value.get("handler_id") or command_id),
+        origin=origin,
+        availability=dict(availability),
+        visibility={
+            "help": bool(visibility.get("help", True)),
+            "completion": bool(visibility.get("completion", True)),
+            "native_menu": bool(visibility.get("native_menu", True)),
+            "hidden": bool(visibility.get("hidden", False)),
+        },
+        busy_policy=str(value.get("busy_policy") or "reject"),
+        live_session_requirement=str(value.get("live_session_requirement") or "session"),
+        authorization_policy=str(value.get("authorization_policy") or "existing"),
+        confirmation_policy=str(value.get("confirmation_policy") or "existing"),
+        mutation_scope=str(value.get("mutation_scope") or "existing"),
+        idempotency_policy=str(value.get("idempotency_policy") or "existing"),
+        retry_policy=str(value.get("retry_policy") or "existing"),
+        result_capabilities=tuple(str(item) for item in value.get("result_capabilities", ("text",)) or ()),
+    )
+
+
+def validate_command_specs(specs: Sequence[CommandSpec]) -> None:
+    ids: dict[str, str] = {}
+    tokens: dict[str, str] = {}
+    for spec in specs:
+        previous = ids.setdefault(spec.command_id, spec.origin)
+        if previous != spec.origin:
+            raise ValueError(f"duplicate command_id {spec.command_id!r}: {previous} vs {spec.origin}")
+        if spec.busy_policy not in {"dispatch", "reject", "interrupt_then_dispatch"}:
+            raise ValueError(f"{spec.command_id}: invalid busy_policy {spec.busy_policy!r}")
+        for token in (spec.name, *spec.aliases):
+            key = token.lower()
+            owner = tokens.setdefault(key, spec.command_id)
+            if owner != spec.command_id:
+                raise ValueError(f"command token {token!r} collides: {owner} vs {spec.command_id}")
+
+
+def _fingerprint(specs: Sequence[CommandSpec]) -> str:
+    payload = json.dumps(
+        [spec.to_dict() for spec in specs],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_command_catalog(
+    *,
+    contributions: Iterable[tuple[str, Mapping[str, Any]]] = (),
+) -> CommandCatalog:
+    specs = [_legacy_spec(command) for command in COMMAND_REGISTRY]
+    specs.extend(_normalize_external_spec(value, origin) for origin, value in contributions)
+    specs.sort(key=lambda item: (item.category.casefold(), item.name.casefold(), item.command_id))
+    validate_command_specs(specs)
+    return CommandCatalog(
+        schema_version=SCHEMA_VERSION,
+        revision=_fingerprint(specs),
+        commands=tuple(specs),
+    )
+
+
+def resolve_catalog_command(catalog: CommandCatalog, token: str) -> CommandSpec | None:
+    normalized = str(token or "").lstrip("/").casefold()
+    if not normalized:
+        return None
+    for spec in catalog.commands:
+        if spec.name.casefold() == normalized:
+            return spec
+        if any(alias.casefold() == normalized for alias in spec.aliases):
+            return spec
+    return None

--- a/tests/hermes_cli/test_command_catalog.py
+++ b/tests/hermes_cli/test_command_catalog.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.command_catalog import (
+    SCHEMA_VERSION,
+    build_command_catalog,
+    resolve_catalog_command,
+)
+
+
+def test_catalog_is_deterministic_and_aliases_preserve_identity():
+    first = build_command_catalog()
+    second = build_command_catalog()
+
+    assert first.schema_version == SCHEMA_VERSION
+    assert first.revision == second.revision
+    assert first.to_dict() == second.to_dict()
+
+    new = resolve_catalog_command(first, "/new")
+    reset = resolve_catalog_command(first, "/reset")
+    assert new is not None
+    assert reset is not None
+    assert new.command_id == reset.command_id == "command.new"
+
+
+def test_catalog_serializes_legacy_argument_and_busy_contract():
+    catalog = build_command_catalog()
+    model = resolve_catalog_command(catalog, "model")
+    stop = resolve_catalog_command(catalog, "stop")
+
+    assert model is not None
+    assert model.to_dict()["argument_schema"]["hint"]
+    assert model.busy_policy == "reject"
+    assert stop is not None
+    assert stop.busy_policy == "interrupt_then_dispatch"
+
+
+def test_dynamic_contributions_are_fingerprinted_and_resolvable():
+    catalog = build_command_catalog(
+        contributions=(
+            (
+                "plugin.example",
+                {
+                    "command_id": "plugin.example.deploy",
+                    "name": "deploy",
+                    "aliases": ["ship"],
+                    "description": "Deploy the current project",
+                    "category": "Plugins",
+                    "execution_owner": "plugin",
+                    "handler_id": "plugin.example.deploy",
+                },
+            ),
+        )
+    )
+    assert resolve_catalog_command(catalog, "ship").command_id == "plugin.example.deploy"
+    assert catalog.revision != build_command_catalog().revision
+
+
+def test_duplicate_alias_fails_closed():
+    with pytest.raises(ValueError, match="collides"):
+        build_command_catalog(
+            contributions=(
+                (
+                    "plugin.example",
+                    {
+                        "command_id": "plugin.example.not-new",
+                        "name": "not-new",
+                        "aliases": ["new"],
+                    },
+                ),
+            )
+        )


### PR DESCRIPTION
## Current topology — 2026-08-27 21:51 CDT

This PR is **draft** and is no longer a valid landing object in its present two-file shape.

While this operating cycle was reconciling #96692, [#96791](https://github.com/NousResearch/hermes-agent/pull/96791) merged to `main@595ee9228957523e46e19997775db6a9d44e7777` and moved the live command plane materially toward the same ownership boundary: `COMMAND_REGISTRY` now owns Desktop slash metadata (`argument_mode`, `desktop`), `commands.catalog` projects built-in and plugin command metadata, and Desktop consumes that catalog instead of maintaining the same semantic table locally.

That is current-main product truth. This draft must now be evaluated against it, not against the pre-#96791 topology.

## Exact submitted object

- **head:** `5184fa0015faa4b5ba36fbb2a30ca06595525f3c`
- **state:** open / draft
- **submitted commits:** 2
- **changed paths:**
  - `hermes_cli/command_catalog.py`
  - `tests/hermes_cli/test_command_catalog.py`
- **final-head execution:** CI `33123857620` success; Docker `33123856807` success; Nix `33123856772` success
- **predecessor commit:** `510b639199aecb6414b2ca1b8c4703460789224e` has **zero registered workflow runs**

Under the repository's exact-object/every-commit rule, final-head green does not certify that predecessor commit.

## What #96791 now owns on main

[#96791](https://github.com/NousResearch/hermes-agent/pull/96791), by `OutThisLife`, is now the current implementation owner for the immediate cross-surface duplication defect it fixed:

- canonical command definitions carry `argument_mode` and Desktop projection metadata;
- `commands.catalog` exposes built-in and plugin command metadata;
- Desktop command grouping/completion consumes backend `kind` / catalog metadata instead of re-deriving command identity from its own table;
- local Desktop semantic rows are reduced to genuinely client-local actions/pickers/RPCs.

This directly supersedes the premise in the original draft body that no live shared semantic projection existed yet. It does **not** automatically prove every richer policy field proposed by this draft is needed.

## Unique remainder to characterize, not assume

The draft still contains concepts not established merely by #96791:

- a stable `command_id` distinct from presentation name;
- alias-as-projection identity guarantees;
- deterministic catalog revision/fingerprint;
- fail-closed duplicate ID/name/alias validation across contributed commands;
- explicit execution owner / handler key;
- explicit availability, authorization, confirmation, mutation-scope, idempotency, retry, and result-capability fields.

Those are **proposed semantics**, not current-main requirements by assertion. #96692's declared migration order still begins with **PR 0 — inventory and characterization**. The next valid step is to compare each proposed field against live behavior after #96791 and keep only fields that close a demonstrated cross-surface semantic gap.

## Interlocks / provenance

- [#96692](https://github.com/NousResearch/hermes-agent/issues/96692) — architecture root and characterization/migration order.
- [#96791](https://github.com/NousResearch/hermes-agent/pull/96791) by `OutThisLife` — **merged current-main owner** for registry-backed Desktop slash metadata and `commands.catalog` projection. This work must be credited and composed, not duplicated.
- #93338 — Discord alias projection lineage.
- #93501 / #94073 — Desktop command presentation lineage; #96791 explicitly subsumes #94073's curated `/review` row symptom.
- #95028 / #95101 — Authority architecture / proposed policy ABI; command invocation policy may interlock but this PR must not reconstruct that ABI independently.

## Required disposition

1. Keep this PR draft while `main@595ee922…` exact-head workflows settle.
2. Re-run #96692 characterization against the post-#96791 command graph.
3. Delete any field/module responsibility already owned by `COMMAND_REGISTRY` + `commands.catalog` on main.
4. If a unique versioned identity/policy remainder survives, rematerialize only that smallest current-main object with preserved #96791 authorship/provenance and zero semantic ownership collision.
5. Every submitted commit of the final object must execute and pass the required CI/Docker/Nix matrix. No trigger-only commit and no historical receipt transfer.

The goal is one semantic core, not a second catalog beside the one main just adopted.

Refs #96692