### PR TITLE
fix(desktop): keep remote profiles on their own models

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -334,10 +334,10 @@ const ROUTES = [
     expected: { backend: 'primary', descriptorProfile: null, scopePath: false }
   },
   {
-    name: 'a renamed primary profile still owns the window backend',
+    name: 'a renamed primary profile on a global remote is still scoped on the wire',
     profile: ' coder ',
     opts: { primaryProfile: 'coder', globalRemote: true },
-    expected: { backend: 'primary', descriptorProfile: null, scopePath: false }
+    expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
   },
   {
     name: 'an unset profile resolves to the primary',
@@ -526,14 +526,14 @@ test('pathWithGlobalRemoteProfile appends profile in global remote mode', () => 
   )
 })
 
-test('pathWithGlobalRemoteProfile skips the primary profile, which the remote already serves', () => {
+test('pathWithGlobalRemoteProfile scopes the primary label because the dashboard launch home may differ', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info', 'coder', {
       globalRemote: true,
       primaryProfile: 'coder',
       profileRemoteOverride: false
     }),
-    '/api/model/info'
+    '/api/model/info?profile=coder'
   )
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -653,7 +653,9 @@ function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
  * The one place that answers "which backend serves profile P, and does its
  * REST path need a profile scope?". Six routes, in precedence order:
  *
- *  1. The primary profile owns the window backend outright.
+ *  1. The primary profile owns a local/window backend outright; on a global
+ *     remote its label is still carried per request because launch home can
+ *     differ from the selected profile.
  *  2. A profile with its own remote override gets a pooled descriptor for that
  *     host, which is already scoped to it.
  *  3. A profile inheriting the app-global remote shares the primary backend —
@@ -673,8 +675,18 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
   const scopedProfile = connectionScopeKey(profile)
   const primaryProfile = connectionScopeKey(opts.primaryProfile) || 'default'
 
-  if (!scopedProfile || scopedProfile === primaryProfile) {
+  if (!scopedProfile) {
     return { backend: 'primary', descriptorProfile: null, scopePath: false }
+  }
+
+  if (scopedProfile === primaryProfile) {
+    // A global remote is a multi-profile dashboard, not a backend process
+    // launched for this Desktop label. Even its "primary" label must travel on
+    // the wire: the dashboard's process HERMES_HOME can belong to a different
+    // launch profile, so a bare request silently reads that profile instead.
+    return opts.globalRemote
+      ? { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
+      : { backend: 'primary', descriptorProfile: null, scopePath: false }
   }
 
   if (opts.profileRemoteOverride) {

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
+import { pathForRegistryBackendRequest } from './connection-config'
 import type { ConnectionRegistry } from './connection-registry'
 import {
   agentHandle,
@@ -33,6 +34,7 @@ import {
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySharedBackend,
   reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
@@ -260,6 +262,38 @@ test('registry primary reuses a matching primary backend descriptor', () => {
 
   assert.equal(registrySourceOwnsPrimaryBackend(registry, 'hermes-vps', descriptor), true)
   assert.equal(registrySourceOwnsPrimaryBackend(registry, LOCAL_CONNECTION_ID, descriptor), false)
+})
+
+test('reused shared primary scopes registry REST requests to the requested profile', async () => {
+  const registry = normalizeRegistry({
+    version: REGISTRY_VERSION,
+    primary: 'shared-remote',
+    launchMode: 'primary',
+    lastUsed: 'shared-remote',
+    connections: [
+      { id: LOCAL_CONNECTION_ID, kind: 'local', label: 'This device' },
+      { id: 'shared-remote', kind: 'remote', label: 'Shared remote', url: 'https://remote.example' }
+    ]
+  })
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+  const descriptor = await reuseMatchingPrimarySharedBackend({
+    connectionId: source.id,
+    ensurePrimary: async () => ({
+      connectionId: source.id,
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    profile: 'beta',
+    registry,
+    source
+  })
+
+  assert.ok(descriptor)
+  assert.equal(descriptor.sharedRemote, true)
+  assert.equal(
+    pathForRegistryBackendRequest('/api/model/info', 'beta', descriptor),
+    '/api/model/info?profile=beta'
+  )
 })
 
 test('resolvedConnectionId identifies local and migrated remote descriptors', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -449,6 +449,43 @@ export function registrySourceOwnsPrimaryBackend(
   return Boolean(id) && id === registry.primary && resolvedConnectionId(registry, descriptor) === id
 }
 
+/**
+ * Reuse the already-running v1 primary for the registry's matching shared
+ * remote. The returned descriptor must retain the shared-host routing marker:
+ * registry REST dispatch relies on it to append the requested profile rather
+ * than reading the dashboard process's launch home.
+ */
+export async function reuseMatchingPrimarySharedBackend(opts: {
+  connectionId: string
+  ensurePrimary: () => Promise<ResolvedConnectionDescriptor>
+  profile: null | string | undefined
+  registry: ConnectionRegistry
+  source: RegistryConnection
+}) {
+  const { connectionId, ensurePrimary, profile, registry, source } = opts
+
+  if (
+    connectionId !== registry.primary ||
+    source.kind === 'local' ||
+    source.kind === 'ssh'
+  ) {
+    return null
+  }
+
+  const descriptor = await ensurePrimary()
+
+  if (!registrySourceOwnsPrimaryBackend(registry, connectionId, descriptor)) {
+    return null
+  }
+
+  return {
+    ...descriptor,
+    profile: String(profile ?? '').trim() || 'default',
+    connectionId,
+    sharedRemote: true as const
+  }
+}
+
 function normalizedSshTarget(route: { host?: unknown; port?: unknown; user?: unknown }): null | string {
   const ssh = normalizeSshConfig({ ...route, mode: 'ssh' })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -136,11 +136,11 @@ import {
   parseBackendScopeKey,
   reconcileAppliedGlobalConnection,
   reconcileRegistryDrift,
-  registrySourceOwnsPrimaryBackend,
   rememberSshEnumeration,
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySharedBackend,
   reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
@@ -11140,16 +11140,16 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
   // resolves its live descriptor back to this exact source id; otherwise one
   // Desktop window starts two isolated servers whose transient runtime ids
   // are not interchangeable.
-  if (id === registry.primary && source.kind !== 'local' && source.kind !== 'ssh') {
-    const primaryDescriptor = await ensureBackend(profile)
+  const sharedPrimary = await reuseMatchingPrimarySharedBackend({
+    connectionId: id,
+    ensurePrimary: () => ensureBackend(profile),
+    profile,
+    registry,
+    source
+  })
 
-    if (registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)) {
-      return {
-        ...primaryDescriptor,
-        profile: profileKey,
-        connectionId: id
-      }
-    }
+  if (sharedPrimary) {
+    return sharedPrimary
   }
 
   if (source.kind === 'local') {

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -81,7 +81,9 @@ import { advanceTranscriptWindow, type TranscriptWindowState } from './transcrip
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
+  modelOptionsProfile?: string
   modelMenuContent?: React.ReactNode
+  requestModelOptionsForOwner?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   onToggleSelectedPin: () => void
   onDeleteSelectedSession: () => void
   onCancel: () => Promise<void> | void
@@ -357,7 +359,9 @@ export const ChatView = memo(function ChatView(props: ChatViewProps) {
 const ChatViewContent = memo(function ChatViewContent({
   className,
   gateway,
+  modelOptionsProfile,
   modelMenuContent,
+  requestModelOptionsForOwner,
   onToggleSelectedPin,
   onDeleteSelectedSession,
   onCancel,
@@ -525,8 +529,14 @@ const ChatViewContent = memo(function ChatViewContent({
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({
-    queryKey: modelOptionsQueryKey(activeGatewayProfile, activeSessionId),
-    queryFn: () => requestModelOptions({ gateway: gateway || undefined, sessionId: activeSessionId }),
+    queryKey: modelOptionsQueryKey(modelOptionsProfile || activeGatewayProfile, activeSessionId),
+    queryFn: () =>
+      requestModelOptions({
+        gateway: gateway || undefined,
+        profile: modelOptionsProfile || activeGatewayProfile,
+        request: requestModelOptionsForOwner,
+        sessionId: activeSessionId
+      }),
     enabled: gatewayOpen
   })
 

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -81,6 +81,7 @@ import { advanceTranscriptWindow, type TranscriptWindowState } from './transcrip
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
+  modelOptionsOwnerConnectionId?: string
   modelOptionsProfile?: string
   modelMenuContent?: React.ReactNode
   requestModelOptionsForOwner?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -359,6 +360,7 @@ export const ChatView = memo(function ChatView(props: ChatViewProps) {
 const ChatViewContent = memo(function ChatViewContent({
   className,
   gateway,
+  modelOptionsOwnerConnectionId,
   modelOptionsProfile,
   modelMenuContent,
   requestModelOptionsForOwner,
@@ -529,7 +531,11 @@ const ChatViewContent = memo(function ChatViewContent({
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({
-    queryKey: modelOptionsQueryKey(modelOptionsProfile || activeGatewayProfile, activeSessionId),
+    queryKey: modelOptionsQueryKey(
+      modelOptionsProfile || activeGatewayProfile,
+      activeSessionId,
+      modelOptionsOwnerConnectionId
+    ),
     queryFn: () =>
       requestModelOptions({
         gateway: gateway || undefined,

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -165,7 +165,12 @@ function TileChat({
     [ownerRoute, requestGateway]
   )
 
-  const { selectModel } = useModelControls({ queryClient, requestGateway: requestTileGateway })
+  const { selectModel } = useModelControls({
+    cacheOwnerConnectionId: ownerRoute?.connectionId || undefined,
+    cacheProfile: ownerRoute?.targetProfile || ownerRoute?.profile || undefined,
+    queryClient,
+    requestGateway: requestTileGateway
+  })
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const cwd = useStore(view.$cwd)
   const gatewayOpen = useStore($gatewayState) === 'open'

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -246,6 +246,7 @@ function TileChat({
         <ChatView
           gateway={gateway}
           modelMenuContent={modelMenuContent}
+          modelOptionsProfile={ownerRoute?.targetProfile || ownerRoute?.profile || activeGatewayProfile}
           onAddContextRef={addContextRefAttachment}
           onAddUrl={onAddUrl}
           onAttachDroppedItems={composer.attachDroppedItems}
@@ -268,6 +269,7 @@ function TileChat({
           onThreadMessagesChange={actions.handleThreadMessagesChange}
           onToggleSelectedPin={noop}
           onTranscribeAudio={tileTranscribeAudio}
+          requestModelOptionsForOwner={requestTileGateway}
         />
       </ComposerScopeProvider>
     </SessionViewProvider>

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -233,11 +233,20 @@ function TileChat({
       gatewayOpen ? (
         <ModelMenuPanel
           onSelectModel={selectModel}
+          ownerConnectionId={ownerRoute?.connectionId || undefined}
           profile={ownerRoute?.targetProfile || ownerRoute?.profile || activeGatewayProfile}
           requestGateway={requestTileGateway}
         />
       ) : null,
-    [activeGatewayProfile, gatewayOpen, ownerRoute?.profile, ownerRoute?.targetProfile, requestTileGateway, selectModel]
+    [
+      activeGatewayProfile,
+      gatewayOpen,
+      ownerRoute?.connectionId,
+      ownerRoute?.profile,
+      ownerRoute?.targetProfile,
+      requestTileGateway,
+      selectModel
+    ]
   )
 
   return (
@@ -246,6 +255,7 @@ function TileChat({
         <ChatView
           gateway={gateway}
           modelMenuContent={modelMenuContent}
+          modelOptionsOwnerConnectionId={ownerRoute?.connectionId || undefined}
           modelOptionsProfile={ownerRoute?.targetProfile || ownerRoute?.profile || activeGatewayProfile}
           onAddContextRef={addContextRefAttachment}
           onAddUrl={onAddUrl}

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -143,6 +143,8 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       gateway={gateway}
       maxVoiceRecordingSeconds={maxVoiceRecordingSeconds}
       modelMenuContent={modelMenuContent}
+      modelOptionsProfile={activeGatewayProfile}
+      requestModelOptionsForOwner={actions.requestGateway}
       {...chatActions}
     />
   )

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -117,6 +117,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   actions: WiringActions
   maxVoiceRecordingSeconds?: number
 }) {
+  const activeConnectionId = useStore($activeConnectionId)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const gateway = useStore($gateway)
   const gatewayState = useStore($gatewayState)
@@ -129,11 +130,12 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
         <ModelMenuPanel
           gateway={gateway || undefined}
           onSelectModel={actions.selectModel}
+          ownerConnectionId={activeConnectionId || undefined}
           profile={activeGatewayProfile}
           requestGateway={actions.requestGateway}
         />
       ) : null,
-    [actions, activeGatewayProfile, gateway, gatewayState]
+    [actions, activeConnectionId, activeGatewayProfile, gateway, gatewayState]
   )
 
   const chatActions = useMemo(() => latestChatActions(actions), [actions])
@@ -143,6 +145,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       gateway={gateway}
       maxVoiceRecordingSeconds={maxVoiceRecordingSeconds}
       modelMenuContent={modelMenuContent}
+      modelOptionsOwnerConnectionId={activeConnectionId || undefined}
       modelOptionsProfile={activeGatewayProfile}
       requestModelOptionsForOwner={actions.requestGateway}
       {...chatActions}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1163,6 +1163,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         onSelect={selectModel}
         ownerConnectionId={activeConnectionId || undefined}
         profile={activeGatewayProfile}
+        requestGateway={requestGateway}
       />
       <SessionPickerOverlay onResume={sessionId => openSession(sessionId, navigate)} />
       <ModelVisibilityOverlay

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -337,6 +337,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({ activeSessionIdRef })
 
   const { applySavedMainModel, refreshCurrentModel, selectModel } = useModelControls({
+    cacheOwnerConnectionId: activeConnectionId || undefined,
+    cacheProfile: activeGatewayProfile,
     queryClient,
     requestGateway
   })
@@ -1156,11 +1158,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           requestGateway={requestGateway}
         />
       )}
-      <ModelPickerOverlay gateway={gateway || undefined} onSelect={selectModel} profile={activeGatewayProfile} />
+      <ModelPickerOverlay
+        gateway={gateway || undefined}
+        onSelect={selectModel}
+        ownerConnectionId={activeConnectionId || undefined}
+        profile={activeGatewayProfile}
+      />
       <SessionPickerOverlay onResume={sessionId => openSession(sessionId, navigate)} />
       <ModelVisibilityOverlay
         gateway={gateway || undefined}
         onOpenProviders={openProviderSettings}
+        ownerConnectionId={activeConnectionId || undefined}
         profile={activeGatewayProfile}
       />
       <UpdatesOverlay />

--- a/apps/desktop/src/app/model-picker-overlay.tsx
+++ b/apps/desktop/src/app/model-picker-overlay.tsx
@@ -17,10 +17,11 @@ import { $focusedRuntimeId, $focusedSessionState } from '@/store/session-states'
 interface ModelPickerOverlayProps {
   gateway?: HermesGateway
   onSelect: (selection: ModelSelection) => void
+  ownerConnectionId?: string
   profile: string
 }
 
-export function ModelPickerOverlay({ gateway, onSelect, profile }: ModelPickerOverlayProps) {
+export function ModelPickerOverlay({ gateway, onSelect, ownerConnectionId, profile }: ModelPickerOverlayProps) {
   const primarySessionId = useStore($activeSessionId)
   const primaryModel = useStore($currentModel)
   const primaryProvider = useStore($currentProvider)
@@ -54,6 +55,7 @@ export function ModelPickerOverlay({ gateway, onSelect, profile }: ModelPickerOv
       onOpenChange={setModelPickerOpen}
       onSelect={selection => onSelect({ ...selection, sessionId })}
       open={open}
+      ownerConnectionId={ownerConnectionId}
       profile={profile}
       sessionId={sessionId}
     />

--- a/apps/desktop/src/app/model-picker-overlay.tsx
+++ b/apps/desktop/src/app/model-picker-overlay.tsx
@@ -1,8 +1,12 @@
 import { useStore } from '@nanostores/react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
+import { useModelControls } from '@/app/session/hooks/use-model-controls'
 import type { ModelSelection } from '@/app/shell/model-menu-panel'
 import { ModelPickerDialog } from '@/components/model-picker'
 import type { HermesGateway } from '@/hermes'
+import { resolveModelPickerOwner } from '@/lib/model-picker-owner'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import {
   $activeSessionId,
@@ -10,22 +14,40 @@ import {
   $currentProvider,
   $gatewayState,
   $modelPickerOpen,
+  $selectedStoredSessionId,
   setModelPickerOpen
 } from '@/store/session'
-import { $focusedRuntimeId, $focusedSessionState } from '@/store/session-states'
+import { requestForSessionProfile } from '@/store/session-request-router'
+import {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  $sessionTiles
+} from '@/store/session-states'
 
 interface ModelPickerOverlayProps {
   gateway?: HermesGateway
   onSelect: (selection: ModelSelection) => void
   ownerConnectionId?: string
   profile: string
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function ModelPickerOverlay({ gateway, onSelect, ownerConnectionId, profile }: ModelPickerOverlayProps) {
+export function ModelPickerOverlay({
+  gateway,
+  onSelect,
+  ownerConnectionId,
+  profile,
+  requestGateway
+}: ModelPickerOverlayProps) {
+  const queryClient = useQueryClient()
   const primarySessionId = useStore($activeSessionId)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const primaryModel = useStore($currentModel)
   const primaryProvider = useStore($currentProvider)
   const focusedRuntimeId = useStore($focusedRuntimeId)
+  const focusedStoredSessionId = useStore($focusedStoredSessionId)
+  const sessionTiles = useStore($sessionTiles)
   // `$focusedSessionState` is a projection of `$sessionStates`, republished on
   // EVERY message delta — and this overlay is mounted app-wide. Only two
   // fields are read off it, so subscribing to the whole object re-rendered
@@ -36,6 +58,27 @@ export function ModelPickerOverlay({ gateway, onSelect, ownerConnectionId, profi
   const focusedProvider = useStoreSelector($focusedSessionState, state => state?.provider ?? null)
   const gatewayOpen = useStore($gatewayState) === 'open'
   const open = useStore($modelPickerOpen)
+
+  const pickerOwner = resolveModelPickerOwner({
+    ambientConnectionId: ownerConnectionId,
+    ambientProfile: profile,
+    focusedStoredSessionId,
+    selectedStoredSessionId,
+    sessionTiles
+  })
+
+  const requestPickerGateway = useCallback(
+    <T,>(method: string, params?: Record<string, unknown>): Promise<T> =>
+      requestForSessionProfile<T>(pickerOwner.route, requestGateway, method, params),
+    [pickerOwner.route, requestGateway]
+  )
+
+  const { selectModel: selectFocusedModel } = useModelControls({
+    cacheOwnerConnectionId: pickerOwner.connectionId,
+    cacheProfile: pickerOwner.profile,
+    queryClient,
+    requestGateway: requestPickerGateway
+  })
 
   // Prefer the focused tile's runtime when the overlay opens from a tile that
   // lacked a live menu (gateway closed → fallback path).
@@ -53,10 +96,13 @@ export function ModelPickerOverlay({ gateway, onSelect, ownerConnectionId, profi
       currentProvider={currentProvider}
       gw={gateway}
       onOpenChange={setModelPickerOpen}
-      onSelect={selection => onSelect({ ...selection, sessionId })}
+      onSelect={selection =>
+        (pickerOwner.route ? selectFocusedModel : onSelect)({ ...selection, sessionId })
+      }
       open={open}
-      ownerConnectionId={ownerConnectionId}
-      profile={profile}
+      ownerConnectionId={pickerOwner.connectionId}
+      profile={pickerOwner.profile}
+      request={pickerOwner.route ? requestPickerGateway : undefined}
       sessionId={sessionId}
     />
   )

--- a/apps/desktop/src/app/model-visibility-overlay.tsx
+++ b/apps/desktop/src/app/model-visibility-overlay.tsx
@@ -8,10 +8,16 @@ import { $activeSessionId, $gatewayState } from '@/store/session'
 interface ModelVisibilityOverlayProps {
   gateway?: HermesGateway
   onOpenProviders: () => void
+  ownerConnectionId?: string
   profile: string
 }
 
-export function ModelVisibilityOverlay({ gateway, onOpenProviders, profile }: ModelVisibilityOverlayProps) {
+export function ModelVisibilityOverlay({
+  gateway,
+  onOpenProviders,
+  ownerConnectionId,
+  profile
+}: ModelVisibilityOverlayProps) {
   const activeSessionId = useStore($activeSessionId)
   const gatewayOpen = useStore($gatewayState) === 'open'
   const open = useStore($modelVisibilityOpen)
@@ -26,6 +32,7 @@ export function ModelVisibilityOverlay({ gateway, onOpenProviders, profile }: Mo
       onOpenChange={setModelVisibilityOpen}
       onOpenProviders={onOpenProviders}
       open={open}
+      ownerConnectionId={ownerConnectionId}
       profile={profile}
       sessionId={activeSessionId}
     />

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -97,6 +97,27 @@ describe('useModelControls', () => {
     setCurrentProvider('')
   })
 
+  it('writes optimistic selections only to the owning connection cache', async () => {
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() =>
+      useModelControls({
+        cacheOwnerConnectionId: 'source-a',
+        cacheProfile: 'beta',
+        queryClient,
+        requestGateway: vi.fn()
+      })
+    )
+
+    await act(() => result.current.selectModel({ model: 'a/model', provider: 'a' }))
+
+    expect(queryClient.getQueryData(modelOptionsQueryKey('beta', null, 'source-a'))).toMatchObject({
+      model: 'a/model',
+      provider: 'a'
+    })
+    expect(queryClient.getQueryData(modelOptionsQueryKey('beta'))).toBeUndefined()
+    expect(queryClient.getQueryData(modelOptionsQueryKey('beta', null, 'source-b'))).toBeUndefined()
+  })
+
   it('applies the global model when there is no active runtime session', async () => {
     vi.mocked(getGlobalModelInfo).mockResolvedValue({
       model: 'openai/gpt-5.5',

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -14,7 +14,7 @@ import {
   setCurrentModelSource,
   setCurrentProvider
 } from '@/store/session'
-import type * as SessionStates from '@/store/session-states'
+import * as SessionStates from '@/store/session-states'
 
 import { deferred } from '../../../test/deferred'
 
@@ -85,6 +85,7 @@ describe('useModelControls', () => {
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
+    SessionStates.$sessionStates.set({})
   })
 
   afterEach(() => {
@@ -95,10 +96,12 @@ describe('useModelControls', () => {
     setCurrentModel('')
     setCurrentModelSource('')
     setCurrentProvider('')
+    SessionStates.$sessionStates.set({})
   })
 
   it('writes optimistic selections only to the owning connection cache', async () => {
     const queryClient = new QueryClient()
+
     const { result } = renderHook(() =>
       useModelControls({
         cacheOwnerConnectionId: 'source-a',
@@ -650,35 +653,82 @@ describe('useModelControls', () => {
     expect(getCurrentModelSource()).toBe('default')
   })
 
-  it('targets an explicit tile sessionId without clobbering the primary model', async () => {
+  it('keeps an active-A focused-B selection cache and request on B', async () => {
     const queryClient = new QueryClient()
-    $activeGatewayProfile.set('compass')
-    $activeSessionId.set('primary-runtime')
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    $activeGatewayProfile.set('profile-a')
+    $activeSessionId.set('runtime-a')
     setCurrentModel('primary/model')
     setCurrentProvider('openai')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'tile-model' }) as never)
-    const { result } = renderHook(() => useModelControls({ queryClient, requestGateway }))
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        cacheOwnerConnectionId: 'connection-b',
+        cacheProfile: 'profile-b',
+        queryClient,
+        requestGateway
+      })
+    )
 
     await expect(
       result.current.selectModel({
         model: 'tile-model',
         provider: 'anthropic',
-        sessionId: 'tile-runtime'
+        sessionId: 'runtime-b'
       })
     ).resolves.toBe(true)
 
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
-      session_id: 'tile-runtime',
+      session_id: 'runtime-b',
       key: 'model',
       value: 'tile-model --provider anthropic --session'
     })
     // Primary footer untouched — the busy primary must not absorb a tile pick.
     expect($currentModel.get()).toBe('primary/model')
     expect($currentProvider.get()).toBe('openai')
-    expect(queryClient.getQueryData(modelOptionsQueryKey('compass', 'tile-runtime'))).toMatchObject({
+    expect(queryClient.getQueryData(modelOptionsQueryKey('profile-b', 'runtime-b', 'connection-b'))).toMatchObject({
       model: 'tile-model',
       provider: 'anthropic'
     })
-    expect(queryClient.getQueryData(modelOptionsQueryKey('default', 'tile-runtime'))).toBeUndefined()
+    expect(queryClient.getQueryData(modelOptionsQueryKey('profile-a', 'runtime-b'))).toBeUndefined()
+    expect(queryClient.getQueryData(modelOptionsQueryKey('profile-b', 'runtime-b', 'connection-a'))).toBeUndefined()
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: modelOptionsQueryKey('profile-b', 'runtime-b', 'connection-b')
+    })
+  })
+
+  it('rolls a failed focused-B selection back only in B cache', async () => {
+    const queryClient = new QueryClient()
+    const ownerBKey = modelOptionsQueryKey('profile-b', 'runtime-b', 'connection-b')
+    const ambientAKey = modelOptionsQueryKey('profile-a', 'runtime-b', 'connection-a')
+    queryClient.setQueryData(ownerBKey, { model: 'old-b', provider: 'provider-b', providers: [] })
+    queryClient.setQueryData(ambientAKey, { model: 'model-a', provider: 'provider-a', providers: [] })
+    $activeGatewayProfile.set('profile-a')
+    $activeSessionId.set('runtime-a')
+    SessionStates.$sessionStates.set({
+      'runtime-b': { model: 'old-b', provider: 'provider-b' }
+    } as never)
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('no such model')
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        cacheOwnerConnectionId: 'connection-b',
+        cacheProfile: 'profile-b',
+        queryClient,
+        requestGateway
+      })
+    )
+
+    await expect(
+      result.current.selectModel({ model: 'bogus', provider: 'xai', sessionId: 'runtime-b' })
+    ).resolves.toBe(false)
+
+    expect(queryClient.getQueryData(ownerBKey)).toMatchObject({ model: 'old-b', provider: 'provider-b' })
+    expect(queryClient.getQueryData(ambientAKey)).toMatchObject({ model: 'model-a', provider: 'provider-a' })
+    expect(notifyError).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -491,6 +491,23 @@ describe('useModelControls', () => {
     expect($currentModel.get()).toBe('openai/gpt-5.5')
   })
 
+  it('reads a forced profile reseed from that concrete profile', async () => {
+    $activeGatewayProfile.set('fred-work')
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'local/model', provider: 'custom:local' })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel(true)
+
+    expect(getGlobalModelInfo).toHaveBeenCalledWith('fred-work')
+    expect($currentProvider.get()).toBe('custom:local')
+  })
+
   it('reseeds a sticky manual pick that was removed from the catalog', async () => {
     vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
 

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -24,6 +24,8 @@ import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelControlsOptions {
+  cacheOwnerConnectionId?: string
+  cacheProfile?: string
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
@@ -34,7 +36,12 @@ interface ModelSwitchResponse {
   deferred?: boolean
 }
 
-export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
+export function useModelControls({
+  cacheOwnerConnectionId,
+  cacheProfile,
+  queryClient,
+  requestGateway
+}: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
   const profileRefreshEpochRef = useRef(0)
@@ -50,7 +57,8 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       provider: string,
       model: string,
       includeGlobal: boolean,
-      profile = $activeGatewayProfile.get()
+      profile = cacheProfile || $activeGatewayProfile.get(),
+      ownerConnectionId = cacheOwnerConnectionId
     ) => {
       const patch = (prev: ModelOptionsResponse | undefined) => {
         // Selection state can update before the catalog query has resolved.
@@ -65,13 +73,16 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         return { ...prev, provider, model, providers }
       }
 
-      queryClient.setQueryData<ModelOptionsResponse>(modelOptionsQueryKey(profile, sessionId), patch)
+      queryClient.setQueryData<ModelOptionsResponse>(
+        modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
+        patch
+      )
 
       if (includeGlobal) {
-        queryClient.setQueryData<ModelOptionsResponse>(modelOptionsQueryKey(profile), patch)
+        queryClient.setQueryData<ModelOptionsResponse>(modelOptionsQueryKey(profile, null, ownerConnectionId), patch)
       }
     },
-    [queryClient]
+    [cacheOwnerConnectionId, cacheProfile, queryClient]
   )
 
   // Settings → Model writes the profile default, which the backend applies to
@@ -129,7 +140,11 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           }
 
           const options = queryClient.getQueryData<ModelOptionsResponse>(
-            modelOptionsQueryKey($activeGatewayProfile.get())
+            modelOptionsQueryKey(
+              cacheProfile || $activeGatewayProfile.get(),
+              null,
+              cacheOwnerConnectionId
+            )
           )
 
           return !manualPickRemoved(options?.providers, $currentProvider.get(), $currentModel.get())
@@ -169,7 +184,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // The delayed session.info event still updates this once the agent is ready.
       }
     },
-    [queryClient]
+    [cacheOwnerConnectionId, cacheProfile, queryClient]
   )
 
   // Returns whether the switch was applied so callers can await it before
@@ -202,7 +217,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         : ($sessionStates.get()[liveSessionId!]?.provider ?? '')
 
       const prevSource = getCurrentModelSource()
-      const liveGatewayProfile = $activeGatewayProfile.get()
+      const liveGatewayProfile = cacheProfile || $activeGatewayProfile.get()
 
       const paintSelection = () => {
         if (touchesPrimary) {
@@ -280,7 +295,9 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // the switch publishes session.info when it lands, and that is what
         // re-syncs every surface.
         if (!result?.deferred) {
-          void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
+          void queryClient.invalidateQueries({
+            queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId, cacheOwnerConnectionId)
+          })
         }
       }
 
@@ -339,7 +356,15 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         return false
       }
     },
-    [copy.modelSwitchFailed, queryClient, requestGateway, t.common.confirm, updateModelOptionsCache]
+    [
+      cacheOwnerConnectionId,
+      cacheProfile,
+      copy.modelSwitchFailed,
+      queryClient,
+      requestGateway,
+      t.common.confirm,
+      updateModelOptionsCache
+    ]
   )
 
   return { applySavedMainModel, refreshCurrentModel, selectModel }

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -111,6 +111,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       }
 
       const profileRefreshEpoch = profileRefreshEpochRef.current
+      const profile = $activeGatewayProfile.get()
 
       try {
         if ($activeSessionId.get()) {
@@ -142,7 +143,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // that lands while getGlobalModelInfo is in flight wins over this older
         // default — value comparisons alone miss re-selecting the same row.
         const selectionGeneration = getComposerSelectionGeneration()
-        const result = await getGlobalModelInfo()
+        const result = await getGlobalModelInfo(profile)
 
         if (
           profileRefreshEpochRef.current !== profileRefreshEpoch ||

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -99,6 +99,9 @@ interface ModelCatalogMenuProps {
   /** Render the virtual `moa` provider's presets as a selectable section.
    *  Off for override surfaces, where a MoA preset isn't a worker model. */
   includeMoa?: boolean
+  /** Registry source owning this catalog. Profile/session names are not unique
+   * across sources, so this participates in the React Query cache key. */
+  ownerConnectionId?: string
   profile?: string
   /** Session whose catalog to fetch. A live session's catalog can differ from
    *  the profile-global one, and the app invalidates the SESSION-scoped query
@@ -124,6 +127,7 @@ export function ModelCatalogMenu({
   footer,
   gateway,
   includeMoa = false,
+  ownerConnectionId,
   profile = 'default',
   request,
   sessionId = null
@@ -141,7 +145,7 @@ export function ModelCatalogMenu({
   const visibleModels = useStore($visibleModels)
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
     // Gateway-first even with no session: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers the local
     // REST fallback can't know about (#53817).

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -69,11 +69,19 @@ afterEach(() => {
 function renderPanel(onSelectModel = vi.fn()) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
+  const requestGateway = vi.fn(async (method: string) => {
+    if (method === 'model.options') {
+      return getGlobalModelOptions()
+    }
+
+    throw new Error(`unexpected gateway method: ${method}`)
+  })
+
   const content = render(
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={requestGateway as never} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
@@ -497,14 +505,18 @@ describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake',
         providers: [{ models: ['muse-spark-1.2-contributor'], name: 'OpenCode', slug: 'opencode-go' }, MOA_PROVIDER]
       })
 
-    // Method-aware gateway: the panel's catalog reads (`model.options`) fall
-    // back to the REST mock; `config.set` runs the guarded handshake —
+    // Method-aware gateway: the panel's catalog reads (`model.options`) use
+    // the routed catalog mock; `config.set` runs the guarded handshake —
     // confirm_required first, success on the confirmed resend.
     let configSets = 0
 
     const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+      if (method === 'model.options') {
+        return getGlobalModelOptions()
+      }
+
       if (method !== 'config.set') {
-        throw new Error('use REST catalog')
+        throw new Error(`unexpected gateway method: ${method}`)
       }
 
       configSets += 1

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -260,6 +260,7 @@ export function ModelMenuPanel({
       }
       gateway={gateway}
       includeMoa
+      ownerConnectionId={ownerConnectionId}
       profile={profile}
       request={requestGateway}
       sessionId={activeSessionId}

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -37,6 +37,7 @@ export interface ModelSelection {
 
 interface ModelMenuPanelProps {
   gateway?: HermesGateway
+  ownerConnectionId?: string
   onSelectModel: (selection: ModelSelection) => Promise<boolean> | void
   profile?: string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -48,7 +49,13 @@ interface ModelMenuPanelProps {
  * surface's session, remember the pick as a global preset, keep the optimistic
  * stores honest, and roll back on a failed gateway write.
  */
-export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', requestGateway }: ModelMenuPanelProps) {
+export function ModelMenuPanel({
+  gateway,
+  onSelectModel,
+  ownerConnectionId,
+  profile = 'default',
+  requestGateway
+}: ModelMenuPanelProps) {
   const { t } = useI18n()
   const copy = t.shell.modelMenu
   const [refreshing, setRefreshing] = useState(false)
@@ -72,7 +79,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   // back to the catalog's reported current, and a non-reactive read would
   // never repaint that fallback once the catalog resolved.
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, activeSessionId),
+    queryKey: modelOptionsQueryKey(profile, activeSessionId, ownerConnectionId),
     queryFn: (): Promise<ModelOptionsResponse> =>
       requestModelOptions({ gateway, profile, request: requestGateway, sessionId: activeSessionId })
   })
@@ -94,7 +101,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
     setRefreshing(true)
 
     try {
-      const queryKey = modelOptionsQueryKey(profile, activeSessionId)
+      const queryKey = modelOptionsQueryKey(profile, activeSessionId, ownerConnectionId)
 
       const next = await requestModelOptions({
         gateway,

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -27,6 +27,7 @@ interface ModelPickerDialogProps {
   currentModel: string
   currentProvider: string
   onSelect: (selection: { provider: string; model: string }) => void
+  ownerConnectionId?: string
   profile?: string
   /**
    * Optional class for DialogContent. Use it to lift the picker onto a higher
@@ -45,6 +46,7 @@ export function ModelPickerDialog({
   currentModel,
   currentProvider,
   onSelect,
+  ownerConnectionId,
   profile = 'default',
   contentClassName
 }: ModelPickerDialogProps) {
@@ -58,7 +60,7 @@ export function ModelPickerDialog({
   const [search, setSearch] = useState('')
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
     queryFn: () => requestModelOptions({ gateway: gw, profile, sessionId }),
     enabled: open
   })

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -29,6 +29,7 @@ interface ModelPickerDialogProps {
   onSelect: (selection: { provider: string; model: string }) => void
   ownerConnectionId?: string
   profile?: string
+  request?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   /**
    * Optional class for DialogContent. Use it to lift the picker onto a higher
    * rung of the overlay ladder when it opens over another fixed overlay (the
@@ -48,6 +49,7 @@ export function ModelPickerDialog({
   onSelect,
   ownerConnectionId,
   profile = 'default',
+  request,
   contentClassName
 }: ModelPickerDialogProps) {
   const { t } = useI18n()
@@ -61,7 +63,7 @@ export function ModelPickerDialog({
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
-    queryFn: () => requestModelOptions({ gateway: gw, profile, sessionId }),
+    queryFn: () => requestModelOptions({ gateway: gw, profile, request, sessionId }),
     enabled: open
   })
 

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -59,7 +59,7 @@ export function ModelPickerDialog({
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId),
-    queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
+    queryFn: () => requestModelOptions({ gateway: gw, profile, sessionId }),
     enabled: open
   })
 

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -52,7 +52,7 @@ export function ModelVisibilityDialog({
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId),
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway: gw, sessionId }),
+    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway: gw, profile, sessionId }),
     enabled: open
   })
 

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -32,6 +32,7 @@ interface ModelVisibilityDialogProps {
   onOpenChange: (open: boolean) => void
   onOpenProviders: () => void
   open: boolean
+  ownerConnectionId?: string
   profile?: string
   sessionId?: string | null
 }
@@ -41,6 +42,7 @@ export function ModelVisibilityDialog({
   onOpenChange,
   onOpenProviders,
   open,
+  ownerConnectionId,
   profile = 'default',
   sessionId
 }: ModelVisibilityDialogProps) {
@@ -51,7 +53,7 @@ export function ModelVisibilityDialog({
   const collapsedProviders = useStore($collapsedProviders)
 
   const modelOptions = useQuery({
-    queryKey: modelOptionsQueryKey(profile, sessionId),
+    queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
     queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway: gw, profile, sessionId }),
     enabled: open
   })

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelOptions } from '@/hermes'
@@ -201,16 +202,22 @@ describe('modelOptionsQueryKey', () => {
   })
 
   it('isolates identical profile and session names across registry connections', () => {
-    expect(modelOptionsQueryKey('default', 'session-1', 'source-a')).toEqual([
+    const sourceAKey = modelOptionsQueryKey('default', 'session-1', 'source-a')
+    const sourceBKey = modelOptionsQueryKey('default', 'session-1', 'source-b')
+    const queryClient = new QueryClient()
+
+    expect(sourceAKey).toEqual([
       'model-options',
       'default',
       'session-1',
       'owner',
       'source-a'
     ])
-    expect(modelOptionsQueryKey('default', 'session-1', 'source-a')).not.toEqual(
-      modelOptionsQueryKey('default', 'session-1', 'source-b')
-    )
+    queryClient.setQueryData(sourceAKey, { providers: [{ models: ['a/model'], slug: 'a' }] })
+    queryClient.setQueryData(sourceBKey, { providers: [{ models: ['b/model'], slug: 'b' }] })
+
+    expect(queryClient.getQueryData(sourceAKey)).toMatchObject({ providers: [{ models: ['a/model'] }] })
+    expect(queryClient.getQueryData(sourceBKey)).toMatchObject({ providers: [{ models: ['b/model'] }] })
   })
 })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -119,6 +119,19 @@ describe('requestModelOptions', () => {
     expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
   })
 
+  it('passes the catalog owner profile through the shared gateway RPC', async () => {
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(globalOptions))
+    }
+
+    await requestModelOptions({ gateway: gateway as never, profile: 'fred-work' })
+
+    expect(gateway.request).toHaveBeenCalledWith('model.options', {
+      explicit_only: true,
+      profile: 'fred-work'
+    })
+  })
+
   it('falls back to REST when no gateway is connected', async () => {
     await requestModelOptions({ refresh: true })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -168,19 +168,24 @@ describe('requestModelOptions', () => {
     expect(gateway.request).not.toHaveBeenCalled()
   })
 
-  it('scopes REST recovery to the catalog owner profile', async () => {
-    const restPayload = {
-      model: 'berry-local',
-      provider: 'hermes-local',
-      providers: [{ models: ['berry-local'], name: 'Hermes Local', slug: 'hermes-local' }]
-    }
+  it('does not recover an owner-routed failure through the ambient REST connection', async () => {
+    const ownerError = new Error('owner gateway unavailable')
+    const request = vi.fn(() => Promise.reject(ownerError))
 
-    const request = vi.fn(() => Promise.reject(new Error('gateway request unavailable')))
+    await expect(requestModelOptions({ profile: 'berry', request, sessionId: 'tile-1' })).rejects.toBe(ownerError)
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
 
-    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+  it('keeps an empty owner-routed catalog instead of replacing it from ambient REST', async () => {
+    const ownerPayload = { model: 'berry-local', provider: 'hermes-local', providers: [] }
 
-    await expect(requestModelOptions({ profile: 'berry', request, sessionId: 'tile-1' })).resolves.toEqual(restPayload)
-    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true }, 'berry')
+    const request = vi.fn(() => Promise.resolve(ownerPayload)) as unknown as <T>(
+      method: string,
+      params?: Record<string, unknown>
+    ) => Promise<T>
+
+    await expect(requestModelOptions({ profile: 'berry', request, sessionId: 'tile-1' })).resolves.toBe(ownerPayload)
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -199,6 +199,19 @@ describe('modelOptionsQueryKey', () => {
   it('keeps session catalogs inside the owning profile namespace', () => {
     expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual(['model-options', 'compass', 'session-1'])
   })
+
+  it('isolates identical profile and session names across registry connections', () => {
+    expect(modelOptionsQueryKey('default', 'session-1', 'source-a')).toEqual([
+      'model-options',
+      'default',
+      'session-1',
+      'owner',
+      'source-a'
+    ])
+    expect(modelOptionsQueryKey('default', 'session-1', 'source-a')).not.toEqual(
+      modelOptionsQueryKey('default', 'session-1', 'source-b')
+    )
+  })
 })
 
 describe('manualPickRemoved', () => {

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -174,23 +174,26 @@ export async function requestModelOptions({
       return gatewayOptions
     }
 
-    // A connected Desktop gateway can occasionally return only the current
-    // provider/model (or an empty provider list) while its authenticated REST
-    // catalog is already populated. Recover through the same profile-scoped
-    // endpoint Settings uses, but keep the live session selection authoritative.
-    try {
-      const restOptions = await restModelOptions(explicitOnly, refresh, profile)
+    // An owner-routed dispatcher can name a different registry connection than
+    // the ambient REST client. Never recover that request through ambient REST:
+    // profile names are not unique across sources, so doing so can cache B's
+    // catalog under A's tile. Ambient gateway requests retain the compatibility
+    // recovery used by older backends with incomplete model.options responses.
+    if (!request) {
+      try {
+        const restOptions = await restModelOptions(explicitOnly, refresh, profile)
 
-      if (hasSelectableModels(restOptions)) {
-        return {
-          ...restOptions,
-          ...(gatewayOptions?.provider ? { provider: gatewayOptions.provider } : {}),
-          ...(gatewayOptions?.model ? { model: gatewayOptions.model } : {})
+        if (hasSelectableModels(restOptions)) {
+          return {
+            ...restOptions,
+            ...(gatewayOptions?.provider ? { provider: gatewayOptions.provider } : {}),
+            ...(gatewayOptions?.model ? { model: gatewayOptions.model } : {})
+          }
         }
+      } catch {
+        // Preserve the gateway result (or its original error) when the recovery
+        // path is unavailable.
       }
-    } catch {
-      // Preserve the gateway result (or its original error) when the recovery
-      // path is unavailable.
     }
 
     if (gatewayOptions) {

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -109,10 +109,15 @@ interface ModelOptionsRequest {
   sessionId?: null | string
 }
 
-export function modelOptionsQueryKey(profile: null | string | undefined, sessionId?: null | string) {
+export function modelOptionsQueryKey(
+  profile: null | string | undefined,
+  sessionId?: null | string,
+  ownerConnectionId?: null | string
+) {
   const profileKey = (profile ?? '').trim() || 'default'
+  const ownerKey = (ownerConnectionId ?? '').trim()
 
-  return ['model-options', profileKey, sessionId || 'global'] as const
+  return ['model-options', profileKey, sessionId || 'global', ...(ownerKey ? ['owner', ownerKey] : [])] as const
 }
 
 function hasSelectableModels(options: ModelOptionsResponse | null | undefined): boolean {

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -155,6 +155,12 @@ export async function requestModelOptions({
       params.explicit_only = true
     }
 
+    const profileKey = (profile ?? '').trim()
+
+    if (profileKey) {
+      params.profile = profileKey
+    }
+
     let gatewayError: unknown
     let gatewayOptions: ModelOptionsResponse | undefined
 

--- a/apps/desktop/src/lib/model-picker-owner.test.ts
+++ b/apps/desktop/src/lib/model-picker-owner.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveModelPickerOwner } from './model-picker-owner'
+
+describe('resolveModelPickerOwner', () => {
+  it('keeps an active-A focused-B picker on the focused tile owner', () => {
+    expect(
+      resolveModelPickerOwner({
+        ambientConnectionId: 'connection-a',
+        ambientProfile: 'profile-a',
+        focusedStoredSessionId: 'stored-b',
+        selectedStoredSessionId: 'stored-a',
+        sessionTiles: [
+          {
+            ownerRoute: {
+              connectionId: 'connection-b',
+              profile: 'desktop-b',
+              targetProfile: 'backend-b'
+            },
+            storedSessionId: 'stored-b'
+          }
+        ]
+      })
+    ).toEqual({
+      connectionId: 'connection-b',
+      profile: 'backend-b',
+      route: {
+        connectionId: 'connection-b',
+        profile: 'desktop-b',
+        targetProfile: 'backend-b'
+      }
+    })
+  })
+
+  it('uses the ambient owner when the primary session is focused', () => {
+    expect(
+      resolveModelPickerOwner({
+        ambientConnectionId: 'connection-a',
+        ambientProfile: 'profile-a',
+        focusedStoredSessionId: 'stored-a',
+        selectedStoredSessionId: 'stored-a',
+        sessionTiles: []
+      })
+    ).toEqual({ connectionId: 'connection-a', profile: 'profile-a', route: undefined })
+  })
+})

--- a/apps/desktop/src/lib/model-picker-owner.ts
+++ b/apps/desktop/src/lib/model-picker-owner.ts
@@ -1,0 +1,39 @@
+import type { SessionOwnerRoute } from '@/store/session-request-router'
+
+interface ModelPickerOwnerInput {
+  ambientConnectionId?: string
+  ambientProfile: string
+  focusedStoredSessionId: null | string
+  selectedStoredSessionId: null | string
+  sessionTiles: readonly {
+    ownerRoute?: SessionOwnerRoute
+    storedSessionId: string
+  }[]
+}
+
+export interface ModelPickerOwner {
+  connectionId?: string
+  profile: string
+  route?: SessionOwnerRoute
+}
+
+/** Resolve one coherent owner for every picker operation. A tile route wins
+ * only when the tile, rather than the primary session, owns keyboard focus. */
+export function resolveModelPickerOwner({
+  ambientConnectionId,
+  ambientProfile,
+  focusedStoredSessionId,
+  selectedStoredSessionId,
+  sessionTiles
+}: ModelPickerOwnerInput): ModelPickerOwner {
+  const route =
+    focusedStoredSessionId && focusedStoredSessionId !== selectedStoredSessionId
+      ? sessionTiles.find(tile => tile.storedSessionId === focusedStoredSessionId)?.ownerRoute
+      : undefined
+
+  return {
+    connectionId: route?.connectionId || ambientConnectionId,
+    profile: route?.targetProfile || route?.profile || ambientProfile,
+    route
+  }
+}

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -136,6 +136,34 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
     expect($currentProvider.get()).toBe('custom:local')
   })
 
+  it('does not persist a legacy profile reseed when its owner descriptor is unresolved', async () => {
+    setComposerSelectionOwner('homelab', 'default')
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+    getConnection.mockRejectedValue(new Error('source unreachable'))
+
+    const unbind = $activeGatewayProfile.subscribe(profile => {
+      if (profile === 'research') {
+        setCurrentModel('unresolved-model')
+        setCurrentProvider('unresolved-provider')
+        setCurrentModelSource('default')
+      }
+    })
+
+    await ensureGatewayProfile('research')
+    unbind()
+
+    setComposerSelectionOwner('homelab', 'default')
+    expect($currentModel.get()).toBe('grok-4')
+    expect($currentProvider.get()).toBe('xai-oauth')
+    expect(
+      [...Array(window.localStorage.length)].map((_, index) =>
+        window.localStorage.getItem(window.localStorage.key(index) || '')
+      )
+    ).not.toContain('unresolved-model')
+  })
+
   it('does not republish a registry identity invalidated during activation', async () => {
     ensureGatewayForAgent.mockResolvedValueOnce(false)
 

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -36,7 +36,16 @@ vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
 const { $activeGatewayProfile, ensureGatewayAgent, ensureGatewayProfile } = await import('./profile')
-const { $connection } = await import('./session')
+
+const {
+  $connection,
+  $currentModel,
+  $currentProvider,
+  setComposerSelectionOwner,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentProvider
+} = await import('./session')
 
 const agentConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: 'https://homelab.invalid', mode: 'remote', profile: 'research', ...over }) as HermesConnection
@@ -50,6 +59,9 @@ const getConnectionFor =
   vi.fn<(payload: { connectionId?: null | string; profile?: null | string }) => Promise<HermesConnection>>()
 
 beforeEach(() => {
+  const localStorage = window.localStorage
+
+  localStorage.clear()
   getConnection.mockReset()
   getConnectionFor.mockReset()
   ensureGatewayForAgent.mockClear()
@@ -57,7 +69,8 @@ beforeEach(() => {
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
-  vi.stubGlobal('window', { hermesDesktop: { getConnection, getConnectionFor } })
+  vi.stubGlobal('window', { hermesDesktop: { getConnection, getConnectionFor }, localStorage })
+  setComposerSelectionOwner('homelab', 'default')
 })
 
 afterEach(() => {
@@ -88,6 +101,39 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
     expect($activeGatewayProfile.get()).toBe('research')
     // Best-effort: boot/reconnect resyncs later; we must not null it out here.
     expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('reseeds and persists under the activated owner when its descriptor fetch fails', async () => {
+    setComposerSelectionOwner('homelab', 'default')
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+    getConnectionFor.mockRejectedValue(new Error('source unreachable'))
+
+    // Mirrors ContribWiring's gateway-scope effect: the active-profile
+    // publication forces the target profile's model/provider defaults.
+    const unbind = $activeGatewayProfile.subscribe(profile => {
+      if (profile === 'research') {
+        setCurrentModel('local/model')
+        setCurrentProvider('custom:local')
+        setCurrentModelSource('default')
+      }
+    })
+
+    await ensureGatewayAgent('homelab', 'research')
+    unbind()
+
+    expect($connection.get()?.mode).toBe('local')
+    expect($currentModel.get()).toBe('local/model')
+    expect($currentProvider.get()).toBe('custom:local')
+
+    setComposerSelectionOwner('homelab', 'default')
+    expect($currentModel.get()).toBe('grok-4')
+    expect($currentProvider.get()).toBe('xai-oauth')
+
+    setComposerSelectionOwner('homelab', 'research')
+    expect($currentModel.get()).toBe('local/model')
+    expect($currentProvider.get()).toBe('custom:local')
   })
 
   it('does not republish a registry identity invalidated during activation', async () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -25,7 +25,7 @@ import {
 } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
-import { setConnection } from '@/store/session'
+import { clearComposerSelectionOwner, setComposerSelectionOwner, setConnection } from '@/store/session'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -508,11 +508,13 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // descriptor become visible together; a null descriptor (no bridge, or a
     // failed best-effort lookup) keeps the previous one — fail open.
     batch(() => {
-      $activeGatewayProfile.set(target)
-
       if (connection) {
         setConnection(connection)
+      } else {
+        clearComposerSelectionOwner()
       }
+
+      $activeGatewayProfile.set(target)
     })
   })()
 
@@ -695,11 +697,15 @@ export async function ensureGatewayAgent(
     // descriptor keeps the previous one — fail open, resynced by
     // boot/reconnect later.
     batch(() => {
-      $activeGatewayProfile.set(target)
-
       if (descriptor) {
         setConnection(descriptor)
       }
+
+      // The activated registry coordinate is authoritative even when the
+      // best-effort descriptor lookup failed. Publish it before the profile
+      // atom wakes forced model reseeds or a picker can persist a selection.
+      setComposerSelectionOwner(connection, target)
+      $activeGatewayProfile.set(target)
     })
   })()
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -45,6 +45,7 @@ import {
   resolveComposerSessionKey,
   sessionBelongsToProfile,
   sessionPinId,
+  setComposerSelectionOwner,
   setConnection,
   setCurrentCwd,
   setCurrentCwdTransient,
@@ -104,6 +105,31 @@ describe('composer model persistence scope', () => {
 
     expect($currentModel.get()).toBe('grok-4')
     expect($currentProvider.get()).toBe('xai-oauth')
+  })
+
+  it('uses the live registry owner when the connection descriptor is stale', () => {
+    const remote = (profile: string) =>
+      ({ baseUrl: 'https://aibox.example', connectionId: 'aibox', mode: 'remote', profile }) as never
+
+    setConnection(remote('fred'))
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+
+    // ensureGatewayAgent publishes this coordinate even if getConnectionFor
+    // fails and $connection therefore still describes fred.
+    setComposerSelectionOwner('aibox', 'fred-work')
+    setCurrentModel('local/model')
+    setCurrentProvider('custom:local')
+    setCurrentModelSource('default')
+
+    setComposerSelectionOwner('aibox', 'fred')
+    expect($currentModel.get()).toBe('grok-4')
+    expect($currentProvider.get()).toBe('xai-oauth')
+
+    setComposerSelectionOwner('aibox', 'fred-work')
+    expect($currentModel.get()).toBe('local/model')
+    expect($currentProvider.get()).toBe('custom:local')
   })
 })
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -107,6 +107,20 @@ describe('composer model persistence scope', () => {
     expect($currentProvider.get()).toBe('xai-oauth')
   })
 
+  it('keeps inferred local-primary connections on the historical bare keys', () => {
+    setComposerSelectionOwner('remote', 'default')
+    window.localStorage.setItem('hermes.desktop.composer.model', 'legacy-model')
+    window.localStorage.setItem('hermes.desktop.composer.provider', 'legacy-provider')
+
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+
+    expect($currentModel.get()).toBe('legacy-model')
+    expect($currentProvider.get()).toBe('legacy-provider')
+    setCurrentModel('next-model')
+    expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('next-model')
+    expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBeNull()
+  })
+
   it('uses the live registry owner when the connection descriptor is stale', () => {
     const remote = (profile: string) =>
       ({ baseUrl: 'https://aibox.example', connectionId: 'aibox', mode: 'remote', profile }) as never

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -22,6 +22,8 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $selectedStoredSessionId,
   $sessions,
   $unreadFinishedSessionIds,
@@ -43,8 +45,12 @@ import {
   resolveComposerSessionKey,
   sessionBelongsToProfile,
   sessionPinId,
+  setConnection,
   setCurrentCwd,
   setCurrentCwdTransient,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentProvider,
   setRememberedRoute,
   setRememberedSessionId,
   setSelectedStoredSessionId,
@@ -62,6 +68,44 @@ import {
 } from './session-states'
 
 const session = (over: Partial<SessionInfo>): SessionInfo => makeSessionInfo({ id: 'live', ...over })
+
+describe('composer model persistence scope', () => {
+  const local = { baseUrl: '', connectionId: 'local', mode: 'local' } as never
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    setConnection(local)
+    setCurrentModel('')
+    setCurrentProvider('')
+    setCurrentModelSource('')
+  })
+
+  afterEach(() => {
+    setConnection(local)
+    window.localStorage.clear()
+  })
+
+  it('keeps manual model selections isolated by remote connection and profile', () => {
+    const remote = (profile: string) =>
+      ({ baseUrl: 'https://aibox.example', connectionId: 'aibox', mode: 'remote', profile }) as never
+
+    setConnection(remote('fred'))
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+
+    setConnection(remote('fred-work'))
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
+
+    setCurrentModel('local/model')
+    setCurrentProvider('custom:local')
+    setConnection(remote('fred'))
+
+    expect($currentModel.get()).toBe('grok-4')
+    expect($currentProvider.get()).toBe('xai-oauth')
+  })
+})
 
 describe('session owner hints', () => {
   afterEach(() => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -41,6 +41,13 @@ function composerScopeForConnection(connection: HermesConnection | null): string
     return null
   }
 
+  // Electron may infer the sole `local` registry id onto the ordinary primary
+  // descriptor. That remains the legacy single-backend path: only an explicit
+  // registry-scoped route earns a new namespace.
+  if (connection.mode !== 'remote' && !connection.registryScoped) {
+    return ''
+  }
+
   if (connection.connectionId) {
     return `.registry.${encodeURIComponent(connection.connectionId)}.${encodeURIComponent(connection.profile || 'default')}`
   }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -30,8 +30,32 @@ const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
 
-function composerSelectionKey(base: string, connection: HermesConnection | null = $connection.get()): string {
-  return `${base}${connectionScopeSuffix(connection)}`
+// Unlike presentation-oriented $connection, this scope is published from the
+// gateway activation coordinate before profile-change effects can reseed the
+// composer. null means the exact owner is temporarily unknown: values may still
+// paint, but must not be written through the previous backend's storage key.
+let composerSelectionScope: string | null = ''
+
+function composerScopeForConnection(connection: HermesConnection | null): string | null {
+  if (!connection) {
+    return null
+  }
+
+  if (connection.connectionId) {
+    return `.registry.${encodeURIComponent(connection.connectionId)}.${encodeURIComponent(connection.profile || 'default')}`
+  }
+
+  return connectionScopeSuffix(connection)
+}
+
+function composerSelectionKey(base: string): string | null {
+  return composerSelectionScope === null ? null : `${base}${composerSelectionScope}`
+}
+
+function storedComposerString(base: string): string | null {
+  const key = composerSelectionKey(base)
+
+  return key === null ? null : storedString(key)
 }
 
 // The last chat the user had open, so a relaunch lands back on it instead of an
@@ -913,8 +937,8 @@ export function getSessionOwnerHint(
 // clears it and resets the retry counter. Null whenever the active route has a
 // healthy, in-flight, or still-auto-retrying resume.
 export const $resumeExhaustedSessionId = atom<string | null>(null)
-export const $currentModel = atom(storedString(composerSelectionKey(COMPOSER_MODEL_KEY)) ?? '')
-export const $currentProvider = atom(storedString(composerSelectionKey(COMPOSER_PROVIDER_KEY)) ?? '')
+export const $currentModel = atom(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
+export const $currentProvider = atom(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
@@ -970,8 +994,32 @@ export const $contextSuggestions = atom<ContextSuggestion[]>([])
 export const $modelPickerOpen = atom(false)
 export const $sessionPickerOpen = atom(false)
 
+function rescopeComposerSelection(nextScope: string | null): void {
+  if (nextScope === composerSelectionScope) {
+    return
+  }
+
+  composerSelectionScope = nextScope
+  $currentModel.set(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
+  $currentProvider.set(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
+  $currentModelSource.set(getCurrentModelSource())
+}
+
+/** Publish an exact registry route before active-profile effects can persist a
+ * forced default. A registry id is authority even while its descriptive
+ * HermesConnection lookup is unavailable. */
+export function setComposerSelectionOwner(connectionId: string, profile: string): void {
+  rescopeComposerSelection(
+    `.registry.${encodeURIComponent(connectionId)}.${encodeURIComponent(profile.trim() || 'default')}`
+  )
+}
+
+/** Fail closed while a successful legacy profile activation has no descriptor. */
+export function clearComposerSelectionOwner(): void {
+  rescopeComposerSelection(null)
+}
+
 export const setConnection = (next: Updater<HermesConnection | null>) => {
-  const previousComposerScope = connectionScopeSuffix($connection.get())
   updateAtom($connection, next)
   // Repoint connection-scoped persistence (pins, manual session order,
   // remembered navigation) at the new backend's storage scope before any
@@ -979,12 +1027,7 @@ export const setConnection = (next: Updater<HermesConnection | null>) => {
   // keeps the current scope.
   rescopeConnectionScopedStores($connection.get())
   syncCronModelImpactConnection($connection.get())
-
-  if (connectionScopeSuffix($connection.get()) !== previousComposerScope) {
-    $currentModel.set(storedString(composerSelectionKey(COMPOSER_MODEL_KEY)) ?? '')
-    $currentProvider.set(storedString(composerSelectionKey(COMPOSER_PROVIDER_KEY)) ?? '')
-    $currentModelSource.set(getCurrentModelSource())
-  }
+  rescopeComposerSelection(composerScopeForConnection($connection.get()))
 }
 
 export const setGatewayState = (next: Updater<ConnectionState>) => updateAtom($gatewayState, next)
@@ -1109,16 +1152,24 @@ export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($await
 
 export const setCurrentModel = (next: Updater<string>) => {
   updateAtom($currentModel, next)
-  persistString(composerSelectionKey(COMPOSER_MODEL_KEY), $currentModel.get() || null)
+  const key = composerSelectionKey(COMPOSER_MODEL_KEY)
+
+  if (key !== null) {
+    persistString(key, $currentModel.get() || null)
+  }
 }
 
 export const setCurrentProvider = (next: Updater<string>) => {
   updateAtom($currentProvider, next)
-  persistString(composerSelectionKey(COMPOSER_PROVIDER_KEY), $currentProvider.get() || null)
+  const key = composerSelectionKey(COMPOSER_PROVIDER_KEY)
+
+  if (key !== null) {
+    persistString(key, $currentProvider.get() || null)
+  }
 }
 
 export const getCurrentModelSource = (): ComposerModelSource => {
-  const source = storedString(composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY))
+  const source = storedComposerString(COMPOSER_MODEL_SOURCE_KEY)
 
   return source === 'default' || source === 'manual' ? source : ''
 }
@@ -1129,7 +1180,12 @@ export const getCurrentModelSource = (): ComposerModelSource => {
 export const $currentModelSource = atom<ComposerModelSource>(getCurrentModelSource())
 
 export const setCurrentModelSource = (source: ComposerModelSource) => {
-  persistString(composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY), source || null)
+  const key = composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY)
+
+  if (key !== null) {
+    persistString(key, source || null)
+  }
+
   $currentModelSource.set(source)
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -5,7 +5,7 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { activeConnectionScopeSuffix, rescopeConnectionScopedStores } from '@/lib/connection-scoped'
+import { activeConnectionScopeSuffix, connectionScopeSuffix, rescopeConnectionScopedStores } from '@/lib/connection-scoped'
 import { persistBoolean, persistString, readJson, storedBoolean, storedString, writeJson } from '@/lib/storage'
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
@@ -21,13 +21,18 @@ const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 // The composer's model/effort/fast is sticky UI state, NOT the profile default
 // (that lives in Settings → Model). Persisting it in localStorage makes a pick
 // follow across Cmd+N and app restarts instead of snapping back to the default.
-// It's deliberately global (not per-profile): a profile switch force-reseeds to
-// that profile's default, while within a profile new chats keep your last pick.
+// Model/provider/source are scoped to the remote (connection, profile) owner so
+// a provider authenticated on one profile cannot contaminate another profile's
+// session.create. Local/single-backend users retain the historical bare keys.
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
 const COMPOSER_EFFORT_KEY = 'hermes.desktop.composer.reasoning-effort'
 const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
+
+function composerSelectionKey(base: string, connection: HermesConnection | null = $connection.get()): string {
+  return `${base}${connectionScopeSuffix(connection)}`
+}
 
 // The last chat the user had open, so a relaunch lands back on it instead of an
 // empty new-chat. Stored (not runtime) id — the route is keyed by stored id.
@@ -908,8 +913,8 @@ export function getSessionOwnerHint(
 // clears it and resets the retry counter. Null whenever the active route has a
 // healthy, in-flight, or still-auto-retrying resume.
 export const $resumeExhaustedSessionId = atom<string | null>(null)
-export const $currentModel = atom(storedString(COMPOSER_MODEL_KEY) ?? '')
-export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
+export const $currentModel = atom(storedString(composerSelectionKey(COMPOSER_MODEL_KEY)) ?? '')
+export const $currentProvider = atom(storedString(composerSelectionKey(COMPOSER_PROVIDER_KEY)) ?? '')
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
@@ -966,6 +971,7 @@ export const $modelPickerOpen = atom(false)
 export const $sessionPickerOpen = atom(false)
 
 export const setConnection = (next: Updater<HermesConnection | null>) => {
+  const previousComposerScope = connectionScopeSuffix($connection.get())
   updateAtom($connection, next)
   // Repoint connection-scoped persistence (pins, manual session order,
   // remembered navigation) at the new backend's storage scope before any
@@ -973,6 +979,12 @@ export const setConnection = (next: Updater<HermesConnection | null>) => {
   // keeps the current scope.
   rescopeConnectionScopedStores($connection.get())
   syncCronModelImpactConnection($connection.get())
+
+  if (connectionScopeSuffix($connection.get()) !== previousComposerScope) {
+    $currentModel.set(storedString(composerSelectionKey(COMPOSER_MODEL_KEY)) ?? '')
+    $currentProvider.set(storedString(composerSelectionKey(COMPOSER_PROVIDER_KEY)) ?? '')
+    $currentModelSource.set(getCurrentModelSource())
+  }
 }
 
 export const setGatewayState = (next: Updater<ConnectionState>) => updateAtom($gatewayState, next)
@@ -1097,16 +1109,16 @@ export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($await
 
 export const setCurrentModel = (next: Updater<string>) => {
   updateAtom($currentModel, next)
-  persistString(COMPOSER_MODEL_KEY, $currentModel.get() || null)
+  persistString(composerSelectionKey(COMPOSER_MODEL_KEY), $currentModel.get() || null)
 }
 
 export const setCurrentProvider = (next: Updater<string>) => {
   updateAtom($currentProvider, next)
-  persistString(COMPOSER_PROVIDER_KEY, $currentProvider.get() || null)
+  persistString(composerSelectionKey(COMPOSER_PROVIDER_KEY), $currentProvider.get() || null)
 }
 
 export const getCurrentModelSource = (): ComposerModelSource => {
-  const source = storedString(COMPOSER_MODEL_SOURCE_KEY)
+  const source = storedString(composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY))
 
   return source === 'default' || source === 'manual' ? source : ''
 }
@@ -1117,7 +1129,7 @@ export const getCurrentModelSource = (): ComposerModelSource => {
 export const $currentModelSource = atom<ComposerModelSource>(getCurrentModelSource())
 
 export const setCurrentModelSource = (source: ComposerModelSource) => {
-  persistString(COMPOSER_MODEL_SOURCE_KEY, source || null)
+  persistString(composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY), source || null)
   $currentModelSource.set(source)
 }
 

--- a/tests/tui_gateway/test_model_options_profile_scope.py
+++ b/tests/tui_gateway/test_model_options_profile_scope.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import tui_gateway.server as server
+
+
+def test_model_options_binds_requested_profile_home(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profiles" / "fred-work"
+    profile_home.mkdir(parents=True)
+    seen = {}
+
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda name: profile_home if name == "fred-work" else None,
+    )
+    monkeypatch.setattr(server, "_model_picker_context", lambda agent: object())
+
+    def build_payload(ctx, **kwargs):
+        from hermes_constants import get_hermes_home
+
+        seen["home"] = Path(get_hermes_home())
+        return {"providers": []}
+
+    monkeypatch.setattr("hermes_cli.inventory.build_model_options_payload", build_payload)
+
+    response = server._methods["model.options"](1, {"profile": "fred-work"})
+
+    assert response["result"] == {"providers": []}
+    assert seen["home"] == profile_home

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -467,6 +467,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("model.options")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.inventory import build_model_options_payload


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now keeps model catalogs and sticky composer selections inside the remote connection/profile that owns them. Switching from an OAuth-backed profile to a custom-provider profile no longer lets the first profile's provider override contaminate the second profile's new chats.

### Symptom

On a multi-profile remote dashboard, Desktop could show the dashboard launch home's model catalog for the focused profile. A new chat could then send a sticky provider from another profile and fail agent initialization because the target profile did not own those credentials.

### Impact

Remote multi-profile users could not reliably select the configured custom model for a profile, and new chats could fail before the agent started. Existing sessions with a stored profile-correct provider continued to work.

### Bug Cause

**Trigger:** `apps/desktop/src/lib/model-options.ts:133` / a catalog request or new chat after changing the active remote profile.

**Causal chain:**
1. Desktop reused one remote dashboard for multiple profiles.
2. `model.options` omitted the focused profile and was not profile-scoped, while primary-label REST routes could also omit `?profile=`.
3. Global composer localStorage then supplied a provider selected under a different profile to `session.create`, producing the wrong catalog or an authentication failure.

**Why it is wrong:** A renderer profile label is not proof that the remote dashboard process was launched with that profile's `HERMES_HOME`. Both request routing and persisted UI state must carry the actual connection/profile owner.

**Working sibling / contrast:** The browser Dashboard passed an explicit profile to `/api/model/options`, so the same backend returned the correct custom provider catalog there.

**Ruled out:** The custom provider was not missing from server config; the browser Dashboard and existing profile-correct sessions both resolved it successfully.

### Fix

- Carry the concrete owner profile through model catalog RPCs and forced composer-default refreshes.
- Bind `model.options` to the requested profile home in the TUI gateway.
- Keep global-remote primary-label REST paths explicitly profile-scoped.
- Persist composer model/provider/source by remote connection and profile while preserving legacy bare keys for local users.

## Related Issue

Closes #96699

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/model-options.ts` - include the owner profile in model catalog RPCs.
- `apps/desktop/src/store/session.ts` - isolate sticky composer model state by remote connection/profile.
- `apps/desktop/electron/connection-config.ts` - keep global-remote primary profile requests scoped on the wire.
- `tui_gateway/methods_complete.py` - execute `model.options` under the requested profile home.
- Desktop and gateway regression tests cover routing, persistence, reseeding, and profile-home binding.

## How to Test

1. Run the focused Desktop model/profile tests.
2. Run the TUI gateway profile-scope regression test.
3. Run Desktop type checking and linting.

```bash
cd apps/desktop && npx vitest run src/lib/model-options.test.ts src/app/session/hooks/use-model-controls.test.tsx src/store/session.test.ts electron/connection-config.test.ts
cd apps/desktop && npm run typecheck
cd apps/desktop && npm run lint
scripts/run_tests.sh tests/tui_gateway/test_model_options_profile_scope.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline architecture documentation was updated
- [x] Config example changes are N/A
- [x] Contributor guide changes are N/A
- [x] Cross-platform impact was considered; storage key generation and routing logic are platform-neutral
- [x] Tool description/schema changes are N/A
