### PR TITLE
perf(serve): overlap cached startup preparation

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3059,24 +3059,221 @@ def _pin_kanban_board_env() -> None:
         pass
 
 
-def _sync_bundled_skills_quietly() -> None:
+_STARTUP_SKILLS_STAMP_SCHEMA = b"hermes-startup-skills-v1\0"
+
+
+def _hash_startup_skills_path(digest, path: Path, *, label: str) -> None:
+    """Add one bounded path tree to the startup fingerprint."""
+    digest.update(label.encode("utf-8", errors="surrogatepass"))
+    digest.update(b"\0")
+    try:
+        if path.is_symlink():
+            digest.update(b"link\0")
+            digest.update(os.readlink(path).encode("utf-8", errors="surrogatepass"))
+            return
+        if path.is_file():
+            digest.update(b"file\0")
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+            return
+        if path.is_dir():
+            digest.update(b"dir\0")
+            for child in sorted(path.rglob("*"), key=lambda item: item.as_posix()):
+                relative = child.relative_to(path).as_posix()
+                _hash_startup_skills_path(digest, child, label=f"{label}/{relative}")
+            return
+    except OSError:
+        digest.update(b"unreadable")
+        return
+    digest.update(b"missing")
+
+
+def _startup_skills_fingerprint() -> str | None:
+    """Fingerprint every input that can change automatic bundled-skill sync.
+
+    The normal sync hashes every bundled skill and can recursively inspect the
+    installed skill tree to recover upstream moves. On an unchanged checkout,
+    a revision plus bounded dirty-path fingerprint proves that work redundant.
+    External skill trees remain on the full sync path because they can mutate
+    independently of this checkout and profile.
+    """
+    if os.environ.get("HERMES_FORCE_BUNDLED_SKILLS_SYNC") == "1":
+        return None
+    if os.environ.get("HERMES_BUNDLED_SKILLS"):
+        return None
+
+    try:
+        from hashlib import sha256
+
+        from hermes_cli._subprocess_compat import windows_hide_flags
+        from hermes_cli.config import read_raw_config
+
+        raw_config = read_raw_config() or {}
+        skills_config = raw_config.get("skills", {})
+        if isinstance(skills_config, dict) and skills_config.get("external_dirs"):
+            return None
+
+        revision = _read_git_revision_fingerprint(PROJECT_ROOT)
+        if not revision:
+            return None
+
+        status = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(PROJECT_ROOT),
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+                "--",
+                "skills",
+                "optional-skills",
+            ],
+            capture_output=True,
+            timeout=5,
+            check=False,
+            creationflags=windows_hide_flags(),
+        )
+        if status.returncode != 0:
+            return None
+
+        digest = sha256()
+        digest.update(_STARTUP_SKILLS_STAMP_SCHEMA)
+        digest.update(revision.encode("utf-8", errors="surrogatepass"))
+        digest.update(b"\0status\0")
+        digest.update(status.stdout)
+
+        root = PROJECT_ROOT.resolve()
+        for record in status.stdout.split(b"\0"):
+            # Porcelain -z records start with "XY ". A rename's second record
+            # is its old path and has no status prefix; the raw status bytes
+            # above already include it while the destination record supplies
+            # the content that will actually be synchronized.
+            if len(record) < 4 or record[2:3] != b" ":
+                continue
+            relative = Path(os.fsdecode(record[3:]))
+            candidate = (PROJECT_ROOT / relative).resolve()
+            try:
+                candidate.relative_to(root)
+            except ValueError:
+                return None
+            _hash_startup_skills_path(
+                digest,
+                candidate,
+                label=f"source:{relative.as_posix()}",
+            )
+
+        hermes_home = get_hermes_home()
+        profile_inputs = (
+            hermes_home / "config.yaml",
+            hermes_home / ".no-bundled-skills",
+            hermes_home / "skills" / ".bundled_manifest",
+            hermes_home / "skills" / ".curator_suppressed",
+            hermes_home / "skills" / ".hub" / "lock.json",
+        )
+        for path in profile_inputs:
+            _hash_startup_skills_path(
+                digest,
+                path,
+                label=f"profile:{path.relative_to(hermes_home).as_posix()}",
+            )
+        return digest.hexdigest()
+    except (OSError, subprocess.SubprocessError, UnicodeError, ValueError):
+        return None
+
+
+def _startup_skills_stamp_path() -> Path:
+    return get_hermes_home() / "skills" / ".startup_sync_stamp"
+
+
+def _write_startup_skills_stamp(fingerprint: str) -> None:
+    stamp = _startup_skills_stamp_path()
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    temporary = stamp.with_name(
+        f".{stamp.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    try:
+        temporary.write_text(fingerprint + "\n", encoding="utf-8")
+        os.replace(temporary, stamp)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _bundled_skills_startup_cache_hit(fingerprint: str | None) -> bool:
+    """Return whether the last successful startup sync covers these inputs."""
+    if not fingerprint:
+        return False
+    try:
+        return _startup_skills_stamp_path().read_text(encoding="utf-8").strip() == fingerprint
+    except OSError:
+        return False
+
+
+def _sync_bundled_skills_quietly(*, cache_checked: bool = False) -> None:
     """Seed ``~/.hermes/skills/`` with the bundled skill library on first launch.
 
     Called from any CLI entrypoint that the user might use as their first
     interaction with Hermes — chat, dashboard (the desktop GUI's backend),
-    and gateway. The skills_sync module is manifest-based and idempotent:
-    skipped skills cost ~milliseconds, so calling this repeatedly is fine.
+    and gateway. A startup fingerprint avoids repeating the recursive
+    reconciliation when every relevant input matches the previous run.
 
     Failures are swallowed because skills are an enhancement, not a hard
     dependency. Hermes still functions without them; the user just sees an
     empty skills library.
     """
+    if not cache_checked:
+        fingerprint = _startup_skills_fingerprint()
+        if _bundled_skills_startup_cache_hit(fingerprint):
+            logger.info("Bundled skill startup sync cache hit")
+            return
+
     try:
         from tools.skills_sync import sync_skills
 
         sync_skills(quiet=True)
+        completed_fingerprint = _startup_skills_fingerprint()
+        if completed_fingerprint:
+            _write_startup_skills_stamp(completed_fingerprint)
     except Exception:
-        pass
+        logger.debug("Bundled skill startup sync failed", exc_info=True)
+
+
+def _start_bundled_skills_sync_background() -> threading.Thread | None:
+    """Run an uncached bundled-skill sync alongside independent startup work."""
+    fingerprint = _startup_skills_fingerprint()
+    if _bundled_skills_startup_cache_hit(fingerprint):
+        logger.info("Bundled skill startup sync cache hit")
+        return None
+
+    thread = threading.Thread(
+        target=lambda: _sync_bundled_skills_quietly(cache_checked=True),
+        name="dashboard-skills-sync",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _start_gateway_module_warmup_background() -> threading.Thread:
+    """Pre-import first-request modules while other server setup proceeds."""
+
+    def _warm() -> None:
+        from hermes_cli.server_startup import warm_gateway_modules
+
+        warm_gateway_modules()
+
+    thread = threading.Thread(
+        target=_warm,
+        name="dashboard-gateway-warmup",
+        daemon=True,
+    )
+    thread.start()
+    return thread
 
 
 def _resolve_use_tui(args) -> bool:
@@ -12113,6 +12310,11 @@ def cmd_dashboard(args):
     except Exception:
         pass
 
+    # Start independent initialization early, then join at the same visibility
+    # boundary used by the former serial path before importing web_server.
+    _skills_sync_thread = _start_bundled_skills_sync_background()
+    _gateway_warmup_thread = _start_gateway_module_warmup_background()
+
     try:
         import fastapi  # noqa: F401
         import uvicorn  # noqa: F401
@@ -12126,12 +12328,6 @@ def cmd_dashboard(args):
         )
         print(f"Import error: {e}")
         sys.exit(1)
-
-    # Seed bundled skills on first dashboard launch so the desktop GUI's
-    # skills picker / agent skill discovery sees the bundled library.
-    # cmd_chat does this in its own pre-dispatch block; the dashboard
-    # backend is the desktop's primary entrypoint and needs the same.
-    _sync_bundled_skills_quietly()
 
     # Bridge terminal.* config into the TERMINAL_* env vars for THIS process,
     # mirroring the CLI (cli.py env_mappings) and gateway (gateway/run.py
@@ -12240,6 +12436,10 @@ def cmd_dashboard(args):
             "Background MCP tool discovery failed at dashboard startup",
             exc_info=True,
         )
+
+    if _skills_sync_thread is not None:
+        _skills_sync_thread.join()
+    _gateway_warmup_thread.join()
 
     from hermes_cli.web_server import start_server
 

--- a/hermes_cli/server_startup.py
+++ b/hermes_cli/server_startup.py
@@ -1,0 +1,39 @@
+"""Shared warmup work for Dashboard and Desktop backend startup."""
+
+from __future__ import annotations
+
+import threading
+
+
+_WARM_MODULES = (
+    "hermes_cli.gateway",
+    "hermes_cli.auth",
+    "hermes_cli.copilot_auth",
+    "hermes_cli.runtime_provider",
+    "hermes_cli.skin_engine",
+    "hermes_cli.inventory",
+    "hermes_cli.model_switch",
+)
+_warm_lock = threading.Lock()
+_warm_complete = False
+
+
+def warm_gateway_modules() -> None:
+    """Import request-hot modules exactly once per backend process.
+
+    Import failures remain non-fatal, matching the historical web-server
+    warmup. Their owning request paths still surface a real failure if the
+    missing module is later required.
+    """
+    global _warm_complete
+    if _warm_complete:
+        return
+    with _warm_lock:
+        if _warm_complete:
+            return
+        for module_name in _WARM_MODULES:
+            try:
+                __import__(module_name)
+            except Exception:
+                pass
+        _warm_complete = True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -329,28 +329,9 @@ def _warm_gateway_module() -> None:
     the ~14s cold-start stall (#60800). Warm them all here so the cost
     is paid in a worker thread while the server socket is already open.
     """
-    for mod in (
-        "hermes_cli.gateway",
-        # setup.status / setup.runtime_check resolve provider auth state,
-        # which imports copilot_auth (→ subprocess module) and scans
-        # credential files. First import is noticeably slow on Windows.
-        "hermes_cli.auth",
-        "hermes_cli.copilot_auth",
-        "hermes_cli.runtime_provider",
-        # resolve_skin() reads config + initialises the skin engine.
-        # Even though handle_ws now calls it via asyncio.to_thread
-        # (see tui_gateway/ws.py), warming it here avoids the first-call
-        # import cost inside that thread.
-        "hermes_cli.skin_engine",
-        # model.options / picker context — parses provider catalogs and
-        # the models.dev cache on first use.
-        "hermes_cli.inventory",
-        "hermes_cli.model_switch",
-    ):
-        try:
-            __import__(mod)
-        except Exception:
-            pass
+    from hermes_cli.server_startup import warm_gateway_modules
+
+    warm_gateway_modules()
 
 
 def _resolve_restart_drain_timeout() -> float:

--- a/tests/hermes_cli/test_server_startup_prep.py
+++ b/tests/hermes_cli/test_server_startup_prep.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import builtins
+import subprocess
+
+import hermes_cli.config as config_mod
+import hermes_cli.main as main_mod
+import hermes_cli.server_startup as startup_mod
+import tools.skills_sync as skills_sync_mod
+
+
+def _configure_fingerprint(monkeypatch, tmp_path, status: bytes = b""):
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    repo.mkdir()
+    home.mkdir()
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", repo)
+    monkeypatch.setattr(main_mod, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(main_mod, "_read_git_revision_fingerprint", lambda _root: "revision")
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: {})
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=status),
+    )
+    return repo, home
+
+
+def test_startup_skills_fingerprint_is_stable_for_unchanged_inputs(monkeypatch, tmp_path) -> None:
+    _configure_fingerprint(monkeypatch, tmp_path)
+
+    first = main_mod._startup_skills_fingerprint()
+    second = main_mod._startup_skills_fingerprint()
+
+    assert first
+    assert first == second
+
+
+def test_startup_skills_fingerprint_tracks_dirty_skill_content(monkeypatch, tmp_path) -> None:
+    repo, _home = _configure_fingerprint(
+        monkeypatch,
+        tmp_path,
+        status=b"?? skills/example/SKILL.md\0",
+    )
+    skill = repo / "skills" / "example" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("first", encoding="utf-8")
+    first = main_mod._startup_skills_fingerprint()
+
+    skill.write_text("second", encoding="utf-8")
+    second = main_mod._startup_skills_fingerprint()
+
+    assert first
+    assert second
+    assert first != second
+
+
+def test_external_skill_dirs_disable_the_shortcut(monkeypatch, tmp_path) -> None:
+    _configure_fingerprint(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        config_mod,
+        "read_raw_config",
+        lambda: {"skills": {"external_dirs": ["external"]}},
+    )
+
+    assert main_mod._startup_skills_fingerprint() is None
+
+
+def test_successful_sync_writes_stamp_and_cache_hit_skips_work(monkeypatch, tmp_path) -> None:
+    _repo, home = _configure_fingerprint(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(main_mod, "_startup_skills_fingerprint", lambda: "fingerprint")
+    monkeypatch.setattr(skills_sync_mod, "sync_skills", lambda **kwargs: calls.append(kwargs))
+
+    main_mod._sync_bundled_skills_quietly()
+    main_mod._sync_bundled_skills_quietly()
+
+    assert calls == [{"quiet": True}]
+    assert (home / "skills" / ".startup_sync_stamp").read_text(encoding="utf-8") == "fingerprint\n"
+
+
+def test_failed_sync_does_not_stamp_success(monkeypatch, tmp_path) -> None:
+    _repo, home = _configure_fingerprint(monkeypatch, tmp_path)
+    monkeypatch.setattr(main_mod, "_startup_skills_fingerprint", lambda: "fingerprint")
+
+    def fail(**_kwargs) -> None:
+        raise RuntimeError("sync failed")
+
+    monkeypatch.setattr(skills_sync_mod, "sync_skills", fail)
+
+    main_mod._sync_bundled_skills_quietly()
+
+    assert not (home / "skills" / ".startup_sync_stamp").exists()
+
+
+def test_gateway_module_warmup_is_process_idempotent(monkeypatch) -> None:
+    imported = []
+    original_import = builtins.__import__
+
+    def tracking_import(name, *args, **kwargs):
+        if name in startup_mod._WARM_MODULES:
+            imported.append(name)
+            return object()
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(startup_mod, "_warm_complete", False)
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    startup_mod.warm_gateway_modules()
+    startup_mod.warm_gateway_modules()
+
+    assert imported == list(startup_mod._WARM_MODULES)


### PR DESCRIPTION
## What does this PR do?

`hermes serve` repeats two pieces of startup preparation on the serial readiness path: bundled-skill reconciliation and imports that warm the first gateway request. The skill sync re-hashes unchanged inputs on every launch, while the gateway warmup begins late enough that its import cost cannot overlap earlier setup.

This adds a conservative skill-sync stamp and starts both independent jobs early. The process still joins them at the same correctness boundary before the web server becomes visible. Cache eligibility fails closed for forced sync, custom bundled-skill roots, external skill directories, dirty skill content, or changed profile skill configuration.

This complements the module warmup introduced in #77814 by starting that established warmup earlier and sharing the implementation between the command and server paths.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns pre-bind preparation: independent skill reconciliation and gateway import work overlap without moving their correctness join.


## Related Issue

Follow-up to #77814

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `hermes_cli/server_startup.py` as the process-idempotent owner of gateway module warmup.
- Fingerprint the bundled skill source revision, dirty skill contents, and profile skill configuration before reusing a successful sync stamp.
- Write the stamp atomically only after the canonical sync succeeds.
- Start bundled-skill reconciliation and gateway warmup early, overlap them with dependency/configuration work, and join before the existing visibility boundary.
- Add behavioral coverage for cache hits, invalidation, failure handling, dirty content, custom-source fallback, and idempotent warmup.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_server_startup_prep.py tests/tui_gateway/test_cold_start_gil_stall.py -q -j 4`.
2. Confirm all 12 focused tests pass.
3. Start `hermes serve` twice from an unchanged checkout and confirm the second run reuses the successful skill-sync stamp while preserving the existing pre-server join boundary.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused result: 12 tests passed.