### PR TITLE
fix(desktop): restore active chat across profile switches

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -10,13 +10,41 @@ vi.mock('./client', () => ({
 }))
 
 const client = await import('./client')
-const { listSidebarSessions } = await import('./sessions')
+const { getSession, listSidebarSessions } = await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(client.getApiRequestConnection).mockReturnValue('prometheus')
+})
+
+describe('getSession routing', () => {
+  it('clears the ambient connection tag for an explicit profile-door target', async () => {
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'arthur' })
+    hermesApi.mockResolvedValue({ id: 's1' } as never)
+
+    await getSession('s1', { connectionId: null, profile: 'arthur' })
+
+    expect(hermesApi).toHaveBeenCalledWith({
+      connectionId: undefined,
+      path: '/api/sessions/s1?profile=arthur',
+      profile: 'arthur'
+    })
+  })
+
+  it('preserves an explicit local registry target', async () => {
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'arthur' })
+    hermesApi.mockResolvedValue({ id: 's1' } as never)
+
+    await getSession('s1', { connectionId: 'local', profile: 'arthur' })
+
+    expect(hermesApi).toHaveBeenCalledWith({
+      connectionId: 'local',
+      path: '/api/sessions/s1?profile=arthur',
+      profile: 'arthur'
+    })
+  })
 })
 
 describe('listSidebarSessions remote ownership', () => {

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -21,8 +21,19 @@ function sessionScoped(scope?: ProfileScope): { connectionId?: string; profile?:
 
   const scoped = capabilityScoped(scope)
 
-  if (typeof scope === 'object' && scope.connectionId?.trim() === 'local') {
-    return { ...scoped, connectionId: 'local' }
+  if (typeof scope === 'object') {
+    const connectionId = scope.connectionId?.trim() || null
+
+    if (connectionId === 'local') {
+      return { ...scoped, connectionId: 'local' }
+    }
+
+    if (connectionId === null) {
+      // An explicit null is the legacy/profile-door route, not "inherit the
+      // active registry source". Preserve the key so hermesApi's request spread
+      // clears its ambient connection tag before IPC.
+      return { ...scoped, connectionId: undefined }
+    }
   }
 
   return scoped
@@ -339,7 +350,9 @@ export function searchSessions(query: string): Promise<SessionSearchResponse> {
 }
 
 // Resolves a single session row by id on one backend (the active profile, or
-// the given `profile`). The backend resolves exact ids and unique prefixes and
+// the given `profile`). Pass an explicit `{ connectionId: null, profile }` to
+// select the profile-door route without inheriting the ambient registry source.
+// The backend resolves exact ids and unique prefixes and
 // 404s when the id isn't on that profile — so a cheap by-id lookup replaces the
 // cross-profile list scan when locating an unknown id's owner.
 export function getSession(id: string, profile?: ProfileScope): Promise<SessionInfo> {

--- a/apps/desktop/src/app/chat/close-tab.test.ts
+++ b/apps/desktop/src/app/chat/close-tab.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/store/profile', () => ({
   // The layout store reads the sidebar's profile scope; this suite only cares
   // about the fresh-session call.
   $showAllProfiles: atom(false),
-  requestFreshSession: () => requestFreshSession(),
+  requestFreshSession: (intent: unknown) => requestFreshSession(intent),
   setShowAllProfiles: () => {}
 }))
 
@@ -106,7 +106,7 @@ describe('closeWorkspaceTab', () => {
     loadedMainOnly()
 
     expect(closeWorkspaceTab(vi.fn())).toBe(true)
-    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(requestFreshSession).toHaveBeenCalledWith({ cause: 'close-chat', persistence: 'explicit' })
   })
 
   it('empties main even with no session loader wired', () => {

--- a/apps/desktop/src/app/chat/close-tab.ts
+++ b/apps/desktop/src/app/chat/close-tab.ts
@@ -45,7 +45,7 @@ export function closeWorkspaceTab(loadSessionIntoWorkspace?: (storedSessionId: s
     return false
   }
 
-  requestFreshSession()
+  requestFreshSession({ cause: 'close-chat', persistence: 'explicit' })
 
   return true
 }

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -32,7 +32,7 @@ import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
 import { $activeGatewayProfile, $gatewaySwapTarget, $hydrationSyncProfile, $profiles } from '@/store/profile'
-import { $profileConversationRestore } from '@/store/profile-conversation-restore'
+import { $appliedFreshDraftProvenance, $profileConversationRestore } from '@/store/profile-conversation-restore'
 import {
   $connection,
   $contextSuggestions,
@@ -65,7 +65,7 @@ import { ComposerSurfaceProvider, useComposerScope, useComposerSurfaceId } from 
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
-import { shouldShowIntro } from './intro-visibility'
+import { shouldShowConversationRestoreLoading, shouldShowIntro } from './intro-visibility'
 import { ProfileTag } from './profile-tag'
 import { isRouteSessionMismatch } from './route-session-state'
 import { useRuntimeMessageRepository } from './runtime-repository'
@@ -437,6 +437,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
   const profileConversationRestore = useStore($profileConversationRestore)
+  const appliedFreshDraftProvenance = useStore($appliedFreshDraftProvenance)
 
   // Durable composer/queue scope (lineage root) so auto-compression tip rotation
   // does not wipe an in-progress draft or orphan /queue entries. For the
@@ -482,7 +483,11 @@ const ChatViewContent = memo(function ChatViewContent({
   // A tile IS its session — no route involved, never "mismatched".
   const routedSessionId = isPrimary ? routeSessionId(location.pathname) : selectedSessionId
   const isRoutedSessionView = Boolean(routedSessionId)
-  const restoringConversation = isPrimary && profileConversationRestore !== null
+  const restoringConversation = shouldShowConversationRestoreLoading({
+    primary: isPrimary,
+    provenance: appliedFreshDraftProvenance,
+    restore: profileConversationRestore
+  })
 
   // The URL points at a session the store hasn't loaded yet (sidebar / cmd-K /
   // direct nav). Derived in render so the swap reads instantly: the same frame

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -32,6 +32,7 @@ import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
 import { $activeGatewayProfile, $gatewaySwapTarget, $hydrationSyncProfile, $profiles } from '@/store/profile'
+import { $profileConversationRestore } from '@/store/profile-conversation-restore'
 import {
   $connection,
   $contextSuggestions,
@@ -435,6 +436,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const selectedSessionId = useStore(view.$storedId)
   const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
+  const profileConversationRestore = useStore($profileConversationRestore)
 
   // Durable composer/queue scope (lineage root) so auto-compression tip rotation
   // does not wipe an in-progress draft or orphan /queue entries. For the
@@ -480,6 +482,7 @@ const ChatViewContent = memo(function ChatViewContent({
   // A tile IS its session — no route involved, never "mismatched".
   const routedSessionId = isPrimary ? routeSessionId(location.pathname) : selectedSessionId
   const isRoutedSessionView = Boolean(routedSessionId)
+  const restoringConversation = isPrimary && profileConversationRestore !== null
 
   // The URL points at a session the store hasn't loaded yet (sidebar / cmd-K /
   // direct nav). Derived in render so the swap reads instantly: the same frame
@@ -497,6 +500,7 @@ const ChatViewContent = memo(function ChatViewContent({
     freshDraftReady,
     messagesEmpty,
     primary: isPrimary,
+    restoringConversation,
     routedSessionView: isRoutedSessionView,
     selectedSessionId
   })
@@ -515,7 +519,8 @@ const ChatViewContent = memo(function ChatViewContent({
   const resumeExhausted = isPrimary && isRoutedSessionView && resumeExhaustedSessionId === routedSessionId
 
   const loadingSession =
-    !resumeExhausted && isRoutedSessionView && (routeSessionMismatch || (messagesEmpty && !activeSessionId))
+    restoringConversation ||
+    (!resumeExhausted && isRoutedSessionView && (routeSessionMismatch || (messagesEmpty && !activeSessionId)))
 
   const threadLoading = threadLoadingState(loadingSession, busy, awaitingResponse, lastVisibleIsUser)
   // Hide the composer in the exhausted error state too: there's no live runtime

--- a/apps/desktop/src/app/chat/intro-visibility.test.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldShowIntro } from './intro-visibility'
+import { shouldShowConversationRestoreLoading, shouldShowIntro } from './intro-visibility'
 
 const showing = {
   activeSessionId: null,
@@ -13,6 +13,99 @@ const showing = {
   routedSessionView: false,
   selectedSessionId: null
 } as const
+
+describe('shouldShowConversationRestoreLoading', () => {
+  const profileRestore = {
+    origin: 'profile-switch',
+    phase: 'activating',
+    sequence: 7,
+    target: { connectionId: null, profile: 'work' }
+  } as const
+  const connectionRestore = {
+    origin: 'connection-switch',
+    phase: 'activating',
+    sequence: 9,
+    target: { connectionId: 'homelab', profile: 'default' }
+  } as const
+  const matchingProvenance = {
+    cause: 'connection-switch',
+    freshSequence: 12,
+    kind: 'automatic',
+    restoreSequence: 9
+  } as const
+
+  it('masks profile restores from activation through navigation', () => {
+    expect(shouldShowConversationRestoreLoading({ primary: true, provenance: null, restore: profileRestore })).toBe(
+      true
+    )
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: null,
+        restore: { ...profileRestore, phase: 'committed' }
+      })
+    ).toBe(true)
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: null,
+        restore: { ...profileRestore, phase: 'navigating', sessionId: 'work-last' }
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the current transcript visible while a connection switch is only dialing', () => {
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: matchingProvenance,
+        restore: connectionRestore
+      })
+    ).toBe(false)
+  })
+
+  it('masks committed and navigating connection restores only for their matching automatic draft', () => {
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: matchingProvenance,
+        restore: { ...connectionRestore, phase: 'committed' }
+      })
+    ).toBe(true)
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: matchingProvenance,
+        restore: { ...connectionRestore, phase: 'navigating', sessionId: 'remote-last' }
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: { ...matchingProvenance, restoreSequence: 8 },
+        restore: { ...connectionRestore, phase: 'committed' }
+      })
+    ).toBe(false)
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: true,
+        provenance: { cause: 'new-chat', freshSequence: 13, kind: 'explicit' },
+        restore: { ...connectionRestore, phase: 'committed' }
+      })
+    ).toBe(false)
+  })
+
+  it('never masks a non-primary chat surface', () => {
+    expect(
+      shouldShowConversationRestoreLoading({
+        primary: false,
+        provenance: matchingProvenance,
+        restore: { ...connectionRestore, phase: 'committed' }
+      })
+    ).toBe(false)
+  })
+})
 
 describe('shouldShowIntro', () => {
   it('shows on a fresh draft in the primary window', () => {

--- a/apps/desktop/src/app/chat/intro-visibility.test.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.test.ts
@@ -9,6 +9,7 @@ const showing = {
   freshDraftReady: true,
   messagesEmpty: true,
   primary: true,
+  restoringConversation: false,
   routedSessionView: false,
   selectedSessionId: null
 } as const
@@ -40,6 +41,7 @@ describe('shouldShowIntro', () => {
     expect(shouldShowIntro({ ...showing, primary: false })).toBe(false)
     expect(shouldShowIntro({ ...showing, auxiliaryWindow: true })).toBe(false)
     expect(shouldShowIntro({ ...showing, freshDraftReady: false })).toBe(false)
+    expect(shouldShowIntro({ ...showing, restoringConversation: true })).toBe(false)
     expect(shouldShowIntro({ ...showing, routedSessionView: true })).toBe(false)
     expect(shouldShowIntro({ ...showing, selectedSessionId: 'session-1' })).toBe(false)
     expect(shouldShowIntro({ ...showing, activeSessionId: 'session-1' })).toBe(false)

--- a/apps/desktop/src/app/chat/intro-visibility.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.ts
@@ -16,6 +16,7 @@ export function shouldShowIntro(input: {
   freshDraftReady: boolean
   messagesEmpty: boolean
   primary: boolean
+  restoringConversation: boolean
   routedSessionView: boolean
   selectedSessionId: null | string
 }): boolean {
@@ -23,6 +24,7 @@ export function shouldShowIntro(input: {
     input.enabled &&
     input.primary &&
     !input.auxiliaryWindow &&
+    !input.restoringConversation &&
     input.freshDraftReady &&
     !input.routedSessionView &&
     !input.selectedSessionId &&

--- a/apps/desktop/src/app/chat/intro-visibility.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.ts
@@ -1,3 +1,40 @@
+import type {
+  AppliedFreshDraftProvenance,
+  ProfileConversationRestoreRequest
+} from '@/store/profile-conversation-restore'
+
+/**
+ * Whether an in-flight remembered-conversation restore should replace the
+ * current transcript with the loading surface.
+ *
+ * Profile switches mutate the active backend profile in place, so the old
+ * transcript stops being authoritative as soon as activation begins.
+ * Connection switches are deliberately two-phase: their pre-dial keeps the
+ * current source fully usable. Do not flash a loader until the commit has
+ * applied the matching automatic isolation draft; unrelated or stale draft
+ * provenance must never blank the visible conversation.
+ */
+export function shouldShowConversationRestoreLoading(input: {
+  primary: boolean
+  provenance: AppliedFreshDraftProvenance | null
+  restore: ProfileConversationRestoreRequest | null
+}): boolean {
+  if (!input.primary || !input.restore) {
+    return false
+  }
+
+  if (input.restore.origin === 'profile-switch') {
+    return true
+  }
+
+  return (
+    input.restore.phase !== 'activating' &&
+    input.provenance?.kind === 'automatic' &&
+    input.provenance.cause === 'connection-switch' &&
+    input.provenance.restoreSequence === input.restore.sequence
+  )
+}
+
 /**
  * Whether the empty-chat intro splash renders.
  *

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,19 +1,38 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
-import { _resetLegacyDiscardForTests } from '@/store/session'
+import { gatewayActivationEpoch } from '@/store/gateway'
+import {
+  $appliedFreshDraftProvenance,
+  $profileConversationRestore,
+  _resetProfileConversationRestoreForTests,
+  applyFreshDraftProvenance,
+  beginProfileConversationRestore,
+  commitProfileConversationRestore
+} from '@/store/profile-conversation-restore'
+import { _resetLegacyDiscardForTests, getRememberedConversation, setRememberedConversation } from '@/store/session'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
+import type { HermesConnection } from '@/global'
 
 import { makeSessionInfo } from '../../../test/session-info'
 
-import { useDesktopIntegrations } from './use-desktop-integrations'
+import { type ConversationRestoreScope, useDesktopIntegrations } from './use-desktop-integrations'
 
 // Mutable HUD-window flag so the restore tests can flip the window kind the
 // hook believes it runs in. Default false keeps the pre-existing restore
 // coverage exercising the real main-window path.
-const { hudWindowMock } = vi.hoisted(() => ({ hudWindowMock: vi.fn(() => false) }))
+const { hudWindowMock, publishRestoreMock, restoreLookupMock } = vi.hoisted(() => ({
+  hudWindowMock: vi.fn(() => false),
+  publishRestoreMock: vi.fn(),
+  restoreLookupMock: vi.fn()
+}))
+
+vi.mock('../../session/hooks/use-session-actions/utils', () => ({
+  publishResolvedSessionForRestore: publishRestoreMock,
+  resolveStoredSessionForRestore: restoreLookupMock
+}))
 
 vi.mock('@/store/mcp-deeplink-install', () => ({
   requestMcpInstallFromDeepLink: vi.fn()
@@ -46,6 +65,10 @@ describe('useDesktopIntegrations', () => {
   beforeEach(() => {
     window.localStorage.clear()
     _resetLegacyDiscardForTests()
+    _resetProfileConversationRestoreForTests()
+    publishRestoreMock.mockReset()
+    restoreLookupMock.mockReset()
+    restoreLookupMock.mockResolvedValue({ status: 'found', session: session() })
     vi.mocked(requestMcpInstallFromDeepLink).mockClear()
     navigate = vi.fn()
     // Every test starts as a main window; only the HUD describe flips this.
@@ -68,6 +91,7 @@ describe('useDesktopIntegrations', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     if (initialHermesDesktop) {
       desktopWindow.hermesDesktop = initialHermesDesktop
     }
@@ -79,7 +103,7 @@ describe('useDesktopIntegrations', () => {
     activeProfile = 'default',
     locationPathname = '/',
     profileReady = false,
-    resumeExhaustedSessionId = null as string | null,
+    restoreScopeOverride = undefined as ConversationRestoreScope | undefined,
     routedSessionId = null as string | null,
     sessions = [] as readonly SessionInfo[]
   } = {}) {
@@ -88,36 +112,47 @@ describe('useDesktopIntegrations', () => {
         activeProfile,
         locationPathname,
         profileReady,
-        resumeExhaustedSessionId,
+        restoreScopeOverride,
         routedSessionId,
         sessions
       }: {
         activeProfile: string
         locationPathname: string
         profileReady: boolean
-        resumeExhaustedSessionId: string | null
+        restoreScopeOverride?: ConversationRestoreScope
         routedSessionId: string | null
         sessions: readonly SessionInfo[]
       }) =>
         useDesktopIntegrations({
+          activeSessionId: null,
           activeProfile,
           chatOpen: false,
+          creatingSessionRef: { current: false },
+          gatewayState: 'open',
           hasPreview: false,
           locationPathname,
           navigate,
           profileReady,
           refreshSessions: vi.fn(),
-          resumeExhaustedSessionId,
           routedSessionId,
+          restoreScope: restoreScopeOverride ?? {
+            activationEpoch: gatewayActivationEpoch(),
+            connection: { mode: 'local', profile: activeProfile } as HermesConnection,
+            connectionId: null,
+            gatewayScope: `\0${activeProfile}`,
+            profile: activeProfile,
+            storageSuffix: ''
+          },
           runtimeIdByStoredSessionId: { current: new Map() },
-          sessions
+          sessions,
+          selectedStoredSessionId: null
         }),
       {
         initialProps: {
           activeProfile,
           locationPathname,
           profileReady,
-          resumeExhaustedSessionId,
+          restoreScopeOverride,
           routedSessionId,
           sessions
         }
@@ -137,17 +172,17 @@ describe('useDesktopIntegrations', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
-    it('restores on profileReady when remembered route exists and owns the session', () => {
+    it('restores on profileReady when the authoritative lookup finds the remembered route', async () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/remembered-session')
 
       const sessions = [session({ id: 'remembered-session', profile: 'default' })]
 
       render({ profileReady: true, sessions })
 
-      expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true })
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true }))
     })
 
-    it('restores remembered session id when no remembered route exists', () => {
+    it('restores remembered session id when no remembered route exists', async () => {
       window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
 
       const sessions = [session({ id: 'remembered-session', profile: 'default' })]
@@ -155,40 +190,40 @@ describe('useDesktopIntegrations', () => {
       render({ profileReady: true, sessions })
 
       // sessionRoute('remembered-session') = '/remembered-session'
-      expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true })
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true }))
     })
 
-    it('waits for sessions before validating a remembered session route', () => {
+    it('preserves the remembered route when authoritative lookup is inconclusive', async () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/remembered-session')
 
-      const result = render({ profileReady: true, sessions: [] })
+      restoreLookupMock.mockResolvedValue({ status: 'inconclusive', reason: 'network' })
+      vi.useFakeTimers()
+      render({ profileReady: true, sessions: [] })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500)
+      })
 
       expect(navigate).not.toHaveBeenCalled()
       expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBe('/remembered-session')
-
-      result.rerender({
-        activeProfile: 'default',
-        locationPathname: '/',
-        profileReady: true,
-        resumeExhaustedSessionId: null,
-        routedSessionId: null,
-        sessions: [session({ id: 'remembered-session', profile: 'default' })]
-      })
-
-      expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true })
     })
   })
 
   describe('ownership validation', () => {
-    it('refuses to restore a session route owned by another profile', () => {
+    it('refuses to restore when exact lookup reports a conflicting owner', async () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/ai-session')
 
       const sessions = [session({ id: 'ai-session', profile: 'ai-engineer' })]
 
-      // The route belongs to ai-engineer; active profile is default.
-      // No navigation should happen — wrong owner.
+      restoreLookupMock.mockResolvedValue({
+        status: 'inconclusive',
+        reason: 'session response belongs to another connection'
+      })
+      vi.useFakeTimers()
       render({ activeProfile: 'default', profileReady: true, sessions })
-
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500)
+      })
       expect(navigate).not.toHaveBeenCalled()
     })
 
@@ -204,7 +239,7 @@ describe('useDesktopIntegrations', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
-    it('clears stale remembered route owned by wrong profile', () => {
+    it('restores a remembered route owned by the active profile', async () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.ai-engineer', '/ai-session')
 
       const sessions = [session({ id: 'ai-session', profile: 'ai-engineer' })]
@@ -212,12 +247,12 @@ describe('useDesktopIntegrations', () => {
       render({ activeProfile: 'ai-engineer', profileReady: true, sessions })
 
       // The route and session match the active profile — should restore.
-      expect(navigate).toHaveBeenCalledWith('/ai-session', { replace: true })
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/ai-session', { replace: true }))
     })
   })
 
   describe('two profiles with distinct sessions', () => {
-    it('restores profile A session when profile A is active', () => {
+    it('restores profile A session when profile A is active', async () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.coder', '/coder-session')
 
       const sessions = [
@@ -227,7 +262,7 @@ describe('useDesktopIntegrations', () => {
 
       render({ activeProfile: 'coder', profileReady: true, sessions })
 
-      expect(navigate).toHaveBeenCalledWith('/coder-session', { replace: true })
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/coder-session', { replace: true }))
     })
 
     it('does NOT bleed profile A session into profile B', () => {
@@ -328,7 +363,7 @@ describe('useDesktopIntegrations', () => {
         activeProfile: 'ops',
         locationPathname: '/ops-session',
         profileReady: true,
-        resumeExhaustedSessionId: null,
+        restoreScopeOverride: undefined,
         routedSessionId: 'ops-session',
         sessions
       })
@@ -394,7 +429,7 @@ describe('useDesktopIntegrations', () => {
         activeProfile: 'default',
         locationPathname: '/settings',
         profileReady: true,
-        resumeExhaustedSessionId: null,
+        restoreScopeOverride: undefined,
         routedSessionId: null,
         sessions: []
       })
@@ -404,58 +439,15 @@ describe('useDesktopIntegrations', () => {
     })
   })
 
-  describe('exhausted session cleanup', () => {
-    it('clears remembered session id when the exhausted session matches', () => {
+  describe('resume exhaustion persistence', () => {
+    it('preserves rollback navigation because generic exhaustion is not authoritative deletion proof', () => {
       window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'exhausted')
-
-      const sessions = [session({ id: 'exhausted', profile: 'default' })]
-
-      render({
-        profileReady: true,
-        resumeExhaustedSessionId: 'exhausted',
-        sessions
-      })
-
-      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
-    })
-
-    it('clears remembered route when it carries the exhausted session', () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/exhausted')
 
-      const sessions = [session({ id: 'exhausted', profile: 'default' })]
+      render({ profileReady: true, sessions: [session({ id: 'exhausted', profile: 'default' })] })
 
-      render({
-        profileReady: true,
-        resumeExhaustedSessionId: 'exhausted',
-        sessions
-      })
-
-      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBeNull()
-    })
-
-    it('does NOT clear exhausted when profileReady is false', () => {
-      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'exhausted')
-
-      render({
-        profileReady: false,
-        resumeExhaustedSessionId: 'exhausted',
-        sessions: []
-      })
-
-      // profileReady=false gates the cleanup effect.
       expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBe('exhausted')
-    })
-
-    it('does NOT clear remembered state when exhausted id does not match', () => {
-      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'other-session')
-
-      render({
-        profileReady: true,
-        resumeExhaustedSessionId: 'exhausted',
-        sessions: [session({ id: 'other-session', profile: 'default' })]
-      })
-
-      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBe('other-session')
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBe('/exhausted')
     })
   })
 
@@ -509,6 +501,254 @@ describe('useDesktopIntegrations', () => {
       deepLink?.({ kind: 'mcp', name: 'install', params: { name: 'context7' } })
       expect(requestMcpInstallFromDeepLink).toHaveBeenCalledWith({ name: 'context7' })
       expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('profile conversation restore transaction', () => {
+    it('restores a committed automatic draft through the authoritative lookup without overwriting memory', async () => {
+      setRememberedConversation({ kind: 'session', sessionId: 'work-last', version: 1 }, 'work')
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: sequence
+      })
+      restoreLookupMock.mockResolvedValueOnce({
+        status: 'found',
+        session: session({ id: 'work-last', profile: 'work' })
+      })
+
+      render({ activeProfile: 'work', profileReady: true })
+
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/work-last', { replace: true }))
+      expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'work-last', version: 1 })
+      expect($profileConversationRestore.get()).toMatchObject({ phase: 'navigating', sequence })
+    })
+
+    it('treats the explicit local descriptor as the same owner as a profile-door target', async () => {
+      setRememberedConversation({ kind: 'session', sessionId: 'local-last', version: 1 }, 'work')
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: sequence
+      })
+      restoreLookupMock.mockResolvedValueOnce({
+        status: 'found',
+        session: session({ connection_id: 'local', id: 'local-last', profile: 'work' })
+      })
+
+      render({
+        activeProfile: 'work',
+        profileReady: true,
+        restoreScopeOverride: {
+          activationEpoch: gatewayActivationEpoch(),
+          connection: {
+            connectionId: 'local',
+            mode: 'local'
+          } as HermesConnection,
+          connectionId: 'local',
+          gatewayScope: `local\0work`,
+          profile: 'work',
+          storageSuffix: ''
+        }
+      })
+
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/local-last', { replace: true }))
+      expect(restoreLookupMock).toHaveBeenCalledWith('local-last', {
+        connectionId: 'local',
+        profile: 'work',
+        storageSuffix: ''
+      })
+    })
+
+    it('rejects an explicit conflicting profile on the local descriptor', async () => {
+      vi.useFakeTimers()
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: sequence
+      })
+
+      render({
+        activeProfile: 'work',
+        profileReady: true,
+        restoreScopeOverride: {
+          activationEpoch: gatewayActivationEpoch(),
+          connection: {
+            connectionId: 'local',
+            mode: 'local',
+            profile: 'previous'
+          } as HermesConnection,
+          connectionId: 'local',
+          gatewayScope: `local\0work`,
+          profile: 'work',
+          storageSuffix: ''
+        }
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500)
+      })
+
+      expect(restoreLookupMock).not.toHaveBeenCalled()
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('rejects a retained registry descriptor for a true null/profile-door target', async () => {
+      vi.useFakeTimers()
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: sequence
+      })
+
+      render({
+        activeProfile: 'work',
+        profileReady: true,
+        restoreScopeOverride: {
+          activationEpoch: gatewayActivationEpoch(),
+          connection: {
+            connectionId: 'previous-source',
+            mode: 'remote',
+            profile: 'work',
+            registryScoped: true
+          } as HermesConnection,
+          connectionId: 'previous-source',
+          gatewayScope: `previous-source\0work`,
+          profile: 'work',
+          storageSuffix: ''
+        }
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500)
+      })
+
+      expect(restoreLookupMock).not.toHaveBeenCalled()
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('durably records an explicit blank while an automatic isolation blank remains non-durable', async () => {
+      applyFreshDraftProvenance({ cause: 'profile-switch', freshSequence: 1, kind: 'automatic' })
+      const automatic = render({ activeProfile: 'work', profileReady: true })
+
+      expect(getRememberedConversation('work')).toBeNull()
+      automatic.unmount()
+
+      applyFreshDraftProvenance({ cause: 'new-chat', freshSequence: 2, kind: 'explicit' })
+      render({ activeProfile: 'work', profileReady: true })
+
+      await waitFor(() => expect(getRememberedConversation('work')).toEqual({ kind: 'blank', version: 1 }))
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.work')).toBeNull()
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.work')).toBe('/')
+    })
+
+    it('bounds inconclusive retries to 500/1000ms and preserves the remembered session', async () => {
+      vi.useFakeTimers()
+      setRememberedConversation({ kind: 'session', sessionId: 'retry-me', version: 1 }, 'work')
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: sequence
+      })
+      restoreLookupMock.mockResolvedValue({ status: 'inconclusive', reason: 'network' })
+
+      render({ activeProfile: 'work', profileReady: true })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500)
+      })
+
+      expect(restoreLookupMock).toHaveBeenCalledTimes(3)
+      expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'retry-me', version: 1 })
+      expect($profileConversationRestore.get()).toBeNull()
+      expect(vi.getTimerCount()).toBe(0)
+      vi.useRealTimers()
+    })
+
+    it('lets a rapid B to C switch strand B lookup completion so only C navigates', async () => {
+      setRememberedConversation({ kind: 'session', sessionId: 'b-last', version: 1 }, 'b')
+      setRememberedConversation({ kind: 'session', sessionId: 'c-last', version: 1 }, 'c')
+      let resolveB!: (value: unknown) => void
+      const pendingB = new Promise(resolve => {
+        resolveB = resolve
+      })
+      restoreLookupMock
+        .mockImplementationOnce(() => pendingB)
+        .mockResolvedValueOnce({ status: 'found', session: session({ id: 'c-last', profile: 'c' }) })
+
+      const b = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'b' })
+      commitProfileConversationRestore(b)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 1,
+        kind: 'automatic',
+        restoreSequence: b
+      })
+      const result = render({ activeProfile: 'b', profileReady: true })
+      await waitFor(() => expect(restoreLookupMock).toHaveBeenCalledTimes(1))
+
+      const c = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'c' })
+      commitProfileConversationRestore(c)
+      applyFreshDraftProvenance({
+        cause: 'profile-switch',
+        freshSequence: 2,
+        kind: 'automatic',
+        restoreSequence: c
+      })
+      result.rerender({
+        activeProfile: 'c',
+        locationPathname: '/',
+        profileReady: true,
+        restoreScopeOverride: undefined,
+        routedSessionId: null,
+        sessions: []
+      })
+
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith('/c-last', { replace: true }))
+      await act(async () => {
+        resolveB({ status: 'found', session: session({ id: 'b-last', profile: 'b' }) })
+        await pendingB
+      })
+      expect(navigate).not.toHaveBeenCalledWith('/b-last', expect.anything())
+      expect(publishRestoreMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'b-last' }),
+        'b-last',
+        expect.anything()
+      )
+    })
+
+    it('cancels a pending restore before explicit notification navigation', () => {
+      const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+      commitProfileConversationRestore(sequence)
+      let activate: ((payload: { activate?: string; notifyId: string }) => void) | undefined
+      desktopWindow.hermesDesktop = {
+        ...desktopWindow.hermesDesktop,
+        onNotificationActivate: (
+          cb: (payload: { actionId?: string; activate?: string; notifyId?: string; tag?: string }) => void
+        ) => {
+          activate = cb
+          return () => undefined
+        }
+      } as unknown as Window['hermesDesktop']
+
+      render({ activeProfile: 'work', profileReady: true })
+      activate?.({ activate: '/skills', notifyId: 'n1' })
+      expect($profileConversationRestore.get()).toBeNull()
+      expect(navigate).toHaveBeenCalledWith('/skills')
     })
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -560,7 +560,12 @@ describe('useDesktopIntegrations', () => {
 
       await waitFor(() => expect(navigate).toHaveBeenCalledWith('/local-last', { replace: true }))
       expect(restoreLookupMock).toHaveBeenCalledWith('local-last', {
-        connectionId: 'local',
+        connectionId: null,
+        profile: 'work',
+        storageSuffix: ''
+      })
+      expect(publishRestoreMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'local-last' }), 'local-last', {
+        connectionId: null,
         profile: 'work',
         storageSuffix: ''
       })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -51,7 +51,8 @@ import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionR
 import {
   publishResolvedSessionForRestore,
   resolveStoredSessionForRestore,
-  type RestoreLookupResult
+  type RestoreLookupResult,
+  type RestoreLookupTarget
 } from '../../session/hooks/use-session-actions/utils'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'connection_id' | 'id' | 'profile'>
@@ -108,7 +109,7 @@ function restoreDelay(control: RestoreAttemptControl, milliseconds: number): Pro
 
 async function resolveRememberedConversation(
   sessionId: string,
-  scope: ConversationRestoreScope,
+  target: RestoreLookupTarget,
   control: RestoreAttemptControl,
   isValid: () => boolean
 ): Promise<RestoreLookupResult | null> {
@@ -124,11 +125,7 @@ async function resolveRememberedConversation(
       return null
     }
 
-    last = await resolveStoredSessionForRestore(sessionId, {
-      connectionId: scope.connectionId,
-      profile: scope.profile,
-      storageSuffix: scope.storageSuffix
-    })
+    last = await resolveStoredSessionForRestore(sessionId, target)
 
     if (control.cancelled || !isValid() || last.status !== 'inconclusive') {
       return control.cancelled || !isValid() ? null : last
@@ -383,7 +380,12 @@ export function useDesktopIntegrations({
       }
 
       const valid = () => exactScopeStillCurrent(captured) && !$profileConversationRestore.get()
-      const result = await resolveRememberedConversation(candidate, captured, control, valid)
+      const lookupTarget: RestoreLookupTarget = {
+        connectionId: captured.connectionId,
+        profile: captured.profile,
+        storageSuffix: captured.storageSuffix
+      }
+      const result = await resolveRememberedConversation(candidate, lookupTarget, control, valid)
 
       if (!result || !valid()) {
         return
@@ -392,7 +394,7 @@ export function useDesktopIntegrations({
       restoredRef.current = true
 
       if (result.status === 'found') {
-        publishResolvedSessionForRestore(result.session, candidate, captured)
+        publishResolvedSessionForRestore(result.session, candidate, lookupTarget)
         setRememberedConversation({ kind: 'session', sessionId: candidate, version: 1 }, captured.profile)
         requestSessionResume(candidate, result.ownerRoute, { forceCold: true })
         clearAppliedFreshDraftProvenance()
@@ -479,7 +481,12 @@ export function useDesktopIntegrations({
       }
 
       const candidate = remembered.sessionId
-      const result = await resolveRememberedConversation(candidate, captured, control, valid)
+      const lookupTarget: RestoreLookupTarget = {
+        connectionId: request.target.connectionId,
+        profile: normalizeProfileKey(request.target.profile),
+        storageSuffix: captured.storageSuffix
+      }
+      const result = await resolveRememberedConversation(candidate, lookupTarget, control, valid)
 
       if (!result || !valid()) {
         return
@@ -490,7 +497,7 @@ export function useDesktopIntegrations({
           return
         }
 
-        publishResolvedSessionForRestore(result.session, candidate, captured)
+        publishResolvedSessionForRestore(result.session, candidate, lookupTarget)
         setRememberedConversation({ kind: 'session', sessionId: candidate, version: 1 }, captured.profile)
         requestSessionResume(candidate, result.ownerRoute, { forceCold: true })
         navigate(sessionRoute(candidate), { replace: true })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,4 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useStore } from '@nanostores/react'
+import { LOCAL_CONNECTION_ID, type ConnectionState } from '@hermes/shared'
+import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
@@ -6,6 +8,8 @@ import { openSession } from '@/app/open-session'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
 import { pathFromHermesDeepLink, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
+import { activeConnectionScopeSuffix } from '@/lib/connection-scoped'
+import { gatewayActivationEpoch } from '@/store/gateway'
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
 import { startMcpHealthChecker, stopMcpHealthChecker } from '@/store/mcp-health'
 import {
@@ -16,35 +20,182 @@ import {
 } from '@/store/native-notifications'
 import { openPluginInstallRequest } from '@/store/plugin-install-request'
 import { openFolderAsProject } from '@/store/projects'
+import { normalizeProfileKey } from '@/store/profile'
 import {
+  $appliedFreshDraftProvenance,
+  $profileConversationRestore,
+  cancelProfileConversationRestore,
+  clearAppliedFreshDraftProvenance,
+  completeProfileConversationRestore,
+  isCurrentProfileConversationRestore,
+  markProfileConversationRestoreNavigating,
+  type ProfileConversationRestoreRequest
+} from '@/store/profile-conversation-restore'
+import {
+  clearRememberedConversationIfSession,
+  getRememberedConversation,
   getRememberedRoute,
-  getRememberedSessionId,
+  requestSessionResume,
   sessionBelongsToProfile,
-  setRememberedRoute,
-  setRememberedSessionId
+  setRememberedConversation,
+  setRememberedRoute
 } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
 import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
+import type { HermesConnection } from '@/global'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
+import {
+  publishResolvedSessionForRestore,
+  resolveStoredSessionForRestore,
+  type RestoreLookupResult
+} from '../../session/hooks/use-session-actions/utils'
 
-type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
+type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'connection_id' | 'id' | 'profile'>
+
+export interface ConversationRestoreScope {
+  activationEpoch: number
+  connection: HermesConnection | null
+  connectionId: null | string
+  gatewayScope: string
+  profile: string
+  storageSuffix: string
+}
 
 interface DesktopIntegrationsParams {
+  activeSessionId: null | string
   activeProfile: string
   chatOpen: boolean
+  creatingSessionRef: MutableRefObject<boolean>
+  gatewayState: ConnectionState
   hasPreview: boolean
   locationPathname: string
   navigate: (to: string, options?: { replace?: boolean }) => void
   profileReady: boolean
   refreshSessions: () => Promise<unknown> | unknown
-  resumeExhaustedSessionId: null | string
   routedSessionId: null | string
+  restoreScope: ConversationRestoreScope
   runtimeIdByStoredSessionId: { readonly current: Map<string, string> }
   sessions: readonly RememberedSession[]
+  selectedStoredSessionId: null | string
+}
+
+interface RestoreAttemptControl {
+  cancelled: boolean
+  timers: Set<ReturnType<typeof setTimeout>>
+}
+
+function cancelRestoreAttempt(control: RestoreAttemptControl): void {
+  control.cancelled = true
+  for (const timer of control.timers) {
+    clearTimeout(timer)
+  }
+  control.timers.clear()
+}
+
+function restoreDelay(control: RestoreAttemptControl, milliseconds: number): Promise<void> {
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      control.timers.delete(timer)
+      resolve()
+    }, milliseconds)
+    control.timers.add(timer)
+  })
+}
+
+async function resolveRememberedConversation(
+  sessionId: string,
+  scope: ConversationRestoreScope,
+  control: RestoreAttemptControl,
+  isValid: () => boolean
+): Promise<RestoreLookupResult | null> {
+  const delays = [0, 500, 1_000]
+  let last: RestoreLookupResult | null = null
+
+  for (let attempt = 0; attempt < delays.length; attempt += 1) {
+    if (attempt > 0) {
+      await restoreDelay(control, delays[attempt])
+    }
+
+    if (control.cancelled || !isValid()) {
+      return null
+    }
+
+    last = await resolveStoredSessionForRestore(sessionId, {
+      connectionId: scope.connectionId,
+      profile: scope.profile,
+      storageSuffix: scope.storageSuffix
+    })
+
+    if (control.cancelled || !isValid() || last.status !== 'inconclusive') {
+      return control.cancelled || !isValid() ? null : last
+    }
+  }
+
+  return last
+}
+
+function scopeMatchesRequest(scope: ConversationRestoreScope, request: ProfileConversationRestoreRequest): boolean {
+  const profile = normalizeProfileKey(scope.profile)
+  const descriptorProfile = scope.connection?.profile?.trim()
+
+  if (
+    scope.gatewayScope !== `${scope.connectionId ?? ''}\0${profile}` ||
+    profile !== normalizeProfileKey(request.target.profile) ||
+    (descriptorProfile && normalizeProfileKey(descriptorProfile) !== profile) ||
+    scope.storageSuffix !== activeConnectionScopeSuffix()
+  ) {
+    return false
+  }
+
+  if (request.target.connectionId) {
+    return (
+      scope.connectionId === request.target.connectionId &&
+      scope.connection?.connectionId === request.target.connectionId &&
+      scope.connection.registryScoped === true
+    )
+  }
+
+  // A profile-door activation is represented as null by the restore request,
+  // while the main process stamps the live local descriptor with the explicit
+  // `local` registry id. They are the same owner. Still fail closed for any
+  // retained remote/registry descriptor from the previously active source.
+  const scopeConnectionId = scope.connectionId?.trim() || null
+  const descriptorConnectionId = scope.connection?.connectionId?.trim() || null
+  const localDoor = (value: null | string) => value === null || value === LOCAL_CONNECTION_ID
+
+  return localDoor(scopeConnectionId) && localDoor(descriptorConnectionId) && scope.connection?.registryScoped !== true
+}
+
+function scopeDescriptorIsSettled(scope: ConversationRestoreScope): boolean {
+  const profile = normalizeProfileKey(scope.profile)
+  const descriptorProfile = scope.connection?.profile?.trim()
+
+  return (
+    scope.gatewayScope === `${scope.connectionId ?? ''}\0${profile}` &&
+    (!descriptorProfile || normalizeProfileKey(descriptorProfile) === profile) &&
+    (scope.connectionId
+      ? scope.connection?.connectionId === scope.connectionId
+      : !scope.connection?.connectionId && scope.connection?.registryScoped !== true) &&
+    scope.storageSuffix === activeConnectionScopeSuffix()
+  )
+}
+
+function sessionOwnedByScope(
+  sessions: readonly RememberedSession[],
+  sessionId: string,
+  scope: ConversationRestoreScope
+): boolean {
+  return sessions.some(row => {
+    const identityMatches = row.id === sessionId || (row._lineage_root_id ?? row.id) === sessionId
+    const profileMatches = normalizeProfileKey(row.profile) === normalizeProfileKey(scope.profile)
+    const connectionMatches = scope.connectionId ? row.connection_id === scope.connectionId : !row.connection_id
+
+    return identityMatches && profileMatches && connectionMatches
+  })
 }
 
 /**
@@ -55,15 +206,19 @@ interface DesktopIntegrationsParams {
  * "talks to the desktop shell" surface reads as one unit.
  */
 export function useDesktopIntegrations({
+  activeSessionId,
   activeProfile,
+  creatingSessionRef,
+  gatewayState,
   locationPathname,
   navigate,
   profileReady,
   refreshSessions,
-  resumeExhaustedSessionId,
   routedSessionId,
+  restoreScope,
   runtimeIdByStoredSessionId,
-  sessions
+  sessions,
+  selectedStoredSessionId
 }: DesktopIntegrationsParams): void {
   // Update polling — populates $desktopVersion/$updateStatus, which feed the
   // statusbar version pill and the update toasts. Also honors the main
@@ -89,95 +244,345 @@ export function useDesktopIntegrations({
     window.hermesDesktop?.setPreviewShortcutActive?.(true)
   }, [])
 
+  const restoreRequest = useStore($profileConversationRestore)
+  const appliedProvenance = useStore($appliedFreshDraftProvenance)
   const restoredRef = useRef(false)
+  const latestRef = useRef({
+    activeSessionId,
+    appliedProvenance,
+    creatingSessionRef,
+    gatewayState,
+    locationPathname,
+    restoreRequest,
+    restoreScope,
+    selectedStoredSessionId
+  })
 
-  // Wait until boot has adopted the primary profile, then restore that profile's
-  // navigation exactly once. The same effect owns subsequent writes so the
-  // initial `/` cannot overwrite remembered history before it is read.
-  // This ref is a one-time lifecycle latch, not a mirror of reactive atom state.
-  // eslint-disable-next-line no-restricted-syntax
+  latestRef.current = {
+    activeSessionId,
+    appliedProvenance,
+    creatingSessionRef,
+    gatewayState,
+    locationPathname,
+    restoreRequest,
+    restoreScope,
+    selectedStoredSessionId
+  }
+
+  // A pathname change is a backup cancellation boundary. Real user actions
+  // cancel synchronously at their open/navigation/submit door; this observer
+  // catches browser/deep-link paths while recognizing the route owned by a
+  // restore transaction itself.
+  useEffect(() => {
+    const current = $profileConversationRestore.get()
+
+    if (!current) {
+      if (locationPathname !== NEW_CHAT_ROUTE) {
+        clearAppliedFreshDraftProvenance()
+      }
+      return
+    }
+
+    if (current.phase === 'navigating' && routeSessionId(locationPathname) === current.sessionId) {
+      clearAppliedFreshDraftProvenance()
+      completeProfileConversationRestore(current.sequence)
+      return
+    }
+
+    const provenance = $appliedFreshDraftProvenance.get()
+    const ownsBlank =
+      provenance?.kind === 'automatic' &&
+      provenance.restoreSequence === current.sequence &&
+      locationPathname === NEW_CHAT_ROUTE
+
+    if (
+      (current.phase === 'activating' || current.phase === 'committed' || current.phase === 'navigating') &&
+      !ownsBlank
+    ) {
+      cancelProfileConversationRestore(current.sequence, 'pathname-changed')
+      clearAppliedFreshDraftProvenance()
+    }
+  }, [locationPathname])
+
+  // Cold restore and live restore share one cancellation boundary through this
+  // dependency: beginning any live request tears down the cold attempt before
+  // it can publish navigation. Cold retains the historic non-overlay route
+  // policy; live switching restores conversations only.
   useEffect(() => {
     if (!profileReady || isHudWindow() || isBrowserWindow()) {
       return
     }
 
-    if (!restoredRef.current) {
-      // Only cold-start navigation at the default route is replaceable; a deep
-      // link or hidden-then-shown window keeps its explicit destination.
-      if (locationPathname === NEW_CHAT_ROUTE) {
-        const route = getRememberedRoute(activeProfile)
-        const routeSession = route ? routeSessionId(route) : null
-        const last = getRememberedSessionId(activeProfile)
+    const control: RestoreAttemptControl = { cancelled: false, timers: new Set() }
+    const live = restoreRequest
 
-        const restorableNonSessionRoute =
-          !!route && route !== NEW_CHAT_ROUTE && !routeSession && !isOverlayView(appViewForPath(route))
+    const exactScopeStillCurrent = (captured: ConversationRestoreScope): boolean => {
+      const latest = latestRef.current
 
-        // Boot adoption can publish renderer.ready before its async session
-        // refresh completes. Keep the restore latch open until ownership can be
-        // decided; treating an unloaded list as authoritative would erase valid
-        // remembered navigation permanently.
-        if (sessions.length === 0 && !restorableNonSessionRoute && (routeSession || last)) {
-          return
-        }
+      return (
+        !control.cancelled &&
+        latest.gatewayState === 'open' &&
+        latest.restoreScope.activationEpoch === captured.activationEpoch &&
+        latest.restoreScope.connectionId === captured.connectionId &&
+        latest.restoreScope.gatewayScope === captured.gatewayScope &&
+        latest.restoreScope.profile === captured.profile &&
+        latest.restoreScope.storageSuffix === captured.storageSuffix &&
+        activeConnectionScopeSuffix() === captured.storageSuffix
+      )
+    }
 
+    const runColdRestore = async () => {
+      if (restoredRef.current) {
+        return
+      }
+
+      if (locationPathname !== NEW_CHAT_ROUTE) {
         restoredRef.current = true
+        return
+      }
 
-        if (
-          route &&
-          route !== NEW_CHAT_ROUTE &&
-          !isOverlayView(appViewForPath(route)) &&
-          (!routeSession || sessionBelongsToProfile(sessions, routeSession, activeProfile))
-        ) {
-          navigate(route, { replace: true })
+      const captured = restoreScope
 
-          return
+      if (
+        gatewayState !== 'open' ||
+        captured.activationEpoch !== gatewayActivationEpoch() ||
+        !scopeDescriptorIsSettled(captured)
+      ) {
+        return
+      }
+
+      const rememberedRoute = getRememberedRoute(captured.profile)
+      const rememberedRouteSession = rememberedRoute ? routeSessionId(rememberedRoute) : null
+      const restorablePage =
+        !!rememberedRoute &&
+        rememberedRoute !== NEW_CHAT_ROUTE &&
+        !rememberedRouteSession &&
+        !isOverlayView(appViewForPath(rememberedRoute))
+
+      if (restorablePage) {
+        if (exactScopeStillCurrent(captured) && !$profileConversationRestore.get()) {
+          restoredRef.current = true
+          clearAppliedFreshDraftProvenance()
+          navigate(rememberedRoute, { replace: true })
         }
+        return
+      }
 
-        // A remembered route carried a session id we can no longer validate —
-        // clear the stale entry so the next cold start won't re-try it.
-        if (routeSession) {
-          setRememberedRoute(null, activeProfile)
-        }
+      const remembered = getRememberedConversation(captured.profile)
 
-        if (last && sessionBelongsToProfile(sessions, last, activeProfile)) {
-          navigate(sessionRoute(last), { replace: true })
+      if (remembered?.kind === 'blank') {
+        restoredRef.current = true
+        return
+      }
 
-          return
-        }
+      const candidate = remembered?.kind === 'session' ? remembered.sessionId : null
 
-        if (last) {
-          setRememberedSessionId(null, activeProfile)
-        }
+      if (!candidate) {
+        restoredRef.current = true
+        return
+      }
+
+      const valid = () => exactScopeStillCurrent(captured) && !$profileConversationRestore.get()
+      const result = await resolveRememberedConversation(candidate, captured, control, valid)
+
+      if (!result || !valid()) {
+        return
+      }
+
+      restoredRef.current = true
+
+      if (result.status === 'found') {
+        publishResolvedSessionForRestore(result.session, candidate, captured)
+        setRememberedConversation({ kind: 'session', sessionId: candidate, version: 1 }, captured.profile)
+        requestSessionResume(candidate, result.ownerRoute, { forceCold: true })
+        clearAppliedFreshDraftProvenance()
+        navigate(sessionRoute(candidate), { replace: true })
+      } else if (result.status === 'not-found') {
+        clearRememberedConversationIfSession(captured.profile, candidate)
       } else {
-        restoredRef.current = true
+        console.warn(
+          `[desktop] remembered conversation lookup remained inconclusive for ${captured.gatewayScope}`,
+          result.reason
+        )
       }
     }
 
-    // Remember the open chat (session id for notifications/resume) AND the last
-    // non-overlay route (a page like /skills, or a session route) per profile.
-    // Session-shaped routes require an explicit matching owner; unresolved and
-    // wrong-profile rows must not replace known-safe navigation.
-    if (routedSessionId && sessionBelongsToProfile(sessions, routedSessionId, activeProfile)) {
-      setRememberedSessionId(routedSessionId, activeProfile)
-      setRememberedRoute(locationPathname, activeProfile)
-    } else if (!routedSessionId && !isOverlayView(appViewForPath(locationPathname))) {
-      setRememberedRoute(locationPathname, activeProfile)
-    }
-  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, sessions])
+    const runLiveRestore = async (request: ProfileConversationRestoreRequest) => {
+      if (request.phase !== 'committed') {
+        return
+      }
 
+      // Commit and the passive fresh-draft consumer can settle in either order.
+      // Give the exact scope/provenance three bounded opportunities to converge.
+      let captured: ConversationRestoreScope | null = null
+      for (const delay of [0, 500, 1_000]) {
+        if (delay) {
+          await restoreDelay(control, delay)
+        }
+
+        const latest = latestRef.current
+        const current = $profileConversationRestore.get()
+        const provenance = $appliedFreshDraftProvenance.get()
+        const candidateScope = latest.restoreScope
+        const ready =
+          current?.sequence === request.sequence &&
+          current.phase === 'committed' &&
+          latest.gatewayState === 'open' &&
+          candidateScope.activationEpoch === gatewayActivationEpoch() &&
+          scopeMatchesRequest(candidateScope, current) &&
+          provenance?.kind === 'automatic' &&
+          provenance.restoreSequence === request.sequence &&
+          latest.locationPathname === NEW_CHAT_ROUTE &&
+          !latest.activeSessionId &&
+          !latest.selectedStoredSessionId &&
+          !latest.creatingSessionRef.current
+
+        if (ready) {
+          captured = candidateScope
+          break
+        }
+
+        if (control.cancelled || !isCurrentProfileConversationRestore(request.sequence)) {
+          return
+        }
+      }
+
+      if (!captured) {
+        completeProfileConversationRestore(request.sequence)
+        return
+      }
+
+      const valid = () => {
+        const latest = latestRef.current
+        const current = $profileConversationRestore.get()
+        const provenance = $appliedFreshDraftProvenance.get()
+
+        return (
+          exactScopeStillCurrent(captured!) &&
+          current?.sequence === request.sequence &&
+          current.phase === 'committed' &&
+          scopeMatchesRequest(latest.restoreScope, current) &&
+          provenance?.kind === 'automatic' &&
+          provenance.restoreSequence === request.sequence &&
+          latest.locationPathname === NEW_CHAT_ROUTE &&
+          !latest.activeSessionId &&
+          !latest.selectedStoredSessionId &&
+          !latest.creatingSessionRef.current
+        )
+      }
+
+      const remembered = getRememberedConversation(captured.profile)
+
+      if (remembered?.kind === 'blank' || !remembered) {
+        completeProfileConversationRestore(request.sequence)
+        return
+      }
+
+      const candidate = remembered.sessionId
+      const result = await resolveRememberedConversation(candidate, captured, control, valid)
+
+      if (!result || !valid()) {
+        return
+      }
+
+      if (result.status === 'found') {
+        if (!markProfileConversationRestoreNavigating(request.sequence, candidate)) {
+          return
+        }
+
+        publishResolvedSessionForRestore(result.session, candidate, captured)
+        setRememberedConversation({ kind: 'session', sessionId: candidate, version: 1 }, captured.profile)
+        requestSessionResume(candidate, result.ownerRoute, { forceCold: true })
+        navigate(sessionRoute(candidate), { replace: true })
+        return
+      }
+
+      if (result.status === 'not-found') {
+        clearRememberedConversationIfSession(captured.profile, candidate)
+      } else {
+        console.warn(
+          `[desktop] profile conversation restore remained inconclusive for ${captured.gatewayScope}`,
+          result.reason
+        )
+      }
+
+      completeProfileConversationRestore(request.sequence)
+    }
+
+    if (live) {
+      restoredRef.current = true
+      void runLiveRestore(live)
+    } else {
+      void runColdRestore()
+    }
+
+    return () => cancelRestoreAttempt(control)
+  }, [gatewayState, locationPathname, navigate, profileReady, restoreRequest, restoreScope])
+
+  // Persist independently from restoration. The coordinator atom is read
+  // synchronously so an activation cannot slip a transitional old route or `/`
+  // into the target scope before React has painted the new transaction.
   useEffect(() => {
-    if (!profileReady || !resumeExhaustedSessionId) {
+    if (
+      !profileReady ||
+      isHudWindow() ||
+      isBrowserWindow() ||
+      $profileConversationRestore.get() ||
+      gatewayState !== 'open' ||
+      restoreScope.activationEpoch !== gatewayActivationEpoch() ||
+      !scopeDescriptorIsSettled(restoreScope)
+    ) {
       return
     }
 
-    if (getRememberedSessionId(activeProfile) === resumeExhaustedSessionId) {
-      setRememberedSessionId(null, activeProfile)
+    if (
+      routedSessionId &&
+      sessionBelongsToProfile(sessions, routedSessionId, activeProfile) &&
+      sessionOwnedByScope(sessions, routedSessionId, restoreScope)
+    ) {
+      setRememberedConversation({ kind: 'session', sessionId: routedSessionId, version: 1 }, activeProfile)
+      return
     }
 
-    if (routeSessionId(getRememberedRoute(activeProfile) ?? '') === resumeExhaustedSessionId) {
-      setRememberedRoute(null, activeProfile)
+    if (routedSessionId || isOverlayView(appViewForPath(locationPathname))) {
+      return
     }
-  }, [activeProfile, profileReady, resumeExhaustedSessionId])
+
+    const provenance = $appliedFreshDraftProvenance.get()
+
+    if (
+      locationPathname === NEW_CHAT_ROUTE &&
+      !activeSessionId &&
+      !selectedStoredSessionId &&
+      provenance?.kind === 'explicit'
+    ) {
+      setRememberedConversation({ kind: 'blank', version: 1 }, activeProfile)
+      return
+    }
+
+    // `/` has no durable meaning without typed provenance. In particular,
+    // cold restoration starts on `/` and may still be validating a remembered
+    // conversation asynchronously; writing the route here would destroy the
+    // rollback keys on an inconclusive lookup. Only the explicit branch above
+    // is allowed to persist a blank preference.
+    if (locationPathname === NEW_CHAT_ROUTE) {
+      return
+    }
+
+    setRememberedRoute(locationPathname, activeProfile)
+  }, [
+    activeProfile,
+    activeSessionId,
+    appliedProvenance,
+    gatewayState,
+    locationPathname,
+    profileReady,
+    restoreRequest,
+    restoreScope,
+    routedSessionId,
+    selectedStoredSessionId,
+    sessions
+  ])
 
   // Native-notification click -> jump to the session WHERE IT ALREADY IS (open
   // tile / main), else beside what's loaded rather than over it — the click
@@ -224,6 +629,7 @@ export function useDesktopIntegrations({
         const path = resolveHermesOpenPath(payload.activate)
 
         if (path) {
+          cancelProfileConversationRestore(undefined, 'notification-navigation')
           navigate(path)
         }
       }
@@ -288,6 +694,7 @@ export function useDesktopIntegrations({
       const path = pathFromHermesDeepLink(payload.kind, payload.name || '', payload.params || {})
 
       if (path) {
+        cancelProfileConversationRestore(undefined, 'deep-link-navigation')
         navigate(path)
       }
     })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -35,6 +35,7 @@ import { SendDiagnosticsHost } from '@/components/send-diagnostics-dialog'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { activeConnectionScopeSuffix } from '@/lib/connection-scoped'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
@@ -44,11 +45,13 @@ import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
 import { $activeConnectionId } from '@/store/connections'
 import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
+import { $gatewayActivationEpoch } from '@/store/gateway'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
+  $freshSessionIntent,
   $freshSessionRequest,
   $profileScope,
   ALL_PROFILES,
@@ -57,6 +60,7 @@ import {
   normalizeProfileKey,
   refreshActiveProfile
 } from '@/store/profile'
+import { createFreshSessionIntent } from '@/store/profile-conversation-restore'
 import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -187,6 +191,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const actionsRef = useRef<WiringActions | null>(null)
 
   const gatewayState = useStore($gatewayState)
+  const gatewayActivationEpoch = useStore($gatewayActivationEpoch)
   const activeSessionId = useStore($activeSessionId)
   const billingSettingsRequest = useStore($billingSettingsRequest)
   const cronReviewRequest = useStore($cronReviewRequest)
@@ -225,6 +230,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const messagingSessions = useStore($messagingSessions)
   const sessions = useStore($sessions)
   const activeConnectionId = useStore($activeConnectionId)
+  const connection = useStore($connection)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
   const boot = useStore($desktopBoot)
@@ -507,6 +513,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   // A profile switch/create drops to a fresh new-session draft so the
   // previously open session doesn't bleed across contexts. Skip initial value.
+  const freshSessionIntent = useStore($freshSessionIntent)
   const freshSessionRequest = useStore($freshSessionRequest)
   const lastFreshRef = useRef(freshSessionRequest)
 
@@ -517,8 +524,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
-  }, [freshSessionRequest, startFreshSessionDraft])
+
+    if (freshSessionIntent?.sequence === freshSessionRequest) {
+      startFreshSessionDraft({ intent: freshSessionIntent })
+    }
+  }, [freshSessionIntent, freshSessionRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another source or profile must re-pull that
   // source's model/config/profile state. Two sources commonly both expose a
@@ -668,7 +678,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // The global-hotkey Quick Entry window's bridge: its captured text rides the
   // SAME submit machinery the normal composer uses (current chat / picked
   // session / new session), and it hears gateway truth from this window.
-  useQuickEntryBridge({ startFreshSessionDraft, submitText })
+  const startQuickEntryDraft = useCallback(
+    () =>
+      startFreshSessionDraft({
+        intent: createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+      }),
+    [startFreshSessionDraft]
+  )
+
+  useQuickEntryBridge({ startFreshSessionDraft: startQuickEntryDraft, submitText })
 
   // Leaving HUD mode hands this window the session back (see hud/handoff).
   useHudHandoff({ navigate, resumeSession })
@@ -765,7 +783,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             })
           }
         } else if (payload?.start_new_session !== false) {
-          startFreshSessionDraft()
+          startFreshSessionDraft({
+            intent: createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+          })
         }
 
         requestVoiceConversationStart()
@@ -780,7 +800,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   useGatewayBoot({
     beforeConnectionSwitch: () => {
-      startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null })
+      startFreshSessionDraft({
+        intent: createFreshSessionIntent({ cause: 'gateway-transition', persistence: 'automatic' }),
+        preserveRoute: true,
+        workspaceTarget: null
+      })
       resetOverlayReturnRoute()
       resetProjectTreeState()
       closeAllTerminals()
@@ -834,19 +858,34 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // deep links, native-notification nav, preview-shortcut enablement,
   // remembered-session restore, and cross-window session-list sync.
   const previewTarget = useStore($previewTarget)
+  const conversationRestoreScope = useMemo(
+    () => ({
+      activationEpoch: gatewayActivationEpoch,
+      connection,
+      connectionId: activeConnectionId,
+      gatewayScope,
+      profile: normalizeProfileKey(activeGatewayProfile),
+      storageSuffix: activeConnectionScopeSuffix()
+    }),
+    [activeConnectionId, activeGatewayProfile, connection, gatewayActivationEpoch, gatewayScope]
+  )
 
   useDesktopIntegrations({
+    activeSessionId,
     activeProfile: normalizeProfileKey(activeGatewayProfile),
     chatOpen,
+    creatingSessionRef,
+    gatewayState,
     hasPreview: Boolean(previewTarget),
     locationPathname: location.pathname,
     navigate,
     profileReady: boot.phase === 'renderer.ready',
     refreshSessions,
-    resumeExhaustedSessionId,
     routedSessionId,
+    restoreScope: conversationRestoreScope,
     runtimeIdByStoredSessionId: runtimeIdByStoredSessionIdRef,
-    sessions
+    sessions,
+    selectedStoredSessionId
   })
 
   // Pin/unpin the selected session (statusbar keybind + chat header) — pinned
@@ -921,10 +960,18 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   // Single global listener for every rebindable hotkey plus the on-screen
   // keybind editor's capture mode (same as DesktopController).
+  const startFreshSessionFromKeybind = useCallback(
+    () =>
+      startFreshSessionDraft({
+        intent: createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+      }),
+    [startFreshSessionDraft]
+  )
+
   useKeybinds({
     archiveSelectedSession,
     openNewSessionTab,
-    startFreshSession: startFreshSessionDraft,
+    startFreshSession: startFreshSessionFromKeybind,
     toggleCommandCenter,
     toggleSelectedPin
   })
@@ -1084,7 +1131,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // (preview's monitor/devtools cluster, …) arrive as registry contributions.
   const leftTitlebarTools = useTitlebarToolContributions('left')
   const rightTitlebarTools = useTitlebarToolContributions('right')
-  const connection = useStore($connection)
   const controlsPos = titlebarControlsPosition(connection?.windowButtonPosition, Boolean(connection?.isFullscreen))
   // Windows/WSLg reserve native min/max/close on the right (AppShell parity:
   // prefer the live WCO measurement, fall back to the static reservation).

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -28,6 +28,11 @@ vi.mock('./routes', () => ({
 }))
 
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import {
+  $profileConversationRestore,
+  _resetProfileConversationRestoreForTests,
+  beginProfileConversationRestore
+} from '@/store/profile-conversation-restore'
 
 import { mainChatOccupied, openSession, openSessionIntentFromModifiers } from './open-session'
 
@@ -94,11 +99,14 @@ describe('openSession', () => {
     setSessionTileWorkspaceScope.mockReset()
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
+    _resetProfileConversationRestoreForTests()
   })
 
   it('in-place focuses an existing tile and does not navigate', () => {
+    beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
     focusOpenSession.mockReturnValue('tile')
     openSession('s1', navigate)
+    expect($profileConversationRestore.get()).toBeNull()
     expect(focusOpenSession).toHaveBeenCalledWith('s1', { workspaceMode: 'sessions' })
     expect(navigate).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -16,6 +16,7 @@
  */
 import type { WorkspaceMode } from '@/contrib/types'
 import { $activeSessionId, $selectedStoredSessionId, markSessionRead } from '@/store/session'
+import { cancelProfileConversationRestore } from '@/store/profile-conversation-restore'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   focusedSessionNeedsRoute,
@@ -88,6 +89,8 @@ export function openSession(
   if (!storedSessionId) {
     return
   }
+
+  cancelProfileConversationRestore(undefined, 'session-open')
 
   // Any explicit open/focus means the user has seen the finished-turn marker.
   // Must run BEFORE the focus short-circuits below: clicking a session that is

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -14,6 +14,11 @@ import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
 import {
+  $appliedFreshDraftProvenance,
+  _resetProfileConversationRestoreForTests,
+  applyFreshDraftProvenance
+} from '@/store/profile-conversation-restore'
+import {
   $busy,
   $connection,
   $currentCwd,
@@ -40,6 +45,7 @@ import { uploadComposerAttachment, usePromptActions } from '.'
 // never-settling in-flight promise from one test into the next.
 beforeEach(() => {
   clearSingleFlightSessionResumeState()
+  _resetProfileConversationRestoreForTests()
 })
 
 vi.mock('@/hermes', () => ({
@@ -4022,6 +4028,36 @@ describe('usePromptActions sleep/wake session recovery', () => {
       { session_id: RECOVERED_SESSION_ID, text: 'retry after recovery' },
       1_800_000
     )
+  })
+
+  it('promotes an automatic blank before failed prompt and skill session creation', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const createBackendSessionForSend = vi.fn(async () => null)
+    let handle: HarnessHandle | null = null
+
+    await actRender(
+      <Harness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={vi.fn(async () => ({}) as never)}
+        storedSessionId={null}
+      />
+    )
+
+    applyFreshDraftProvenance({ cause: 'profile-switch', freshSequence: 1, kind: 'automatic' })
+    const prompt = handle!.submitText('first message')
+    expect($appliedFreshDraftProvenance.get()).toMatchObject({ kind: 'explicit' })
+    await expect(prompt).resolves.toBe(false)
+
+    applyFreshDraftProvenance({ cause: 'profile-switch', freshSequence: 2, kind: 'automatic' })
+    const skill = handle!.submitText('/my-skill')
+    expect($appliedFreshDraftProvenance.get()).toMatchObject({ kind: 'explicit' })
+    await skill
+
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(2)
   })
 
   it('still creates a new session for a genuine new-chat draft (no stored session selected)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -3,6 +3,7 @@ import { JsonRpcGatewayError } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
 import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
@@ -26,6 +27,7 @@ import { requestGatewayForAgent } from '@/store/gateway'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
+import { promoteAutomaticFreshDraftToExplicit } from '@/store/profile-conversation-restore'
 import {
   $busy,
   $connection,
@@ -243,7 +245,7 @@ interface PromptActionsOptions {
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  startFreshSessionDraft: () => void
+  startFreshSessionDraft: (options: FreshSessionDraftOptions) => void
   sttEnabled: boolean
   updateSessionState: (
     sessionId: string,
@@ -641,6 +643,18 @@ export function usePromptActions({
         await executeSlashCommand(visibleText, options?.sessionId ? { sessionId: options.sessionId } : undefined)
 
         return true
+      }
+
+      if (
+        (visibleText || attachments.length) &&
+        !options?.fromQueue &&
+        !options?.sessionId &&
+        !options?.storedSessionId &&
+        !options?.displayKind &&
+        !activeSessionIdRef.current &&
+        !selectedStoredSessionIdRef.current
+      ) {
+        promoteAutomaticFreshDraftToExplicit()
       }
 
       return await submitPromptText(rawText, options)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,6 +1,7 @@
 import { skillInvocationText } from '@hermes/shared'
 import { type MutableRefObject, useCallback, useRef } from 'react'
 
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
@@ -21,6 +22,7 @@ import { setComposerDraft } from '@/store/composer'
 import { enqueueQueuedPrompt } from '@/store/composer-queue'
 import { applyGoalStatusText } from '@/store/goals'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
+import { createFreshSessionIntent, promoteAutomaticFreshDraftToExplicit } from '@/store/profile-conversation-restore'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import {
@@ -148,7 +150,7 @@ interface SlashCommandDeps {
   requestGateway: GatewayRequest
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  startFreshSessionDraft: () => void
+  startFreshSessionDraft: (options: FreshSessionDraftOptions) => void
   submitPromptText: (rawText: string, options?: SubmitTextOptions) => Promise<boolean>
   updateSessionState: (
     sessionId: string,
@@ -184,6 +186,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
   return useCallback(
     async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
+      // Slash/skill/quick-command dispatch may create a backend session before
+      // it reaches the prompt pipeline. Claim an automatic blank synchronously
+      // at this user-action boundary, including backend-create failure paths.
+      if (!options?.sessionId && !activeSessionIdRef.current && !selectedStoredSessionIdRef.current) {
+        promoteAutomaticFreshDraftToExplicit()
+      }
+
       // Resolve the session this command targets through the SHARED ladder that
       // submit.ts uses. A slash command runs backend commands against a runtime
       // session, and per-session state (`/goal`, `/usage`, `/status`) is keyed by
@@ -492,7 +501,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // new branch in a dispatch ladder.
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
         new: async () => {
-          startFreshSessionDraft()
+          startFreshSessionDraft({
+            intent: createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+          })
         },
         branch: async () => {
           await branchCurrentSession()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -21,6 +21,7 @@ import {
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { consumePendingCredentialWarning, requestDesktopOnboarding } from '@/store/onboarding'
+import { promoteAutomaticFreshDraftToExplicit } from '@/store/profile-conversation-restore'
 import { isStoredTranscriptReadOnly } from '@/store/read-only-transcript'
 import {
   $sessions,
@@ -178,6 +179,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         return false
       }
 
+      // The first real user send owns an automatic isolation blank immediately.
+      // Promote before credential checks, attachment sync, resume, or backend
+      // creation so even an early failure cannot resurrect the previous chat.
+      if (
+        !options?.fromQueue &&
+        !options?.sessionId &&
+        !options?.storedSessionId &&
+        !activeSessionIdRef.current &&
+        !selectedStoredSessionIdRef.current
+      ) {
+        promoteAutomaticFreshDraftToExplicit()
+      }
+
       // Typing barge-in: a new send silences any in-flight spoken reply.
       if (isVoicePlaybackActive()) {
         markVoicePlaybackInterrupted()
@@ -282,9 +296,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       const routedSessionNeedsResume = Boolean(
         routedStoredSessionId &&
-        (selectedStoredSessionId !== routedStoredSessionId ||
-          !startingActiveSessionId ||
-          startingActiveSessionId !== routedRuntimeId)
+          (selectedStoredSessionId !== routedStoredSessionId ||
+            !startingActiveSessionId ||
+            startingActiveSessionId !== routedRuntimeId)
       )
 
       // For an ordinary foreground submit, the durable route is the authority

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
 import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
@@ -21,15 +22,25 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (
+    sessionId: string,
+    focus: boolean,
+    ownerRoute?: SessionProfileRoute,
+    options?: { forceCold?: boolean }
+  ) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
-  sessionResumeRequest?: null | { ownerRoute?: SessionProfileRoute; sequence: number; sessionId: string }
+  sessionResumeRequest?: null | {
+    forceCold?: boolean
+    ownerRoute?: SessionProfileRoute
+    sequence: number
+    sessionId: string
+  }
   routedSessionId: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
-  startFreshSessionDraft: (focus: boolean) => unknown
+  startFreshSessionDraft: (options: FreshSessionDraftOptions) => unknown
 }
 
 function RouteResumeHarness({
@@ -343,6 +354,111 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('forwards owner routing and forceCold only from the matching monotonic request', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+    const ownerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'worker' }
+
+    const props = {
+      activeSessionId: 'runtime-1',
+      activeSessionIdRef,
+      creatingSessionRef,
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/session-1',
+      resumeSession,
+      routedSessionId: 'session-1',
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId: 'session-1',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...props} />)
+
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        sessionResumeRequest={{ forceCold: true, ownerRoute, sequence: 1, sessionId: 'session-1' }}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute, { forceCold: true })
+    resumeSession.mockClear()
+
+    // The same sequence has already been consumed. A later pathname edge must
+    // not inherit either its owner or its forced-cold cache policy.
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        locationPathname="/session-2"
+        routedSessionId="session-2"
+        sessionResumeRequest={{ forceCold: true, ownerRoute, sequence: 1, sessionId: 'session-1' }}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('session-2', true)
+  })
+
+  it('preserves exact owner routing and forceCold across a failed restore retry', () => {
+    vi.useFakeTimers()
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-collision' }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+    const ownerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'worker' }
+    const props = {
+      activeSessionId: 'runtime-collision',
+      activeSessionIdRef,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/session-1',
+      resumeSession,
+      routedSessionId: 'session-1',
+      runtimeIdByStoredSessionIdRef: { current: new Map([['session-1', 'runtime-collision']]) },
+      selectedStoredSessionId: 'session-1',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft
+    }
+
+    const request = { forceCold: true, ownerRoute, sequence: 1, sessionId: 'session-1' }
+    const { rerender } = render(<RouteResumeHarness {...props} sessionResumeRequest={request} />)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute, { forceCold: true })
+
+    resumeSession.mockClear()
+    activeSessionIdRef.current = null
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        activeSessionId={null}
+        gatewayState="closed"
+        resumeFailedSessionId="session-1"
+        sessionResumeRequest={request}
+      />
+    )
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        activeSessionId={null}
+        gatewayState="open"
+        resumeFailedSessionId="session-1"
+        sessionResumeRequest={request}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute, { forceCold: true })
+    resumeSession.mockClear()
+    vi.advanceTimersByTime(1_000)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute, { forceCold: true })
   })
 
   it('does not reuse a stale plugin owner route after pathname navigation', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -1,6 +1,8 @@
 import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
+import { createFreshSessionIntent } from '@/store/profile-conversation-restore'
 import { type SessionResumeRequest, setResumeExhaustedSessionId } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
@@ -13,7 +15,12 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (
+    sessionId: string,
+    focus: boolean,
+    ownerRoute?: SessionProfileRoute,
+    options?: { forceCold?: boolean }
+  ) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -30,7 +37,7 @@ interface RouteResumeOptions {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  startFreshSessionDraft: (focus: boolean) => unknown
+  startFreshSessionDraft: (options: FreshSessionDraftOptions) => unknown
 }
 
 // Bounded auto-retry for a stranded session window. A resume can fail terminally
@@ -106,6 +113,11 @@ export function useRouteResume({
   // never touches this latch, so it can't spuriously trigger the reset).
   const prevResumeExhaustedRef = useRef<string | null>(null)
   const handledResumeRequestRef = useRef(0)
+  const retryResumeRequestRef = useRef<{
+    forceCold?: boolean
+    ownerRoute?: SessionProfileRoute
+    sessionId: string
+  } | null>(null)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -165,8 +177,17 @@ export function useRouteResume({
       // a dead id ("session not found"). An explicit plugin reselect similarly
       // bypasses the warm-id skip when the focused transcript disappeared.
       if ((gatewayBecameOpen || explicitlyRequested || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
-        if (explicitlyRequested) {
-          handledResumeRequestRef.current = sessionResumeRequest.sequence
+        const explicitRequest = explicitlyRequested ? sessionResumeRequest : null
+
+        if (explicitRequest) {
+          handledResumeRequestRef.current = explicitRequest.sequence
+          retryResumeRequestRef.current = {
+            sessionId: routedSessionId,
+            ...(explicitRequest.ownerRoute ? { ownerRoute: explicitRequest.ownerRoute } : {}),
+            ...(explicitRequest.forceCold ? { forceCold: true } : {})
+          }
+        } else if (retryResumeRequestRef.current?.sessionId !== routedSessionId) {
+          retryResumeRequestRef.current = null
         }
 
         // The window's FIRST resume re-attaches the pre-reload route rather
@@ -180,10 +201,13 @@ export function useRouteResume({
 
         bootResumeRef.current = false
 
-        const ownerRoute =
-          sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
+        const retryRequest = retryResumeRequestRef.current
+        const effectiveRequest = explicitRequest ?? (retryRequest?.sessionId === routedSessionId ? retryRequest : null)
+        const ownerRoute = effectiveRequest?.ownerRoute
 
-        if (ownerRoute) {
+        if (effectiveRequest?.forceCold) {
+          void resumeSession(routedSessionId, true, ownerRoute, { forceCold: true })
+        } else if (ownerRoute) {
           void resumeSession(routedSessionId, true, ownerRoute)
         } else {
           void resumeSession(routedSessionId, true)
@@ -201,7 +225,10 @@ export function useRouteResume({
     ) {
       // A fresh draft is a real navigation — any later resume homes normally.
       bootResumeRef.current = false
-      startFreshSessionDraft(true)
+      startFreshSessionDraft({
+        intent: createFreshSessionIntent({ cause: 'context-recovery', persistence: 'automatic' }),
+        replaceRoute: true
+      })
     }
   }, [
     activeSessionId,
@@ -267,6 +294,9 @@ export function useRouteResume({
       if (retrySessionIdRef.current !== routedSessionId) {
         retrySessionIdRef.current = null
         retryAttemptRef.current = 0
+        if (retryResumeRequestRef.current?.sessionId !== routedSessionId) {
+          retryResumeRequestRef.current = null
+        }
         setResumeExhaustedSessionId(current => (current && current !== routedSessionId ? null : current))
       }
 
@@ -311,7 +341,18 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      const retryRequest = retryResumeRequestRef.current
+
+      if (retryRequest?.sessionId === sessionId) {
+        void resumeSession(
+          sessionId,
+          true,
+          retryRequest.ownerRoute,
+          retryRequest.forceCold ? { forceCold: true } : undefined
+        )
+      } else {
+        void resumeSession(sessionId, true)
+      }
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -24,6 +24,11 @@ import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/stor
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
+import {
+  $appliedFreshDraftProvenance,
+  $profileConversationRestore,
+  beginProfileConversationRestore
+} from '@/store/profile-conversation-restore'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, $profiles, ensureGatewayProfile } from '@/store/profile'
 import {
   $projectScope,
@@ -523,11 +528,61 @@ describe('startFreshSessionDraft', () => {
     render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
     await waitFor(() => expect(handle).not.toBeNull())
 
-    act(() => handle!.startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null }))
+    act(() =>
+      handle!.startFreshSessionDraft({
+        intent: { cause: 'gateway-transition', persistence: 'automatic', sequence: 1 },
+        preserveRoute: true,
+        workspaceTarget: null
+      })
+    )
 
+    expect($appliedFreshDraftProvenance.get()).toEqual({
+      cause: 'gateway-transition',
+      freshSequence: 1,
+      kind: 'automatic'
+    })
     expect(navigate).not.toHaveBeenCalled()
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
+  it('cancels a pending restore and applies explicit provenance before clearing state', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+    beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+
+    act(() =>
+      handle!.startFreshSessionDraft({
+        intent: { cause: 'new-chat', persistence: 'explicit', sequence: 2 }
+      })
+    )
+
+    expect($profileConversationRestore.get()).toBeNull()
+    expect($appliedFreshDraftProvenance.get()).toEqual({
+      cause: 'new-chat',
+      freshSequence: 2,
+      kind: 'explicit'
+    })
+
+    act(() =>
+      handle!.startFreshSessionDraft({
+        intent: {
+          cause: 'profile-switch',
+          persistence: 'automatic',
+          restoreSequence: 1,
+          sequence: 1
+        }
+      })
+    )
+
+    expect($appliedFreshDraftProvenance.get()).toEqual({
+      cause: 'new-chat',
+      freshSequence: 2,
+      kind: 'explicit'
+    })
   })
 
   it('fronts the workspace without closing a terminal that is merely behind a tab', async () => {
@@ -548,7 +603,13 @@ describe('startFreshSessionDraft', () => {
     render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
     await waitFor(() => expect(handle).not.toBeNull())
 
-    act(() => handle!.startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null }))
+    act(() =>
+      handle!.startFreshSessionDraft({
+        intent: { cause: 'gateway-transition', persistence: 'automatic', sequence: 1 },
+        preserveRoute: true,
+        workspaceTarget: null
+      })
+    )
 
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
     expect($terminalTakeover.get()).toBe(true)
@@ -737,7 +798,12 @@ function ResumeHarness({
 }: {
   onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   onReady: (
-    resume: (storedSessionId: string, replaceRoute?: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+    resume: (
+      storedSessionId: string,
+      replaceRoute?: boolean,
+      ownerRoute?: SessionProfileRoute,
+      options?: { forceCold?: boolean }
+    ) => Promise<unknown>
   ) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
@@ -769,6 +835,10 @@ function ResumeHarness({
       // turnStartedAt behave as in production state updates.
       const current = stateMapRef.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
       const next = updater(current)
+
+      if (storedSessionId) {
+        runtimeMapRef.current.set(storedSessionId, sessionId)
+      }
 
       stateMapRef.current.set(sessionId, next)
       onStateUpdate?.(sessionId, next)
@@ -1410,8 +1480,11 @@ describe('resumeSession failure recovery', () => {
     })
 
     expect(requestGateway).not.toHaveBeenCalledWith('session.usage', { session_id: 'runtime-stale' })
-    expect(runtimeIdByStoredSessionIdRef.current.has('stored-1')).toBe(false)
+    // The stale runtime is evicted, then the successful cold resume immediately
+    // installs the fresh binding for subsequent warm resumes.
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-1')).toBe('runtime-1')
     expect(sessionStateByRuntimeIdRef.current.has('runtime-stale')).toBe(false)
+    expect(sessionStateByRuntimeIdRef.current.get('runtime-1')?.storedSessionId).toBe('stored-1')
     expect($activeSessionId.get()).toBe('runtime-1')
     expect($messages.get().length).toBe(1)
   })
@@ -2184,6 +2257,94 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(ambientRequest).not.toHaveBeenCalled()
   })
 
+  it('forceCold bypasses a colliding warm runtime without deleting background state', async () => {
+    const ownerRoute: SessionProfileRoute = { connectionId: 'source-a', profile: 'default' }
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([
+        ['stored-shared', 'runtime-other-owner'],
+        ['stored-sibling', 'runtime-sibling']
+      ])
+    }
+    const otherOwnerState = clientState('stored-shared')
+    const siblingState = clientState('stored-sibling')
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([
+        ['runtime-other-owner', otherOwnerState],
+        ['runtime-sibling', siblingState]
+      ])
+    }
+
+    setSessions([storedSession({ connection_id: 'source-a', id: 'stored-shared', profile: 'default' })])
+    $sessionTiles.set([
+      { ownerRoute, storedSessionId: 'stored-shared' },
+      {
+        ownerRoute: { connectionId: 'source-b', profile: 'default' },
+        storedSessionId: 'stored-shared'
+      }
+    ])
+    setMessages([{ id: 'foreign', role: 'assistant', parts: [{ type: 'text', text: 'other owner transcript' }] }])
+    vi.mocked(getSession).mockResolvedValue(
+      storedSession({
+        connection_id: 'source-a',
+        id: 'stored-shared',
+        profile: 'default'
+      })
+    )
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-shared' } as never)
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method, params) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          messages: [],
+          resumed: params?.session_id,
+          session_id: 'runtime-target'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    let resume:
+      | null
+      | ((
+          storedSessionId: string,
+          replaceRoute?: boolean,
+          ownerRoute?: SessionProfileRoute,
+          options?: { forceCold?: boolean }
+        ) => Promise<unknown>) = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={ambientRequest}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="stored-shared"
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    await resume!('stored-shared', true, ownerRoute, { forceCold: true })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'default',
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-shared' })
+    )
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.some(call => call[2] === 'session.activate')).toBe(false)
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-shared')).toBe('runtime-target')
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-sibling')).toBe('runtime-sibling')
+    expect(sessionStateByRuntimeIdRef.current.get('runtime-other-owner')).toBe(otherOwnerState)
+    expect(sessionStateByRuntimeIdRef.current.get('runtime-sibling')).toBe(siblingState)
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({ ownerRoute: { connectionId: 'source-b', profile: 'default' } })
+    ])
+    expect($messages.get()).toEqual([])
+    expect(ambientRequest).not.toHaveBeenCalled()
+  })
+
   it('keeps a registry-tagged cached session on its owning connection without an explicit route', async () => {
     setSessions([
       storedSession({
@@ -2272,9 +2433,11 @@ describe('resumeSession warm-cache mapping integrity', () => {
     })
     expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-A', undefined)
 
-    // The corrupt mapping was purged so it can't mis-resolve again.
-    expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    // The cross-wired runtime was purged so it can't mis-resolve again, then
+    // the successful full resume installed the correct fresh binding.
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A-fresh')
     expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
+    expect(sessionStateByRuntimeIdRef.current.get('rt-A-fresh')?.storedSessionId).toBe('stored-A')
   })
 
   it('paints the bounded latest transcript after the deferred resume acknowledgement', async () => {
@@ -3504,7 +3667,10 @@ describe('createBackendSessionForSend workspace target', () => {
         $activeGatewayProfile.set('default')
       },
       handle => {
-        handle.startFreshSessionDraft({ workspaceTarget: null })
+        handle.startFreshSessionDraft({
+          intent: { cause: 'new-project-chat', persistence: 'explicit', sequence: 2 },
+          workspaceTarget: null
+        })
         $currentCwd.set('/project-open-in-file-browser')
       }
     )
@@ -3519,7 +3685,10 @@ describe('createBackendSessionForSend workspace target', () => {
         $activeGatewayProfile.set('default')
       },
       handle => {
-        handle.startFreshSessionDraft({ workspaceTarget: '/clicked-workspace' })
+        handle.startFreshSessionDraft({
+          intent: { cause: 'new-project-chat', persistence: 'explicit', sequence: 3 },
+          workspaceTarget: '/clicked-workspace'
+        })
         $currentCwd.set('/project-open-in-file-browser')
       }
     )

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -50,6 +50,14 @@ import {
   resolveNewChatOwnerRoute
 } from '@/store/profile'
 import {
+  $appliedFreshDraftProvenance,
+  applyFreshDraftProvenance,
+  cancelProfileConversationRestore,
+  createFreshSessionIntent,
+  type FreshSessionIntent,
+  provenanceForFreshSessionIntent
+} from '@/store/profile-conversation-restore'
+import {
   $projectScope,
   beginSessionMutation,
   endSessionMutation,
@@ -272,7 +280,8 @@ async function desktopSessionCreateParams(
   }
 }
 
-interface FreshSessionDraftOptions {
+export interface FreshSessionDraftOptions {
+  intent: FreshSessionIntent
   preserveRoute?: boolean
   replaceRoute?: boolean
   workspaceTarget?: NewChatWorkspaceTarget
@@ -386,8 +395,26 @@ export function useSessionActions({
   }, [activeSessionIdRef, getRoutedStoredSessionId, navigate, selectedStoredSessionIdRef, storedIdRotation])
 
   const startFreshSessionDraft = useCallback(
-    (options: boolean | FreshSessionDraftOptions = false) => {
-      const draftOptions = typeof options === 'boolean' ? { replaceRoute: options } : options
+    (draftOptions: FreshSessionDraftOptions) => {
+      const { intent } = draftOptions
+      const applied = $appliedFreshDraftProvenance.get()
+
+      if (applied && applied.freshSequence > intent.sequence) {
+        return
+      }
+
+      if (
+        intent.persistence === 'explicit' ||
+        (intent.persistence === 'automatic' &&
+          intent.restoreSequence === undefined &&
+          intent.cause !== 'boot-transition' &&
+          intent.cause !== 'gateway-transition')
+      ) {
+        cancelProfileConversationRestore(undefined, `fresh-draft:${intent.cause}`)
+      }
+
+      applyFreshDraftProvenance(provenanceForFreshSessionIntent(intent))
+
       const preserveRoute = draftOptions.preserveRoute ?? false
       const replaceRoute = draftOptions.replaceRoute ?? false
 
@@ -473,6 +500,7 @@ export function useSessionActions({
 
   const createBackendSessionForSend = useCallback(
     async (preview: string | null = null): Promise<string | null> => {
+      cancelProfileConversationRestore(undefined, 'session-create')
       const startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
 
@@ -648,12 +676,15 @@ export function useSessionActions({
     (item: SidebarNavItem) => {
       if (item.action === 'new-session') {
         setWorkspaceScope('sessions')
-        startFreshSessionDraft()
+        startFreshSessionDraft({
+          intent: createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+        })
 
         return
       }
 
       if (item.route) {
+        cancelProfileConversationRestore(undefined, 'sidebar-page')
         navigateToWorkspacePage(navigate, item.route)
       }
     },
@@ -800,10 +831,20 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionProfileRoute) => {
+    async (
+      storedSessionId: string,
+      replaceRoute = false,
+      capturedOwner?: SessionProfileRoute,
+      options?: { forceCold?: boolean }
+    ) => {
+      const forceCold = options?.forceCold === true
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
-      const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
+      // forceCold is an ownership boundary, not only a runtime-cache policy.
+      // A colliding durable id may currently paint another connection's
+      // transcript, so never carry foreground messages into the exact-target
+      // resume even when the bare selected id happens to match.
+      const resumedSameSelectedSession = !forceCold && selectedStoredSessionIdRef.current === storedSessionId
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
       const isCurrentResume = () =>
@@ -832,7 +873,7 @@ export function useSessionActions({
       // now-redundant tile so main owns it. Runs before the async awaits below (and
       // before the selection listener homes focus) so the tile is gone the same tick
       // the route takes over; the warm cache/runtime binding survives for main to reuse.
-      if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
+      if (!forceCold && $sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
         closeSessionTile(storedSessionId)
       }
 
@@ -874,7 +915,7 @@ export function useSessionActions({
         return { runtimeId, state }
       }
 
-      if (!takeWarmCache()) {
+      if (forceCold || !takeWarmCache()) {
         setActiveSessionId(null)
         activeSessionIdRef.current = null
         // History load is not turn-busy. Drop the previous session's leftover
@@ -908,6 +949,14 @@ export function useSessionActions({
 
       if (resumeRequestRef.current !== requestId) {
         return
+      }
+
+      if (forceCold && storedForProfile) {
+        closeSessionTile(storedSessionId, {
+          connectionId: capturedOwner?.connectionId || storedForProfile.connection_id?.trim() || null,
+          profile: normalizeProfileKey(capturedOwner?.profile || sessionProfile),
+          ...(capturedOwner?.targetProfile ? { targetProfile: capturedOwner.targetProfile } : {})
+        })
       }
 
       const resolvedConnectionId = ownerRoute?.connectionId || storedForProfile?.connection_id || ambientConnectionId
@@ -970,7 +1019,7 @@ export function useSessionActions({
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
       // purges a cross-wired mapping before we trust the fast-path.
-      const warmHit = takeWarmCache()
+      const warmHit = forceCold ? null : takeWarmCache()
 
       if (warmHit) {
         const cachedRuntimeId = warmHit.runtimeId
@@ -1114,8 +1163,8 @@ export function useSessionActions({
 
               const busyChangedWhileActivating = Boolean(
                 latestCachedState?.busy &&
-                (latestCachedState.turnStartedAt !== activateBaselineState.turnStartedAt ||
-                  (latestCachedState.turnLive && !activateBaselineState.turnLive))
+                  (latestCachedState.turnStartedAt !== activateBaselineState.turnStartedAt ||
+                    (latestCachedState.turnLive && !activateBaselineState.turnLive))
               )
 
               const running =
@@ -1811,7 +1860,7 @@ export function useSessionActions({
               // draft fallback for genuinely dead ids on secondary profiles.
               Boolean(
                 sessionProfile?.trim() &&
-                normalizeProfileKey(sessionProfile) !== normalizeProfileKey($activeGatewayProfile.get())
+                  normalizeProfileKey(sessionProfile) !== normalizeProfileKey($activeGatewayProfile.get())
               )
           })
 
@@ -1821,7 +1870,10 @@ export function useSessionActions({
             return
           }
 
-          startFreshSessionDraft(true)
+          startFreshSessionDraft({
+            intent: createFreshSessionIntent({ cause: 'context-recovery', persistence: 'automatic' }),
+            replaceRoute: true
+          })
 
           return
         }
@@ -2172,7 +2224,10 @@ export function useSessionActions({
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
       if (wasSelected) {
-        startFreshSessionDraft(true)
+        startFreshSessionDraft({
+          intent: createFreshSessionIntent({ cause: 'context-recovery', persistence: 'automatic' }),
+          replaceRoute: true
+        })
       }
 
       try {
@@ -2291,7 +2346,10 @@ export function useSessionActions({
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
 
       if (wasSelected) {
-        startFreshSessionDraft(true)
+        startFreshSessionDraft({
+          intent: createFreshSessionIntent({ cause: 'context-recovery', persistence: 'automatic' }),
+          replaceRoute: true
+        })
       }
 
       try {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -239,8 +239,36 @@ describe('resolveStoredSessionForRestore exact target lookup', () => {
       storageSuffix: ''
     })
 
-    expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
+    expect(mockGetSession).toHaveBeenCalledWith('s1', { connectionId: null, profile: 'meta' })
     expect(result).toEqual({ status: 'found', session: expect.objectContaining({ id: 's1', profile: 'meta' }) })
+  })
+
+  it('keeps a profile-door lookup ownerless and preserves same-id registry twins when publishing', async () => {
+    const profileTarget = { connectionId: null, profile: 'meta', storageSuffix: '' }
+    $sessions.set([
+      session({ connection_id: 'local', id: 's1', profile: 'meta' }),
+      session({ connection_id: 'source-b', id: 's1', profile: 'meta' })
+    ])
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
+
+    const result = await resolveStoredSessionForRestore('s1', profileTarget)
+
+    expect(mockGetSession).toHaveBeenCalledWith('s1', { connectionId: null, profile: 'meta' })
+    expect(result).toEqual({
+      status: 'found',
+      session: expect.objectContaining({ connection_id: undefined, id: 's1', profile: 'meta' })
+    })
+
+    if (result.status !== 'found') {
+      throw new Error('expected found restore candidate')
+    }
+
+    publishResolvedSessionForRestore(result.session, 's1', profileTarget)
+    expect($sessions.get().filter(row => row.id === 's1')).toEqual([
+      expect.objectContaining({ connection_id: undefined, profile: 'meta' }),
+      expect.objectContaining({ connection_id: 'local', profile: 'meta' }),
+      expect.objectContaining({ connection_id: 'source-b', profile: 'meta' })
+    ])
   })
 
   it('returns not-found only for a target-scoped session-gone response', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -6,7 +6,13 @@ import { $activeGatewayProfile, $profiles } from '@/store/profile'
 import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { resolveSessionProfile, resolveStoredSession } from './utils'
+import {
+  classifySessionLookupError,
+  publishResolvedSessionForRestore,
+  resolveSessionProfile,
+  resolveStoredSession,
+  resolveStoredSessionForRestore
+} from './utils'
 
 vi.mock('@/hermes', async importActual => ({
   ...(await importActual<typeof HermesModule>()),
@@ -142,5 +148,139 @@ describe('resolveStoredSession profile ownership', () => {
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
 
     await expect(resolveSessionProfile('s1')).resolves.toBe('default')
+  })
+})
+
+describe('resolveStoredSessionForRestore exact target lookup', () => {
+  const registryTarget = { connectionId: 'source-a', profile: 'meta', storageSuffix: '.source-a' }
+
+  beforeEach(() => {
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $sessions.set([])
+    mockGetSession.mockReset()
+  })
+
+  afterEach(() => {
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $sessions.set([])
+  })
+
+  it('always probes the exact registry target instead of trusting a colliding bare-id cache row', async () => {
+    $sessions.set([session({ connection_id: 'source-b', id: 's1', profile: 'meta' })])
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
+
+    const result = await resolveStoredSessionForRestore('s1', registryTarget)
+
+    expect(mockGetSession).toHaveBeenCalledWith('s1', { connectionId: 'source-a', profile: 'meta' })
+    expect(result).toMatchObject({
+      ownerRoute: { connectionId: 'source-a', profile: 'meta' },
+      session: { connection_id: 'source-a', id: 's1', profile: 'meta' },
+      status: 'found'
+    })
+    // Lookup is read-only until the caller validates its activation generation.
+    expect($sessions.get()).toEqual([expect.objectContaining({ connection_id: 'source-b', profile: 'meta' })])
+
+    if (result.status !== 'found') {
+      throw new Error('expected found restore candidate')
+    }
+
+    publishResolvedSessionForRestore(result.session, 's1', registryTarget)
+    expect($sessions.get().filter(row => row.id === 's1')).toEqual([
+      expect.objectContaining({ connection_id: 'source-a', profile: 'meta' }),
+      expect.objectContaining({ connection_id: 'source-b', profile: 'meta' })
+    ])
+  })
+
+  it('replaces same-owner lineage aliases while preserving foreign twins', () => {
+    $sessions.set([
+      session({ connection_id: 'source-a', id: 'root-1', profile: 'meta' }),
+      session({ connection_id: 'source-b', id: 'root-1', profile: 'meta' })
+    ])
+    const resolved = session({
+      _lineage_root_id: 'root-1',
+      connection_id: 'source-a',
+      id: 'tip-2',
+      profile: 'meta'
+    })
+
+    publishResolvedSessionForRestore(resolved, 'tip-2', registryTarget)
+
+    expect($sessions.get()).toEqual([
+      expect.objectContaining({ connection_id: 'source-a', id: 'tip-2' }),
+      expect.objectContaining({ connection_id: 'source-b', id: 'root-1' })
+    ])
+  })
+
+  it('does not publish a late candidate before caller generation validation', async () => {
+    $sessions.set([session({ connection_id: 'source-b', id: 's1', profile: 'meta' })])
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
+
+    await expect(resolveStoredSessionForRestore('s1', registryTarget)).resolves.toMatchObject({ status: 'found' })
+
+    expect($sessions.get()).toEqual([expect.objectContaining({ connection_id: 'source-b' })])
+  })
+
+  it('accepts a compressed tip whose lineage root is the requested durable id', async () => {
+    mockGetSession.mockResolvedValueOnce(session({ _lineage_root_id: 'root-1', id: 'tip-9' }))
+
+    const result = await resolveStoredSessionForRestore('root-1', registryTarget)
+
+    expect(result).toMatchObject({ status: 'found', session: { _lineage_root_id: 'root-1', id: 'tip-9' } })
+  })
+
+  it('routes a legacy/profile-only target without treating null connection as a wildcard', async () => {
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
+
+    const result = await resolveStoredSessionForRestore('s1', {
+      connectionId: null,
+      profile: 'meta',
+      storageSuffix: ''
+    })
+
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
+    expect(result).toEqual({ status: 'found', session: expect.objectContaining({ id: 's1', profile: 'meta' }) })
+  })
+
+  it('returns not-found only for a target-scoped session-gone response', async () => {
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+
+    await expect(resolveStoredSessionForRestore('s1', registryTarget)).resolves.toEqual({ status: 'not-found' })
+    expect(classifySessionLookupError(new Error('session not found'))).toBe('not-found')
+  })
+
+  it.each([
+    ['generic endpoint miss', new Error('404 Not Found')],
+    ['auth', new Error('401 Unauthorized')],
+    ['server', new Error('503 Service Unavailable')],
+    ['network', new Error('ECONNREFUSED')],
+    ['timeout', new Error('request timed out')],
+    ['abort', new DOMException('aborted', 'AbortError')]
+  ])('preserves %s failures as inconclusive', async (_name, error) => {
+    mockGetSession.mockRejectedValueOnce(error)
+
+    const result = await resolveStoredSessionForRestore('s1', registryTarget)
+
+    expect(result.status).toBe('inconclusive')
+    expect(classifySessionLookupError(error)).toBe('inconclusive')
+  })
+
+  it('fails closed for malformed, mismatched-lineage, and conflicting-owner responses', async () => {
+    mockGetSession
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(session({ id: 'other' }))
+      .mockResolvedValueOnce(session({ connection_id: 'source-b', id: 's1' }))
+
+    await expect(resolveStoredSessionForRestore('s1', registryTarget)).resolves.toMatchObject({
+      status: 'inconclusive'
+    })
+    await expect(resolveStoredSessionForRestore('s1', registryTarget)).resolves.toMatchObject({
+      status: 'inconclusive'
+    })
+    await expect(resolveStoredSessionForRestore('s1', registryTarget)).resolves.toMatchObject({
+      status: 'inconclusive'
+    })
+    expect($sessions.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -852,8 +852,8 @@ export function appendLiveSessionProjection(messages: ChatMessage[], projection:
 
   const turnAlreadyStructured = Boolean(
     liveAssistantOfCurrentTurn &&
-    hasStructuralParts(liveAssistantOfCurrentTurn) &&
-    isLiveTailRow(liveAssistantOfCurrentTurn)
+      hasStructuralParts(liveAssistantOfCurrentTurn) &&
+      isLiveTailRow(liveAssistantOfCurrentTurn)
   )
 
   const wantsAssistantRow = Boolean(
@@ -1385,6 +1385,124 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
       return (existing._lineage_root_id ?? existing.id) !== lineage
     })
   ])
+}
+
+/** Publish a restore candidate only after its caller has revalidated the exact
+ * activation generation. Replacement is owner-qualified so same-id rows from
+ * another connection/profile remain available to their own workspace. */
+export function publishResolvedSessionForRestore(
+  session: SessionInfo,
+  storedSessionId: string,
+  target: RestoreLookupTarget
+): void {
+  const targetProfile = normalizeProfileKey(target.profile)
+  const targetConnectionId = target.connectionId?.trim() || null
+  const published: SessionInfo = {
+    ...session,
+    profile: targetProfile,
+    ...(targetConnectionId ? { connection_id: targetConnectionId } : { connection_id: undefined })
+  }
+  const publishedLineage = published._lineage_root_id ?? published.id
+  const sameOwner = (existing: SessionInfo) =>
+    normalizeProfileKey(existing.profile) === targetProfile &&
+    (existing.connection_id?.trim() || null) === targetConnectionId
+  const sameConversation = (existing: SessionInfo) =>
+    sessionMatchesStoredId(existing, storedSessionId) || (existing._lineage_root_id ?? existing.id) === publishedLineage
+
+  setSessions(prev => [published, ...prev.filter(existing => !(sameOwner(existing) && sameConversation(existing)))])
+}
+
+export interface RestoreLookupTarget {
+  connectionId: string | null
+  profile: string
+  storageSuffix: string
+}
+
+export type RestoreLookupResult =
+  | { status: 'found'; session: SessionInfo; ownerRoute?: SessionProfileRoute }
+  | { status: 'not-found' }
+  | { status: 'inconclusive'; reason: string }
+
+export type SessionLookupErrorClassification = 'not-found' | 'inconclusive'
+
+/** Shared classification for authoritative session reads. Only a target-scoped
+ * session-gone response is deletion proof; every other failure keeps durable
+ * navigation state intact so callers can retry or recover later. */
+export function classifySessionLookupError(error: unknown): SessionLookupErrorClassification {
+  if (!isSessionGoneError(error)) {
+    return 'inconclusive'
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  // A generic HTTP/proxy/endpoint 404 is not proof that the session row is
+  // gone. Require the backend's session-specific absence wording before a
+  // restore caller is allowed to clear durable navigation.
+  return /session(?:[_ -]?id)?[^\n]*not found|session gone/i.test(message) ? 'not-found' : 'inconclusive'
+}
+
+/**
+ * Resolve one remembered durable id against exactly one already-proven target.
+ * Unlike resolveStoredSession(), this never accepts the renderer's bare-id
+ * caches as ownership evidence and never probes another profile/source.
+ */
+export async function resolveStoredSessionForRestore(
+  storedSessionId: string,
+  target: RestoreLookupTarget
+): Promise<RestoreLookupResult> {
+  const durableId = storedSessionId.trim()
+  const targetProfile = normalizeProfileKey(target.profile)
+  const connectionId = target.connectionId?.trim() || null
+
+  if (!durableId) {
+    return { status: 'inconclusive', reason: 'missing stored session id' }
+  }
+
+  try {
+    const scope = connectionId ? { connectionId, profile: targetProfile } : targetProfile
+    const candidate = await getSession(durableId, scope)
+
+    if (!candidate || typeof candidate !== 'object') {
+      return { status: 'inconclusive', reason: 'malformed session response' }
+    }
+
+    const candidateId = typeof candidate.id === 'string' ? candidate.id.trim() : ''
+    const lineageId = typeof candidate._lineage_root_id === 'string' ? candidate._lineage_root_id.trim() : ''
+
+    if (!candidateId || (candidateId !== durableId && lineageId !== durableId)) {
+      return { status: 'inconclusive', reason: 'session response does not match requested lineage' }
+    }
+
+    const returnedConnectionId = candidate.connection_id?.trim() || null
+
+    if (returnedConnectionId && returnedConnectionId !== connectionId) {
+      return { status: 'inconclusive', reason: 'session response belongs to another connection' }
+    }
+
+    // Return an isolated candidate. The caller owns generation/scope validation
+    // after this await and is the only place allowed to publish it globally.
+    const resolved: SessionInfo = {
+      ...candidate,
+      profile: targetProfile,
+      ...(connectionId ? { connection_id: connectionId } : { connection_id: undefined })
+    }
+    const ownerRoute = connectionId ? { connectionId, profile: targetProfile } : undefined
+
+    return {
+      status: 'found',
+      session: resolved,
+      ...(ownerRoute ? { ownerRoute } : {})
+    }
+  } catch (error) {
+    const classification = classifySessionLookupError(error)
+
+    return classification === 'not-found'
+      ? { status: 'not-found' }
+      : {
+          status: 'inconclusive',
+          reason: error instanceof Error ? error.message : String(error ?? 'session lookup failed')
+        }
+  }
 }
 
 export async function resolveStoredSession(

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -852,8 +852,8 @@ export function appendLiveSessionProjection(messages: ChatMessage[], projection:
 
   const turnAlreadyStructured = Boolean(
     liveAssistantOfCurrentTurn &&
-      hasStructuralParts(liveAssistantOfCurrentTurn) &&
-      isLiveTailRow(liveAssistantOfCurrentTurn)
+    hasStructuralParts(liveAssistantOfCurrentTurn) &&
+    isLiveTailRow(liveAssistantOfCurrentTurn)
   )
 
   const wantsAssistantRow = Boolean(
@@ -1412,6 +1412,10 @@ export function publishResolvedSessionForRestore(
   setSessions(prev => [published, ...prev.filter(existing => !(sameOwner(existing) && sameConversation(existing)))])
 }
 
+/** Canonical backend identity for restore RPCs. This is intentionally
+ * distinct from any observed descriptor used only to prove readiness: a null
+ * connection is the profile-door route and must remain null even when that
+ * route currently resolves through an explicit local descriptor. */
 export interface RestoreLookupTarget {
   connectionId: string | null
   profile: string
@@ -1459,7 +1463,7 @@ export async function resolveStoredSessionForRestore(
   }
 
   try {
-    const scope = connectionId ? { connectionId, profile: targetProfile } : targetProfile
+    const scope = { connectionId, profile: targetProfile }
     const candidate = await getSession(durableId, scope)
 
     if (!candidate || typeof candidate !== 'object') {

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
   $newChatWorkspaceTarget,
-  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -36,9 +36,9 @@ describe('startWorkspaceSession', () => {
 
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
-      setNewChatWorkspaceTarget(options?.workspaceTarget)
-      setCurrentCwd(options?.workspaceTarget || '')
+    const startFreshSessionDraft = vi.fn((options: FreshSessionDraftOptions) => {
+      setNewChatWorkspaceTarget(options.workspaceTarget)
+      setCurrentCwd(options.workspaceTarget || '')
     })
 
     const followActiveSessionCwd = vi.fn()
@@ -90,9 +90,9 @@ describe('startWorkspaceSession', () => {
     const requestGateway = vi.fn()
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
-      setNewChatWorkspaceTarget(options?.workspaceTarget)
-      setCurrentCwd(options?.workspaceTarget || '')
+    const startFreshSessionDraft = vi.fn((options: FreshSessionDraftOptions) => {
+      setNewChatWorkspaceTarget(options.workspaceTarget)
+      setCurrentCwd(options.workspaceTarget || '')
     })
 
     startWorkspaceSession({
@@ -102,7 +102,10 @@ describe('startWorkspaceSession', () => {
       startFreshSessionDraft
     })
 
-    expect(startFreshSessionDraft).toHaveBeenCalledWith({ workspaceTarget: null })
+    expect(startFreshSessionDraft).toHaveBeenCalledWith({
+      intent: expect.objectContaining({ cause: 'new-project-chat', persistence: 'explicit' }),
+      workspaceTarget: null
+    })
     expect(requestGateway).not.toHaveBeenCalled()
     expect($newChatWorkspaceTarget.get()).toBeNull()
     expect($currentCwd.get()).toBe('')

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -1,9 +1,10 @@
 import type { MutableRefObject } from 'react'
 
+import type { FreshSessionDraftOptions } from '@/app/session/hooks/use-session-actions'
+import { createFreshSessionIntent } from '@/store/profile-conversation-restore'
 import { followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $newChatWorkspaceTargetGeneration,
-  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -15,7 +16,7 @@ interface WorkspaceSessionOptions {
   onExplicitWorkspace?: (cwd: string) => void
   path: null | string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
-  startFreshSessionDraft: (options?: { workspaceTarget: NewChatWorkspaceTarget }) => void
+  startFreshSessionDraft: (options: FreshSessionDraftOptions) => void
 }
 
 export function startWorkspaceSession({
@@ -31,7 +32,10 @@ export function startWorkspaceSession({
   // return a default/remembered project folder and re-attach the last repo
   // (digitwo: New session in Home still shows `main`).
   if (path === null) {
-    startFreshSessionDraft({ workspaceTarget: null })
+    startFreshSessionDraft({
+      intent: createFreshSessionIntent({ cause: 'new-project-chat', persistence: 'explicit' }),
+      workspaceTarget: null
+    })
 
     return
   }
@@ -41,7 +45,10 @@ export function startWorkspaceSession({
   const explicitTarget = path.trim()
   const target = explicitTarget || resolveNewSessionCwd()
 
-  startFreshSessionDraft(target ? { workspaceTarget: target } : undefined)
+  startFreshSessionDraft({
+    intent: createFreshSessionIntent({ cause: 'new-project-chat', persistence: 'explicit' }),
+    ...(target ? { workspaceTarget: target } : {})
+  })
 
   if (!target) {
     return

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -57,12 +57,14 @@ const endGatewaySwitch = vi.fn((token?: number) => {
 })
 
 const recoverActiveSourceAfterFailedGatewaySwitch = vi.fn()
+const isCurrentGatewaySwitch = vi.fn((token: number) => token === latestSwitchToken)
 
 vi.mock('@/store/session', () => ({ $connection }))
 vi.mock('@/store/gateway-switch', () => ({
   $gatewaySwitching,
   beginGatewaySwitch,
   endGatewaySwitch,
+  isCurrentGatewaySwitch,
   recoverActiveSourceAfterFailedGatewaySwitch,
   wipeSessionListsForGatewaySwitch
 }))
@@ -137,6 +139,7 @@ beforeEach(() => {
   beginGatewaySwitch.mockClear()
   endGatewaySwitch.mockClear()
   recoverActiveSourceAfterFailedGatewaySwitch.mockClear()
+  isCurrentGatewaySwitch.mockClear()
   wipeSessionListsForGatewaySwitch.mockClear()
   $activeSessionId.set(null)
   $gatewaySwitching.set(false)
@@ -434,6 +437,47 @@ describe('selectConnection', () => {
     expect($newChatProfile.get()).toBeNull()
     expect($pendingConnectionId.get()).toBeNull()
     expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it('recovers a source wiped by a superseded switch when the newer dial fails before acquiring a token', async () => {
+    const firstActivation = deferred()
+
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    $activeSessionId.set('a93bb39d')
+    ensureGatewayAgent.mockImplementationOnce(async (_connectionId, _profile, options) => {
+      options?.beforeActivate?.()
+      await firstActivation.promise
+    })
+    openGatewayAgent.mockImplementation(async connectionId => {
+      if (connectionId === 'work-vps') {
+        throw new Error('newer dial offline')
+      }
+    })
+
+    const superseded = selectConnection('homelab')
+    await vi.waitFor(() => expect(beginGatewaySwitch).toHaveBeenCalledTimes(1))
+    const wipedToken = beginGatewaySwitch.mock.results[0]?.value
+    expect($activeSessionId.get()).toBeNull()
+
+    await expect(selectConnection('work-vps')).rejects.toThrow('newer dial offline')
+    expect($profileConversationRestore.get()).toBeNull()
+
+    firstActivation.reject(new Error('superseded commit failed'))
+    await expect(superseded).resolves.toBeUndefined()
+
+    // The newer request never reached its commit point, so the older token is
+    // still the latest token and remains responsible for repainting the source
+    // it wiped. Because that request no longer owns user intent, it must not
+    // also navigate to a recovery draft.
+    expect(recoverActiveSourceAfterFailedGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect(recoverActiveSourceAfterFailedGatewaySwitch).toHaveBeenCalledWith(wipedToken)
+    expect(requestFreshSession).not.toHaveBeenCalledWith({
+      cause: 'switch-recovery',
+      persistence: 'automatic'
+    })
+    expect($connection.get()?.connectionId).toBe('local')
+    expect($pendingConnectionId.get()).toBeNull()
   })
 
   it("#93937: severs the previous source's runtime session binding BEFORE the new source is published, behind the barrier", async () => {

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -88,6 +88,8 @@ const {
   selectConnection,
   setConnectionsRegistry
 } = await import('./connections')
+const { $profileConversationRestore, _resetProfileConversationRestoreForTests, cancelProfileConversationRestore } =
+  await import('./profile-conversation-restore')
 
 const registry: DesktopConnectionsRegistry = {
   connections: [
@@ -106,6 +108,7 @@ const setLastUsed = vi.fn(async (id: string) => ({ ok: true, registry: { ...regi
 beforeEach(() => {
   localStorage.clear()
   _resetConnectionsForTests()
+  _resetProfileConversationRestoreForTests()
   $connectionsRegistry.set(null)
   $connection.set(null)
   $activeGatewayProfile.set('default')
@@ -163,6 +166,8 @@ describe('connection registry cache', () => {
     expect(ensureGatewayAgent).toHaveBeenCalledTimes(1)
     expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect(setLastUsed).toHaveBeenCalledWith('homelab')
+    expect($profileConversationRestore.get()).toBeNull()
+    expect(requestFreshSession).toHaveBeenCalledWith({ cause: 'boot-transition', persistence: 'automatic' })
   })
 
   it('preserves the established Primary-source launch behavior by default', async () => {
@@ -226,11 +231,35 @@ describe('selectConnection', () => {
     expect(openGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
     expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
-    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(requestFreshSession).toHaveBeenCalledWith({
+      cause: 'connection-switch',
+      persistence: 'automatic',
+      restoreSequence: $profileConversationRestore.get()?.sequence
+    })
+    expect($profileConversationRestore.get()).toMatchObject({
+      origin: 'connection-switch',
+      phase: 'committed',
+      target: { connectionId: 'homelab', profile: 'default' }
+    })
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
     expect($newChatProfile.get()).toBe('default')
     expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
     expect(setLastUsed).toHaveBeenCalledWith('homelab')
+  })
+
+  it('treats a first user click with no adopted descriptor as user intent, not boot', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set(null)
+
+    await selectConnection('homelab')
+
+    expect($profileConversationRestore.get()).toMatchObject({
+      phase: 'committed',
+      target: { connectionId: 'homelab', profile: 'default' }
+    })
+    expect(requestFreshSession).toHaveBeenCalledWith(
+      expect.objectContaining({ cause: 'connection-switch', persistence: 'automatic' })
+    )
   })
 
   it('does not reset or dial when the active source/profile is selected again', async () => {
@@ -250,6 +279,25 @@ describe('selectConnection', () => {
     await selectConnection('local')
 
     expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default', expect.anything())
+  })
+
+  it('does not commit a pending dial after another context action cancels its restore ownership', async () => {
+    const dial = deferred()
+
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    openGatewayAgent.mockImplementationOnce(() => dial.promise)
+
+    const switching = selectConnection('homelab')
+    await vi.waitFor(() => expect(openGatewayAgent).toHaveBeenCalledTimes(1))
+    cancelProfileConversationRestore(undefined, 'all-profiles')
+    dial.resolve()
+    await switching
+
+    expect(ensureGatewayAgent).not.toHaveBeenCalled()
+    expect(beginGatewaySwitch).not.toHaveBeenCalled()
+    expect(requestFreshSession).not.toHaveBeenCalled()
+    expect($connection.get()?.connectionId).toBe('local')
   })
 
   it('lets a later source choice win while an earlier dial is still pending', async () => {
@@ -355,6 +403,7 @@ describe('selectConnection', () => {
     expect($activeSessionId.get()).toBe('a93bb39d')
     expect($gatewaySwitching.get()).toBe(false)
     expect(requestFreshSession).not.toHaveBeenCalled()
+    expect($profileConversationRestore.get()).toBeNull()
     expect($newChatProfile.get()).toBeNull()
     expect($pendingConnectionId.get()).toBeNull()
     expect(setLastUsed).not.toHaveBeenCalled()
@@ -379,7 +428,8 @@ describe('selectConnection', () => {
     // The lists were wiped for a commit that never happened; the source that
     // is still active gets repainted and the user lands on a fresh draft there.
     expect(recoverActiveSourceAfterFailedGatewaySwitch).toHaveBeenCalledTimes(1)
-    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(requestFreshSession).toHaveBeenCalledWith({ cause: 'switch-recovery', persistence: 'automatic' })
+    expect($profileConversationRestore.get()).toBeNull()
     expect(setLastUsed).not.toHaveBeenCalled()
     expect($newChatProfile.get()).toBeNull()
     expect($pendingConnectionId.get()).toBeNull()
@@ -584,7 +634,12 @@ describe('selectConnection', () => {
       expect($connection.get()?.connectionId).toBe('homelab')
       expect($gatewaySwitching.get()).toBe(false)
       expect(setLastUsed).toHaveBeenCalledWith('homelab')
-      expect(requestFreshSession).toHaveBeenCalledTimes(1)
+      expect(requestFreshSession).toHaveBeenCalledWith({
+        cause: 'connection-switch',
+        persistence: 'automatic',
+        restoreSequence: $profileConversationRestore.get()?.sequence
+      })
+      expect($profileConversationRestore.get()?.phase).toBe('committed')
       expect(recoverActiveSourceAfterFailedGatewaySwitch).not.toHaveBeenCalled()
       expect($pendingConnectionId.get()).toBeNull()
     } finally {
@@ -812,6 +867,26 @@ describe('selectConnection', () => {
 
     expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect($showAllProfiles.get()).toBe(false)
+  })
+
+  it('restores synchronously when leaving All Profiles onto the already-active exact pair', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'default', registryScoped: true })
+    $activeGatewayProfile.set('default')
+    $showAllProfiles.set(true)
+
+    await selectConnection('local')
+
+    expect(openGatewayAgent).not.toHaveBeenCalled()
+    expect($profileConversationRestore.get()).toMatchObject({
+      phase: 'committed',
+      target: { connectionId: 'local', profile: 'default' }
+    })
+    expect(requestFreshSession).toHaveBeenCalledWith({
+      cause: 'connection-switch',
+      persistence: 'automatic',
+      restoreSequence: $profileConversationRestore.get()?.sequence
+    })
   })
 
   it('never re-homes a live connection the registry cannot name', async () => {

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -21,6 +21,13 @@ import {
   refreshActiveProfile,
   requestFreshSession
 } from '@/store/profile'
+import {
+  $profileConversationRestore,
+  beginProfileConversationRestore,
+  cancelProfileConversationRestore,
+  commitProfileConversationRestore,
+  isCurrentProfileConversationRestore
+} from '@/store/profile-conversation-restore'
 import { $connection } from '@/store/session'
 
 const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
@@ -230,7 +237,7 @@ export async function initializeConnectionsRegistry(): Promise<DesktopConnection
   if ($activeConnectionId.get() === preferredId) {
     await rememberConnection(preferredId)
   } else {
-    await selectConnection(preferredId)
+    await selectConnection(preferredId, { initiator: 'boot' })
   }
 
   return $connectionsRegistry.get() ?? registry
@@ -261,6 +268,8 @@ export async function initializeConnectionsRegistry(): Promise<DesktopConnection
  * the barrier and repaints the source that is still active.
  */
 export interface SelectConnectionOptions {
+  /** Boot adoption remains owned by cold restoration; user is the default. */
+  initiator?: 'boot' | 'user'
   /** Land on this profile of the target source instead of the one last used
    *  there. The fleet profile rail passes the exact square the user clicked. */
   profile?: null | string
@@ -274,12 +283,10 @@ export async function selectConnection(connectionId: string, options: SelectConn
     return
   }
 
-  // A user-initiated source switch collapses "All profiles" browse mode: the
-  // picker is a concrete-source action. The silent boot-time restore (below,
-  // from initializeConnectionsRegistry) is not — it must leave the persisted
-  // browse-mode preference alone so it survives restart (#93197).
-  const restoreOnBoot = pendingTarget === null && $activeConnectionId.get() === null
-
+  // Boot adoption remains under the cold-start restoration controller. This
+  // explicit initiator is the sole authority; ambient connection state cannot
+  // safely distinguish boot from a user's first click after failed adoption.
+  const initiator = options.initiator ?? 'user'
   const currentConnectionId = $activeConnectionId.get()
   const currentProfile = normalizeProfileKey($activeGatewayProfile.get())
   const explicitProfile = String(options.profile ?? '').trim()
@@ -312,6 +319,11 @@ export async function selectConnection(connectionId: string, options: SelectConn
     return
   }
 
+  const restoreSequence =
+    initiator === 'user'
+      ? beginProfileConversationRestore('connection-switch', { connectionId, profile: targetProfile })
+      : null
+
   if (pendingTarget === null && currentConnectionId === connectionId && currentProfile === targetProfile) {
     $showAllProfiles.set(false)
     $newChatProfile.set(targetProfile)
@@ -319,7 +331,17 @@ export async function selectConnection(connectionId: string, options: SelectConn
     // registry identity with the profile so the next create names local::x /
     // <source>::x exactly, never a bare profile string.
     captureNewChatSource()
-    requestFreshSession()
+
+    if (restoreSequence !== null && commitProfileConversationRestore(restoreSequence)) {
+      requestFreshSession({
+        cause: 'connection-switch',
+        persistence: 'automatic',
+        restoreSequence
+      })
+    } else if (initiator === 'boot') {
+      requestFreshSession({ cause: 'boot-transition', persistence: 'automatic' })
+    }
+
     await rememberConnection(connectionId)
 
     return
@@ -332,6 +354,10 @@ export async function selectConnection(connectionId: string, options: SelectConn
   // barrier and, if the commit then fails, owes the still-active source a
   // repaint. Null while queued, or if it stepped aside before its turn.
   let token = null as GatewaySwitchToken | null
+  let targetLanded = false
+
+  const ownsSwitchIntent = () =>
+    revision === switchRevision && (restoreSequence === null || isCurrentProfileConversationRestore(restoreSequence))
 
   try {
     // Phase 1 — open the target's socket; the active route is untouched.
@@ -346,7 +372,7 @@ export async function selectConnection(connectionId: string, options: SelectConn
     // A newer click owns the switch from here on. The superseded dial never
     // activates, so the user doesn't flip through it on the way to the source
     // they picked last; its socket stays warm for that click or idles out.
-    if (revision !== switchRevision) {
+    if (!ownsSwitchIntent()) {
       return
     }
 
@@ -356,6 +382,14 @@ export async function selectConnection(connectionId: string, options: SelectConn
     // superseded this switch while it was queued makes the hook decline —
     // neither wipe nor activation — so the user never flips through it.
     const activationController = new AbortController()
+    const stopWatchingRestore =
+      restoreSequence === null
+        ? () => undefined
+        : $profileConversationRestore.listen(current => {
+            if (current?.sequence !== restoreSequence && !activationController.signal.aborted) {
+              activationController.abort(new Error('Connection switch superseded by newer context intent'))
+            }
+          })
     let markActivationStarted: () => void = () => undefined
 
     const activationStarted = new Promise<void>(resolve => {
@@ -367,7 +401,7 @@ export async function selectConnection(connectionId: string, options: SelectConn
         const activation = ensureGatewayAgent(connectionId, targetProfile, {
           signal: activationController.signal,
           beforeActivate: () => {
-            if (revision !== switchRevision) {
+            if (!ownsSwitchIntent()) {
               return false
             }
 
@@ -414,7 +448,10 @@ export async function selectConnection(connectionId: string, options: SelectConn
       if (!targetIsActive()) {
         throw new Error(`Connection "${targetConnection.label}" did not become active.`)
       }
+
+      targetLanded = true
     } finally {
+      stopWatchingRestore()
       // Lower the barrier the moment the commit settles — before the
       // bookkeeping awaits below — but only if this switch still owns it.
       if (token !== null) {
@@ -425,27 +462,43 @@ export async function selectConnection(connectionId: string, options: SelectConn
     // A newer click owns the final refresh. Serialized gateway activation
     // already makes the latest source win; this guard also prevents an older
     // request from repainting its profile list after that newer activation.
-    if (revision === switchRevision) {
-      await rememberConnection(connectionId)
-
-      if (!restoreOnBoot) {
+    if (ownsSwitchIntent()) {
+      if (initiator === 'user') {
         $showAllProfiles.set(false)
       }
 
       $newChatProfile.set(targetProfile)
       captureNewChatSource()
-      requestFreshSession()
+
+      if (restoreSequence !== null && commitProfileConversationRestore(restoreSequence)) {
+        requestFreshSession({
+          cause: 'connection-switch',
+          persistence: 'automatic',
+          restoreSequence
+        })
+      } else if (initiator === 'boot') {
+        requestFreshSession({ cause: 'boot-transition', persistence: 'automatic' })
+      }
+
+      await rememberConnection(connectionId)
       await refreshActiveProfile()
     }
   } catch (error) {
-    if (revision === switchRevision) {
-      if (token !== null) {
+    if (ownsSwitchIntent()) {
+      if (restoreSequence !== null && !targetLanded) {
+        cancelProfileConversationRestore(
+          restoreSequence,
+          token === null ? 'connection-dial-failed' : 'connection-commit-failed'
+        )
+      }
+
+      if (token !== null && !targetLanded) {
         // This switch wiped for a commit that never landed. The previous
         // source is still the active one, and nothing reactive re-pulls its
         // lists (no scope moved): repaint it and land on a fresh draft there,
         // matching what a failed Settings apply leaves behind.
         recoverActiveSourceAfterFailedGatewaySwitch(token)
-        requestFreshSession()
+        requestFreshSession({ cause: 'switch-recovery', persistence: 'automatic' })
       }
 
       throw error

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -8,6 +8,7 @@ import {
   beginGatewaySwitch,
   endGatewaySwitch,
   type GatewaySwitchToken,
+  isCurrentGatewaySwitch,
   recoverActiveSourceAfterFailedGatewaySwitch
 } from '@/store/gateway-switch'
 import {
@@ -484,23 +485,36 @@ export async function selectConnection(connectionId: string, options: SelectConn
       await refreshActiveProfile()
     }
   } catch (error) {
-    if (ownsSwitchIntent()) {
-      if (restoreSequence !== null && !targetLanded) {
-        cancelProfileConversationRestore(
-          restoreSequence,
-          token === null ? 'connection-dial-failed' : 'connection-commit-failed'
-        )
-      }
+    const ownsIntent = ownsSwitchIntent()
+    const recoveryToken = token
+    // Capture ownership before scheduling recovery. A newer intent can begin
+    // between this catch and the helper's microtask; the helper re-checks the
+    // token before every publication, while this snapshot decides whether the
+    // failed owner may also paint a recovery draft.
+    const tokenWasCurrent = recoveryToken !== null && !targetLanded && isCurrentGatewaySwitch(recoveryToken)
 
-      if (token !== null && !targetLanded) {
-        // This switch wiped for a commit that never landed. The previous
-        // source is still the active one, and nothing reactive re-pulls its
-        // lists (no scope moved): repaint it and land on a fresh draft there,
-        // matching what a failed Settings apply leaves behind.
-        recoverActiveSourceAfterFailedGatewaySwitch(token)
+    if (ownsIntent && restoreSequence !== null && !targetLanded) {
+      cancelProfileConversationRestore(
+        restoreSequence,
+        token === null ? 'connection-dial-failed' : 'connection-commit-failed'
+      )
+    }
+
+    if (recoveryToken !== null && !targetLanded) {
+      // Acquiring a token means this switch synchronously wiped the outgoing
+      // source. Recovery is therefore an obligation of the token, not of the
+      // still-current click. A superseding intent may fail before acquiring a
+      // token of its own; in that case this older request remains responsible
+      // for repainting the source it wiped. The token-aware helper safely
+      // declines once a newer commit has actually taken ownership.
+      recoverActiveSourceAfterFailedGatewaySwitch(recoveryToken)
+
+      if (ownsIntent && tokenWasCurrent) {
         requestFreshSession({ cause: 'switch-recovery', persistence: 'automatic' })
       }
+    }
 
+    if (ownsIntent) {
       throw error
     }
   } finally {

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -47,6 +47,7 @@ vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() })
 
 const {
   $gateway,
+  $gatewayActivationEpoch,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
@@ -204,7 +205,6 @@ describe('requestGatewayForAgent', () => {
 
     setPrimaryGateway(primary as never, 'default')
     setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
-
     ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
       getConnection: vi.fn(),
       getConnectionFor,
@@ -242,7 +242,6 @@ describe('requestGatewayForAgent', () => {
 
     setPrimaryGateway(primary as never, 'default')
     setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
-
     ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
       getConnection: vi.fn(),
       getConnectionFor,
@@ -402,6 +401,7 @@ describe('requestGatewayForAgent', () => {
     const sourceBActivation = ensureGatewayForAgent('source-b', 'pinned')
     await vi.waitFor(() => expect(secondaryGateways[1]?.connect).toHaveBeenCalledOnce())
     expect(gatewayActivationEpoch()).toBeGreaterThan(invalidationEpoch)
+    expect($gatewayActivationEpoch.get()).toBe(gatewayActivationEpoch())
     releaseConnect()
     await sourceBActivation
     expect(onActiveConnectionChanged).toHaveBeenLastCalledWith(expect.objectContaining({ connectionId: 'source-b' }))

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -17,6 +17,11 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import {
+  $profileConversationRestore,
+  _resetProfileConversationRestoreForTests,
+  beginProfileConversationRestore
+} from '@/store/profile-conversation-restore'
 import { $stalledSessionIds } from '@/store/session-states'
 
 import {
@@ -92,6 +97,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
 describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit point (#93937)', () => {
   beforeEach(() => {
     $gatewaySwitching.set(false)
+    _resetProfileConversationRestoreForTests()
     setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
     setActiveSessionId('a93bb39d')
     setSessionsLoading(false)
@@ -102,6 +108,19 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     setActiveSessionId(null)
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
+  })
+
+  it('preserves renderer restore coordination across the gateway-bound wipe', () => {
+    const sequence = beginProfileConversationRestore('connection-switch', {
+      connectionId: 'homelab',
+      profile: 'default'
+    })
+
+    beginGatewaySwitch()
+
+    expect($profileConversationRestore.get()?.sequence).toBe(sequence)
+    expect($profileConversationRestore.get()?.phase).toBe('activating')
+    endGatewaySwitch()
   })
 
   it('raises the barrier, runs the registered machine-context reset, then wipes — synchronously, in that order', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -136,6 +136,7 @@ interface GatewayRegistryState {
   primaryProfile: string
   activeKey: string
   activationEpoch: number
+  $activationEpoch: ReturnType<typeof atom<number>>
   secondaries: Map<string, Secondary>
   /** Scopes that opened in this renderer generation, even if later pruned. */
   openedSecondaryScopes?: Set<string>
@@ -157,7 +158,8 @@ function createRegistryState(): GatewayRegistryState {
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
-    secondaries: new Map<string, Secondary>(),
+    $activationEpoch: atom(0),
+    secondaries: new Map(),
     openedSecondaryScopes: new Set<string>(),
     turnLeases: new Map<string, () => void>(),
     turnLeaseReleaseTimers: new Map<string, ReturnType<typeof setTimeout>>(),
@@ -190,6 +192,7 @@ function gatewayState(): GatewayRegistryState {
     // Existing dev-HMR containers predate whole-turn leases.
     store[STATE_KEY].turnLeases ??= new Map()
     store[STATE_KEY].turnLeaseReleaseTimers ??= new Map()
+    store[STATE_KEY].$activationEpoch ??= atom(store[STATE_KEY].activationEpoch ?? 0)
 
     return store[STATE_KEY]
   }
@@ -215,6 +218,8 @@ export const $gateway = g.$gateway
 // surfaces (store/profile.ts's $activeGatewayProfile) mirror this atom
 // instead of writing their own copy.
 export const $activeGatewayRoute = g.$activeProfile
+/** Monotonic active-route generation, including same-route reactivations. */
+export const $gatewayActivationEpoch = g.$activationEpoch
 
 /** Bare profile name the active gateway serves (never a composite scope). */
 export function activeGatewayProfileKey(): string {
@@ -381,6 +386,7 @@ function setActive(profile: string): void {
 
 function beginGatewayActivation(): number {
   g.activationEpoch = gatewayActivationEpoch() + 1
+  g.$activationEpoch.set(g.activationEpoch)
 
   return g.activationEpoch
 }

--- a/apps/desktop/src/store/layout-connection-scope.test.ts
+++ b/apps/desktop/src/store/layout-connection-scope.test.ts
@@ -4,7 +4,15 @@ import type { HermesConnection } from '@/global'
 import { readKey } from '@/lib/storage'
 
 import { $pinnedSessionIds, $sidebarSessionOrderIds, $sidebarSessionOrderManual, pinSession } from './layout'
-import { getRememberedSessionId, setConnection, setRememberedSessionId } from './session'
+import {
+  getRememberedConversation,
+  getRememberedRoute,
+  getRememberedSessionId,
+  setConnection,
+  setRememberedConversation,
+  setRememberedRoute,
+  setRememberedSessionId
+} from './session'
 
 // Two Desktop windows share one renderer origin (and therefore one
 // localStorage area) while each can be connected to a DIFFERENT gateway.
@@ -162,5 +170,37 @@ describe('connection-scoped sidebar lists (#77318)', () => {
 
     setConnection(localConn)
     expect(getRememberedSessionId('default')).toBe('local-session')
+  })
+
+  it('scopes remembered routes and conversation records to the exact connection', () => {
+    setRememberedRoute('/skills', 'default')
+    setRememberedConversation({ kind: 'session', sessionId: 'local-root', version: 1 }, 'default')
+
+    setConnection(remoteA)
+    expect(getRememberedRoute('default')).toBeNull()
+    expect(getRememberedConversation('default')).toBeNull()
+    setRememberedConversation({ kind: 'session', sessionId: 'remote-a-root', version: 1 }, 'default')
+
+    setConnection(remoteB)
+    expect(getRememberedConversation('default')).toBeNull()
+    setRememberedConversation({ kind: 'blank', version: 1 }, 'default')
+
+    setConnection(remoteA)
+    expect(getRememberedConversation('default')).toEqual({ kind: 'session', sessionId: 'remote-a-root', version: 1 })
+
+    setConnection(remoteB)
+    expect(getRememberedConversation('default')).toEqual({ kind: 'blank', version: 1 })
+
+    setConnection(localConn)
+    expect(getRememberedConversation('default')).toEqual({ kind: 'session', sessionId: 'local-root', version: 1 })
+  })
+
+  it('keeps the active remembered-conversation scope during a null reconnect blip', () => {
+    setConnection(remoteA)
+    setRememberedConversation({ kind: 'session', sessionId: 'remote-root', version: 1 }, 'default')
+
+    setConnection(null)
+
+    expect(getRememberedConversation('default')).toEqual({ kind: 'session', sessionId: 'remote-root', version: 1 })
   })
 })

--- a/apps/desktop/src/store/profile-conversation-restore.test.ts
+++ b/apps/desktop/src/store/profile-conversation-restore.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $appliedFreshDraftProvenance,
+  $profileConversationRestore,
+  _resetProfileConversationRestoreForTests,
+  applyFreshDraftProvenance,
+  beginProfileConversationRestore,
+  cancelProfileConversationRestore,
+  clearAppliedFreshDraftProvenance,
+  commitProfileConversationRestore,
+  createFreshSessionIntent,
+  completeProfileConversationRestore,
+  isCurrentProfileConversationRestore,
+  provenanceForFreshSessionIntent,
+  markProfileConversationRestoreNavigating,
+  promoteAutomaticFreshDraftToExplicit
+} from './profile-conversation-restore'
+
+describe('profile conversation restore coordinator', () => {
+  beforeEach(_resetProfileConversationRestoreForTests)
+
+  it('normalizes targets and supersedes older generations', () => {
+    const first = beginProfileConversationRestore('profile-switch', { connectionId: ' remote-a ', profile: ' work ' })
+    const second = beginProfileConversationRestore('connection-switch', { connectionId: ' ', profile: ' ' })
+
+    expect([first, second]).toEqual([1, 2])
+    expect($profileConversationRestore.get()).toEqual({
+      origin: 'connection-switch',
+      phase: 'activating',
+      sequence: 2,
+      target: { connectionId: null, profile: 'default' }
+    })
+    expect(isCurrentProfileConversationRestore(first)).toBe(false)
+    expect(isCurrentProfileConversationRestore(second)).toBe(true)
+  })
+
+  it('makes stale commit, cancel, completion, and navigation no-ops', () => {
+    const stale = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+    const current = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'personal' })
+
+    expect(commitProfileConversationRestore(stale)).toBe(false)
+    cancelProfileConversationRestore(stale, 'activation-failed')
+    completeProfileConversationRestore(stale)
+    expect(markProfileConversationRestoreNavigating(stale, 'stale-session')).toBe(false)
+    expect($profileConversationRestore.get()?.sequence).toBe(current)
+  })
+
+  it('commits and claims navigation only through valid phases', () => {
+    const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+
+    expect(markProfileConversationRestoreNavigating(sequence, 'session-1')).toBe(false)
+    expect(commitProfileConversationRestore(sequence)).toBe(true)
+    expect(commitProfileConversationRestore(sequence)).toBe(false)
+    expect(markProfileConversationRestoreNavigating(sequence, ' ')).toBe(false)
+    expect(markProfileConversationRestoreNavigating(sequence, ' session-1 ')).toBe(true)
+    expect($profileConversationRestore.get()).toMatchObject({ phase: 'navigating', sequence, sessionId: 'session-1' })
+
+    completeProfileConversationRestore(sequence)
+    expect($profileConversationRestore.get()).toBeNull()
+  })
+
+  it('cancels a request without converting its automatic draft provenance', () => {
+    const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+    const provenance = {
+      cause: 'profile-switch',
+      freshSequence: 4,
+      kind: 'automatic',
+      restoreSequence: sequence
+    } as const
+
+    applyFreshDraftProvenance(provenance)
+    cancelProfileConversationRestore(undefined, 'explicit-navigation')
+
+    expect($profileConversationRestore.get()).toBeNull()
+    expect($appliedFreshDraftProvenance.get()).toEqual(provenance)
+  })
+
+  it('creates globally monotonic typed fresh intents and converts them to applied provenance', () => {
+    const automatic = createFreshSessionIntent({
+      cause: 'profile-switch',
+      persistence: 'automatic',
+      restoreSequence: 7
+    })
+    const explicit = createFreshSessionIntent({ cause: 'new-chat', persistence: 'explicit' })
+
+    expect(automatic.sequence).toBe(1)
+    expect(explicit.sequence).toBe(2)
+    expect(provenanceForFreshSessionIntent(automatic)).toEqual({
+      cause: 'profile-switch',
+      freshSequence: 1,
+      kind: 'automatic',
+      restoreSequence: 7
+    })
+    expect(provenanceForFreshSessionIntent(explicit)).toEqual({
+      cause: 'new-chat',
+      freshSequence: 2,
+      kind: 'explicit'
+    })
+  })
+
+  it('tracks automatic and explicit applied provenance independently', () => {
+    applyFreshDraftProvenance({
+      cause: 'connection-switch',
+      freshSequence: 2,
+      kind: 'automatic',
+      restoreSequence: 1
+    })
+    expect($appliedFreshDraftProvenance.get()?.kind).toBe('automatic')
+
+    applyFreshDraftProvenance({ cause: 'new-chat', freshSequence: 3, kind: 'explicit' })
+    expect($appliedFreshDraftProvenance.get()).toEqual({ cause: 'new-chat', freshSequence: 3, kind: 'explicit' })
+
+    clearAppliedFreshDraftProvenance()
+    expect($appliedFreshDraftProvenance.get()).toBeNull()
+  })
+
+  it('promotes only an automatic draft and cancels its pending restore synchronously', () => {
+    const sequence = beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+    applyFreshDraftProvenance({
+      cause: 'profile-switch',
+      freshSequence: 1,
+      kind: 'automatic',
+      restoreSequence: sequence
+    })
+
+    promoteAutomaticFreshDraftToExplicit()
+
+    expect($profileConversationRestore.get()).toBeNull()
+    expect($appliedFreshDraftProvenance.get()).toEqual({
+      cause: 'message-on-automatic-draft',
+      freshSequence: 1,
+      kind: 'explicit'
+    })
+  })
+
+  it('resets atoms and generation state for tests', () => {
+    beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })
+    applyFreshDraftProvenance({ cause: 'new-chat', freshSequence: 9, kind: 'explicit' })
+
+    _resetProfileConversationRestoreForTests()
+
+    expect($profileConversationRestore.get()).toBeNull()
+    expect($appliedFreshDraftProvenance.get()).toBeNull()
+    expect(beginProfileConversationRestore('profile-switch', { connectionId: null, profile: 'work' })).toBe(1)
+  })
+})

--- a/apps/desktop/src/store/profile-conversation-restore.ts
+++ b/apps/desktop/src/store/profile-conversation-restore.ts
@@ -1,0 +1,197 @@
+import { atom } from 'nanostores'
+
+export type ProfileConversationRestoreOrigin = 'connection-switch' | 'profile-switch'
+
+export interface ProfileConversationRestoreTarget {
+  connectionId: null | string
+  profile: string
+}
+
+interface ProfileConversationRestoreBase {
+  origin: ProfileConversationRestoreOrigin
+  sequence: number
+  target: ProfileConversationRestoreTarget
+}
+
+export type ProfileConversationRestoreRequest =
+  | (ProfileConversationRestoreBase & { phase: 'activating' })
+  | (ProfileConversationRestoreBase & { phase: 'committed' })
+  | (ProfileConversationRestoreBase & { phase: 'navigating'; sessionId: string })
+
+export type AutomaticFreshDraftCause =
+  | 'boot-transition'
+  | 'connection-switch'
+  | 'context-recovery'
+  | 'gateway-transition'
+  | 'profile-switch'
+  | 'switch-recovery'
+
+export type ExplicitFreshDraftCause =
+  | 'close-chat'
+  | 'message-on-automatic-draft'
+  | 'new-chat'
+  | 'new-chat-in-agent'
+  | 'new-chat-in-profile'
+  | 'new-project-chat'
+
+export type FreshSessionIntentInput =
+  | {
+      cause: AutomaticFreshDraftCause
+      persistence: 'automatic'
+      restoreSequence?: number
+    }
+  | {
+      cause: ExplicitFreshDraftCause
+      persistence: 'explicit'
+    }
+
+export type FreshSessionIntent = FreshSessionIntentInput & { sequence: number }
+
+export type AppliedFreshDraftProvenance =
+  | {
+      cause: AutomaticFreshDraftCause
+      freshSequence: number
+      kind: 'automatic'
+      restoreSequence?: number
+    }
+  | {
+      cause: ExplicitFreshDraftCause
+      freshSequence: number
+      kind: 'explicit'
+    }
+
+export const $profileConversationRestore = atom<null | ProfileConversationRestoreRequest>(null)
+export const $appliedFreshDraftProvenance = atom<AppliedFreshDraftProvenance | null>(null)
+
+let restoreSequence = 0
+let freshSequence = 0
+
+/** Create one classified reset intent for direct and counter-driven producers. */
+export function createFreshSessionIntent(input: FreshSessionIntentInput): FreshSessionIntent {
+  return { ...input, sequence: ++freshSequence }
+}
+
+export function provenanceForFreshSessionIntent(intent: FreshSessionIntent): AppliedFreshDraftProvenance {
+  return intent.persistence === 'automatic'
+    ? {
+        cause: intent.cause,
+        freshSequence: intent.sequence,
+        kind: 'automatic',
+        ...(intent.restoreSequence === undefined ? {} : { restoreSequence: intent.restoreSequence })
+      }
+    : { cause: intent.cause, freshSequence: intent.sequence, kind: 'explicit' }
+}
+
+function normalizeTarget(target: ProfileConversationRestoreTarget): ProfileConversationRestoreTarget {
+  const connectionId = target.connectionId?.trim() || null
+  const profile = target.profile.trim() || 'default'
+
+  return { connectionId, profile }
+}
+
+/** Begin a latest-only live restore transaction, superseding any older request. */
+export function beginProfileConversationRestore(
+  origin: ProfileConversationRestoreOrigin,
+  target: ProfileConversationRestoreTarget
+): number {
+  const sequence = ++restoreSequence
+
+  $profileConversationRestore.set({
+    origin,
+    phase: 'activating',
+    sequence,
+    target: normalizeTarget(target)
+  })
+
+  return sequence
+}
+
+/** Commit only the latest matching activation. */
+export function commitProfileConversationRestore(sequence: number): boolean {
+  const current = $profileConversationRestore.get()
+
+  if (!current || current.sequence !== sequence || current.phase !== 'activating') {
+    return false
+  }
+
+  $profileConversationRestore.set({ ...current, phase: 'committed' })
+
+  return true
+}
+
+/** Claim the matching route navigation before publishing it to React Router. */
+export function markProfileConversationRestoreNavigating(sequence: number, sessionId: string): boolean {
+  const current = $profileConversationRestore.get()
+  const durableId = sessionId.trim()
+
+  if (!current || current.sequence !== sequence || current.phase !== 'committed' || !durableId) {
+    return false
+  }
+
+  $profileConversationRestore.set({ ...current, phase: 'navigating', sessionId: durableId })
+
+  return true
+}
+
+/** Complete only the latest matching restore. */
+export function completeProfileConversationRestore(sequence: number): void {
+  if (isCurrentProfileConversationRestore(sequence)) {
+    $profileConversationRestore.set(null)
+  }
+}
+
+/**
+ * Cancel one matching generation, or the current generation when no sequence is
+ * supplied. The reason is accepted for call-site diagnostics without becoming
+ * renderer state.
+ */
+export function cancelProfileConversationRestore(sequence?: number, _reason?: string): void {
+  const current = $profileConversationRestore.get()
+
+  if (current && (sequence === undefined || current.sequence === sequence)) {
+    $profileConversationRestore.set(null)
+  }
+}
+
+export function isCurrentProfileConversationRestore(sequence: number): boolean {
+  return $profileConversationRestore.get()?.sequence === sequence
+}
+
+/** Record the reset that currently owns the visible fresh draft. */
+export function applyFreshDraftProvenance(provenance: AppliedFreshDraftProvenance): void {
+  $appliedFreshDraftProvenance.set(provenance)
+}
+
+export function clearAppliedFreshDraftProvenance(): void {
+  $appliedFreshDraftProvenance.set(null)
+}
+
+/**
+ * Adopt an automatically-created isolation draft as the user's explicit blank
+ * before a prompt/create attempt. This is deliberately synchronous: callers
+ * invoke it at the submission boundary, before any async session creation can
+ * race persistence or a pending restore completion.
+ */
+export function promoteAutomaticFreshDraftToExplicit(): void {
+  const current = $appliedFreshDraftProvenance.get()
+
+  cancelProfileConversationRestore(undefined, 'message-on-automatic-draft')
+
+  if (current?.kind !== 'automatic') {
+    return
+  }
+
+  applyFreshDraftProvenance(
+    provenanceForFreshSessionIntent(
+      createFreshSessionIntent({ cause: 'message-on-automatic-draft', persistence: 'explicit' })
+    )
+  )
+}
+
+/** @internal */
+export function _resetProfileConversationRestoreForTests(): void {
+  restoreSequence = 0
+  freshSequence = 0
+  $profileConversationRestore.set(null)
+  $appliedFreshDraftProvenance.set(null)
+}

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -29,7 +29,16 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, newSessionInProfile, selectProfile } = await import('./profile')
+const {
+  $activeGatewayProfile,
+  $freshSessionIntent,
+  $showAllProfiles,
+  newSessionInProfile,
+  selectProfile,
+  setShowAllProfiles
+} = await import('./profile')
+const { $profileConversationRestore, _resetProfileConversationRestoreForTests } =
+  await import('./profile-conversation-restore')
 
 beforeEach(() => {
   ensureGatewayForProfile.mockClear()
@@ -38,9 +47,12 @@ beforeEach(() => {
   activeGatewayConnectionId.mockReturnValue(null)
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
+  $showAllProfiles.set(false)
+  _resetProfileConversationRestoreForTests()
   // resolveConnectionForAgent is best-effort; without a bridge it resolves
-  // null and the previous descriptor stays, which is fine here.
-  ;(globalThis as { window?: unknown }).window = {}
+  // null and the previous descriptor stays, which is fine here. Preserve the
+  // jsdom Window itself because notifications rely on its timer APIs.
+  ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = undefined
 })
 
 describe('selectProfile', () => {
@@ -70,6 +82,73 @@ describe('selectProfile', () => {
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
+
+  it('begins before isolation and commits only after activation succeeds', async () => {
+    let resolveActivation!: () => void
+
+    ensureGatewayForProfile.mockImplementationOnce(
+      () =>
+        new Promise<undefined>(resolve => {
+          resolveActivation = () => resolve(undefined)
+        })
+    )
+
+    selectProfile('research')
+
+    const activating = $profileConversationRestore.get()
+    expect(activating).toMatchObject({ phase: 'activating', target: { connectionId: null, profile: 'research' } })
+    expect($freshSessionIntent.get()).toMatchObject({
+      cause: 'profile-switch',
+      persistence: 'automatic',
+      restoreSequence: activating?.sequence
+    })
+
+    resolveActivation()
+    await vi.waitFor(() => expect($profileConversationRestore.get()?.phase).toBe('committed'))
+  })
+
+  it('cancels the matching restore when activation fails', async () => {
+    ensureGatewayForProfile.mockRejectedValueOnce(new Error('offline'))
+
+    selectProfile('research')
+
+    await vi.waitFor(() => expect($profileConversationRestore.get()).toBeNull())
+  })
+
+  it('keeps only the latest restore across rapid selections', async () => {
+    let resolveFirst!: () => void
+
+    ensureGatewayForProfile.mockImplementationOnce(
+      () =>
+        new Promise<undefined>(resolve => {
+          resolveFirst = () => resolve(undefined)
+        })
+    )
+
+    selectProfile('research')
+    const first = $profileConversationRestore.get()?.sequence
+    selectProfile('ops')
+    resolveFirst()
+
+    await vi.waitFor(() =>
+      expect($profileConversationRestore.get()).toMatchObject({ phase: 'committed', target: { profile: 'ops' } })
+    )
+
+    expect($profileConversationRestore.get()?.sequence).not.toBe(first)
+    expect($profileConversationRestore.get()?.target.profile).toBe('ops')
+  })
+
+  it('restores on concrete re-entry from All Profiles but not a same-profile retap', async () => {
+    $activeGatewayProfile.set('default')
+
+    selectProfile('default')
+    await Promise.resolve()
+    expect($profileConversationRestore.get()).toBeNull()
+
+    setShowAllProfiles(true)
+    selectProfile('default')
+    await vi.waitFor(() => expect($profileConversationRestore.get()?.phase).toBe('committed'))
+  })
 })
 
 describe('newSessionInProfile', () => {
@@ -80,6 +159,11 @@ describe('newSessionInProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'designer'))
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+    expect($profileConversationRestore.get()).toBeNull()
+    expect($freshSessionIntent.get()).toMatchObject({
+      cause: 'new-chat-in-profile',
+      persistence: 'explicit'
+    })
   })
 
   it('keeps the legacy profile-only path for a new chat on the explicit local source', async () => {
@@ -102,12 +186,10 @@ describe('selectProfile startup preference (#79886)', () => {
 
     const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
 
-    ;(globalThis as { window?: unknown }).window = {
-      hermesDesktop: {
-        getConnection,
-        getConnectionConfig,
-        profile: { remember: rememberProfile }
-      }
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      getConnection,
+      getConnectionConfig,
+      profile: { remember: rememberProfile }
     }
   })
 
@@ -140,6 +222,16 @@ describe('selectProfile startup preference (#79886)', () => {
     await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
   })
 
+  it('keeps a landed restore committed when startup-profile persistence fails', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+    rememberProfile.mockRejectedValueOnce(new Error('read-only userData'))
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+    await vi.waitFor(() => expect($profileConversationRestore.get()?.phase).toBe('committed'))
+  })
+
   it('does not replace the startup preference for a registry-source pick', async () => {
     activeGatewayConnectionId.mockReturnValue('mini')
 
@@ -167,12 +259,10 @@ describe('selectProfile startup preference (#79886)', () => {
 
     const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
 
-    ;(globalThis as { window?: unknown }).window = {
-      hermesDesktop: {
-        getConnection,
-        getConnectionConfig,
-        profile: { remember: rememberProfile }
-      }
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      getConnection,
+      getConnectionConfig,
+      profile: { remember: rememberProfile }
     }
 
     selectProfile('tilly')
@@ -188,12 +278,10 @@ describe('selectProfile startup preference (#79886)', () => {
 
     const getConnectionConfig = vi.fn(async () => ({ mode: 'ssh' }))
 
-    ;(globalThis as { window?: unknown }).window = {
-      hermesDesktop: {
-        getConnection,
-        getConnectionConfig,
-        profile: { remember: rememberProfile }
-      }
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      getConnection,
+      getConnectionConfig,
+      profile: { remember: rememberProfile }
     }
 
     selectProfile('macmini-hermes')

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -24,6 +24,15 @@ import {
   openGatewayForProfile
 } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import {
+  beginProfileConversationRestore,
+  cancelProfileConversationRestore,
+  commitProfileConversationRestore,
+  createFreshSessionIntent,
+  type FreshSessionIntent,
+  isCurrentProfileConversationRestore,
+  type FreshSessionIntentInput
+} from '@/store/profile-conversation-restore'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { setConnection } from '@/store/session'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
@@ -332,9 +341,23 @@ export function resolveNewChatOwnerRoute(): AgentProfileRoute | null {
 // currently-open session (store/projects). The chat controller subscribes and
 // resets to the intro draft, so we never strand the user in an orphaned view.
 export const $freshSessionRequest = atom(0)
+export const $freshSessionIntent = atom<FreshSessionIntent | null>(null)
 
-export function requestFreshSession(): void {
-  $freshSessionRequest.set($freshSessionRequest.get() + 1)
+export function requestFreshSession(input: FreshSessionIntentInput): void {
+  if (
+    input.persistence === 'explicit' ||
+    (input.persistence === 'automatic' &&
+      input.restoreSequence === undefined &&
+      input.cause !== 'boot-transition' &&
+      input.cause !== 'gateway-transition')
+  ) {
+    cancelProfileConversationRestore(undefined, `fresh-session:${input.cause}`)
+  }
+
+  const intent = createFreshSessionIntent(input)
+
+  $freshSessionIntent.set(intent)
+  $freshSessionRequest.set(intent.sequence)
 }
 
 // Route profile-scoped REST settings (config/env/skills/tools/model/…) to the
@@ -756,6 +779,9 @@ export function selectProfile(name: string): void {
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
+  const sourceConnectionId = profilePickConnectionId()
+  const onPrimary = activeGatewayConnectionId() == null
+
   $showAllProfiles.set(false)
   $newChatProfile.set(target)
   $newChatRoute.set(null)
@@ -763,38 +789,55 @@ export function selectProfile(name: string): void {
   // is made on the source the user is looking at (activateOnCurrentSource
   // dials exactly that pair), so the draft's exact owner is that pair — or the
   // legacy profile-only path when that is the door the pick takes.
-  captureNewChatSource(profilePickConnectionId())
+  captureNewChatSource(sourceConnectionId)
 
-  if (switching) {
-    requestFreshSession()
+  const restoreSequence = switching
+    ? beginProfileConversationRestore('profile-switch', { connectionId: sourceConnectionId, profile: target })
+    : null
+
+  if (restoreSequence !== null) {
+    requestFreshSession({
+      cause: 'profile-switch',
+      persistence: 'automatic',
+      restoreSequence
+    })
   }
 
-  // A profile with a remote override can fail to activate because the remote
-  // host rejected its saved token (rotated/revoked). That must surface as a
-  // "re-enter token" affordance, never a silently dead profile (#91349).
-  // #81094: any other failed switch must be visible too — the profile pill
-  // stays on the previous profile and the user learns why the backend is
-  // unreachable.
-  //
-  // The profile rail is a live workspace switch, so it must not call
-  // profile.set() and reload the window. Once activation succeeds, remember
-  // the selection for the next Desktop launch through the persistence-only
-  // IPC instead (#79886). Registry-source picks name ANOTHER source's
-  // profiles, so only a primary-backend activation updates the startup
-  // preference.
-  const onPrimary = activeGatewayConnectionId() == null
+  // Restore authority follows activation itself. Startup-profile persistence is
+  // separate best-effort bookkeeping and must never cancel a landed restore.
+  const activation = activateOnCurrentSource(target)
 
-  const shouldRememberStartupProfile = onPrimary ? isLocalDesktopProfile(target) : Promise.resolve(false)
-
-  void Promise.all([activateOnCurrentSource(target), shouldRememberStartupProfile])
-    .then(([, shouldRemember]) => {
-      if (shouldRemember) {
-        return window.hermesDesktop?.profile?.remember(target)
+  void activation
+    .then(() => {
+      if (restoreSequence !== null && !commitProfileConversationRestore(restoreSequence)) {
+        return
       }
 
-      return undefined
+      if (!onPrimary) {
+        return
+      }
+
+      void isLocalDesktopProfile(target)
+        .then(shouldRemember => {
+          if (shouldRemember) {
+            return window.hermesDesktop?.profile?.remember(target)
+          }
+
+          return undefined
+        })
+        .catch((error: unknown) => {
+          notifyError(error, `Failed to switch to profile "${target}"`)
+        })
     })
     .catch((error: unknown) => {
+      if (restoreSequence !== null && !isCurrentProfileConversationRestore(restoreSequence)) {
+        return
+      }
+
+      if (restoreSequence !== null) {
+        cancelProfileConversationRestore(restoreSequence, 'profile-activation-failed')
+      }
+
       if (!notifyRemoteOverrideAuthFailure(target, error)) {
         notifyError(error, `Failed to switch to profile "${target}"`)
       }
@@ -846,7 +889,7 @@ export function newSessionInProfile(name: string): void {
   $newChatProfile.set(target)
   $newChatRoute.set(null)
   captureNewChatSource(profilePickConnectionId())
-  requestFreshSession()
+  requestFreshSession({ cause: 'new-chat-in-profile', persistence: 'explicit' })
   // #81094: surface the failed dial instead of failing silently.
   void activateOnCurrentSource(target).catch((error: unknown) => {
     if (!notifyRemoteOverrideAuthFailure(target, error)) {
@@ -873,7 +916,7 @@ export function newSessionInAgent(route: AgentProfileRoute): void {
   $newChatProfile.set(captured.profile)
   $newChatRoute.set(captured)
   $newChatConnectionId.set(captured.connectionId)
-  requestFreshSession()
+  requestFreshSession({ cause: 'new-chat-in-agent', persistence: 'explicit' })
   // #81094: surface the failed dial instead of failing silently.
   void ensureGatewayAgent(captured.connectionId, captured.profile).catch((error: unknown) => {
     notifyError(error, `Failed to open profile "${captured.profile}"`)
@@ -881,11 +924,15 @@ export function newSessionInAgent(route: AgentProfileRoute): void {
 }
 
 export function setShowAllProfiles(value: boolean): void {
+  if (value) {
+    cancelProfileConversationRestore(undefined, 'all-profiles')
+  }
+
   $showAllProfiles.set(value)
 }
 
 export function toggleShowAllProfiles(): void {
-  $showAllProfiles.set(!$showAllProfiles.get())
+  setShowAllProfiles(!$showAllProfiles.get())
 }
 
 // ── Hotkey-driven profile switching ────────────────────────────────────────

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -200,7 +200,7 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
   if (cwd) {
     requestStartWorkSession(cwd, undefined, { openTab: true })
   } else {
-    requestFreshSession()
+    requestFreshSession({ cause: 'new-project-chat', persistence: 'explicit' })
   }
 }
 
@@ -1134,7 +1134,7 @@ export async function deleteProject(id: string): Promise<void> {
   // The open session's project is gone — reset to the intro draft (the session
   // itself survives; it just falls back to Recents).
   if (kickToIntro) {
-    requestFreshSession()
+    requestFreshSession({ cause: 'context-recovery', persistence: 'automatic' })
   }
 
   await persistOrRollback(snap, async () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1495,14 +1495,24 @@ export function reuseBlankDraftTile(
 const closedTilesByProfile: Record<string, SessionTile[]> = {}
 const closedStack = (): SessionTile[] => (closedTilesByProfile[profileKey()] ??= [])
 
-export function closeSessionTile(storedSessionId: string) {
-  const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
+export function closeSessionTile(
+  storedSessionId: string,
+  ownerScope?: { connectionId: string | null; profile: string; targetProfile?: string }
+) {
+  const ownerMatches = (tile: SessionTile) =>
+    !ownerScope ||
+    (ownerScope.connectionId === null
+      ? !tile.ownerRoute
+      : tile.ownerRoute?.connectionId === ownerScope.connectionId &&
+        tile.ownerRoute?.profile === ownerScope.profile &&
+        tile.ownerRoute?.targetProfile === ownerScope.targetProfile)
+  const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId && ownerMatches(t))
 
   if (tile) {
     closedStack().push(toStored(tile))
   }
 
-  saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
+  saveTiles($sessionTiles.get().filter(t => !(t.storedSessionId === storedSessionId && ownerMatches(t))))
 
   // A settled session may never publish again, so the publish-time eviction
   // in publishSessionState can't reach it — drop its cached state here. A

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -28,10 +28,12 @@ import {
   _resetLegacyDiscardForTests,
   _resetSessionOwnerHintsForTests,
   applyConfiguredDefaultProjectDir,
+  clearRememberedConversationIfSession,
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
   getConfiguredDefaultProjectDir,
+  getRememberedConversation,
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
@@ -45,6 +47,7 @@ import {
   sessionPinId,
   setCurrentCwd,
   setCurrentCwdTransient,
+  setRememberedConversation,
   setRememberedRoute,
   setRememberedSessionId,
   setSelectedStoredSessionId,
@@ -1098,6 +1101,81 @@ describe('remembered route (per profile)', () => {
     expect(getRememberedRoute('default')).toBeNull()
     expect(getRememberedSessionId('default')).toBeNull()
     expect(getRememberedRoute('ai-engineer')).toBe('/session/stored-1')
+  })
+})
+
+describe('remembered conversation (per profile)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    _resetLegacyDiscardForTests()
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('round-trips session, explicit blank, and absence', () => {
+    expect(getRememberedConversation('work')).toBeNull()
+
+    setRememberedConversation({ kind: 'session', sessionId: 'root-1', version: 1 }, 'work')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'root-1', version: 1 })
+
+    setRememberedConversation({ kind: 'blank', version: 1 }, 'work')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'blank', version: 1 })
+  })
+
+  it('falls back from malformed or unknown records to legacy scoped candidates', () => {
+    const key = 'hermes.desktop.lastConversation.profile.work'
+
+    setRememberedSessionId('legacy-id', 'work')
+    localStorage.setItem(key, '{bad json')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'legacy-id', version: 1 })
+
+    localStorage.setItem(key, JSON.stringify({ kind: 'blank', version: 2 }))
+    setRememberedRoute('/route-id', 'work')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'route-id', version: 1 })
+  })
+
+  it('prefers a legacy session route, but never treats / as a blank sentinel', () => {
+    setRememberedSessionId('fallback-id', 'work')
+    setRememberedRoute('/route-id', 'work')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'route-id', version: 1 })
+
+    setRememberedRoute('/', 'work')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'fallback-id', version: 1 })
+
+    setRememberedSessionId(null, 'work')
+    expect(getRememberedConversation('work')).toBeNull()
+  })
+
+  it('dual-writes sessions and makes explicit blanks rollback-safe', () => {
+    setRememberedConversation({ kind: 'session', sessionId: 'root-1', version: 1 }, 'work')
+    expect(getRememberedSessionId('work')).toBe('root-1')
+    expect(getRememberedRoute('work')).toBe('/root-1')
+
+    setRememberedConversation({ kind: 'blank', version: 1 }, 'work')
+    expect(getRememberedSessionId('work')).toBeNull()
+    expect(getRememberedRoute('work')).toBe('/')
+  })
+
+  it('conditionally clears only matching session-shaped state', () => {
+    setRememberedConversation({ kind: 'session', sessionId: 'root-1', version: 1 }, 'work')
+    clearRememberedConversationIfSession('work', 'other')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'session', sessionId: 'root-1', version: 1 })
+
+    clearRememberedConversationIfSession('work', 'root-1')
+    expect(getRememberedConversation('work')).toBeNull()
+
+    setRememberedConversation({ kind: 'blank', version: 1 }, 'work')
+    clearRememberedConversationIfSession('work', 'root-1')
+    expect(getRememberedConversation('work')).toEqual({ kind: 'blank', version: 1 })
+  })
+
+  it('uses the established encoded profile namespace', () => {
+    setRememberedConversation({ kind: 'session', sessionId: 'ops-root', version: 1 }, 'research/ops')
+
+    expect(localStorage.getItem('hermes.desktop.lastConversation.profile.research%2Fops')).toBe(
+      JSON.stringify({ kind: 'session', sessionId: 'ops-root', version: 1 })
+    )
+    expect(getRememberedConversation('research')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -2,6 +2,7 @@ import type { ConnectionState } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
+import { routeSessionId, sessionRoute } from '@/app/routes'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -40,6 +41,7 @@ const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
 // cross-profile corruption this storage boundary prevents (#67709).
 const LAST_SESSION_KEY = 'hermes.desktop.lastSessionId'
 const LAST_ROUTE_KEY = 'hermes.desktop.lastRoute'
+const LAST_CONVERSATION_KEY = 'hermes.desktop.lastConversation'
 
 function profileNavigationKey(base: string, profile: string): string {
   const key = profile.trim() || 'default'
@@ -100,6 +102,123 @@ export function getRememberedSessionId(profile: string): null | string {
 export function setRememberedSessionId(id: null | string, profile: string): void {
   discardLegacyRememberedNavigation()
   persistString(profileNavigationKey(LAST_SESSION_KEY, profile), id)
+}
+
+export type RememberedConversation = { kind: 'blank'; version: 1 } | { kind: 'session'; sessionId: string; version: 1 }
+
+function validRememberedConversation(value: unknown): RememberedConversation | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  const candidate = value as Partial<RememberedConversation>
+
+  if (candidate.version !== 1) {
+    return null
+  }
+
+  if (candidate.kind === 'blank') {
+    return { kind: 'blank', version: 1 }
+  }
+
+  if (candidate.kind === 'session' && typeof candidate.sessionId === 'string' && candidate.sessionId.trim()) {
+    return { kind: 'session', sessionId: candidate.sessionId.trim(), version: 1 }
+  }
+
+  return null
+}
+
+/**
+ * The durable conversation preference for one exact profile + connection.
+ *
+ * Invalid or not-yet-written records fall through to the rollback-compatible
+ * navigation keys. Legacy candidates are deliberately not migrated here: the
+ * restore path must first prove their exact backend ownership. In particular,
+ * `/` is never inferred to be a blank tombstone because older renderers also
+ * wrote it for automatic profile/connection isolation transitions.
+ */
+export function getRememberedConversation(profile: string): RememberedConversation | null {
+  discardLegacyRememberedNavigation()
+
+  const stored = validRememberedConversation(readJson<unknown>(profileNavigationKey(LAST_CONVERSATION_KEY, profile)))
+
+  if (stored) {
+    return stored
+  }
+
+  const rememberedRoute = getRememberedRoute(profile)
+  const routedSessionId = rememberedRoute ? routeSessionId(rememberedRoute) : null
+
+  if (routedSessionId) {
+    return { kind: 'session', sessionId: routedSessionId, version: 1 }
+  }
+
+  const rememberedSessionId = getRememberedSessionId(profile)
+
+  return rememberedSessionId ? { kind: 'session', sessionId: rememberedSessionId, version: 1 } : null
+}
+
+/**
+ * Persist a validated durable preference and maintain the old navigation keys
+ * so rolling back Desktop preserves the same outcome.
+ */
+export function setRememberedConversation(value: RememberedConversation, profile: string): void {
+  discardLegacyRememberedNavigation()
+
+  if (value.kind === 'blank') {
+    // Compatibility writes happen first: an older renderer must not resurrect
+    // the previous session if it observes storage before the new record lands.
+    setRememberedSessionId(null, profile)
+    setRememberedRoute('/', profile)
+    writeJson(profileNavigationKey(LAST_CONVERSATION_KEY, profile), { kind: 'blank', version: 1 })
+    return
+  }
+
+  const sessionId = value.sessionId.trim()
+
+  if (!sessionId) {
+    return
+  }
+
+  writeJson(profileNavigationKey(LAST_CONVERSATION_KEY, profile), {
+    kind: 'session',
+    sessionId,
+    version: 1
+  })
+  setRememberedSessionId(sessionId, profile)
+  setRememberedRoute(sessionRoute(sessionId), profile)
+}
+
+/**
+ * Remove a stale remembered session only when every persisted session-shaped
+ * value still names that exact durable id. Unrelated sessions, non-session
+ * routes, and explicit blank tombstones are preserved.
+ */
+export function clearRememberedConversationIfSession(profile: string, sessionId: string): void {
+  discardLegacyRememberedNavigation()
+
+  const target = sessionId.trim()
+
+  if (!target) {
+    return
+  }
+
+  const conversationKey = profileNavigationKey(LAST_CONVERSATION_KEY, profile)
+  const remembered = validRememberedConversation(readJson<unknown>(conversationKey))
+
+  if (remembered?.kind === 'session' && remembered.sessionId === target) {
+    writeJson(conversationKey, null)
+  }
+
+  if (getRememberedSessionId(profile) === target) {
+    setRememberedSessionId(null, profile)
+  }
+
+  const rememberedRoute = getRememberedRoute(profile)
+
+  if (rememberedRoute && routeSessionId(rememberedRoute) === target) {
+    setRememberedRoute(null, profile)
+  }
 }
 
 export function sessionBelongsToProfile(
@@ -732,6 +851,7 @@ export const $awaitingResponse = atom(false)
 // Null whenever the active route has a healthy (or in-flight) resume.
 export const $resumeFailedSessionId = atom<string | null>(null)
 export interface SessionResumeRequest {
+  forceCold?: boolean
   ownerRoute?: SessionOwnerRoute
   sequence: number
   sessionId: string
@@ -1073,7 +1193,11 @@ export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($message
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 
-export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwnerRoute) => {
+export const requestSessionResume = (
+  sessionId: string,
+  ownerRoute?: SessionOwnerRoute,
+  options?: { forceCold?: boolean }
+) => {
   const id = sessionId.trim()
 
   if (!id) {
@@ -1085,6 +1209,7 @@ export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwne
   }
 
   $sessionResumeRequest.set({
+    ...(options?.forceCold ? { forceCold: true } : {}),
     ...(ownerRoute ? { ownerRoute: { ...ownerRoute } } : {}),
     sequence: ++sessionResumeRequestSequence,
     sessionId: id

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -5,6 +5,14 @@ import type { DesktopUpdateStatus } from '@/global'
 const storage = new Map<string, string>()
 
 vi.mock('@/lib/storage', () => ({
+  readKey: (key: string) => storage.get(key) ?? null,
+  writeKey: (key: string, value: null | string) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, value)
+    }
+  },
   persistBoolean: (key: string, value: boolean) => {
     storage.set(key, String(value))
   },

--- a/docs/investigations/desktop-profile-active-chat-restore-2026-08-27.md
+++ b/docs/investigations/desktop-profile-active-chat-restore-2026-08-27.md
@@ -1,0 +1,420 @@
+# Investigation: Desktop Profile Active Chat Restoration
+
+## Summary
+Investigation complete. The live-switch gap is caused by a window-lifetime
+restore latch combined with persistence of the intentional transitional `/`
+route; backend session availability, route resume, and splash rendering are not
+the initiating cause.
+
+## Symptoms
+- Switching between Hermes Desktop agent profiles shows the default splash screen.
+- The previously active conversation for the selected profile is not restored automatically.
+- The user must perform extra clicks to reopen the conversation.
+
+## Background / Prior Research
+- `b94b3622b5faabadf36d8d51f5804c0a655553e7` introduced reload-free, per-session profile switching and cross-profile session aggregation.
+- `a40e20e1368d6626197f0316361d33b80aff2dd8` deliberately changed a real profile switch to open a fresh draft so the prior profile's conversation cannot remain visible in the new profile context; the current reset path is in `apps/desktop/src/store/profile.ts:756-770` and `apps/desktop/src/app/contrib/wiring.tsx:508-521`.
+- `143942d497f8345d34b2168d0345f8f4ece1ef9c`, `c4212b94530025300166797cf0e406f857cc4645`, and `530d8148aa2f2d7111729d512e39d9e1570e82ce` progressively scoped cold-start session/route restoration per profile and validated ownership. Current persistence logic is in `apps/desktop/src/store/session.ts:40-110,192-211`; cold-start restore is in `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts:95-180`.
+- `afe238ac7e3cd9a50c4f6bdacf2acff3c864714c` further scoped remembered navigation by `(connection, profile)` to prevent cross-window/backend leakage.
+- `fdf6f1d4c80f510c1d579e7fc3b2769f81a97892` defines the splash as renderer-local chrome for an empty, ready, primary fresh draft (`apps/desktop/src/app/chat/intro-visibility.ts:1-32`).
+- History therefore indicates that showing a fresh draft on profile switch is intentional protection against displaying the wrong profile's conversation, while profile-scoped restoration already exists for cold start. The requested behavior likely requires extending the established ownership-safe restoration mechanism to live profile switches rather than removing isolation.
+
+## Investigator Findings
+
+### Verdict
+
+The initial assessment is **proved, with one important refinement**: the gap is
+not merely that live switches fail to invoke the cold-start restore. The same
+one-lifecycle effect that skips the restore also persists the transitional `/`
+route under the newly active scope. Once a successful switch settles on the
+target `(connection, profile)` while the router is on `/`, overwriting that
+scope's remembered route is deterministic. Source-scope overwrite and a write
+under the wrong connection suffix depend on whether routing, activation, and
+descriptor publication interleave.
+
+The root cause is a scope/lifetime mismatch:
+
+- restore readiness is represented by a window-lifetime boolean
+  (`restoredRef`),
+- the data is scoped by `(connection, profile)`, and
+- `/` is both the intentional isolation route and an ordinary persistable route.
+
+The switch correctly isolates the old conversation, but there is no second,
+scope-aware phase that restores the new profile's owned navigation before `/`
+is allowed to become durable.
+
+### Proven Current Sequence
+
+1. **The selector requests isolation before activation succeeds.** Profile rail
+   clicks call `selectProfile()` (`apps/desktop/src/app/chat/sidebar/profile-switcher.tsx:368-384`,
+   with default/condensed variants at `:415-445` and `:477-483`).
+   `selectProfile()` computes whether this is a real switch, updates the next
+   draft owner, and synchronously bumps `$freshSessionRequest` at
+   `apps/desktop/src/store/profile.ts:754-770`. Only afterward does it start the
+   asynchronous activation at `:785-800`. A same-profile retap does not request
+   a reset; returning from All Profiles does.
+
+2. **Wiring deliberately clears the foreground.** The changed request is
+   consumed at `apps/desktop/src/app/contrib/wiring.tsx:508-521` and calls
+   `startFreshSessionDraft()`. That callback clears the durable routed-session
+   intent, navigates to `NEW_CHAT_ROUTE` (`/`), nulls active and selected session
+   IDs, clears messages, and finally marks the empty draft ready at
+   `apps/desktop/src/app/session/hooks/use-session-actions/index.ts:388-471`
+   (the destructive/navigation core is `:417-431`; `/` is defined at
+   `apps/desktop/src/app/routes.ts:9-10`). This is the intentional cross-profile
+   isolation introduced by `a40e20e1368d6626197f0316361d33b80aff2dd8`, whose
+   commit message says a switch starts a fresh draft so the prior profile's
+   session cannot remain sticky.
+
+3. **Reset versus activation has no strict wall-clock order.** The fresh request
+   is synchronous, but its consumer is a React passive effect; activation has
+   already been launched. A warm/primary activation can publish before the
+   router commits `/`, while a cold spawn usually publishes later. Current tests
+   explicitly cover the fast case and prevent the old session from being
+   re-resumed when profile B opens before `/` commits
+   (`apps/desktop/src/app/session/hooks/use-route-resume.test.tsx:393-463`).
+   Regardless of that race, a normal successful switch converges on the target
+   active scope plus `/` and an empty fresh draft.
+
+4. **Cold restoration is intentionally one-shot.** `useDesktopIntegrations()`
+   declares `restoredRef = useRef(false)` and labels it a one-time lifecycle
+   latch at `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts:92-104`.
+   Its only reads of `getRememberedRoute()` / `getRememberedSessionId()` and its
+   ownership-safe navigation ladder are inside `if (!restoredRef.current)` at
+   `:104-153`. Profile switching is explicitly reload-free
+   (`apps/desktop/src/store/profile.ts:779-782`), so the ref stays true and that
+   read path is never revisited for the target profile.
+
+5. **The transitional route is then persisted.** The same effect owns later
+   writes. With no routed session and a non-overlay path, it unconditionally
+   calls `setRememberedRoute(locationPathname, activeProfile)` at
+   `use-desktop-integrations.ts:156-166`; `/` satisfies that branch. The storage
+   helper writes synchronously to the profile-and-connection-scoped key through
+   `apps/desktop/src/store/session.ts:202-210` and
+   `apps/desktop/src/lib/storage.ts:44-56,90-96`. Session ownership is not
+   consulted for the no-session route branch.
+
+6. **Target session arrival cannot heal the missed read.** `sessions` is an
+   effect dependency (`use-desktop-integrations.ts:166`), but subsequent runs
+   still see the closed lifecycle latch and only persist the current route. The
+   cold-start safeguard that keeps remembered state intact while ownership data
+   is absent (`:115-123`) is unreachable on a live switch.
+
+### Exact Scope and Readiness Ordering
+
+- Remembered keys are correctly scoped: `profileNavigationKey()` combines the
+  encoded profile with `activeConnectionScopeSuffix()` at
+  `apps/desktop/src/store/session.ts:44-53`. This rules out a fundamentally
+  global persistence design as the current cause.
+- A connection descriptor publication calls `setConnection()`, which immediately
+  repoints connection-scoped persistence before consumers reconcile
+  (`apps/desktop/src/store/session.ts:968-975`). Registry activation applies the
+  active route and then publishes its active connection at
+  `apps/desktop/src/store/gateway.ts:388-425,1364-1373,1437-1448`; the profile
+  wrapper also resolves descriptor and socket together and batches profile plus
+  connection publication at `apps/desktop/src/store/profile.ts:495-516` and
+  `:672-703`.
+- Wiring already derives the narrow exact reactive identity as
+  ``${activeConnectionId}\0${activeGatewayProfile}`` at
+  `apps/desktop/src/app/contrib/wiring.tsx:523-544`; `$activeConnectionId` is
+  derived from the published connection descriptor at
+  `apps/desktop/src/store/connections.ts:47`.
+- The hook's current `profileReady` input is only
+  `boot.phase === 'renderer.ready'` (`wiring.tsx:838-850`). Standard cold boot
+  adopts the profile and awaits a `refreshSessions()` alongside config/cwd before
+  publishing `renderer.ready` (`apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts:1029-1064`).
+  That is a cold-start barrier; it remains true throughout every reload-free live
+  switch and says nothing about the new target pair.
+- Live list refresh already has strong guards. `refreshSessions()` captures the
+  profile scope and `gatewayActivationEpoch()`, then publishes only if its owner
+  predicate, request ID, current profile, and activation epoch still match
+  (`apps/desktop/src/app/session/hooks/use-session-list-actions.ts:227-350`).
+  The epoch changes on every active route selection, including same-profile
+  source swaps (`apps/desktop/src/store/gateway.ts:303-305,377-390`). Tests reject
+  stale prior-profile and same-profile/different-source responses at
+  `apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx:433-568`.
+- `$sessionsLoading === false` is **not** a readiness signal: loading is raised
+  only when the existing global list is empty
+  (`use-session-list-actions.ts:238-246`). A normal live switch with old rows
+  present remains `false` while the target fetch is in flight. Likewise,
+  `sessions.length !== 0` proves only that some scope has rows, not that the
+  target scope is authoritative.
+- `useBackgroundSync()` does start a target refresh after connection/profile
+  changes, but it is fire-and-forget (`apps/desktop/src/app/contrib/hooks/use-background-sync.ts:601-625`).
+  Restoration therefore needs its own guarded completion/generation signal; it
+  cannot infer readiness from the current atoms.
+
+### Deterministic Versus Conditional Persistence
+
+**Deterministic after a successful, fully published switch:** in a normal main
+window, once the renderer observes the target profile, target connection suffix,
+and `/`, `useDesktopIntegrations` writes `/` to the target's remembered-route
+key. This does not depend on session-list readiness and happens even if the
+window was already on `/`, because changing `activeProfile` reruns the effect.
+Later list changes repeat the `/` write instead of restoring.
+
+The `/` branch does **not** clear `lastSessionId`; only `lastRoute` is replaced
+(`use-desktop-integrations.ts:160-165`). Consequently, a later cold launch can
+still fall back from remembered route `/` to the surviving remembered session id
+at `:142-145`. That does not help the current live switch because its one-time
+read block remains closed, but it explains why a relaunch may appear to restore
+state that repeated in-window profile swaps do not.
+
+**Conditional interleavings:**
+
+- If `/` commits before target activation, the source scope can also have its
+  remembered route replaced before the target write. If activation publishes
+  first, an outgoing session route is normally rejected for the target by the
+  ownership check and the later `/` write still replaces the target route.
+- If target descriptor lookup fails, the profile code deliberately keeps the
+  previous connection descriptor (`profile.ts:506-515`), and null descriptors
+  deliberately keep the previous storage suffix
+  (`apps/desktop/src/lib/connection-scoped.ts:170-181`). A premature `/` can then
+  land under the old connection suffix. That may spare the true target key, but
+  it still performs no restoration and can corrupt a different scoped key.
+- A failed activation still received the fresh request before the rejection is
+  surfaced (`profile.ts:768-800`), so the old scope can be left on a fresh `/`
+  even though the requested target never became active.
+- Low-level localStorage failure is best-effort, but that is unrelated to the
+  control-flow gap.
+
+### Eliminated Hypotheses
+
+1. **Splash logic is not causal.** `shouldShowIntro()` only renders the splash
+   when the primary main chat is an empty, ready fresh draft with no routed,
+   selected, or active session
+   (`apps/desktop/src/app/chat/intro-visibility.ts:12-31`). The switch reset
+   deliberately creates exactly that state. The splash is the visible result of
+   no restore navigation, not the component preventing restoration.
+
+2. **Missing backend session data is not required to reproduce the gap.** The
+   target remembered key is never read after the lifecycle latch closes, so the
+   failure occurs before any target session lookup. The scoped sidebar fetch
+   reads the profile DBs and stamps ownership
+   (`hermes_cli/web_routers/profiles.py:371-443`), and the renderer guards its
+   publication as described above. An individual session can of course truly be
+   deleted, but that is a separate stale-memory case, not an explanation for all
+   live switches landing on the splash.
+
+3. **Route-resume failure is not the initiating cause.** No remembered route is
+   supplied, so route resume is never invoked. When navigation does change from
+   `/` to `/:storedId`, `useRouteResume()` treats `pathnameChanged` as a resume
+   trigger and calls `resumeSession()` while chat/gateway are ready
+   (`apps/desktop/src/app/session/hooks/use-route-resume.ts:111-191`); the direct
+   transition is covered at `use-route-resume.test.tsx:158-202`. Resume then has
+   per-request stale suppression, exact owner routing, warm-cache ownership
+   checks, concurrent REST/RPC hydration, and bounded recovery
+   (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts:802-940,
+   943-1017,1294-1317,1386-1451`; `use-route-resume.ts:223-329`). A real resume
+   failure yields loader/retry/error handling, not the untouched fresh-draft
+   splash.
+
+4. **The fresh reset itself is not an accidental regression.** Commit
+   `a40e20e1368d6626197f0316361d33b80aff2dd8` deliberately added it after
+   `b94b3622b5faabadf36d8d51f5804c0a655553e7` introduced live profile switching.
+   Removing or delaying isolation until after restoration would reintroduce the
+   prior profile's visible conversation and violate the Desktop context-switch
+   invariant.
+
+### Narrow Existing Signals and APIs to Reuse
+
+- The existing restoration ladder:
+  `getRememberedRoute`, `getRememberedSessionId`, `routeSessionId`,
+  `sessionBelongsToProfile`, overlay rejection, and `sessionRoute`
+  (`use-desktop-integrations.ts:20-32,104-150`). Cold and live restoration should
+  call one shared attempt function rather than maintain two policies.
+- Exact settled identity: the existing `gatewayScope` pair in
+  `wiring.tsx:523-527`, plus `gatewayActivationEpoch()` for asynchronous stale
+  suppression.
+- Authoritative list barrier: `refreshSessions(shouldPublish)` and its existing
+  request/profile/epoch checks (`use-session-list-actions.ts:227-350`). Promise
+  resolution alone is insufficient because a superseded request can resolve
+  without publishing.
+- Existing request-generation patterns: `requestSessionResume()` carries a
+  monotonically increasing sequence (`apps/desktop/src/store/session.ts:1076-1091`),
+  route resume consumes it once (`use-route-resume.ts:108,135-170`), and
+  connection switching uses latest-only `switchRevision` plus exact
+  `connectionId::profile` validation
+  (`apps/desktop/src/store/connections.ts:269-334,410-457`).
+- Exact by-ID fallback, if required for an aged-out remembered session:
+  `resolveStoredSession()` checks cache, performs a scoped by-ID GET, stamps
+  ownership, and fails closed for an explicit owner
+  (`apps/desktop/src/app/session/hooks/use-session-actions/utils.ts:1390-1485`).
+
+`$freshSessionRequest` alone is **not** enough: it is targetless and is also used
+for explicit new-chat flows (`newSessionInProfile`, `newSessionInAgent`, project
+deletion, and connection recovery). Resetting the restore latch on every fresh
+edge would make Cmd-N/explicit new-chat actions resurrect old conversations.
+`$gatewaySwapTarget` is likewise profile-only and transient, so it cannot prove
+same-profile/different-connection ownership.
+
+### Viable Designs and Tradeoffs
+
+#### Recommended: explicit successful-switch restore intent
+
+Keep the immediate fresh reset, but add a distinct latest-only navigation
+restore request for context switches. The request should carry a generation and
+the final exact connection/profile identity, and should publish only after the
+selector's activation succeeds and still owns latest intent. `selectProfile`
+already captures the source it dials; the cross-connection selector already has
+the stronger `switchRevision`/`targetIsActive()` template.
+
+On receipt, `useDesktopIntegrations` should:
+
+1. mark that exact scope/generation as pending and suppress persistence of the
+   transitional `/` for it;
+2. await or observe an authoritative target `refreshSessions()` publication;
+3. recheck generation, exact scope, activation epoch, and current route before
+   every read or navigation;
+4. read the connection-scoped remembered route/id and run the existing ownership
+   ladder;
+5. navigate with `{replace: true}` when valid, or clear only after an
+   authoritative negative result; and
+6. release the pending write barrier without allowing stale generations to
+   publish or navigate.
+
+This preserves immediate isolation and makes rapid B→C switches latest-wins. It
+also cleanly excludes explicit New Chat / `newSessionInProfile()` because those
+flows should remain fresh.
+
+`refreshSessions()` currently returns `void`. The safest narrow API refinement
+is to return whether the captured current-scope response actually published (or
+publish a small scope-generation completion token). After awaiting, do not read
+the hook's captured `sessions` array—it is the pre-refresh render. Either let a
+`[sessions, readyGeneration]` effect perform validation on the next render, or
+re-read `$sessions.get()` after rechecking the exact generation/scope.
+
+#### Smaller but unsafe variants
+
+- Replacing the boolean with `restoredScopeRef` alone still cannot distinguish a
+  context switch from explicit New Chat and can restore under a half-published
+  connection descriptor.
+- Resetting `restoredRef` on `$freshSessionRequest` resurrects sessions for
+  intentional fresh-draft actions.
+- Waiting on `$sessionsLoading` or `sessions.length` accepts old-scope rows as
+  target readiness.
+- Calling `ensureGatewayProfile()` from the integration hook duplicates selector
+  ownership and creates another activation race.
+
+#### Optional robustness extension
+
+The current cold ladder treats a nonempty page that lacks a remembered session
+as authoritative. Because the sidebar page is bounded, a valid old unpinned
+session can be absent. A scoped by-ID validation through the existing
+`resolveStoredSession()`/`getSession()` path before clearing would avoid that
+false negative, at the cost of an extra REST request and a less tidy dependency
+boundary. This is not necessary to prove the reported gap, but is safer if live
+restore is expected to honor arbitrarily old remembered chats.
+
+### Recommended Exact Edit Locations (future implementation)
+
+1. **`apps/desktop/src/store/profile.ts:330-338,754-800`** — define and emit a
+   typed latest-only successful profile-navigation restore request; keep
+   `requestFreshSession()` in its current pre-activation isolation position.
+   Do not emit from `newSessionInProfile()` / `newSessionInAgent()`
+   (`:838-880`).
+2. **`apps/desktop/src/store/connections.ts:269-334,410-438`** — if fleet
+   cross-connection profile squares should share the behavior, emit the same
+   request only from the already verified winning commit. Reuse `switchRevision`
+   and `targetIsActive()`; do not broaden boot-time restore or failed-switch
+   recovery.
+3. **`apps/desktop/src/app/contrib/wiring.tsx:508-527,838-850`** — pass the exact
+   gateway scope, restore request/generation, and guarded refresh contract to the
+   integration hook. Keep the existing fresh-draft effect as the isolation
+   owner.
+4. **`apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts:92-166`** —
+   extract the current read/ownership ladder, add exact-scope live restore and a
+   pending transitional-route write barrier, and retain the current deep-link,
+   overlay, HUD/browser-window, and cold-start semantics.
+5. **`apps/desktop/src/app/session/hooks/use-session-list-actions.ts:227-350`** —
+   only if needed, make guarded publication completion observable; preserve all
+   current request/profile/activation-epoch guards.
+6. **Do not edit** `intro-visibility.ts` or weaken `use-route-resume.ts`; both are
+   behaving correctly for the state/routes they receive.
+
+### Test Locations and Required Cases
+
+- Extend
+  `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx:128-180,
+  307-360`. The current "stale-result suppression" test jumps directly from a
+  valid A route to a valid B route and therefore misses the actual transient `/`
+  sequence. Add:
+  - A session → pending fresh `/` → B exact scope: B's remembered route is not
+    overwritten;
+  - B list initially unavailable: key remains intact, then restores after the
+    guarded B publication;
+  - wrong-owner/stale B route is cleared only after an authoritative result;
+  - rapid B→C: late B readiness cannot navigate or persist;
+  - same profile name on two connections restores only the matching connection;
+  - explicit New Chat and `newSessionInProfile()` remain fresh.
+- Extend `apps/desktop/src/store/profile-select-source.test.ts:46-93` to prove
+  `selectProfile()` emits a restore request only for the latest successful exact
+  target, while new-session helpers do not.
+- If `refreshSessions()` exposes publication status, extend
+  `apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx:433-568`
+  for success, superseded request, stale profile, and same-profile/source-change
+  outcomes.
+- Add a remembered-**route** connection-scope assertion beside the existing
+  remembered-session test at
+  `apps/desktop/src/store/layout-connection-scope.test.ts:151-165`; current route
+  storage tests at `apps/desktop/src/store/session.test.ts:1041-1101` cover only
+  per-profile isolation.
+- Keep the route-resume regressions at
+  `apps/desktop/src/app/session/hooks/use-route-resume.test.tsx:158-202,393-463`
+  as proof that restored navigation resumes the target while the outgoing route
+  cannot self-heal during isolation.
+
+### Root Cause Statement
+
+Hermes Desktop intentionally clears the foreground to `/` before a live profile
+activation, but remembered navigation restoration is gated by a window-lifetime
+boolean rather than the active `(connection, profile)` scope. Since live profile
+switches do not reload, the target's remembered route/id is never read. The
+shared persistence half of that effect then treats the intentional isolation
+route as ordinary navigation and, after exact target publication, overwrites the
+target remembered route with `/` without waiting for target-owned session data.
+
+## Investigation Log
+
+### Oracle Synthesis - Minimal safe lifecycle seam
+**Hypothesis:** An explicit successful-switch restore intent plus a transitional-route write barrier is the narrowest safe correction.
+**Findings:** Confirmed, with refinements: the intent/barrier must begin synchronously before the isolation reset; restoration should prefer exact target-scoped by-ID validation; activation success requires exact scope/epoch verification; and bare-ID warm cache reuse must be bypassed or owner-qualified.
+**Evidence:** `profile.ts:754-800`; `use-desktop-integrations.ts:92-166`; `use-session-actions/index.ts:858-867`; selected gateway/session ownership and stale-generation primitives listed above.
+**Conclusion:** Recommended design is a small latest-only renderer transaction, not a reset-latch change or session-list rewrite.
+
+### Initial Assessment - Desktop profile/session restoration
+**Hypothesis:** Profile switching resets renderer chat state without restoring the selected profile's last active session, or the active-session identity is stored globally rather than per profile.
+**Findings:** The reset is intentional, remembered navigation is already scoped
+by connection and profile, but restoration runs only once per renderer lifetime.
+The later persistence branch records the transitional `/` under the new scope.
+**Evidence:** See the exact selector, wiring, restore/persist, session-list,
+gateway-publication, and route-resume file:line traces in Investigator Findings.
+**Conclusion:** The first half of the hypothesis is confirmed. The alternative
+global-identity premise is disproved by the current scoped key implementation.
+
+## Root Cause
+See **Investigator Findings → Root Cause Statement**. The defect is the
+window-lifetime restore latch plus unguarded persistence of the transitional `/`
+route across a reload-free, connection/profile-scoped switch.
+
+## Recommendations
+1. Preserve the immediate pre-activation fresh-draft isolation. Begin a latest-only restore transaction synchronously before `requestFreshSession()`, carrying a sequence plus the captured target connection/source and normalized profile. Activation success must be verified against the final exact gateway scope and activation epoch; promise fulfillment alone is insufficient.
+2. Add renderer-local provenance for the automatically generated isolation `/` and suppress only that route's persistence while its transaction is pending. Release on validated restoration, explicit user navigation/new-chat intent, replacement by a newer switch, or teardown—not merely on an inconclusive lookup.
+3. After exact activation and connection-storage rescoping, prefer a target-scoped by-ID lookup of the remembered chat over global session-list readiness. Restore only on exact profile/connection ownership (including lineage where supported); treat timeout, ambiguity, capped-list absence, and transient failure as inconclusive rather than stale.
+4. Recheck sequence, exact scope, activation epoch, automatic-route provenance, null selected/runtime IDs, and absence of newer user intent immediately before navigating through existing resume machinery.
+5. Force this automatic restoration through an ownership-validated/cold resume path, or qualify warm runtime cache entries by exact owner. The current `runtimeIdByStoredSessionIdRef` is keyed by bare stored-session ID (`use-session-actions/index.ts:858-867`), so identical IDs across profiles/sources are a hidden cross-owner cache hazard.
+6. Keep the first implementation limited to explicit same-window `selectProfile()` switches. Do not trigger it from generic `$freshSessionRequest`, explicit New Chat flows, background activations, or connection-switch transactions.
+
+### Minimum transaction contract
+- Begin payload: monotonic sequence, captured connection/source identity, normalized target profile.
+- Ready proof: same latest sequence, settled gateway scope, activation epoch, and matching connection-storage scope.
+- Cancellation: newer profile selection; explicit New Chat/chat/page selection; message submission; All Profiles; connection/source switch; activation or identity-proof failure; teardown.
+- Negative lookup policy: clear stale memory only after an authoritative exact-target not-found result.
+
+### What must not change
+- Do not remove or delay the isolation reset, change splash visibility, reset the cold-start latch on profile changes, infer readiness from `renderer.ready`/`$sessionsLoading`/nonempty `$sessions`, weaken route-resume race guards, wipe background gateways/lists, or replace backend ownership validation with renderer memory.
+
+## Preventive Measures
+- Test every context switch as an ordered invariant: old foreground clears first; only the latest exact target may restore; transitional routes never become durable; stale activation/list/lookup completions cannot navigate; and explicit new-chat actions never restore.
+- Add duplicate-ID tests across profiles and connections so renderer warm caches cannot bypass exact ownership.
+- Treat route provenance and scope transitions as explicit state rather than inferring user intent from the final pathname.

--- a/docs/plans/desktop-profile-last-conversation-restore-2026-08-27.md
+++ b/docs/plans/desktop-profile-last-conversation-restore-2026-08-27.md
@@ -1,0 +1,1190 @@
+# Desktop Profile Last-Conversation Restore: Implementation Plan
+
+## Goal
+Restore each profile's last valid conversation when users switch profiles in Hermes Desktop, across both same-source profile-rail switches and cross-connection/fleet switches, while preserving immediate cross-profile isolation and preserving explicitly chosen blank New Chat drafts.
+
+## Executive Summary
+Hermes Desktop lands on the fresh-draft splash because live profile switches intentionally clear the outgoing conversation, while remembered navigation restoration is gated by a window-lifetime `restoredRef` and therefore never reruns for the newly active `(connection, profile)` scope. The same effect then persists the switch-generated `/`, overwriting the target scope’s remembered route. The safest fix is a targeted renderer-side restore transaction: preserve the immediate isolation reset, distinguish automatic isolation drafts from explicit blank drafts, suppress remembered-navigation writes during automatic transitions, and restore only the target scope’s last conversation after exact gateway/storage identity is proven and an authoritative scoped by-ID lookup validates ownership. Explicit New Chat remains durable, switch races are latest-wins, and restoration enters the existing route-resume machinery through an ownership-qualified forced-cold resume.
+
+## Background
+- `selectProfile()` records the target draft owner, synchronously issues the generic fresh-session edge, then asynchronously activates the target (`apps/desktop/src/store/profile.ts:754-800`). The profile rail and workspace group are current entry points (`apps/desktop/src/app/chat/sidebar/profile-switcher.tsx:368-384,415-445,477-483`; `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx:126-128`).
+- `selectConnection()` is a distinct two-phase, latest-wins transaction keyed by `connectionId::profile`: it dials first, commits inside the gateway-switch barrier, validates the exact target, and has separate pre-wipe and post-wipe failure behavior (`apps/desktop/src/store/connections.ts:269-457`; `apps/desktop/src/store/gateway-switch.ts:44-159`). Fleet profile squares supply the exact connection/profile pair (`apps/desktop/src/app/chat/sidebar/profile-switcher.tsx:224-235`).
+- Both switch paths and explicit New Chat actions converge on the targetless numeric `$freshSessionRequest` (`apps/desktop/src/store/profile.ts:330-338,754-770,838-883`; `apps/desktop/src/store/connections.ts:311-324,423-449`). Wiring consumes every edge identically and calls `startFreshSessionDraft()` (`apps/desktop/src/app/contrib/wiring.tsx:508-521`), which clears route intent, session IDs, messages, and navigates to `/` (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts:388-471`). No state records whether `/` came from automatic isolation or explicit user intent.
+- The intentional reset was introduced by `a40e20e1368d6626197f0316361d33b80aff2dd8` to prevent the outgoing transcript remaining visible after a live profile re-home; it must remain the foreground isolation boundary. Reload-free profile switching originated in `b94b3622b5faabadf36d8d51f5804c0a655553e7`.
+- Remembered route/session keys are already scoped by normalized profile and active connection suffix (`apps/desktop/src/store/session.ts:40-53,82-108,201-211`; `apps/desktop/src/lib/connection-scoped.ts:49-97,170-203`). `afe238ac7e3cd9a50c4f6bdacf2acff3c864714c` established the connection-scoped isolation needed across windows/backends.
+- `useDesktopIntegrations()` owns both cold restore and subsequent persistence. Its `restoredRef` is a window-lifetime latch; live switches rerun the effect but cannot reread the destination scope, while the write branch persists the transitional `/` (`apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts:92-166`). The full root-cause and eliminated hypotheses are documented in `docs/investigations/desktop-profile-active-chat-restore-2026-08-27.md`.
+- Current cold-start policy can restore arbitrary non-overlay routes, and `/` is not a durable blank sentinel because the surviving remembered session ID may be used as fallback (`apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts:104-165`). This plan intentionally differs for live switching: per user decision, restore only the last conversation and make an explicitly chosen blank New Chat draft durable.
+- Exact active identity is available through `$activeConnectionId`, `$activeGatewayProfile`, `gatewayActivationEpoch()`, and wiring's `gatewayScope` (`apps/desktop/src/store/connections.ts:43-47`; `apps/desktop/src/store/gateway.ts:303-305,377-425`; `apps/desktop/src/app/contrib/wiring.tsx:523-544`). Profile activation descriptor lookup is best-effort and can retain the prior suffix (`apps/desktop/src/store/profile.ts:426-457,495-516,672-703`), so promise fulfillment alone is not proof of a safe persistence scope.
+- Session list refresh has request/profile/activation-epoch stale guards, but `$sessionsLoading` and nonempty `$sessions` are not target-scope readiness signals (`apps/desktop/src/app/session/hooks/use-session-list-actions.ts:227-350`; tests at `use-session-list-actions.test.tsx:433-568`). Exact stored-session lookup exists in `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts:1390-1485`.
+- Resume and owner routing are fail-closed patterns: exact owner resolution is represented in `apps/desktop/src/store/session-request-router.ts`, and route resume consumes monotonic explicit requests (`apps/desktop/src/store/session.ts:1076-1091`; `apps/desktop/src/app/session/hooks/use-route-resume.ts:108,135-170`). Prior ownership commits include `cb75983abfdceed3e544a3dea183bfd46904ee8d` and `07b87f1470aedf86e6ab6d33726b3c4a009a1ff5`.
+- The warm runtime map is keyed by bare stored-session ID (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts:858-867`), so automatic restoration must not reuse a cached runtime without proving exact connection/profile ownership.
+- Existing test seams include restoration/persistence (`use-desktop-integrations.test.tsx:121-180,182-286,307-360`), route reset/resume races (`use-route-resume.test.tsx:158-202,393-463`), same-source selection (`store/profile-select-source.test.ts:46-93`), fleet revisions/failures (`store/connections.test.ts` around the `selectConnection()` transaction), gateway barriers (`store/gateway-switch.test.ts:92-229`), connection-scoped storage (`store/layout-connection-scope.test.ts:151-165`), and explicit blank close behavior (`app/chat/close-tab.test.ts:99-129`).
+- `docs/plans/` and `docs/completed/` contained no earlier plan; the investigation report and commit history are the prior-art baseline.
+
+## Orchestration Progress
+
+- [x] Stage 1: Durable conversation storage and restore coordinator foundations — implemented; formatting passes, focused execution blocked by missing Desktop workspace dependencies
+- [x] Stage 2: Typed draft provenance and both switch transactions — implemented; Prettier/esbuild parsing pass, test runner blocked by missing Desktop dependencies
+- [x] Stage 3: Exact scoped lookup and ownership-forced resume — implemented; Prettier/esbuild/diff checks pass, runtime suites blocked by missing Desktop dependencies
+- [x] Stage 4: Live/cold integration, cancellation, and full regression verification — implemented and independently reviewed; Prettier/esbuild/diff checks pass, runtime suites blocked by missing Desktop dependencies
+
+## Execution Index
+
+| Work item | Goal | Done when | Key files | Dependencies | Size |
+|---|---|---|---|---|---|
+| 1. Durable conversation preference | Distinguish session, explicit blank, absence, and legacy values per exact scope | Versioned record round-trips, dual-write rollback behavior, legacy fallback, and connection isolation tests pass | `store/session.ts`, `store/session.test.ts`, `store/layout-connection-scope.test.ts` | None | M |
+| 2. Restore coordinator and typed draft provenance | Give switch resets latest-only identity and distinguish automatic from explicit `/` | Coordinator generations and every reset producer—including direct Cmd-N, `/new`, Quick Entry, voice, and boot callers—is exhaustively classified at `startFreshSessionDraft()` | New `store/profile-conversation-restore.ts`, `store/profile.ts`, `use-session-actions/index.ts`, `wiring.tsx`, prompt/composer actions, `close-tab.ts`, `projects.ts` | Work item 1 for final persistence behavior | L |
+| 3. Instrument both switch transactions | Begin/commit/cancel restores without changing each switch path's isolation/failure contract | Same-source and fleet success, supersession, All Profiles, pre/post-wipe failures, boot, and landed timeout tests pass | `store/profile.ts`, `store/connections.ts`, related tests | Work item 2 | L |
+| 4. Exact restore lookup | Resolve remembered IDs against the authoritative target and distinguish not-found from inconclusive | Found, lineage, 404, auth/network/5xx, malformed, collision, and cancellation cases are classified correctly | `use-session-actions/utils.ts` and focused tests | Work item 1 | M |
+| 5. Ownership-forced resume | Prevent bare-ID warm cache reuse from crossing profile/source ownership | Forced-cold requests bypass warm activation, retain unrelated background runtimes, and resume with exact owner | `store/session.ts`, `use-route-resume.ts`, `use-session-actions/index.ts`, tests | Work item 4 | M |
+| 6. Live/cold restore and persistence effects | Coordinate exact-scope restoration, durable blank semantics, cancellation, retries, and write barriers | Full integration matrix passes without changing splash, route, list, or gateway-switch behavior | `use-desktop-integrations.ts`, `wiring.tsx`, integration tests | Work items 1–5 | L |
+| 7. Regression and manual validation | Prove no isolation, cache, prompt, or switch regressions | Focused suites, Desktop typecheck/lint/full tests, and manual profile/fleet scenarios pass | Desktop package | Work items 1–6 | M |
+
+## Current-State Analysis
+
+### State ownership and existing reusable seams
+
+- **Renderer navigation and blank-draft presentation**
+  - React Router owns the visible path.
+  - `startFreshSessionDraft()` in `app/session/hooks/use-session-actions/index.ts` clears selected/runtime IDs, transcript and view state, navigates to `NEW_CHAT_ROUTE`, and marks `$freshDraftReady`.
+  - `$freshSessionRequest` in `store/profile.ts` is only a numeric edge; it does not say why the reset was requested.
+
+- **Backend session truth**
+  - Session rows and transcripts come from the backend.
+  - `useSessionListActions.refreshSessions()` publishes guarded foreground list snapshots.
+  - `resolveStoredSession()` performs cache/by-ID resolution, but its current explicit-owner path collapses all errors to `undefined` and therefore cannot distinguish authoritative not-found from transient failure.
+
+- **Gateway/profile identity**
+  - `$activeGatewayProfile`, `$activeConnectionId`, `$connection`, `gatewayActivationEpoch()`, and `activeConnectionScopeSuffix()` collectively identify the active route and persistence namespace.
+  - Profile names alone are insufficient because two connections can both expose `default`.
+  - A resolved socket/profile is not sufficient if the connection descriptor failed and connection-scoped storage still points at the previous suffix.
+
+- **Remembered navigation**
+  - `get/setRememberedSessionId()` and `get/setRememberedRoute()` in `store/session.ts` use keys scoped by normalized profile plus the active connection suffix.
+  - Legacy global keys are discarded rather than migrated.
+  - `sessionBelongsToProfile()` supports durable ID and lineage-root matches but validates only profile ownership.
+  - `useDesktopIntegrations()` owns both the cold-start read and all subsequent writes.
+
+- **Route resume**
+  - `useRouteResume()` converts a routed durable ID into `resumeSession()`.
+  - It already prevents re-resuming the outgoing session while a fresh `/` transition is pending.
+  - `requestSessionResume()` provides a monotonic explicit-resume request and can carry an exact `SessionOwnerRoute`.
+  - `resumeSession()` uses owner-aware backend routing, but its warm runtime map is keyed only by stored session ID. Its cache validation proves stored-ID equality, not connection/profile equality.
+
+These seams should be extended rather than replaced. No backend, Electron, splash, or general session-list architecture change is required.
+
+### Same-source profile switch: current sequence
+
+Entry points include profile rail squares, condensed profile dropdown, default-profile pill, hotkeys, and profile groups in `workspace-group.tsx`. They all converge on `selectProfile()`.
+
+1. `selectProfile(target)` synchronously:
+   - Normalizes the target.
+   - Decides whether this is a real switch:
+     - target differs from `$activeGatewayProfile`, or
+     - the user is returning from All Profiles.
+   - Leaves All Profiles.
+   - Seeds `$newChatProfile`, clears `$newChatRoute`, and captures the source used for the new draft.
+   - Calls targetless `requestFreshSession()` for a real switch.
+
+2. Wiring observes the numeric edge in a passive effect and calls `startFreshSessionDraft()`:
+   - The outgoing transcript disappears.
+   - Route becomes `/`.
+   - Active and selected IDs become `null`.
+   - Messages are cleared.
+   - `$freshDraftReady` becomes true.
+
+3. Independently, `activateOnCurrentSource()` asynchronously activates:
+   - The legacy profile-only door for primary/explicit-local selection.
+   - The exact registry `(connectionId, profile)` door for a remote source.
+
+4. Activation publishes the active gateway route and connection descriptor. The descriptor lookup is intentionally best-effort; failure may leave the previous descriptor and therefore the previous storage suffix.
+
+5. `useDesktopIntegrations()` sees the new profile/scope, but `restoredRef.current` is already true from cold boot. It skips all remembered-state reads.
+
+6. Its persistence branch sees `/` as a non-overlay, non-session route and writes it under whichever profile/connection suffix is active at that render.
+
+There is no strict wall-clock ordering between step 2 and activation publication because the reset consumer is a React passive effect. The normal converged state is nevertheless target profile + `/` + empty draft.
+
+### Same-source failure and overlap behavior
+
+- Activation failure occurs after the fresh request, so the previous scope can remain visible but blank.
+- Rapid B→C selection can leave B’s activation or descriptor work settling after C’s intent unless a separate latest-only restore generation is used.
+- A same-target retap outside All Profiles does not reset and must continue to be a no-op.
+- Returning from All Profiles is intentionally a real context re-entry and should restore the concrete profile.
+
+### Cross-connection/fleet switch: current sequence
+
+Fleet squares call `selectConnection(connectionId, { profile })`.
+
+1. `selectConnection()` derives exact `connectionId::profile` identity and increments `switchRevision`.
+2. **Dial phase:** `openGatewayAgent()` opens the target without changing the foreground.
+   - Failure or timeout here preserves the outgoing transcript and lists.
+3. **Commit phase:** inside serialized gateway activation:
+   - `beginGatewaySwitch()` raises the barrier.
+   - The registered machine-context reset runs.
+   - Gateway-bound session lists, selected/runtime IDs, messages, cached transcript tails, and related state are wiped.
+   - Only then is the target socket activated and its descriptor published.
+4. Exact `targetIsActive()` verification determines whether the switch landed.
+5. The barrier is lowered as soon as commit settles.
+6. Only the latest winning transaction:
+   - Remembers the connection.
+   - Leaves All Profiles for a user switch.
+   - Seeds the target new-chat owner.
+   - Calls `requestFreshSession()`.
+   - Refreshes profile data.
+
+### Fleet failure distinctions
+
+- **Pre-wipe dial failure:** old foreground remains intact; no blank and no restore should occur.
+- **Superseded queued commit:** no wipe, activation, reset, or restore from the superseded request.
+- **Post-wipe activation failure:** the old source is repainted, then intentionally left on a recovery blank.
+- **Activation timeout after target publication:** treated as a successful fail-open commit because exact target identity already landed; this case should restore the target conversation.
+- **Boot-time source restoration:** is not a user live-switch request and must remain under cold-start restoration, not start a second live restore transaction.
+
+### Root cause
+
+The defect is a scope/lifetime mismatch:
+
+- Remembered conversation data belongs to `(connection persistence suffix, normalized profile)`.
+- Cold restoration readiness is represented by a window-lifetime boolean.
+- `/` represents both a deliberate automatic isolation transition and an ordinary persistable route.
+
+Because live switches do not reload, the target scope is never read. Once the target scope and `/` become visible together, `/` is synchronously persisted and can replace the target’s remembered route.
+
+Backend session availability, splash rendering, and route resume are downstream effects, not the initiating cause.
+
+### Hard constraints and invariants
+
+1. The outgoing transcript must clear before another profile becomes usable in the foreground.
+2. Automatic restoration may occur only for the latest explicit profile/source switch.
+3. Exact identity means:
+   - normalized profile;
+   - connection route identity when present;
+   - connection descriptor/storage suffix;
+   - gateway activation epoch.
+4. An automatic switch-generated `/` must never become a durable blank preference.
+5. An explicit blank New Chat must durably prevent an older conversation from returning on a later switch or restart.
+6. Live restore is conversation-only. It must not restore `/skills`, `/artifacts`, contributed pages, or overlays.
+7. Cold start retains its existing valid non-overlay page restoration policy.
+8. List emptiness, `$sessionsLoading`, `renderer.ready`, and activation promise fulfillment are not live-target readiness proofs.
+9. A capped sidebar list cannot prove that an older remembered session was deleted.
+10. Duplicate stored IDs across connections/profiles must fail closed.
+11. Stale generations may finish network work but may not navigate, clear persistence, or release a newer transaction.
+12. Restoration must use established resume semantics; it must not create a session, submit a prompt, rebuild prompt context as a new chat, or overwrite model/prompt choices independently of normal resume behavior.
+
+## Detailed Design
+
+### Scope: targeted transaction, not a broader switch refactor
+
+Implement a small renderer navigation transaction shared by the two existing switch producers. Do not merge `selectProfile()` and `selectConnection()`:
+
+- Same-source selection isolates before asynchronous activation and keeps background profile sockets/lists.
+- Fleet switching dials first, atomically wipes at commit, and has materially different recovery rules.
+
+A universal context-switch framework would obscure these distinctions. The shared abstraction should cover only restore intent, draft provenance, latest-generation ownership, and completion/cancellation.
+
+### New profile-conversation restore coordinator
+
+### Location and ownership
+
+Add `apps/desktop/src/store/profile-conversation-restore.ts`.
+
+This is a renderer-local Nanostores coordination module. It owns no backend truth and no persisted data. `selectProfile()` and `selectConnection()` produce transactions; wiring applies fresh drafts; `useDesktopIntegrations()` consumes and completes restoration.
+
+### Types
+
+Use explicit closed variants similar to:
+
+```ts
+type RestoreOrigin = 'profile-switch' | 'connection-switch'
+
+interface RequestedRestoreTarget {
+  connectionId: string | null
+  profile: string
+}
+
+type ProfileConversationRestoreRequest =
+  | {
+      phase: 'activating'
+      sequence: number
+      origin: RestoreOrigin
+      target: RequestedRestoreTarget
+    }
+  | {
+      phase: 'committed'
+      sequence: number
+      origin: RestoreOrigin
+      target: RequestedRestoreTarget
+    }
+  | {
+      phase: 'navigating'
+      sequence: number
+      origin: RestoreOrigin
+      target: RequestedRestoreTarget
+      sessionId: string
+    }
+```
+
+The coordinator owns:
+
+- A monotonically increasing sequence.
+- `$profileConversationRestore`, containing only the latest live request or `null`.
+- `$appliedFreshDraftProvenance`, describing the reset currently responsible for the visible blank draft.
+
+Fresh-draft provenance should be:
+
+```ts
+type AppliedFreshDraftProvenance =
+  | {
+      kind: 'automatic'
+      cause:
+        | 'profile-switch'
+        | 'connection-switch'
+        | 'switch-recovery'
+        | 'context-recovery'
+        | 'gateway-transition'
+        | 'boot-transition'
+      freshSequence: number
+      restoreSequence?: number
+    }
+  | {
+      kind: 'explicit'
+      cause:
+        | 'new-chat'
+        | 'new-chat-in-profile'
+        | 'new-chat-in-agent'
+        | 'close-chat'
+        | 'new-project-chat'
+        | 'message-on-automatic-draft'
+      freshSequence: number
+    }
+```
+
+The provenance describes the currently applied `/` draft, not merely a requested reset. Wiring must set it immediately before calling `startFreshSessionDraft()`.
+
+### Interfaces
+
+Provide internal functions with these contracts:
+
+- `beginProfileConversationRestore(origin, target) -> sequence`
+  - Normalizes profile and trims connection ID.
+  - Atomically supersedes the previous request.
+  - Returns the new sequence.
+
+- `commitProfileConversationRestore(sequence) -> boolean`
+  - Changes only the matching latest request from `activating` to `committed`.
+  - Returns false for stale/canceled requests.
+
+- `markProfileConversationRestoreNavigating(sequence, sessionId) -> boolean`
+  - Marks the route change as coordinator-owned before calling `navigate`.
+  - Prevents the subsequent pathname effect from treating the automatic route as user cancellation.
+
+- `completeProfileConversationRestore(sequence) -> void`
+  - Clears only the matching latest request.
+
+- `cancelProfileConversationRestore(sequence?, reason) -> void`
+  - With a sequence, clears only that request.
+  - Without a sequence, cancels the current request for an explicit user/context action.
+  - Cancellation does not turn an automatic blank into an explicit one.
+
+- `isCurrentProfileConversationRestore(sequence) -> boolean`
+  - Used after every asynchronous boundary.
+
+- `applyFreshDraftProvenance(intent)`, `clearAppliedFreshDraftProvenance()`
+  - `startFreshSessionDraft()` calls the apply function synchronously at the reset choke point; integrations clear it after restoration or superseding navigation.
+
+- `_resetProfileConversationRestoreForTests()`
+  - Resets counters and atoms.
+
+All calls are synchronous; asynchronous work remains in selectors and the integration hook.
+
+### Typed fresh-session intent and applied provenance
+
+Retain `$freshSessionRequest` as the compatibility edge, and add `$freshSessionIntent` with the same sequence:
+
+```ts
+interface FreshSessionIntent {
+  sequence: number
+  persistence: 'automatic' | 'explicit'
+  cause: AppliedFreshDraftProvenance['cause']
+  restoreSequence?: number
+}
+
+requestFreshSession(intent: Omit<FreshSessionIntent, 'sequence'>): void
+```
+
+Keep the argument mandatory for every `requestFreshSession()` producer. The function cancels a pending restore when the intent is explicit or is unrelated automatic recovery, increments the numeric edge, and publishes the correlated intent.
+
+**Applied provenance must be classified at the real choke point, not only in wiring.** Extend `FreshSessionDraftOptions` so every `startFreshSessionDraft()` call supplies a required `intent` (or an equivalently required closed `provenance` field). At the start of `startFreshSessionDraft()`, record `$appliedFreshDraftProvenance` from that intent before route/session state is cleared. Wiring passes `$freshSessionIntent` through for counter-driven resets; direct callers must classify themselves. This compile-time boundary covers the producers that bypass `requestFreshSession()`:
+
+- Cmd-N/keybind wiring (`apps/desktop/src/app/contrib/wiring.tsx:924-930`);
+- `/new` (`apps/desktop/src/app/contrib/hooks/use-prompt-actions/slash.ts:494-496`);
+- Quick Entry (`apps/desktop/src/app/contrib/wiring.tsx:671`);
+- voice `start_new_session` (`apps/desktop/src/app/contrib/wiring.tsx:767-769`);
+- gateway boot/connection wipe (`apps/desktop/src/app/contrib/wiring.tsx:781-786`);
+- direct sidebar/workspace/session-action callers.
+
+This replaces the weaker timing rule that wiring alone records provenance immediately before reset. Future direct callers cannot create an unclassified blank. `clearAppliedFreshDraftProvenance()` remains coordinator-owned when a route is restored, explicit navigation supersedes the draft, or the window tears down.
+
+### Switch-producer behavior
+
+### `selectProfile()`
+
+For a real switch:
+
+1. Capture the source that `activateOnCurrentSource()` will dial.
+2. Begin a restore request before `requestFreshSession()`.
+3. Issue an automatic fresh intent:
+   - cause `profile-switch`;
+   - persistence `automatic`;
+   - matching restore sequence.
+4. Start activation.
+5. Attach commit/cancel directly to the `activateOnCurrentSource(target)` promise: commit immediately on activation success and cancel only on activation rejection.
+   - Do not wait for `isLocalDesktopProfile()` or the startup-profile `remember()` IPC.
+   - Do not attach cancellation to the current conflated tail `.catch()`: a `remember()` IPC failure after successful activation must not cancel an already committed restore.
+6. Surface activation and persistence errors through their existing UX without changing restore authority after a successful activation.
+   - The previous scope may remain on an automatic blank.
+   - That blank must remain non-durable.
+
+Refactor the current `Promise.all([activation, shouldRememberStartupProfile])` chain so restore commitment follows activation itself. Startup-profile `remember()` remains best-effort bookkeeping after successful activation and does not gate restore.
+
+Do not begin restoration for:
+
+- A same-profile retap outside All Profiles.
+- `newSessionInProfile()`.
+- `newSessionInAgent()`.
+
+Returning from All Profiles to a concrete profile is a real switch and should begin/commit restoration even when the gateway is already active.
+
+### `selectConnection()`
+
+Extend options additively:
+
+```ts
+interface SelectConnectionOptions {
+  profile?: null | string
+  initiator?: 'boot' | 'user'
+}
+```
+
+Default `initiator` to `user`. Make it the single source of truth for boot versus user behavior: `initializeConnectionsRegistry()` passes `initiator: 'boot'`, and the existing `restoreOnBoot` inference is replaced rather than allowed to disagree or misclassify a user's first click after a failed/missing boot adoption.
+
+For a user switch:
+
+1. Begin the restore request before the dial phase, using the exact requested `connectionId` and target profile.
+2. Do not apply a fresh draft during phase-one dial.
+3. On revision supersession, leave the older request replaced by the newer generation.
+4. After commit and `targetIsActive()` verification:
+   - Commit the matching restore sequence.
+   - Issue automatic `connection-switch` fresh intent with that sequence.
+   - Continue existing remember/profile refresh bookkeeping.
+5. A timeout with `targetIsActive() === true` follows this successful path.
+6. On pre-wipe failure:
+   - Cancel the request.
+   - Do not reset or alter draft provenance.
+7. On post-wipe non-landed failure:
+   - Cancel the target restore.
+   - Run current repaint recovery.
+   - Issue automatic `switch-recovery` fresh intent with no restore sequence.
+8. A queued superseded switch that never commits emits no fresh draft and no restore.
+9. Handle the already-active early-return branch (`connections.ts:305-328`) explicitly: when a user exits All Profiles onto the already-active exact pair, begin and commit the restore synchronously, then issue the correlated automatic `connection-switch` draft; there is no dial/barrier to await.
+
+For `initiator: 'boot'`, do not begin a live restore transaction. Any reset caused by the source adoption is automatic/non-durable, and cold-start restore remains the sole reader.
+
+### All Profiles
+
+`setShowAllProfiles(true)` must cancel any pending live restore synchronously because there is no longer one exact foreground profile owner. It does not create or persist a blank.
+
+`setShowAllProfiles(false)` alone does not restore. Concrete re-entry through `selectProfile()` or `selectConnection()` owns restoration.
+
+### Exact settled identity
+
+Add a controller-facing snapshot type:
+
+```ts
+interface ConversationRestoreScope {
+  activationEpoch: number
+  connectionId: string | null
+  gatewayScope: string
+  profile: string
+  storageSuffix: string
+}
+```
+
+Wiring derives it from:
+
+- `$activeConnectionId`;
+- normalized `$activeGatewayProfile`;
+- `gatewayActivationEpoch()`;
+- `activeConnectionScopeSuffix()`;
+- the existing `gatewayScope`.
+
+The integration hook may begin a committed restore only when:
+
+1. Request sequence is still latest.
+2. Request profile equals snapshot profile.
+3. For an explicit registry source, request connection ID equals snapshot connection ID.
+4. `$connection` describes the same normalized profile and expected registry source.
+5. Storage suffix is the suffix derived from that descriptor, not a retained prior descriptor.
+6. Gateway state is open.
+7. Activation epoch is unchanged from scope capture.
+8. Matching automatic draft provenance has been applied.
+9. Route is `/`.
+10. Active and selected session IDs are null.
+11. No session creation or newer user intent is underway.
+
+For profile-only activation, a null requested connection ID means “legacy/profile door,” not a wildcard. The implementation must validate the published descriptor/profile combination before reading storage. If descriptor lookup failed and the old suffix remains active, identity is inconclusive: do not read or write either scope and do not navigate.
+
+**Implementation gate:** first verify how shared-primary remote profile routes stamp `$connection.profile` with a focused real-activation mock test, then finalize the exact descriptor predicate from that evidence. If the descriptor intentionally exposes a backend `targetProfile`, compare against the Desktop profile using the same route/target mapping already represented by `SessionOwnerRoute`; do not weaken the check to bare profile equality.
+
+### Durable remembered-conversation state
+
+### New schema
+
+Add a new connection/profile-scoped key:
+
+`hermes.desktop.lastConversation.profile.<encoded-profile><connection-suffix>`
+
+The JSON value is a versioned tagged record:
+
+```ts
+type RememberedConversation =
+  | { version: 1; kind: 'blank' }
+  | { version: 1; kind: 'session'; sessionId: string }
+```
+
+Storage absence means no durable preference. Malformed/unknown-version values are ignored and fall back to the existing keys.
+
+### API
+
+Add to `store/session.ts`:
+
+- `getRememberedConversation(profile) -> RememberedConversation | null`
+- `setRememberedConversation(value, profile) -> void`
+- `clearRememberedConversationIfSession(profile, sessionId) -> void`
+
+Continue exposing `get/setRememberedSessionId()` and `get/setRememberedRoute()` for compatibility.
+
+### Compatibility ladder
+
+When no valid new record exists:
+
+1. A session-shaped remembered route is the first legacy conversation candidate.
+2. Existing `lastSessionId` is the fallback candidate.
+3. `/` is **not** interpreted as an old blank sentinel because current versions wrote it during automatic transitions.
+4. After a legacy session candidate is authoritatively validated, write the new session record.
+5. After an authoritative not-found, clear the matching legacy candidate instead of migrating it.
+
+### Write semantics
+
+#### Valid session route
+
+Write the new session record only from an existing ownership proof; do not add an RPC to every persistence effect. Accept either (a) a successful exact scoped restore/resume result for that route, or (b) the current owned-session row/owner-route evidence already used by normal routed-session persistence. If an aged-off open session lacks current list evidence, retain its previous durable record until the next authoritative resume rather than clearing or rewriting it.
+
+After that proof:
+
+- Write `{ kind: 'session', sessionId, version: 1 }`.
+- Dual-write `lastSessionId = sessionId`.
+- Write `lastRoute = current session route`.
+
+Use the durable stored/lineage ID already used by routing; do not replace it merely because lookup returned a compressed tip.
+
+#### Explicit blank
+
+Once an explicit fresh intent has actually applied and the renderer is on `/` with no selected/runtime session:
+
+- Write `{ kind: 'blank', version: 1 }`.
+- Clear `lastSessionId`.
+- Write `lastRoute = '/'`.
+
+Order the compatibility writes so rollback code cannot resurrect the old session: clear the old ID and write `/` before finalizing the new blank record.
+
+#### Automatic blank
+
+For profile isolation, connection isolation, switch recovery, or context recovery:
+
+- Do not write `{ kind: 'blank' }`.
+- Do not write `/`.
+- Do not clear a remembered session.
+- Keep this rule after the restore transaction is canceled or exhausts retries; automatic provenance remains until the route changes or a later explicit blank adopts it.
+
+#### Non-session route
+
+- Continue persisting valid non-overlay routes for cold start.
+- Do not change the remembered-conversation record.
+- Therefore:
+  - Cold start may still restore `/skills`.
+  - A live profile switch ignores `/skills` and restores the remembered conversation.
+  - If the conversation record is blank, live switching remains blank.
+
+#### Stale/deleted session
+
+Only after authoritative exact-target not-found:
+
+- Remove the matching new session record.
+- Clear matching `lastSessionId`.
+- Clear `lastRoute` only if it is a session route for the same durable ID.
+- Leave an unrelated non-session route intact.
+- Do not replace stale state with a blank tombstone; stale deletion means absence, not explicit user preference.
+
+### Old/new version behavior
+
+- **New code reading old scoped keys:** falls back as above; validates before migrating.
+- **Old code reading new writes after rollback:**
+  - Session writes are dual-written to existing keys.
+  - Blank writes clear the old session ID and write `/`, so old code also remains blank.
+  - Old code ignores the new JSON key safely.
+- No migration of legacy global unsuffixed keys is introduced.
+
+### Ownership-safe lookup
+
+Add `resolveStoredSessionForRestore()` beside `resolveStoredSession()` in `use-session-actions/utils.ts`.
+
+### Input
+
+```ts
+interface RestoreLookupTarget {
+  connectionId: string | null
+  profile: string
+  storageSuffix: string
+}
+
+type RestoreLookupResult =
+  | { status: 'found'; session: SessionInfo; ownerRoute?: SessionOwnerRoute }
+  | { status: 'not-found' }
+  | { status: 'inconclusive'; reason: string }
+```
+
+The helper must always perform an authoritative scoped by-ID request for automatic/cold restoration. It must not accept a matching bare-ID cache entry as proof.
+
+- Registry target: call by ID with exact `{ connectionId, profile }`.
+- Legacy/profile-only target: call by ID through the already-proven active target profile.
+- Stamp returned rows with Desktop profile and connection ownership using the same policy as `resolveStoredSession()`, then upsert them into `$sessions`.
+- Preserve the candidate stored ID for lineage routing.
+
+### Result classification
+
+- `found` only when:
+  - Returned ID or lineage root matches the requested durable ID.
+  - Returned/derived profile matches the target.
+  - Any connection identity matches the target.
+- `not-found` only for an explicit target-scoped 404/session-gone result.
+- `inconclusive` for:
+  - Timeout or abort.
+  - Connectivity failure.
+  - 401/403 or other auth failure.
+  - 5xx.
+  - Missing compatibility capability.
+  - Malformed result.
+  - Conflicting profile/connection ownership.
+  - Response that does not match the requested ID/lineage.
+
+Reuse the repository’s existing session-gone/error classifier rather than introducing a second interpretation of backend errors. If that classifier currently lives inside `use-session-actions/index.ts`, move only the pure classification helper to the existing error utility module or the smallest shared location.
+
+### Retry policy
+
+For `inconclusive` results:
+
+- Retry at most two additional times while all transaction guards remain true.
+- Use bounded delays of 500 ms and 1,000 ms.
+- Drive these delays with Vitest fake timers in unit/integration tests; assert cancellation clears pending timers and exhaustion never requires wall-clock sleeps.
+- Abort or logically strand work immediately on cancellation/unmount.
+- After exhaustion:
+  - Preserve remembered state.
+  - Remain on the automatic blank.
+  - Complete the transaction so it does not block later work.
+  - Log a scoped diagnostic; do not report “session deleted.”
+  - The sidebar and switching away/back provide recovery.
+
+Do not use session-list absence as a fallback negative result.
+
+### Restore algorithm in `useDesktopIntegrations()`
+
+Split the current combined effect into three responsibilities:
+
+1. Cold-start restoration.
+2. Live-switch conversation restoration.
+3. Remembered-state persistence.
+
+Extract shared candidate selection and lookup completion logic so cold/live restoration cannot drift on ownership or stale-clearing policy.
+
+### Live-switch algorithm
+
+Beginning any live restore synchronously supersedes/closes an unfinished cold-start attempt. Cold and live restoration share a controller generation/abort boundary so a fast profile choice during boot cannot produce two navigations. The cold attempt must recheck its captured exact scope and absence of a live transaction after every await, using the same stale-result discipline as live restore.
+
+For each committed sequence:
+
+1. Wait until exact target scope and matching automatic draft provenance are present.
+2. Capture scope, activation epoch, transaction sequence, route, and user-intent generation.
+3. Read `getRememberedConversation(target.profile)` only after the storage suffix is proven.
+4. Interpret state:
+   - `blank`: complete and stay on `/`.
+   - `session`: use its ID.
+   - absent: inspect legacy session-route/last-ID candidates.
+   - no candidate: complete and stay on the non-durable automatic blank.
+5. Perform `resolveStoredSessionForRestore()`.
+6. After every await/retry delay, recheck:
+   - transaction sequence;
+   - target profile/connection;
+   - activation epoch;
+   - storage suffix;
+   - automatic provenance;
+   - route `/`;
+   - selected/runtime IDs null;
+   - no creating session;
+   - no newer navigation/message intent.
+7. On `found`:
+   - Migrate legacy candidate if necessary.
+   - Mark the transaction `navigating`.
+   - Call `requestSessionResume(candidateId, ownerRoute, { forceCold: true })`.
+   - Navigate to `sessionRoute(candidateId)` with `{ replace: true }`.
+   - Let `useRouteResume()` dispatch the established resume.
+8. On `not-found`:
+   - Clear matching persisted conversation state.
+   - Complete without navigation.
+9. On exhausted `inconclusive`:
+   - Preserve persistence.
+   - Complete without navigation.
+10. When the matching restored route is observed, clear automatic draft provenance.
+
+### Cold-start algorithm
+
+Preserve existing gates for main vs HUD/browser windows and explicit deep links.
+
+At initial `/` after `profileReady` and exact scope readiness:
+
+1. Read remembered non-overlay route and remembered-conversation state.
+2. If the remembered route is valid, non-session, non-overlay, **and not `NEW_CHAT_ROUTE`**, restore it as today.
+3. If conversation state is `blank`, finish cold restoration at `/`; do not fall back to old session keys.
+4. Otherwise choose the session candidate using the compatibility ladder.
+5. Validate it through the same exact by-ID resolver and result policy as live restore.
+6. Use forced-cold explicit resume plus route replacement on success.
+7. Clear only on authoritative not-found.
+8. Preserve memory on inconclusive exhaustion.
+
+A non-`/` initial route remains user/deep-link authority and closes the cold latch without restoration.
+
+Because by-ID lookup becomes authoritative, `sessions.length` is no longer the cold session-readiness barrier. The `sessions` input remains necessary for safe ongoing persistence.
+
+### Persistence and user-cancellation behavior
+
+The persistence effect must consult the current coordinator atom synchronously, not rely only on a render-captured prop. This closes the fast-activation window between beginning a transaction and React rerendering.
+
+Suppress all remembered-navigation writes while a live restore is activating, committed, or navigating. This prevents both:
+
+- transitional `/` writes;
+- an outgoing same-profile session route being written under a newly active connection before `/` commits.
+
+Cancellation rules:
+
+| Trigger | Restore result | Blank provenance |
+|---|---|---|
+| Newer profile/source choice | Older sequence superseded | New switch owns its own provenance |
+| Explicit New Chat / profile new-chat / agent new-chat | Cancel immediately | Explicit; persist blank after reset applies |
+| Close lone main chat | Cancel immediately | Explicit |
+| Path-less project “new session” | Cancel immediately | Explicit |
+| Project deletion kicks open session out | Cancel | Automatic context recovery; non-durable |
+| Enter All Profiles | Cancel | Existing route retained; no blank write |
+| User selects another chat | Cancel before/at selection; pathname effect is backup | Route/session persistence follows selected chat |
+| User navigates to a page/deep link | Cancel | Page persists normally if non-overlay |
+| Message submission on automatic blank | Cancel and promote draft to explicit before create | Persist blank until created session supersedes it |
+| Activation failure | Cancel matching sequence | Automatic blank remains non-durable |
+| Component teardown | Abort/logically strand work | No persistence mutation |
+
+The route observer must recognize a `navigating` transaction whose pathname equals its target session route and must not cancel it as user navigation.
+
+### Gateway wipe, streaming, and submit interactions
+
+- The coordinator and applied-provenance atoms are renderer navigation intent and must **not** be registered in the gateway-bound reset lifecycle. Add a contract test that `beginGatewaySwitch()`/machine-context wipe does not erase the pending restore generation.
+- A fleet commit can apply two resets: the `beforeConnectionSwitch` preserve-route reset and the winning post-commit correlated `/` reset. Classify the former as automatic `gateway-transition` with no restore sequence; it must not replace/cancel the pending transaction. The later correlated `connection-switch` reset becomes the restore-owning provenance. Pin the ordering with a fleet integration test.
+- Switching while the outgoing session is streaming must preserve existing stale callback/request guards: late deltas or completion from the outgoing runtime may update background-owned state but may not repaint the cleared foreground or cancel/navigate the target restore. Add a regression test using a deferred stream completion.
+- Quick Entry and voice are explicit user attempts to start a new conversation. Promote their draft to durable explicit blank before submission; if submission fails, the blank remains durable. A successful create/resume replaces it with the new session record.
+- Message submission cancellation/promotion is owned at the shared prompt/composer submission boundary (`use-prompt-actions` / composer actions), before dispatching create/send. Session creation keeps a defensive cancellation check in `use-session-actions`; wiring should not guess ownership with an optional callback.
+
+### Forced-cold resume and runtime cache safety
+
+Extend resume request and resume interfaces additively:
+
+### Before
+
+```ts
+requestSessionResume(sessionId, ownerRoute?)
+resumeSession(sessionId, replaceRoute?, capturedOwner?)
+```
+
+### After
+
+```ts
+requestSessionResume(sessionId, ownerRoute?, options?: { forceCold?: boolean })
+resumeSession(sessionId, replaceRoute?, capturedOwner?, options?: { forceCold?: boolean })
+```
+
+Add `forceCold?: boolean` to `SessionResumeRequest`.
+
+`useRouteResume()` forwards this option only for the matching monotonic request.
+
+When `forceCold` is true, `resumeSession()`:
+
+- Skips both warm-cache checks for that invocation.
+- Does not call `session.activate` using a bare-ID cached runtime.
+- Continues through exact metadata resolution and `session.resume`.
+- Uses the captured exact owner route when available.
+- Replaces the bare-ID runtime mapping with the newly resumed target runtime when normal resume publication completes.
+- Does not delete unrelated background runtime state merely because a colliding stored ID exists elsewhere.
+
+This is narrower than converting all runtime caches to composite owner keys, while making automatic restoration safe. A full composite-cache refactor should remain separate.
+
+Normal sidebar clicks retain their existing warm behavior unless they carry the forced-cold restore request.
+
+### Automatic-versus-explicit reset classification
+
+| Existing entry point | Classification | Live restore? | Durable blank? |
+|---|---|---:|---:|
+| Real `selectProfile()` switch | Automatic profile isolation | Yes | No |
+| Return from All Profiles via `selectProfile()` | Automatic profile isolation | Yes | No |
+| Same-target `selectProfile()` retap | No reset | No | No change |
+| Winning user `selectConnection()` commit | Automatic connection isolation | Yes | No |
+| Boot `selectConnection()` adoption / pre-commit gateway wipe | Automatic boot or gateway transition | Cold restore only | No |
+| Fleet pre-wipe failure | No reset | No | No change |
+| Fleet post-wipe recovery | Automatic switch recovery | No | No |
+| Fleet landed timeout | Successful automatic connection isolation | Yes | No |
+| `newSessionInProfile()` | Explicit new chat | No | Yes |
+| `newSessionInAgent()` | Explicit new chat | No | Yes |
+| Generic Cmd-N, `/new`, Quick Entry, or voice new-chat action | Explicit new chat | No | Yes, including submit failure |
+| Close lone loaded main chat | Explicit close-to-blank | No | Yes |
+| Path-less `goToProject(..., {newSession:true})` | Explicit project new chat | No | Yes |
+| Project deletion kicks open chat out | Automatic context recovery | No | No |
+| Enter All Profiles | Context cancellation only | No | No |
+| User submits on automatic blank | Explicit adoption of blank | No | Yes until session creation succeeds |
+| User selects another session during restore | User navigation | Cancel | Selected session replaces memory |
+| User navigates to page during restore | User navigation | Cancel | Conversation unchanged |
+
+`workspace-group.tsx` needs no direct provenance change because `newSessionInProfile()` owns its explicit classification centrally.
+
+## File-by-File Impact
+
+## New files
+
+### `apps/desktop/src/store/profile-conversation-restore.ts`
+
+- Add restore request, sequence, draft-provenance types and atoms.
+- Add begin/commit/navigating/complete/cancel/current-check functions.
+- Add test reset helper.
+- Own latest-only coordination; no persistence or backend calls.
+
+### `apps/desktop/src/store/profile-conversation-restore.test.ts`
+
+Cover:
+
+- Monotonic generations.
+- Stale commit/cancel no-ops.
+- New begin superseding old.
+- Automatic vs explicit applied provenance.
+- Navigating-state route ownership.
+- Test reset semantics.
+
+### `apps/desktop/src/app/session/hooks/use-session-actions/restore-resume.test.tsx`
+
+Add a focused resume harness for:
+
+- `forceCold` bypassing a bare-ID warm runtime.
+- Same stored ID cached for another owner.
+- Exact owner route passed to `session.resume`.
+- Background cached runtime state not deleted solely by forced-cold bypass.
+- Newly resumed runtime replacing the stored-ID mapping.
+
+If an existing session-actions hook test file already provides the necessary harness, place these cases there instead; do not create two competing harnesses.
+
+## Modified production files
+
+### `apps/desktop/src/store/profile.ts`
+
+- Add `$freshSessionIntent` and typed `requestFreshSession(intent)`.
+- Keep numeric `$freshSessionRequest` as a compatibility edge.
+- Update `selectProfile()` to begin restore before isolation, commit immediately after activation success, and cancel on failure.
+- Separate activation completion from startup-profile persistence.
+- Classify:
+  - `newSessionInProfile()` and `newSessionInAgent()` as explicit.
+  - `setShowAllProfiles(true)` as restore cancellation.
+- Update every module-internal fresh request with an explicit cause.
+
+Depends on the coordinator module.
+
+### `apps/desktop/src/store/connections.ts`
+
+- Add `SelectConnectionOptions.initiator`.
+- Have boot initialization pass `initiator: 'boot'`.
+- Begin user restore before dial.
+- Commit only after latest revision and exact target verification.
+- Emit automatic connection isolation on successful/landed-timeout commit.
+- Cancel on pre-wipe and post-wipe failure.
+- Emit automatic recovery blank after post-wipe failure.
+- Preserve existing barrier, timeout, repaint, and revision behavior.
+
+Depends on typed fresh intents and the coordinator.
+
+### `apps/desktop/src/store/session.ts`
+
+- Add versioned remembered-conversation type and profile/connection-scoped key.
+- Add read/write/conditional-clear APIs.
+- Add compatibility fallback helpers without changing legacy-global discard.
+- Extend `SessionResumeRequest` and `requestSessionResume()` with `forceCold`.
+- Keep existing remembered route/session APIs for rollback compatibility.
+
+Persistence changes can land independently before the live coordinator begins using them.
+
+### `apps/desktop/src/app/contrib/wiring.tsx`
+
+- Observe `$freshSessionIntent` instead of deriving behavior from the bare numeric edge.
+- Pass the typed intent into `startFreshSessionDraft()` for counter-driven resets; the session-action choke point records applied provenance.
+- Classify direct keybind, Quick Entry, voice, and boot reset calls explicitly.
+- Pass the exact restore scope, current transaction, gateway state, active/selected IDs, and creation-state guard to `useDesktopIntegrations()`.
+- Continue using existing `gatewayScope`.
+- Add synchronous cancellation at the main chat/session selection boundary.
+- Keep message/create promotion in the shared prompt/composer submission owner, not an optional wiring callback.
+- Do not change model/config refresh behavior or the immediate reset.
+
+Depends on profile/session/coordinator interfaces.
+
+### `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts`
+
+- Replace the single combined restore/write effect with cold restore, live restore, and persistence effects.
+- Extract shared conversation candidate and outcome handling.
+- Add latest-generation, exact-scope, activation-epoch, pathname, provenance, and selected/runtime guards.
+- Add bounded retry and cleanup/abort handling.
+- Suppress writes while a transaction is active.
+- Persist explicit blanks using the new tombstone.
+- Keep non-overlay page persistence and main/HUD/browser window restrictions.
+- Before native/deep-link navigation, cancel a pending automatic restore because those events are explicit external user intent.
+
+Depends on scope inputs, resolver result type, and new storage APIs.
+
+### `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`
+
+- Add authoritative `resolveStoredSessionForRestore()`.
+- Bypass bare-ID cache proof.
+- Return `found` / `not-found` / `inconclusive`.
+- Validate exact target identity and lineage.
+- Reuse existing row upsert logic.
+- Accept cancellation signal if the underlying `getSession()` API supports it; otherwise rely on transaction guards and bounded timeout.
+
+### `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
+
+- Extend `resumeSession()` with `forceCold`.
+- Gate both `takeWarmCache()` uses on `forceCold`.
+- Preserve owner-routed `session.resume`, transcript prefetch, model/runtime hydration, retry, and prompt semantics.
+- Extend `FreshSessionDraftOptions` with required typed intent and record applied provenance inside `startFreshSessionDraft()` before clearing state.
+- At session creation start, defensively cancel pending restoration; prompt/composer submission owns the primary explicit promotion before dispatch.
+
+Depends on extended resume types/coordinator.
+
+### `apps/desktop/src/app/session/hooks/use-route-resume.ts`
+
+- Forward `sessionResumeRequest.forceCold` to `resumeSession()`.
+- Preserve the existing pathname, fresh-draft, reconnect, and stale request guards.
+- Do not alter retry counts or gateway-open logic.
+
+### `apps/desktop/src/app/session/hooks/use-prompt-actions/` and `apps/desktop/src/app/chat/hooks/use-composer-actions.ts`
+
+- Classify `/new` as explicit when calling `startFreshSessionDraft()`.
+- At the common prompt submission boundary, cancel pending restoration and promote an automatic blank to explicit before create/send; Quick Entry and voice therefore remain durably blank if submission fails.
+- Add focused tests for `/new`, normal composer send, Quick Entry, voice, and failed submission.
+
+### `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` / wiring boot callback
+
+- Classify preserve-route machine-context resets as automatic `gateway-transition` or `boot-transition`.
+- Ensure they neither persist a blank nor replace the pending correlated restore provenance.
+
+### `apps/desktop/src/app/chat/close-tab.ts`
+
+- Classify the lone-loaded-main fallback as explicit `close-chat`.
+- Promotion of a stacked session remains unchanged and must not write a blank.
+
+### `apps/desktop/src/store/projects.ts`
+
+- Classify path-less `goToProject(..., { newSession: true })` as explicit `new-project-chat`.
+- Classify project-deletion kick-to-intro as automatic `context-recovery`.
+
+## Modified test files
+
+### `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx`
+
+Expand the harness with exact scope, gateway state, selected/runtime IDs, transaction and resolver controls.
+
+Required cases:
+
+- A session → automatic `/` → B scope does not overwrite B memory.
+- B restore waits for exact committed scope.
+- B restore succeeds through scoped by-ID lookup even when sidebar rows are empty.
+- Remembered blank stays blank.
+- Explicit blank writes tombstone, clears old ID, and survives remount.
+- Automatic blank writes nothing.
+- Rapid B→C: late B found/not-found/inconclusive results cannot navigate or clear.
+- Same profile on two connection suffixes restores only its matching conversation.
+- Authoritative not-found clears matching state.
+- Timeout/auth/5xx preserves state.
+- Wrong-owner/conflicting response is inconclusive and never navigates.
+- User session/page navigation cancels.
+- Message submission, `/new`, Quick Entry, and voice promote automatic blank to explicit; failed submission retains the tombstone.
+- Fast live switch while cold restore is unresolved permits only the live generation to navigate.
+- Deferred outgoing stream completion cannot repaint or redirect the target.
+- Cold non-session page restore remains intact and remembered `/` does not short-circuit conversation state.
+- Cold blank prevents legacy session fallback.
+- HUD/browser windows neither restore nor persist.
+
+### `apps/desktop/src/store/profile-select-source.test.ts`
+
+Add assertions that:
+
+- Restore begins before automatic isolation.
+- Request commits only after activation success.
+- Activation failure cancels.
+- Rapid selections only leave the latest committed request.
+- Returning from All Profiles restores.
+- Same-profile retap does not.
+- `newSessionInProfile()` is explicit and produces no restore.
+- `newSessionInAgent()` gets equivalent coverage in this file or the coordinator test.
+
+### `apps/desktop/src/store/connections.test.ts`
+
+Update fresh-request mocks to inspect typed intent. Add:
+
+- User successful switch begins and commits one restore.
+- Boot restore starts no live transaction.
+- Pre-wipe failure cancels without blank/provenance.
+- Queued superseded switch cannot commit restore.
+- Post-wipe failure emits automatic recovery blank, not target restore.
+- Landed activation timeout commits restore.
+- Rapid source/profile choices leave only latest exact target.
+- Returning from All Profiles on the already-active pair begins/commits synchronously and restores.
+- `initiator: 'boot'` is the sole boot signal, including the user's first click after no boot adoption.
+- The preserve-route gateway-transition reset survives the wipe and is superseded by the winning correlated reset without canceling restore.
+
+### `apps/desktop/src/store/session.test.ts`
+
+Add:
+
+- JSON session/blank/absence round trips.
+- Malformed and unknown-version fallback.
+- Old scoped session/route candidate compatibility.
+- `/` alone is not migrated as a blank.
+- Explicit blank clears old session compatibility key.
+- Session dual-write rollback behavior.
+- Conditional stale clear affects only the matching ID.
+- Lineage-root candidate remains durable.
+- Profile encoding remains identical.
+
+### `apps/desktop/src/store/layout-connection-scope.test.ts`
+
+Add connection-scope assertions for:
+
+- Remembered route.
+- Remembered conversation session.
+- Remembered blank.
+- Same profile name on remote A and B retaining independent values.
+- Null connection preserving the active scope.
+
+### `apps/desktop/src/app/session/hooks/use-route-resume.test.tsx`
+
+Add:
+
+- Forced-cold monotonic resume request reaches `resumeSession`.
+- Owner route and `forceCold` are forwarded together.
+- Superseded forced-cold request is not reused for later pathname navigation.
+- Existing “gateway opens before `/` commits” test remains unchanged.
+
+### `apps/desktop/src/app/chat/close-tab.test.ts`
+
+- Assert lone-main close requests explicit blank intent.
+- Assert stacked-session promotion still requests no blank.
+
+### `apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx`
+
+No production API change is required, but add or retain proof that:
+
+- Empty/populated/loading states cannot be treated as target-authoritative.
+- Stale profile and same-profile/different-source responses remain rejected.
+
+The restore tests must mock exact by-ID lookup rather than wait on this hook.
+
+## Intentionally unchanged production files
+
+- `app/chat/intro-visibility.ts`: correctly renders the state it receives.
+- `app/routes.ts`: `/` and session-route parsing remain correct.
+- `store/gateway-switch.ts`: its wipe/barrier/recovery ownership remains unchanged.
+- `app/chat/sidebar/profile-switcher.tsx`: already calls the correct same-source and exact fleet selectors.
+- `app/chat/sidebar/projects/workspace-group.tsx`: `newSessionInProfile()` centrally owns explicit classification.
+- `store/boot.ts`: `renderer.ready` remains cold-start readiness only.
+- `app/session/hooks/use-session-list-actions.ts`: restoration no longer infers readiness from lists.
+- `store/session-request-router.ts`: existing exact RPC routing contract is reused.
+
+## Risks and Migration
+
+## Breaking/internal API risk
+
+Making fresh intent classification mandatory changes every internal `requestFreshSession()` call. Land the signature and all call-site updates atomically. Keep the numeric atom temporarily to avoid breaking unknown secondary consumers; remove it only in a later cleanup after repository-wide search confirms no readers remain.
+
+## Persistence migration
+
+The new key is additive and lazily populated:
+
+- Existing scoped values continue to work.
+- No eager global migration runs.
+- Stale legacy data is never canonicalized until validated.
+- Dual writes make rollback safe.
+- Explicit blank is rollback-safe because old session state is cleared.
+
+## Descriptor ambiguity
+
+A best-effort descriptor failure can leave the old connection suffix active after socket activation. The design deliberately fails closed: it leaves the automatic blank visible and preserves both scopes’ storage rather than risk cross-backend restoration.
+
+Validate shared-primary/remote-override descriptor profile behavior with the real gateway test harness before hard-coding the final predicate.
+
+## Runtime cache collision
+
+Forced-cold restoration removes the immediate hazard without rekeying every runtime cache. Normal non-restore opens retain the existing bare-ID map risk. Do not expand this work into a global composite-key migration unless the new collision test proves the forced-cold bypass cannot be isolated.
+
+## Cross-window writes
+
+LocalStorage is shared across windows and best-effort. Exact connection/profile keys prevent cross-scope bleed, but simultaneous windows on the same exact scope remain last-writer-wins as today. The plan does not introduce a new synchronization policy.
+
+### Implementation discovery gates
+
+Before wiring exact identity, add a focused real-activation harness test for legacy per-profile remote overrides. Determine whether `$connection.profile` carries the Desktop alias or backend target profile; if it differs, validate through the existing `SessionOwnerRoute.targetProfile` mapping rather than weakening to profile-only matching. This is an implementation gate, not an open product question.
+
+Before finalizing the fleet effect ordering, pin whether `beforeConnectionSwitch` fires for the same `selectConnection()` commit and assert the coordinator survives the gateway-bound wipe. The design already handles both resets; the test establishes the concrete ordering.
+
+## Failure and Edge-Case Matrix
+
+| Condition | Navigation | Persistence | Recovery |
+|---|---|---|---|
+| No remembered conversation | Stay automatic `/` | No write | User may choose chat/new chat |
+| Remembered explicit blank | Stay `/` | Preserve blank | Explicit choice honored |
+| Exact session found | Replace to durable route | Write/migrate session after validation | Existing resume/retry UI |
+| Exact 404/gone | Stay `/` | Clear only matching session memory | Sidebar remains usable |
+| Timeout/network/5xx | Stay `/` after bounded retries | Preserve memory | Switch away/back or select row |
+| 401/403 | Stay `/`; existing connection auth UX remains authoritative | Preserve memory | Reauthenticate/retry |
+| Conflicting owner/duplicate ID | No navigation | Preserve memory | Fail closed |
+| Descriptor/storage suffix not settled | No lookup/navigation | No reads or writes in uncertain scope | Bounded wait, then automatic blank |
+| Rapid B→C or live switch during unresolved cold restore | Only latest live target may navigate/clear | Older/cold completions no-op | Latest wins |
+| User clicks chat while B pending | User chat wins | Persist clicked chat after ownership validation | B canceled |
+| User navigates page | Page wins | Persist non-overlay page; conversation unchanged | B canceled |
+| User sends, Quick Entry, or voice starts on blank | Old restore canceled | Blank becomes explicit before dispatch; failure keeps it blank | New session later replaces it |
+| Fleet pre-wipe failure | Old chat remains | Unchanged | Existing error |
+| Fleet post-wipe failure | Old source recovery blank | Automatic blank not persisted | Repaint old source |
+| Fleet landed timeout | Target automatic blank, then restore | Target scope only | Treated as committed |
+| Outgoing stream completes after switch | No foreground repaint/navigation | Target persistence unchanged | Background ownership/stale guards absorb completion |
+| Session compressed | Restore durable/root ID | Keep durable ID | Resolver accepts lineage match |
+| Remembered session aged off list | Exact by-ID lookup still finds it | No list-based clearing | Restores normally |
+
+## Rejected Alternatives
+
+1. **Reset `restoredRef` on every profile change**
+   - Cannot distinguish explicit New Chat from profile isolation and can read under a half-published connection suffix.
+
+2. **Reset on `$freshSessionRequest`**
+   - Generic fresh requests include Cmd-N, close-tab, project actions, and recovery; this would resurrect conversations after deliberate blank choices.
+
+3. **Key restoration only by profile**
+   - Same-named profiles across connections would leak sessions.
+
+4. **Wait for `$sessionsLoading === false` or nonempty `$sessions`**
+   - Both can describe old-scope rows while a target fetch is still in flight.
+
+5. **Use list absence as deletion proof**
+   - The sidebar page is bounded; an aged-out valid session could be cleared.
+
+6. **Delay or remove the isolation reset**
+   - Reintroduces the outgoing-transcript leak the current behavior intentionally fixed.
+
+7. **Restore arbitrary remembered routes on live switch**
+   - Conflicts with the settled conversation-only behavior and could make background profile activity redirect users to pages.
+
+8. **Trust the bare stored-ID warm runtime map**
+   - Duplicate IDs across profiles/sources can bind the wrong runtime.
+
+9. **Merge the profile and connection switch implementations**
+   - Their dial, wipe, failure, background-socket, and cancellation contracts are different.
+
+## Implementation Order
+
+1. **Add remembered-conversation storage**
+   - Add schema/APIs and session/layout scope tests.
+   - Independently compilable; no callers changed yet.
+
+2. **Add the restore coordinator**
+   - Add atoms/functions and focused unit tests.
+   - Independently compilable.
+
+3. **Introduce typed fresh intents**
+   - Add `$freshSessionIntent`.
+   - Atomically update every `requestFreshSession()` call site with explicit classification.
+   - Update close-tab/project/profile tests.
+   - Keep existing numeric atom during migration.
+
+4. **Instrument same-source and fleet producers**
+   - Add begin/commit/cancel behavior.
+   - Add `SelectConnectionOptions.initiator`.
+   - Update profile and connection transaction tests.
+   - This step must land atomically with the coordinator imports.
+
+5. **Add authoritative restore lookup**
+   - Implement structured outcomes and scoped by-ID behavior.
+   - Add lookup tests for found, lineage, 404, transient, owner conflict, and duplicate IDs.
+
+6. **Add forced-cold resume**
+   - Extend resume request, route-resume forwarding, and `resumeSession()`.
+   - Add cache-collision tests.
+   - Independently testable before integrations consume it.
+
+7. **Update wiring**
+   - Apply typed fresh provenance.
+   - Supply exact scope and cancellation signals.
+   - Keep existing isolation/reset and gateway refresh effects intact.
+
+8. **Refactor `useDesktopIntegrations()`**
+   - Extract cold/live/persistence responsibilities.
+   - Add live transaction, bounded lookup, write barrier, explicit blank, and cancellation behavior.
+   - Land with its expanded tests.
+
+9. **Run race/regression suites**
+   - Ensure existing route-reset, gateway-switch, source-switch and persistence tests remain green.
+   - Confirm no changes to splash or session-list production logic are needed.
+
+10. **Finalize documentation**
+    - Update `docs/plans/desktop-profile-last-conversation-restore-2026-08-27.md` with the implemented interfaces and move it to the repository’s completed-plan location only after code lands.
+
+## Verification commands
+
+Run focused Vitest files from `apps/desktop` using the package's npm-managed toolchain:
+
+```bash
+npm exec vitest -- run \
+  src/store/profile-conversation-restore.test.ts \
+  src/store/profile-select-source.test.ts \
+  src/store/connections.test.ts \
+  src/store/gateway-switch.test.ts \
+  src/store/session.test.ts \
+  src/store/layout-connection-scope.test.ts \
+  src/app/contrib/hooks/use-desktop-integrations.test.tsx \
+  src/app/session/hooks/use-route-resume.test.tsx \
+  src/app/session/hooks/use-session-actions/restore-resume.test.tsx \
+  src/app/session/hooks/use-session-list-actions.test.tsx \
+  src/app/chat/close-tab.test.ts
+```
+
+Then run the verified package scripts:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:ui
+npm test
+```
+
+Use `npm run check` only when the full Desktop platform/install matrix is appropriate for the implementation environment; do not introduce one-off scripts.
+
+## References
+- `docs/investigations/desktop-profile-active-chat-restore-2026-08-27.md`
+- `apps/desktop/AGENTS.md:81-101`
+- Commits: `b94b3622b5faabadf36d8d51f5804c0a655553e7`, `a40e20e1368d6626197f0316361d33b80aff2dd8`, `afe238ac7e3cd9a50c4f6bdacf2acff3c864714c`, `530d8148aa2f2d7111729d512e39d9e1570e82ce`, `cb75983abfdceed3e544a3dea183bfd46904ee8d`, `07b87f1470aedf86e6ab6d33726b3c4a009a1ff5`

--- a/docs/reviews/desktop-profile-last-conversation-restore-plan-critique-2026-08-27.md
+++ b/docs/reviews/desktop-profile-last-conversation-restore-plan-critique-2026-08-27.md
@@ -1,0 +1,85 @@
+# Critique: Desktop Profile Last-Conversation Restore Plan
+
+Reviewed: `docs/plans/desktop-profile-last-conversation-restore-2026-08-27.md` (the plan) against the generated-plan section of `prompt-exports/oracle-plan-2026-08-27-111021-profile-restore-plan-b90a.md` (the baseline), with targeted code spot-checks of every load-bearing seam the two documents assert.
+
+Settled decisions respected throughout: restore last conversation only; explicitly blank New Chat is durable; both same-source and cross-connection/fleet switches are in scope. No scope expansion is proposed.
+
+## 1. Export → plan fidelity
+
+**No implementation-bearing content is missing, weakened, or generalized.** A line-granularity diff of the export's generated plan against the plan doc (headings and numbering normalized) matches at ratio 0.972; every differing hunk is either an addition the plan makes (Goal, Background with commit/test-seam references, Execution Index, References) or a heading rename. No baseline line was dropped or reworded. Anyone auditing this plan against the export needs to look only at what the plan *adds*, not what it might have lost.
+
+## 2. Under-specified seams, contradictions, incorrect references, missing dependencies
+
+### F1 (high) — The typed-intent mechanism misses most fresh-draft producers; the classification table promises behavior the mechanism cannot deliver
+
+The plan's mechanism is: `requestFreshSession(intent)` becomes mandatory-typed, wiring observes `$freshSessionIntent`, and wiring marks `$appliedFreshDraftProvenance` "immediately before `startFreshSessionDraft()`". But `requestFreshSession()` has only 8 production call sites (`close-tab.ts:48`, `connections.ts:322,437,448`, `profile.ts:769,849,876`, `projects.ts:203,1137`) — while `startFreshSessionDraft()` is invoked **directly**, bypassing the atom entirely, from:
+
+- `wiring.tsx:924-930` — `useKeybinds({ startFreshSession: startFreshSessionDraft })`: the rebindable new-chat hotkey (the plan's "Generic Cmd-N/new-chat action" row).
+- `use-prompt-actions/slash.ts:494-496` — the `/new` slash action.
+- `wiring.tsx:671` — `useQuickEntryBridge({ startFreshSessionDraft, submitText })` (global Quick Entry hotkey).
+- `wiring.tsx:767-769` — voice-conversation payload with `start_new_session !== false`.
+- `wiring.tsx:781-786` — `useGatewayBoot({ beforeConnectionSwitch: () => startFreshSessionDraft({ preserveRoute: true, ... }) })`.
+
+Consequence: after a profile switch, provenance sits at `automatic` and — per the plan's own rule — persists "until the route changes or a later explicit blank adopts it". A Cmd-N or `/new` applied through any of these paths leaves provenance stale-`automatic`, so the persistence effect treats an **explicit** blank as automatic and never writes `{kind:'blank'}`. Switching away and back then resurrects the old conversation — a direct violation of invariant 5 and the settled durability decision, and a regression the plan's own classification table ("Generic Cmd-N/new-chat action … Durable blank: **Yes**") claims is handled. No file in the File-by-File Impact owns making that row true; `use-keybinds.ts`, `slash.ts`, `use-quick-entry-bridge.ts`, and `use-gateway-boot.ts` appear nowhere in the plan. See §3 for the precise correction.
+
+### F2 (medium) — `selectConnection()`'s early-return branch issues a fresh reset outside the instrumented path
+
+`connections.ts:305-328`: when `pendingTarget === null` and the target pair is already active (reachable when returning from All Profiles on the already-active square), the function seeds the draft owner, calls `requestFreshSession()` (~line 322), and returns — no dial, no barrier, no `targetIsActive()` verification. The plan's numbered `selectConnection()` steps (begin before dial, commit after verification) never mention this branch; only the `connections.test.ts` addition ("Returning from All Profiles on the already-active pair restores") implies it. The design section must state that this branch begins and commits its restore synchronously (trivially — the target is already active) and issues the automatic `connection-switch` intent there.
+
+### F3 (medium) — Cancel-on-activation-rejection must not hook the existing conflated `.catch`
+
+`profile.ts:787-803`: the current chain is `Promise.all([activateOnCurrentSource(target), shouldRememberStartupProfile]).then(→ remember IPC).catch(→ notify)`. That single `.catch` fires for activation rejection *and* for `profile.remember()` IPC rejection after a successful activation. The plan says to "commit … immediately after activation success" and "if activation rejects, cancel that sequence" but does not name this trap: if cancel is attached to the existing catch, a transient remember-IPC failure will cancel an already-committed restore. Commit and cancel must hook the activation promise specifically; the plan should say so explicitly.
+
+### F4 (medium) — The message/create submission boundary has no concrete owner
+
+The plan assigns "at session creation/message submission start, cancel pending restore and promote an automatic draft to explicit" to `use-session-actions/index.ts`, while the wiring section hedges "message/create submission boundary **if that boundary is owned here**". It is not: message submission lives in `use-prompt-actions` / `use-composer-actions` (`submitPromptText` — see `slash.ts:152,178`), and session creation is in `use-session-actions`. Neither `use-prompt-actions/index.ts` nor `use-composer-actions` appears in the File-by-File Impact, so the "message-on-automatic-draft" promotion — a row in the classification table and the cancellation table — has no implementing file.
+
+### F5 (medium) — Cold latch vs. live transaction interplay is unspecified
+
+Today the `restoredRef` latch can still be open when a live switch happens (fast switch during the boot window, while the cold effect waits on `sessions.length`): the effect re-runs with the new `activeProfile` and may read/navigate the *new* scope under the still-open latch (`use-desktop-integrations.ts:99-137`). The plan splits cold and live restore into separate effects but never states that `beginProfileConversationRestore()` must close/supersede an unfinished cold restore, nor that the cold algorithm rechecks scope/transaction after its awaits the way the live algorithm does (live steps list a full recheck discipline; cold steps 1-8 list none). Without that, cold and live can both navigate for one switch.
+
+### F6 (low) — New persistence write's ownership proof is unspecified
+
+The current write branch gates session-route persistence on list membership: `routedSessionId && sessionBelongsToProfile(sessions, routedSessionId, activeProfile)` (`use-desktop-integrations.ts:155-160`). The plan says the new `{kind:'session'}` record is written "after a routed session has exact active-scope ownership" without saying whether that proof remains list-based or becomes by-ID. If list-based, a session aged off the capped sidebar while still open stops refreshing the record (probably acceptable, but must be stated); if by-ID, that is a new RPC on every route settlement. Either is defensible; the plan must pick one.
+
+### F7 (low) — Cold algorithm step 2 must explicitly exclude `NEW_CHAT_ROUTE`
+
+Cold step 2 says "if the remembered route is a valid non-session, non-overlay route, restore it as today" — but "as today" includes a `route !== NEW_CHAT_ROUTE` exclusion the sentence drops. The combination *session conversation record + `lastRoute === '/'`* is newly reachable and meaningful (e.g. the user backs out of a session to the splash without an explicit New Chat; the non-session-route branch then writes `/` while the conversation record keeps the session). As written, step 2 would restore `/` and stop, ignoring the session record — restart would then behave differently from a live switch for identical stored state. Step 2 needs the explicit `route !== NEW_CHAT_ROUTE` guard so the conversation record is consulted.
+
+### F8 (low) — `initiator` option vs. the existing `restoreOnBoot` inference
+
+`connections.ts:289` already infers boot: `restoreOnBoot = pendingTarget === null && $activeConnectionId.get() === null`, and behavior is pinned to it (#93197, All-Profiles preservation). The plan adds `SelectConnectionOptions.initiator` without reconciling the two. Note also the inference can misfire: if boot adoption never landed (no saved connection), the *user's first click* also satisfies it. Decision needed: `initiator` becomes the single source (driving `restoreOnBoot` too) or stays separate with a test proving they agree.
+
+### F9 (low) — Incorrect reference and a missing test file in verification
+
+- The `selectProfile()` section says "Do not wait for startup-profile persistence or `refreshActiveProfile()`". `refreshActiveProfile()` is not in `selectProfile()`'s chain — it is `selectConnection()`'s bookkeeping (`connections.ts:447-448`). For `selectProfile` the accurate statement is: don't wait on the `Promise.all` (activation + `isLocalDesktopProfile`) or the `remember()` IPC.
+- The verification command list omits the new `src/app/session/hooks/use-session-actions/restore-resume.test.tsx` the plan itself creates.
+
+## 3. Details the code disproves, or a simpler design replaces
+
+**Verified accurate (no correction needed):** every "Before" interface and load-bearing line reference I checked matches the code — `requestSessionResume(sessionId, ownerRoute?)` (`session.ts:1076-1091`, including the `setSessionOwnerHint` side effect); `resumeSession(storedSessionId, replaceRoute = false, capturedOwner?)` (`use-session-actions/index.ts:797-799`); exactly two `takeWarmCache()` uses (defined `index.ts:858`, used at 877 and 973); `resolveStoredSession()`'s explicit-owner path collapsing all errors to `undefined` (`utils.ts:1416-1425`); the combined restore/write effect and window-lifetime `restoredRef` (`use-desktop-integrations.ts:92-166`); `close-tab.ts:44-53` lone-main fallback with stacked promotion clean; `projects.ts:203` path-less new-session and `projects.ts:1137` deletion kick; `selectProfile()`'s synchronous reset-then-async-activation ordering (`profile.ts:756-803`); the fleet dial/commit/barrier/revision structure and post-wipe recovery reset (`connections.ts:330-457`). The root cause and both current-state sequences are faithful to the code.
+
+**Disproven by the code — the mechanism of F1:** the claim that making `requestFreshSession(intent)` mandatory "forces every compile-time call site to classify its reset" is false as a completeness argument: the majority of fresh-draft producers never call `requestFreshSession()` (see F1's list). Until corrected, the closed `cause` union's `'new-chat'` variant has no producer, and the classification table's Cmd-N row is unimplementable as specified.
+
+**Precise correction for F1 (a strictly simpler design than the plan's provenance timing contract):** classify at the single choke point every producer already calls — `startFreshSessionDraft()`. It already accepts an options argument (`{ preserveRoute, workspaceTarget }`, `wiring.tsx:783`); extend it with a mandatory intent/cause (wiring's `$freshSessionIntent` consumer passes the typed intent through). That one change (a) forces classification of the *complete* producer set at compile time — keybinds, slash, quick-entry, voice, and gateway-boot included; (b) makes `$appliedFreshDraftProvenance` a simple function of the applied draft rather than a "wiring must set it immediately before calling" timing contract that every future caller must remember; and (c) leaves the coordinator, `$freshSessionIntent`, restore transaction, and all persistence semantics exactly as planned. Keep `requestFreshSession(intent)` typed for the switch producers (they need the `restoreSequence` correlation); the correction only moves where *applied* provenance is recorded. The alternative — migrating five additional direct callers onto `requestFreshSession()` — also works but touches more files and leaves the choke point unguarded against the next caller.
+
+## 4. Requirements, edge cases, and architectural problems absent from both
+
+- **Streaming/turn-in-flight during a switch (lifecycle/failure):** neither document addresses switching profile while a response is streaming in the outgoing session, or restoring a target session that has a live runtime elsewhere. The wipe clears messages, but late stream-completion callbacks racing the restore's `navigate` is untested territory; the plan's test matrix has no case for it.
+- **Double reset on fleet commit (ordering):** `useGatewayBoot.beforeConnectionSwitch` runs a `preserveRoute: true` fresh draft on connection switches while the winning `selectConnection()` transaction separately issues its automatic intent after the barrier. When both fire for one switch, the plan doesn't specify which owns provenance or whether the preserve-route reset must be exempt from (or participate in) classification. Under the §3 correction each call classifies itself, but the interaction still needs a stated rule and a test.
+- **Coordinator survival across the gateway-switch wipe (ownership):** the machine-context reset deliberately wipes gateway-bound stores and does *not* call `requestFreshSession()` (`gateway-switch.ts:174`). The new coordinator/provenance atoms must never be registered with that reset — trivially true for plain module atoms today, but nothing pins it; one line in the coordinator test file ("wipe does not clear restore request or provenance") makes it a contract instead of an accident.
+- **Testability of retries:** the 500 ms/1000 ms bounded retry delays need a declared fake-timer strategy in the integration harness; otherwise the exhaustion cases are either slow or flaky. Neither document mentions timer control.
+- **Quick Entry / voice blank-on-failure semantics:** those paths call `startFreshSessionDraft()` and then immediately submit; on submit *failure* the draft stays blank. Whether that blank is durable-explicit (persisted tombstone) or transient is undefined; it changes what a later switch restores.
+
+## 5. Questions whose answers materially change the design or order
+
+1. **How does `$connection.profile` stamp for legacy per-profile remote overrides?** `resolveStoredSession()`'s comment (`utils.ts:1455-1460`) says a per-profile remote override strips the alias so the backend answers as its own `default`. If the descriptor then carries the backend's profile rather than the Desktop key, identity predicate #4 ("`$connection` describes the same normalized profile") fails for every remote-override profile and live restore goes permanently inconclusive for them. The plan's "validation unknown" flag is right; this decides whether remote-override profiles get live restore at all, and whether the predicate must map through `SessionOwnerRoute.targetProfile` from day one.
+2. **When exactly does `beforeConnectionSwitch` fire relative to `selectConnection()`'s commit** — only for switches initiated outside it (`newSessionInAgent`, profile remote-source picks), or also inside it? Determines whether the double-reset rule (§4) is a real path or a theoretical one, and whether `newSessionInAgent`'s connection swap needs restore-adjacent handling.
+3. **Is restore confirmed for the already-active early-return branch** (F2)? The test list implies yes; the design section should say it, since that branch has no commit/verification structure to hang begin/commit on.
+4. **List-membership or by-ID ownership proof for the new session-record write** (F6)? Decides whether aged-out-but-open sessions keep refreshing their record, and whether persistence adds RPCs.
+5. **Single boot signal?** Should `initiator: 'boot'` replace the `restoreOnBoot` inference (F8), including fixing the user-first-click-when-boot-never-adopted misfire, or must the inference survive for #93197 compatibility?
+6. **Quick Entry / voice submit-failure blanks: durable or transient** (§4)? A one-word answer fixes a persistence row in the classification table.
+
+## Verdict
+
+The plan is a faithful, verified-against-code superset of the baseline export — the architecture (coordinator, exact-scope gate, authoritative by-ID lookup, forced-cold resume, durable tombstone) is sound and its code claims check out. The one material defect is F1: the provenance mechanism instruments the wrong producer surface, which would silently break the settled explicit-blank durability decision through Cmd-N, `/new`, Quick Entry, and voice. Fixing it at the `startFreshSessionDraft()` choke point (§3) removes the defect and simplifies the design. The remaining findings are specification gaps (F2-F9) and unstated interactions (§4) that an implementer would otherwise discover as bugs or ambiguous tests mid-flight.


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now remembers the active conversation independently for each agent profile and restores it when the user switches back. Previously, a profile switch always landed on the default Hermes Agent splash, adding extra clicks and sometimes losing the visible thread.

The restore path is latest-intent-only and owner-qualified: it distinguishes an explicit blank from a remembered session, resolves the durable session against the exact profile/connection route, forces a cold resume so foreign warm cache state cannot leak across profiles, and cancels stale work at navigation/session-creation boundaries. Connection pre-dial keeps the current transcript visible, while committed restores use a loading state rather than flashing the splash.

## Related Issue

No issue found. Searched open/closed issues and PRs for Desktop profile-switch conversation restoration before opening this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added versioned per-profile remembered-conversation persistence, including explicit-blank records, legacy fallback, and rollback-compatible dual writes in `apps/desktop/src/store/session.ts`.
- Added a latest-only profile conversation restore coordinator in `apps/desktop/src/store/profile-conversation-restore.ts` and wired profile/connection switch producers through classified fresh-session intents.
- Added exact, read-only restore lookup and owner-qualified publication in `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`, with forced-cold resume support.
- Integrated bounded restore/retry/persistence behavior in `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` and cancellation at explicit navigation/session-creation boundaries.
- Preserved the visible transcript during connection pre-dial and suppressed the Hermes Agent splash for committed remembered-chat restores.
- Hardened superseded gateway-switch recovery and explicit null/profile-door REST routing.
- Added focused unit/integration coverage for profile collisions, stale generations, rapid switches, retries, cancellation, connection recovery, loading visibility, and prompt promotion.

## How to Test

1. Open a conversation under profile A and note its route/thread.
2. Switch to profile B, open or select a different conversation, then switch back to profile A.
3. Confirm profile A's original conversation is restored without the Hermes Agent splash; switch back to B and confirm B's conversation is restored independently.
4. Run `cd apps/desktop && npm run typecheck`.
5. Run `cd apps/desktop && npm run test:ui`.

Automated result on rebased upstream `main`: **619 test files / 6,158 tests passed**. Live Electron/CDP smoke test restored Arthur → Surplus → Arthur to the exact remembered routes with no splash observed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript-only change; full Desktop typecheck and UI suite passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by colocated API comments/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer/store logic uses existing cross-platform browser/Electron APIs only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool changes

## Screenshots / Logs

Live route trace after the fix:

```text
Arthur   #/20260826_205518_acd196  splash=false
Surplus  #/20260817_122819_e66827  splash=false
Arthur   #/20260826_205518_acd196  splash=false
```
