### PR TITLE
fix(desktop): label group human as G

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -464,6 +464,10 @@ const $groupClarify = atom({})
 // away), and a rename re-keys the room (the feed starts clean under the new
 // name — stale events under the old key simply have no room to attach to).
 const GROUP_ACTIVITY_LIMIT = 50
+// G's human-facing identity in Bot Mode. Keep the durable room wire shape
+// (`kind: 'user'`, legacy `name: 'You'`) unchanged and translate only at
+// presentation/model-facing boundaries so old room history needs no migration.
+const GROUP_HUMAN_LABEL = 'G'
 const $groupActivity = atom({})
 
 function recordGroupActivity(group, event) {
@@ -498,7 +502,7 @@ function groupActivityLabel(event) {
     return base
   }
 
-  const who = event?.member === 'You' ? 'You' : groupSpeakerLabel(event?.member || 'A bot')
+  const who = event?.member === 'You' ? GROUP_HUMAN_LABEL : groupSpeakerLabel(event?.member || 'A bot')
 
   return `${who} ${base}`
 }
@@ -6921,7 +6925,7 @@ function formatGroupChatLine(entry, viewerName) {
     : ''
 
   if (entry.from.kind === 'user') {
-    return `${entry.from.name || 'User'} (user): ${entry.text}${attached}`
+    return `${GROUP_HUMAN_LABEL} (user): ${entry.text}${attached}`
   }
 
   const suffix = entry.from.name === viewerName ? ' (you)' : ''
@@ -13698,13 +13702,13 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                           ? (b.connectionLabel || b.connectionId) === entry.from.source
                           : !b.remoteSource)
                       ) || null
-                  const display = isUser ? 'You' : displayName(member || { name: entry.from.name }, meta)
+                  const display = isUser ? GROUP_HUMAN_LABEL : displayName(member || { name: entry.from.name }, meta)
                   const entryKey = `${entry.at}:${index}`
                   const revealed = !isUser && revealedSpeaker === entryKey
                   // Clicked: append the gateway name so same-named agents on
                   // two connections are tellable apart on demand.
                   const label = isUser
-                    ? 'You'
+                    ? GROUP_HUMAN_LABEL
                     : revealed
                       ? `${display}${entry.from.source ? `-${entry.from.source}` : ''} (@${botHandle(entry.from.name, member || undefined)})`
                       : display
@@ -14654,7 +14658,7 @@ function GroupRow({ active, group, members, needsYou, onOpen, onDisband }) {
   const lastFrom = last?.from?.name || ''
   const lastHandle = botHandle(lastFrom || 'bot', members.find(member => member?.name === lastFrom))
   const preview = last
-    ? `${last.from?.kind === 'user' ? 'You' : `@${lastHandle}`}: ${stripPreviewMarkdown(last.text) || '…'}`
+    ? `${last.from?.kind === 'user' ? GROUP_HUMAN_LABEL : `@${lastHandle}`}: ${stripPreviewMarkdown(last.text) || '…'}`
     : `${members.length} bots`
   const availableMembers = members.filter(member => botSourceStatus(member).available).length
   const availabilityLabel = `${availableMembers} of ${members.length} available`

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1406,6 +1406,13 @@ test('default profile speaks as Hermes in room transcripts, not @default', () =>
   assert.equal(plain, 'builder: yo')
 })
 
+test('human speaker is named G in member-facing group transcripts', () => {
+  const gc = load(() => '(pass)')
+  const line = gc.formatGroupChatLine({ from: { kind: 'user', name: 'You' }, text: 'hello room' }, 'builder')
+
+  assert.equal(line, 'G (user): hello room')
+})
+
 test('speaker labels honor friendly identity: Bot Mode title, then display_name, never a stale Hermes', () => {
   const gc = load(() => '(pass)')
 
@@ -1802,11 +1809,11 @@ test('source contract: group chat message bodies opt back into selectable text',
   assert.match(src, /'data-selectable-text':\s*'true'/)
 })
 
-test('group room preview renders the bot HANDLE, not the raw profile name', () => {
+test('group room preview renders the bot HANDLE and the human label, not raw identity fields', () => {
   // #89484: the room line read "@default: …" while the bot answers to
   // @hermes, so users concluded mention routing was broken.
   assert.match(pluginSource, /const lastHandle = botHandle\(lastFrom \|\| 'bot', members\.find\(/)
-  assert.match(pluginSource, /\? `\$\{last\.from\?\.kind === 'user' \? 'You' : `@\$\{lastHandle\}`\}/)
+  assert.match(pluginSource, /\? `\$\{last\.from\?\.kind === 'user' \? GROUP_HUMAN_LABEL : `@\$\{lastHandle\}`\}/)
   assert.doesNotMatch(pluginSource, /`@\$\{last\.from\?\.name \|\| 'bot'\}`/)
 })
 


### PR DESCRIPTION
## Summary

- label the human participant as `G` in Bot Mode group-room messages, previews, activity labels, and member-facing transcripts
- preserve stored room identity records as `{ kind: 'user', name: 'You' }` to avoid migrations
- keep this separate from #95265, which addresses Bot profile model/provider leakage

## Problem

Bot Mode group chats currently expose the human participant as `You` or `User`, and member-facing transcript/reasoning context can surface the generic identity as `user`. This is confusing when the configured human identity is known as G.

## Scope

This is presentation/context labeling only. It does not change models, providers, tools, memory, profile IDs, routing, room storage schema, or mention behavior.

## Verification

- `node --test apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` → 91 passed
- `git diff --check` → passed

Fixes the Bot Mode group human-labeling issue.
