### PR TITLE
fix(kanban): durable worker exit sidecar so one-shot dispatch can classify orphaned worker deaths

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21625,9 +21625,42 @@ def main(
                                     _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
+                        # Durably self-record the worker's exit code beside its
+                        # log (troubleshooting#83): under one-shot dispatch the
+                        # dispatcher is usually dead by now, init reaps this
+                        # process, and no hermes process ever sees the wait
+                        # status — so without this record a later dispatch
+                        # classifies the death as "unknown"/"crashed" and burns
+                        # the retry budget even for quota-wall exits.
+                        if os.environ.get("HERMES_KANBAN_TASK"):
+                            try:
+                                from hermes_cli.kanban_db import (
+                                    record_worker_exit_status as _rec_exit,
+                                )
+                                _rec_exit(
+                                    os.environ["HERMES_KANBAN_TASK"],
+                                    os.getpid(),
+                                    _exit_code,
+                                    board=os.environ.get("HERMES_KANBAN_BOARD"),
+                                )
+                            except Exception:
+                                pass
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails
+                if os.environ.get("HERMES_KANBAN_TASK"):
+                    try:
+                        from hermes_cli.kanban_db import (
+                            record_worker_exit_status as _rec_exit,
+                        )
+                        _rec_exit(
+                            os.environ["HERMES_KANBAN_TASK"],
+                            os.getpid(),
+                            1,
+                            board=os.environ.get("HERMES_KANBAN_BOARD"),
+                        )
+                    except Exception:
+                        pass
                 sys.exit(1)
             else:
                 # Single-query mode (`hermes chat -q "…"`): skip the welcome

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8131,7 +8131,96 @@ def _record_worker_exit(pid: int, raw_status: int) -> None:
             _recent_worker_exits.pop(_pid, None)
 
 
-def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
+def worker_exit_record_path(task_id: str, board: Optional[str] = None) -> Path:
+    """Path of the durable per-task worker exit sidecar.
+
+    Lives beside the worker log under the board's ``logs/`` dir so it
+    shares the board's isolation and GC story.
+    """
+    return worker_logs_dir(board=board) / f"{task_id}.exit.json"
+
+
+def record_worker_exit_status(
+    task_id: str,
+    pid: int,
+    exit_code: int,
+    *,
+    board: Optional[str] = None,
+) -> bool:
+    """Durably record a worker's own exit code for later classification.
+
+    Written by the WORKER PROCESS ITSELF on its controlled exit paths
+    (see the kanban exit-code branch in ``cli.py``). This exists because
+    the in-process ``_recent_worker_exits`` registry only works when the
+    dispatcher that spawned the worker is still alive to ``waitpid`` it.
+    Workers are spawned with ``start_new_session=True`` and the Popen
+    handle abandoned, so under one-shot ``hermes kanban dispatch`` the
+    dispatcher exits first, the worker is orphaned to init, init reaps
+    it, and NO hermes process ever observes the wait status. A later
+    dispatch then classifies every death as ``unknown`` -> ``crashed``,
+    which burns the retry budget even for quota-wall exits that were
+    deliberately assigned ``KANBAN_RATE_LIMIT_EXIT_CODE`` so they would
+    NOT count as failures (troubleshooting#83).
+
+    Best-effort: returns False (never raises) when the record cannot be
+    written. Signal deaths (SIGKILL/OOM) cannot be self-recorded and
+    still fall back to ``unknown``, which is the pre-existing behavior.
+    """
+    try:
+        path = worker_exit_record_path(task_id, board=board)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
+        tmp.write_text(
+            json.dumps({
+                "pid": int(pid),
+                "exit_code": int(exit_code),
+                "recorded_at": int(time.time()),
+            }),
+            encoding="utf-8",
+        )
+        tmp.replace(path)
+        return True
+    except Exception:
+        return False
+
+
+def _read_worker_exit_record(
+    task_id: Optional[str],
+    pid: int,
+    *,
+    board: Optional[str] = None,
+) -> Optional[int]:
+    """Return the sidecar-recorded exit code for ``pid``, or None.
+
+    The record must name the same pid we are classifying: a stale
+    sidecar from a previous run of the same task must not be applied to
+    a different worker's death. The consumed record is removed so it can
+    never be read twice.
+    """
+    if not task_id:
+        return None
+    try:
+        path = worker_exit_record_path(task_id, board=board)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        if int(data.get("pid", -1)) != int(pid):
+            return None
+        return int(data["exit_code"])
+    except Exception:
+        return None
+
+
+def _classify_worker_exit(
+    pid: int,
+    task_id: Optional[str] = None,
+    *,
+    board: Optional[str] = None,
+) -> "tuple[str, Optional[int]]":
     """Classify a recently-reaped worker by pid.
 
     Returns ``(kind, code)`` where ``kind`` is one of:
@@ -8147,9 +8236,10 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       counting a failure, so a long quota window can't trip the breaker.
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
     * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
-    * ``"unknown"`` — pid was not in the reap registry (either reaped by
-      something else, or died between reap tick and liveness check). Fall
-      back to existing crashed-counter behavior.
+    * ``"unknown"`` — pid was neither in the reap registry nor covered by
+      a durable exit sidecar (e.g. it was reaped by init after the
+      dispatcher died, and then died by signal so it could not self-
+      record). Fall back to existing crashed-counter behavior.
 
     ``code`` is the exit status (for ``clean_exit`` / ``rate_limited`` /
     ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
@@ -8157,6 +8247,16 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     """
     entry = _recent_worker_exits.get(int(pid))
     if entry is None:
+        # In-process registry miss: the worker outlived the dispatcher
+        # that spawned it and was reaped by init. Fall back to the durable
+        # sidecar the worker's own exit path wrote (troubleshooting#83).
+        recorded = _read_worker_exit_record(task_id, pid, board=board)
+        if recorded is not None:
+            if recorded == 0:
+                return ("clean_exit", 0)
+            if recorded == KANBAN_RATE_LIMIT_EXIT_CODE:
+                return ("rate_limited", recorded)
+            return ("nonzero_exit", recorded)
         return ("unknown", None)
     raw, _ = entry
     try:
@@ -8925,7 +9025,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 continue
 
             pid = int(row["worker_pid"])
-            kind, code = _classify_worker_exit(pid)
+            kind, code = _classify_worker_exit(pid, row["id"])
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1647,3 +1647,79 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Durable worker exit sidecar (troubleshooting#83): under one-shot dispatch
+# the dispatcher dies before its workers, init reaps them, and the in-process
+# _recent_worker_exits registry never sees the wait status. The worker's own
+# exit path writes a sidecar; classification falls back to it so quota-wall
+# exits stop burning the retry budget.
+# ---------------------------------------------------------------------------
+
+
+def test_exit_sidecar_classifies_rate_limit_after_dispatcher_death(
+    kanban_home, monkeypatch,
+):
+    """Registry miss + sidecar with the rate-limit sentinel must classify
+    as ``rate_limited`` and requeue without counting a failure."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="sidecar-rl", assignee="a")
+        pid = 81234
+        kb.claim_task(conn, tid, claimer=f"{host}:deaddispatcher")
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, consecutive_failures=0 WHERE id=?",
+            (pid, tid),
+        )
+        conn.commit()
+
+        # No _record_worker_exit call: the dispatcher that would have
+        # reaped this worker is dead. The worker self-recorded instead.
+        assert pid not in _kb._recent_worker_exits
+        assert _kb.record_worker_exit_status(
+            tid, pid, _kb.KANBAN_RATE_LIMIT_EXIT_CODE
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid not in crashed
+        rl = getattr(_kb.detect_crashed_workers, "_last_rate_limited", [])
+        assert tid in rl
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        # Sidecar consumed: a later death of a different pid must not
+        # inherit this record.
+        assert not _kb.worker_exit_record_path(tid).exists()
+
+
+def test_exit_sidecar_ignores_stale_pid_and_falls_back_unknown(
+    kanban_home, monkeypatch,
+):
+    """A sidecar naming a DIFFERENT pid is stale and must not be applied;
+    classification falls back to unknown -> crashed (pre-existing path)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="sidecar-stale", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:deaddispatcher")
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (91234, tid))
+        conn.commit()
+
+        # Sidecar from a previous run's worker, different pid.
+        assert _kb.record_worker_exit_status(
+            tid, 90000, _kb.KANBAN_RATE_LIMIT_EXIT_CODE
+        )
+
+        kind, code = _kb._classify_worker_exit(91234, tid)
+        assert (kind, code) == ("unknown", None)


### PR DESCRIPTION
## Problem

Under one-shot `hermes kanban dispatch`, workers are spawned with `start_new_session=True` and the Popen handle abandoned, so the dispatcher usually exits before its workers. Orphaned workers are then reaped by init, and the in-process `_recent_worker_exits` registry (filled by `reap_worker_zombies`/`os.waitpid`) never sees the wait status. `_classify_worker_exit` therefore returns `unknown` for every such death, and `detect_crashed_workers` records it as `crashed`.

This structurally defeats the rate-limit sentinel design: a worker that exits with `KANBAN_RATE_LIMIT_EXIT_CODE` (75) on a provider quota wall is supposed to be requeued WITHOUT counting a failure, but under one-shot dispatch the code is never observed, so quota walls burn the retry budget and trip the circuit breaker.

Observed live (full evidence in https://github.com/anombyte93/troubleshooting/issues/83): a card assigned to a profile whose provider had exhausted its weekly quota died in ~5 seconds three times in a row; each death was classified as a crash, exhausting the card's retries, and between one-shot dispatches the dead worker ghosted as `running` on the board.

## Fix

- `record_worker_exit_status(task_id, pid, exit_code)`: the worker's own controlled exit paths (the kanban branch of `cli.py`, both the normal exit and the init-failure exit) atomically write a small `{pid, exit_code, recorded_at}` sidecar beside the worker log (`logs/<task>.exit.json`).
- `_classify_worker_exit(pid, task_id)` falls back to that sidecar on a registry miss. The record must name the same pid (stale sidecars from a previous run are ignored) and is consumed on read.
- Signal deaths (SIGKILL/OOM) cannot self-record and still classify `unknown`, exactly as before. Continuous dispatch (gateway/daemon) is unaffected: the registry-hit path is unchanged and takes precedence.

## Tests

Two new cases in `tests/hermes_cli/test_kanban_db.py`:
- registry miss + sidecar with the sentinel code → `rate_limited`, task requeued `ready`, `consecutive_failures` untouched, sidecar consumed;
- sidecar naming a different pid → ignored, classification falls back to `unknown`.

`tests/hermes_cli/test_kanban_db.py` and `test_kanban_core_functionality.py`: 57 passed, 1 skipped.