### PR TITLE
fix(cron): guard 3 remaining schedule=None crash sites in run-claim helpers

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2530,7 +2530,7 @@ def rearm_oneshot(job_id: str, run_at: Any) -> Optional[Dict[str, Any]]:
                 raise ValueError("Cannot re-arm one-shot over a live run claim.")
             if _claim_is_live(job.get("fire_claim"), now, 300):
                 raise ValueError("Cannot re-arm one-shot over a live fire claim.")
-            if job.get("schedule", {}).get("kind") != "once":
+            if (job.get("schedule") or {}).get("kind") != "once":
                 raise ValueError(
                     "Cannot re-arm recurring jobs: re-arm is one-shot-only; "
                     "use plain resume or cron run."
@@ -3027,7 +3027,7 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
         for job in jobs:
             if job.get("id") != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
+            if (job.get("schedule") or {}).get("kind") != "once":
                 return False
             claim = job.get("run_claim")
             if not isinstance(claim, dict) or claim.get("by") != expected_owner:
@@ -3056,7 +3056,7 @@ def clear_run_claim(job_id: str) -> bool:
         for job in jobs:
             if job.get("id") != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
+            if (job.get("schedule") or {}).get("kind") != "once":
                 return False
             if job.get("run_claim") is not None:
                 job["run_claim"] = None

--- a/tests/cron/test_oneshot_dispatch_failure_run_claim.py
+++ b/tests/cron/test_oneshot_dispatch_failure_run_claim.py
@@ -23,7 +23,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import cron.jobs as jobs_mod
-from cron.jobs import clear_run_claim
+from cron.jobs import clear_run_claim, heartbeat_run_claim
 
 
 @pytest.fixture
@@ -73,6 +73,45 @@ class TestClearRunClaim:
 
     def test_unknown_job_id_returns_false(self, cron_store):
         assert clear_run_claim("no-such-job") is False
+
+    def test_none_schedule_does_not_crash(self, cron_store):
+        """schedule=None (disk corruption / old-writer record) must degrade to
+        a plain False, not raise AttributeError out of a dispatch-failure path
+        that is itself supposed to be the safety net."""
+        job = _make_oneshot(claimed=True)
+        jobs = jobs_mod.load_jobs()
+        for j in jobs:
+            if j["id"] == job["id"]:
+                j["schedule"] = None
+        jobs_mod.save_jobs(jobs)
+        assert clear_run_claim(job["id"]) is False
+
+
+class TestHeartbeatRunClaim:
+    def test_refreshes_claim_timestamp_for_expected_owner(self, cron_store):
+        job = _make_oneshot(claimed=True)  # claim stamped with by="test:1"
+        assert heartbeat_run_claim(job["id"], expected_owner="test:1") is True
+        reloaded = [j for j in jobs_mod.load_jobs() if j["id"] == job["id"]][0]
+        assert reloaded["run_claim"]["at"] != "2026-08-17T10:00:00+00:00"
+
+    def test_mismatched_owner_returns_false(self, cron_store):
+        job = _make_oneshot(claimed=True)  # claim stamped with by="test:1"
+        assert heartbeat_run_claim(job["id"], expected_owner="someone-else") is False
+
+    def test_unknown_job_id_returns_false(self, cron_store):
+        assert heartbeat_run_claim("no-such-job", expected_owner="test:1") is False
+
+    def test_none_schedule_does_not_crash(self, cron_store):
+        """schedule=None (disk corruption / old-writer record) must degrade to
+        a plain False, not raise AttributeError out of the scheduler's
+        periodic run-monitor heartbeat tick (#62002)."""
+        job = _make_oneshot(claimed=True)  # claim stamped with by="test:1"
+        jobs = jobs_mod.load_jobs()
+        for j in jobs:
+            if j["id"] == job["id"]:
+                j["schedule"] = None
+        jobs_mod.save_jobs(jobs)
+        assert heartbeat_run_claim(job["id"], expected_owner="test:1") is False
 
 
 class TestDispatchFailurePathsClearClaim:

--- a/tests/cron/test_terminal_job_rearm.py
+++ b/tests/cron/test_terminal_job_rearm.py
@@ -143,6 +143,21 @@ def test_rearm_refuses_recurring_and_live_claim(tmp_cron_dir):
         rearm_oneshot(oneshot["id"], future)
 
 
+def test_rearm_none_schedule_raises_value_error_not_attribute_error(tmp_cron_dir):
+    """schedule=None (disk corruption / old-writer record) must be refused
+    with the normal "recurring jobs" ValueError, not crash with
+    AttributeError out of the re-arm-only-once-shots check."""
+    from cron.jobs import rearm_oneshot
+
+    job = create_job("corrupted", "30m")
+    record = get_job(job["id"])
+    record["schedule"] = None
+    save_jobs([record])
+    future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    with pytest.raises(ValueError, match="one-shot"):
+        rearm_oneshot(job["id"], future)
+
+
 class TestRecurringJobStuckInErrorStateIsRecoverable:
     """A recurring (cron/interval) job that could not compute its next
     occurrence is marked ``state=error`` but left ``enabled=True`` — issue


### PR DESCRIPTION
## Summary

`job.get("schedule", {}).get(...)` returns the *stored* value, not the default, when `"schedule"` is present but explicitly `None` (disk corruption, an old writer, a hand-edited `jobs.json`). A recent fix already landed the `(job.get("schedule") or {})` idiom for `_is_recoverable_error_job`, citing prior art already used elsewhere in this file (`cron/scheduler.py`).

Three more call sites in `cron/jobs.py` still had the unguarded form and, as far as I can tell, aren't covered by any currently-open PR touching this bug class:

- **`rearm_oneshot()`** — raises `AttributeError` instead of the intended "recurring jobs" `ValueError` when re-arming a corrupted record
- **`heartbeat_run_claim()`** — called from the scheduler's periodic run-monitor tick (#62002); an unhandled `AttributeError` there would crash the tick, not just this one job
- **`clear_run_claim()`** — called from every dispatch-failure early-exit path (#86522), which exists specifically to be a safety net; crashing here defeats its purpose

An older closed PR (#70728) proposed the same fix for `heartbeat_run_claim`, but it predates `clear_run_claim` and `rearm_oneshot` (neither existed yet at the time) and never merged for `heartbeat_run_claim` either — that bug is still live on current `main`.

**Scope note:** `hermes_cli/cron.py`'s `cron_list()` has the exact same unguarded pattern on its schedule-display line, but that's already covered by two open PRs (#32916, #37465), so I left it out of this PR to avoid duplicating in-flight work.

## Test plan

- Added a `schedule=None` regression test at each of the three sites, following each file's existing fixture conventions (direct `job.get()`/`load_jobs()`/`save_jobs()` manipulation, matching the style already used by neighboring tests in the same files).
- Mutation-verified: stashed the production fix and confirmed all three new tests fail with the real `AttributeError`; restored and confirmed they pass.
- `uv run --frozen --extra dev python -m pytest tests/cron/ -q`: 1012 passed, 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)