### PR TITLE
fix(goals): kanban goal loop honours the judge's transport_failed flag

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2202,7 +2202,7 @@ def run_kanban_goal_loop(
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"review_requested_by_worker"``,
     ``"changes_requested_by_reviewer"``, ``"blocked_budget"``,
-    ``"blocked_by_worker"``, or ``"stopped"``.
+    ``"blocked_judge_transport"``, ``"blocked_by_worker"``, or ``"stopped"``.
     """
 
     def _log(msg: str) -> None:
@@ -2220,6 +2220,14 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    # Judge API/transport errors in a row. Mirrors
+    # GoalManager.check_goal_progress: a judge that cannot reach its API
+    # returns ("continue", ..., transport_failed=True), and without this
+    # guard those error verdicts are indistinguishable from real "not done
+    # yet" verdicts — a permanently broken judge (bad key, DNS, 401) burns
+    # the worker's entire turn budget and the resulting blocked message
+    # blames the worker instead of the judge config.
+    consecutive_transport_failures = 0
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -2253,10 +2261,41 @@ def run_kanban_goal_loop(
         # The kanban worker loop has no wait-barrier concept (workers finish
         # via kanban_complete / kanban_block, not by parking), so a WAIT
         # verdict is treated as CONTINUE here.
-        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
+        verdict, reason, _parse_failed, _wait, transport_failed = judge_goal(goal_text, last_response)
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
+
+        # Honour the judge's transport_failed flag the way the GoalManager
+        # path does (see check_goal_progress): N consecutive transport
+        # failures mean the judge config is broken, not the worker. Block
+        # the card with a message that names the judge — spending the
+        # remaining turn budget on an unreachable API produces nothing and
+        # the blocked_budget message would blame the worker.
+        if transport_failed:
+            consecutive_transport_failures += 1
+        else:
+            consecutive_transport_failures = 0
+        if consecutive_transport_failures >= DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES:
+            _log(
+                f"kanban goal loop: task {task_id} judge API unreachable "
+                f"{consecutive_transport_failures} turns in a row; blocking"
+            )
+            try:
+                block_fn(
+                    f"Goal-mode judge could not reach its API "
+                    f"{consecutive_transport_failures} turns in a row "
+                    f"(check auxiliary.goal_judge provider/key in config.yaml). "
+                    f"The worker was not at fault; {turns_used}/{max_turns} "
+                    f"turns were used before pausing."
+                )
+            except Exception as exc:
+                _log(f"kanban goal loop: block_fn failed ({exc})")
+            return {
+                "outcome": "blocked_judge_transport",
+                "turns_used": turns_used,
+                "reason": "judge API unreachable",
+            }
 
         if verdict == "done":
             if nudged_to_finalize:

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -128,6 +128,78 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     assert turns == []  # no extra turns
 
 
+def _patch_judge_transport_failing(monkeypatch):
+    """Make judge_goal permanently unable to reach its API.
+
+    Matches the real transport-failure contract: verdict "continue",
+    parse_failed False, transport_failed True.
+    """
+
+    def _fake_judge(goal, response, subgoals=None, background_processes=None, **_kw):
+        return "continue", "[Judge check skipped: HTTP 401]", False, None, True
+
+    monkeypatch.setattr(goals, "judge_goal", _fake_judge)
+
+
+def test_loop_blocks_on_persistent_judge_transport_failure(monkeypatch):
+    # A judge that can never reach its API must NOT burn the whole turn
+    # budget: after DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES consecutive
+    # failures the loop blocks the card blaming the judge config, not the
+    # worker (troubleshooting regression: 20 turns in 43s, blocked_budget).
+    _patch_judge_transport_failing(monkeypatch)
+    turns = []
+    blocks = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: turns.append(p) or "still going",
+        task_status_fn=lambda: "running",
+        block_fn=lambda r: blocks.append(r),
+        first_response="working on it",
+        max_turns=20,
+    )
+    assert res["outcome"] == "blocked_judge_transport"
+    threshold = goals.DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES
+    # The loop stops at the threshold, far short of the 20-turn budget.
+    assert res["turns_used"] < 20
+    assert len(turns) == threshold - 1
+    assert len(blocks) == 1
+    assert "judge" in blocks[0].lower()
+    assert "worker was not at fault" in blocks[0]
+
+
+def test_transport_failure_counter_resets_on_recovery(monkeypatch):
+    # Transient flakiness must not accumulate: failures below the threshold
+    # followed by a healthy judge verdict reset the counter and the loop
+    # proceeds normally (here: judged done -> finalize nudge -> completed).
+    threshold = goals.DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES
+    seq = []
+    for _ in range(threshold - 1):
+        seq.append(("continue", "[Judge check skipped: timeout]", False, None, True))
+    seq.append(("done", "all criteria met", False, None, False))
+
+    def _fake_judge(goal, response, subgoals=None, background_processes=None, **_kw):
+        return seq.pop(0) if seq else ("done", "all criteria met", False, None, False)
+
+    monkeypatch.setattr(goals, "judge_goal", _fake_judge)
+
+    statuses = iter(["running"] * threshold + ["done"] * 10)
+    blocks = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: "ok",
+        task_status_fn=lambda: next(statuses),
+        block_fn=lambda r: blocks.append(r),
+        first_response="working on it",
+        max_turns=50,
+    )
+    assert res["outcome"] == "completed_by_worker"
+    assert blocks == []
+
+
 
 
 


### PR DESCRIPTION
## Problem

`run_kanban_goal_loop` (hermes_cli/goals.py) destructures `judge_goal()`'s `transport_failed` flag as `_transport_failed` and discards it. A judge that cannot reach its API at all (401 auth, DNS failure, timeout) returns `("continue", ..., transport_failed=True)` by design — the flag exists, per its own docstring, "so a permanently broken judge doesn't burn the entire turn budget".

The GoalManager path (`check_goal_progress`) already honours it: it counts consecutive transport failures and auto-pauses after `DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES`. The kanban goal loop is the second caller and throws the flag away, so every judge transport error is treated as an ordinary "not done yet" verdict and a continuation turn is spent.

**Observed consequence:** with a misconfigured judge, a kanban goal-mode worker consumed its entire 20-turn budget in 43 seconds, produced nothing, and the card was blocked with a message blaming the worker's turn budget ("Goal-mode worker exhausted its turn budget") rather than the judge configuration.

## Fix

Mirror the existing GoalManager guard in `run_kanban_goal_loop`:

- track `consecutive_transport_failures` in the loop's local state (the loop is deliberately persistence-free, so a local counter matches its design);
- after `DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES` consecutive failures, block the card with a message that names the judge config (`auxiliary.goal_judge` provider/key) and states the worker was not at fault;
- return a new `blocked_judge_transport` outcome (docstring updated);
- reset the counter on any turn where the judge is reachable, so transient network flakiness does not accumulate.

## Tests

Two new tests in `tests/hermes_cli/test_kanban_goal_mode.py`:

- `test_loop_blocks_on_persistent_judge_transport_failure` — a permanently unreachable judge blocks at the threshold (well short of a 20-turn budget) with a judge-blaming block message.
- `test_transport_failure_counter_resets_on_recovery` — threshold-1 transport failures followed by a healthy verdict reset the counter and the loop completes normally with no block.

`python3 -m pytest tests/hermes_cli/test_kanban_goal_mode.py -q` → 6 passed.
`test_kanban_review_surfaces.py::test_review_tools_are_gated_and_visible_to_kanban_workers` fails identically on clean `main` (verified via stash) and is unrelated.
