### PR TITLE
fix(gateway): recommend read_file before the terminal tool for document extraction

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3172,6 +3172,15 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     wording ("Ask the user what they'd like you to do with it") steered the
     model into punting back to the user, which is why attached PDFs/DOCX looked
     "unreadable" to the agent even though it has the tools to read them.
+
+    The extraction guidance points at ``read_file`` first, not the terminal
+    tool. ``read_file`` already extracts PDF/DOCX/XLSX/PPT text natively (see
+    ``tools/read_extract.py``) with no approval prompt — the terminal tool and
+    the ocr-and-documents skill both go through the command-approval gate,
+    which stalls on any platform whose approval UI is unreliable (e.g. a known
+    Teams adaptive-card bug at the time of writing). Sending the model to the
+    gated path first for what is usually a zero-approval read caused it to get
+    stuck waiting on approvals a chat platform couldn't reliably deliver.
     """
     if mtype.startswith("text/"):
         return (
@@ -3182,9 +3191,12 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     return (
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
         f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
-        f"To read it, extract the document's text yourself — for example with the "
-        f"terminal tool or the ocr-and-documents skill — before answering, instead "
-        f"of asking the user to paste the contents.]"
+        f"To read it, first use the read_file tool directly on that path — it "
+        f"extracts PDF/DOCX/XLSX/PPT text natively and requires no approval. "
+        f"Only if read_file comes back empty or flags an extraction-coverage "
+        f"warning (a scanned/image-only document with no text layer), fall back "
+        f"to the terminal tool or the ocr-and-documents skill for OCR. Do this "
+        f"before answering, instead of asking the user to paste the contents.]"
     )
 
 

--- a/tests/gateway/test_document_context_note.py
+++ b/tests/gateway/test_document_context_note.py
@@ -8,6 +8,11 @@ is perfectly capable of reading. These tests pin the contract:
 - text documents: note confirms the (adapter-)inlined content + records path.
 - binary documents (PDF/DOCX/…): note tells the agent to extract the text
   itself and never tells it to punt back to the user.
+- binary documents: note recommends the zero-approval `read_file` tool before
+  the terminal tool / ocr-and-documents skill, both of which are gated behind
+  command approval. A prior wording pointed straight at the terminal tool,
+  which stalled indefinitely on any platform whose approval UI can't deliver
+  the prompt (e.g. a known Teams adaptive-card bug at the time of writing).
 """
 
 import importlib
@@ -47,4 +52,22 @@ class TestBinaryDocumentNote:
         # ...and does NOT steer it into punting back to the user (the bug).
         assert "ask the user" not in note.lower()
         assert "paste" in note.lower()
+
+    @pytest.mark.parametrize(
+        "mtype",
+        [
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/octet-stream",
+        ],
+    )
+    def test_binary_note_recommends_read_file_before_terminal_tool(self, mtype):
+        note = _build_document_context_note("contract.pdf", "/cache/doc_contract.pdf", mtype)
+        lower = note.lower()
+        assert "read_file" in lower
+        # read_file must be the first extraction path offered, not a mention
+        # buried after the gated terminal-tool/skill fallback.
+        assert lower.index("read_file") < lower.index("terminal tool")
+        assert lower.index("read_file") < lower.index("ocr-and-documents")
 


### PR DESCRIPTION
## Problem

`_build_document_context_note` in `gateway/run.py` is the context note prepended to a user turn when they attach a binary document (PDF, DOCX, XLSX, ...). It told the agent to extract the text via "the terminal tool or the ocr-and-documents skill" — both of which route through the command-approval gate.

It never mentioned `read_file`, which already extracts PDF/DOCX/XLSX/PPT text natively (`tools/read_extract.py`, via the optional `firecrawl-anydoc` package) with **zero approval**.

## Impact

This sends the model down the gated path for what is usually a zero-approval read. On any platform whose approval UI can't reliably deliver the prompt — for example the Teams adaptive-card auth bug (#93516) — the agent gets stuck waiting on an approval the user has no way to grant, even though `read_file` would have already answered the question with no prompt at all. Traced this from a real stuck-approval-loop report: a user attached a scanned PDF, the agent tried `execute_code`/`fitz` and various terminal invocations (all approval-gated or blocked by the anti-script-injection check), and never once tried the already-available zero-approval tool.

This affects every Hermes deployment on every channel, not just Teams — any platform where a user can't click through an approval card hits the same stall.

## Fix

Reordered the note to point at `read_file` first. Falls back to the terminal tool / `ocr-and-documents` skill only when `read_file` reports an extraction-coverage warning (scanned/image-only pages with no text layer) — which is exactly the condition the `ocr-and-documents` skill's own docs already assume ("Coming from a `read_file` EXTRACTION COVERAGE WARNING?").

## Testing

Added a regression test (`test_binary_note_recommends_read_file_before_terminal_tool`) asserting `read_file` appears in the note before both fallback paths. All 11 tests in `tests/gateway/test_document_context_note.py` pass; `ruff check` clean on both changed files.