### PR TITLE
fix(browser): scope real-profile CDP cache and session by Hermes profile

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -222,6 +222,117 @@ class TestRealProfileCdpLaunch:
         assert not bt._cdp_on_data_dir("http://127.0.0.1:9999", str(tmp_path))
 
 
+class TestRealProfileCrossProfileScope:
+    """A multiplexed gateway must never hand one profile's real-profile
+    copy-browser session (real, signed-in cookies) to another profile.
+
+    _real_profile_cdp_cache and the agent-browser --session name it drives
+    are process-global, but browser_tool is shared across profiles' turns via
+    the hermes_home_key()/get_hermes_home_override() ContextVar (same
+    mechanism _get_cloud_provider already scopes by above in this file).
+    """
+
+    def _reset(self):
+        import tools.browser_tool as bt
+        bt._real_profile_cdp_cache.clear()
+
+    def _run_launch(self, tmp_path, cdp_url):
+        """Drive one full _real_profile_cdp() launch under the active profile
+        scope. Returns (cdp, err, launch_argv, session_names_seen)."""
+        import tools.browser_tool as bt
+        proc = Mock(returncode=0, stdout="", stderr="")
+        seen_sessions = []
+
+        def fake_get_cdp(session_name):
+            seen_sessions.append(session_name)
+            # 1st call is the pre-snapshot reuse probe (no live session yet);
+            # 2nd call is the post-launch discovery of the browser just started.
+            return None if len(seen_sessions) == 1 else cdp_url
+
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            return proc
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(str(tmp_path), None)), \
+             patch.object(bt, "_agent_browser_get_cdp", side_effect=fake_get_cdp), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", side_effect=fake_run):
+            cdp, err = bt._real_profile_cdp()
+        return cdp, err, captured.get("argv"), seen_sessions
+
+    def test_two_profiles_get_distinct_sessions_and_caches(self, tmp_path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        self._reset()
+
+        token_a = set_hermes_home_override(str(tmp_path / "profile-a"))
+        try:
+            cdp_a, err_a, argv_a, sessions_a = self._run_launch(
+                tmp_path / "copy-a", "http://127.0.0.1:40001"
+            )
+        finally:
+            reset_hermes_home_override(token_a)
+        assert err_a is None
+        assert cdp_a == "http://127.0.0.1:40001"
+
+        token_b = set_hermes_home_override(str(tmp_path / "profile-b"))
+        try:
+            cdp_b, err_b, argv_b, sessions_b = self._run_launch(
+                tmp_path / "copy-b", "http://127.0.0.1:40002"
+            )
+        finally:
+            reset_hermes_home_override(token_b)
+        assert err_b is None
+        assert cdp_b == "http://127.0.0.1:40002"
+
+        import tools.browser_tool as bt
+
+        # Without profile scoping, the process-global cache holds a single
+        # "cdp" entry: profile B's write would silently overwrite (or, had
+        # _cdp_http_ready() reported it live, be served) profile A's cached
+        # endpoint. With scoping, both profiles' entries must coexist.
+        assert len(bt._real_profile_cdp_cache) == 2
+        assert cdp_a in bt._real_profile_cdp_cache.values()
+        assert cdp_b in bt._real_profile_cdp_cache.values()
+        assert cdp_a != cdp_b
+
+        # The --session name driving each copy-browser must differ per
+        # profile — a shared name means B's launch/close targets A's live,
+        # signed-in copy-browser session (agent-browser sessions are looked
+        # up by this name, external to our cache dict entirely).
+        assert "--session" in argv_a and "--session" in argv_b
+        session_arg_a = argv_a[argv_a.index("--session") + 1]
+        session_arg_b = argv_b[argv_b.index("--session") + 1]
+        assert session_arg_a != session_arg_b
+        assert sessions_a[0] == session_arg_a
+        assert sessions_b[0] == session_arg_b
+
+        self._reset()
+
+    def test_second_call_same_profile_reuses_cache(self, tmp_path):
+        """Sanity check: the fix must not break same-profile cache reuse."""
+        import tools.browser_tool as bt
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        self._reset()
+
+        token = set_hermes_home_override(str(tmp_path / "profile-single"))
+        try:
+            cdp1, err1, _, _ = self._run_launch(tmp_path / "copy", "http://127.0.0.1:40003")
+            assert err1 is None
+            with patch.object(bt, "_use_real_profile", return_value=True), \
+                 patch.object(bt, "_cdp_http_ready", return_value=True):
+                cdp2, err2 = bt._real_profile_cdp()
+        finally:
+            reset_hermes_home_override(token)
+        assert err2 is None
+        assert cdp2 == cdp1  # same profile, same call → cache hit, no relaunch
+        self._reset()
+
+
 class TestConsentConfigRead:
     """Unmocked config read: _use_real_profile against a real config.yaml."""
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -51,6 +51,7 @@ Usage:
 
 import atexit
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -1450,10 +1451,24 @@ def _use_real_profile() -> bool:
 # Session name for the single shared real-profile copy-browser. All consented
 # local browsing attaches to this one agent-browser session so concurrent
 # tasks reuse the same copy-browser instead of each launching a rival Chromium
-# on the same copied user-data-dir.
-_REAL_PROFILE_SESSION = "hermes-real-profile"
+# on the same copied user-data-dir. Both the session name and the CDP cache
+# below are scoped per Hermes profile (see _real_profile_session_name): this
+# copy-browser holds the user's real, signed-in cookies, so a multiplexed
+# gateway must never hand one profile's live session to another profile
+# (mirrors the hermes_home_key() scoping _get_cloud_provider uses above).
+_REAL_PROFILE_SESSION_PREFIX = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
+
+
+def _real_profile_session_name() -> str:
+    """Per-profile agent-browser session name for real-profile browsing.
+
+    hermes_home_key() is a filesystem path, not usable as a CLI argument
+    verbatim, so it's hashed here into a short, stable suffix.
+    """
+    digest = hashlib.sha256(hermes_home_key().encode("utf-8")).hexdigest()[:16]
+    return f"{_REAL_PROFILE_SESSION_PREFIX}-{digest}"
 
 
 def _agent_browser_argv(browser_cmd: str) -> list:
@@ -1562,7 +1577,7 @@ def _real_profile_cdp() -> tuple:
             cleanup_real_profile_snapshots()
         except Exception as e:
             logger.debug("real-profile cleanup-on-consent-off failed: %s", e)
-        _real_profile_cdp_cache.pop("cdp", None)
+        _real_profile_cdp_cache.pop(hermes_home_key(), None)
         return None, None
 
     # Lightpanda cannot load a Chromium profile — agent-browser rejects
@@ -1586,11 +1601,18 @@ def _real_profile_cdp() -> tuple:
     )
 
     with _real_profile_cdp_lock:
-        # Reuse a live copy-browser from an earlier call this process made.
-        cached = _real_profile_cdp_cache.get("cdp")
+        scope = hermes_home_key()
+        session_name = _real_profile_session_name()
+
+        # Reuse a live copy-browser from an earlier call this process made —
+        # scoped to THIS Hermes profile. A multiplexed gateway shares this
+        # module across profiles' turns; the cached CDP endpoint drives a
+        # copy-browser holding another profile's real signed-in cookies
+        # otherwise (mirrors the hermes_home_key() scoping used elsewhere).
+        cached = _real_profile_cdp_cache.get(scope)
         if cached and _cdp_http_ready(cached):
             return cached, None
-        _real_profile_cdp_cache.pop("cdp", None)
+        _real_profile_cdp_cache.pop(scope, None)
 
         browser = detect_default_chromium()
         if browser is None:
@@ -1623,14 +1645,14 @@ def _real_profile_cdp() -> tuple:
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
         copy_dir = real_profile_copy_dir(browser)
-        existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
+        existing = _agent_browser_get_cdp(session_name)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
-            _real_profile_cdp_cache["cdp"] = existing
+            _real_profile_cdp_cache[scope] = existing
             return existing, None
         if existing:
             # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
             # close it so nothing holds the dir open before we overlay + relaunch.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+            _agent_browser_close_session(session_name)
 
         # No live browser owns the dir now — safe to (re)snapshot + overlay.
         snap_dir, err = snapshot_real_profile(browser)
@@ -1663,7 +1685,7 @@ def _real_profile_cdp() -> tuple:
             )
         argv = [
             *_agent_browser_argv(browser_cmd),
-            "--session", _REAL_PROFILE_SESSION,
+            "--session", session_name,
             "--profile", copy_dir,
         ]
         # Do NOT pass agent-browser's ``--headless``: it maps to Chrome's legacy
@@ -1695,14 +1717,14 @@ def _real_profile_cdp() -> tuple:
                 f"failed to start: {reason}"
             )
 
-        cdp = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
+        cdp = _agent_browser_get_cdp(session_name)
         if not cdp:
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
                 "the toggle off."
             )
-        _real_profile_cdp_cache["cdp"] = cdp
+        _real_profile_cdp_cache[scope] = cdp
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
 


### PR DESCRIPTION
## Summary

`_real_profile_cdp()` in `tools/browser_tool.py` caches the launched real-profile browser's CDP URL in a process-global dict under a single literal key (`"cdp"`), and always drives a hardcoded agent-browser session name (`hermes-real-profile`). Neither is scoped by `hermes_home_key()`/`get_hermes_home_override()`, unlike the sibling `_allow_private_urls` cache in this same file, which already carries that guard with an explicit comment: "The profile multiplexer scopes config with a ContextVar while sharing this module. Never reuse another profile's ... opt-out."

The copy-browser this function launches holds the user's real, signed-in cookies (`browser.use_real_profile`). In a multiplexed gateway process serving two or more profiles that both enable this setting:

- Profile B's turn can reuse Profile A's cached CDP endpoint, or
- Profile B's launch can find and take over Profile A's still-running agent-browser session by name (since the session name is identical for every profile)

handing one profile's agent access to another profile's real, signed-in browser session — and potentially closing it out from under the first profile in the process.

## Fix

Scope both the CDP cache key and the agent-browser `--session` name by `hermes_home_key()`, mirroring the pattern `_get_cloud_provider()` already uses elsewhere in this same file. The session name is a hash of the key (not the raw path) since it's passed as a CLI argument to `agent-browser`, not used as a cache key.

## Test plan

- Added `TestRealProfileCrossProfileScope` in `tests/tools/test_browser_real_profile.py`:
  - `test_two_profiles_get_distinct_sessions_and_caches`: simulates two profiles via `set_hermes_home_override()` (the same ContextVar mechanism the real profile multiplexer uses) and asserts the cache holds two independent entries and the `--session` argv differs per profile.
  - `test_second_call_same_profile_reuses_cache`: sanity check that same-profile cache reuse still works after the change.
- Mutation-verified: stashed the production fix and confirmed the new test fails against the old code (`assert 1 == 2` on the cache dict; both profiles get the literal session name `hermes-real-profile`), then restored the fix and confirmed it passes.
- Full file: `uv run --frozen --extra dev python -m pytest tests/tools/test_browser_real_profile.py -q` → 75 passed.
- Broader `tests/tools/ -k browser` suite: 607 passed, 4 pre-existing failures unrelated to this change (confirmed identical failures occur with this branch's changes fully reverted — test-order pollution in `test_browser_lightpanda.py`/`test_strict_provider_selection.py`, unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)