### PR TITLE
fix(compression): hot-apply native compaction settings

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26790,6 +26790,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "threshold_tokens"),
         ("compression", "codex_gpt55_autoraise"),
         ("compression", "codex_app_server_auto"),
+        ("compression", "codex_responses_native"),
+        ("compression", "codex_responses_compact_threshold"),
         ("compression", "target_ratio"),
         ("compression", "tail_mode"),
         ("compression", "protect_last_n"),

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -120,6 +120,8 @@ class TestExtractCacheBustingConfig:
                     "enabled": False,
                     "threshold": 0.6,
                     "codex_gpt55_autoraise": False,
+                    "codex_responses_native": True,
+                    "codex_responses_compact_threshold": 120_000,
                     "target_ratio": 0.3,
                     "protect_last_n": 25,
                     "codex_app_server_auto": "hermes",
@@ -130,6 +132,8 @@ class TestExtractCacheBustingConfig:
         assert out["compression.enabled"] is False
         assert out["compression.threshold"] == 0.6
         assert out["compression.codex_gpt55_autoraise"] is False
+        assert out["compression.codex_responses_native"] is True
+        assert out["compression.codex_responses_compact_threshold"] == 120_000
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"

--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -27,6 +27,8 @@ def _session_with_compressor(**compression_ctor):
         context_compressor=compressor,
         compression_enabled=True,
         compression_idle_compact_after_seconds=0,
+        codex_responses_native_compaction=False,
+        codex_responses_compact_threshold=200_000,
     )
     return {
         "agent": agent,
@@ -65,6 +67,36 @@ def test_live_threshold_tokens_applies_on_next_turn_without_rebuild(monkeypatch)
     assert compressor.proactive_prune_tokens == 48_000
     assert compressor.tail_mode == "lean"
     assert live_agent.compression_idle_compact_after_seconds == 1800
+
+
+def test_live_codex_native_compaction_applies_on_next_turn(monkeypatch):
+    session, _ = _session_with_compressor()
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"compression": {"codex_responses_native": True}},
+    )
+
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].codex_responses_native_compaction is True
+
+
+def test_live_codex_native_threshold_applies_on_next_turn(monkeypatch):
+    session, _ = _session_with_compressor()
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "compression": {"codex_responses_compact_threshold": 120_000}
+        },
+    )
+
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].codex_responses_compact_threshold == 120_000
 
 
 def test_unchanged_compression_config_is_noop(monkeypatch):
@@ -133,6 +165,8 @@ def _neutral_session(**compression_ctor):
         context_compressor=compressor,
         compression_enabled=True,
         compression_idle_compact_after_seconds=0,
+        codex_responses_native_compaction=False,
+        codex_responses_compact_threshold=200_000,
     )
     return {"agent": agent, "session_key": "session-unset"}, compressor
 
@@ -233,3 +267,17 @@ def test_removing_enabled_restores_true(monkeypatch):
     session["agent"].compression_enabled = False
     _sync_with_cfg(monkeypatch, session, {"compression": {}})
     assert session["agent"].compression_enabled is True
+
+
+def test_removing_codex_native_compaction_restores_false(monkeypatch):
+    session, _ = _neutral_session()
+    session["agent"].codex_responses_native_compaction = True
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert session["agent"].codex_responses_native_compaction is False
+
+
+def test_removing_codex_native_threshold_restores_default(monkeypatch):
+    session, _ = _neutral_session()
+    session["agent"].codex_responses_compact_threshold = 120_000
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert session["agent"].codex_responses_compact_threshold == 200_000

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6447,7 +6447,8 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     acted only on PRESENT keys, leaving stale values active forever.
     """
     cfg = cfg if isinstance(cfg, dict) else {}
-    compression = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+    compression_raw = cfg.get("compression")
+    compression = compression_raw if isinstance(compression_raw, dict) else {}
     model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
 
     enabled_raw = compression.get("enabled", True)
@@ -6455,6 +6456,27 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
         agent.compression_enabled = enabled_raw
     else:
         agent.compression_enabled = str(enabled_raw).lower() in {"true", "1", "yes"}
+
+    agent.codex_responses_native_compaction = is_truthy_value(
+        compression.get("codex_responses_native", False)
+    )
+    native_threshold_raw = compression.get(
+        "codex_responses_compact_threshold", 200_000
+    )
+    try:
+        if isinstance(native_threshold_raw, bool):
+            raise ValueError
+        native_threshold = int(native_threshold_raw)
+        if native_threshold <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid compression.codex_responses_compact_threshold=%r; "
+            "using 200000.",
+            native_threshold_raw,
+        )
+        native_threshold = 200_000
+    agent.codex_responses_compact_threshold = native_threshold
 
     # Absence restores the agent_init/config default (0 = disabled).
     idle_raw = compression.get("idle_compact_after_seconds", 0)


### PR DESCRIPTION
## Summary
- hot-apply `compression.codex_responses_native` and its threshold to already-open Desktop/TUI sessions
- restore defaults when either setting is removed
- include both settings in the messaging-gateway agent cache signature

## Root cause
Enabling native Responses compaction after a Desktop session was already open only changed the profile config. The cached agent kept local summarization enabled, so large Codex sessions still spent minutes on a full transcript summary. Fresh auxiliary agents used native compaction, which made the stale foreground agent especially easy to miss.

## Test plan
- `python -m pytest -q tests/tui_gateway/test_compression_config_hot_reload.py tests/gateway/test_agent_cache.py tests/run_agent/test_native_compaction.py tests/run_agent/test_native_compaction_summary_retention.py tests/agent/test_pre_compress_checkpoint_contract.py`
- `git diff --check`
- `python -m compileall -q tui_gateway/server.py gateway/run.py`