### PR TITLE
perf(serve): move Desktop runtime services after bind

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11942,6 +11942,29 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+def _desktop_runtime_discovery_can_follow_bind(
+    args,
+    *,
+    dashboard_public_url: str,
+    environ=None,
+) -> bool:
+    """Return whether runtime discovery may safely follow the ready socket.
+
+    Dashboard auth providers are plugins, so ordinary dashboards, public URLs,
+    and non-loopback binds must retain pre-bind discovery. The packaged Desktop
+    headless backend is different: its authenticated loopback control socket is
+    useful before agent plugins and MCP servers finish loading, while the agent
+    build path already waits for those registries before taking a tool snapshot.
+    """
+    env = os.environ if environ is None else environ
+    return bool(
+        getattr(args, "headless_backend", False)
+        and env.get("HERMES_DESKTOP") == "1"
+        and getattr(args, "host", "") in {"127.0.0.1", "localhost", "::1"}
+        and not dashboard_public_url.strip()
+    )
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -11972,6 +11995,30 @@ def cmd_dashboard(args):
     # ready sentinel. Resolved once and threaded through the re-exec, the
     # build gate, and start_server.
     _headless_backend = getattr(args, "headless_backend", False)
+    _dashboard_public_url = ""
+    try:
+        from hermes_cli.config import read_raw_config as _read_raw_dashboard_config
+
+        _raw_dashboard = _read_raw_dashboard_config() or {}
+        _dashboard_section = _raw_dashboard.get("dashboard") or {}
+        if isinstance(_dashboard_section, dict):
+            _dashboard_public_url = str(
+                _dashboard_section.get("public_url") or ""
+            ).strip()
+    except Exception:
+        # Failure to prove that no public URL is configured keeps the
+        # conservative pre-bind discovery order.
+        _dashboard_public_url = "<unresolved>"
+    _dashboard_public_url = (
+        os.environ.get("HERMES_DASHBOARD_PUBLIC_URL", "").strip()
+        or _dashboard_public_url
+    )
+    _defer_desktop_runtime_discovery = (
+        _desktop_runtime_discovery_can_follow_bind(
+            args,
+            dashboard_public_url=_dashboard_public_url,
+        )
+    )
     _ssh_owner_nonce = getattr(args, "ssh_owner_nonce", None)
     if _ssh_owner_nonce and not re.fullmatch(r"[0-9a-f]{16}", _ssh_owner_nonce):
         raise SystemExit("--ssh-owner-nonce must be 16 lowercase hex characters")
@@ -12212,14 +12259,15 @@ def cmd_dashboard(args):
     # save ~500ms startup; we have to trigger it explicitly here because
     # the dashboard's server-side runtime depends on plugin-registered
     # providers (image_gen, web, dashboard_auth, …).
-    try:
-        from hermes_cli.plugins import discover_plugins
-        discover_plugins()
-    except Exception as exc:
-        # Discovery failures must not block dashboard startup outright —
-        # log and proceed; the gate's fail-closed branch will surface
-        # the missing-provider state if it matters.
-        print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
+    if not _defer_desktop_runtime_discovery:
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+        except Exception as exc:
+            # Discovery failures must not block dashboard startup outright —
+            # log and proceed; the gate's fail-closed branch will surface
+            # the missing-provider state if it matters.
+            print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
     # Desktop chat uses the dashboard's in-process /api/ws gateway, which builds
     # agents via tui_gateway.server._make_agent.  That path only snapshots the
@@ -12228,18 +12276,25 @@ def cmd_dashboard(args):
     # this, a profile's configured MCP servers never connect, so desktop
     # sessions show no MCP tools.  Spawn discovery in the background here so a
     # slow/dead server can't block dashboard startup.
-    try:
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
+    if not _defer_desktop_runtime_discovery:
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-        start_background_mcp_discovery(
-            logger=logger,
-            thread_name="dashboard-mcp-discovery",
-        )
-    except Exception:
-        logger.debug(
-            "Background MCP tool discovery failed at dashboard startup",
-            exc_info=True,
-        )
+            start_background_mcp_discovery(
+                logger=logger,
+                thread_name="dashboard-mcp-discovery",
+            )
+        except Exception:
+            logger.debug(
+                "Background MCP tool discovery failed at dashboard startup",
+                exc_info=True,
+            )
+
+    # web_server consumes this one-shot import policy before mounting plugin
+    # API routes. Only the verified local Desktop path reaches this branch;
+    # dashboard/public paths retain the established eager ordering above.
+    if _defer_desktop_runtime_discovery:
+        os.environ["HERMES_DEFER_DESKTOP_PLUGIN_API_MOUNT"] = "1"
 
     from hermes_cli.web_server import start_server
 
@@ -12262,6 +12317,7 @@ def cmd_dashboard(args):
         headless=_headless_backend,
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
+        defer_runtime_discovery=_defer_desktop_runtime_discovery,
     )
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -142,6 +142,17 @@ except ImportError:
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
 
+# One-shot import policy set only by cmd_dashboard's verified local Desktop
+# serve path. Consume the marker now so unrelated child processes cannot
+# inherit a Desktop-only startup policy.
+_DEFER_DESKTOP_PLUGIN_API_MOUNT = (
+    env_var_enabled("HERMES_DEFER_DESKTOP_PLUGIN_API_MOUNT")
+    and os.getenv("HERMES_DESKTOP") == "1"
+    and os.getenv("HERMES_SERVE_HEADLESS") == "1"
+)
+os.environ.pop("HERMES_DEFER_DESKTOP_PLUGIN_API_MOUNT", None)
+_deferred_plugin_api_routes_ready = threading.Event()
+
 
 def _process_start_marker(pid: int) -> str:
     """Return a cross-runtime marker for the current incarnation of ``pid``.
@@ -383,6 +394,39 @@ def _eager_reconcile_own_session_db() -> None:
         )
 
 
+def _start_desktop_services_after_bind(app: "FastAPI") -> threading.Event:
+    """Arm Desktop cron and orphan cleanup behind the bound-socket event."""
+    ready = threading.Event()
+    app.state.desktop_post_bind = ready
+    stop = threading.Event()
+
+    def _reap_gateway_orphans() -> None:
+        ready.wait()
+        try:
+            from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+
+            _reap_unsupervised_gateway_orphans()
+        except Exception:
+            _log.exception("Desktop startup: orphan gateway reap failed")
+
+    def _start_cron() -> None:
+        ready.wait()
+        if not stop.is_set():
+            _start_desktop_cron_ticker(stop)
+
+    threading.Thread(
+        target=_reap_gateway_orphans,
+        daemon=True,
+        name="desktop-gateway-orphan-reaper",
+    ).start()
+    threading.Thread(
+        target=_start_cron,
+        daemon=True,
+        name="desktop-cron-ticker",
+    ).start()
+    return stop
+
+
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -434,29 +478,15 @@ async def _lifespan(app: "FastAPI"):
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.
     cron_stop: "threading.Event | None" = None
-    cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
-        # Before forking a fresh gateway, reap any orphan left by a previous
-        # serve session. Graceful shutdown reaps the managed child, but an
-        # abnormal exit (crash, SIGKILL, power loss, forced update) reparents
-        # the old gateway to launchd (PPID=1). It keeps holding the QQ
-        # WebSocket, and a newly forked gateway then races the same credential,
-        # splitting messages across parallel session trees (#77276).
-        try:
-            from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
-
-            _reap_unsupervised_gateway_orphans()
-        except Exception:
-            _log.exception("Desktop startup: orphan gateway reap failed")
-
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+        # The socket, auth/health probes, and renderer do not depend on cron or
+        # process cleanup. Keep those services enabled on every Desktop run,
+        # but do not let their imports and Windows process scans delay the
+        # readiness sentinel. _serve sets this event immediately after bind.
+        # The gateway-start endpoint repeats orphan cleanup at its own
+        # correctness boundary, so moving this startup sweep after bind does
+        # not let a replacement gateway race stale credentials.
+        cron_stop = _start_desktop_services_after_bind(app)
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -523,6 +553,27 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
 
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
+
+
+@app.middleware("http")
+async def _wait_for_deferred_plugin_api_routes(request: Request, call_next):
+    """Avoid a transient plugin-route 404 during local Desktop startup."""
+    if (
+        _DEFER_DESKTOP_PLUGIN_API_MOUNT
+        and request.url.path.startswith("/api/plugins/")
+        and not _deferred_plugin_api_routes_ready.is_set()
+    ):
+        ready = await asyncio.to_thread(
+            _deferred_plugin_api_routes_ready.wait,
+            10.0,
+        )
+        if not ready:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Plugin routes are still loading"},
+                headers={"Retry-After": "1"},
+            )
+    return await call_next(request)
 
 
 # Memory-provider OAuth connect routes live in the memory layer, not here.
@@ -19250,8 +19301,52 @@ def _mount_plugin_api_routes():
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
 
 
-# Mount plugin API routes before the SPA catch-all.
-_mount_plugin_api_routes()
+def _run_deferred_runtime_discovery() -> None:
+    """Load Desktop agent/plugin routes and MCP servers off the bind path."""
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        _log.warning("Deferred Desktop plugin discovery failed", exc_info=True)
+
+    if _DEFER_DESKTOP_PLUGIN_API_MOUNT:
+        try:
+            _mount_plugin_api_routes()
+        except Exception:
+            _log.warning("Deferred Desktop plugin API mount failed", exc_info=True)
+        finally:
+            _deferred_plugin_api_routes_ready.set()
+
+    try:
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=_log,
+            thread_name="desktop-mcp-discovery",
+        )
+    except Exception:
+        _log.debug(
+            "Deferred Desktop MCP discovery failed to start",
+            exc_info=True,
+        )
+
+
+def _schedule_deferred_runtime_discovery(delay: float = 0.75):
+    """Schedule runtime discovery after the renderer can connect and paint."""
+    timer = threading.Timer(delay, _run_deferred_runtime_discovery)
+    timer.daemon = True
+    timer.name = "desktop-runtime-discovery-delay"
+    timer.start()
+    return timer
+
+
+# Public Dashboard and ordinary serve paths preserve the established import
+# ordering. The verified local Desktop headless path has no SPA catch-all and
+# mounts these routes just after the socket binds instead.
+if not _DEFER_DESKTOP_PLUGIN_API_MOUNT:
+    _mount_plugin_api_routes()
+    _deferred_plugin_api_routes_ready.set()
 
 # Mount the dashboard auth routes (/login, /auth/*, /api/auth/*) before the
 # SPA catch-all so /{full_path:path} doesn't swallow them.  These are
@@ -19627,6 +19722,7 @@ def start_server(
     headless: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
+    defer_runtime_discovery: bool = False,
 ):
     """Start the web UI server.
 
@@ -20003,6 +20099,13 @@ def start_server(
                 print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
+
+            desktop_post_bind = getattr(app.state, "desktop_post_bind", None)
+            if isinstance(desktop_post_bind, threading.Event):
+                desktop_post_bind.set()
+            if defer_runtime_discovery:
+                _schedule_deferred_runtime_discovery()
+
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -427,6 +427,25 @@ def _start_desktop_services_after_bind(app: "FastAPI") -> threading.Event:
     return stop
 
 
+def _start_desktop_services_immediately() -> threading.Event:
+    """Start Desktop-owned services for non-uvicorn lifespan consumers."""
+    try:
+        from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+
+        _reap_unsupervised_gateway_orphans()
+    except Exception:
+        _log.exception("Desktop startup: orphan gateway reap failed")
+
+    stop = threading.Event()
+    threading.Thread(
+        target=_start_desktop_cron_ticker,
+        args=(stop,),
+        daemon=True,
+        name="desktop-cron-ticker",
+    ).start()
+    return stop
+
+
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -479,14 +498,22 @@ async def _lifespan(app: "FastAPI"):
     # dashboard` is unaffected — it relies on its own gateway.
     cron_stop: "threading.Event | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
-        # The socket, auth/health probes, and renderer do not depend on cron or
-        # process cleanup. Keep those services enabled on every Desktop run,
-        # but do not let their imports and Windows process scans delay the
-        # readiness sentinel. _serve sets this event immediately after bind.
-        # The gateway-start endpoint repeats orphan cleanup at its own
-        # correctness boundary, so moving this startup sweep after bind does
-        # not let a replacement gateway race stale credentials.
-        cron_stop = _start_desktop_services_after_bind(app)
+        if getattr(app.state, "defer_desktop_services_until_bind", False):
+            # The socket, auth/health probes, and renderer do not depend on cron
+            # or process cleanup. Keep those services enabled on every packaged
+            # Desktop run, but do not let their imports and Windows process
+            # scans delay the readiness sentinel. _serve sets this event
+            # immediately after bind. The gateway-start endpoint repeats orphan
+            # cleanup at its own correctness boundary, so moving this startup
+            # sweep after bind does not let a replacement gateway race stale
+            # credentials.
+            cron_stop = _start_desktop_services_after_bind(app)
+        else:
+            # Lifespan can also be owned directly (for example by an ASGI host
+            # or TestClient) with no uvicorn bind phase to release the deferred
+            # workers. Preserve the established startup behavior unless
+            # start_server explicitly selected the post-bind Desktop path.
+            cron_stop = _start_desktop_services_immediately()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -19738,6 +19765,10 @@ def start_server(
     ``ssh_session_token`` and ``ssh_owner_nonce`` are process-local Desktop SSH
     bootstrap state. Neither is persisted or exported to child processes.
     """
+    # _lifespan is also exercised without start_server, so the post-bind policy
+    # must be explicit rather than inferred from HERMES_DESKTOP alone. Reset it
+    # on every invocation to avoid leaking one server's policy into another.
+    app.state.defer_desktop_services_until_bind = bool(defer_runtime_discovery)
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 

--- a/tests/hermes_cli/test_desktop_post_bind_runtime_discovery.py
+++ b/tests/hermes_cli/test_desktop_post_bind_runtime_discovery.py
@@ -1,0 +1,228 @@
+import asyncio
+import sys
+import threading
+import types
+from argparse import Namespace
+
+from hermes_cli import main as main_mod
+from hermes_cli import web_server
+
+
+def _serve_args(**overrides):
+    values = {
+        "headless_backend": True,
+        "host": "127.0.0.1",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_runtime_discovery_defers_only_for_local_desktop_headless_serve():
+    desktop_env = {"HERMES_DESKTOP": "1"}
+
+    assert main_mod._desktop_runtime_discovery_can_follow_bind(
+        _serve_args(),
+        dashboard_public_url="",
+        environ=desktop_env,
+    )
+    assert not main_mod._desktop_runtime_discovery_can_follow_bind(
+        _serve_args(headless_backend=False),
+        dashboard_public_url="",
+        environ=desktop_env,
+    )
+    assert not main_mod._desktop_runtime_discovery_can_follow_bind(
+        _serve_args(host="0.0.0.0"),
+        dashboard_public_url="",
+        environ=desktop_env,
+    )
+    assert not main_mod._desktop_runtime_discovery_can_follow_bind(
+        _serve_args(),
+        dashboard_public_url="https://example.test/hermes",
+        environ=desktop_env,
+    )
+    assert not main_mod._desktop_runtime_discovery_can_follow_bind(
+        _serve_args(),
+        dashboard_public_url="",
+        environ={},
+    )
+
+
+def test_deferred_plugin_request_waits_instead_of_falling_through(monkeypatch):
+    waits = []
+
+    class Pending:
+        def is_set(self):
+            return False
+
+        def wait(self, timeout):
+            waits.append(timeout)
+            return False
+
+    monkeypatch.setattr(web_server, "_DEFER_DESKTOP_PLUGIN_API_MOUNT", True)
+    monkeypatch.setattr(web_server, "_deferred_plugin_api_routes_ready", Pending())
+    request = types.SimpleNamespace(
+        url=types.SimpleNamespace(path="/api/plugins/example/status")
+    )
+
+    async def call_next(_request):
+        raise AssertionError("request must not reach routing before mount completes")
+
+    response = asyncio.run(
+        web_server._wait_for_deferred_plugin_api_routes(request, call_next)
+    )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "1"
+    assert waits == [10.0]
+
+
+def test_unrelated_request_never_waits_for_plugin_routes(monkeypatch):
+    class Pending:
+        def is_set(self):
+            return False
+
+        def wait(self, _timeout):
+            raise AssertionError("unrelated requests must stay on the fast path")
+
+    monkeypatch.setattr(web_server, "_DEFER_DESKTOP_PLUGIN_API_MOUNT", True)
+    monkeypatch.setattr(web_server, "_deferred_plugin_api_routes_ready", Pending())
+    request = types.SimpleNamespace(url=types.SimpleNamespace(path="/api/status"))
+    expected = object()
+
+    async def call_next(_request):
+        return expected
+
+    assert (
+        asyncio.run(
+            web_server._wait_for_deferred_plugin_api_routes(request, call_next)
+        )
+        is expected
+    )
+
+
+def test_deferred_discovery_mounts_routes_then_starts_mcp(monkeypatch):
+    calls = []
+    ready = threading.Event()
+    monkeypatch.setattr(web_server, "_DEFER_DESKTOP_PLUGIN_API_MOUNT", True)
+    monkeypatch.setattr(web_server, "_deferred_plugin_api_routes_ready", ready)
+    monkeypatch.setattr(
+        web_server,
+        "_mount_plugin_api_routes",
+        lambda: calls.append("mount"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: calls.append("plugins")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        types.SimpleNamespace(
+            start_background_mcp_discovery=lambda **_kwargs: calls.append("mcp")
+        ),
+    )
+
+    web_server._run_deferred_runtime_discovery()
+
+    assert calls == ["plugins", "mount", "mcp"]
+    assert ready.is_set()
+
+
+def test_deferred_route_waiters_release_when_plugin_mount_fails(monkeypatch):
+    ready = threading.Event()
+    monkeypatch.setattr(web_server, "_DEFER_DESKTOP_PLUGIN_API_MOUNT", True)
+    monkeypatch.setattr(web_server, "_deferred_plugin_api_routes_ready", ready)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        types.SimpleNamespace(start_background_mcp_discovery=lambda **_kwargs: None),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_mount_plugin_api_routes",
+        lambda: (_ for _ in ()).throw(RuntimeError("synthetic failure")),
+    )
+
+    web_server._run_deferred_runtime_discovery()
+
+    assert ready.is_set()
+
+
+def test_deferred_discovery_timer_is_daemonized_and_started(monkeypatch):
+    created = []
+
+    class FakeTimer:
+        def __init__(self, delay, target):
+            self.delay = delay
+            self.target = target
+            self.daemon = False
+            self.name = ""
+            self.started = False
+            created.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(web_server.threading, "Timer", FakeTimer)
+
+    timer = web_server._schedule_deferred_runtime_discovery(0.25)
+
+    assert timer is created[0]
+    assert timer.delay == 0.25
+    assert timer.target is web_server._run_deferred_runtime_discovery
+    assert timer.daemon is True
+    assert timer.name == "desktop-runtime-discovery-delay"
+    assert timer.started is True
+
+
+def test_desktop_cron_and_orphan_reap_wait_for_bound_socket(monkeypatch):
+    threads = []
+    calls = []
+
+    class FakeThread:
+        def __init__(self, *, target, daemon, name):
+            self.target = target
+            self.daemon = daemon
+            self.name = name
+            self.started = False
+            threads.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(web_server.threading, "Thread", FakeThread)
+    monkeypatch.setattr(
+        web_server,
+        "_start_desktop_cron_ticker",
+        lambda stop: calls.append(("cron", stop)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.gateway",
+        types.SimpleNamespace(
+            _reap_unsupervised_gateway_orphans=lambda: calls.append(("reap", None))
+        ),
+    )
+    application = types.SimpleNamespace(state=types.SimpleNamespace())
+
+    stop = web_server._start_desktop_services_after_bind(application)
+
+    assert calls == []
+    assert application.state.desktop_post_bind.is_set() is False
+    assert {thread.name for thread in threads} == {
+        "desktop-gateway-orphan-reaper",
+        "desktop-cron-ticker",
+    }
+    assert all(thread.daemon and thread.started for thread in threads)
+
+    application.state.desktop_post_bind.set()
+    for thread in threads:
+        thread.target()
+
+    assert calls == [("reap", None), ("cron", stop)]


### PR DESCRIPTION
## What does this PR do?

The packaged Desktop only needs its authenticated loopback `hermes serve` socket before the renderer can connect and paint, but agent plugin discovery, plugin API loading, MCP startup, cron initialization, and orphan-gateway cleanup currently run ahead of that ready point.

This moves those Desktop-only runtime services behind the bound-socket event. The optimization is deliberately unavailable to ordinary Dashboard launches, non-headless serves, non-loopback binds, non-Desktop processes, or any configuration with a public dashboard URL, because those paths may require plugin-provided authentication before bind.

Plugin API requests arriving during the short deferred window wait for route mounting instead of receiving a transient 404. Agent construction continues to use the existing plugin and MCP readiness gates before snapshotting tools.

## Desktop performance series

This change is one independently reviewable layer of the same Desktop startup and first-interaction performance pass.

- #96749 removes unrelated CLI parser work from the `hermes serve` entry path.
- #96750 overlaps independent cached startup preparation before the existing readiness join.
- #96751 lets the verified local Desktop control socket bind before nonessential runtime services finish loading.
- #97032 starts the backend before first-window setup and defers noncritical Electron integrations.
- #97027 releases the renderer boot barrier once the gateway socket and active profile are ready, while noncritical hydration continues.
- #96717 paints connection/profile-scoped session and project navigation from bounded snapshots while live refresh continues.
- #96721 paints the exact connection/profile-scoped remembered transcript before backend/profile hydration, then keeps it visible while the live runtime resumes.
- #96921 prevents the existing transcript cache from discarding a complete suffix that still fits its storage bound.
- #97037 warms common lazy route code serially during idle time in the connected primary window, without prefetching route data.
- #96728 progressively hydrates Bot Mode roster presentation without changing canonical chat identity.

The three Python backend PRs share startup files but solve separate stages. Recommended landing order is #96749, then #96750, then #96751, rebasing the next PR only after the preceding one lands. #97032 is an independently reviewable Electron ordering change. The remaining renderer and Bot Mode PRs can also land independently; their effects compose without making cached state authoritative.
This PR owns the backend readiness boundary: the verified local Desktop socket binds before nonessential runtime services finish loading.


## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a fail-closed detector for the packaged, headless, loopback Desktop path with no configured public URL.
- Defer agent plugin discovery, plugin API route mounting, and MCP startup until after Uvicorn binds and emits the ready sentinel.
- Return a bounded retryable 503 only if deferred plugin routes cannot become ready within 10 seconds; unrelated requests never wait.
- Start Desktop cron and startup orphan cleanup after the same bound-socket event.
- Preserve eager plugin/auth ordering for Dashboard and public surfaces.
- Add behavioral tests for the guard matrix, deferred ordering, route wait/release behavior, timer ownership, failure release, cron, and orphan cleanup.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_desktop_post_bind_runtime_discovery.py tests/hermes_cli/test_plugin_api_compat.py tests/hermes_cli/test_web_server_cron_profiles.py tests/hermes_cli/test_dashboard_auth_plugin_hook.py -q -j 4`.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server_boot_handshake.py tests/tui_gateway/test_cold_start_gil_stall.py tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py -q -j 4`.
3. Confirm the focused groups pass 50/50 and 16/16 respectively, then launch packaged Desktop and verify the ready socket is available before runtime discovery completes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused results: 66 tests passed across the two explicit groups.