### PR TITLE
perf(desktop): progressively hydrate Bot Mode roster

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/data.cached-roster.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.cached-roster.test.ts
@@ -85,3 +85,108 @@ describe('cachedUnionRoster', () => {
     expect(cachedUnionRoster()).toBeNull()
   })
 })
+
+describe('progressive roster cache', () => {
+  it('hydrates bounded connection-scoped rows without a gateway request', async () => {
+    const { hydrateRosterSnapshot } = await import('./data')
+
+    const stored = {
+      entries: {
+        local: {
+          fetchedAt: 1234,
+          profiles: [
+            {
+              canonical_session: { id: 'must-not-survive' },
+              display_name: 'Writer',
+              last_session: { preview: 'private text' },
+              name: 'writer'
+            }
+          ],
+          sources: [{ connectionId: 'local', kind: 'local', label: 'This device', reachable: true }]
+        }
+      },
+      version: 1
+    }
+
+    const set = vi.fn()
+
+    const storage = {
+      get<T>(_key: string, _fallback: T): T {
+        return stored as T
+      },
+      remove: vi.fn(),
+      set
+    }
+
+    await expect(hydrateRosterSnapshot(storage)).resolves.toBe(true)
+    expect(cache.get(JSON.stringify(['hermes-bots', 'roster', 'local']))?.value).toEqual({
+      fetchedAt: 1234,
+      partial: true,
+      profiles: [{ display_name: 'Writer', name: 'writer' }],
+      sources: [{ connectionId: 'local', kind: 'local', label: 'This device', reachable: true }]
+    })
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('never lets a late lightweight response overwrite rich roster data', async () => {
+    const { publishColdRosterSnapshot } = await import('./data')
+    const key = ['hermes-bots', 'roster', 'local']
+    const rich = { fetchedAt: 2000, profiles: [{ canonical_session: { id: 'live' }, name: 'writer' }] }
+
+    seed(key, rich)
+
+    expect(publishColdRosterSnapshot(key, { profiles: [{ name: 'stale' }] }, 3000)).toBe(false)
+    expect(cache.get(JSON.stringify(key))?.value).toBe(rich)
+  })
+
+  it('persists sanitized rows after hydration has settled', async () => {
+    const { persistRosterSnapshot } = await import('./data')
+    const writes: Array<{ key: string; value: unknown }> = []
+
+    const storage = {
+      get<T>(_key: string, fallback: T): T {
+        return fallback
+      },
+      remove: vi.fn(),
+      set: vi.fn((key: string, value: unknown) => {
+        writes.push({ key, value })
+      })
+    }
+
+    await expect(
+      persistRosterSnapshot(
+        'remote-a',
+        [
+          {
+            canonical_session: { id: 'must-not-persist', preview: 'private text' },
+            connectionId: 'remote-a',
+            name: 'writer'
+          }
+        ],
+        [],
+        4321,
+        storage
+      )
+    ).resolves.toBe(true)
+
+    expect(writes.at(-1)?.key).toBe('roster-snapshot-v1')
+    expect(writes.at(-1)?.value).toMatchObject({
+      entries: {
+        'remote-a': {
+          fetchedAt: 4321,
+          profiles: [{ connectionId: 'remote-a', name: 'writer' }]
+        }
+      },
+      version: 1
+    })
+    expect(JSON.stringify(writes.at(-1)?.value)).not.toContain('must-not-persist')
+    expect(JSON.stringify(writes.at(-1)?.value)).not.toContain('private text')
+  })
+
+  it('uses a slower rich-roster interval while the pane is hidden', async () => {
+    const { rosterRefreshInterval } = await import('./data')
+
+    expect(rosterRefreshInterval(true)).toBe(5000)
+    expect(rosterRefreshInterval(false)).toBe(30000)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -21,21 +21,22 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $lastRoster, useRoster } from './data'
 import type { RosterRow } from './types'
 
-const { hostMock } = vi.hoisted(() => ({
+const { hostMock, queryBridge } = vi.hoisted(() => ({
   hostMock: {
     agents: vi.fn(),
     profileRoutes: undefined as unknown,
     request: vi.fn(),
     requestProfile: vi.fn(),
     state: { connectionId: { get: vi.fn(() => 'local') }, profile: { get: () => 'default' } }
-  }
+  },
+  queryBridge: { client: null as null | QueryClient }
 }))
 
 vi.mock('@hermes/plugin-sdk', async () => {
@@ -45,7 +46,11 @@ vi.mock('@hermes/plugin-sdk', async () => {
   return {
     atom,
     host: hostMock,
-    queryClient: { getQueryData: vi.fn(), invalidateQueries: vi.fn() },
+    queryClient: {
+      getQueryData: (key: unknown[]) => queryBridge.client?.getQueryData(key),
+      invalidateQueries: (filters: object) => queryBridge.client?.invalidateQueries(filters),
+      setQueryData: (key: unknown[], value: unknown) => queryBridge.client?.setQueryData(key, value)
+    },
     useQuery,
     useValue: (store: { get: () => unknown }) => store.get()
   }
@@ -90,6 +95,7 @@ async function mergedRoster(
   }
 
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryBridge.client = client
 
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -106,6 +112,7 @@ const identities = (rows: RowFixture[]) => rows.map(row => `${row.connectionId}:
 
 beforeEach(() => {
   vi.clearAllMocks()
+  queryBridge.client = null
   $lastRoster.set([])
 })
 
@@ -574,6 +581,46 @@ describe('connect-on-demand sources', () => {
   })
 })
 
+describe('progressive roster hydration', () => {
+  it('publishes lightweight rows while the rich session scan is still pending', async () => {
+    hostMock.state.connectionId.get.mockReturnValue('progressive-test')
+    let resolveRich: ((value: { profiles: RowFixture[] }) => void) | undefined
+
+    const rich = new Promise<{ profiles: RowFixture[] }>(resolve => {
+      resolveRich = resolve
+    })
+
+    hostMock.request.mockImplementation((_method: string, params: Record<string, unknown>) => {
+      if (params.include_sessions === false) {
+        return Promise.resolve({ profiles: [{ display_name: 'Writer', name: 'writer' }] })
+      }
+
+      return rich
+    })
+    hostMock.agents.mockRejectedValue(new Error('no union roster on this build'))
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryBridge.client = client
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useRoster(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toMatchObject({ partial: true }))
+    expect(result.current.data?.profiles).toEqual([{ display_name: 'Writer', name: 'writer' }])
+
+    await act(async () => {
+      resolveRich?.({ profiles: [{ canonical_session: { id: 'live' }, name: 'writer' }] })
+    })
+    await waitFor(() => expect(result.current.data?.partial).not.toBe(true))
+    expect(result.current.data?.profiles?.[0]?.canonical_session?.id).toBe('live')
+    expect(hostMock.request).toHaveBeenCalledWith('profiles.list', { include_sessions: false })
+    expect(hostMock.request).toHaveBeenCalledWith('profiles.list', {})
+  })
+})
+
 describe('a stalled profiles.list cannot pin the spinner forever', () => {
   it('gives up after bounded retries and surfaces the error', async () => {
     // `retry: true` keeps React Query in isLoading until the first success, so
@@ -584,6 +631,7 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     hostMock.request.mockRejectedValue(new Error('state.db is locked'))
 
     const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
+    queryBridge.client = client
 
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -7,8 +7,15 @@
  */
 
 import { atom, host, queryClient, useQuery, useValue } from '@hermes/plugin-sdk'
+import type { PluginContext } from '@hermes/plugin-sdk'
 
 import { displayName } from './labels'
+import {
+  EMPTY_ROSTER_SNAPSHOT,
+  normalizeRosterSnapshot,
+  ROSTER_SNAPSHOT_KEY,
+  updateRosterSnapshot
+} from './roster-snapshot'
 import {
   aliasIdentityFor,
   beginAliasRouteIndex,
@@ -38,6 +45,8 @@ export const ROSTER_KEY = [ID, 'roster']
 // flap) leaves the Bots sidebar on a spinner with no error card. The 5s
 // refetchInterval and the gateway-open effect already recover drops.
 const ROSTER_QUERY_RETRY = 2
+const ROSTER_VISIBLE_REFRESH_MS = 5000
+const ROSTER_BACKGROUND_REFRESH_MS = 30000
 
 export const BOT_META_V1_KEY = 'bot-meta'
 const BOT_META_V2_KEY = 'bot-meta-v2'
@@ -48,6 +57,10 @@ const migratedLocalRoutes = new Map<string, ProfileRoute>()
 
 /** Live roster snapshot for imperative handlers (context menus). */
 export const $lastRoster = atom<RosterRow[]>([])
+let rosterSnapshotCache = EMPTY_ROSTER_SNAPSHOT
+let rosterSnapshotCommit = Promise.resolve()
+let rosterSnapshotReady = Promise.resolve(false)
+const coldRosterConnections = new Set<string>()
 
 // ── needs-attention badge (#93091 item 3) ───────────────────────────────────
 // Attention-worthy failure classes — matches the #93091 item-1 reason-code
@@ -603,11 +616,13 @@ export let serverInjectsProtocol = false
  *  multi-source merge and the roster query stamp on afterwards. Not in
  *  types.ts: this is the query-cache envelope around RosterRow, not a domain
  *  object. */
-interface RosterSnapshot {
+export interface RosterSnapshot {
   /** Newer backends inject the teammate protocol into the system prompt. */
   bot_mode_protocol?: boolean
   /** Time the request was ISSUED, the conservative bound mergeServerMeta wants. */
   fetchedAt?: number
+  /** Presentation-only data that must be replaced by the rich gateway answer. */
+  partial?: boolean
   primaryConnectionId?: string
   profiles?: RosterRow[]
   sources?: GatewaySource[]
@@ -631,11 +646,141 @@ interface UnionRoster {
   sources?: GatewaySource[]
 }
 
-export function useRoster() {
+export function rosterRefreshInterval(paneVisible: boolean): number {
+  return paneVisible ? ROSTER_VISIBLE_REFRESH_MS : ROSTER_BACKGROUND_REFRESH_MS
+}
+
+function publishPartialRoster(queryKey: unknown[], snapshot: RosterSnapshot): boolean {
+  if (!Array.isArray(snapshot.profiles)) {
+    return false
+  }
+
+  const current = queryClient.getQueryData<RosterSnapshot>(queryKey)
+
+  if (current && current.partial !== true) {
+    return false
+  }
+
+  if (current?.partial && Number(current.fetchedAt || 0) >= Number(snapshot.fetchedAt || 0)) {
+    return false
+  }
+
+  queryClient.setQueryData(queryKey, snapshot)
+
+  return true
+}
+
+export function publishColdRosterSnapshot(queryKey: unknown[], response: RosterSnapshot, fetchedAt: number): boolean {
+  return publishPartialRoster(queryKey, {
+    ...(response && typeof response === 'object' ? response : {}),
+    fetchedAt,
+    partial: true
+  })
+}
+
+export async function publishColdRosterOnce(
+  activeBot: Partial<RosterRow>,
+  activeConnectionId: unknown,
+  queryKey: unknown[],
+  fetchedAt: number,
+  request: (bot: Partial<RosterRow>, method: string, params: Record<string, unknown>) => Promise<RosterSnapshot> = (
+    bot,
+    method,
+    params
+  ) => requestForBot<RosterSnapshot>(bot, method, params)
+): Promise<boolean> {
+  const connectionId = String(activeConnectionId || 'local').trim() || 'local'
+
+  if (coldRosterConnections.has(connectionId)) {
+    return false
+  }
+
+  coldRosterConnections.add(connectionId)
+
+  try {
+    const light = await request(activeBot, 'profiles.list', { include_sessions: false })
+    serverInjectsProtocol = Boolean(light?.bot_mode_protocol)
+
+    return publishColdRosterSnapshot(queryKey, light, fetchedAt)
+  } catch {
+    // The rich request owns retries and the terminal error state.
+    return false
+  }
+}
+
+/** Restore every connection-scoped snapshot into the query cache. Mark each
+ *  entry stale immediately so the live rich request still starts on mount. */
+export function hydrateRosterSnapshot(storage: PluginContext['storage'] | undefined = getPluginCtx()?.storage) {
+  const hydration = Promise.resolve()
+    .then(() => storage?.get(ROSTER_SNAPSHOT_KEY, null))
+    .then(stored => {
+      rosterSnapshotCache = normalizeRosterSnapshot(stored)
+      let restored = false
+
+      for (const [connectionId, entry] of Object.entries(rosterSnapshotCache.entries)) {
+        const queryKey = [...ROSTER_KEY, connectionId]
+
+        const published = publishPartialRoster(queryKey, {
+          ...entry,
+          partial: true
+        })
+
+        if (published) {
+          restored = true
+          void queryClient.invalidateQueries({ exact: true, queryKey, refetchType: 'none' })
+        }
+      }
+
+      return restored
+    })
+    .catch(() => false)
+
+  rosterSnapshotReady = hydration
+
+  return hydration
+}
+
+export function persistRosterSnapshot(
+  connectionId: unknown,
+  profiles: unknown,
+  sources: unknown,
+  fetchedAt: unknown,
+  storage: PluginContext['storage'] | undefined = getPluginCtx()?.storage
+): Promise<boolean> {
+  if (!storage) {
+    return Promise.resolve(false)
+  }
+
+  const commit = rosterSnapshotCommit
+    .then(() => rosterSnapshotReady)
+    .then(async () => {
+      const next = updateRosterSnapshot(rosterSnapshotCache, connectionId, profiles, sources, fetchedAt)
+
+      if (next === rosterSnapshotCache) {
+        return false
+      }
+
+      rosterSnapshotCache = next
+      await Promise.resolve(storage.set(ROSTER_SNAPSHOT_KEY, rosterSnapshotCache))
+
+      return true
+    })
+
+  rosterSnapshotCommit = commit.then(
+    () => undefined,
+    () => undefined
+  )
+
+  return commit.catch(() => false)
+}
+
+export function useRoster(paneVisible = true) {
   const activeConnectionId = useValue(host.state.connectionId)
+  const rosterConnectionId = String(activeConnectionId || host.activeConnectionId?.() || 'local').trim() || 'local'
+  const queryKey = [...ROSTER_KEY, rosterConnectionId]
 
   return useQuery({
-    queryKey: [...ROSTER_KEY, activeConnectionId],
+    queryKey,
     queryFn: async () => {
       // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
       // against each bot's last local meta write, and a fetch issued before
@@ -652,15 +797,16 @@ export function useRoster() {
       // keep its configured friendly identity after activation (#89131).
       // Best-effort and feature-detected — a failed read keeps the last
       // good index rather than dropping identities mid-session.
-      if (typeof host.profileRoutes === 'function') {
-        const epoch = beginAliasRouteIndex()
+      const aliasRoutes =
+        typeof host.profileRoutes === 'function'
+          ? (() => {
+              const epoch = beginAliasRouteIndex()
 
-        try {
-          indexAliasRoutes(await host.profileRoutes(), epoch)
-        } catch {
-          /* keep the previous alias index */
-        }
-      }
+              return Promise.resolve(host.profileRoutes())
+                .then(routes => indexAliasRoutes(routes, epoch))
+                .catch(() => undefined)
+            })()
+          : Promise.resolve()
 
       // Owner routing is ambient in the SDK now (post-#92731): requestForBot
       // resolves the active owner itself, no captured route needed here.
@@ -668,7 +814,10 @@ export function useRoster() {
         name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
       }
 
-      const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+      // Start the lightweight and rich reads together. The lightweight result
+      // can paint first, but it is never allowed to overwrite a rich answer.
+      void publishColdRosterOnce(activeBot, rosterConnectionId, queryKey, issuedAt)
+      const [local] = await Promise.all([requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {}), aliasRoutes])
       // Newer backends inject the teammate-messaging protocol into every
       // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
       // carry a second copy. Older gateways lack the flag: keep appending.
@@ -686,24 +835,32 @@ export function useRoster() {
           const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
           const sources = Array.isArray(union?.sources) ? union.sources : []
 
-          return {
+          const snapshot = {
             ...merged,
             profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
             sources,
             fetchedAt: issuedAt
           }
+
+          void persistRosterSnapshot(rosterConnectionId, snapshot.profiles, snapshot.sources, snapshot.fetchedAt)
+
+          return snapshot
         } catch {
           /* older build or roster failure — single-source list stands */
         }
       }
 
-      return {
+      const snapshot = {
         ...(local && typeof local === 'object' ? local : {}),
         fetchedAt: issuedAt
       }
+
+      void persistRosterSnapshot(rosterConnectionId, snapshot.profiles, snapshot.sources, snapshot.fetchedAt)
+
+      return snapshot
     },
-    refetchInterval: 5000,
-    staleTime: 5000,
+    refetchInterval: rosterRefreshInterval(paneVisible),
+    staleTime: rosterRefreshInterval(paneVisible),
     retry: ROSTER_QUERY_RETRY,
     retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
   })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -38,6 +38,7 @@ import {
   botHandle,
   botMentionTag,
   cachedUnionRoster,
+  hydrateRosterSnapshot,
   isActiveRosterBot,
   migrateBotMeta,
   resolveRosterMentions
@@ -95,6 +96,10 @@ export default {
     'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx: PluginContext) {
     setPluginCtx(ctx)
+    // Paint a bounded presentation-only snapshot while the live rich roster
+    // starts. Hydration performs no gateway RPC and marks the cache stale so
+    // the backend remains authoritative immediately.
+    void hydrateRosterSnapshot(ctx.storage)
     const disposeLocales = ctx.i18n.register(BOTS_LOCALES)
     setGroupChatSyncDisposed(false)
     startFaceClock()

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -240,7 +240,8 @@ interface RosterGroupRow {
 export function BotsPane() {
   const { t } = useI18n()
   const b = useBots()
-  const { data, error, isLoading, refetch } = useRoster()
+  const paneVisible = useValue($botsPaneVisible)
+  const { data, error, isLoading, refetch } = useRoster(paneVisible)
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
@@ -483,10 +484,15 @@ export function BotsPane() {
       $lastSources.set(data.sources)
     }
 
-    mergeServerMeta(activeSourceRoster, data?.fetchedAt || 0)
-    pullServerAvatars(activeSourceRoster)
-    trackInboundActivity(roster)
-    backfillMessagingProtocol(activeSourceRoster)
+    // Cached and lightweight rows are presentation-only. They deliberately
+    // omit ui_meta, session activity and other server-owned fields, so none of
+    // the rich reconciliation side effects may run until the full answer wins.
+    if (!data?.partial) {
+      mergeServerMeta(activeSourceRoster, data?.fetchedAt || 0)
+      pullServerAvatars(activeSourceRoster)
+      trackInboundActivity(roster)
+      backfillMessagingProtocol(activeSourceRoster)
+    }
     // React Query owns the stable server snapshot; derived arrays intentionally
     // follow that snapshot rather than retriggering on their own atom writes.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/desktop/src/plugins/hermes-bots/roster-snapshot.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-snapshot.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compactRosterProfile,
+  EMPTY_ROSTER_SNAPSHOT,
+  normalizeRosterSnapshot,
+  ROSTER_SNAPSHOT_MAX_CONNECTIONS,
+  ROSTER_SNAPSHOT_MAX_ROWS,
+  updateRosterSnapshot
+} from './roster-snapshot'
+
+describe('compactRosterProfile', () => {
+  it('keeps bounded paint and routing fields without persisting chat identity or text', () => {
+    const compact = compactRosterProfile({
+      canonical_session: { id: 'must-not-persist', preview: 'private canonical preview' },
+      connectionId: 'local',
+      description: 'Drafts things',
+      display_name: 'Writer',
+      last_session: { id: 'also-no', preview: 'private recent preview' },
+      name: 'writer',
+      route: { connectionId: 'local', mode: 'local', profile: 'writer', targetProfile: 'writer' },
+      ui_meta: { 'hermes-bots': { chat: 'legacy-session-pointer' } },
+      worker_session: { last_active: 123 }
+    })
+
+    expect(compact).toEqual({
+      connectionId: 'local',
+      description: 'Drafts things',
+      display_name: 'Writer',
+      name: 'writer',
+      route: { connectionId: 'local', mode: 'local', profile: 'writer', targetProfile: 'writer' }
+    })
+    expect(compact).not.toHaveProperty('canonical_session')
+    expect(compact).not.toHaveProperty('last_session')
+    expect(compact).not.toHaveProperty('ui_meta')
+    expect(compact).not.toHaveProperty('worker_session')
+  })
+
+  it('bounds row text before persistence', () => {
+    const compact = compactRosterProfile({ description: 'x'.repeat(2000), name: 'y'.repeat(100) })
+
+    expect(compact?.name).toHaveLength(64)
+    expect(compact?.description).toHaveLength(1024)
+  })
+})
+
+describe('roster snapshot normalization', () => {
+  it('rejects unknown versions and malformed entries', () => {
+    expect(normalizeRosterSnapshot({ entries: { local: { profiles: [{ name: 'writer' }] } }, version: 2 })).toEqual(
+      EMPTY_ROSTER_SNAPSHOT
+    )
+    expect(normalizeRosterSnapshot(null)).toEqual(EMPTY_ROSTER_SNAPSHOT)
+  })
+
+  it('bounds connections and rows while re-sanitizing stored data', () => {
+    let snapshot = EMPTY_ROSTER_SNAPSHOT
+
+    for (let index = 0; index < ROSTER_SNAPSHOT_MAX_CONNECTIONS + 3; index += 1) {
+      snapshot = updateRosterSnapshot(
+        snapshot,
+        `connection-${index}`,
+        Array.from({ length: ROSTER_SNAPSHOT_MAX_ROWS + 4 }, (_, row) => ({
+          canonical_session: { id: `secret-${row}` },
+          name: `bot-${row}`
+        })),
+        [],
+        index + 1
+      )
+    }
+
+    expect(Object.keys(snapshot.entries)).toHaveLength(ROSTER_SNAPSHOT_MAX_CONNECTIONS)
+    expect(snapshot.entries['connection-10'].profiles).toHaveLength(ROSTER_SNAPSHOT_MAX_ROWS)
+    expect(snapshot.entries).not.toHaveProperty('connection-0')
+
+    const normalized = normalizeRosterSnapshot(snapshot)
+    expect(normalized.entries['connection-10'].profiles[0]).not.toHaveProperty('canonical_session')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-snapshot.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-snapshot.ts
@@ -1,0 +1,175 @@
+/**
+ * Bounded, presentation-only Bot roster persistence.
+ *
+ * The live gateway remains authoritative. These helpers deliberately exclude
+ * session identity, previews, activity, prompts and ui_meta so restoring a
+ * snapshot can paint rows but can never choose or create a chat.
+ */
+
+import type { GatewaySource, RosterRow } from './types'
+
+export const ROSTER_SNAPSHOT_KEY = 'roster-snapshot-v1'
+export const ROSTER_SNAPSHOT_MAX_CONNECTIONS = 8
+export const ROSTER_SNAPSHOT_MAX_ROWS = 256
+
+export interface PersistedRosterEntry {
+  fetchedAt: number
+  profiles: RosterRow[]
+  sources: GatewaySource[]
+}
+
+export interface PersistedRosterSnapshot {
+  entries: Record<string, PersistedRosterEntry>
+  version: 1
+}
+
+export const EMPTY_ROSTER_SNAPSHOT: PersistedRosterSnapshot = {
+  entries: {},
+  version: 1
+}
+
+function boundedText(value: unknown, limit = 512): string | undefined {
+  return typeof value === 'string' ? value.slice(0, limit) : undefined
+}
+
+/** Keep only the fields needed to paint and route one roster row. */
+export function compactRosterProfile(value: unknown): RosterRow | null {
+  const profile = value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+  const name = boundedText(profile?.name, 64)?.trim()
+
+  if (!profile || !name) {
+    return null
+  }
+
+  const displayName = boundedText(profile.display_name, 160)
+  const description = boundedText(profile.description, 1024)
+  const connectionId = boundedText(profile.connectionId, 160)
+  const connectionLabel = boundedText(profile.connectionLabel, 160)
+  const connectionKind = boundedText(profile.connectionKind, 32)
+  const targetProfile = boundedText(profile.targetProfile, 64)
+  const handle = boundedText(profile.handle, 160)
+  const title = boundedText(profile.title, 160)
+  const sourceError = boundedText(profile.sourceError, 512)
+
+  const compact: RosterRow = {
+    name,
+    ...(displayName !== undefined ? { display_name: displayName } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(connectionId !== undefined ? { connectionId } : {}),
+    ...(connectionLabel !== undefined ? { connectionLabel } : {}),
+    ...(connectionKind !== undefined ? { connectionKind } : {}),
+    ...(targetProfile !== undefined ? { targetProfile } : {}),
+    ...(handle !== undefined ? { handle } : {}),
+    ...(title !== undefined ? { title } : {}),
+    ...(sourceError !== undefined ? { sourceError } : {})
+  }
+
+  for (const key of ['has_avatar', 'sourceScoped', 'remoteSource', 'sourceMissing', 'sourceReachable'] as const) {
+    if (typeof profile[key] === 'boolean') {
+      compact[key] = profile[key]
+    }
+  }
+
+  const route = profile.route && typeof profile.route === 'object' ? (profile.route as Record<string, unknown>) : null
+  const routeConnectionId = boundedText(route?.connectionId, 160)?.trim()
+  const routeProfile = boundedText(route?.profile, 64)?.trim()
+
+  if (route && routeConnectionId && routeProfile) {
+    compact.route = {
+      connectionId: routeConnectionId,
+      mode: route.mode === 'local' ? 'local' : 'remote',
+      profile: routeProfile,
+      targetProfile: boundedText(route.targetProfile, 64)?.trim() || routeProfile
+    }
+  }
+
+  return compact
+}
+
+export function compactRosterSource(value: unknown): GatewaySource | null {
+  const source = value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+  const connectionId = boundedText(source?.connectionId, 160)?.trim()
+
+  if (!source || !connectionId) {
+    return null
+  }
+
+  const error = boundedText(source.error, 512)
+
+  return {
+    connectionId,
+    kind: boundedText(source.kind, 32) || 'remote',
+    label: boundedText(source.label, 160) || connectionId,
+    ...(typeof source.reachable === 'boolean' ? { reachable: source.reachable } : {}),
+    ...(error ? { error } : {})
+  }
+}
+
+export function normalizeRosterSnapshot(value: unknown): PersistedRosterSnapshot {
+  const root = value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+  const rawEntries = root?.version === 1 && root.entries && typeof root.entries === 'object' ? root.entries : {}
+  const entries: Record<string, PersistedRosterEntry> = {}
+
+  for (const [connectionId, rawEntry] of Object.entries(rawEntries).slice(-ROSTER_SNAPSHOT_MAX_CONNECTIONS)) {
+    const entry = rawEntry && typeof rawEntry === 'object' ? (rawEntry as Record<string, unknown>) : null
+
+    const profiles = (Array.isArray(entry?.profiles) ? entry.profiles : [])
+      .slice(0, ROSTER_SNAPSHOT_MAX_ROWS)
+      .map(compactRosterProfile)
+      .filter((profile): profile is RosterRow => profile !== null)
+
+    const sources = (Array.isArray(entry?.sources) ? entry.sources : [])
+      .slice(0, ROSTER_SNAPSHOT_MAX_CONNECTIONS)
+      .map(compactRosterSource)
+      .filter((source): source is GatewaySource => source !== null)
+
+    if (profiles.length) {
+      entries[String(connectionId)] = {
+        fetchedAt: Math.max(0, Number(entry?.fetchedAt || 0)),
+        profiles,
+        sources
+      }
+    }
+  }
+
+  return { entries, version: 1 }
+}
+
+export function updateRosterSnapshot(
+  snapshot: PersistedRosterSnapshot,
+  connectionId: unknown,
+  profiles: unknown,
+  sources: unknown,
+  fetchedAt: unknown
+): PersistedRosterSnapshot {
+  const key = String(connectionId || 'local').trim() || 'local'
+
+  const compactProfiles = (Array.isArray(profiles) ? profiles : [])
+    .slice(0, ROSTER_SNAPSHOT_MAX_ROWS)
+    .map(compactRosterProfile)
+    .filter((profile): profile is RosterRow => profile !== null)
+
+  if (!compactProfiles.length) {
+    return snapshot
+  }
+
+  const compactSources = (Array.isArray(sources) ? sources : [])
+    .slice(0, ROSTER_SNAPSHOT_MAX_CONNECTIONS)
+    .map(compactRosterSource)
+    .filter((source): source is GatewaySource => source !== null)
+
+  const entries = {
+    ...snapshot.entries,
+    [key]: {
+      fetchedAt: Math.max(0, Number(fetchedAt || Date.now())),
+      profiles: compactProfiles,
+      sources: compactSources
+    }
+  }
+
+  const newest = Object.entries(entries)
+    .sort(([, left], [, right]) => left.fetchedAt - right.fetchedAt)
+    .slice(-ROSTER_SNAPSHOT_MAX_CONNECTIONS)
+
+  return { entries: Object.fromEntries(newest), version: 1 }
+}


### PR DESCRIPTION
## What does this PR do?

Makes the rebuilt TypeScript Bot Mode roster useful immediately instead of waiting for every profile database to be scanned before first paint.

The renderer restores a bounded, connection-scoped presentation snapshot at plugin startup and starts a lightweight `profiles.list { include_sessions: false }` request alongside the existing rich request. Cached or lightweight rows may paint and route clicks, but they cannot run metadata, avatar, activity, or session reconciliation. The rich gateway response remains authoritative and cannot be overwritten by a late lightweight result.

The persisted snapshot cannot contain canonical or recent session IDs, previews, prompts, activity records, `ui_meta`, worker state, or legacy chat pointers. Bot chat identity remains the exact `(profile, "Bot Chat")` server registry; this change introduces no session pin.

Rich roster polling remains five seconds while Bot Mode is visible and backs off to thirty seconds while its retained pane is hidden.

This is a forward-port of the original PR after #96726 intentionally replaced the monolithic `plugin.js` implementation with typed Bot Mode modules and Vitest coverage. It preserves that architecture instead of resurrecting deleted files.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

This PR owns only the Bot Mode roster layer. It does not change backend startup, session navigation, transcript caching, or canonical Bot Chat identity.

## Related Issue

Related: #92836 concerns bounded Bot presentation metadata in the REST profile inventory. It does not implement this Desktop cache or progressive hydration path.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add pure, bounded snapshot normalization in `apps/desktop/src/plugins/hermes-bots/roster-snapshot.ts`.
- Restore sanitized snapshots into the connection-scoped React Query cache while marking them stale so live hydration starts immediately.
- Start one profile-only roster request per connection alongside the existing rich request.
- Prevent cached and lightweight rows from running rich metadata, avatar, activity, or protocol reconciliation.
- Persist only rich roster answers and prevent late lightweight responses from replacing authoritative data.
- Keep five-second polling while the Bot pane is visible and use a thirty-second interval while hidden.
- Add behavioral coverage for bounds, redaction, connection scoping, progressive publication, rich-result precedence, legacy remote-owner inference, and adaptive polling.

## How to Test

1. From `apps/desktop`, run `npx vitest run --project ui --maxWorkers=4 src/plugins/hermes-bots`.
2. Run `npm run typecheck`.
3. Run ESLint over the seven changed Bot Mode source and test files.

Expected result: a sanitized persisted or lightweight roster can paint while the rich request is pending; the rich result replaces it; late partial data cannot replace rich data; and existing Bot Mode identity, routing, and session behavior remains intact.

Focused result: 58 Bot Mode test files passed with 565 tests. Desktop renderer, Electron, and E2E typechecks passed. Affected-file ESLint and `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

The Python suite was not run because this PR changes only Desktop TypeScript. The full rebuilt Bot Mode Vitest directory passed with four workers.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not included. This changes first-paint and background-loading behavior rather than visual design.
