### PR TITLE
feat: add Cursor Cloud Agents optional skill

### DIFF
--- a/optional-skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: cursor-cloud-agents
+description: "Launch and track Cursor Cloud Agents for repository work."
+version: 0.1.0
+author: Iven Simon (ivenms), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Coding-Agent, Cursor, Cloud-Agents, GitHub, Pull-Requests, Automation]
+    related_skills: [requesting-code-review, test-driven-development]
+---
+
+# Cursor Cloud Agents Skill
+
+Delegate repository coding work to Cursor Cloud Agents through Cursor's public-beta v1 API. This optional integration uses a dependency-free Python helper and returns durable agent/run identifiers, branches, and pull-request URLs. It does not replace local tests, code review, merge approval, or deployment controls.
+
+## When to Use
+
+- The user explicitly asks Cursor Cloud Agent to implement, fix, refactor, test, or document code.
+- A long-running coding task should run remotely against an accessible GitHub repository.
+- A bot needs to continue an existing Cursor agent conversation with a follow-up prompt.
+- A second technical bot needs to inspect or continue work from an existing `agent-id` and `run-id`.
+
+**Do not use for:** local-only edits, a review that does not require Cursor coding, production deployment, or a task without a repository and acceptance criteria.
+
+## Prerequisites
+
+- A Cursor API key with Cloud Agents access, stored only as `CURSOR_API_KEY` in the active Hermes profile's `.env` or process environment.
+- Configure the persistent key through Hermes; do not hand-edit YAML:
+
+```bash
+hermes config set CURSOR_API_KEY 'YOUR_CURSOR_API_KEY'
+```
+
+This writes the secret to the active profile's `.env`, not `config.yaml`. Replace the placeholder locally; never place the real key in chat, prompts, repository files, URLs, or logs. Start a new profile session after changing the key so Hermes loads it.
+- The repository must be accessible through Cursor's GitHub App installation.
+- The repository URL and starting branch/ref must be known.
+- For an explicit model, query `models` first and use an ID returned by Cursor. Otherwise omit `--model` and use Cursor's configured default.
+
+The Cloud Agents API v1 is public beta and may change. Reference: <https://cursor.com/docs/cloud-agent/api/endpoints>.
+
+## How to Run
+
+Run the bundled helper through the Hermes `terminal` tool. The helper is relative to the active profile's `$HERMES_HOME`:
+
+```bash
+AGENT="$HERMES_HOME/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud_agent.py"
+```
+
+Launch work on a new Cursor branch and request a pull request:
+
+```bash
+python "$AGENT" launch \
+  --repo https://github.com/ORG/REPO \
+  --ref main \
+  --prompt "Implement the approved task. Add or update tests and report verification commands." \
+  --auto-create-pr \
+  --wait
+```
+
+For a prompt in a file, use `--prompt-file PATH`. The helper prints JSON for non-streaming commands; preserve `agent.id`, `run.id`, final status, pushed branch, and PR URL in the handoff.
+
+## Quick Reference
+
+```text
+launch       Create an agent and enqueue its first run.
+follow-up    Send a prompt to an existing agent.
+status       Read one run's current or terminal state.
+stream       Print SSE status, assistant, and tool events.
+cancel       Cancel an active run; cancellation is terminal.
+models       List model IDs and supported parameters.
+```
+
+Examples:
+
+```bash
+python "$AGENT" follow-up --agent-id AGENT_ID --prompt "Address the failing test and rerun the focused suite." --wait
+python "$AGENT" status --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" stream --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" cancel --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" models
+```
+
+## Procedure
+
+### 1. Define the task
+
+State the repository URL, starting ref, desired change, constraints, acceptance criteria, and required tests. Completion criterion: the prompt is specific enough for the remote agent to work without an interactive clarification loop.
+
+### 2. Check credentials
+
+Confirm `CURSOR_API_KEY` is present without printing its value. Completion criterion: the helper passes credential preflight and no secret appears in the prompt or output.
+
+### 3. Choose the model
+
+Run `models` when explicit model selection matters. Completion criterion: every selected model ID and parameter is present in Cursor's response.
+
+### 4. Launch safely
+
+Use `launch` with `--auto-create-pr` unless a branch-only result was requested. Keep `--work-on-current-branch` disabled by default. Completion criterion: the API returns both an agent ID and a run ID.
+
+### 5. Track execution
+
+Use `--wait` for bounded tasks or `status`/`stream` for separately monitored work. Completion criterion: the run reaches `FINISHED`, `ERROR`, `CANCELLED`, or `EXPIRED`; never infer completion from an HTTP 2xx response alone.
+
+### 6. Inspect the result
+
+Read the terminal result and `git.branches[]`. Completion criterion: the final response, pushed branch, and PR URL (if created) are recorded, or the API error is reported verbatim without credentials.
+
+### 7. Verify before merge
+
+Inspect the branch or PR and run the repository's actual tests locally or in CI. Load `requesting-code-review` before committing or merging. Completion criterion: tests and review state have real evidence; the agent's prose alone is not proof.
+
+### 8. Continue or stop
+
+Send a follow-up only after the current run is terminal; Cursor rejects concurrent runs with `agent_busy`. Completion criterion: each follow-up returns a new run ID and is recorded separately.
+
+## Pitfalls
+
+- The v1 API separates a durable agent from per-prompt runs; never substitute one identifier for the other.
+- `agent_busy` means another run is active. Wait or cancel it instead of retrying blindly.
+- `--work-on-current-branch` can push directly to the supplied ref. Use it only with explicit approval.
+- `--auto-create-pr` opens a PR but does not mean the code is reviewed, tested, or safe to merge.
+- Run-level `git` is an agent-scoped snapshot. Use the agent's `latestRunId` or stream when attributing work across multiple runs.
+- The API key is a secret. Do not pass it through prompts, `envVars`, repository files, URLs, or reports unless the user explicitly approves the scope and lifetime.
+- If an SSE stream expires or disconnects, use `status` to read terminal state rather than retrying the expired stream indefinitely.
+- Profiles isolate credentials and skills. A bot that should invoke this skill needs both the skill and `CURSOR_API_KEY` in its own active profile.
+
+## Verification
+
+Run these through the Hermes `terminal` tool for a setup-only check:
+
+```bash
+python "$AGENT" --help
+python "$AGENT" launch --help
+python "$AGENT" status --help
+```
+
+For a live integration check, run `models` and verify that the response is valid JSON with an `items` array. Do not launch a coding agent merely to test credentials unless the user approves the API usage.
+
+**Sources:**
+
+- <https://cursor.com/docs/cloud-agent/api/endpoints>
+- <https://cursor.com/docs/api>

--- a/optional-skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud_agent.py
+++ b/optional-skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud_agent.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Small, dependency-free CLI for Cursor Cloud Agents API v1."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_BASE = "https://api.cursor.com"
+TERMINAL_STATUSES = {"FINISHED", "ERROR", "CANCELLED", "EXPIRED"}
+
+
+class ApiError(RuntimeError):
+    """A user-actionable Cursor API or input error."""
+
+
+def api_request(
+    method: str,
+    path: str,
+    payload: Optional[Dict[str, Any]] = None,
+    *,
+    accept: str = "application/json",
+) -> Any:
+    key = os.environ.get("CURSOR_API_KEY")
+    if not key:
+        raise ApiError("CURSOR_API_KEY is not set")
+    base = DEFAULT_BASE
+    token = base64.b64encode((key + ":").encode("utf-8")).decode("ascii")
+    body = None
+    headers = {"Authorization": f"Basic {token}", "Accept": accept}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = Request(base + path, data=body, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=120) as response:
+            raw = response.read()
+            content_type = response.headers.get("Content-Type", "")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise ApiError(f"Cursor API HTTP {exc.code}: {detail}") from exc
+    except URLError as exc:
+        raise ApiError(f"Cursor API connection failed: {exc.reason}") from exc
+    if not raw:
+        return {}
+    if "json" in content_type or raw.lstrip().startswith((b"{", b"[")):
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ApiError("Cursor API returned invalid JSON") from exc
+    return raw.decode("utf-8", "replace")
+
+
+def require_https_github_repo(value: str) -> str:
+    prefix = "https://github.com/"
+    parts = value.removeprefix(prefix).rstrip("/").split("/")
+    if not value.startswith(prefix) or len(parts) != 2 or not all(parts):
+        raise argparse.ArgumentTypeError(
+            "--repo must be an HTTPS GitHub repository URL"
+        )
+    return value.rstrip("/")
+
+
+def prompt_value(args: argparse.Namespace) -> str:
+    text = args.prompt or ""
+    if args.prompt_file:
+        try:
+            file_text = Path(args.prompt_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ApiError(f"cannot read --prompt-file: {exc}") from exc
+        text = f"{text}\n\n{file_text}" if text else file_text
+    if not text.strip():
+        raise ApiError("a non-empty --prompt or --prompt-file is required")
+    return text.strip()
+
+
+def print_result(value: Any) -> None:
+    if isinstance(value, str):
+        print(value)
+    else:
+        print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def create_payload(args: argparse.Namespace) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "prompt": {"text": prompt_value(args)},
+        "repos": [{"url": args.repo, "startingRef": args.ref}],
+    }
+    if args.name:
+        payload["name"] = args.name
+    if args.model:
+        payload["model"] = {"id": args.model}
+    if args.auto_create_pr:
+        payload["autoCreatePR"] = True
+    if args.work_on_current_branch:
+        payload["workOnCurrentBranch"] = True
+    if args.mode:
+        payload["mode"] = args.mode
+    return payload
+
+
+def run_object(response: Dict[str, Any]) -> Dict[str, Any]:
+    run = response.get("run")
+    if not isinstance(run, dict) or not run.get("id") or not run.get("agentId"):
+        raise ApiError("Cursor response did not contain an agent run")
+    return run
+
+
+def get_run(agent_id: str, run_id: str) -> Dict[str, Any]:
+    value = api_request("GET", f"/v1/agents/{agent_id}/runs/{run_id}")
+    if not isinstance(value, dict):
+        raise ApiError("Cursor returned a non-object run response")
+    return value
+
+
+def wait_for_run(
+    agent_id: str,
+    run_id: str,
+    poll_seconds: float,
+    wait_timeout: float,
+) -> Dict[str, Any]:
+    deadline = time.monotonic() + wait_timeout if wait_timeout > 0 else None
+    while True:
+        run = get_run(agent_id, run_id)
+        status = str(run.get("status", "")).upper()
+        if status in TERMINAL_STATUSES:
+            return run
+        if deadline is not None and time.monotonic() >= deadline:
+            raise ApiError(f"timed out waiting for run {run_id}")
+        time.sleep(poll_seconds)
+
+
+def command_launch(args: argparse.Namespace) -> Dict[str, Any]:
+    response = api_request("POST", "/v1/agents", create_payload(args))
+    run = run_object(response)
+    result: Dict[str, Any] = {"agent": response.get("agent"), "run": run}
+    if args.wait:
+        result["finalRun"] = wait_for_run(
+            run["agentId"], run["id"], args.poll_seconds, args.wait_timeout
+        )
+    return result
+
+
+def command_follow_up(args: argparse.Namespace) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"prompt": {"text": prompt_value(args)}}
+    if args.mode:
+        payload["mode"] = args.mode
+    response = api_request("POST", f"/v1/agents/{args.agent_id}/runs", payload)
+    run = run_object({"run": response.get("run")})
+    result: Dict[str, Any] = {"run": run}
+    if args.wait:
+        result["finalRun"] = wait_for_run(
+            args.agent_id, run["id"], args.poll_seconds, args.wait_timeout
+        )
+    return result
+
+
+def iter_sse(response: Any) -> Iterable[Dict[str, Any]]:
+    event = "message"
+    data_lines = []
+    for raw_line in response:
+        line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+        if not line:
+            if data_lines:
+                text = "\n".join(data_lines)
+                try:
+                    data = json.loads(text)
+                except json.JSONDecodeError:
+                    data = {"raw": text}
+                yield {"event": event, "data": data}
+            event = "message"
+            data_lines = []
+            continue
+        if line.startswith("event:"):
+            event = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+
+
+def command_stream(args: argparse.Namespace) -> None:
+    key = os.environ.get("CURSOR_API_KEY")
+    if not key:
+        raise ApiError("CURSOR_API_KEY is not set")
+    base = DEFAULT_BASE
+    token = base64.b64encode((key + ":").encode("utf-8")).decode("ascii")
+    request = Request(
+        f"{base}/v1/agents/{args.agent_id}/runs/{args.run_id}/stream",
+        headers={"Authorization": f"Basic {token}", "Accept": "text/event-stream"},
+        method="GET",
+    )
+    try:
+        with urlopen(request, timeout=args.timeout) as response:
+            for event in iter_sse(response):
+                print(json.dumps(event, sort_keys=True), flush=True)
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise ApiError(f"Cursor stream HTTP {exc.code}: {detail}") from exc
+    except URLError as exc:
+        raise ApiError(f"Cursor stream connection failed: {exc.reason}") from exc
+
+
+def add_prompt_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--prompt")
+    parser.add_argument("--prompt-file")
+
+
+def add_wait_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--wait", action="store_true", help="poll until a terminal status")
+    parser.add_argument("--poll-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--wait-timeout",
+        type=float,
+        default=3600.0,
+        help="maximum seconds to wait; 0 disables the timeout",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    launch = sub.add_parser("launch", help="create an agent and enqueue its first run")
+    launch.add_argument("--repo", required=True, type=require_https_github_repo)
+    launch.add_argument("--ref", default="main")
+    add_prompt_arguments(launch)
+    launch.add_argument("--name")
+    launch.add_argument("--model")
+    launch.add_argument("--mode", choices=("agent", "plan"))
+    launch.add_argument("--auto-create-pr", action="store_true")
+    launch.add_argument("--work-on-current-branch", action="store_true")
+    add_wait_arguments(launch)
+    launch.set_defaults(handler=command_launch)
+
+    follow = sub.add_parser("follow-up", help="send a prompt to an existing agent")
+    follow.add_argument("--agent-id", required=True)
+    add_prompt_arguments(follow)
+    follow.add_argument("--mode", choices=("agent", "plan"))
+    add_wait_arguments(follow)
+    follow.set_defaults(handler=command_follow_up)
+
+    status = sub.add_parser("status", help="read one run")
+    status.add_argument("--agent-id", required=True)
+    status.add_argument("--run-id", required=True)
+    status.set_defaults(handler=lambda a: get_run(a.agent_id, a.run_id))
+
+    stream = sub.add_parser("stream", help="print Server-Sent Events for one run")
+    stream.add_argument("--agent-id", required=True)
+    stream.add_argument("--run-id", required=True)
+    stream.add_argument("--timeout", type=float, default=900)
+    stream.set_defaults(handler=command_stream)
+
+    cancel = sub.add_parser("cancel", help="cancel an active run")
+    cancel.add_argument("--agent-id", required=True)
+    cancel.add_argument("--run-id", required=True)
+    cancel.set_defaults(
+        handler=lambda a: api_request(
+            "POST", f"/v1/agents/{a.agent_id}/runs/{a.run_id}/cancel"
+        )
+    )
+
+    models = sub.add_parser("models", help="list available models")
+    models.set_defaults(handler=lambda a: api_request("GET", "/v1/models"))
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        value = args.handler(args)
+        if value is not None:
+            print_result(value)
+        return 0
+    except ApiError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_cursor_cloud_agents_skill.py
+++ b/tests/skills/test_cursor_cloud_agents_skill.py
@@ -1,0 +1,182 @@
+"""Contract tests for the optional Cursor Cloud Agents skill.
+
+These tests validate the local skill asset and helper construction only. They
+never contact Cursor or transmit credentials.
+"""
+
+import base64
+import importlib.util
+import re
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "cursor-cloud-agents"
+    / "SKILL.md"
+)
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "cursor-cloud-agents"
+    / "scripts"
+    / "cursor_cloud_agent.py"
+)
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+def _frontmatter_and_body():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    match = re.search(r"\n---\s*\n", content[3:])
+    assert match, "frontmatter must close with ---"
+    fm_text = content[3 : match.start() + 3]
+    body = content[match.end() + 3 :]
+    fields = {}
+    for line in fm_text.splitlines():
+        field = re.match(r"^(\w[\w-]*):\s*(.*)$", line)
+        if field:
+            fields[field.group(1)] = field.group(2).strip().strip('"')
+    return fields, body
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("cursor_cloud_agent_test", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_file_and_helper_exist():
+    assert SKILL_PATH.is_file()
+    assert SCRIPT_PATH.is_file()
+
+
+def test_frontmatter_required_fields():
+    fm, _ = _frontmatter_and_body()
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in fm, f"missing frontmatter field: {field}"
+    assert fm["name"] == "cursor-cloud-agents"
+    assert not fm["author"].startswith("Hermes Agent")
+
+
+def test_description_hardline():
+    fm, _ = _frontmatter_and_body()
+    description = fm["description"]
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert description.count(".") == 1
+
+
+def test_required_sections_are_ordered():
+    _, body = _frontmatter_and_body()
+    positions = [body.find(section) for section in REQUIRED_SECTIONS]
+    assert all(position >= 0 for position in positions)
+    assert positions == sorted(positions)
+
+
+def test_steps_have_completion_criteria():
+    _, body = _frontmatter_and_body()
+    steps = re.findall(
+        r"^### \d+\..*?(?=^### \d+\.|^## )",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert len(steps) == 8
+    assert all("Completion criterion:" in step for step in steps)
+
+
+def test_related_skills_resolve_in_repo():
+    fm, _ = _frontmatter_and_body()
+    related = re.search(r"related_skills:\s*\[(.*?)\]", SKILL_PATH.read_text())
+    assert related
+    for name in (item.strip() for item in related.group(1).split(",")):
+        hits = list(REPO_ROOT.glob(f"skills/*/{name}/SKILL.md"))
+        hits += list(REPO_ROOT.glob(f"optional-skills/*/{name}/SKILL.md"))
+        assert hits, f"related skill does not resolve: {name}"
+
+
+def test_skill_references_native_tools_and_no_local_paths():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "`terminal`" in content
+    assert "/Users/" not in content
+    assert "/home/" not in content
+    assert not re.search(r"[A-Z]:\\\\Users", content)
+
+
+def test_helper_builds_safe_launch_payload(monkeypatch):
+    helper = _load_helper()
+    args = helper.build_parser().parse_args(
+        [
+            "launch",
+            "--repo",
+            "https://github.com/acme/demo",
+            "--ref",
+            "main",
+            "--prompt",
+            "Implement the approved change",
+            "--auto-create-pr",
+        ]
+    )
+    payload = helper.create_payload(args)
+    assert payload == {
+        "prompt": {"text": "Implement the approved change"},
+        "repos": [{"url": "https://github.com/acme/demo", "startingRef": "main"}],
+        "autoCreatePR": True,
+    }
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+
+def test_helper_uses_basic_auth_without_leaking_key(monkeypatch):
+    helper = _load_helper()
+    secret = "test-cursor-key"
+    monkeypatch.setenv("CURSOR_API_KEY", secret)
+    response = Mock()
+    response.read.return_value = b'{"items": []}'
+    response.headers = {"Content-Type": "application/json"}
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    with patch.object(helper, "urlopen", return_value=response) as mocked:
+        assert helper.api_request("GET", "/v1/models") == {"items": []}
+    request = mocked.call_args.args[0]
+    encoded = request.get_header("Authorization").removeprefix("Basic ")
+    assert base64.b64decode(encoded).decode() == secret + ":"
+    assert secret not in repr(request)
+
+
+def test_helper_uses_fixed_cursor_api_host(monkeypatch):
+    helper = _load_helper()
+    monkeypatch.setenv("CURSOR_API_KEY", "test-cursor-key")
+    monkeypatch.setenv("CURSOR_API_BASE_URL", "https://attacker.example")
+    response = Mock()
+    response.read.return_value = b'{"items": []}'
+    response.headers = {"Content-Type": "application/json"}
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    with patch.object(helper, "urlopen", return_value=response) as mocked:
+        helper.api_request("GET", "/v1/models")
+    assert mocked.call_args.args[0].full_url == "https://api.cursor.com/v1/models"
+
+
+def test_helper_rejects_invalid_repository_urls():
+    helper = _load_helper()
+    with pytest.raises(Exception):
+        helper.require_https_github_repo("https://example.com/acme/demo")
+    with pytest.raises(Exception):
+        helper.require_https_github_repo("https://github.com/acme")
+    assert helper.require_https_github_repo("https://github.com/acme/demo.git") == "https://github.com/acme/demo.git"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -33,6 +33,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**antigravity-cli**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli) | Operate the Antigravity CLI (agy): plugins, auth, sandbox. |
 | [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to the Blackbox AI multi-model CLI. |
+| [**cursor-cloud-agents**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents) | Launch and track Cursor Cloud Agents for repository work. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and troubleshoot Honcho memory for Hermes. |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents.md
@@ -1,0 +1,163 @@
+---
+title: "Cursor Cloud Agents — Launch and track Cursor Cloud Agents for repository work"
+sidebar_label: "Cursor Cloud Agents"
+description: "Launch and track Cursor Cloud Agents for repository work"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Cursor Cloud Agents
+
+Launch and track Cursor Cloud Agents for repository work.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/cursor-cloud-agents` |
+| Path | `optional-skills/autonomous-ai-agents/cursor-cloud-agents` |
+| Version | `0.1.0` |
+| Author | Iven Simon (ivenms), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Coding-Agent`, `Cursor`, `Cloud-Agents`, `GitHub`, `Pull-Requests`, `Automation` |
+| Related skills | [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Cursor Cloud Agents Skill
+
+Delegate repository coding work to Cursor Cloud Agents through Cursor's public-beta v1 API. This optional integration uses a dependency-free Python helper and returns durable agent/run identifiers, branches, and pull-request URLs. It does not replace local tests, code review, merge approval, or deployment controls.
+
+## When to Use
+
+- The user explicitly asks Cursor Cloud Agent to implement, fix, refactor, test, or document code.
+- A long-running coding task should run remotely against an accessible GitHub repository.
+- A bot needs to continue an existing Cursor agent conversation with a follow-up prompt.
+- A second technical bot needs to inspect or continue work from an existing `agent-id` and `run-id`.
+
+**Do not use for:** local-only edits, a review that does not require Cursor coding, production deployment, or a task without a repository and acceptance criteria.
+
+## Prerequisites
+
+- A Cursor API key with Cloud Agents access, stored only as `CURSOR_API_KEY` in the active Hermes profile's `.env` or process environment.
+- Configure the persistent key through Hermes; do not hand-edit YAML:
+
+```bash
+hermes config set CURSOR_API_KEY 'YOUR_CURSOR_API_KEY'
+```
+
+This writes the secret to the active profile's `.env`, not `config.yaml`. Replace the placeholder locally; never place the real key in chat, prompts, repository files, URLs, or logs. Start a new profile session after changing the key so Hermes loads it.
+- The repository must be accessible through Cursor's GitHub App installation.
+- The repository URL and starting branch/ref must be known.
+- For an explicit model, query `models` first and use an ID returned by Cursor. Otherwise omit `--model` and use Cursor's configured default.
+
+The Cloud Agents API v1 is public beta and may change. Reference: &lt;https://cursor.com/docs/cloud-agent/api/endpoints>.
+
+## How to Run
+
+Run the bundled helper through the Hermes `terminal` tool. The helper is relative to the active profile's `$HERMES_HOME`:
+
+```bash
+AGENT="$HERMES_HOME/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud_agent.py"
+```
+
+Launch work on a new Cursor branch and request a pull request:
+
+```bash
+python "$AGENT" launch \
+  --repo https://github.com/ORG/REPO \
+  --ref main \
+  --prompt "Implement the approved task. Add or update tests and report verification commands." \
+  --auto-create-pr \
+  --wait
+```
+
+For a prompt in a file, use `--prompt-file PATH`. The helper prints JSON for non-streaming commands; preserve `agent.id`, `run.id`, final status, pushed branch, and PR URL in the handoff.
+
+## Quick Reference
+
+```text
+launch       Create an agent and enqueue its first run.
+follow-up    Send a prompt to an existing agent.
+status       Read one run's current or terminal state.
+stream       Print SSE status, assistant, and tool events.
+cancel       Cancel an active run; cancellation is terminal.
+models       List model IDs and supported parameters.
+```
+
+Examples:
+
+```bash
+python "$AGENT" follow-up --agent-id AGENT_ID --prompt "Address the failing test and rerun the focused suite." --wait
+python "$AGENT" status --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" stream --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" cancel --agent-id AGENT_ID --run-id RUN_ID
+python "$AGENT" models
+```
+
+## Procedure
+
+### 1. Define the task
+
+State the repository URL, starting ref, desired change, constraints, acceptance criteria, and required tests. Completion criterion: the prompt is specific enough for the remote agent to work without an interactive clarification loop.
+
+### 2. Check credentials
+
+Confirm `CURSOR_API_KEY` is present without printing its value. Completion criterion: the helper passes credential preflight and no secret appears in the prompt or output.
+
+### 3. Choose the model
+
+Run `models` when explicit model selection matters. Completion criterion: every selected model ID and parameter is present in Cursor's response.
+
+### 4. Launch safely
+
+Use `launch` with `--auto-create-pr` unless a branch-only result was requested. Keep `--work-on-current-branch` disabled by default. Completion criterion: the API returns both an agent ID and a run ID.
+
+### 5. Track execution
+
+Use `--wait` for bounded tasks or `status`/`stream` for separately monitored work. Completion criterion: the run reaches `FINISHED`, `ERROR`, `CANCELLED`, or `EXPIRED`; never infer completion from an HTTP 2xx response alone.
+
+### 6. Inspect the result
+
+Read the terminal result and `git.branches[]`. Completion criterion: the final response, pushed branch, and PR URL (if created) are recorded, or the API error is reported verbatim without credentials.
+
+### 7. Verify before merge
+
+Inspect the branch or PR and run the repository's actual tests locally or in CI. Load `requesting-code-review` before committing or merging. Completion criterion: tests and review state have real evidence; the agent's prose alone is not proof.
+
+### 8. Continue or stop
+
+Send a follow-up only after the current run is terminal; Cursor rejects concurrent runs with `agent_busy`. Completion criterion: each follow-up returns a new run ID and is recorded separately.
+
+## Pitfalls
+
+- The v1 API separates a durable agent from per-prompt runs; never substitute one identifier for the other.
+- `agent_busy` means another run is active. Wait or cancel it instead of retrying blindly.
+- `--work-on-current-branch` can push directly to the supplied ref. Use it only with explicit approval.
+- `--auto-create-pr` opens a PR but does not mean the code is reviewed, tested, or safe to merge.
+- Run-level `git` is an agent-scoped snapshot. Use the agent's `latestRunId` or stream when attributing work across multiple runs.
+- The API key is a secret. Do not pass it through prompts, `envVars`, repository files, URLs, or reports unless the user explicitly approves the scope and lifetime.
+- If an SSE stream expires or disconnects, use `status` to read terminal state rather than retrying the expired stream indefinitely.
+- Profiles isolate credentials and skills. A bot that should invoke this skill needs both the skill and `CURSOR_API_KEY` in its own active profile.
+
+## Verification
+
+Run these through the Hermes `terminal` tool for a setup-only check:
+
+```bash
+python "$AGENT" --help
+python "$AGENT" launch --help
+python "$AGENT" status --help
+```
+
+For a live integration check, run `models` and verify that the response is valid JSON with an `items` array. Do not launch a coding agent merely to test credentials unless the user approves the API usage.
+
+**Sources:**
+
+- &lt;https://cursor.com/docs/cloud-agent/api/endpoints>
+- &lt;https://cursor.com/docs/api>

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -348,6 +348,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox',
+                    'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands',


### PR DESCRIPTION
## Summary

- Add an optional Hermes skill for launching and managing Cursor Cloud Agents through the public-beta v1 API.
- Include a dependency-free Python helper for launch, follow-up, status, streaming, cancellation, and model discovery.
- Add generated documentation, catalog, and sidebar entries.

## Motivation

Hermes technical profiles need a reusable, auditable way to delegate long-running repository work to Cursor Cloud Agents without embedding API keys in prompts or repository files.

## Changes

- Add `optional-skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md` with prerequisites, safe operating procedure, API lifecycle guidance, pitfalls, and verification criteria.
- Add `scripts/cursor_cloud_agent.py` using Python's standard library only.
- Read `CURSOR_API_KEY` from the process environment and keep the Cursor API host fixed at `https://api.cursor.com`.
- Add no-network contract tests covering skill metadata, related skills, payload construction, Basic authentication, fixed-host behavior, and repository URL validation.
- Register the optional skill in the generated catalog and Docusaurus sidebar.

## Test Plan

- [x] `scripts/run_tests.sh tests/skills/test_cursor_cloud_agents_skill.py -q` — 11 passed.
- [x] Ruff — all checks passed.
- [x] Python bytecode compilation — passed.
- [x] `npm run build:fast` — production build succeeded; it reports the repository's pre-existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings.
- [ ] Live Cursor agent launch — intentionally not run because it would create billable/external agent work; the existing API credential check was previously verified separately.

## Screenshots / Examples

Not applicable; this is a CLI skill and documentation change.

## Notes for Reviewers

- The helper follows Cursor's current Cloud Agents API v1 contract: durable agent IDs are kept separate from per-run IDs, and completion is verified through terminal run status.
- `--work-on-current-branch` is opt-in; the documented default creates a new Cursor branch.
- The full website TypeScript check remains blocked by existing repository configuration/component errors (`baseUrl` deprecation under TypeScript 6, missing JSX namespace, and missing generated JSON); the Docusaurus production build itself succeeds.

## Sources

- https://cursor.com/docs/cloud-agent/api/endpoints
- https://cursor.com/docs-static/cloud-agents-openapi.yaml
