### PR TITLE
fix(approval): show MCP write details and remove misleading consent scopes

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -24,6 +24,79 @@ from tools.approval import (
 )
 
 
+class TestElicitationConsentScope:
+    def test_gateway_payload_offers_only_one_shot_consent(self, monkeypatch):
+        session_key = "gateway:slack:approval"
+        notify_cb = object()
+        monkeypatch.setattr(
+            approval_module, "get_current_session_key", lambda: session_key
+        )
+        monkeypatch.setattr(
+            approval_module, "_is_gateway_approval_context", lambda: True
+        )
+
+        with mock_patch.dict(
+            approval_module._gateway_notify_cbs,
+            {session_key: notify_cb},
+            clear=True,
+        ), mock_patch.object(
+            approval_module,
+            "_await_gateway_decision",
+            return_value={"resolved": True, "choice": "once"},
+        ) as await_decision:
+            result = approval_module.request_elicitation_consent(
+                "MCP write", "untrusted MCP server"
+            )
+
+        approval_data = await_decision.call_args.args[2]
+        assert result == "accept"
+        assert approval_data["allow_session"] is False
+        assert approval_data["allow_permanent"] is False
+
+    def test_cli_prompt_offers_only_one_shot_consent(self, monkeypatch):
+        monkeypatch.setattr(
+            approval_module, "get_current_session_key", lambda: "cli:approval"
+        )
+        monkeypatch.setattr(
+            approval_module, "_is_gateway_approval_context", lambda: False
+        )
+
+        with mock_patch.object(
+            approval_module, "prompt_dangerous_approval", return_value="once"
+        ) as prompt:
+            result = approval_module.request_elicitation_consent(
+                "MCP write", "untrusted MCP server"
+            )
+
+        assert result == "accept"
+        assert prompt.call_args.kwargs["allow_session"] is False
+        assert prompt.call_args.kwargs["allow_permanent"] is False
+
+    def test_gateway_rejects_an_unoffered_broader_scope(self, monkeypatch):
+        session_key = "gateway:slack:stale-scope"
+        monkeypatch.setattr(
+            approval_module, "get_current_session_key", lambda: session_key
+        )
+        monkeypatch.setattr(
+            approval_module, "_is_gateway_approval_context", lambda: True
+        )
+
+        with mock_patch.dict(
+            approval_module._gateway_notify_cbs,
+            {session_key: object()},
+            clear=True,
+        ), mock_patch.object(
+            approval_module,
+            "_await_gateway_decision",
+            return_value={"resolved": True, "choice": "always"},
+        ):
+            result = approval_module.request_elicitation_consent(
+                "MCP write", "untrusted MCP server"
+            )
+
+        assert result == "decline"
+
+
 class TestApprovalModeParsing:
     def test_normalization_table(self):
         # Unquoted YAML `off`/`on` arrive as booleans; unknown/empty fall back

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -104,6 +104,30 @@ class TestTrustGateAtCallTime:
         assert json.loads(raw) == {"result": "ok"}
         fake_session.call_tool.assert_awaited_once()
 
+    def test_approval_card_shows_redacted_bounded_arguments(self, fake_session):
+        """The approver sees the exact call payload without exposed secrets."""
+        _set_trust("srv", "untrusted")
+        handler = mcp_tool._make_tool_handler("srv", "trigger_build", 30.0)
+        args = {
+            "job": "release",
+            "api_key": "sk-supersecretcredential123456",
+            "notes": "x" * 5_000,
+        }
+
+        with patch(
+            "tools.approval.request_elicitation_consent",
+            return_value="decline",
+        ) as consent:
+            handler(args)
+
+        message = consent.call_args.args[0]
+        assert "```json" in message
+        assert '"job": "release"' in message
+        assert "sk-supersecretcredential123456" not in message
+        assert "truncated" in message
+        assert len(message) < 3_000
+        fake_session.call_tool.assert_not_awaited()
+
     def test_denied_approval_blocks_rpc(self, fake_session):
         """'decline' blocks the call — the RPC must never fire."""
         _set_trust("srv", "untrusted")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -5746,6 +5746,8 @@ def request_elicitation_consent(
             "description": description,
             "pattern_key": "mcp_elicitation",
             "pattern_keys": ["mcp_elicitation"],
+            "allow_session": False,
+            "allow_permanent": False,
         }
         try:
             decision = _await_gateway_decision(
@@ -5762,18 +5764,19 @@ def request_elicitation_consent(
         if not decision.get("resolved"):
             return "cancel"
         choice = decision.get("choice")
-        if choice in ("once", "session", "always"):
+        if choice == "once":
             return "accept"
         return "decline"
 
-    # CLI / TUI path. allow_permanent=False because elicitation is a
-    # per-call confirmation — there is no pattern to remember.
+    # CLI / TUI path. Elicitation is a per-call confirmation with no
+    # persistence key, so offering broader scopes would be misleading.
     try:
         choice = prompt_dangerous_approval(
             message,
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            allow_session=False,
         )
     except Exception as exc:
         logger.error(
@@ -5781,7 +5784,7 @@ def request_elicitation_consent(
         )
         return "decline"
 
-    if choice in ("once", "session", "always"):
+    if choice == "once":
         return "accept"
     if choice == "timeout":
         # Prompt expired without a user response — mirror the gateway's

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4603,6 +4603,8 @@ _tool_read_only_hints: Dict[str, Dict[str, bool]] = {}
 
 _TRUST_FULL = "full"
 _TRUST_UNTRUSTED = "untrusted"
+_TRUST_GATE_ARGUMENTS_MAX_CHARS = 2_048
+_TRUST_GATE_ARGUMENTS_TRUNCATION_MARKER = "\n... [arguments truncated]"
 
 
 def _normalize_server_trust(value: Any) -> str:
@@ -4659,7 +4661,27 @@ def _record_tool_trust_metadata(
                 hints[name] = _annotation_read_only_hint(tool)
 
 
-def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
+def _format_trust_gate_arguments(args: dict) -> str:
+    """Return redacted, bounded JSON for the user-facing approval card."""
+    from agent.redact import redact_sensitive_text
+
+    rendered = json.dumps(args, ensure_ascii=False, indent=2, default=str)
+    rendered = redact_sensitive_text(rendered)
+    if len(rendered) > _TRUST_GATE_ARGUMENTS_MAX_CHARS:
+        prefix_length = (
+            _TRUST_GATE_ARGUMENTS_MAX_CHARS
+            - len(_TRUST_GATE_ARGUMENTS_TRUNCATION_MARKER)
+        )
+        rendered = (
+            rendered[:prefix_length].rstrip()
+            + _TRUST_GATE_ARGUMENTS_TRUNCATION_MARKER
+        )
+    return rendered
+
+
+def _trust_gate_check(
+    server_name: str, tool_name: str, args: dict
+) -> Optional[str]:
     """Consult the approval path for write-capable tools on untrusted servers.
 
     Returns None when the call may proceed, or an error string (already
@@ -4678,12 +4700,13 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     try:
         from tools.approval import request_elicitation_consent
 
+        display_args = _format_trust_gate_arguments(args)
         answer = request_elicitation_consent(
             (
                 f"MCP tool '{tool_name}' on UNTRUSTED server "
                 f"'{server_name}' wants to run. This tool is write-capable "
                 f"(no readOnlyHint=true annotation) and may modify external "
-                f"state."
+                f"state.\n\nArguments:\n```json\n{display_args}\n```"
             ),
             (
                 f"Server '{server_name}' is configured 'trust: untrusted'. "
@@ -6079,7 +6102,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         # servers configured ``trust: untrusted`` must be approved by the
         # user before ANY transport work happens — including the lazy
         # first-use spawn below. A denied call never touches the server.
-        gate_error = _trust_gate_check(server_name, tool_name)
+        gate_error = _trust_gate_check(server_name, tool_name, args)
         if gate_error is not None:
             return gate_error
 


### PR DESCRIPTION
## What does this PR do?

Untrusted MCP write approvals now show the actual call arguments as redacted, size-capped JSON, so an approver can verify the requested external mutation before allowing it. The same one-shot consent flow now exposes only Once and Deny instead of presenting Session and Always choices that it cannot persist.

### Symptom

The approval card identified the MCP server and tool but omitted the tool arguments. It also rendered Session and Always actions even though both were normalized to a one-call acceptance.

### Impact

Operators could not compare the requested job, target, or parameters with the action they intended to authorize. The broader-scope button labels also overstated the lifetime of the resulting consent.

### Bug Cause

**Trigger:** `tools/mcp_tool.py:_trust_gate_check` and `tools/approval.py:request_elicitation_consent`

**Causal chain:**
1. A write-capable tool on a server configured with `trust: untrusted` reaches the trust gate with an argument dictionary.
2. The handler called `_trust_gate_check` without that dictionary, so the user-facing approval message could only include the tool and server names.
3. The elicitation approval payload omitted `allow_session` and `allow_permanent`; gateway surfaces defaulted both capabilities to enabled, while the consent helper discarded the selected scope.

**Why it is wrong:** The approval decision lacked the mutation payload, and the UI advertised persistence semantics that the caller did not implement.

**Working sibling / contrast:** Dangerous command approvals already render the concrete command and pass explicit scope capabilities through their approval payloads.

**Ruled out:** The MCP transport and trust-tier classification are not responsible. Existing tests confirm denial happens before transport work and trusted or read-only tools continue to bypass this gate.

### Fix

Pass the tool arguments into the trust gate, JSON-serialize them, apply the existing secret redactor, cap the rendered payload at 2 KiB, and include it in a fenced JSON block. Mark MCP elicitation approval payloads as one-shot on gateway and CLI surfaces, and reject stale broader-scope outcomes instead of silently treating them as Once.

## Related Issue

Closes #96703

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - render redacted, bounded MCP arguments in trust-gate approvals.
- `tools/approval.py` - expose only one-shot consent and reject unavailable broader scopes.
- `tests/tools/test_mcp_trust_gating.py` - cover argument visibility, redaction, truncation, and pre-transport denial.
- `tests/tools/test_approval.py` - cover gateway and CLI scope capabilities plus stale-scope rejection.

## How to Test

1. Run the focused MCP trust-gate, elicitation, and approval tests.
2. Confirm the approval message includes a JSON argument block with secrets removed and long payloads truncated.
3. Confirm gateway and CLI approval requests set both broader consent capabilities to false.

```bash
scripts/run_tests.sh tests/tools/test_mcp_elicitation.py tests/tools/test_mcp_trust_gating.py tests/tools/test_approval.py -k 'ElicitationConsentScope or TestTrustGateAtCallTime or TestElicitationHandler' -q
```

Result: 22 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; the user-visible behavior is encoded in the approval card and tests
- [x] `cli-config.yaml.example` is N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses platform-independent JSON formatting and approval metadata
- [x] Tool descriptions and schemas are N/A; no model-facing tool contract changed

## Screenshots / Logs

N/A - focused automated tests exercise the approval payloads and rendered message directly.
