### PR TITLE
perf(desktop): keep cached transcript visible while session resumes

### DIFF
--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -17,7 +17,8 @@ import {
   $gatewayState,
   $messages,
   $selectedStoredSessionId,
-  $sessions
+  $sessions,
+  $startupNavigationPending
 } from '@/store/session'
 
 const threadRenderCount = vi.hoisted(() => ({ current: 0 }))
@@ -48,7 +49,14 @@ vi.mock('@/lib/model-options', () => ({
 }))
 vi.mock('./chat-drop-overlay', () => ({ ChatDropOverlay: () => null }))
 vi.mock('./chat-swap-overlay', () => ({ ChatSwapOverlay: () => null, ChatSyncBadge: () => null }))
-vi.mock('./composer', () => ({ ChatBar: () => null, ChatBarFallback: () => null }))
+vi.mock('./composer', async () => {
+  const React = await import('react')
+
+  return {
+    ChatBar: () => React.createElement('div', { 'data-testid': 'chat-bar' }),
+    ChatBarFallback: () => null
+  }
+})
 vi.mock('./hooks/use-file-drop-zone', () => ({
   useFileDropZone: () => ({ dragKind: null, dropHandlers: {} })
 }))
@@ -86,6 +94,7 @@ describe('ChatView render isolation', () => {
     $messages.set([assistantMessage('assistant-1', 'Stable historical answer')])
     $selectedStoredSessionId.set('stored-1')
     $sessions.set([{ id: 'stored-1', message_count: 1, title: 'Stable chat' } as never])
+    $startupNavigationPending.set(false)
   })
 
   afterEach(() => {
@@ -103,6 +112,7 @@ describe('ChatView render isolation', () => {
     $messages.set([])
     $selectedStoredSessionId.set(null)
     $sessions.set([])
+    $startupNavigationPending.set(false)
   })
 
   it('does not re-render chat history when an unrelated parent idle tick updates', () => {
@@ -160,5 +170,48 @@ describe('ChatView render isolation', () => {
     // memo(ChatView) with stable props must absorb the parent's idle tick —
     // the transcript (Thread) must not re-render. This is PR #38470's contract.
     expect(threadRenderCount.current).toBe(1)
+  })
+
+  it('does not expose a fresh composer while remembered startup navigation is unresolved', () => {
+    $activeSessionId.set(null)
+    $freshDraftReady.set(true)
+    $messages.set([])
+    $selectedStoredSessionId.set(null)
+    $startupNavigationPending.set(true)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/']}>
+          <ChatView
+            gateway={null}
+            maxVoiceRecordingSeconds={120}
+            onAddContextRef={vi.fn()}
+            onAddUrl={vi.fn()}
+            onAttachDroppedItems={vi.fn()}
+            onAttachImageBlob={vi.fn()}
+            onCancel={vi.fn()}
+            onDeleteSelectedSession={vi.fn()}
+            onEdit={vi.fn()}
+            onPasteClipboardImage={vi.fn()}
+            onPickFiles={vi.fn()}
+            onPickFolders={vi.fn()}
+            onPickImages={vi.fn()}
+            onReload={vi.fn()}
+            onRemoveAttachment={vi.fn()}
+            onRetryResume={vi.fn()}
+            onSteer={vi.fn()}
+            onSubmit={vi.fn()}
+            onThreadMessagesChange={vi.fn()}
+            onToggleSelectedPin={vi.fn()}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    expect(screen.queryByTestId('chat-bar')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -502,12 +502,11 @@ const ChatViewContent = memo(function ChatViewContent({
     selectedSessionId
   })
 
-  // Session is still loading if the route references a session we haven't
-  // resumed yet. Brand-new routed drafts are empty on purpose once a runtime
-  // is bound. A session the list already knows has history must keep the
-  // loader up until a display-authoritative transcript arrives — including
-  // the unproven warm-cache hold, where the runtime is bound but messages
-  // are still suppressed.
+  // A persisted transcript may paint before its runtime is rebound, but the
+  // composer stays gated until activeSessionId exists. Brand-new routed
+  // drafts are empty on purpose once a runtime is bound. A session the list
+  // already knows has history must keep the loader up until a
+  // display-authoritative transcript arrives.
   //
   // resumeExhausted: the bounded auto-retry in use-route-resume gave up on this
   // routed session (gateway RPC + REST fallback failed through every attempt).
@@ -530,7 +529,7 @@ const ChatViewContent = memo(function ChatViewContent({
     routedSessionView: isRoutedSessionView
   })
 
-  const threadLoading = threadLoadingState(loadingSession, busy, awaitingResponse, lastVisibleIsUser)
+  const threadLoading = threadLoadingState(loadingSession, !messagesEmpty, busy, awaitingResponse, lastVisibleIsUser)
   // Hide the composer in the exhausted error state too: there's no live runtime
   // to send to until a retry rebinds one. Watch windows are pure spectators of a
   // subagent run driven elsewhere — no composer, transcript is read-only.

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -42,6 +42,7 @@ import {
   $introSeed,
   $resumeExhaustedSessionId,
   $sessions,
+  $startupNavigationPending,
   getSessionOwnerHint,
   resolveComposerSessionKey,
   sessionMatchesStoredId,
@@ -278,9 +279,14 @@ function ChatRuntimeBoundary({
     ? getSessionOwnerHint(storedId, connectionId ? { connectionId, profile: activeProfile } : undefined)
     : undefined
 
-  const tailProfile = ownerRoute
-    ? { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile || ownerRoute.profile }
-    : undefined
+  const tailConnectionId = ownerRoute?.connectionId
+  const tailOwnerProfile = ownerRoute?.targetProfile || ownerRoute?.profile
+
+  const tailProfile = useMemo(
+    () =>
+      tailConnectionId && tailOwnerProfile ? { connectionId: tailConnectionId, profile: tailOwnerProfile } : undefined,
+    [tailConnectionId, tailOwnerProfile]
+  )
 
   const tailState = storedId && transcriptTailStates ? transcriptTailState(storedId, tailProfile) : undefined
   const restBackfillAvailable = Boolean(tailState?.possiblyTruncated)
@@ -436,6 +442,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const selectedSessionId = useStore(view.$storedId)
   const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
+  const startupNavigationPending = useStore($startupNavigationPending)
 
   // Durable composer/queue scope (lineage root) so auto-compression tip rotation
   // does not wipe an in-progress draft or orphan /queue entries. For the
@@ -526,7 +533,8 @@ const ChatViewContent = memo(function ChatViewContent({
     messagesEmpty,
     resumeExhausted,
     routeSessionMismatch,
-    routedSessionView: isRoutedSessionView
+    routedSessionView: isRoutedSessionView,
+    startupNavigationPending: isPrimary && startupNavigationPending
   })
 
   const threadLoading = threadLoadingState(loadingSession, !messagesEmpty, busy, awaitingResponse, lastVisibleIsUser)
@@ -657,7 +665,7 @@ const ChatViewContent = memo(function ChatViewContent({
             clampToComposer={showChatBar}
             cwd={currentCwd}
             gateway={gateway}
-            intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
+            intro={!loadingSession && showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
             loading={threadLoading}
             onBranchInNewChat={onBranchInNewChat}
             onCancel={haltRun}

--- a/apps/desktop/src/app/chat/thread-loading.test.ts
+++ b/apps/desktop/src/app/chat/thread-loading.test.ts
@@ -15,21 +15,25 @@ function message(id: string, role: ChatMessage['role'], hidden = false): ChatMes
 
 describe('thread loading state', () => {
   it('returns session when routed session is still hydrating', () => {
-    expect(threadLoadingState(true, true, true, false)).toBe('session')
+    expect(threadLoadingState(true, false, true, true, false)).toBe('session')
+  })
+
+  it('keeps a cached transcript visible while its runtime binds', () => {
+    expect(threadLoadingState(true, true, false, false, false)).toBeUndefined()
   })
 
   it('returns response while awaiting an assistant reply to the last visible user message', () => {
     const messages = [message('u1', 'user'), message('a1', 'assistant', true)]
 
     expect(lastVisibleMessageIsUser(messages)).toBe(true)
-    expect(threadLoadingState(false, true, true, lastVisibleMessageIsUser(messages))).toBe('response')
+    expect(threadLoadingState(false, true, true, true, lastVisibleMessageIsUser(messages))).toBe('response')
   })
 
   it('does not show response loading when the last visible message is not user-authored', () => {
     const messages = [message('u1', 'user'), message('a1', 'assistant')]
 
     expect(lastVisibleMessageIsUser(messages)).toBe(false)
-    expect(threadLoadingState(false, true, true, lastVisibleMessageIsUser(messages))).toBeUndefined()
+    expect(threadLoadingState(false, true, true, true, lastVisibleMessageIsUser(messages))).toBeUndefined()
   })
 })
 
@@ -42,6 +46,25 @@ describe('routedSessionIsLoading', () => {
     routeSessionMismatch: false,
     routedSessionView: true
   }
+
+  it('keeps the composer gated until a routed session has a bound runtime', () => {
+    expect(
+      routedSessionIsLoading({
+        ...base,
+        activeSessionId: null
+      })
+    ).toBe(true)
+  })
+
+  it('ends pending state when bounded recovery is exhausted', () => {
+    expect(
+      routedSessionIsLoading({
+        ...base,
+        activeSessionId: null,
+        resumeExhausted: true
+      })
+    ).toBe(false)
+  })
 
   it('keeps the session loader up when known history is held off the view', () => {
     expect(

--- a/apps/desktop/src/app/chat/thread-loading.test.ts
+++ b/apps/desktop/src/app/chat/thread-loading.test.ts
@@ -47,6 +47,16 @@ describe('routedSessionIsLoading', () => {
     routedSessionView: true
   }
 
+  it('claims the fresh route while remembered startup navigation is unresolved', () => {
+    expect(
+      routedSessionIsLoading({
+        ...base,
+        routedSessionView: false,
+        startupNavigationPending: true
+      })
+    ).toBe(true)
+  })
+
   it('keeps the composer gated until a routed session has a bound runtime', () => {
     expect(
       routedSessionIsLoading({

--- a/apps/desktop/src/app/chat/thread-loading.ts
+++ b/apps/desktop/src/app/chat/thread-loading.ts
@@ -15,11 +15,12 @@ export function lastVisibleMessageIsUser(messages: ChatMessage[]): boolean {
 
 export function threadLoadingState(
   loadingSession: boolean,
+  hasVisibleMessages: boolean,
   busy: boolean,
   awaitingResponse: boolean,
   lastVisibleIsUser: boolean
 ): ThreadLoadingState | undefined {
-  if (loadingSession) {
+  if (loadingSession && !hasVisibleMessages) {
     return 'session'
   }
 
@@ -49,7 +50,7 @@ export function routedSessionIsLoading({
     return false
   }
 
-  if (routeSessionMismatch) {
+  if (routeSessionMismatch || !activeSessionId) {
     return true
   }
 
@@ -61,5 +62,5 @@ export function routedSessionIsLoading({
   // knows has history must keep the loader up until a display-authoritative
   // transcript arrives — including the unproven warm-cache hold, where the
   // runtime is bound but messages are still suppressed.
-  return !activeSessionId || knownHistory
+  return knownHistory
 }

--- a/apps/desktop/src/app/chat/thread-loading.ts
+++ b/apps/desktop/src/app/chat/thread-loading.ts
@@ -37,7 +37,8 @@ export function routedSessionIsLoading({
   messagesEmpty,
   resumeExhausted,
   routeSessionMismatch,
-  routedSessionView
+  routedSessionView,
+  startupNavigationPending = false
 }: {
   activeSessionId: string | null
   knownHistory: boolean
@@ -45,8 +46,17 @@ export function routedSessionIsLoading({
   resumeExhausted: boolean
   routeSessionMismatch: boolean
   routedSessionView: boolean
+  startupNavigationPending?: boolean
 }): boolean {
-  if (resumeExhausted || !routedSessionView) {
+  if (resumeExhausted) {
+    return false
+  }
+
+  if (startupNavigationPending) {
+    return true
+  }
+
+  if (!routedSessionView) {
     return false
   }
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -2,7 +2,14 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
-import { _resetLegacyDiscardForTests } from '@/store/session'
+import {
+  $activeSessionId,
+  $messages,
+  $selectedStoredSessionId,
+  $startupNavigationPending,
+  _resetLegacyDiscardForTests
+} from '@/store/session'
+import { saveTranscriptTail } from '@/store/transcript-tail-cache'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -46,6 +53,10 @@ describe('useDesktopIntegrations', () => {
   beforeEach(() => {
     window.localStorage.clear()
     _resetLegacyDiscardForTests()
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $messages.set([])
+    $startupNavigationPending.set(false)
     vi.mocked(requestMcpInstallFromDeepLink).mockClear()
     navigate = vi.fn()
     // Every test starts as a main window; only the HUD describe flips this.
@@ -73,9 +84,14 @@ describe('useDesktopIntegrations', () => {
     }
 
     vi.restoreAllMocks()
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $messages.set([])
+    $startupNavigationPending.set(false)
   })
 
   function render({
+    activeSessionId = null as string | null,
     activeProfile = 'default',
     locationPathname = '/',
     profileReady = false,
@@ -85,6 +101,7 @@ describe('useDesktopIntegrations', () => {
   } = {}) {
     return renderHook(
       ({
+        activeSessionId,
         activeProfile,
         locationPathname,
         profileReady,
@@ -92,6 +109,7 @@ describe('useDesktopIntegrations', () => {
         routedSessionId,
         sessions
       }: {
+        activeSessionId?: string | null
         activeProfile: string
         locationPathname: string
         profileReady: boolean
@@ -100,6 +118,7 @@ describe('useDesktopIntegrations', () => {
         sessions: readonly SessionInfo[]
       }) =>
         useDesktopIntegrations({
+          activeSessionId: activeSessionId ?? null,
           activeProfile,
           chatOpen: false,
           hasPreview: false,
@@ -114,6 +133,7 @@ describe('useDesktopIntegrations', () => {
         }),
       {
         initialProps: {
+          activeSessionId,
           activeProfile,
           locationPathname,
           profileReady,
@@ -135,6 +155,105 @@ describe('useDesktopIntegrations', () => {
 
       // no navigation should have occurred
       expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('paints the exact connection-scoped transcript before profile readiness', () => {
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+      saveTranscriptTail(
+        'remembered-session',
+        [{ id: 'cached-message', role: 'assistant', parts: [{ type: 'text', text: 'cached hello' }] }],
+        { connectionId: 'local', profile: 'default' }
+      )
+
+      render({ profileReady: false })
+
+      expect(navigate).not.toHaveBeenCalled()
+      expect($selectedStoredSessionId.get()).toBe('remembered-session')
+      expect($messages.get()).toMatchObject([{ id: 'cached-message', role: 'assistant' }])
+      expect($activeSessionId.get()).toBeNull()
+      expect($startupNavigationPending.get()).toBe(true)
+    })
+
+    it('uses the last-opened session when its persisted chat route is torn', () => {
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/older-session')
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'newer-session')
+      saveTranscriptTail(
+        'older-session',
+        [{ id: 'wrong-chat', role: 'assistant', parts: [{ type: 'text', text: 'wrong chat' }] }],
+        { connectionId: 'local', profile: 'default' }
+      )
+      saveTranscriptTail(
+        'newer-session',
+        [{ id: 'right-chat', role: 'assistant', parts: [{ type: 'text', text: 'right chat' }] }],
+        { connectionId: 'local', profile: 'default' }
+      )
+
+      const result = render({ profileReady: false })
+
+      expect($selectedStoredSessionId.get()).toBe('newer-session')
+      expect($messages.get()).toMatchObject([{ id: 'right-chat' }])
+
+      result.rerender({
+        activeSessionId: null,
+        activeProfile: 'default',
+        locationPathname: '/',
+        profileReady: true,
+        resumeExhaustedSessionId: null,
+        routedSessionId: null,
+        sessions: [
+          session({ id: 'older-session', profile: 'default' }),
+          session({ id: 'newer-session', profile: 'default' })
+        ]
+      })
+
+      expect(navigate).toHaveBeenCalledWith('/newer-session', { replace: true })
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBe('/newer-session')
+    })
+
+    it('keeps startup navigation pending until the remembered runtime binds', () => {
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+      saveTranscriptTail(
+        'remembered-session',
+        [{ id: 'cached-message', role: 'assistant', parts: [{ type: 'text', text: 'cached hello' }] }],
+        { connectionId: 'local', profile: 'default' }
+      )
+
+      const result = render({ profileReady: false })
+
+      result.rerender({
+        activeSessionId: null,
+        activeProfile: 'default',
+        locationPathname: '/',
+        profileReady: true,
+        resumeExhaustedSessionId: null,
+        routedSessionId: null,
+        sessions: [session({ id: 'remembered-session', profile: 'default' })]
+      })
+      expect($startupNavigationPending.get()).toBe(true)
+
+      result.rerender({
+        activeSessionId: null,
+        activeProfile: 'default',
+        locationPathname: '/remembered-session',
+        profileReady: true,
+        resumeExhaustedSessionId: null,
+        routedSessionId: 'remembered-session',
+        sessions: [session({ id: 'remembered-session', profile: 'default' })]
+      })
+      expect($startupNavigationPending.get()).toBe(true)
+
+      result.rerender({
+        activeSessionId: 'runtime-session',
+        activeProfile: 'default',
+        locationPathname: '/remembered-session',
+        profileReady: true,
+        resumeExhaustedSessionId: null,
+        routedSessionId: 'remembered-session',
+        sessions: [session({ id: 'remembered-session', profile: 'default' })]
+      })
+
+      expect($startupNavigationPending.get()).toBe(false)
+      expect($messages.get()).toMatchObject([{ id: 'cached-message' }])
     })
 
     it('restores on profileReady when remembered route exists and owns the session', () => {
@@ -167,6 +286,7 @@ describe('useDesktopIntegrations', () => {
       expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBe('/remembered-session')
 
       result.rerender({
+        activeSessionId: null,
         activeProfile: 'default',
         locationPathname: '/',
         profileReady: true,
@@ -325,6 +445,7 @@ describe('useDesktopIntegrations', () => {
 
       // Now switch to ops.
       rerender({
+        activeSessionId: null,
         activeProfile: 'ops',
         locationPathname: '/ops-session',
         profileReady: true,
@@ -391,6 +512,7 @@ describe('useDesktopIntegrations', () => {
 
       // Remembering effect fires on route change.
       rerender({
+        activeSessionId: null,
         activeProfile: 'default',
         locationPathname: '/settings',
         profileReady: true,

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
@@ -17,13 +17,20 @@ import {
 import { openPluginInstallRequest } from '@/store/plugin-install-request'
 import { openFolderAsProject } from '@/store/projects'
 import {
+  $activeSessionId,
+  $connection,
+  $selectedStoredSessionId,
   getRememberedRoute,
   getRememberedSessionId,
+  getSessionOwnerHint,
   sessionBelongsToProfile,
+  setMessages,
   setRememberedRoute,
-  setRememberedSessionId
+  setRememberedSessionId,
+  setStartupNavigationPending
 } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
+import { loadTranscriptTail } from '@/store/transcript-tail-cache'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
 import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
@@ -33,7 +40,34 @@ import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionR
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
+interface RememberedStartupTarget {
+  conflict: boolean
+  lastSessionId: null | string
+  route: null | string
+  routeSessionId: null | string
+  sessionId: null | string
+}
+
+function rememberedStartupTarget(profile: string): RememberedStartupTarget {
+  const route = getRememberedRoute(profile)
+  const routeSessionIdValue = route ? routeSessionId(route) : null
+  const lastSessionId = getRememberedSessionId(profile)
+  const conflict = Boolean(routeSessionIdValue && lastSessionId && routeSessionIdValue !== lastSessionId)
+
+  return {
+    conflict,
+    lastSessionId,
+    route,
+    routeSessionId: routeSessionIdValue,
+    // A chat-shaped route is redundant navigation state. The explicit
+    // last-opened session is the chat authority; a non-chat route remains the
+    // route authority. This also heals a shutdown between the two writes.
+    sessionId: lastSessionId || routeSessionIdValue
+  }
+}
+
 interface DesktopIntegrationsParams {
+  activeSessionId: null | string
   activeProfile: string
   chatOpen: boolean
   hasPreview: boolean
@@ -55,6 +89,7 @@ interface DesktopIntegrationsParams {
  * "talks to the desktop shell" surface reads as one unit.
  */
 export function useDesktopIntegrations({
+  activeSessionId,
   activeProfile,
   locationPathname,
   navigate,
@@ -90,6 +125,86 @@ export function useDesktopIntegrations({
   }, [])
 
   const restoredRef = useRef(false)
+  const pendingSessionRef = useRef<string | null>(null)
+  const prepaintedSessionRef = useRef<string | null>(null)
+
+  const clearProvisionalSessionPaint = useCallback(() => {
+    const id = prepaintedSessionRef.current
+
+    if (!id) {
+      return
+    }
+
+    prepaintedSessionRef.current = null
+
+    // Clear only provisional state owned by this hook. A user-driven open or
+    // a runtime that bound while boot was settling wins and stays visible.
+    if ($selectedStoredSessionId.get() === id && !$activeSessionId.get()) {
+      $selectedStoredSessionId.set(null)
+      setMessages([])
+    }
+  }, [])
+
+  // Claim remembered startup navigation before paint, not after the profile's
+  // async session refresh. Otherwise `/` exposes a real fresh composer for the
+  // whole refresh window and the remembered session can replace text the user
+  // already started entering. This is a presentation claim only: ownership is
+  // still checked against the live session list below.
+  useLayoutEffect(() => {
+    if (isHudWindow() || isBrowserWindow()) {
+      setStartupNavigationPending(false)
+
+      return
+    }
+
+    if (restoredRef.current) {
+      return
+    }
+
+    if (locationPathname !== NEW_CHAT_ROUTE) {
+      setStartupNavigationPending(false)
+
+      return
+    }
+
+    const remembered = rememberedStartupTarget(activeProfile)
+
+    const restorableNonSessionRoute =
+      !!remembered.route &&
+      remembered.route !== NEW_CHAT_ROUTE &&
+      !remembered.routeSessionId &&
+      !isOverlayView(appViewForPath(remembered.route))
+
+    pendingSessionRef.current = remembered.sessionId
+    setStartupNavigationPending(Boolean(remembered.sessionId || restorableNonSessionRoute))
+
+    if (!remembered.sessionId) {
+      return
+    }
+
+    const profile = activeProfile.trim() || 'default'
+    const owner = getSessionOwnerHint(remembered.sessionId)
+    const connection = $connection.get()
+
+    const connectionId =
+      owner?.connectionId || connection?.connectionId || (connection?.mode === 'remote' ? '' : 'local')
+
+    const ownerProfile = owner?.targetProfile || owner?.profile || profile
+
+    // Remembered navigation is already connection-scoped. Still fail closed
+    // when a legacy/unregistered remote cannot name its connection: guessing
+    // local would let one gateway's cached transcript paint under another.
+    const cached =
+      connectionId && ownerProfile === profile
+        ? loadTranscriptTail(remembered.sessionId, { connectionId, profile })
+        : null
+
+    if (cached) {
+      prepaintedSessionRef.current = remembered.sessionId
+      $selectedStoredSessionId.set(remembered.sessionId)
+      setMessages(cached)
+    }
+  }, [activeProfile, locationPathname])
 
   // Wait until boot has adopted the primary profile, then restore that profile's
   // navigation exactly once. The same effect owns subsequent writes so the
@@ -101,13 +216,30 @@ export function useDesktopIntegrations({
       return
     }
 
+    // The remembered target remains presentation-only until the exact route
+    // has a live runtime. That keeps the cached transcript visible but the
+    // composer unavailable throughout ownership validation and runtime binding.
+    const pendingSession = pendingSessionRef.current
+
+    if (
+      pendingSession &&
+      activeSessionId &&
+      routeSessionId(locationPathname) === pendingSession &&
+      $selectedStoredSessionId.get() === pendingSession
+    ) {
+      pendingSessionRef.current = null
+      prepaintedSessionRef.current = null
+      setStartupNavigationPending(false)
+    }
+
     if (!restoredRef.current) {
       // Only cold-start navigation at the default route is replaceable; a deep
       // link or hidden-then-shown window keeps its explicit destination.
       if (locationPathname === NEW_CHAT_ROUTE) {
-        const route = getRememberedRoute(activeProfile)
-        const routeSession = route ? routeSessionId(route) : null
-        const last = getRememberedSessionId(activeProfile)
+        const remembered = rememberedStartupTarget(activeProfile)
+        const { route } = remembered
+        const routeSession = remembered.routeSessionId
+        const last = remembered.lastSessionId
 
         const restorableNonSessionRoute =
           !!route && route !== NEW_CHAT_ROUTE && !routeSession && !isOverlayView(appViewForPath(route))
@@ -124,11 +256,22 @@ export function useDesktopIntegrations({
 
         if (
           route &&
+          !remembered.conflict &&
           route !== NEW_CHAT_ROUTE &&
           !isOverlayView(appViewForPath(route)) &&
           (!routeSession || sessionBelongsToProfile(sessions, routeSession, activeProfile))
         ) {
           navigate(route, { replace: true })
+
+          return
+        }
+
+        if (last && sessionBelongsToProfile(sessions, last, activeProfile)) {
+          if (remembered.conflict) {
+            setRememberedRoute(sessionRoute(last), activeProfile)
+          }
+
+          navigate(sessionRoute(last), { replace: true })
 
           return
         }
@@ -139,16 +282,22 @@ export function useDesktopIntegrations({
           setRememberedRoute(null, activeProfile)
         }
 
-        if (last && sessionBelongsToProfile(sessions, last, activeProfile)) {
-          navigate(sessionRoute(last), { replace: true })
-
-          return
-        }
-
         if (last) {
           setRememberedSessionId(null, activeProfile)
         }
+
+        pendingSessionRef.current = null
+        clearProvisionalSessionPaint()
+        setStartupNavigationPending(false)
       } else {
+        const pendingSession = pendingSessionRef.current
+
+        if (!pendingSession || routeSessionId(locationPathname) !== pendingSession) {
+          pendingSessionRef.current = null
+          clearProvisionalSessionPaint()
+          setStartupNavigationPending(false)
+        }
+
         restoredRef.current = true
       }
     }
@@ -163,7 +312,16 @@ export function useDesktopIntegrations({
     } else if (!routedSessionId && !isOverlayView(appViewForPath(locationPathname))) {
       setRememberedRoute(locationPathname, activeProfile)
     }
-  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, sessions])
+  }, [
+    activeProfile,
+    activeSessionId,
+    clearProvisionalSessionPaint,
+    locationPathname,
+    navigate,
+    profileReady,
+    routedSessionId,
+    sessions
+  ])
 
   useEffect(() => {
     if (!profileReady || !resumeExhaustedSessionId) {

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,6 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  $startupNavigationPending,
   requestSessionResume,
   sessionMatchesStoredId,
   sessionPinId,
@@ -223,6 +224,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
   const sessionResumeRequest = useStore($sessionResumeRequest)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const startupNavigationPending = useStore($startupNavigationPending)
   const messagingSessions = useStore($messagingSessions)
   const sessions = useStore($sessions)
   const activeConnectionId = useStore($activeConnectionId)
@@ -730,7 +732,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
-    startFreshSessionDraft
+    startFreshSessionDraft,
+    startupNavigationPending
   })
 
   // Plugins hear the stream FIRST (isolated fan-out in contrib/events), then
@@ -839,6 +842,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const previewTarget = useStore($previewTarget)
 
   useDesktopIntegrations({
+    activeSessionId,
     activeProfile: normalizeProfileKey(activeGatewayProfile),
     chatOpen,
     hasPreview: Boolean(previewTarget),

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -30,6 +30,7 @@ interface HarnessProps {
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   startFreshSessionDraft: (focus: boolean) => unknown
+  startupNavigationPending?: boolean
 }
 
 function RouteResumeHarness({
@@ -98,6 +99,33 @@ describe('useRouteResume', () => {
       />
     )
 
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
+
+  it('does not erase a preboot snapshot while remembered navigation is pending', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={{ current: null }}
+        creatingSessionRef={{ current: false }}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={{ current: new Map() }}
+        selectedStoredSessionId="remembered-session"
+        selectedStoredSessionIdRef={{ current: 'remembered-session' }}
+        startFreshSessionDraft={startFreshSessionDraft}
+        startupNavigationPending
+      />
+    )
+
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
     expect(resumeSession).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -31,6 +31,7 @@ interface RouteResumeOptions {
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: (focus: boolean) => unknown
+  startupNavigationPending?: boolean
 }
 
 // Bounded auto-retry for a stranded session window. A resume can fail terminally
@@ -84,7 +85,8 @@ export function useRouteResume({
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
-  startFreshSessionDraft
+  startFreshSessionDraft,
+  startupNavigationPending = false
 }: RouteResumeOptions) {
   const lastPathnameRef = useRef<string | null>(null)
   const seenGatewayStateRef = useRef(false)
@@ -195,6 +197,7 @@ export function useRouteResume({
 
     if (
       isNewChatRoute(locationPathname) &&
+      !startupNavigationPending &&
       !creatingSessionRef.current &&
       (selectedStoredSessionId || activeSessionId || !freshDraftReady) &&
       !rawHashLooksLikeSession()
@@ -217,7 +220,8 @@ export function useRouteResume({
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
-    startFreshSessionDraft
+    startFreshSessionDraft,
+    startupNavigationPending
   ])
 
   // Bounded auto-retry: when the routed session's resume failed terminally

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -721,6 +721,11 @@ export const $messagesEmpty = computed($messages, messages => messages.length ==
 export const $lastVisibleMessageIsUser = computed($messages, lastVisibleMessageIsUser)
 
 export const $freshDraftReady = atom(false)
+// Cold-start navigation restore is decided after the profile and its session
+// rows arrive. Claim the foreground before that async validation so the `/`
+// route cannot briefly expose a usable fresh composer that a remembered
+// session then replaces.
+export const $startupNavigationPending = atom(false)
 export const $busy = atom(false)
 export const $awaitingResponse = atom(false)
 // Stored-session id whose most recent resume FAILED terminally (the gateway RPC
@@ -1071,6 +1076,7 @@ export const markSessionRead = (storedSessionId: string | null | undefined) => {
 
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
+export const setStartupNavigationPending = (next: Updater<boolean>) => updateAtom($startupNavigationPending, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 
 export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwnerRoute) => {


### PR DESCRIPTION
## What does this PR do?

Desktop can already have the exact remembered session's bounded transcript snapshot before backend/profile hydration and `session.resume` finish binding a live runtime. Without an early navigation claim, the cold `/` route can expose a usable fresh composer during that window and later replace what the user was doing when remembered navigation resolves.

This claims remembered navigation before first paint, restores only the exact connection/profile-scoped transcript snapshot, and keeps that presentation provisional until the live session list validates ownership. Cached text may remain visible while the runtime binds, but the composer and fresh-session intro remain unavailable until the remembered route owns a live runtime.

Current `main` also keeps the loader visible when the session list says a routed session has history but no display-authoritative transcript has arrived. The rebased implementation preserves that behavior: a brand-new routed draft with a bound runtime may be empty, while known history, route mismatch, missing runtime binding, or unresolved remembered navigation remains pending. The transcript loader is suppressed only when cached text is already visible; the composer gate remains active.

The explicit last-opened session is authoritative when a torn shutdown left the remembered route and session ID disagreeing. The route is healed only after live validation. Cached text never creates or impersonates a runtime, and stale, missing, cross-profile, or unnameable remote targets fail closed and clear only the provisional paint.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

This PR owns remembered-session presentation and pending-runtime gating. It does not change backend startup, session-list caching, transcript snapshot bounds, or Bot Mode roster behavior.

## Related Issue

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Claim remembered startup navigation during layout so `/` cannot expose a competing fresh composer before session hydration.
- Restore a bounded transcript tail only for the exact remembered connection/profile/session scope.
- Keep cached transcript presentation visible while live ownership validation and `session.resume` bind the runtime.
- Keep the composer and fresh-session intro unavailable throughout that pending state.
- Preserve current main's distinction between a legitimately empty new draft and a known-history session whose transcript has not arrived.
- Treat the explicit last-opened session as the chat authority when route/session persistence was torn, then heal the route after live validation.
- Fail closed for stale, cross-profile, or unnameable legacy remote ownership and clear only provisional state owned by startup restore.
- Add behavioral coverage for pre-profile paint, torn persistence, ownership rejection, runtime binding, fresh-route gating, cached-transcript loading, known-history loading, and exhausted recovery.

## How to Test

1. From `apps/desktop`, run `npx vitest run --project ui --maxWorkers=4 src/app/contrib/hooks/use-desktop-integrations.test.tsx src/app/session/hooks/use-route-resume.test.tsx src/app/chat/index.test.tsx src/app/chat/thread-loading.test.ts`.
2. Run `npm run typecheck`.
3. Run ESLint over the ten changed renderer and store files.

Expected result: the exact scoped cached transcript can paint before live hydration; cached text stays visible while runtime binding is pending; the composer remains gated; known-history sessions do not flash blank; new empty drafts remain usable after runtime binding; and invalid ownership fails closed.

Focused result: 4 Vitest files passed with 56 tests. Desktop renderer, Electron, and E2E typechecks passed. Affected-file ESLint and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

The Python suite was not run because this is a renderer-only change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. This changes loading behavior without changing the visual design.
