### PR TITLE
perf(desktop): paint cached shell state before live refresh

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -309,7 +309,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   )
 
   const { loadMoreMessagingForPlatform, loadMoreSessions, refreshCronJobs, refreshMessagingSessions, refreshSessions } =
-    useSessionListActions({ profileScope })
+    useSessionListActions({ activeConnectionId, profileScope })
 
   const updateActiveSessionRuntimeInfo = useCallback(
     (info: { branch?: string; cwd?: string }) => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -28,6 +28,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import { writeSessionListSnapshot } from '@/store/session-list-cache'
 
 import { deferred } from '../../../test/deferred'
 
@@ -103,6 +104,7 @@ vi.mock('@/store/projects', () => ({
 }))
 
 beforeEach(() => {
+  window.localStorage.clear()
   gatewayScope.epoch = 0
   getCronJobs.mockReset()
   getCronJobs.mockResolvedValue([])
@@ -121,6 +123,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  window.localStorage.clear()
   setCronJobs([])
   setSessions([])
   setCronSessions([])
@@ -130,6 +133,52 @@ afterEach(() => {
   setSessionProfilesTruncated({})
   setSessionProfilesUsage({})
   setSessionsLoading(false)
+})
+
+describe('persisted session-list fast paint', () => {
+  it('hydrates the matching connection/profile before the live refresh', () => {
+    writeSessionListSnapshot(
+      { connectionId: 'connection-a', profile: 'profile-a' },
+      {
+        cron: [row('cached-cron', { profile: 'profile-a', source: 'cron' })],
+        messaging: [row('cached-message', { profile: 'profile-a', source: 'signal' })],
+        messagingTruncated: true,
+        profilesTruncated: { 'profile-a': true },
+        profilesUsage: { 'profile-a': { cost_usd: 3, tokens: 30 } },
+        recents: [row('cached-recent', { profile: 'profile-a' })]
+      }
+    )
+
+    renderHook(() => useSessionListActions({ activeConnectionId: 'connection-a', profileScope: 'profile-a' }))
+
+    expect($sessions.get().map(session => session.id)).toEqual(['cached-recent'])
+    expect($cronSessions.get().map(session => session.id)).toEqual(['cached-cron'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['cached-message'])
+    expect($messagingTruncated.get()).toBe(true)
+    expect($sessionProfilesTruncated.get()).toEqual({ 'profile-a': true })
+    expect($sessionProfilesUsage.get()).toEqual({ 'profile-a': { cost_usd: 3, tokens: 30 } })
+    expect($sessionsLoading.get()).toBe(false)
+    expect(listSidebarSessions).not.toHaveBeenCalled()
+  })
+
+  it('does not paint another connection or profile cache', () => {
+    writeSessionListSnapshot(
+      { connectionId: 'connection-b', profile: 'profile-a' },
+      {
+        cron: [],
+        messaging: [],
+        messagingTruncated: false,
+        profilesTruncated: {},
+        profilesUsage: {},
+        recents: [row('wrong-owner', { profile: 'profile-a' })]
+      }
+    )
+
+    renderHook(() => useSessionListActions({ activeConnectionId: 'connection-a', profileScope: 'profile-a' }))
+
+    expect($sessions.get()).toEqual([])
+    expect($sessionsLoading.get()).toBe(false)
+  })
 })
 
 describe('refreshSessions identity + loading hygiene', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -36,6 +36,11 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import {
+  readSessionListSnapshot,
+  sessionListCacheScopeKey,
+  writeSessionListSnapshot
+} from '@/store/session-list-cache'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
 import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
@@ -94,30 +99,69 @@ function sessionsToKeep(scope?: string): Set<string> {
 }
 
 interface UseSessionListActionsArgs {
+  activeConnectionId?: null | string
   profileScope: string
 }
 
 /** Owns the sidebar's session-list fetching + paging: recents, cron runs/jobs,
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
-export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+export function useSessionListActions({ activeConnectionId, profileScope }: UseSessionListActionsArgs) {
+  const normalizedConnectionId = activeConnectionId ?? null
+  const activeConnectionIdRef = useRef(normalizedConnectionId)
   const profileScopeRef = useRef(profileScope)
+  const paintedCacheScopeRef = useRef<null | string>(null)
   const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
 
   useLayoutEffect(() => {
+    activeConnectionIdRef.current = normalizedConnectionId
     profileScopeRef.current = profileScope
-  }, [profileScope])
+
+    const profile = sidebarProfileForScope(profileScope)
+    const scope = { connectionId: normalizedConnectionId, profile }
+    const scopeKey = sessionListCacheScopeKey(scope)
+
+    if (paintedCacheScopeRef.current === scopeKey) {
+      return
+    }
+
+    paintedCacheScopeRef.current = scopeKey
+    // Requests started for the previous connection/profile are obsolete even
+    // when the gateway activation epoch has not advanced yet.
+    refreshSessionsRequestRef.current += 1
+    refreshMessagingSessionsRequestRef.current += 1
+
+    const cached = readSessionListSnapshot(scope)
+
+    // A cache hit replaces an empty cold renderer immediately. A miss is
+    // deliberately non-destructive because the context-switch owner may have
+    // already published newer state before this layout effect commits.
+    if (cached) {
+      setSessions(cached.recents)
+      setCronSessions(cached.cron)
+      setMessagingSessions(cached.messaging)
+      setMessagingPlatformTotals({})
+      setMessagingTruncated(cached.messagingTruncated)
+      setSessionProfilesTruncated(cached.profilesTruncated)
+      setSessionProfilesUsage(cached.profilesUsage)
+      setSessionsLoading(false)
+    }
+  }, [normalizedConnectionId, profileScope])
 
   /** Refresh the active profile's messaging-platform sidebar slice. */
   const refreshMessagingSessions = useCallback(async () => {
     const sessionProfile = sidebarProfileForScope(profileScope)
+    const requestConnectionId = normalizedConnectionId
     const activationEpoch = gatewayActivationEpoch()
 
     // A callback captured before a profile switch may still be queued by an
     // event subscription. Do not let it start a request against the old scope.
-    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    if (
+      activeConnectionIdRef.current !== requestConnectionId ||
+      sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
+    ) {
       return
     }
 
@@ -131,6 +175,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         refreshMessagingSessionsRequestRef.current !== requestId ||
+        activeConnectionIdRef.current !== requestConnectionId ||
         sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
         gatewayActivationEpoch() !== activationEpoch
       ) {
@@ -148,15 +193,19 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [profileScope])
+  }, [normalizedConnectionId, profileScope])
 
   /** Page one messaging platform without replacing another platform's rows. */
   const loadMoreMessagingForPlatform = useCallback(
     async (platform: string) => {
       const sessionProfile = sidebarProfileForScope(profileScope)
+      const requestConnectionId = normalizedConnectionId
       const activationEpoch = gatewayActivationEpoch()
 
-      if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      if (
+        activeConnectionIdRef.current !== requestConnectionId ||
+        sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
+      ) {
         return
       }
 
@@ -188,6 +237,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         loadMoreMessagingRequestRef.current[requestKey] !== requestId ||
+        activeConnectionIdRef.current !== requestConnectionId ||
         sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
         gatewayActivationEpoch() !== activationEpoch
       ) {
@@ -205,14 +255,18 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       setMessagingPlatformTotals(prev => ({ ...prev, [requestKey]: Math.max(total, incoming.length) }))
     },
-    [profileScope]
+    [normalizedConnectionId, profileScope]
   )
 
   /** Refresh cron jobs only while the profile that requested them remains active. */
   const refreshCronJobs = useCallback(async () => {
     const sessionProfile = sidebarProfileForScope(profileScope)
+    const requestConnectionId = normalizedConnectionId
 
-    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    if (
+      activeConnectionIdRef.current !== requestConnectionId ||
+      sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
+    ) {
       return
     }
 
@@ -221,15 +275,20 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
-  }, [profileScope])
+  }, [normalizedConnectionId, profileScope])
 
   /** Refresh every sidebar session slice without committing an obsolete profile response. */
   const refreshSessions = useCallback(
     async (shouldPublish: () => boolean = () => true) => {
       const sessionProfile = sidebarProfileForScope(profileScope)
+      const requestConnectionId = normalizedConnectionId
       const activationEpoch = gatewayActivationEpoch()
 
-      if (!shouldPublish() || sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      if (
+        !shouldPublish() ||
+        activeConnectionIdRef.current !== requestConnectionId ||
+        sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
+      ) {
         return
       }
 
@@ -273,6 +332,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         if (
           shouldPublish() &&
           refreshSessionsRequestRef.current === requestId &&
+          activeConnectionIdRef.current === requestConnectionId &&
           sidebarProfileForScope(profileScopeRef.current) === sessionProfile &&
           gatewayActivationEpoch() === activationEpoch
         ) {
@@ -332,6 +392,21 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
           // Hit the cap → at least one platform may have more on disk than loaded.
           setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+
+          // Store exactly what the sidebar accepted after tombstones, source
+          // filtering, and active-row preservation. A later launch can paint
+          // this bounded snapshot while the same authoritative request runs.
+          writeSessionListSnapshot(
+            { connectionId: requestConnectionId, profile: sessionProfile },
+            {
+              cron: result.cron.sessions,
+              messaging: messagingRows,
+              messagingTruncated: result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT,
+              profilesTruncated: result.recents.profiles_truncated ?? {},
+              profilesUsage: result.recents.profiles_usage ?? {},
+              recents: $sessions.get()
+            }
+          )
         }
       } finally {
         // Request identity preserves the zero-argument refresh contract across a
@@ -347,7 +422,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         void refreshCronJobs()
       }
     },
-    [profileScope, refreshCronJobs]
+    [normalizedConnectionId, profileScope, refreshCronJobs]
   )
 
   const loadMoreSessions = useCallback(async () => {

--- a/apps/desktop/src/store/project-tree-cache.test.ts
+++ b/apps/desktop/src/store/project-tree-cache.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+
+import {
+  PROJECT_TREE_CACHE_STORAGE_KEY,
+  projectTreeCacheScopeKey,
+  readProjectTreeSnapshot,
+  writeProjectTreeSnapshot
+} from './project-tree-cache'
+
+const project = (id: string): SidebarProjectTree =>
+  ({ id, label: `Project ${id}`, path: `/${id}`, repos: [], sessionCount: 0 }) as SidebarProjectTree
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('project tree cache', () => {
+  it('round-trips only within the exact connection and profile scope', () => {
+    const scope = { connectionId: 'connection-a', profile: 'profile-a' }
+
+    writeProjectTreeSnapshot(scope, { activeId: 'alpha', projects: [project('alpha')] })
+
+    expect(readProjectTreeSnapshot(scope)).toEqual({ activeId: 'alpha', projects: [project('alpha')] })
+    expect(readProjectTreeSnapshot({ connectionId: 'connection-a', profile: 'profile-b' })).toBeNull()
+    expect(readProjectTreeSnapshot({ connectionId: 'connection-b', profile: 'profile-a' })).toBeNull()
+  })
+
+  it('rejects malformed or expired persisted data', () => {
+    window.localStorage.setItem(PROJECT_TREE_CACHE_STORAGE_KEY, '{broken')
+    expect(readProjectTreeSnapshot({ connectionId: 'local', profile: 'default' })).toBeNull()
+
+    const key = projectTreeCacheScopeKey({ connectionId: 'local', profile: 'default' })
+    window.localStorage.setItem(
+      PROJECT_TREE_CACHE_STORAGE_KEY,
+      JSON.stringify({
+        [key]: {
+          activeId: null,
+          projects: [project('stale')],
+          savedAt: Date.now() - 15 * 24 * 60 * 60 * 1000
+        }
+      })
+    )
+
+    expect(readProjectTreeSnapshot({ connectionId: 'local', profile: 'default' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/project-tree-cache.ts
+++ b/apps/desktop/src/store/project-tree-cache.ts
@@ -1,0 +1,121 @@
+import type { SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import { readKey, writeKey } from '@/lib/storage'
+
+const STORAGE_KEY = 'hermes.desktop.projectTreeCache.v1'
+const MAX_CONTEXTS = 8
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
+export interface ProjectTreeCacheScope {
+  connectionId: string
+  profile: string
+}
+
+export interface ProjectTreeSnapshot {
+  activeId: null | string
+  projects: SidebarProjectTree[]
+}
+
+interface StoredProjectTreeSnapshot extends ProjectTreeSnapshot {
+  savedAt: number
+}
+
+type ProjectTreeCache = Record<string, StoredProjectTreeSnapshot>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+function isProjectTree(value: unknown): value is SidebarProjectTree {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.label !== 'string' || !Array.isArray(value.repos)) {
+    return false
+  }
+
+  return value.repos.every(
+    repo =>
+      isRecord(repo) &&
+      typeof repo.id === 'string' &&
+      typeof repo.label === 'string' &&
+      Array.isArray(repo.groups) &&
+      repo.groups.every(
+        group =>
+          isRecord(group) &&
+          typeof group.id === 'string' &&
+          typeof group.label === 'string' &&
+          Array.isArray(group.sessions)
+      )
+  )
+}
+
+function isStoredSnapshot(value: unknown, now: number): value is StoredProjectTreeSnapshot {
+  return (
+    isRecord(value) &&
+    (value.activeId === null || typeof value.activeId === 'string') &&
+    typeof value.savedAt === 'number' &&
+    Number.isFinite(value.savedAt) &&
+    now - value.savedAt <= MAX_AGE_MS &&
+    Array.isArray(value.projects) &&
+    value.projects.every(isProjectTree)
+  )
+}
+
+function readCache(): ProjectTreeCache {
+  const raw = readKey(STORAGE_KEY)
+
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+
+    if (!isRecord(parsed)) {
+      return {}
+    }
+
+    const now = Date.now()
+
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, StoredProjectTreeSnapshot] => isStoredSnapshot(entry[1], now))
+        .sort((left, right) => right[1].savedAt - left[1].savedAt)
+        .slice(0, MAX_CONTEXTS)
+    )
+  } catch {
+    return {}
+  }
+}
+
+export function projectTreeCacheScopeKey(scope: ProjectTreeCacheScope): string {
+  return JSON.stringify([scope.connectionId.trim() || 'local', scope.profile.trim() || 'default'])
+}
+
+export function readProjectTreeSnapshot(scope: ProjectTreeCacheScope): ProjectTreeSnapshot | null {
+  const cached = readCache()[projectTreeCacheScopeKey(scope)]
+
+  if (!cached) {
+    return null
+  }
+
+  const { savedAt: _savedAt, ...snapshot } = cached
+
+  return snapshot
+}
+
+export function writeProjectTreeSnapshot(scope: ProjectTreeCacheScope, snapshot: ProjectTreeSnapshot): void {
+  const key = projectTreeCacheScopeKey(scope)
+  const cache = readCache()
+
+  cache[key] = { ...snapshot, savedAt: Date.now() }
+
+  writeKey(
+    STORAGE_KEY,
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(cache)
+          .sort((left, right) => right[1].savedAt - left[1].savedAt)
+          .slice(0, MAX_CONTEXTS)
+      )
+    )
+  )
+}
+
+export const PROJECT_TREE_CACHE_STORAGE_KEY = STORAGE_KEY

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
-import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
+import {
+  $connection,
+  $currentCwd,
+  $selectedStoredSessionId,
+  $sessions,
+  applyConfiguredDefaultProjectDir
+} from '@/store/session'
 
 import {
   $activeProjectId,
@@ -171,6 +177,48 @@ describe('projects RPC profile forwarding', () => {
 
     expect(request).not.toHaveBeenCalled()
     setShowAllProfiles(false)
+  })
+})
+
+describe('project tree startup cache', () => {
+  afterEach(() => {
+    $connection.set(null)
+    $activeGatewayProfile.set('default')
+    window.localStorage.clear()
+  })
+
+  it('paints the matching connection and profile before live reconciliation finishes', async () => {
+    const cached = { id: 'cached', label: 'Cached', path: '/cached', repos: [], sessionCount: 1 }
+    const live = { id: 'live', label: 'Live', path: '/live', repos: [], sessionCount: 2 }
+    const response = deferred<{ active_id: string; projects: SidebarProjectTree[]; scoped_session_ids: string[] }>()
+    const request = vi.fn(() => response.promise)
+
+    $connection.set({ connectionId: 'connection-a' } as never)
+    $activeGatewayProfile.set('profile-a')
+    $projectTree.set([])
+    $activeProjectId.set(null)
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+    window.localStorage.setItem(
+      'hermes.desktop.projectTreeCache.v1',
+      JSON.stringify({
+        [JSON.stringify(['connection-a', 'profile-a'])]: {
+          activeId: 'cached',
+          projects: [cached],
+          savedAt: Date.now()
+        }
+      })
+    )
+
+    const pending = refreshProjectTree()
+
+    expect($projectTree.get().map(project => project.id)).toEqual(['cached'])
+    expect($activeProjectId.get()).toBe('cached')
+
+    response.resolve({ active_id: 'live', projects: [live], scoped_session_ids: [] })
+    await pending
+
+    expect($projectTree.get().map(project => project.id)).toEqual(['live'])
+    expect($activeProjectId.get()).toBe('live')
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -24,6 +24,13 @@ import {
   requestFreshSession
 } from '@/store/profile'
 import {
+  type ProjectTreeCacheScope,
+  projectTreeCacheScopeKey,
+  readProjectTreeSnapshot,
+  writeProjectTreeSnapshot
+} from '@/store/project-tree-cache'
+import {
+  $connection,
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
@@ -46,6 +53,42 @@ export const $activeProjectId = atom<null | string>(null)
 // source of project membership — the desktop no longer derives it.
 export const $projectTree = atom<SidebarProjectTree[]>([])
 export const $projectTreeLoading = atom(false)
+
+function currentProjectConnectionId(): string {
+  return $connection.get()?.connectionId?.trim() || 'local'
+}
+
+function currentProjectTreeCacheScope(): ProjectTreeCacheScope | null {
+  const profile = $profileScope.get() === ALL_PROFILES ? ALL_PROFILES : projectProfile()
+
+  return profile ? { connectionId: currentProjectConnectionId(), profile } : null
+}
+
+let paintedProjectTreeScopeKey: null | string = null
+
+function hydrateProjectTreeCache(scope: ProjectTreeCacheScope): void {
+  const key = projectTreeCacheScopeKey(scope)
+
+  if (paintedProjectTreeScopeKey === key) {
+    return
+  }
+
+  paintedProjectTreeScopeKey = key
+  const cached = readProjectTreeSnapshot(scope)
+
+  if (cached) {
+    $projectTree.set(cached.projects)
+    $activeProjectId.set(cached.activeId)
+  }
+}
+
+function keepCurrentProjectTreeAheadOfCache(): void {
+  const scope = currentProjectTreeCacheScope()
+
+  if (scope) {
+    paintedProjectTreeScopeKey = projectTreeCacheScopeKey(scope)
+  }
+}
 
 // False when the connected backend predates the projects.* JSON-RPC surface
 // (same semver label, older install). Null until the first probe.
@@ -379,12 +422,17 @@ function isRetryableProjectTreeReadError(error: unknown): boolean {
 }
 
 interface ActiveProjectsContext {
+  connectionId: string
   gateway: HermesGateway
   profile: string
 }
 
 function stillOnProjectsContext(context: ActiveProjectsContext): boolean {
-  return activeGateway() === context.gateway && projectProfile() === context.profile
+  return (
+    activeGateway() === context.gateway &&
+    currentProjectConnectionId() === context.connectionId &&
+    projectProfile() === context.profile
+  )
 }
 
 async function activeProjectsContext(): Promise<ActiveProjectsContext> {
@@ -404,7 +452,7 @@ async function activeProjectsContext(): Promise<ActiveProjectsContext> {
     throw new Error('Active Hermes profile changed while connecting')
   }
 
-  return { gateway, profile }
+  return { connectionId: currentProjectConnectionId(), gateway, profile }
 }
 
 function applyPayload(payload: ProjectsPayload): void {
@@ -457,10 +505,15 @@ const PROJECT_TREE_REQUEST_TIMEOUT_MS = 60_000
 
 let projectTreeRefreshGeneration = 0
 
-function applyProjectTreePayload(res: ProjectTreePayload): void {
+function applyProjectTreePayload(res: ProjectTreePayload, scope: ProjectTreeCacheScope): void {
   const scoped = new Set(res.scoped_session_ids ?? [])
   $projectTree.set(res.projects ?? [])
   $activeProjectId.set(res.active_id ?? null)
+  paintedProjectTreeScopeKey = projectTreeCacheScopeKey(scope)
+  writeProjectTreeSnapshot(scope, {
+    activeId: res.active_id ?? null,
+    projects: res.projects ?? []
+  })
   const tombstones = $removedSessionIds.get()
 
   if (tombstones.size) {
@@ -478,7 +531,9 @@ function applyProjectTreePayload(res: ProjectTreePayload): void {
 
 async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<void> {
   const generation = ++projectTreeRefreshGeneration
-  const { gateway, profile } = context
+  const { connectionId, gateway, profile } = context
+
+  hydrateProjectTreeCache({ connectionId, profile })
 
   if (activeGateway() === gateway) {
     $projectTreeLoading.set(true)
@@ -513,7 +568,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
       return
     }
 
-    applyProjectTreePayload(res)
+    applyProjectTreePayload(res, { connectionId, profile })
     markProjectsRpcSuccess()
   } catch (err) {
     if (generation === projectTreeRefreshGeneration && stillOnProjectsContext(context)) {
@@ -530,8 +585,14 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
 // sessions + the scoped-session-id set). Best-effort: a failure leaves the
 // cached tree intact so the sidebar doesn't flicker.
 export async function refreshProjectTree(): Promise<void> {
+  const cacheScope = currentProjectTreeCacheScope()
+
+  if (cacheScope) {
+    hydrateProjectTreeCache(cacheScope)
+  }
+
   if ($profileScope.get() === ALL_PROFILES) {
-    await refreshProjectTreeAcrossProfiles()
+    await refreshProjectTreeAcrossProfiles(cacheScope)
 
     return
   }
@@ -547,7 +608,7 @@ export async function refreshProjectTree(): Promise<void> {
 // backend's own profile, so it can only ever describe a slice of this view;
 // the REST fan-out reads every profile's databases directly instead of asking
 // us to hold a backend open per profile just to draw lanes.
-async function refreshProjectTreeAcrossProfiles(): Promise<void> {
+async function refreshProjectTreeAcrossProfiles(cacheScope: ProjectTreeCacheScope | null): Promise<void> {
   const generation = ++projectTreeRefreshGeneration
   $projectTreeLoading.set(true)
 
@@ -563,7 +624,13 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
       return
     }
 
-    applyProjectTreePayload(res)
+    if (cacheScope) {
+      applyProjectTreePayload(res, cacheScope)
+    } else {
+      $projectTree.set(res.projects ?? [])
+      $activeProjectId.set(res.active_id ?? null)
+    }
+
     markProjectsRpcSuccess()
   } catch (err) {
     markProjectsRpcFailure(err)
@@ -898,6 +965,9 @@ async function persistOrRollback(snap: ProjectsSnapshot, write: () => Promise<vo
 }
 
 const reconcileProjects = (): void => {
+  // A mutation has already painted newer local state. Reconcile from the
+  // backend without first restoring an older persisted snapshot.
+  keepCurrentProjectTreeAheadOfCache()
   void refreshProjects()
   void refreshProjectTree()
 }

--- a/apps/desktop/src/store/session-list-cache.test.ts
+++ b/apps/desktop/src/store/session-list-cache.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  readSessionListSnapshot,
+  SESSION_LIST_CACHE_STORAGE_KEY,
+  sessionListCacheScopeKey,
+  writeSessionListSnapshot
+} from './session-list-cache'
+
+const row = (id: string, profile = 'default'): SessionInfo =>
+  ({
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1000,
+    message_count: 2,
+    model: 'model',
+    output_tokens: 0,
+    preview: 'preview',
+    profile,
+    source: 'desktop',
+    started_at: 900,
+    title: `Chat ${id}`,
+    tool_call_count: 0
+  }) as SessionInfo
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.useRealTimers()
+})
+
+describe('session list cache', () => {
+  it('round-trips a bounded snapshot in the exact connection and profile scope', () => {
+    const scope = { connectionId: 'connection-a', profile: 'profile-a' }
+
+    writeSessionListSnapshot(scope, {
+      cron: [row('cron', 'profile-a')],
+      messaging: [row('message', 'profile-a')],
+      messagingTruncated: true,
+      profilesTruncated: { 'profile-a': true },
+      profilesUsage: { 'profile-a': { cost_usd: 1.5, tokens: 42 } },
+      recents: [row('recent', 'profile-a')]
+    })
+
+    expect(readSessionListSnapshot(scope)).toEqual({
+      cron: [row('cron', 'profile-a')],
+      messaging: [row('message', 'profile-a')],
+      messagingTruncated: true,
+      profilesTruncated: { 'profile-a': true },
+      profilesUsage: { 'profile-a': { cost_usd: 1.5, tokens: 42 } },
+      recents: [row('recent', 'profile-a')]
+    })
+    expect(readSessionListSnapshot({ connectionId: 'connection-a', profile: 'profile-b' })).toBeNull()
+    expect(readSessionListSnapshot({ connectionId: 'connection-b', profile: 'profile-a' })).toBeNull()
+  })
+
+  it('rejects malformed or expired persisted data', () => {
+    window.localStorage.setItem(SESSION_LIST_CACHE_STORAGE_KEY, '{broken')
+    expect(readSessionListSnapshot({ connectionId: 'local', profile: 'default' })).toBeNull()
+
+    const key = sessionListCacheScopeKey({ connectionId: 'local', profile: 'default' })
+    window.localStorage.setItem(
+      SESSION_LIST_CACHE_STORAGE_KEY,
+      JSON.stringify({
+        [key]: {
+          cron: [],
+          messaging: [],
+          messagingTruncated: false,
+          profilesTruncated: {},
+          profilesUsage: {},
+          recents: [row('stale')],
+          savedAt: Date.now() - 15 * 24 * 60 * 60 * 1000
+        }
+      })
+    )
+
+    expect(readSessionListSnapshot({ connectionId: 'local', profile: 'default' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/session-list-cache.ts
+++ b/apps/desktop/src/store/session-list-cache.ts
@@ -1,0 +1,154 @@
+import { readKey, writeKey } from '@/lib/storage'
+import type { SessionInfo } from '@/types/hermes'
+
+const STORAGE_KEY = 'hermes.desktop.sidebarSessionsCache.v1'
+const MAX_CONTEXTS = 8
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+const MAX_RECENTS = 350
+const MAX_CRON = 100
+const MAX_MESSAGING = 250
+
+export interface SessionListCacheScope {
+  connectionId: null | string
+  profile: string
+}
+
+export interface SessionListSnapshot {
+  cron: SessionInfo[]
+  messaging: SessionInfo[]
+  messagingTruncated: boolean
+  profilesTruncated: Record<string, boolean>
+  profilesUsage: Record<string, { cost_usd: number; tokens: number }>
+  recents: SessionInfo[]
+}
+
+interface StoredSessionListSnapshot extends SessionListSnapshot {
+  savedAt: number
+}
+
+type SessionListCache = Record<string, StoredSessionListSnapshot>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+function isSessionInfo(value: unknown): value is SessionInfo {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    value.id.length > 0 &&
+    typeof value.last_active === 'number' &&
+    Number.isFinite(value.last_active) &&
+    (value.profile === undefined || typeof value.profile === 'string') &&
+    (value.connection_id === undefined || typeof value.connection_id === 'string')
+  )
+}
+
+function isBooleanRecord(value: unknown): value is Record<string, boolean> {
+  return isRecord(value) && Object.values(value).every(item => typeof item === 'boolean')
+}
+
+function isUsageRecord(value: unknown): value is Record<string, { cost_usd: number; tokens: number }> {
+  return (
+    isRecord(value) &&
+    Object.values(value).every(
+      item =>
+        isRecord(item) &&
+        typeof item.cost_usd === 'number' &&
+        Number.isFinite(item.cost_usd) &&
+        typeof item.tokens === 'number' &&
+        Number.isFinite(item.tokens)
+    )
+  )
+}
+
+function isStoredSnapshot(value: unknown, now: number): value is StoredSessionListSnapshot {
+  return (
+    isRecord(value) &&
+    typeof value.savedAt === 'number' &&
+    Number.isFinite(value.savedAt) &&
+    now - value.savedAt <= MAX_AGE_MS &&
+    Array.isArray(value.recents) &&
+    value.recents.length <= MAX_RECENTS &&
+    value.recents.every(isSessionInfo) &&
+    Array.isArray(value.cron) &&
+    value.cron.length <= MAX_CRON &&
+    value.cron.every(isSessionInfo) &&
+    Array.isArray(value.messaging) &&
+    value.messaging.length <= MAX_MESSAGING &&
+    value.messaging.every(isSessionInfo) &&
+    typeof value.messagingTruncated === 'boolean' &&
+    isBooleanRecord(value.profilesTruncated) &&
+    isUsageRecord(value.profilesUsage)
+  )
+}
+
+function readCache(): SessionListCache {
+  const raw = readKey(STORAGE_KEY)
+
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+
+    if (!isRecord(parsed)) {
+      return {}
+    }
+
+    const now = Date.now()
+
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, StoredSessionListSnapshot] => isStoredSnapshot(entry[1], now))
+        .sort((left, right) => right[1].savedAt - left[1].savedAt)
+        .slice(0, MAX_CONTEXTS)
+    )
+  } catch {
+    return {}
+  }
+}
+
+export function sessionListCacheScopeKey(scope: SessionListCacheScope): string {
+  return JSON.stringify([scope.connectionId?.trim() || 'local', scope.profile.trim() || 'default'])
+}
+
+export function readSessionListSnapshot(scope: SessionListCacheScope): SessionListSnapshot | null {
+  const cached = readCache()[sessionListCacheScopeKey(scope)]
+
+  if (!cached) {
+    return null
+  }
+
+  const { savedAt: _savedAt, ...snapshot } = cached
+
+  return snapshot
+}
+
+export function writeSessionListSnapshot(scope: SessionListCacheScope, snapshot: SessionListSnapshot): void {
+  const key = sessionListCacheScopeKey(scope)
+  const cache = readCache()
+
+  cache[key] = {
+    cron: snapshot.cron.slice(0, MAX_CRON),
+    messaging: snapshot.messaging.slice(0, MAX_MESSAGING),
+    messagingTruncated: snapshot.messagingTruncated,
+    profilesTruncated: snapshot.profilesTruncated,
+    profilesUsage: snapshot.profilesUsage,
+    recents: snapshot.recents.slice(0, MAX_RECENTS),
+    savedAt: Date.now()
+  }
+
+  writeKey(
+    STORAGE_KEY,
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(cache)
+          .sort((left, right) => right[1].savedAt - left[1].savedAt)
+          .slice(0, MAX_CONTEXTS)
+      )
+    )
+  )
+}
+
+export const SESSION_LIST_CACHE_STORAGE_KEY = STORAGE_KEY


### PR DESCRIPTION
## What does this PR do?

Desktop currently begins with empty session and project sidebars, then waits for the authoritative backend reads before showing useful navigation. This adds bounded stale-while-revalidate snapshots for those two shell surfaces so a matching connection/profile can paint immediately while the normal live refresh continues in the background.

The backend remains authoritative. Cached data is scoped to the exact connection and profile, malformed or expired entries are ignored, old async responses are fenced out, and a successful live response replaces and refreshes the snapshot.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns the cached shell layer: session and project navigation paint immediately while authoritative refresh continues.


## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add bounded, validated session-list snapshots scoped by connection and profile.
- Paint cached recent, cron, and messaging rows during layout, then reconcile from `session.list_sidebar`.
- Fence session-list callbacks and responses by connection as well as profile and activation generation.
- Add bounded, validated project-tree snapshots with the same connection/profile ownership.
- Preserve optimistic project mutations while the authoritative `projects.tree` refresh runs.
- Add behavioral coverage for fast paint, cross-scope isolation, malformed/expired data, and live replacement.

## How to Test

1. Run `vitest run --maxWorkers=4 src/store/session-list-cache.test.ts src/app/session/hooks/use-session-list-actions.test.tsx src/store/project-tree-cache.test.ts src/store/projects.test.ts` from `apps/desktop`.
2. Run `tsc -p . --noEmit` from `apps/desktop`.
3. Launch Desktop once to populate the snapshots, relaunch it, and confirm matching session/project navigation paints before the live gateway refresh completes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

The Python suite was not run because this is a renderer-only change. The four affected Vitest files pass with 74 tests, and renderer typecheck plus affected-file ESLint pass.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this changes when existing sidebar content becomes visible, not its visual design.