### PR TITLE
fix(browser): stop stale real-profile desktop calls from timing out

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -9,6 +9,7 @@ are limited to OS detection and process launch.
 import json
 import os
 import ntpath
+import threading
 from unittest.mock import Mock, patch
 
 import pytest
@@ -149,6 +150,35 @@ class TestRealProfileCdpLaunch:
             cdp, err = bt._real_profile_cdp()
         assert cdp is None
         assert err and "boom" in err
+
+    def test_stale_resolver_holder_fails_fast(self, monkeypatch):
+        """A timed-out worker holding the launch lock must not wedge later calls."""
+        import tools.browser_tool as bt
+
+        self._reset()
+        monkeypatch.setattr(bt, "_REAL_PROFILE_CDP_LOCK_TIMEOUT_S", 0.05, raising=False)
+        result = {}
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch.object(bt, "_using_lightpanda_engine", return_value=False), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None):
+            bt._real_profile_cdp_lock.acquire()
+            worker = threading.Thread(
+                target=lambda: result.setdefault("value", bt._real_profile_cdp()),
+                daemon=True,
+            )
+            try:
+                worker.start()
+                worker.join(timeout=0.25)
+                stalled = worker.is_alive()
+            finally:
+                bt._real_profile_cdp_lock.release()
+                worker.join(timeout=1.0)
+
+        assert not stalled, "real-profile resolver waited indefinitely on a stale holder"
+        cdp, err = result["value"]
+        assert cdp is None
+        assert err and "already being prepared" in err
 
     def test_launch_returns_http_cdp(self, tmp_path):
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1452,6 +1452,9 @@ def _use_real_profile() -> bool:
 # tasks reuse the same copy-browser instead of each launching a rival Chromium
 # on the same copied user-data-dir.
 _REAL_PROFILE_SESSION = "hermes-real-profile"
+# Keep lock contention well inside the agent's 420-second outer tool deadline.
+# The holder may be an abandoned daemon worker that Python cannot terminate.
+_REAL_PROFILE_CDP_LOCK_TIMEOUT_S = 30.0
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
 
@@ -1585,7 +1588,13 @@ def _real_profile_cdp() -> tuple:
         snapshot_real_profile,
     )
 
-    with _real_profile_cdp_lock:
+    if not _real_profile_cdp_lock.acquire(timeout=_REAL_PROFILE_CDP_LOCK_TIMEOUT_S):
+        return None, (
+            "browser.use_real_profile is on, but the real-profile browser is "
+            "already being prepared by another call that has not finished. "
+            "Retry after that call completes, or restart Hermes if it was abandoned."
+        )
+    try:
         # Reuse a live copy-browser from an earlier call this process made.
         cached = _real_profile_cdp_cache.get("cdp")
         if cached and _cdp_http_ready(cached):
@@ -1705,6 +1714,8 @@ def _real_profile_cdp() -> tuple:
         _real_profile_cdp_cache["cdp"] = cdp
         logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
+    finally:
+        _real_profile_cdp_lock.release()
 
 
 def _url_is_private(url: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

Prevents later real-profile browser calls in a long-lived Desktop process from waiting for the full 420-second tool deadline after an earlier resolver worker is abandoned while holding the launch lock. The resolver now bounds lock contention at 30 seconds and returns an actionable, fail-closed error instead of silently wedging every subsequent call.

### Symptom

With `browser.use_real_profile: true`, `browser_exec(local=true)` can time out after 420 seconds in Hermes Desktop, while the same real-profile path completes in about seven seconds from an independent Python process.

### Impact

Once a Desktop worker is wedged inside real-profile preparation, later calls in that process also block until the outer tool deadline. Users cannot use real-profile browser automation and receive only a generic timeout.

### Bug Cause

**Trigger:** `tools/browser_tool.py:_real_profile_cdp` acquires `_real_profile_cdp_lock` while another resolver worker still owns it.

**Causal chain:**
1. The sequential tool executor reaches its 420-second deadline and abandons a browser worker, but Python cannot terminate that worker thread.
2. If the abandoned worker remains inside the serialized snapshot/reuse/launch region, it continues to own `_real_profile_cdp_lock`.
3. Every later real-profile call uses an unbounded lock acquisition, so it never reaches the resolver's bounded subprocess operations or an actionable error before the outer deadline.

**Why it is wrong:** The process-global serialization lock had no contention deadline even though its holder can outlive an abandoned tool call.

**Working sibling / contrast:** An independent Python process has its own lock and cache, so it does not inherit the Desktop process's wedged holder and completes normally.

**Ruled out:** Open PR #96659 addresses an unbounded SQLite online-backup retry. This change does not overlap that snapshot fix; it specifically bounds the resolver lock acquisition after a worker has already poisoned the long-lived process state.

### Fix

Acquire the real-profile resolver lock with a 30-second timeout, return a fail-closed retry/restart error on contention, and retain unconditional release through `finally`. A regression test holds the lock from another thread and proves a later resolver returns within its configured budget.

## Related Issue

Closes #96731

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py` - bound real-profile resolver lock contention and surface an actionable error.
- `tests/tools/test_browser_real_profile.py` - reproduce a stale lock holder and assert the next resolver fails fast.

## How to Test

1. Run the focused stale-holder regression:

```bash
scripts/run_tests.sh tests/tools/test_browser_real_profile.py -k stale_resolver_holder_fails_fast -q
```

2. Run the real-profile CDP launch test class:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_browser_real_profile.py -k TestRealProfileCdpLaunch -q
```

3. On Windows Desktop with `browser.use_real_profile: true`, reproduce an abandoned resolver holder and confirm a later `browser_exec(local=true)` returns the contention error before the 420-second outer deadline.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related test class and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The focused regression passed (1 test), and the full `TestRealProfileCdpLaunch` class passed (8 tests) through `scripts/run_tests.sh` on Windows 11.
