### PR TITLE
fix(desktop): claim-guard the three remaining unguarded backend dial sites

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -199,4 +199,41 @@ describe('main.ts wiring for #90812', () => {
     expect(body).toContain('backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile)')
     expect(body).toContain('ensureRegistryBackend(registryConnectionId, routeProfile)')
   })
+
+  // Three more surfaces bypassed backendDialClaims entirely, missed by the
+  // #90812 pass above: freshGatewayWsUrl/requestJsonForProfile/the registry
+  // ws-url handler all called ensureBackend()/ensureRegistryBackend() raw.
+  // freshGatewayWsUrl and the registry handler are hotter than most of the
+  // sites above — the renderer calls them immediately before every
+  // gateway.connect() — so an unguarded race there bootstraps a duplicate
+  // backend/SSH tunnel on every reconnect race, not just an occasional probe.
+
+  it('routes the fresh-ws-url mint (called before every gateway.connect()) through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function freshGatewayWsUrl(profile) {')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 1_100)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(null, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes the profile-scoped REST dispatch (fetchJsonForProfile/requestJsonForProfile) through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function requestJsonForProfile(')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 400)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(null, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes the registry-scoped fresh-ws-url mint through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf(
+      'const registryGatewayWsUrlHandler = createRegistryGatewayWsUrlHandler({'
+    )
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 400)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connectionId')
+    expect(body).toContain('ensureRegistryBackend(connectionId, profile)')
+  })
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7928,7 +7928,11 @@ async function freshGatewayWsUrl(profile) {
   // silently lands back on the primary (default) backend and writes sessions to
   // the wrong profile's DB. A null/empty profile resolves to the primary, so
   // legacy callers and single-profile users are unchanged.
-  const connection = await ensureBackend(profile)
+  //
+  // Claim-guarded (#90812): called immediately before every gateway.connect(),
+  // so it can race another dial for the same profile (e.g. a second window
+  // reconnecting) into bootstrapping a duplicate backend/SSH tunnel.
+  const connection = await backendDialClaims.run(backendScopeKey(null, profile), () => ensureBackend(profile))
 
   if (connection.authMode === 'oauth') {
     const ticket = await mintGatewayWsTicket(connection.baseUrl, connection.headers)
@@ -10549,8 +10553,11 @@ async function fetchJsonForProfile(profile, path) {
 }
 
 // Issue an arbitrary method against a profile's resolved backend, parsed JSON.
+// Claim-guarded (#90812): the session-messages REST dispatch below can race a
+// renderer's own WS reconnect dial for the same profile scope; coalescing
+// avoids bootstrapping a second backend/SSH tunnel.
 async function requestJsonForProfile(profile: string, path: string, method: string, body?: string) {
-  const conn = await ensureBackend(profile)
+  const conn = await backendDialClaims.run(backendScopeKey(null, profile), () => ensureBackend(profile))
   const url = `${conn.baseUrl}${path}`
   const opts = { method, body, timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
@@ -15100,8 +15107,15 @@ ipcMain.handle('hermes:agents:roster', async () => {
 
 // Registry-scoped fresh WS URL: the (connectionId, profile) analogue of
 // hermes:gateway:ws-url. Same single-use-ticket discipline for OAuth sources.
+//
+// Claim-guarded (#90812): called immediately before every gateway.connect(),
+// so it can race another dial for the same (connectionId, profile) scope
+// into bootstrapping a duplicate backend/SSH tunnel.
 const registryGatewayWsUrlHandler = createRegistryGatewayWsUrlHandler({
-  ensureBackend: ensureRegistryBackend,
+  ensureBackend: (connectionId, profile) =>
+    backendDialClaims.run(backendScopeKey(connectionId as any, profile as any), () =>
+      ensureRegistryBackend(connectionId, profile)
+    ),
   mintTicket: mintGatewayWsTicket,
   buildTicketUrl: buildGatewayWsUrlWithTicket,
   rememberHeaders: rememberRemoteWsHeaders


### PR DESCRIPTION
## Summary

#90812 introduced `BackendDialClaims` to coalesce concurrent dials for the same `(connectionId, profile)` scope, so two renderer windows (or a window plus a background reconnect) racing the same profile don't each bootstrap a duplicate backend/SSH tunnel. A later pass (landed as part of #95606's salvage, commit history on `main`) claim-guarded five call sites that raced it: media protocol registration, `activeSshTerminalTarget`, `enumerateRegistryAgentSources`, the `hermes:connections:update-all` dispatch, and `dispatchRegistryApiRequest`.

Three more call sites still call `ensureBackend()`/`ensureRegistryBackend()` directly, bypassing the claim entirely:

- **`freshGatewayWsUrl()`** — per its own comment, minted "immediately before every `gateway.connect()`"
- **`requestJsonForProfile()`** — the profile-scoped REST dispatch backing the session-messages endpoints (`fetchJsonForProfile`/`requestJsonForProfile`, 4 call sites)
- **the `ensureBackend` dependency passed to `createRegistryGatewayWsUrlHandler`** — the `(connectionId, profile)` analogue of the first, backing `hermes:gateway:ws-url-for`

The first and third are hotter than most of the already-guarded sites: the renderer calls them on every reconnect, not on an occasional probe. Two windows (or a window plus a background reconnect) racing the same profile scope through one of these and a guarded path can each bootstrap their own backend/SSH tunnel for the same scope — duplicate SSH tunnels / remote dashboards, the same symptom class #90812 fixed for its five sites.

## Fix

Wrap all three in `backendDialClaims.run(backendScopeKey(...), ...)`, matching the pattern already used at the five sites #90812 fixed (e.g. `hermes:connection:for`'s handler).

## Test plan

- Extended `backend-dial-claim.test.ts` with three source-wiring assertions, one per newly-guarded call site — matching the file's existing convention for the five prior sites (it reads its own `main.ts` source and asserts the claim-guard wrapping is present around each dial).
- Mutation-verified: stashed the `main.ts` fix and confirmed all three new tests fail against the unguarded code, then restored and confirmed they pass.
- `npx vitest run electron/` (apps/desktop): 1878 passed, 2 pre-existing failures unrelated to this change — confirmed identical failures occur with this branch's changes fully reverted (both spawn/inspect real OS processes: `managed-ssh-update.test.ts` and `remote-lifecycle.test.ts`, neither touching `backend-dial-claim.ts` or `main.ts`'s dial-guard wiring — sandbox-environment flakes).
- `tsc -p tsconfig.electron.json --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)