### PR TITLE
fix(cache): over-length caller prompt_cache_key no longer 400s Chat Completions requests (opencode#44571 port)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -66,15 +66,36 @@ def _add_prompt_cache_key(
     precedence over the physical ``session_id`` so the key survives
     context-compression session rotation (#79017).
     """
-    if not supports_prompt_cache_key:
+    # An explicit caller body field is authoritative — do not add a duplicate
+    # top-level field whose SDK merge precedence could overwrite it.  But it
+    # must still respect the wire constraint: OpenAI caps ``prompt_cache_key``
+    # at 64 chars (DeepSeek and Zai inherit the same limit via their
+    # OpenAI-compatible APIs) and rejects longer values with HTTP 400.  Bound
+    # caller keys in place with the same hash shape the Responses transport
+    # uses (``_bounded_prompt_cache_key`` in agent/transports/codex.py), so
+    # both transports behave identically for over-length keys.
+    from agent.transports.codex import _bounded_prompt_cache_key
+
+    extra_body = api_kwargs.get("extra_body")
+    caller_supplied = "prompt_cache_key" in api_kwargs or (
+        isinstance(extra_body, dict) and "prompt_cache_key" in extra_body
+    )
+    if caller_supplied:
+        if "prompt_cache_key" in api_kwargs:
+            bounded = _bounded_prompt_cache_key(api_kwargs["prompt_cache_key"])
+            if bounded:
+                api_kwargs["prompt_cache_key"] = bounded
+            else:
+                api_kwargs.pop("prompt_cache_key", None)
+        if isinstance(extra_body, dict) and "prompt_cache_key" in extra_body:
+            bounded = _bounded_prompt_cache_key(extra_body["prompt_cache_key"])
+            if bounded:
+                extra_body["prompt_cache_key"] = bounded
+            else:
+                extra_body.pop("prompt_cache_key", None)
         return
 
-    # An explicit caller body field is authoritative too.  Do not add a
-    # duplicate top-level field whose SDK merge precedence could overwrite it.
-    extra_body = api_kwargs.get("extra_body")
-    if "prompt_cache_key" in api_kwargs or (
-        isinstance(extra_body, dict) and "prompt_cache_key" in extra_body
-    ):
+    if not supports_prompt_cache_key:
         return
 
     # Reuse the Responses transport's single authoritative hash algorithm and

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -875,3 +875,78 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+    def test_overlong_caller_top_level_key_is_bounded(self, transport):
+        """OpenAI caps prompt_cache_key at 64 chars and 400s longer values.
+
+        A caller-supplied over-length key (request_overrides) must be hashed
+        to the same pck_<sha256[:24]> shape the Responses transport uses
+        (opencode#44571 parity — clamp on every chat protocol).
+        """
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        long_key = "sess-" + "x" * 200
+
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": long_key},
+        )
+
+        assert kwargs["prompt_cache_key"].startswith("pck_")
+        assert len(kwargs["prompt_cache_key"]) <= 64
+        body = self._request_body(kwargs)
+        assert body["prompt_cache_key"] == kwargs["prompt_cache_key"]
+
+    def test_overlong_caller_extra_body_key_is_bounded(self, transport):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        long_key = "sess-" + "y" * 200
+
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"extra_body": {"prompt_cache_key": long_key}},
+        )
+
+        eb_key = kwargs["extra_body"]["prompt_cache_key"]
+        assert eb_key.startswith("pck_")
+        assert len(eb_key) <= 64
+        # No duplicate top-level field competing with the caller's extra_body.
+        assert "prompt_cache_key" not in kwargs
+
+    def test_short_caller_key_passes_through_unchanged(self, transport):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": "caller-top-level"},
+        )
+        assert kwargs["prompt_cache_key"] == "caller-top-level"
+
+    def test_overlong_caller_key_bounded_on_legacy_path(self, transport):
+        long_key = "sess-" + "z" * 200
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            supports_prompt_cache_key=True,
+            request_overrides={"prompt_cache_key": long_key},
+        )
+        assert kwargs["prompt_cache_key"].startswith("pck_")
+        assert len(kwargs["prompt_cache_key"]) <= 64
+
+    def test_whitespace_only_caller_key_is_dropped(self, transport):
+        """_bounded_prompt_cache_key returns None for blank keys — the field
+        must be removed rather than sent empty."""
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": "   "},
+        )
+        assert "prompt_cache_key" not in kwargs


### PR DESCRIPTION
## Summary
Caller-supplied `prompt_cache_key` values over 64 chars no longer 400 every Chat Completions request — they're bounded to the same `pck_<sha256[:24]>` hash shape the Responses transport already uses.

Port from [anomalyco/opencode#44571](https://github.com/anomalyco/opencode/pull/44571) ("clamp prompt_cache_key to 64 chars for all chat protocols"): OpenAI caps `prompt_cache_key` at 64 chars; DeepSeek and Zai inherit the same limit via their OpenAI-compatible APIs, and over-length values are rejected with HTTP 400.

**Gap in hermes:** `agent/transports/codex.py` bounds keys via `_bounded_prompt_cache_key` on every Responses path, but `agent/transports/chat_completions.py` `_add_prompt_cache_key()` early-returned when the caller supplied a key via `request_overrides` (top-level or `extra_body`) — passing it to the wire unmodified on both the profile and legacy kwargs paths. Hermes-generated keys were already safe (content-addressed `pck_` hashes).

## Changes
- `agent/transports/chat_completions.py`: caller-supplied keys are bounded in place with codex's `_bounded_prompt_cache_key` (≤64 passes through untouched; over-length → `pck_` hash; blank → field dropped) before the authoritative-caller early return.
- `tests/agent/transports/test_chat_completions.py`: 5 regression tests (top-level, extra_body, legacy path, short-key passthrough, blank-key drop). Sabotage-verified: all new bound-checking tests fail on unpatched main.

## Validation
| | Before | After |
|---|---|---|
| 205-char caller key (profile path, wire body) | sent verbatim, len 205 → HTTP 400 on OpenAI/DeepSeek/Zai | `pck_…` len 28 |
| 205-char caller key (extra_body) | sent verbatim | `pck_…` len 28 |
| 205-char caller key (legacy kwargs path) | sent verbatim | `pck_…` len 28 |
| tests/agent/transports/test_chat_completions.py | 51 passed | 56 passed |

**Live repro:** MockTransport-captured wire bodies on origin/main showed the 205-char key sent verbatim on all three paths; after the fix all three emit a 28-char `pck_` hash (same run, same harness).

Architectural note vs the OpenCode original: OpenCode clamps by unicode-aware truncation; hermes reuses its existing hash-bounding helper instead, so an over-length key keeps full-key entropy (truncation would collide keys sharing a 64-char prefix) and both hermes transports stay identical in behavior.

## Infographic

![Prompt cache key clamp](https://v3b.fal.media/files/b/0aa81527/-RqiLfF2vKVE31mpsbuaH_HQKZ58cd.png)
