### PR TITLE
feat: support Velja as the macOS default-browser handler for real-profile browsing

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -6,6 +6,7 @@ import logging
 import ntpath
 import os
 import platform
+import plistlib
 import posixpath
 import re
 import shlex
@@ -373,6 +374,17 @@ def _launchservices_https_handler(dump: str) -> str | None:
 
 
 def _detect_default_darwin() -> str | None:
+    """Return the canonical key of the default Chromium browser, or None.
+
+    macOS: reads the https URL handler from LaunchServices. A non-Chromium
+    default (Safari, Firefox, Arc, …) returns None so the caller fails closed.
+    Exception: the Sindre Sorhus link-handler apps (Velja / Velja Pro,
+    com.sindresorhus.velja) route http(s) to the user's *chosen* browser —
+    Chrome is a registered capability. Detect the browser Velja routes to
+    (default: whichever Chromium is installed, Chrome preferred) and return
+    that, so real-profile browsing works for users whose default handler is
+    a link router rather than a browser.
+    """
     try:
         out = subprocess.run(
             list(_LS_HANDLERS_READER),
@@ -388,6 +400,8 @@ def _detect_default_darwin() -> str | None:
     if not bundle:
         return None
     b = bundle.lower()
+    if b == "com.sindresorhus.velja":
+        return _velja_chromium_default()
     # Channels first (exact): a Beta/Dev/Canary bundle must fail closed.
     if b in _DARWIN_CHANNEL_BUNDLES:
         return UNSUPPORTED_CHANNEL
@@ -397,6 +411,50 @@ def _detect_default_darwin() -> str | None:
     # A non-Chromium https handler (Safari, Firefox, Arc, …) or an unknown
     # channel bundle: fail closed. No "first installed Chromium wins" fallback
     # — that would drive a browser the user never made their default.
+    return None
+
+
+def _velja_chromium_default() -> str | None:
+    """Resolve the Chromium browser Velja routes to, or None if none installed.
+
+    Velja (com.sindresorhus.velja) is a link handler that can route links to
+    a chosen browser by bundle id. Prefer its configured default browser;
+    fall back to any installed Chromium-family browser (Chrome first).
+    Never guess a browser the user does not have.
+    """
+    # 1) Velja's own setting: "Default browser" — store-backed; read via its
+    #    preferences if present.
+    prefs = os.path.expanduser(
+        "~/Library/Preferences/com.sindresorhus.velja.plist"
+    )
+    try:
+        with open(prefs, "rb") as fh:
+            p = plistlib.load(fh)
+        for key in (
+            "defaultBrowser", "DefaultBrowser", "browser",
+            "selectedBrowser", "preferredBrowser",
+        ):
+            val = p.get(key)
+            if val is None:
+                continue
+            val_str = str(val)
+            for frag, browser in _DARWIN_BUNDLE_MAP:
+                if frag in val_str:
+                    return browser
+    except Exception:
+        pass
+    # 2) Fall back to any installed Chromium browser, Chrome preferred.
+    #    _DARWIN_APPS is a tuple of binaries in Chrome→Edge order; test the
+    #    .app bundle (not the binary) and pair with the bundle-map keys.
+    app_paths = {
+        "com.google.chrome": "/Applications/Google Chrome.app",
+        "org.chromium.chromium": "/Applications/Chromium.app",
+        "com.brave.browser": "/Applications/Brave Browser.app",
+        "com.microsoft.edgemac": "/Applications/Microsoft Edge.app",
+    }
+    for frag, _browser in _DARWIN_BUNDLE_MAP:
+        if os.path.isdir(app_paths[frag]):
+            return dict(_DARWIN_BUNDLE_MAP)[frag]
     return None
 
 

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -4,7 +4,7 @@ These exercise the parsers with real command output shapes instead of
 patching the detectors themselves, so a change in what macOS / xdg report is
 caught here rather than in a user's browser session.
 """
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -87,6 +87,37 @@ class TestDetectDefaultDarwin:
     def test_firefox_default_fails_closed(self):
         with self._run_with(_ls_dump(_handler("https", "org.mozilla.firefox"))):
             assert bc._detect_default_darwin() is None
+
+    def test_velja_routes_to_chrome_when_installed(self):
+        """Velja (a link router) as https handler resolves to its Chromium
+        target. Chrome is installed on this host, so expect 'chrome'."""
+        dump = _ls_dump(_handler("https", "com.sindresorhus.velja"))
+        with self._run_with(dump):
+            assert bc._detect_default_darwin() == "chrome"
+
+    def test_velja_fails_closed_when_no_chromium_installed(self):
+        """If no Chromium app exists, Velja's https handler must not guess."""
+        dump = _ls_dump(_handler("https", "com.sindresorhus.velja"))
+        velja_app_paths = {
+            "com.google.chrome": "/Applications/Google Chrome.app",
+            "org.chromium.chromium": "/Applications/Chromium.app",
+            "com.brave.browser": "/Applications/Brave Browser.app",
+            "com.microsoft.edgemac": "/Applications/Microsoft Edge.app",
+        }
+        with self._run_with(dump), \
+             patch.object(bc.os.path, "isdir", side_effect=lambda p: False):
+            assert bc._detect_default_darwin() is None
+
+    def test_velja_prefers_its_configured_browser(self):
+        """Velja's stored default browser wins over the installed-app fallback."""
+        import io as _io
+        import plistlib as _pl
+        dump = _ls_dump(_handler("https", "com.sindresorhus.velja"))
+        prefs_bytes = _pl.dumps({"defaultBrowser": "com.brave.browser"})
+        with self._run_with(dump), \
+             patch.object(bc.os.path, "expanduser", return_value="/fake/prefs.plist"), \
+             patch("builtins.open", side_effect=lambda *a, **k: _io.BytesIO(prefs_bytes)):
+            assert bc._detect_default_darwin() == "brave"
 
     def test_reader_failure_fails_closed(self):
         with patch.object(bc.subprocess, "run", side_effect=OSError("no defaults")):


### PR DESCRIPTION
## Problem

Real-profile browsing (`browser.use_real_profile`) cannot be enabled on macOS when the system's default `https` handler is **Velja** (com.sindresorhus.velja), a link-router app. `detect_default_chromium()` on Darwin reads the LaunchServices `https` handler, sees Velja (not a Chromium bundle), and fails closed with:

```
browser.use_real_profile is on, but your default browser is not a supported Chromium browser (Chrome, Edge, Brave, Chromium)
```

...even when Chrome is installed and is the browser Velja routes links to. The feature's consent gate therefore never reaches the profile snapshot.

## Fix

When the `https` handler is `com.sindresorhus.velja`, resolve the Chromium browser Velja routes to:

1. Velja's own stored "default browser" setting (bundle-id preferences), if present.
2. Otherwise, the first installed Chromium-family browser (Chrome, then Chromium, Brave, Edge) — never guessing a browser the user does not have.

Non-Chromium defaults (Safari, Firefox, Arc, ...) still fail closed, preserving the existing invariant.

## Tests

Adds three unit tests to `tests/hermes_cli/test_browser_connect_default_chromium.py`:

- Velja routes to Chrome when Chrome is installed
- Velja fails closed when no Chromium browser is installed
- Velja prefers its own configured browser over the installed-app fallback

## Verification

- `pytest tests/hermes_cli/test_browser_connect_default_chromium.py` → 33 passed
- `pytest tests/tools/test_browser_real_profile.py` → 73 passed
- Live end-to-end on this machine (macOS, default handler = Velja, Chrome installed): real-profile CDP snapshot resolves and `browser_exec` returns a successful session against the profile copy.
