### PR TITLE
fix(gateway): log dropped platform config entries instead of swallowing silently

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1196,7 +1196,8 @@ class GatewayConfig:
                 reset_by_platform[platform] = SessionResetPolicy.from_dict(policy_data)
             except ValueError as exc:
                 logger.warning(
-                    "gateway config: dropping reset_by_platform entry %r (%s: %s)",
+                    "gateway config: dropping reset_by_platform entry %r (%s: %s) — "
+                    "not a built-in platform or malformed config",
                     platform_name, type(exc).__name__, exc,
                 )
         

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1173,20 +1173,32 @@ class GatewayConfig:
             try:
                 platform = Platform(platform_name)
                 platforms[platform] = PlatformConfig.from_dict(platform_data)
-            except ValueError:
-                pass  # Skip unknown platforms
-        
+            except ValueError as exc:
+                # Skip, but never silently: a platform configured and expected
+                # to run (e.g. registered via a user plugin, which the Platform
+                # enum does not resolve) would otherwise vanish with no log
+                # line naming it, leaving "No messaging platforms enabled" as
+                # the only symptom (#96747).
+                logger.warning(
+                    "gateway config: dropping platforms entry %r (%s: %s) — "
+                    "not a built-in platform or malformed config",
+                    platform_name, type(exc).__name__, exc,
+                )
+
         reset_by_type = {}
         for type_name, policy_data in _coerce_dict(data.get("reset_by_type", {})).items():
             reset_by_type[type_name] = SessionResetPolicy.from_dict(policy_data)
-        
+
         reset_by_platform = {}
         for platform_name, policy_data in _coerce_dict(data.get("reset_by_platform", {})).items():
             try:
                 platform = Platform(platform_name)
                 reset_by_platform[platform] = SessionResetPolicy.from_dict(policy_data)
-            except ValueError:
-                pass
+            except ValueError as exc:
+                logger.warning(
+                    "gateway config: dropping reset_by_platform entry %r (%s: %s)",
+                    platform_name, type(exc).__name__, exc,
+                )
         
         default_policy = SessionResetPolicy()
         if "default_reset_policy" in data:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1419,6 +1419,10 @@ class TestUnknownPlatformLogging:
             and rec.levelno == _logging.WARNING
             for rec in caplog.records
         ), "dropped platform must be named in a warning"
+        assert any(
+            "not a built-in platform or malformed config" in rec.getMessage()
+            for rec in caplog.records
+        ), "both drop warnings must share the same reason wording"
 
     def test_unknown_reset_by_platform_logs_warning(self, caplog):
         import logging as _logging
@@ -1438,6 +1442,10 @@ class TestUnknownPlatformLogging:
             and rec.levelno == _logging.WARNING
             for rec in caplog.records
         ), "dropped reset policy must be named in a warning"
+        assert any(
+            "not a built-in platform or malformed config" in rec.getMessage()
+            for rec in caplog.records
+        ), "both drop warnings must share the same reason wording"
 
     def test_known_platform_still_silent(self, caplog):
         """Legitimate built-in entries keep loading without noise."""

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1391,3 +1391,64 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestUnknownPlatformLogging:
+    """A configured platform the Platform enum cannot resolve (e.g. one
+    registered via a user plugin) is still dropped from GatewayConfig — the
+    enum-only resolution is the existing contract — but the drop must be
+    visible: before #96747 both `platforms` and `reset_by_platform` entries
+    vanished in a bare `except ValueError: pass`, leaving "No messaging
+    platforms enabled" as the only, nameless symptom."""
+
+    def test_unknown_platform_logs_warning(self, caplog):
+        import logging as _logging
+
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "my_user_plugin_platform": {"enabled": True},
+                },
+            }
+        )
+        assert not any(
+            p.value == "my_user_plugin_platform" for p in config.platforms
+        )
+        assert any(
+            "my_user_plugin_platform" in rec.getMessage()
+            and rec.levelno == _logging.WARNING
+            for rec in caplog.records
+        ), "dropped platform must be named in a warning"
+
+    def test_unknown_reset_by_platform_logs_warning(self, caplog):
+        import logging as _logging
+
+        config = GatewayConfig.from_dict(
+            {
+                "reset_by_platform": {
+                    "my_user_plugin_platform": {"after_turn": "always"},
+                },
+            }
+        )
+        assert not any(
+            p.value == "my_user_plugin_platform" for p in config.reset_by_platform
+        )
+        assert any(
+            "my_user_plugin_platform" in rec.getMessage()
+            and rec.levelno == _logging.WARNING
+            for rec in caplog.records
+        ), "dropped reset policy must be named in a warning"
+
+    def test_known_platform_still_silent(self, caplog):
+        """Legitimate built-in entries keep loading without noise."""
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "telegram": {"enabled": False},
+                },
+            }
+        )
+        assert Platform.TELEGRAM in config.platforms
+        assert not [
+            rec for rec in caplog.records if "telegram" in rec.getMessage()
+        ]


### PR DESCRIPTION
## What does this PR do?

Makes `GatewayConfig.from_dict` log a warning when it drops a configured platform entry instead of swallowing the `ValueError` silently.

Today both the `platforms` and `reset_by_platform` parse loops do `except ValueError: pass`. A platform registered via a **user plugin** (`~/.hermes/plugins/<name>/`, `source: user` in `hermes plugins list`) is not in the `Platform` enum, so its correctly configured entry vanished during config load with no error, warning, or log line naming it — the gateway then started with `No messaging platforms enabled` as the only, undiagnosable symptom (#96747). The same bare swallow also hid malformed `PlatformConfig.from_dict` values.

The skip behavior itself is unchanged (enum-only resolution is the existing contract — supporting user-plugin platforms in the gateway config is a larger design question this PR deliberately does not take on). What changes is observability: each dropped entry now logs a warning naming the platform, the exception type, and the message. Built-in entries stay silent.

## Related Issue

Fixes #96747

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py` — `GatewayConfig.from_dict`: both `except ValueError: pass` sites (platforms, reset_by_platform) now log a warning naming the dropped entry with the exception type and message.
- `tests/gateway/test_config.py` — new `TestUnknownPlatformLogging`: unknown platform entry is still dropped but named in a warning; same for `reset_by_platform`; a built-in entry (`telegram`) loads with no warning.

## How to Test

1. `python -m pytest tests/gateway/test_config.py -q` — should pass (64 passed, including the three new tests).
2. Red/green verified locally: with the bare `pass` restored, the two warning assertions fail (2 failed / 1 passed); with this change, all pass.
3. Manual equivalent: put a non-enum platform under `gateway.platforms` in config.yaml (e.g. a user-plugin platform name) and start the gateway — the log should now contain `gateway config: dropping platforms entry '...'` instead of nothing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/gateway/test_config.py` — 64 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python logging)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
