### PR TITLE
fix(security): redact MCP capability URLs from diagnostics

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -97,6 +97,7 @@ def _setup_logging() -> None:
 
     # Quiet down noisy libraries
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpx2").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("openai").setLevel(logging.WARNING)
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -8,11 +8,13 @@ the first 6 and last 4 characters for debuggability.
 """
 
 import logging
+import math
 import os
 import re
 import shlex
 import threading
-from urllib.parse import unquote_plus
+from collections import Counter
+from urllib.parse import unquote, unquote_plus, urlsplit, urlunsplit
 
 # Basenames treated as ``.env`` files by _command_reads_env_file. Imported
 # from agent/file_safety (the read-block list) so the two defenses can't
@@ -1009,6 +1011,195 @@ def redact_sensitive_text(
     return text
 
 
+_DIAGNOSTIC_URL_RE = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
+_URL_TRAILING_PUNCTUATION = ".,;:!?)}"
+_URL_COMPONENT_SEPARATOR_RE = re.compile(r"([:/?#\[\]@!$&'()*+,;=])")
+_PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_PERCENT_RESERVED_ESCAPE_RE = re.compile(
+    r"%(?:2[fF]|3[aA-fF]|4[0aA]|5[bBdD])"
+)
+_URL_ATOM_RUN_RE = re.compile(r"[A-Za-z0-9_-]+")
+_URL_REG_NAME_RE = re.compile(r"(?:[A-Za-z0-9._~-]|%[0-9A-Fa-f]{2})+")
+_UUID_URL_COMPONENT_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
+def _is_opaque_url_atom(value: str) -> bool:
+    """Return whether a decoded URL atom looks like an unlabelled capability."""
+    if _UUID_URL_COMPONENT_RE.fullmatch(value):
+        return True
+    if len(value) < 16 or not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        return False
+    classes = sum(
+        (
+            any(c.islower() for c in value),
+            any(c.isupper() for c in value),
+            any(c.isdigit() for c in value),
+        )
+    )
+    counts = Counter(value)
+    entropy = -sum(
+        (n / len(value)) * math.log2(n / len(value))
+        for n in counts.values()
+    )
+    if value.isdigit():
+        return len(value) >= 24 and entropy >= 3.0
+    if len(value) < 24:
+        return classes >= 2 and entropy >= 3.5
+    return entropy >= (3.5 if classes >= 2 else 4.0)
+
+
+def _is_opaque_url_path_segment(segment: str) -> bool:
+    """Return whether a URL component looks like an unlabelled capability.
+
+    Keep this deliberately conservative: long filenames and human-readable
+    slugs survive, while a long URL-safe component with high character entropy
+    and no word structure is treated as a bearer capability. Classification
+    uses exactly one decoded view and never renders it. A still-encoded escape
+    after that pass is ambiguous double encoding, so diagnostics fail closed.
+    """
+    decoded = unquote(segment)
+    if _PERCENT_ESCAPE_RE.search(decoded):
+        return True
+    candidates = [
+        candidate.group(0)
+        for part in _URL_COMPONENT_SEPARATOR_RE.split(decoded)
+        if part and not _URL_COMPONENT_SEPARATOR_RE.fullmatch(part)
+        for candidate in _URL_ATOM_RUN_RE.finditer(part)
+    ]
+    for candidate in candidates:
+        if _UUID_URL_COMPONENT_RE.fullmatch(candidate):
+            return True
+        # Source context is stronger than morphology. For arbitrary URLs,
+        # preserve human-readable hyphenated slugs unless one individual
+        # segment is independently token-shaped; never classify the joined
+        # phrase by whole-slug entropy.
+        atoms = candidate.split("-") if "-" in candidate else (candidate,)
+        if any(_is_opaque_url_atom(atom) for atom in atoms):
+            return True
+
+    # Percent-encoded reserved separators can split one opaque capability into
+    # several short atoms. Classify that single decoded view as a unit, but do
+    # not apply this join to ordinary unencoded word slugs.
+    return (
+        bool(candidates)
+        and bool(_PERCENT_RESERVED_ESCAPE_RE.search(segment))
+        and _is_opaque_url_atom("".join(candidates))
+    )
+
+
+def project_diagnostic_url_component(component: str) -> str:
+    """Project one untrusted URL-like component for diagnostic display."""
+    return "<redacted>" if _is_opaque_url_path_segment(component) else component
+
+
+def project_configured_mcp_url(url: str) -> str:
+    """Project a known configured remote MCP endpoint deterministically.
+
+    For configured endpoints, source context is the secrecy boundary: any
+    userinfo, non-root path, query, or fragment is sensitive regardless of its
+    morphology. Only transport and authority are retained.
+    """
+    try:
+        parts = urlsplit(url)
+        if parts.scheme.lower() not in {"http", "https"} or parts.hostname is None:
+            raise ValueError("invalid configured MCP URL")
+        _port = parts.port
+        hostinfo = parts.netloc.rpartition("@")[2]
+        root = urlunsplit((parts.scheme, hostinfo, "/", "", ""))
+        if (
+            "@" in parts.netloc
+            or parts.path not in {"", "/"}
+            or parts.query
+            or parts.fragment
+        ):
+            return f"{root}<redacted>"
+        return root
+    except (TypeError, ValueError):
+        scheme, separator, _remainder = str(url).partition("://")
+        return f"{scheme}{separator}<redacted>" if separator else "<redacted>"
+
+
+def _project_diagnostic_url_structure(value: str) -> str:
+    """Project opaque tokens while preserving URL component separators."""
+    return "".join(
+        part
+        if _URL_COMPONENT_SEPARATOR_RE.fullmatch(part)
+        else project_diagnostic_url_component(part)
+        for part in _URL_COMPONENT_SEPARATOR_RE.split(value)
+    )
+
+
+def project_diagnostic_urls(text: str) -> str:
+    """Hide opaque URL capabilities while retaining useful URL context."""
+    if not text or "://" not in text:
+        return text
+
+    def _project(match: re.Match) -> str:
+        raw = match.group(0)
+        url = raw.rstrip(_URL_TRAILING_PUNCTUATION)
+        trailing = raw[len(url):]
+        try:
+            parts = urlsplit(url)
+            if parts.hostname is None:
+                raise ValueError("diagnostic URL has no hostname")
+            _port = parts.port
+            if ":" not in parts.hostname:
+                try:
+                    ascii_hostname = parts.hostname.encode("idna").decode("ascii")
+                except UnicodeError as exc:
+                    raise ValueError("invalid diagnostic URL hostname") from exc
+                if not _URL_REG_NAME_RE.fullmatch(ascii_hostname):
+                    raise ValueError("invalid diagnostic URL hostname")
+            path = _project_diagnostic_url_structure(parts.path)
+
+            netloc = parts.netloc
+            if "@" in netloc:
+                _userinfo, separator, hostinfo = netloc.rpartition("@")
+                netloc = f"<redacted>{separator}{hostinfo}"
+
+            query = _project_diagnostic_url_structure(parts.query)
+            fragment = _project_diagnostic_url_structure(parts.fragment)
+            projected = urlunsplit((parts.scheme, netloc, path, query, fragment))
+            return projected + trailing
+        except (TypeError, ValueError):
+            scheme, separator, _remainder = url.partition("://")
+            return f"{scheme}{separator}<redacted>{trailing}"
+
+    return _DIAGNOSTIC_URL_RE.sub(_project, text)
+
+
+def redact_diagnostic_text(
+    text: str,
+    *,
+    force: bool = False,
+    redact_secrets: bool = True,
+    configured_urls: tuple[str, ...] = (),
+) -> str:
+    """Central safe projection for logs, exceptions, and CLI diagnostics.
+
+    Callers with an existing credential masker may set ``redact_secrets=False``
+    while still applying the shared capability projection.
+    """
+    redacted = text
+    for configured_url in configured_urls:
+        if configured_url:
+            redacted = redacted.replace(
+                configured_url,
+                project_configured_mcp_url(configured_url),
+            )
+    redacted = project_diagnostic_urls(redacted)
+    if redact_secrets:
+        redacted = redact_sensitive_text(
+            redacted,
+            force=force,
+            redact_url_credentials=True,
+        )
+    return redacted
+
+
 # Commands whose stdout is an environment-variable dump (KEY=value lines),
 # NOT source code. For these, terminal-output redaction must run the
 # ENV-assignment pass (code_file=False) so opaque tokens with no recognized
@@ -1424,4 +1615,4 @@ class RedactingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
-        return redact_sensitive_text(original)
+        return redact_diagnostic_text(original)

--- a/cli.py
+++ b/cli.py
@@ -13812,7 +13812,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
-            for noisy in ('openai', 'openai._base_client', 'httpx', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):
+            for noisy in ('openai', 'openai._base_client', 'httpx', 'httpx2', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):
                 logging.getLogger(noisy).setLevel(logging.WARNING)
         else:
             logging.getLogger().setLevel(logging.INFO)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -43,17 +43,33 @@ _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────
 
+def _safe_mcp_diagnostic(
+    value: object,
+    *,
+    configured_url: Optional[str] = None,
+) -> str:
+    """Project untrusted MCP diagnostic text through the shared redactor."""
+    from agent.redact import redact_diagnostic_text
+
+    configured_urls = (configured_url,) if configured_url else ()
+    return redact_diagnostic_text(
+        str(value),
+        force=True,
+        configured_urls=configured_urls,
+    )
+
+
 def _info(text: str):
-    print(color(f"  {text}", Colors.DIM))
+    print(color(f"  {_safe_mcp_diagnostic(text)}", Colors.DIM))
 
 def _success(text: str):
-    print(color(f"  ✓ {text}", Colors.GREEN))
+    print(color(f"  ✓ {_safe_mcp_diagnostic(text)}", Colors.GREEN))
 
 def _warning(text: str):
-    print(color(f"  ⚠ {text}", Colors.YELLOW))
+    print(color(f"  ⚠ {_safe_mcp_diagnostic(text)}", Colors.YELLOW))
 
 def _error(text: str):
-    print(color(f"  ✗ {text}", Colors.RED))
+    print(color(f"  ✗ {_safe_mcp_diagnostic(text)}", Colors.RED))
 
 
 def _confirm(question: str, default: bool = True) -> bool:
@@ -537,7 +553,7 @@ def cmd_mcp_add(args):
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
-        _info(f"Connecting to {url}")
+        _info("Connecting to HTTP server")
         needs_auth = _confirm("Does this server require authentication?", default=True)
         if needs_auth:
             if auth_type == "header" or not auth_type:
@@ -586,8 +602,10 @@ def cmd_mcp_add(args):
     _success(f"Connected! Found {len(tools)} tool(s) from '{name}':")
     print()
     for tool_name, desc in tools:
-        short = desc[:60] + "..." if len(desc) > 60 else desc
-        print(f"    {color(tool_name, Colors.GREEN):40s} {short}")
+        safe_name = _safe_mcp_diagnostic(tool_name)
+        safe_desc = _safe_mcp_diagnostic(desc)
+        short = safe_desc[:60] + "..." if len(safe_desc) > 60 else safe_desc
+        print(f"    {color(safe_name, Colors.GREEN):40s} {short}")
     print()
 
     # Ask: enable all, select, or cancel
@@ -608,7 +626,10 @@ def cmd_mcp_add(args):
         # Interactive tool selection
         from hermes_cli.curses_ui import curses_checklist
 
-        labels = [f"{t[0]}  —  {t[1]}" for t in tools]
+        labels = [
+            f"{_safe_mcp_diagnostic(t[0])}  —  {_safe_mcp_diagnostic(t[1])}"
+            for t in tools
+        ]
         pre_selected = set(range(len(tools)))
 
         chosen = curses_checklist(
@@ -699,11 +720,7 @@ def cmd_mcp_list(args=None):
     for name, cfg in servers.items():
         # Transport info
         if "url" in cfg:
-            url = cfg["url"]
-            # Truncate long URLs
-            if len(url) > 28:
-                url = url[:25] + "..."
-            transport = url
+            transport = "HTTP"
         elif "command" in cfg:
             cmd = cfg["command"]
             cmd_args = cfg.get("args", [])
@@ -736,7 +753,9 @@ def cmd_mcp_list(args=None):
             enabled = enabled.lower() in {"true", "1", "yes"}
         status = color("✓ enabled", Colors.GREEN) if enabled else color("✗ disabled", Colors.DIM)
 
-        print(f"  {name:<16} {transport:<30} {tools_str:<12} {status}")
+        safe_name = _safe_mcp_diagnostic(name)
+        safe_transport = _safe_mcp_diagnostic(transport)
+        print(f"  {safe_name:<16} {safe_transport:<30} {tools_str:<12} {status}")
 
     print()
 
@@ -745,6 +764,8 @@ def cmd_mcp_list(args=None):
 
 def cmd_mcp_test(args):
     """Test connection to an MCP server."""
+    from agent.redact import project_diagnostic_url_component
+
     name = args.name
     servers = _get_mcp_servers()
 
@@ -761,7 +782,17 @@ def cmd_mcp_test(args):
 
     # Show transport info
     if "url" in cfg:
-        _info(f"Transport: HTTP → {cfg['url']}")
+        _info("Transport: HTTP")
+        env_refs = []
+        for ref in _ENV_VAR_PATTERN.findall(str(cfg["url"])):
+            name = _env_ref_name(ref)
+            if not _ENV_VAR_NAME_RE.fullmatch(name):
+                name = "<redacted>"
+            else:
+                name = project_diagnostic_url_component(name)
+            env_refs.append(name)
+        if env_refs:
+            _info(f"URL environment: {', '.join(env_refs)}")
     else:
         cmd = cfg.get("command", "?")
         _info(f"Transport: stdio → {cmd}")
@@ -791,7 +822,14 @@ def cmd_mcp_test(args):
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
-        _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
+        configured_url = None
+        if "url" in cfg:
+            try:
+                configured_url = str(_resolve_mcp_server_config(cfg).get("url") or "")
+            except Exception:
+                configured_url = str(cfg.get("url") or "")
+        diagnostic = _safe_mcp_diagnostic(exc, configured_url=configured_url)
+        _error(f"Connection failed ({elapsed_ms:.0f}ms): {diagnostic}")
         return
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
@@ -800,8 +838,10 @@ def cmd_mcp_test(args):
     if tools:
         print()
         for tool_name, desc in tools:
-            short = desc[:55] + "..." if len(desc) > 55 else desc
-            print(f"    {color(tool_name, Colors.GREEN):36s} {short}")
+            safe_name = _safe_mcp_diagnostic(tool_name)
+            safe_desc = _safe_mcp_diagnostic(desc)
+            short = safe_desc[:55] + "..." if len(safe_desc) > 55 else safe_desc
+            print(f"    {color(safe_name, Colors.GREEN):36s} {short}")
     print()
 
 
@@ -881,7 +921,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             print()
             print(color("    mcp_servers:", Colors.DIM))
             print(color(f"      {name}:", Colors.DIM))
-            print(color(f"        url: {url}", Colors.DIM))
+            print(color("        url: <configured MCP URL>", Colors.DIM))
             print(color("        auth: oauth", Colors.DIM))
             print(color("        oauth:", Colors.DIM))
             print(color("          client_id: \"<your-oauth-client-id>\"", Colors.DIM))
@@ -1058,7 +1098,10 @@ def cmd_mcp_configure(args):
     # Interactive checklist
     from hermes_cli.curses_ui import curses_checklist
 
-    labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
+    labels = [
+        f"{_safe_mcp_diagnostic(t[0])}  —  {_safe_mcp_diagnostic(t[1])}"
+        for t in all_tools
+    ]
 
     chosen = curses_checklist(
         f"Select tools for '{name}'",

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -144,6 +144,7 @@ _NOISY_LOGGERS = (
     "openai",
     "openai._base_client",
     "httpx",
+    "httpx2",
     "httpcore",
     "asyncio",
     "hpack",

--- a/model_tools.py
+++ b/model_tools.py
@@ -31,6 +31,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.redact import redact_diagnostic_text
 from tools.registry import (
     CHECK_FN_CACHE_BYPASS,
     check_fn_cache_scope,
@@ -833,6 +834,7 @@ def _sanitize_tool_error(error_msg: str) -> str:
     sanitized = _TOOL_ERROR_FENCE_OPEN_RE.sub("", sanitized)
     sanitized = _TOOL_ERROR_FENCE_CLOSE_RE.sub("", sanitized)
     sanitized = _TOOL_ERROR_CDATA_RE.sub("", sanitized)
+    sanitized = redact_diagnostic_text(sanitized, force=True)
     if len(sanitized) > _TOOL_ERROR_MAX_LEN:
         sanitized = sanitized[:_TOOL_ERROR_MAX_LEN - 3] + "..."
     return f"[TOOL_ERROR] {sanitized}"

--- a/tests/security/test_mcp_url_diagnostics.py
+++ b/tests/security/test_mcp_url_diagnostics.py
@@ -1,0 +1,580 @@
+"""Security regressions for opaque capabilities in MCP diagnostics."""
+
+import logging
+from types import SimpleNamespace
+
+
+CAPABILITY = "q7ZP3mN8vK2xR9tW4cY6bH1jF5sL0dG7"
+CAPABILITY_URL = f"https://mcp.example.invalid/api/connect/{CAPABILITY}/events"
+ORDINARY_URL = "https://docs.example.invalid/guides/setup/index.html"
+
+
+def test_url_projection_covers_structural_capability_shapes():
+    from agent.redact import redact_diagnostic_text
+
+    capabilities = (
+        "550e8400-e29b-41d4-a716-446655440000",
+        "q7ZP3mN8vK2xR9tW",
+        "abcdefghijklmnopqrstuvwxyzabcdef",
+    )
+
+    for capability in capabilities:
+        rendered = redact_diagnostic_text(
+            f"failed at https://mcp.example.invalid/connect/{capability}/events; "
+            f"documentation: {ORDINARY_URL}",
+            force=True,
+        )
+        assert capability not in rendered
+        assert "https://mcp.example.invalid/connect/<redacted>/events" in rendered
+        assert ORDINARY_URL in rendered
+
+
+def test_url_projection_covers_query_fragment_and_userinfo_capabilities():
+    from agent.redact import redact_diagnostic_text
+
+    query_capability = "q7ZP3mN8vK2xR9tW4cY6bH1jF5sL0dG7"
+    fragment_capability = "m8Qv2Nx7Kp4Rt9Wy6Bc3Dh1F"
+    userinfo_capability = "u7Qm3Zx9Vp2Ks8Rw5Cd1"
+    url = (
+        f"https://{userinfo_capability}@mcp.example.invalid/connect"
+        f"?relay={query_capability}&view=public#{fragment_capability}"
+    )
+
+    rendered = redact_diagnostic_text(f"request failed for {url}", force=True)
+
+    for capability in (query_capability, fragment_capability, userinfo_capability):
+        assert capability not in rendered
+    assert "https://" + "***" + "@mcp.example.invalid/connect" in rendered
+    assert "relay=<redacted>&view=public#<redacted>" in rendered
+
+
+def test_url_projection_covers_bare_query_capability_and_preserves_ordinary_query():
+    from agent.redact import project_diagnostic_urls
+
+    url = f"https://mcp.example.invalid/callback?{CAPABILITY}"
+    rendered = project_diagnostic_urls(
+        f"request failed for {url}; docs: {ORDINARY_URL}?printable"
+    )
+
+    assert CAPABILITY not in rendered
+    assert url not in rendered
+    assert "https://mcp.example.invalid/callback?<redacted>" in rendered
+    assert f"{ORDINARY_URL}?printable" in rendered
+
+
+def test_url_projection_covers_single_encoded_reserved_character_capabilities():
+    from agent.redact import project_diagnostic_urls
+
+    encoded_capabilities = (
+        f"{CAPABILITY[:18]}%2F{CAPABILITY[18:]}",
+        f"{CAPABILITY[:18]}%26{CAPABILITY[18:]}",
+        f"{CAPABILITY[:18]}%3F{CAPABILITY[18:]}",
+    )
+    urls = (
+        f"https://mcp.example.invalid/connect/{encoded_capabilities[0]}/events",
+        f"https://mcp.example.invalid/callback?relay={encoded_capabilities[1]}",
+        f"https://mcp.example.invalid/#relay={encoded_capabilities[2]}",
+    )
+
+    for url, encoded_capability in zip(urls, encoded_capabilities, strict=True):
+        rendered = project_diagnostic_urls(f"request failed for {url}")
+
+        assert encoded_capability not in rendered
+        assert CAPABILITY not in rendered
+        assert "<redacted>" in rendered
+
+
+def test_url_projection_covers_capability_split_by_repeated_encoded_separators():
+    from agent.redact import project_diagnostic_urls
+
+    encoded_capability = "%2F".join(
+        CAPABILITY[index : index + 8] for index in range(0, len(CAPABILITY), 8)
+    )
+    url = f"https://mcp.example.invalid/connect/{encoded_capability}/events"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert encoded_capability not in rendered
+    assert rendered == (
+        "request failed for https://mcp.example.invalid/connect/<redacted>/events"
+    )
+
+
+def test_url_projection_covers_high_entropy_numeric_capability():
+    from agent.redact import project_diagnostic_urls
+
+    numeric_capability = "3141592653589793238462643383279502884197"
+    url = f"https://mcp.example.invalid/connect/{numeric_capability}/events"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert numeric_capability not in rendered
+    assert rendered == (
+        "request failed for https://mcp.example.invalid/connect/<redacted>/events"
+    )
+
+
+def test_url_projection_preserves_ordinary_single_encoded_component():
+    from agent.redact import project_diagnostic_urls
+
+    url = "https://docs.example.invalid/guides/setup%20guide/index.html"
+
+    assert project_diagnostic_urls(f"documentation: {url}") == f"documentation: {url}"
+
+
+def test_url_projection_preserves_human_readable_hyphenated_slugs():
+    from agent.redact import project_diagnostic_urls
+
+    slugs = (
+        "getting-started-with-python3",
+        "api-reference-v2-endpoints",
+        "ultra-widget-model-1234",
+    )
+
+    for slug in slugs:
+        url = f"https://docs.example.invalid/guides/{slug}"
+        assert project_diagnostic_urls(f"documentation: {url}") == f"documentation: {url}"
+
+
+def test_configured_mcp_url_projection_redacts_every_non_root_component():
+    from agent.redact import project_configured_mcp_url
+
+    assert project_configured_mcp_url("https://mcp.example.invalid/") == (
+        "https://mcp.example.invalid/"
+    )
+    for configured_url in (
+        "https://mcp.example.invalid/english-word-shaped-token",
+        "https://mcp.example.invalid/?relay=public-looking",
+        "https://mcp.example.invalid/#public-looking",
+        "https://" + "fabricated-user" + "@mcp.example.invalid/",
+    ):
+        rendered = project_configured_mcp_url(configured_url)
+        assert "english-word-shaped-token" not in rendered
+        assert "public-looking" not in rendered
+        assert "fabricated-user" not in rendered
+        assert rendered == "https://mcp.example.invalid/<redacted>"
+
+    assert project_configured_mcp_url("not-a-url") == "<redacted>"
+
+
+def test_url_projection_fails_closed_for_double_encoding_ambiguity():
+    from agent.redact import project_diagnostic_urls
+
+    ambiguous_component = f"{CAPABILITY[:18]}%252F{CAPABILITY[18:]}"
+    url = f"https://mcp.example.invalid/connect/{ambiguous_component}/events"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert ambiguous_component not in rendered
+    assert rendered == (
+        "request failed for https://mcp.example.invalid/connect/<redacted>/events"
+    )
+
+
+def test_url_projection_covers_capability_before_diagnostic_suffixes():
+    from agent.redact import project_diagnostic_urls
+
+    for suffix in ("`", "\x1b[0m", "—", "\\", "|"):
+        rendered = project_diagnostic_urls(
+            f"request failed for https://mcp.example.invalid/connect/{CAPABILITY}{suffix}"
+        )
+
+        assert CAPABILITY not in rendered
+        assert "<redacted>" in rendered
+
+
+def test_url_projection_fails_closed_for_malformed_authority():
+    from agent.redact import project_diagnostic_urls
+
+    rendered = project_diagnostic_urls(
+        f"request failed for https://[broken.invalid/connect/{CAPABILITY}/events"
+    )
+
+    assert CAPABILITY not in rendered
+    assert rendered == "request failed for https://<redacted>"
+
+
+def test_url_projection_covers_capability_in_structured_fragment():
+    from agent.redact import project_diagnostic_urls
+
+    url = f"https://mcp.example.invalid/#/connect/{CAPABILITY}"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert CAPABILITY not in rendered
+    assert rendered == (
+        "request failed for https://mcp.example.invalid/#/connect/<redacted>"
+    )
+
+
+def test_url_projection_covers_capability_in_query_like_fragment():
+    from agent.redact import project_diagnostic_urls
+
+    url = f"https://mcp.example.invalid/#/connect?relay={CAPABILITY}&view=public"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert CAPABILITY not in rendered
+    assert rendered == (
+        "request failed for "
+        "https://mcp.example.invalid/#/connect?relay=<redacted>&view=public"
+    )
+
+
+def test_url_projection_fails_closed_for_invalid_port_authority():
+    from agent.redact import project_diagnostic_urls
+
+    url = f"https://mcp.example.invalid:{CAPABILITY}/status"
+    rendered = project_diagnostic_urls(f"request failed for {url}")
+
+    assert CAPABILITY not in rendered
+    assert rendered == "request failed for https://<redacted>"
+
+
+def test_url_projection_fails_closed_for_forbidden_authority_characters():
+    from agent.redact import project_diagnostic_urls
+
+    for separator in ("\\", "|", "%"):
+        url = f"https://mcp.example.invalid{separator}{CAPABILITY}/status"
+        rendered = project_diagnostic_urls(f"request failed for {url}")
+
+        assert CAPABILITY not in rendered
+        assert rendered == "request failed for https://<redacted>"
+
+
+def test_url_projection_preserves_valid_authority_only_ipv6_url():
+    from agent.redact import project_diagnostic_urls
+
+    url = "https://[2001:db8::1]"
+
+    assert project_diagnostic_urls(f"request failed for {url}") == (
+        f"request failed for {url}"
+    )
+
+
+def test_url_projection_and_diagnostic_boundaries(capsys, monkeypatch):
+    from agent.redact import RedactingFormatter, redact_diagnostic_text
+    from hermes_cli import mcp_config
+    from model_tools import _sanitize_tool_error
+
+    projected = redact_diagnostic_text(
+        f"failed at {CAPABILITY_URL}; documentation: {ORDINARY_URL}", force=True
+    )
+    assert CAPABILITY not in projected
+    assert "https://mcp.example.invalid/api/connect/<redacted>/events" in projected
+    assert ORDINARY_URL in projected
+
+    stream = __import__("io").StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(RedactingFormatter("%(levelname)s %(message)s"))
+    record = logging.LogRecord(
+        "tools.mcp_tool",
+        logging.ERROR,
+        __file__,
+        1,
+        "MCP exception: %s",
+        (RuntimeError(CAPABILITY_URL),),
+        None,
+    )
+    handler.handle(record)
+    full_log = stream.getvalue()
+    assert CAPABILITY not in full_log
+    assert CAPABILITY_URL not in full_log
+    assert "<redacted>" in full_log
+
+    tool_error = _sanitize_tool_error(f"connection failed: {CAPABILITY_URL}")
+    assert CAPABILITY not in tool_error
+    assert CAPABILITY_URL not in tool_error
+    assert "<redacted>" in tool_error
+
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": "${env:FABRICATED_MCP_URL}"}},
+    )
+    monkeypatch.setenv("FABRICATED_MCP_URL", CAPABILITY_URL)
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError(CAPABILITY_URL)),
+    )
+    mcp_config.cmd_mcp_test(SimpleNamespace(name="fabricated"))
+    captured = capsys.readouterr()
+    full_cli_output = captured.out + captured.err
+    assert "fabricated" in full_cli_output
+    assert "Transport: HTTP" in full_cli_output
+    assert "FABRICATED_MCP_URL" in full_cli_output
+    assert CAPABILITY not in full_cli_output
+    assert CAPABILITY_URL not in full_cli_output
+    assert "<redacted>" in full_cli_output
+
+
+def test_mcp_test_sanitizes_successful_server_controlled_output(capsys, monkeypatch):
+    from hermes_cli import mcp_config
+
+    capability_desc_url = f"https://m.invalid/{CAPABILITY}"
+    ordinary_tool_url = "https://docs.example.invalid/help"
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": "https://mcp.example.invalid/safe"}},
+    )
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: [
+            (f"https://mcp.example.invalid/tools/{CAPABILITY}", "capability tool"),
+            ("capability_desc", f"Docs: {capability_desc_url}"),
+            ("ordinary_tool", f"Docs: {ordinary_tool_url}"),
+        ],
+    )
+
+    mcp_config.cmd_mcp_test(SimpleNamespace(name="fabricated"))
+    captured = capsys.readouterr()
+    full_cli_output = captured.out + captured.err
+    assert CAPABILITY not in full_cli_output
+    assert CAPABILITY_URL not in full_cli_output
+    assert "https://mcp.example.invalid/tools/<redacted>" in full_cli_output
+    assert "https://m.invalid/<redacted>" in full_cli_output
+    assert ordinary_tool_url in full_cli_output
+
+
+def test_mcp_test_sanitizes_untrusted_url_environment_reference(capsys, monkeypatch):
+    from hermes_cli import mcp_config
+
+    malicious_ref = "https://" + "m.invalid/" + CAPABILITY
+    configured_url = "${env:" + malicious_ref + "}"
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": configured_url}},
+    )
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: [],
+    )
+
+    mcp_config.cmd_mcp_test(SimpleNamespace(name="fabricated"))
+    captured = capsys.readouterr()
+    full_cli_output = captured.out + captured.err
+
+    assert CAPABILITY not in full_cli_output
+    assert malicious_ref not in full_cli_output
+    assert "URL environment: <redacted>" in full_cli_output
+
+
+def test_mcp_add_sanitizes_url_errors_and_server_controlled_tools(capsys, monkeypatch):
+    from hermes_cli import mcp_config
+
+    monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {})
+    monkeypatch.setattr(mcp_config, "validate_mcp_server_entry", lambda *_args: [])
+    monkeypatch.setattr(mcp_config, "_confirm", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: [
+            (f"https://mcp.example.invalid/tools/{CAPABILITY}", CAPABILITY_URL)
+        ],
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    mcp_config.cmd_mcp_add(
+        SimpleNamespace(
+            name="fabricated",
+            url=CAPABILITY_URL,
+            mcp_command=None,
+            args=[],
+            auth=None,
+            preset=None,
+            env=None,
+            connect_timeout=None,
+        )
+    )
+    full_cli_output = capsys.readouterr().out
+
+    assert CAPABILITY not in full_cli_output
+    assert CAPABILITY_URL not in full_cli_output
+    assert "<redacted>" in full_cli_output
+
+
+def test_mcp_list_never_renders_configured_http_url(capsys, monkeypatch):
+    from hermes_cli import mcp_config
+
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": CAPABILITY_URL}},
+    )
+
+    mcp_config.cmd_mcp_list()
+    full_cli_output = capsys.readouterr().out
+
+    assert "fabricated" in full_cli_output
+    assert "HTTP" in full_cli_output
+    assert CAPABILITY not in full_cli_output
+    assert CAPABILITY_URL not in full_cli_output
+
+
+def test_mcp_configure_sanitizes_server_controlled_checklist_labels(
+    capsys, monkeypatch
+):
+    from hermes_cli import curses_ui, mcp_config
+
+    labels_seen = []
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": "https://mcp.example.invalid/safe"}},
+    )
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: [("fabricated_tool", CAPABILITY_URL)],
+    )
+
+    def _capture_labels(_title, labels, pre_selected):
+        labels_seen.extend(labels)
+        return pre_selected
+
+    monkeypatch.setattr(curses_ui, "curses_checklist", _capture_labels)
+
+    mcp_config.cmd_mcp_configure(SimpleNamespace(name="fabricated"))
+
+    assert CAPABILITY not in "".join(labels_seen)
+    assert "<redacted>" in "".join(labels_seen)
+    assert "No changes made" in capsys.readouterr().out
+
+
+def test_mcp_specific_error_sanitizer_uses_central_projection():
+    from tools.mcp_tool import _sanitize_error
+
+    rendered = _sanitize_error(f"transport failed at {CAPABILITY_URL}")
+
+    assert CAPABILITY not in rendered
+    assert CAPABILITY_URL not in rendered
+    assert "https://mcp.example.invalid/api/connect/<redacted>/events" in rendered
+
+
+def test_mcp_error_sanitizer_uses_configured_url_context_for_slug_capability():
+    from tools.mcp_tool import _sanitize_error
+
+    configured_url = "https://mcp.example.invalid/english-word-shaped-token"
+    rendered = _sanitize_error(
+        f"transport failed at {configured_url}",
+        configured_url=configured_url,
+    )
+
+    assert "english-word-shaped-token" not in rendered
+    assert rendered == (
+        "transport failed at https://mcp.example.invalid/<redacted>"
+    )
+
+
+def test_mcp_connect_error_uses_configured_url_context_for_slug_capability():
+    from tools.mcp_tool import _format_connect_error
+
+    configured_url = "https://mcp.example.invalid/english-word-shaped-token"
+    rendered = _format_connect_error(
+        RuntimeError(f"transport failed at {configured_url}"),
+        configured_url=configured_url,
+    )
+
+    assert "english-word-shaped-token" not in rendered
+    assert rendered == (
+        "transport failed at https://mcp.example.invalid/<redacted>"
+    )
+
+
+def test_mcp_error_sanitizer_masks_explicit_url_credential_keys():
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "fabricated-signature-value"
+    rendered = _sanitize_error(
+        f"transport failed at https://mcp.example.invalid/callback?signature={secret}&view=public"
+    )
+
+    assert secret not in rendered
+    assert "?[REDACTED]&view=public" in rendered
+
+
+def test_mcp_test_uses_configured_url_context_for_slug_capability(
+    capsys, monkeypatch
+):
+    from hermes_cli import mcp_config
+
+    configured_url = "https://mcp.example.invalid/english-word-shaped-token"
+    monkeypatch.setattr(
+        mcp_config,
+        "_get_mcp_servers",
+        lambda: {"fabricated": {"url": configured_url}},
+    )
+    monkeypatch.setattr(
+        mcp_config,
+        "_probe_single_server",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError(configured_url)),
+    )
+
+    mcp_config.cmd_mcp_test(SimpleNamespace(name="fabricated"))
+    captured = capsys.readouterr()
+    full_cli_output = captured.out + captured.err
+
+    assert "english-word-shaped-token" not in full_cli_output
+    assert "https://mcp.example.invalid/<redacted>" in full_cli_output
+
+
+def test_diagnostic_projection_masks_named_url_credentials():
+    from agent.redact import redact_diagnostic_text
+
+    secret = "fabricated-query-capability"
+    url = f"https://mcp.example.invalid/callback?token={secret}&view=public"
+    rendered = redact_diagnostic_text(f"request failed for {url}", force=True)
+
+    assert secret not in rendered
+    assert "https://mcp.example.invalid/callback?token=***&view=public" in rendered
+
+
+def test_acp_logging_suppresses_httpx2_info():
+    from acp_adapter.entry import _setup_logging
+
+    root = logging.getLogger()
+    previous_handlers = list(root.handlers)
+    previous_root_level = root.level
+    httpx2_logger = logging.getLogger("httpx2")
+    previous_httpx2_level = httpx2_logger.level
+    try:
+        httpx2_logger.setLevel(logging.NOTSET)
+        _setup_logging()
+        assert httpx2_logger.level == logging.WARNING
+    finally:
+        for handler in root.handlers:
+            if handler not in previous_handlers:
+                handler.close()
+        root.handlers[:] = previous_handlers
+        root.setLevel(previous_root_level)
+        httpx2_logger.setLevel(previous_httpx2_level)
+
+
+def test_httpx2_info_is_suppressed_in_verbose_log_output(capsys):
+    import hermes_logging
+
+    logger = logging.getLogger("httpx2")
+    previous_level = logger.level
+    root = logging.getLogger()
+    previous_root_level = root.level
+    added = []
+    try:
+        for handler in list(root.handlers):
+            if getattr(handler, "_hermes_verbose", False):
+                root.removeHandler(handler)
+        before = set(root.handlers)
+        logger.setLevel(logging.NOTSET)
+        hermes_logging.setup_verbose_logging()
+        added = [handler for handler in root.handlers if handler not in before]
+        logger.info("fabricated httpx2 request detail")
+        logger.warning("fabricated httpx2 warning")
+        output = capsys.readouterr().err
+        assert "fabricated httpx2 request detail" not in output
+        assert "fabricated httpx2 warning" in output
+    finally:
+        for handler in added:
+            root.removeHandler(handler)
+            handler.close()
+        logger.setLevel(previous_level)
+        root.setLevel(previous_root_level)

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1328,6 +1328,42 @@ class TestSanitizeError:
         result = _sanitize_error("normal error message")
         assert result == "normal error message"
 
+    def test_strips_unnamed_query_capability(self):
+        from tools.mcp_tool import _sanitize_error
+
+        capability = "q7ZP3mN8vK2xR9tW4cY6bH1jF5sL0dG7"
+        result = _sanitize_error(
+            f"request failed: https://mcp.example.invalid/cb?{capability}"
+        )
+
+        assert capability not in result
+        assert "https://mcp.example.invalid/cb?<redacted>" in result
+
+    def test_strips_opaque_userinfo_capability(self):
+        from tools.mcp_tool import _sanitize_error
+
+        capability = "u7Qm3Zx9Vp2Ks8Rw5Cd1"
+        result = _sanitize_error(
+            f"request failed: https://{capability}@mcp.example.invalid/cb"
+        )
+
+        assert capability not in result
+        assert "https://<redacted>@mcp.example.invalid/cb" in result
+
+    def test_strips_short_user_password_while_preserving_url_structure(self):
+        from tools.mcp_tool import _sanitize_error
+
+        result = _sanitize_error(
+            "request failed: https://bob:pw@mcp.example.invalid:8443/cb/status"
+        )
+
+        assert "bob" not in result
+        assert "pw" not in result
+        assert result == (
+            "request failed: "
+            "https://<redacted>@mcp.example.invalid:8443/cb/status"
+        )
+
 # ---------------------------------------------------------------------------
 # HTTP config
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -117,6 +117,7 @@ from datetime import datetime
 from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
+from agent.redact import redact_diagnostic_text
 from tools.registry import tool_error
 from tools.ansi_strip import strip_unicode_tags
 
@@ -660,7 +661,13 @@ _CREDENTIAL_PATTERN = re.compile(
     r"|Bearer\s+\S+"                      # Bearer token
     r"|token=[^\s&,;\"']{1,255}"         # token=...
     r"|key=[^\s&,;\"']{1,255}"           # key=...
+    r"|auth=[^\s&,;\"']{1,255}"          # auth=...
+    r"|signature=[^\s&,;\"']{1,255}"     # signature=...
+    r"|sig=[^\s&,;\"']{1,255}"           # sig=...
+    r"|code=[^\s&,;\"']{1,255}"          # OAuth code=...
+    r"|session=[^\s&,;\"']{1,255}"       # session=...
     r"|API_KEY=[^\s&,;\"']{1,255}"       # API_KEY=...
+    r"|api-key=[^\s&,;\"']{1,255}"       # api-key=...
     r"|password=[^\s&,;\"']{1,255}"      # password=...
     r"|secret=[^\s&,;\"']{1,255}"        # secret=...
     r")",
@@ -765,13 +772,19 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     return env
 
 
-def _sanitize_error(text: str) -> str:
+def _sanitize_error(text: str, *, configured_url: Optional[str] = None) -> str:
     """Strip credential-like patterns from error text before returning to LLM.
 
     Replaces tokens, keys, and other secrets with [REDACTED] to prevent
     accidental credential exposure in tool error responses.
     """
-    return _CREDENTIAL_PATTERN.sub("[REDACTED]", text)
+    redacted = _CREDENTIAL_PATTERN.sub("[REDACTED]", text)
+    configured_urls = (configured_url,) if configured_url else ()
+    return redact_diagnostic_text(
+        redacted,
+        redact_secrets=False,
+        configured_urls=configured_urls,
+    )
 
 
 def _exc_str(exc: BaseException) -> str:
@@ -1688,7 +1701,11 @@ def _make_redirect_header_stripper(
     return _strip_on_cross_origin_redirect
 
 
-def _format_connect_error(exc: BaseException) -> str:
+def _format_connect_error(
+    exc: BaseException,
+    *,
+    configured_url: Optional[str] = None,
+) -> str:
     """Render nested MCP connection errors into an actionable short message."""
 
     def _find_missing(current: BaseException) -> Optional[str]:
@@ -1739,13 +1756,16 @@ def _format_connect_error(exc: BaseException) -> str:
                 "or set mcp_servers.<name>.command to an absolute path and include "
                 "that directory in mcp_servers.<name>.env.PATH)"
             )
-        return _sanitize_error(message)
+        return _sanitize_error(message, configured_url=configured_url)
 
     deduped: List[str] = []
     for item in _flatten_messages(exc):
         if item not in deduped:
             deduped.append(item)
-    return _sanitize_error("; ".join(deduped[:3]))
+    return _sanitize_error(
+        "; ".join(deduped[:3]),
+        configured_url=configured_url,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2944,11 +2964,15 @@ class MCPServerTask:
             await asyncio.wait_for(self._keepalive_probe(), timeout=timeout)
         except Exception as exc:
             root = _unwrap_exception_group(exc)
+            root_diagnostic = _sanitize_error(
+                _exc_str(root),
+                configured_url=self._config.get("url"),
+            )
             logger.warning(
                 "MCP server '%s': suspect connection (%s) failed health "
                 "check (%s: %s) — requesting reconnect (state: suspect → "
                 "degraded)",
-                self.name, reason, type(root).__name__, root,
+                self.name, reason, type(root).__name__, root_diagnostic,
             )
             self._suspect_reason = None
             self.mark_suspect(f"health check failed after {reason}")
@@ -3105,13 +3129,18 @@ class MCPServerTask:
                         await _probe_under_lock()
                     except Exception as exc:
                         root = _unwrap_exception_group(exc)
+                        root_diagnostic = _sanitize_error(
+                            _exc_str(root),
+                            configured_url=self._config.get("url"),
+                        )
                         logger.warning(
                             "MCP server '%s' keepalive failed, triggering "
                             "reconnect (state: connected → degraded): %s: %s",
-                            self.name, type(root).__name__, root,
+                            self.name, type(root).__name__, root_diagnostic,
                         )
                         self.mark_suspect(
-                            f"keepalive failed: {type(root).__name__}: {root}"
+                            f"keepalive failed: {type(root).__name__}: "
+                            f"{root_diagnostic}"
                         )
                         self._reconnect_event.set()
                         break
@@ -4137,12 +4166,16 @@ class MCPServerTask:
                 # Empty dead-pipe errors still get a name this way
                 # (e.g. "BrokenPipeError: ").
                 root = _unwrap_exception_group(exc)
+                root_diagnostic = _sanitize_error(
+                    _exc_str(root),
+                    configured_url=config.get("url"),
+                )
                 failure_class = _classify_mcp_failure(root)
                 if self._is_recycled_stdio():
                     logger.warning(
                         "MCP server '%s': lazy reconnect after stdio recycle "
                         "failed, marking unavailable while retrying: %s: %s",
-                        self.name, type(root).__name__, root,
+                        self.name, type(root).__name__, root_diagnostic,
                     )
                     self._recycled_reason = None
 
@@ -4178,14 +4211,14 @@ class MCPServerTask:
                                 "with `hermes mcp login %s` "
                                 "(state: connecting → parked): %s: %s",
                                 self.name, self.name,
-                                type(root).__name__, root,
+                                type(root).__name__, root_diagnostic,
                             )
                         else:
                             logger.warning(
                                 "MCP server '%s' failed initial connection with a "
                                 "permanent error, parking without retries "
                                 "(state: connecting → parked): %s: %s",
-                                self.name, type(root).__name__, root,
+                                self.name, type(root).__name__, root_diagnostic,
                             )
                         self._error = exc
                         self._ready.set()
@@ -4217,7 +4250,7 @@ class MCPServerTask:
                             "%d attempts, parking until a reconnect is "
                             "requested (state: connecting → parked): %s: %s",
                             self.name, _MAX_INITIAL_CONNECT_RETRIES,
-                            type(root).__name__, root,
+                            type(root).__name__, root_diagnostic,
                         )
                         self._error = exc
                         self._ready.set()
@@ -4247,7 +4280,7 @@ class MCPServerTask:
                         "(attempt %d/%d), retrying in %.0fs: %s: %s",
                         self.name, initial_retries,
                         _MAX_INITIAL_CONNECT_RETRIES, backoff,
-                        type(root).__name__, root,
+                        type(root).__name__, root_diagnostic,
                     )
                     await asyncio.sleep(_jittered(backoff))
                     backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
@@ -4263,7 +4296,7 @@ class MCPServerTask:
                 if self._shutdown_event.is_set():
                     logger.debug(
                         "MCP server '%s' disconnected during shutdown: %s: %s",
-                        self.name, type(root).__name__, root,
+                        self.name, type(root).__name__, root_diagnostic,
                     )
                     return
 
@@ -4283,14 +4316,14 @@ class MCPServerTask:
                     ):
                         self._permanent_grace_used = True
                         self.mark_suspect(
-                            f"auth error on proven session: {root}"
+                            f"auth error on proven session: {root_diagnostic}"
                         )
                         logger.warning(
                             "MCP server '%s': auth error on a previously "
                             "healthy session — marking suspect and forcing "
                             "one reconnect instead of parking (state: "
                             "connected → suspect): %s: %s",
-                            self.name, type(root).__name__, root,
+                            self.name, type(root).__name__, root_diagnostic,
                         )
                         self._reconnect_retries = 0
                         backoff = 1.0
@@ -4307,7 +4340,7 @@ class MCPServerTask:
                         "without retries; will self-probe every %ds "
                         "(state: connected → parked): %s: %s",
                         self.name, _PARKED_RETRY_INTERVAL,
-                        type(root).__name__, root,
+                        type(root).__name__, root_diagnostic,
                     )
                     self._was_parked = True
                     self._deregister_tools()
@@ -4335,7 +4368,7 @@ class MCPServerTask:
                         "(state: degraded → parked): %s: %s",
                         self.name, _MAX_RECONNECT_RETRIES,
                         _PARKED_RETRY_INTERVAL,
-                        type(root).__name__, root,
+                        type(root).__name__, root_diagnostic,
                     )
                     # Do NOT return — exiting the task orphans the server:
                     # nothing would ever listen for _reconnect_event again
@@ -4376,7 +4409,7 @@ class MCPServerTask:
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s: %s",
                     self.name, self._reconnect_retries, _MAX_RECONNECT_RETRIES,
-                    backoff, type(root).__name__, root,
+                    backoff, type(root).__name__, root_diagnostic,
                 )
                 await asyncio.sleep(_jittered(backoff))
                 backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
@@ -5941,7 +5974,10 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     try:
         _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
     except BaseException as exc:
-        message = _format_connect_error(exc)
+        message = _format_connect_error(
+            exc,
+            configured_url=config.get("url"),
+        )
         with _lock:
             _server_connecting.discard(server_name)
             _server_connect_errors[server_name] = message
@@ -7768,7 +7804,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         for name, result in zip(server_names, results):
             if isinstance(result, BaseException):
                 command = new_servers.get(name, {}).get("command")
-                message = _format_connect_error(result)
+                message = _format_connect_error(
+                    result,
+                    configured_url=new_servers.get(name, {}).get("url"),
+                )
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors[name] = message


### PR DESCRIPTION
## Summary

- add one central projection path for URLs rendered in diagnostics
- deterministically hide non-root path, query, fragment, and userinfo in configured or resolved remote MCP endpoints
- redact opaque path/query/fragment/userinfo capability values from untrusted diagnostic text while preserving ordinary human-readable URLs
- route MCP logs, tool errors, CLI diagnostics, and successful `hermes mcp test` server-controlled strings through the projector
- suppress `httpx2` INFO request logging alongside `httpx` and `httpcore`

## Why

Opaque capability values can be embedded in URL paths, bare or named queries, fragments, and userinfo. Those values may not match conventional secret names or vendor prefixes, so they can otherwise survive error handling and appear in logs, MCP diagnostics, tool responses, HTTP request output, or successful probe output.

This change uses source context as the strongest boundary: configured remote MCP endpoints never render their resolved non-root components. For arbitrary URLs in diagnostic text, it applies bounded structural detection to UUIDs, explicit credential keys, long opaque tokens, encoded ambiguity, and token-shaped segments, while retaining useful ordinary URL structure.

An existing proposal, #24302, covers named credential query values and userinfo on several MCP paths. This patch addresses the broader capability-URL case, including opaque and bare values, paths, fragments, configured-endpoint projection, successful server-controlled probe strings, and `httpx2` request logging.

## Validation

- `scripts/run_tests.sh tests/security/test_mcp_url_diagnostics.py tests/hermes_cli/test_mcp_config.py tests/test_hermes_logging.py tests/agent/test_redact.py tests/test_sanitize_tool_error.py tests/tools/test_mcp_tool.py`
  - 304 passed, 0 failed, 2 skipped
  - the skips are Windows-only tests on the Linux host
- `uvx --from ruff==0.15.10 ruff check` on all nine changed Python paths
  - passed
- `git diff --check origin/main...HEAD`
  - passed

## Deliberate residual trade-off

Arbitrary short, low-entropy, English-word-shaped, or deliberately slug-shaped bearer tokens cannot be distinguished reliably from benign human-readable paths. This patch therefore preserves ordinary slugs unless an explicit credential form or independently opaque component is present. Configured or resolved MCP endpoints remain protected deterministically regardless of token morphology. Hostname-label and IPv6-scope credential classification are intentionally out of scope to avoid speculative authority over-redaction.
